### PR TITLE
Replace breed-name connections with project-derived naming

### DIFF
--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -889,7 +889,6 @@ declare global {
         connectionId: string,
         worktreeId: string
       ) => Promise<{ success: boolean; connectionDeleted?: boolean; error?: string }>
-      rename: (connectionId: string, name: string) => Promise<{ success: boolean; error?: string }>
       getAll: () => Promise<{
         success: boolean
         connections?: ConnectionWithMembers[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1340,8 +1340,6 @@ const connectionOps = {
     ipcRenderer.invoke('connection:addMember', { connectionId, worktreeId }),
   removeMember: (connectionId: string, worktreeId: string) =>
     ipcRenderer.invoke('connection:removeMember', { connectionId, worktreeId }),
-  rename: (connectionId: string, name: string) =>
-    ipcRenderer.invoke('connection:rename', { connectionId, name }),
   getAll: () => ipcRenderer.invoke('connection:getAll'),
   get: (connectionId: string) => ipcRenderer.invoke('connection:get', { connectionId }),
   openInTerminal: (connectionPath: string) =>

--- a/src/renderer/src/stores/useConnectionStore.ts
+++ b/src/renderer/src/stores/useConnectionStore.ts
@@ -41,7 +41,6 @@ interface ConnectionState {
   deleteConnection: (connectionId: string) => Promise<void>
   addMember: (connectionId: string, worktreeId: string) => Promise<void>
   removeMember: (connectionId: string, worktreeId: string) => Promise<void>
-  renameConnection: (connectionId: string, name: string) => Promise<void>
   selectConnection: (id: string | null) => void
 }
 
@@ -165,24 +164,6 @@ export const useConnectionStore = create<ConnectionState>()(
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
           toast.error(`Failed to remove member: ${message}`)
-        }
-      },
-
-      renameConnection: async (connectionId: string, name: string) => {
-        try {
-          const result = await window.connectionOps.rename(connectionId, name)
-          if (!result.success) {
-            toast.error(result.error || 'Failed to rename connection')
-            return
-          }
-          set((state) => ({
-            connections: state.connections.map((c) =>
-              c.id === connectionId ? { ...c, name, updated_at: new Date().toISOString() } : c
-            )
-          }))
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error)
-          toast.error(`Failed to rename connection: ${message}`)
         }
       },
 

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -275,3 +275,15 @@
 .diff-viewer .d2h-file-side-diff {
   width: 50%;
 }
+
+/* Marquee scroll animation for overflow text on hover */
+@keyframes marquee-scroll {
+  0%,
+  20% {
+    transform: translateX(0);
+  }
+  80%,
+  100% {
+    transform: translateX(var(--scroll-distance));
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the breed-name (dog/cat) connection naming system with automatic names derived from member project names. Connections are now displayed as e.g. **"ProjectA + ProjectB"** instead of random animal breed names, making them immediately identifiable.

## Changes

### Main Process (`src/main/ipc/connection-handlers.ts`)
- **Removed** `getBreedType()` helper and breed-name imports (`selectUniqueBreedName`, `BreedType`)
- **Removed** `renameConnectionDir` / `getConnectionsBaseDir` imports (no longer needed)
- **Added** `deriveConnectionName()` — derives display name from unique member project names joined with ` + `
- Connection directories now use a short random UUID (`randomUUID().slice(0, 8)`) instead of breed names, avoiding filesystem issues with special characters
- Connection name is auto-derived and updated in the DB whenever members are added or removed (`connection:create`, `connection:addMember`, `connection:removeMember`, and worktree deletion cleanup)
- **Removed** the entire `connection:rename` IPC handler

### Preload Layer (`src/preload/index.ts`, `src/preload/index.d.ts`)
- Removed `rename` method from `connectionOps` API
- Removed corresponding type declaration from the `Window` interface

### Renderer — `ConnectionItem.tsx`
- **Removed** inline rename UI: input field, `startRename`/`handleRename` callbacks, `Pencil` icon import, and rename context/dropdown menu items
- **Replaced** the old "name + project subtitle" two-line layout with a single **display name** derived client-side from member project names
- **Added marquee scroll animation** for long connection names: on hover, overflowing text scrolls horizontally at a readable speed (~30px/s) with configurable duration

### Renderer — `useConnectionStore.ts`
- Removed `renameConnection` action and its type from the store interface

### Styles (`globals.css`)
- Added `@keyframes marquee-scroll` animation used by the marquee hover effect

## Impact
- **Net reduction:** 164 lines removed, 93 added (−71 lines)
- No migration needed — existing connection names in the DB will remain as-is until members are next added/removed, at which point the name auto-updates