### PR TITLE
Replace connect dialog with inline sidebar connection mode

### DIFF
--- a/src/renderer/src/components/connections/ConnectionList.tsx
+++ b/src/renderer/src/components/connections/ConnectionList.tsx
@@ -25,7 +25,9 @@ export function ConnectionList(): React.JSX.Element | null {
     setManageConnectionId(null)
   }, [])
 
-  if (connections.length === 0) {
+  const connectionModeActive = useConnectionStore((s) => s.connectionModeActive)
+
+  if (connections.length === 0 || connectionModeActive) {
     return null
   }
 

--- a/src/renderer/src/components/layout/LeftSidebar.tsx
+++ b/src/renderer/src/components/layout/LeftSidebar.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react'
 import { useLayoutStore } from '@/stores/useLayoutStore'
-import { useSpaceStore } from '@/stores'
+import { useSpaceStore, useProjectStore, useConnectionStore } from '@/stores'
 import { ResizeHandle } from './ResizeHandle'
-import { FolderGit2 } from 'lucide-react'
+import { FolderGit2, Link, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { ProjectList, AddProjectButton, SortProjectsButton } from '@/components/projects'
 import { ConnectionList } from '@/components/connections'
 import { SpacesTabBar } from '@/components/spaces'
@@ -10,10 +11,49 @@ import { SpacesTabBar } from '@/components/spaces'
 export function LeftSidebar(): React.JSX.Element {
   const { leftSidebarWidth, leftSidebarCollapsed, setLeftSidebarWidth } = useLayoutStore()
   const loadSpaces = useSpaceStore((s) => s.loadSpaces)
+  const expandAllProjects = useProjectStore((s) => s.expandAllProjects)
+
+  // Connection mode state
+  const connectionModeActive = useConnectionStore((s) => s.connectionModeActive)
+  const connectionModeSelectedIds = useConnectionStore((s) => s.connectionModeSelectedIds)
+  const connectionModeSubmitting = useConnectionStore((s) => s.connectionModeSubmitting)
+  const exitConnectionMode = useConnectionStore((s) => s.exitConnectionMode)
+  const finalizeConnection = useConnectionStore((s) => s.finalizeConnection)
+
+  const canFinalize = connectionModeSelectedIds.size >= 2
 
   useEffect(() => {
     loadSpaces()
   }, [loadSpaces])
+
+  // Expand all projects when entering connection mode
+  useEffect(() => {
+    if (connectionModeActive) {
+      expandAllProjects()
+    }
+  }, [connectionModeActive, expandAllProjects])
+
+  // Escape key exits connection mode
+  useEffect(() => {
+    if (!connectionModeActive) return
+
+    const handleEscape = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        exitConnectionMode()
+      }
+    }
+
+    document.addEventListener('keydown', handleEscape, true)
+    return () => document.removeEventListener('keydown', handleEscape, true)
+  }, [connectionModeActive, exitConnectionMode])
+
+  // Exit connection mode if sidebar collapses
+  useEffect(() => {
+    if (leftSidebarCollapsed && connectionModeActive) {
+      exitConnectionMode()
+    }
+  }, [leftSidebarCollapsed, connectionModeActive, exitConnectionMode])
 
   const handleResize = (delta: number): void => {
     setLeftSidebarWidth(leftSidebarWidth + delta)
@@ -43,21 +83,59 @@ export function LeftSidebar(): React.JSX.Element {
         role="navigation"
         aria-label="Projects and worktrees"
       >
-        <div className="p-3 border-b flex items-center justify-between">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <FolderGit2 className="h-4 w-4" />
-            <span>Projects</span>
+        {connectionModeActive ? (
+          <div className="p-3 border-b flex items-center justify-between bg-muted/50">
+            <div className="flex items-center gap-2 text-sm font-medium min-w-0">
+              <Link className="h-4 w-4 text-primary shrink-0" />
+              <span className="truncate">Select worktrees</span>
+              <span className="text-xs text-muted-foreground shrink-0">
+                ({connectionModeSelectedIds.size})
+              </span>
+            </div>
+            <div className="flex items-center gap-1 shrink-0">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={exitConnectionMode}
+                disabled={connectionModeSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                className="h-7 text-xs"
+                onClick={finalizeConnection}
+                disabled={!canFinalize || connectionModeSubmitting}
+              >
+                {connectionModeSubmitting ? (
+                  <>
+                    <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                    Connecting...
+                  </>
+                ) : (
+                  'Connect'
+                )}
+              </Button>
+            </div>
           </div>
-          <div className="flex items-center gap-1">
-            <SortProjectsButton />
-            <AddProjectButton />
+        ) : (
+          <div className="p-3 border-b flex items-center justify-between">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <FolderGit2 className="h-4 w-4" />
+              <span>Projects</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <SortProjectsButton />
+              <AddProjectButton />
+            </div>
           </div>
-        </div>
+        )}
         <div className="flex-1 overflow-auto p-2">
           <ConnectionList />
           <ProjectList onAddProject={handleAddProject} />
         </div>
-        <SpacesTabBar />
+        {!connectionModeActive && <SpacesTabBar />}
       </aside>
       <ResizeHandle onResize={handleResize} direction="left" />
     </div>

--- a/src/renderer/src/components/projects/ProjectItem.tsx
+++ b/src/renderer/src/components/projects/ProjectItem.tsx
@@ -37,7 +37,7 @@ import {
   ContextMenuSubContent,
   ContextMenuCheckboxItem
 } from '@/components/ui/context-menu'
-import { useProjectStore, useWorktreeStore, useSpaceStore } from '@/stores'
+import { useProjectStore, useWorktreeStore, useSpaceStore, useConnectionStore } from '@/stores'
 import { WorktreeList, BranchPickerDialog } from '@/components/worktrees'
 import { LanguageIcon } from './LanguageIcon'
 import { HighlightedText } from './HighlightedText'
@@ -101,6 +101,8 @@ export function ProjectItem({
   const projectSpaceMap = useSpaceStore((s) => s.projectSpaceMap)
   const assignProjectToSpace = useSpaceStore((s) => s.assignProjectToSpace)
   const removeProjectFromSpace = useSpaceStore((s) => s.removeProjectFromSpace)
+
+  const connectionModeActive = useConnectionStore((s) => s.connectionModeActive)
 
   const projectSpaceIds = projectSpaceMap[project.id] ?? []
 
@@ -241,11 +243,11 @@ export function ProjectItem({
               isDragging && 'opacity-50',
               isDragOver && 'border-t-2 border-primary'
             )}
-            draggable={!!onDragStart && !isEditing}
-            onDragStart={onDragStart}
-            onDragOver={onDragOver}
-            onDrop={onDrop}
-            onDragEnd={onDragEnd}
+            draggable={!!onDragStart && !isEditing && !connectionModeActive}
+            onDragStart={connectionModeActive ? undefined : onDragStart}
+            onDragOver={connectionModeActive ? undefined : onDragOver}
+            onDrop={connectionModeActive ? undefined : onDrop}
+            onDragEnd={connectionModeActive ? undefined : onDragEnd}
             onClick={handleClick}
             data-testid={`project-item-${project.id}`}
           >
@@ -301,8 +303,8 @@ export function ProjectItem({
               </div>
             )}
 
-            {/* Create Worktree Button */}
-            {!isEditing && (
+            {/* Create Worktree Button (hidden in connection mode) */}
+            {!isEditing && !connectionModeActive && (
               <Button
                 variant="ghost"
                 size="icon"
@@ -325,7 +327,7 @@ export function ProjectItem({
           </div>
         </ContextMenuTrigger>
 
-        <ContextMenuContent className="w-48">
+        {!connectionModeActive && <ContextMenuContent className="w-48">
           <ContextMenuItem onClick={handleStartEdit}>
             <Pencil className="h-4 w-4 mr-2" />
             Edit Name
@@ -395,7 +397,7 @@ export function ProjectItem({
             <Trash2 className="h-4 w-4 mr-2" />
             Remove from Hive
           </ContextMenuItem>
-        </ContextMenuContent>
+        </ContextMenuContent>}
       </ContextMenu>
 
       {/* Worktree List - shown when project is expanded */}

--- a/src/renderer/src/stores/useProjectStore.ts
+++ b/src/renderer/src/stores/useProjectStore.ts
@@ -52,6 +52,7 @@ interface ProjectState {
   ) => Promise<boolean>
   selectProject: (id: string | null) => void
   toggleProjectExpanded: (id: string) => void
+  expandAllProjects: () => void
   setEditingProject: (id: string | null) => void
   touchProject: (id: string) => Promise<void>
   refreshLanguage: (projectId: string) => Promise<void>
@@ -235,6 +236,11 @@ export const useProjectStore = create<ProjectState>()(
           }
           return { expandedProjectIds: newExpandedIds }
         })
+      },
+
+      // Expand all projects (used by connection mode)
+      expandAllProjects: () => {
+        set({ expandedProjectIds: new Set(get().projects.map((p) => p.id)) })
       },
 
       // Set project being edited


### PR DESCRIPTION
## Summary

- **Replaces the modal `ConnectDialog`** with an inline "connection mode" directly in the left sidebar, allowing users to select worktrees via checkboxes without leaving the project tree
- **Adds connection mode state to `useConnectionStore`** (`connectionModeActive`, `connectionModeSourceWorktreeId`, `connectionModeSelectedIds`, `connectionModeSubmitting`) with actions to enter, exit, toggle, and finalize connections
- **Updates `LeftSidebar`** with a connection mode header bar showing a selection count, Cancel/Connect buttons, Escape key listener, and auto-expansion of all projects on mode entry
- **Simplifies `WorktreeItem`** by removing the `ConnectDialog` import and rendering a checkbox-based selection UI when connection mode is active, with the source worktree pre-selected and locked
- **Updates `ProjectItem`** to disable drag-and-drop, hide the "Create Worktree" button, and suppress the context menu during connection mode
- **Hides `ConnectionList`** when connection mode is active to reduce visual clutter
- **Adds `expandAllProjects`** action to `useProjectStore` so all project trees are visible for selection

## Test plan

- [ ] Right-click a worktree → "Connect to..." enters connection mode with source worktree pre-checked
- [ ] Dropdown menu "Connect to..." also enters connection mode correctly
- [ ] Sidebar header shows selection count, Cancel and Connect buttons
- [ ] Clicking worktrees toggles checkboxes; source worktree checkbox is locked
- [ ] Connect button is disabled until ≥2 worktrees are selected
- [ ] Pressing Escape exits connection mode
- [ ] Cancel button exits connection mode
- [ ] Connect button creates the connection and exits connection mode
- [ ] Drag-and-drop is disabled during connection mode
- [ ] Context menus on projects are suppressed during connection mode
- [ ] All projects auto-expand when entering connection mode
- [ ] Collapsing the sidebar exits connection mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)