### PR TITLE
Diff view: syntax highlighting and layout fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "diff2html": "^3.4.56",
     "electron-updater": "^6.7.3",
     "fix-path": "^4.0.0",
+    "highlight.js": "^11.11.1",
     "lucide-react": "^0.468.0",
     "node-addon-api": "^8.5.0",
     "node-pty": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       fix-path:
         specifier: ^4.0.0
         version: 4.0.0
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.4)
@@ -9635,8 +9638,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  highlight.js@11.11.1:
-    optional: true
+  highlight.js@11.11.1: {}
 
   highlightjs-vue@1.0.0: {}
 

--- a/src/renderer/src/components/diff/DiffModal.tsx
+++ b/src/renderer/src/components/diff/DiffModal.tsx
@@ -129,7 +129,7 @@ export function DiffModal({
           </div>
         </DialogHeader>
 
-        <div className="flex-1 overflow-hidden border rounded-md">
+        <div className="flex-1 overflow-auto border rounded-md min-h-0">
           {isLoading && (
             <div className="flex items-center justify-center h-full" data-testid="diff-loading">
               <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
@@ -149,7 +149,7 @@ export function DiffModal({
             <DiffViewer
               diff={diff}
               viewMode={viewMode}
-              className={cn('h-full', viewMode === 'split' && 'min-w-[800px]')}
+              className={cn(viewMode === 'split' && 'min-w-[800px]')}
             />
           )}
         </div>

--- a/src/renderer/src/components/diff/DiffViewer.tsx
+++ b/src/renderer/src/components/diff/DiffViewer.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react'
-import { html, Diff2HtmlConfig } from 'diff2html'
+import { useEffect, useRef } from 'react'
+import { Diff2HtmlUI } from 'diff2html/lib-esm/ui/js/diff2html-ui-slim'
+import type { Diff2HtmlUIConfig } from 'diff2html/lib-esm/ui/js/diff2html-ui-base'
 import { cn } from '@/lib/utils'
 
 export type DiffViewMode = 'unified' | 'split'
@@ -15,33 +16,52 @@ export function DiffViewer({
   viewMode = 'unified',
   className
 }: DiffViewerProps): React.JSX.Element {
-  const diffHtml = useMemo(() => {
+  const targetRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!targetRef.current) return
+
     if (!diff) {
-      return '<div class="d2h-empty">No changes</div>'
+      targetRef.current.innerHTML = '<div class="d2h-empty">No changes</div>'
+      return
     }
 
-    const config: Diff2HtmlConfig = {
+    const config: Diff2HtmlUIConfig = {
       drawFileList: false,
       matching: 'lines',
       outputFormat: viewMode === 'split' ? 'side-by-side' : 'line-by-line',
-      renderNothingWhenEmpty: false
+      renderNothingWhenEmpty: false,
+      highlight: true,
+      synchronisedScroll: true,
+      fileListToggle: false,
+      fileContentToggle: false,
+      stickyFileHeaders: false
     }
 
     try {
-      return html(diff, config)
+      const ui = new Diff2HtmlUI(targetRef.current, diff, config)
+      ui.draw()
     } catch (error) {
       console.error('Failed to parse diff:', error)
-      return '<div class="d2h-error">Failed to parse diff</div>'
+      if (targetRef.current) {
+        targetRef.current.innerHTML = '<div class="d2h-error">Failed to parse diff</div>'
+      }
+    }
+
+    return () => {
+      if (targetRef.current) {
+        targetRef.current.innerHTML = ''
+      }
     }
   }, [diff, viewMode])
 
   return (
     <div
-      className={cn('diff-viewer overflow-auto', className)}
+      ref={targetRef}
+      className={cn('diff-viewer', className)}
       data-testid="diff-viewer"
       role="region"
       aria-label="File diff viewer"
-      dangerouslySetInnerHTML={{ __html: diffHtml }}
     />
   )
 }

--- a/src/renderer/src/components/diff/InlineDiffViewer.tsx
+++ b/src/renderer/src/components/diff/InlineDiffViewer.tsx
@@ -383,7 +383,7 @@ export function InlineDiffViewer({
             <DiffViewer
               diff={diff}
               viewMode={viewMode}
-              className={cn('h-full', viewMode === 'split' && 'min-w-[800px]')}
+              className={cn(viewMode === 'split' && 'min-w-[800px]')}
             />
           )
         )}

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import 'diff2html/bundles/css/diff2html.min.css';
+@import 'highlight.js/styles/github-dark-dimmed.css';
 @import './xterm.css';
 
 @theme inline {
@@ -191,6 +192,12 @@
   color: var(--destructive);
 }
 
+/* Scroll containment — prevent diff table from overflowing */
+.diff-viewer .d2h-file-diff {
+  overflow: hidden;
+  position: relative;
+}
+
 /* Dark mode overrides for diff2html — uses theme-aware CSS custom properties */
 .dark .diff-viewer .d2h-wrapper {
   background-color: transparent;
@@ -217,34 +224,37 @@
   border-color: hsl(var(--border));
 }
 
-/* Dark mode — added lines: dark green text on green background */
+/* Dark mode — added lines: green tinted background (text color from syntax highlighting) */
 .dark .diff-viewer .d2h-ins {
   background-color: rgba(46, 160, 67, 0.15);
 }
 
 .dark .diff-viewer .d2h-ins .d2h-code-line-ctn {
   background-color: rgba(46, 160, 67, 0.15);
-  color: #3fb950;
 }
 
-/* Dark mode — removed lines: dark red text on red background */
+/* Dark mode — removed lines: red tinted background (text color from syntax highlighting) */
 .dark .diff-viewer .d2h-del {
   background-color: rgba(248, 81, 73, 0.15);
 }
 
 .dark .diff-viewer .d2h-del .d2h-code-line-ctn {
   background-color: rgba(248, 81, 73, 0.15);
-  color: #f85149;
 }
 
-/* Light mode — added lines: dark green text */
-.diff-viewer .d2h-ins .d2h-code-line-ctn {
-  color: #1a7f37;
+/* Dark mode — word-level inline diff highlights (<ins>/<del> within code lines).
+   diff2html defaults to bright light-mode colors (#97f295 / #ffb6ba) because
+   our .dark class doesn't match its built-in .d2h-dark-color-scheme. Override. */
+.dark .diff-viewer .d2h-code-line ins,
+.dark .diff-viewer .d2h-code-side-line ins {
+  background-color: rgba(46, 160, 67, 0.3);
+  border-radius: 0.2em;
 }
 
-/* Light mode — removed lines: dark red text */
-.diff-viewer .d2h-del .d2h-code-line-ctn {
-  color: #cf222e;
+.dark .diff-viewer .d2h-code-line del,
+.dark .diff-viewer .d2h-code-side-line del {
+  background-color: rgba(248, 81, 73, 0.3);
+  border-radius: 0.2em;
 }
 
 .dark .diff-viewer .d2h-info {
@@ -274,6 +284,69 @@
 /* Split view specific adjustments */
 .diff-viewer .d2h-file-side-diff {
   width: 50%;
+}
+
+/* Scope highlight.js styles to only apply inside diff viewer */
+.diff-viewer .d2h-code-line-ctn.hljs {
+  background: transparent;
+  padding: 0;
+}
+
+/*
+ * Fix syntax highlighting contrast on diff backgrounds.
+ * Some hljs token colors clash with the green/red diff tints:
+ *   - Red keywords (#f47067) disappear on red deletion backgrounds
+ *   - Green entity tags (#8ddb8c) disappear on green addition backgrounds
+ *   - Orange built-ins (#f69d50) have low contrast on red backgrounds
+ * We override only the clashing tokens on each diff line type, shifting
+ * them to a higher-contrast color while keeping full syntax highlighting
+ * on context lines.
+ */
+
+/* --- Added lines (green background): neutralize green-ish tokens --- */
+.dark .diff-viewer .d2h-ins .d2h-code-line-ctn .hljs-name,
+.dark .diff-viewer .d2h-ins .d2h-code-line-ctn .hljs-selector-tag,
+.dark .diff-viewer .d2h-ins .d2h-code-line-ctn .hljs-selector-pseudo,
+.dark .diff-viewer .d2h-ins .d2h-code-line-ctn .hljs-quote {
+  /* green #8ddb8c -> light cyan, still visible on green bg */
+  color: #6cb6ff;
+}
+
+.dark .diff-viewer .d2h-ins .d2h-code-line-ctn .hljs-addition {
+  color: #adbac7;
+  background-color: transparent;
+}
+
+/* --- Deleted lines (red background): neutralize red/orange tokens --- */
+.dark .diff-viewer .d2h-del .d2h-code-line-ctn .hljs-doctag,
+.dark .diff-viewer .d2h-del .d2h-code-line-ctn .hljs-keyword,
+.dark .diff-viewer .d2h-del .d2h-code-line-ctn .hljs-meta .hljs-keyword,
+.dark .diff-viewer .d2h-del .d2h-code-line-ctn .hljs-template-tag,
+.dark .diff-viewer .d2h-del .d2h-code-line-ctn .hljs-template-variable,
+.dark .diff-viewer .d2h-del .d2h-code-line-ctn .hljs-type,
+.dark .diff-viewer .d2h-del .d2h-code-line-ctn .hljs-variable.language_ {
+  /* red #f47067 -> light pink, readable on red bg */
+  color: #ffb4a8;
+}
+
+.dark .diff-viewer .d2h-del .d2h-code-line-ctn .hljs-built_in,
+.dark .diff-viewer .d2h-del .d2h-code-line-ctn .hljs-symbol {
+  /* orange #f69d50 -> light peach, readable on red bg */
+  color: #f0c999;
+}
+
+.dark .diff-viewer .d2h-del .d2h-code-line-ctn .hljs-deletion {
+  color: #adbac7;
+  background-color: transparent;
+}
+
+/* --- Light mode: same clashes apply with lighter backgrounds --- */
+.diff-viewer .d2h-ins .d2h-code-line-ctn .hljs-addition {
+  background-color: transparent;
+}
+
+.diff-viewer .d2h-del .d2h-code-line-ctn .hljs-deletion {
+  background-color: transparent;
 }
 
 /* Marquee scroll animation for overflow text on hover */

--- a/test/phase-13/session-9/integration-verification.test.ts
+++ b/test/phase-13/session-9/integration-verification.test.ts
@@ -99,14 +99,12 @@ describe('Session 9: Integration & Verification', () => {
 
     test('CSS diff2html overrides include correct dark mode colors', () => {
       const css = readSource('src/renderer/src/styles/globals.css')
-      // Dark mode green
-      expect(css).toContain('color: #3fb950')
-      // Dark mode red
-      expect(css).toContain('color: #f85149')
-      // Light mode green
-      expect(css).toContain('color: #1a7f37')
-      // Light mode red
-      expect(css).toContain('color: #cf222e')
+      // Dark mode green tinted background for added lines
+      expect(css).toContain('rgba(46, 160, 67, 0.15)')
+      // Dark mode red tinted background for removed lines
+      expect(css).toContain('rgba(248, 81, 73, 0.15)')
+      // Scroll containment for diff table
+      expect(css).toContain('.diff-viewer .d2h-file-diff')
     })
   })
 


### PR DESCRIPTION
## Summary

- **Added syntax highlighting to diff views** using `highlight.js` (github-dark-dimmed theme) via `Diff2HtmlUI` instead of static `html()` rendering
- **Fixed diff layout overflow** preventing the diff table from breaking out of its container
- **Improved dark-mode contrast** for syntax-highlighted tokens on green/red diff backgrounds

## Changes

### DiffViewer refactor (`DiffViewer.tsx`)
- Replaced `useMemo` + `dangerouslySetInnerHTML` approach with a `useRef`/`useEffect` pattern that mounts `Diff2HtmlUI` directly onto a DOM element
- Enabled `highlight: true` and `synchronisedScroll: true` in the Diff2Html config
- Added proper cleanup on unmount/re-render to avoid stale DOM content

### DiffModal & InlineDiffViewer layout fixes
- Changed the diff container from `overflow-hidden` to `overflow-auto` with `min-h-0` for correct flexbox scrolling
- Removed redundant `h-full` class from the `DiffViewer` wrapper since sizing is now handled by the parent

### CSS / globals.css
- Imported `highlight.js/styles/github-dark-dimmed.css` for syntax theme
- Added `.diff-viewer .d2h-file-diff { overflow: hidden }` scroll containment
- Removed hardcoded text colors (`#3fb950`, `#f85149`, `#1a7f37`, `#cf222e`) from added/deleted lines — syntax highlighting now provides token colors
- Added dark-mode overrides for word-level inline `<ins>`/`<del>` highlights with semi-transparent green/red backgrounds
- Added contrast-fix overrides for clashing hljs tokens on diff backgrounds (e.g. red keywords on red deletion bg, green tags on green addition bg)
- Scoped `.hljs` styles inside `.diff-viewer` to prevent leaking into the rest of the app

### Dependencies
- Added `highlight.js@^11.11.1` as a direct dependency (was previously optional/transitive)

### Tests
- Updated `integration-verification.test.ts` assertions to match the new CSS approach (background tints instead of hardcoded text colors)