### PR TITLE
fix: use UTC date format for release tag date lookup

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -83,7 +83,7 @@ fi
 # ── Generate release notes from merged PRs ───────────────────────
 info "Generating release notes from merged PRs..."
 
-LAST_TAG_DATE=$(git log -1 --format=%aI "v${CURRENT_VERSION}" 2>/dev/null || echo "")
+LAST_TAG_DATE=$(TZ=UTC0 git log -1 --format='%ad' --date=format-local:'%Y-%m-%dT%H:%M:%SZ' "v${CURRENT_VERSION}" 2>/dev/null || echo "")
 
 if [[ -z "$LAST_TAG_DATE" ]]; then
   warn "Could not find tag v${CURRENT_VERSION}. Skipping PR-based release notes."


### PR DESCRIPTION
## Summary

- **Fix timezone-dependent date formatting in `scripts/release.sh`** when generating release notes from merged PRs.
- The `LAST_TAG_DATE` variable (used to filter PRs merged since the last release tag) previously used `git log --format=%aI`, which produces an ISO 8601 date with the local timezone offset (e.g. `+03:00`). This could shift the date boundary and cause PRs to be incorrectly included or excluded from the release notes when the machine's local timezone differs from UTC.
- Replaced with `TZ=UTC0 git log --format='%ad' --date=format-local:'%Y-%m-%dT%H:%M:%SZ'` to always emit a UTC timestamp, matching GitHub's server-side date handling for `gh pr list --search` queries.

## Changes

| File | Change |
|------|--------|
| `scripts/release.sh` | Switch `LAST_TAG_DATE` from `%aI` (local TZ ISO 8601) to explicit UTC format via `TZ=UTC0` + `--date=format-local` |