### PR TITLE
feat: use breed-named branches for createWorktreeFromBranch and add branch picker context menu

### DIFF
--- a/src/main/ipc/worktree-handlers.ts
+++ b/src/main/ipc/worktree-handlers.ts
@@ -614,8 +614,22 @@ export function registerWorktreeHandlers(): void {
     ) => {
       log.info('IPC: worktree:createFromBranch', { projectName, branchName })
       try {
+        // Read breed type preference from settings
+        let breedType: BreedType = 'dogs'
+        try {
+          const settingsJson = getDatabase().getSetting('app_settings')
+          if (settingsJson) {
+            const settings = JSON.parse(settingsJson)
+            if (settings.breedType === 'cats') {
+              breedType = 'cats'
+            }
+          }
+        } catch {
+          // Fall back to dogs
+        }
+
         const gitService = createGitService(projectPath)
-        const result = await gitService.createWorktreeFromBranch(projectName, branchName)
+        const result = await gitService.createWorktreeFromBranch(projectName, branchName, breedType)
         if (!result.success || !result.path) {
           return { success: false, error: result.error || 'Failed to create worktree from branch' }
         }

--- a/src/renderer/src/components/projects/ProjectItem.tsx
+++ b/src/renderer/src/components/projects/ProjectItem.tsx
@@ -308,6 +308,11 @@ export function ProjectItem({
                 size="icon"
                 className={cn('h-5 w-5 p-0 cursor-pointer', 'hover:bg-accent')}
                 onClick={handleCreateWorktree}
+                onContextMenu={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  setBranchPickerOpen(true)
+                }}
                 disabled={isCreatingWorktree}
               >
                 {isCreatingWorktree ? (


### PR DESCRIPTION
## Summary

- **`createWorktreeFromBranch` now generates unique breed-named branches** instead of deriving the worktree directory name from the raw branch name. When checking out an existing branch via "create worktree from branch", a new breed-named branch (e.g. `golden-retriever`, `siamese`) is created that derives from the selected branch, matching the behavior of the regular `createWorktree` flow.
- **Breed type preference is respected** — the handler now reads the `breedType` setting (`dogs` or `cats`) from `app_settings` and passes it through to `createWorktreeFromBranch`, which uses `selectUniqueBreedName` to avoid collisions with existing branches and worktrees.
- **`createWorktree` now branches from the current branch** instead of the repository's default branch, so new worktrees inherit the currently checked-out context.
- **Right-click on the "new worktree" button opens the branch picker**, giving users quick access to create a worktree from a specific branch without extra navigation.

## Changed Files

| File | Change |
|------|--------|
| `src/main/ipc/worktree-handlers.ts` | Read `breedType` from app settings and pass it to `createWorktreeFromBranch` |
| `src/main/services/git-service.ts` | `createWorktreeFromBranch` — generate breed-named branch via `selectUniqueBreedName`; `createWorktree` — branch from `getCurrentBranch()` instead of `getDefaultBranch()` |
| `src/renderer/src/components/projects/ProjectItem.tsx` | Add `onContextMenu` handler to the new-worktree button to open the branch picker |