### PR TITLE
Add .graphqls file extension to GraphQL icon mapping

### DIFF
--- a/src/renderer/src/lib/file-icons.ts
+++ b/src/renderer/src/lib/file-icons.ts
@@ -152,6 +152,7 @@ export const svgIconMap: Record<string, string> = {
 
   // GraphQL
   '.graphql': graphqlIcon,
+  '.graphqls': graphqlIcon,
   '.gql': graphqlIcon,
 
   // Lua


### PR DESCRIPTION
## Summary

- Adds `.graphqls` (GraphQL schema) file extension to the SVG icon map in `src/renderer/src/lib/file-icons.ts`, so `.graphqls` files display the GraphQL icon in the file tree.

## Details

The existing icon map already supported `.graphql` and `.gql` extensions but was missing `.graphqls`, which is the conventional extension for GraphQL **schema definition** files. This one-line addition maps `.graphqls` to the same `graphqlIcon` SVG used by the other GraphQL extensions.

## Changes

| File | Change |
|------|--------|
| `src/renderer/src/lib/file-icons.ts` | Added `'.graphqls': graphqlIcon` entry to `svgIconMap` |