### PR TITLE
Fix QuestionToolView crash when options is undefined

### DIFF
--- a/src/renderer/src/components/sessions/tools/QuestionToolView.tsx
+++ b/src/renderer/src/components/sessions/tools/QuestionToolView.tsx
@@ -51,6 +51,8 @@ export function QuestionToolView({ input, output, error }: ToolViewProps) {
           const answer = answerMap.get(q.question)
           const answerLabels = answer ? answer.split(', ') : []
 
+          const options = q.options || []
+
           return (
             <div key={i}>
               {/* Question header */}
@@ -66,7 +68,7 @@ export function QuestionToolView({ input, output, error }: ToolViewProps) {
 
               {/* Options as compact pills */}
               <div className="flex flex-wrap gap-1">
-                {q.options.map((opt) => {
+                {options.map((opt) => {
                   const isSelected = answerLabels.includes(opt.label)
                   return (
                     <span
@@ -83,10 +85,10 @@ export function QuestionToolView({ input, output, error }: ToolViewProps) {
                   )
                 })}
                 {/* Show custom answer if it doesn't match any option */}
-                {answer && answerLabels.some((a) => !q.options.find((o) => o.label === a)) && (
+                {answer && answerLabels.some((a) => !options.find((o) => o.label === a)) && (
                   <span className="inline-flex items-center gap-1 text-[11px] rounded-md px-2 py-0.5 bg-blue-500/15 text-blue-400 font-medium">
                     <Check className="h-2.5 w-2.5" />
-                    {answerLabels.find((a) => !q.options.find((o) => o.label === a))}
+                    {answerLabels.find((a) => !options.find((o) => o.label === a))}
                   </span>
                 )}
               </div>


### PR DESCRIPTION
## Summary

- **Fix runtime crash in `QuestionToolView`** when a question object has no `options` property defined. Previously, calling `.map()` directly on `q.options` would throw a `TypeError` if `options` was `undefined`.

## Changes

### `src/renderer/src/components/sessions/tools/QuestionToolView.tsx`

- Added a defensive default: `const options = q.options || []` so that missing options gracefully resolve to an empty array instead of crashing.
- Replaced all 3 references to `q.options` (the `.map()` call and two `.find()` calls in the custom-answer detection logic) with the safe `options` local variable.

## Why

Some MCP tool question schemas omit the `options` array entirely (e.g., free-text-only questions). Without this guard, rendering such questions causes an unhandled TypeError that breaks the entire session tool output panel.