### PR TITLE
Fix app freezes from git lock contention and redundant status subscriptions

### DIFF
--- a/src/main/ipc/git-file-handlers.ts
+++ b/src/main/ipc/git-file-handlers.ts
@@ -126,11 +126,6 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
         const gitService = createGitService(worktreePath)
         const result = await gitService.stageFile(filePath)
 
-        // Emit status change event
-        if (result.success && mainWindow) {
-          mainWindow.webContents.send('git:statusChanged', { worktreePath })
-        }
-
         return result
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
@@ -151,11 +146,6 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
       try {
         const gitService = createGitService(worktreePath)
         const result = await gitService.unstageFile(filePath)
-
-        // Emit status change event
-        if (result.success && mainWindow) {
-          mainWindow.webContents.send('git:statusChanged', { worktreePath })
-        }
 
         return result
       } catch (error) {
@@ -178,11 +168,6 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
         const gitService = createGitService(worktreePath)
         const result = await gitService.discardChanges(filePath)
 
-        // Emit status change event
-        if (result.success && mainWindow) {
-          mainWindow.webContents.send('git:statusChanged', { worktreePath })
-        }
-
         return result
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
@@ -204,11 +189,6 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
       try {
         const gitService = createGitService(worktreePath)
         const result = await gitService.addToGitignore(pattern)
-
-        // Emit status change event
-        if (result.success && mainWindow) {
-          mainWindow.webContents.send('git:statusChanged', { worktreePath })
-        }
 
         return result
       } catch (error) {
@@ -293,11 +273,6 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
         const gitService = createGitService(worktreePath)
         const result = await gitService.stageAll()
 
-        // Emit status change event
-        if (result.success && mainWindow) {
-          mainWindow.webContents.send('git:statusChanged', { worktreePath })
-        }
-
         return result
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
@@ -320,11 +295,6 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
         const gitService = createGitService(worktreePath)
         const result = await gitService.unstageAll()
 
-        // Emit status change event
-        if (result.success && mainWindow) {
-          mainWindow.webContents.send('git:statusChanged', { worktreePath })
-        }
-
         return result
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
@@ -346,11 +316,6 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
       try {
         const gitService = createGitService(worktreePath)
         const result = await gitService.commit(message)
-
-        // Emit status change event
-        if (result.success && mainWindow) {
-          mainWindow.webContents.send('git:statusChanged', { worktreePath })
-        }
 
         return result
       } catch (error) {
@@ -378,11 +343,6 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
         const gitService = createGitService(worktreePath)
         const result = await gitService.push(remote, branch, force)
 
-        // Emit status change event to update ahead/behind counts
-        if (result.success && mainWindow) {
-          mainWindow.webContents.send('git:statusChanged', { worktreePath })
-        }
-
         return result
       } catch (error) {
         const errMessage = error instanceof Error ? error.message : 'Unknown error'
@@ -409,11 +369,6 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
         const gitService = createGitService(worktreePath)
         const result = await gitService.pull(remote, branch, rebase)
 
-        // Emit status change event
-        if (result.success && mainWindow) {
-          mainWindow.webContents.send('git:statusChanged', { worktreePath })
-        }
-
         return result
       } catch (error) {
         const errMessage = error instanceof Error ? error.message : 'Unknown error'
@@ -433,11 +388,6 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
       try {
         const gitService = createGitService(worktreePath)
         const result = await gitService.merge(sourceBranch)
-
-        // Emit status change event after merge
-        if (result.success && mainWindow) {
-          mainWindow.webContents.send('git:statusChanged', { worktreePath })
-        }
 
         return result
       } catch (error) {

--- a/src/renderer/src/components/file-tree/FileSidebar.tsx
+++ b/src/renderer/src/components/file-tree/FileSidebar.tsx
@@ -6,6 +6,7 @@ import { ChangesView } from './ChangesView'
 
 interface FileSidebarProps {
   worktreePath: string | null
+  isConnectionMode?: boolean
   onClose: () => void
   onFileClick: (node: { path: string; name: string; isDirectory: boolean }) => void
   className?: string
@@ -13,6 +14,7 @@ interface FileSidebarProps {
 
 export function FileSidebar({
   worktreePath,
+  isConnectionMode,
   onClose,
   onFileClick,
   className
@@ -62,7 +64,7 @@ export function FileSidebar({
 
       <div className="flex-1 overflow-hidden">
         {activeTab === 'changes' ? (
-          <ChangesView worktreePath={worktreePath} />
+          <ChangesView worktreePath={worktreePath} isConnectionMode={isConnectionMode} />
         ) : (
           <FileTree
             worktreePath={worktreePath}

--- a/src/renderer/src/components/file-tree/FileTree.tsx
+++ b/src/renderer/src/components/file-tree/FileTree.tsx
@@ -123,7 +123,6 @@ export function FileTree({
   const { getFileStatuses, loadFileStatuses } = useGitStore()
 
   const unsubscribeRef = useRef<(() => void) | null>(null)
-  const gitUnsubscribeRef = useRef<(() => void) | null>(null)
   const currentWorktreeRef = useRef<string | null>(null)
   const parentRef = useRef<HTMLDivElement>(null)
 
@@ -137,10 +136,6 @@ export function FileTree({
       if (unsubscribeRef.current) {
         unsubscribeRef.current()
         unsubscribeRef.current = null
-      }
-      if (gitUnsubscribeRef.current) {
-        gitUnsubscribeRef.current()
-        gitUnsubscribeRef.current = null
       }
     }
 
@@ -156,17 +151,10 @@ export function FileTree({
     startWatching(worktreePath)
 
     // Subscribe to file change events (file tree refresh only;
-    // git status refresh is handled by the main-process worktree watcher)
+    // git status refresh is handled centrally by useWorktreeWatcher)
     unsubscribeRef.current = window.fileTreeOps.onChange((event) => {
       if (event.worktreePath === worktreePath) {
         handleFileChange(worktreePath, event.eventType, event.changedPath, event.relativePath)
-      }
-    })
-
-    // Subscribe to git status change events (to re-render git indicators on file tree nodes)
-    gitUnsubscribeRef.current = window.gitOps.onStatusChanged((event) => {
-      if (event.worktreePath === worktreePath) {
-        loadFileStatuses(worktreePath)
       }
     })
 
@@ -175,10 +163,6 @@ export function FileTree({
       if (unsubscribeRef.current) {
         unsubscribeRef.current()
         unsubscribeRef.current = null
-      }
-      if (gitUnsubscribeRef.current) {
-        gitUnsubscribeRef.current()
-        gitUnsubscribeRef.current = null
       }
     }
   }, [worktreePath, loadFileTree, loadFileStatuses, startWatching, stopWatching, handleFileChange])

--- a/src/renderer/src/components/git/GitStatusPanel.tsx
+++ b/src/renderer/src/components/git/GitStatusPanel.tsx
@@ -151,22 +151,6 @@ export function GitStatusPanel({
     }
   }, [worktreePath, loadFileStatuses, loadBranchInfo])
 
-  // Subscribe to git status changes
-  useEffect(() => {
-    if (!worktreePath) return
-
-    const unsubscribe = window.gitOps.onStatusChanged((event) => {
-      if (event.worktreePath === worktreePath) {
-        loadFileStatuses(worktreePath)
-        loadBranchInfo(worktreePath)
-      }
-    })
-
-    return () => {
-      unsubscribe()
-    }
-  }, [worktreePath, loadFileStatuses, loadBranchInfo])
-
   // Get branch info directly from store state
   const branchInfo = worktreePath ? branchInfoByWorktree.get(worktreePath) : undefined
 

--- a/src/renderer/src/components/layout/RightSidebar.tsx
+++ b/src/renderer/src/components/layout/RightSidebar.tsx
@@ -77,6 +77,7 @@ export function RightSidebar(): React.JSX.Element {
           >
             <FileSidebar
               worktreePath={selectedWorktreePath}
+              isConnectionMode={isConnectionMode}
               onClose={toggleRightSidebar}
               onFileClick={handleFileClick}
               className="flex-1 min-h-0"

--- a/src/renderer/src/hooks/useWorktreeWatcher.ts
+++ b/src/renderer/src/hooks/useWorktreeWatcher.ts
@@ -59,6 +59,22 @@ export function useWorktreeWatcher(): void {
     previousPathRef.current = worktreePath
   }, [worktreePath])
 
+  // Centralized onStatusChanged subscription — replaces per-component subscriptions
+  // in ChangesView, GitStatusPanel, and FileTree. Uses the debounced refreshStatuses
+  // to batch rapid file-change events.
+  useEffect(() => {
+    const unsubscribe = window.gitOps.onStatusChanged((event) => {
+      const currentPath = previousPathRef.current
+      if (currentPath && event.worktreePath === currentPath) {
+        useGitStore.getState().refreshStatuses(currentPath)
+      }
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [])
+
   useEffect(() => {
     return () => {
       const currentPath = previousPathRef.current

--- a/src/renderer/src/stores/useGitStore.ts
+++ b/src/renderer/src/stores/useGitStore.ts
@@ -223,10 +223,6 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
   stageFile: async (worktreePath: string, relativePath: string) => {
     try {
       const result = await window.gitOps.stageFile(worktreePath, relativePath)
-      if (result.success) {
-        // Refresh statuses after staging
-        await get().loadFileStatuses(worktreePath)
-      }
       return result.success
     } catch (error) {
       console.error('Failed to stage file:', error)
@@ -238,10 +234,6 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
   unstageFile: async (worktreePath: string, relativePath: string) => {
     try {
       const result = await window.gitOps.unstageFile(worktreePath, relativePath)
-      if (result.success) {
-        // Refresh statuses after unstaging
-        await get().loadFileStatuses(worktreePath)
-      }
       return result.success
     } catch (error) {
       console.error('Failed to unstage file:', error)
@@ -253,10 +245,6 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
   stageAll: async (worktreePath: string) => {
     try {
       const result = await window.gitOps.stageAll(worktreePath)
-      if (result.success) {
-        // Refresh statuses after staging all
-        await get().loadFileStatuses(worktreePath)
-      }
       return result.success
     } catch (error) {
       console.error('Failed to stage all files:', error)
@@ -268,10 +256,6 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
   unstageAll: async (worktreePath: string) => {
     try {
       const result = await window.gitOps.unstageAll(worktreePath)
-      if (result.success) {
-        // Refresh statuses after unstaging all
-        await get().loadFileStatuses(worktreePath)
-      }
       return result.success
     } catch (error) {
       console.error('Failed to unstage all files:', error)
@@ -283,10 +267,6 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
   discardChanges: async (worktreePath: string, relativePath: string) => {
     try {
       const result = await window.gitOps.discardChanges(worktreePath, relativePath)
-      if (result.success) {
-        // Refresh statuses after discarding
-        await get().loadFileStatuses(worktreePath)
-      }
       return result.success
     } catch (error) {
       console.error('Failed to discard changes:', error)
@@ -298,10 +278,6 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
   addToGitignore: async (worktreePath: string, pattern: string) => {
     try {
       const result = await window.gitOps.addToGitignore(worktreePath, pattern)
-      if (result.success) {
-        // Refresh statuses after adding to gitignore
-        await get().loadFileStatuses(worktreePath)
-      }
       return result.success
     } catch (error) {
       console.error('Failed to add to .gitignore:', error)

--- a/test/phase-11/session-10/changes-view.test.ts
+++ b/test/phase-11/session-10/changes-view.test.ts
@@ -205,9 +205,11 @@ describe('Session 10: Changes View', () => {
   })
 
   describe('Live updates', () => {
-    test('subscribes to git status changes', () => {
-      const content = readFile('ChangesView.tsx')
+    test('git status changes handled centrally by useWorktreeWatcher', () => {
+      const hooksDir = path.join(fileTreeDir, '..', '..', 'hooks')
+      const content = fs.readFileSync(path.join(hooksDir, 'useWorktreeWatcher.ts'), 'utf-8')
       expect(content).toContain('window.gitOps.onStatusChanged')
+      expect(content).toContain('refreshStatuses')
     })
 
     test('loads file statuses on mount', () => {


### PR DESCRIPTION
## Summary

Fixes application freezing caused by concurrent git processes fighting over `index.lock`. The root cause was that every git operation (stage, unstage, discard, commit, push, pull, merge, etc.) both triggered inline status refreshes **and** emitted `git:statusChanged` events, which in turn triggered additional refreshes — all while creating fresh `GitService` (simple-git) instances that ran in parallel against the same repo.

## Changes

### Main Process

- **Cache `GitService` instances** (`src/main/services/git-service.ts`): Introduced a `Map`-based cache in `createGitService()` so that the same `GitService` instance is reused per repo path. This ensures simple-git's internal task queue serializes operations on the same repository, eliminating lock contention.

- **Remove redundant `git:statusChanged` emissions** (`src/main/ipc/git-file-handlers.ts`): Stripped all manual `mainWindow.webContents.send('git:statusChanged', ...)` calls from 10 IPC handlers (stageFile, unstageFile, discardChanges, addToGitignore, stageAll, unstageAll, commit, push, pull, merge). The file-system watcher already emits these events, making the manual sends duplicative and a major amplifier of the contention problem.

### Renderer — Centralized Status Subscription

- **Consolidate `onStatusChanged` listener** (`src/renderer/src/hooks/useWorktreeWatcher.ts`): Added a single centralized subscription to `window.gitOps.onStatusChanged` that calls the debounced `refreshStatuses` helper. This replaces three separate per-component subscriptions.

- **Remove per-component subscriptions**:
  - `ChangesView.tsx` — removed `onStatusChanged` subscription effect
  - `GitStatusPanel.tsx` — removed `onStatusChanged` subscription effect
  - `FileTree.tsx` — removed `onStatusChanged` subscription and its ref cleanup

### Renderer — Git Store Cleanup

- **Remove inline `loadFileStatuses` calls** (`src/renderer/src/stores/useGitStore.ts`): Removed redundant `await get().loadFileStatuses(worktreePath)` from 6 store actions (`stageFile`, `unstageFile`, `stageAll`, `unstageAll`, `discardChanges`, `addToGitignore`). The centralized watcher now handles all status refreshes.

### Renderer — Connection Mode Guard & Memo Optimization

- **`ChangesView.tsx`**: Added `isConnectionMode` prop — when true, skips git data loading and renders a placeholder message. Wrapped `GroupHeader` and `FileRow` sub-components in `React.memo` to reduce unnecessary re-renders during status updates.

- **`FileSidebar.tsx` / `RightSidebar.tsx`**: Thread `isConnectionMode` prop through to `ChangesView`.

### Tests

- **Updated test** (`test/phase-11/session-10/changes-view.test.ts`): Adjusted the "live updates" test to verify that `onStatusChanged` handling now lives in `useWorktreeWatcher.ts` rather than `ChangesView.tsx`.

## Net Effect

- **10 files changed**, 66 insertions, 137 deletions (net −71 lines)
- Eliminates git lock contention that caused app freezes
- Reduces redundant IPC round-trips and re-renders
- Single source of truth for git status refresh logic