### PR TITLE
Add sort-by-last-message button for projects

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -282,6 +282,22 @@ export class DatabaseService {
     tx()
   }
 
+  getProjectIdsSortedByLastMessage(): string[] {
+    const db = this.getDb()
+    const rows = db
+      .prepare(
+        `SELECT p.id
+         FROM projects p
+         LEFT JOIN worktrees w ON w.project_id = p.id
+         GROUP BY p.id
+         ORDER BY
+           CASE WHEN MAX(w.last_message_at) IS NULL THEN 1 ELSE 0 END ASC,
+           MAX(w.last_message_at) DESC`
+      )
+      .all() as { id: string }[]
+    return rows.map((r) => r.id)
+  }
+
   updateProject(id: string, data: ProjectUpdate): Project | null {
     const db = this.getDb()
     const existing = this.getProject(id)

--- a/src/main/ipc/database-handlers.ts
+++ b/src/main/ipc/database-handlers.ts
@@ -83,6 +83,10 @@ export function registerDatabaseHandlers(): void {
     return true
   })
 
+  ipcMain.handle('db:project:sortByLastMessage', () => {
+    return getDatabase().getProjectIdsSortedByLastMessage()
+  })
+
   // Worktrees
   ipcMain.handle('db:worktree:create', (_event, data: WorktreeCreate) => {
     return getDatabase().createWorktree(data)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -163,6 +163,7 @@ declare global {
         delete: (id: string) => Promise<boolean>
         touch: (id: string) => Promise<boolean>
         reorder: (orderedIds: string[]) => Promise<boolean>
+        sortByLastMessage: () => Promise<string[]>
       }
       worktree: {
         create: (data: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -38,7 +38,8 @@ const db = {
     ) => ipcRenderer.invoke('db:project:update', id, data),
     delete: (id: string) => ipcRenderer.invoke('db:project:delete', id),
     touch: (id: string) => ipcRenderer.invoke('db:project:touch', id),
-    reorder: (orderedIds: string[]) => ipcRenderer.invoke('db:project:reorder', orderedIds)
+    reorder: (orderedIds: string[]) => ipcRenderer.invoke('db:project:reorder', orderedIds),
+    sortByLastMessage: () => ipcRenderer.invoke('db:project:sortByLastMessage')
   },
 
   // Worktrees

--- a/src/renderer/src/components/layout/LeftSidebar.tsx
+++ b/src/renderer/src/components/layout/LeftSidebar.tsx
@@ -3,7 +3,7 @@ import { useLayoutStore } from '@/stores/useLayoutStore'
 import { useSpaceStore } from '@/stores'
 import { ResizeHandle } from './ResizeHandle'
 import { FolderGit2 } from 'lucide-react'
-import { ProjectList, AddProjectButton } from '@/components/projects'
+import { ProjectList, AddProjectButton, SortProjectsButton } from '@/components/projects'
 import { ConnectionList } from '@/components/connections'
 import { SpacesTabBar } from '@/components/spaces'
 
@@ -48,7 +48,10 @@ export function LeftSidebar(): React.JSX.Element {
             <FolderGit2 className="h-4 w-4" />
             <span>Projects</span>
           </div>
-          <AddProjectButton />
+          <div className="flex items-center gap-1">
+            <SortProjectsButton />
+            <AddProjectButton />
+          </div>
         </div>
         <div className="flex-1 overflow-auto p-2">
           <ConnectionList />

--- a/src/renderer/src/components/projects/SortProjectsButton.tsx
+++ b/src/renderer/src/components/projects/SortProjectsButton.tsx
@@ -1,0 +1,37 @@
+import { useState, useCallback } from 'react'
+import { ArrowDownUp, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useProjectStore } from '@/stores'
+
+export function SortProjectsButton(): React.JSX.Element {
+  const [isSorting, setIsSorting] = useState(false)
+  const sortProjectsByLastMessage = useProjectStore((s) => s.sortProjectsByLastMessage)
+
+  const handleSort = useCallback(async (): Promise<void> => {
+    if (isSorting) return
+    setIsSorting(true)
+    try {
+      await sortProjectsByLastMessage()
+    } finally {
+      setIsSorting(false)
+    }
+  }, [isSorting, sortProjectsByLastMessage])
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-6 w-6"
+      title="Sort by last message"
+      onClick={handleSort}
+      disabled={isSorting}
+      data-testid="sort-projects-button"
+    >
+      {isSorting ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <ArrowDownUp className="h-4 w-4" />
+      )}
+    </Button>
+  )
+}

--- a/src/renderer/src/components/projects/index.ts
+++ b/src/renderer/src/components/projects/index.ts
@@ -1,3 +1,4 @@
 export { ProjectList } from './ProjectList'
 export { ProjectItem } from './ProjectItem'
 export { AddProjectButton } from './AddProjectButton'
+export { SortProjectsButton } from './SortProjectsButton'


### PR DESCRIPTION
## Summary

Adds a **Sort by Last Message** button to the Projects section in the left sidebar, allowing users to reorder their project list based on the most recent AI message activity (newest first, projects with no messages sorted to the bottom).

### Changes across the full stack:

- **Database** (`src/main/db/database.ts`): New `getProjectIdsSortedByLastMessage()` method that queries project IDs ordered by the latest `last_message_at` timestamp across their worktrees (NULLs last)
- **IPC handler** (`src/main/ipc/database-handlers.ts`): New `db:project:sortByLastMessage` IPC channel to expose the database query to the renderer process
- **Preload bridge** (`src/preload/index.ts`, `src/preload/index.d.ts`): Added `sortByLastMessage()` to the `db.project` API surface and its type declaration
- **New UI component** (`src/renderer/src/components/projects/SortProjectsButton.tsx`): A ghost icon button (`ArrowDownUp` icon) with a loading spinner state while the sort operation is in progress
- **Sidebar integration** (`src/renderer/src/components/layout/LeftSidebar.tsx`): Placed the sort button next to the existing "Add Project" button in the Projects header
- **State management** (`src/renderer/src/stores/useProjectStore.ts`): New `sortProjectsByLastMessage` action that fetches the sorted order from the database, persists it via `reorder`, and updates the in-memory project list — with defensive handling for projects missing from the sorted result
- **Barrel export** (`src/renderer/src/components/projects/index.ts`): Exported the new `SortProjectsButton` component

## Test plan

- [ ] Click the sort button and verify projects reorder by most recent message activity
- [ ] Verify projects with no messages appear at the bottom after sorting
- [ ] Confirm the loading spinner displays during the sort operation
- [ ] Drag-reorder projects manually after sorting to ensure custom ordering still works
- [ ] Verify behavior with a single project and with no projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)