### PR TITLE
Fix project custom_icon not persisting on update

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -306,6 +306,10 @@ export class DatabaseService {
       updates.push('language = ?')
       values.push(data.language)
     }
+    if (data.custom_icon !== undefined) {
+      updates.push('custom_icon = ?')
+      values.push(data.custom_icon)
+    }
     if (data.setup_script !== undefined) {
       updates.push('setup_script = ?')
       values.push(data.setup_script)


### PR DESCRIPTION
## Summary

- **Bug fix:** The `custom_icon` field was missing from the project update query in `DatabaseService.updateProject()`, causing any icon changes to be silently dropped when updating a project.
- Adds the `custom_icon` column to the dynamic SQL `UPDATE` statement in `src/main/db/database.ts`, following the same pattern used by all other updatable project fields (`language`, `setup_script`, etc.).

## Changes

- `src/main/db/database.ts`: Added a conditional block to include `custom_icon` in the `updates` and `values` arrays when `data.custom_icon !== undefined`, ensuring the value is persisted to SQLite.