### PR TITLE
fix: prevent app freezes from symlink traversal and async store deconfliction

### DIFF
--- a/src/main/ipc/file-tree-handlers.ts
+++ b/src/main/ipc/file-tree-handlers.ts
@@ -121,9 +121,11 @@ export async function scanDirectory(
       }
 
       if (isDir) {
-        // Lazy loading: only get children for first level initially
-        const children =
-          currentDepth < 1
+        // Don't eagerly recurse into symlinked directories — they may be
+        // large external repos (e.g. connection members). Treat as lazy-load.
+        const children = isSymlink
+          ? undefined
+          : currentDepth < 1
             ? await scanDirectory(entryPath, rootPath, maxDepth, currentDepth + 1)
             : undefined
 
@@ -361,6 +363,7 @@ export function registerFileTreeHandlers(window: BrowserWindow): void {
           persistent: true,
           ignoreInitial: true,
           depth: 10,
+          followSymlinks: false,
           awaitWriteFinish: {
             stabilityThreshold: 100,
             pollInterval: 50

--- a/src/renderer/src/components/file-tree/FileSidebar.tsx
+++ b/src/renderer/src/components/file-tree/FileSidebar.tsx
@@ -68,6 +68,7 @@ export function FileSidebar({
         ) : (
           <FileTree
             worktreePath={worktreePath}
+            isConnectionMode={isConnectionMode}
             onClose={onClose}
             onFileClick={onFileClick}
             hideHeader

--- a/src/renderer/src/components/file-tree/FileTree.tsx
+++ b/src/renderer/src/components/file-tree/FileTree.tsx
@@ -35,6 +35,7 @@ interface FlatNode {
 
 interface FileTreeProps {
   worktreePath: string | null
+  isConnectionMode?: boolean
   onClose?: () => void
   onFileClick?: (node: FileTreeNode) => void
   className?: string
@@ -99,6 +100,7 @@ const ROW_HEIGHT = 24
 
 export function FileTree({
   worktreePath,
+  isConnectionMode,
   onClose,
   onFileClick,
   className,
@@ -145,8 +147,8 @@ export function FileTree({
     // Load file tree
     loadFileTree(worktreePath)
 
-    // Load git statuses
-    loadFileStatuses(worktreePath)
+    // Load git statuses (skip for connection paths — no .git directory)
+    if (!isConnectionMode) loadFileStatuses(worktreePath)
 
     // Start watching
     startWatching(worktreePath)
@@ -166,7 +168,15 @@ export function FileTree({
         unsubscribeRef.current = null
       }
     }
-  }, [worktreePath, loadFileTree, loadFileStatuses, startWatching, stopWatching, handleFileChange])
+  }, [
+    worktreePath,
+    isConnectionMode,
+    loadFileTree,
+    loadFileStatuses,
+    startWatching,
+    stopWatching,
+    handleFileChange
+  ])
 
   // Cleanup watching on unmount
   useEffect(() => {

--- a/src/renderer/src/stores/store-coordination.ts
+++ b/src/renderer/src/stores/store-coordination.ts
@@ -1,0 +1,30 @@
+/**
+ * Cross-store coordination helpers.
+ *
+ * These functions use a registration pattern to break the circular dependency
+ * chain between useConnectionStore and useWorktreeStore, while keeping the
+ * deconfliction logic synchronous (no microtask delay).
+ *
+ * Each store registers its "clear selection" callback after creation. The
+ * counterpart store calls the registered function synchronously, so both
+ * state changes (select one + clear the other) happen in the same tick.
+ */
+
+let _clearWorktreeSelection: (() => void) | null = null
+let _clearConnectionSelection: (() => void) | null = null
+
+export function registerWorktreeClear(fn: () => void): void {
+  _clearWorktreeSelection = fn
+}
+
+export function registerConnectionClear(fn: () => void): void {
+  _clearConnectionSelection = fn
+}
+
+export function clearWorktreeSelection(): void {
+  _clearWorktreeSelection?.()
+}
+
+export function clearConnectionSelection(): void {
+  _clearConnectionSelection?.()
+}


### PR DESCRIPTION
## Summary

Fixes app freezes caused by two independent issues: the file tree scanner following symlinks into large external repositories, and cross-store selection deconfliction using async dynamic imports that introduced race conditions.

## Changes

### File tree scanner — symlink handling
- **`src/main/ipc/file-tree-handlers.ts`**: Skip recursive scanning of symlinked directories during `scanDirectory()`. Symlinked dirs (e.g. connection member repos) can be massive and were causing the app to freeze while scanning. They are now treated as lazy-load nodes. Also set `followSymlinks: false` on the chokidar file watcher to prevent filesystem watcher storms from traversing symlink targets.

### File tree component — connection mode awareness
- **`src/renderer/src/components/file-tree/FileSidebar.tsx`**: Pass new `isConnectionMode` prop through to `FileTree`.
- **`src/renderer/src/components/file-tree/FileTree.tsx`**: Accept `isConnectionMode` prop and skip `loadFileStatuses()` when in connection mode, since connection paths have no `.git` directory and the git status call would fail or hang.

### Store deconfliction — synchronous coordination
- **`src/renderer/src/stores/store-coordination.ts`** *(new)*: Introduces a registration-based coordination pattern to break the circular dependency between `useConnectionStore` and `useWorktreeStore`. Each store registers a "clear selection" callback after creation; the counterpart store calls it synchronously.
- **`src/renderer/src/stores/useConnectionStore.ts`**: Replace async `import('./useWorktreeStore')` calls with synchronous `clearWorktreeSelection()` from the coordination module. Register its own clear callback for the reverse direction.
- **`src/renderer/src/stores/useWorktreeStore.ts`**: Replace async `import('./useConnectionStore')` calls with synchronous `clearConnectionSelection()` from the coordination module. Register its own clear callback for the reverse direction.

## Why

The async `import()` pattern for cross-store deconfliction caused state changes to happen across separate microtasks, meaning React could render an intermediate state where both a worktree and a connection appeared selected simultaneously — leading to conflicting file tree loads and UI freezes. The new synchronous pattern ensures both state transitions (select one, clear the other) happen in the same tick.