### PR TITLE
Switch auto-updater to automatic download with improved UX

### DIFF
--- a/src/main/services/updater.ts
+++ b/src/main/services/updater.ts
@@ -7,7 +7,7 @@ const log = createLogger({ component: 'AutoUpdater' })
 const CHECK_INTERVAL = 4 * 60 * 60 * 1000 // 4 hours
 const INITIAL_DELAY = 10 * 1000 // 10 seconds
 
-autoUpdater.autoDownload = false
+autoUpdater.autoDownload = true
 autoUpdater.autoInstallOnAppQuit = true
 autoUpdater.logger = null
 

--- a/src/renderer/src/components/ui/sonner.tsx
+++ b/src/renderer/src/components/ui/sonner.tsx
@@ -3,6 +3,7 @@ import { Toaster as Sonner, type ToasterProps } from 'sonner'
 function Toaster({ ...props }: ToasterProps) {
   return (
     <Sonner
+      theme="dark"
       className="toaster group"
       toastOptions={{
         classNames: {

--- a/src/renderer/src/hooks/useAutoUpdate.ts
+++ b/src/renderer/src/hooks/useAutoUpdate.ts
@@ -10,18 +10,15 @@ export function useAutoUpdate(): void {
 
     const cleanups: (() => void)[] = []
 
-    // Update available — show actionable toast
+    // Update available — download starts automatically in background
     cleanups.push(
       window.updaterOps.onUpdateAvailable((data) => {
-        toastId.current = toast.info(`Update v${data.version} available`, {
-          duration: Infinity,
-          action: {
-            label: 'Download',
-            onClick: () => {
-              window.updaterOps.downloadUpdate()
-            }
+        toastId.current = toast.info(
+          `Update v${data.version} found. Downloading in background...`,
+          {
+            duration: 6000
           }
-        })
+        )
       })
     )
 
@@ -47,7 +44,7 @@ export function useAutoUpdate(): void {
         toastId.current = toast.success(`Update v${data.version} ready to install`, {
           duration: Infinity,
           action: {
-            label: 'Restart Now',
+            label: 'Restart to Update',
             onClick: () => {
               window.updaterOps.installUpdate()
             }

--- a/test/phase-20/session-10/auto-update-behavior.test.tsx
+++ b/test/phase-20/session-10/auto-update-behavior.test.tsx
@@ -1,0 +1,135 @@
+import { act, cleanup, render, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { Toaster } from '../../../src/renderer/src/components/ui/sonner'
+import { useAutoUpdate } from '../../../src/renderer/src/hooks/useAutoUpdate'
+
+const toastMocks = vi.hoisted(() => ({
+  info: vi.fn(),
+  loading: vi.fn(),
+  success: vi.fn(),
+  dismiss: vi.fn(),
+  error: vi.fn()
+}))
+
+const sonnerToasterMock = vi.hoisted(() => vi.fn(() => null))
+
+vi.mock('@/lib/toast', () => ({
+  toast: toastMocks
+}))
+
+vi.mock('sonner', () => ({
+  Toaster: sonnerToasterMock
+}))
+
+type UpdateAvailableData = { version: string; releaseNotes?: string; releaseDate?: string }
+type DownloadProgressData = {
+  percent: number
+  bytesPerSecond: number
+  transferred: number
+  total: number
+}
+type UpdateDownloadedData = { version: string; releaseNotes?: string }
+type UpdateErrorData = { message: string }
+
+let onUpdateAvailableCb: ((data: UpdateAvailableData) => void) | null = null
+let onProgressCb: ((data: DownloadProgressData) => void) | null = null
+let onUpdateDownloadedCb: ((data: UpdateDownloadedData) => void) | null = null
+let onErrorCb: ((data: UpdateErrorData) => void) | null = null
+
+const installUpdateMock = vi.fn().mockResolvedValue(undefined)
+
+describe('Auto update behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    onUpdateAvailableCb = null
+    onProgressCb = null
+    onUpdateDownloadedCb = null
+    onErrorCb = null
+
+    toastMocks.info.mockReturnValue('toast-available')
+    toastMocks.loading.mockReturnValue('toast-progress')
+    toastMocks.success.mockReturnValue('toast-downloaded')
+
+    Object.defineProperty(window, 'updaterOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        checkForUpdate: vi.fn().mockResolvedValue(undefined),
+        downloadUpdate: vi.fn().mockResolvedValue(undefined),
+        installUpdate: installUpdateMock,
+        onChecking: vi.fn().mockReturnValue(() => {}),
+        onUpdateAvailable: vi.fn((cb: (data: UpdateAvailableData) => void) => {
+          onUpdateAvailableCb = cb
+          return () => {
+            onUpdateAvailableCb = null
+          }
+        }),
+        onUpdateNotAvailable: vi.fn().mockReturnValue(() => {}),
+        onProgress: vi.fn((cb: (data: DownloadProgressData) => void) => {
+          onProgressCb = cb
+          return () => {
+            onProgressCb = null
+          }
+        }),
+        onUpdateDownloaded: vi.fn((cb: (data: UpdateDownloadedData) => void) => {
+          onUpdateDownloadedCb = cb
+          return () => {
+            onUpdateDownloadedCb = null
+          }
+        }),
+        onError: vi.fn((cb: (data: UpdateErrorData) => void) => {
+          onErrorCb = cb
+          return () => {
+            onErrorCb = null
+          }
+        })
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  test('update available toast does not require download button click', () => {
+    renderHook(() => useAutoUpdate())
+
+    act(() => {
+      onUpdateAvailableCb?.({ version: '1.2.3' })
+    })
+
+    expect(toastMocks.info).toHaveBeenCalledTimes(1)
+    const options = toastMocks.info.mock.calls[0]?.[1] as { action?: unknown } | undefined
+    expect(options?.action).toBeUndefined()
+  })
+
+  test('downloaded toast exposes restart action that installs update', () => {
+    renderHook(() => useAutoUpdate())
+
+    act(() => {
+      onUpdateDownloadedCb?.({ version: '1.2.3' })
+    })
+
+    expect(toastMocks.success).toHaveBeenCalledTimes(1)
+    const options = toastMocks.success.mock.calls[0]?.[1] as
+      | { action?: { label: string; onClick: () => void } }
+      | undefined
+
+    expect(options?.action?.label).toBe('Restart to Update')
+
+    act(() => {
+      options?.action?.onClick()
+    })
+
+    expect(installUpdateMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('toaster renders in dark theme mode', () => {
+    render(<Toaster />)
+
+    expect(sonnerToasterMock).toHaveBeenCalledTimes(1)
+    const props = sonnerToasterMock.mock.calls[0]?.[0] as { theme?: string } | undefined
+    expect(props?.theme).toBe('dark')
+  })
+})


### PR DESCRIPTION
## Summary

- **Enable automatic background downloads** for app updates by switching `autoUpdater.autoDownload` from `false` to `true` in the main process updater service
- **Simplify the update-available toast** — removes the manual "Download" action button and replaces it with a transient info notification (`duration: 6000`) indicating the download is happening in the background
- **Rename the post-download action** from "Restart Now" to "Restart to Update" for clearer user intent
- **Force dark theme on the Sonner toaster** by adding `theme="dark"` to the `<Sonner>` component

## Changes

### Main process (`src/main/services/updater.ts`)
- Set `autoUpdater.autoDownload = true` so electron-updater downloads updates automatically once detected, removing the need for a user-initiated download step.

### Renderer — Toaster (`src/renderer/src/components/ui/sonner.tsx`)
- Added `theme="dark"` prop to the `<Sonner>` component to ensure toast notifications always render in dark mode.

### Renderer — `useAutoUpdate` hook (`src/renderer/src/hooks/useAutoUpdate.ts`)
- **`onUpdateAvailable`**: Changed from an infinite-duration toast with a "Download" action to a 6-second informational toast stating the download is in progress.
- **`onUpdateDownloaded`**: Renamed the action button label from "Restart Now" to "Restart to Update".

### Tests (`test/phase-20/session-10/auto-update-behavior.test.tsx`)
- New test suite covering the updated auto-update behavior:
  - **`update available toast does not require download button click`** — verifies the info toast has no action button.
  - **`downloaded toast exposes restart action that installs update`** — verifies the "Restart to Update" label and that clicking it calls `installUpdate`.
  - **`toaster renders in dark theme mode`** — verifies the Sonner component receives `theme="dark"`.