### PR TITLE
Extract autoRenameWorktreeBranch helper and rename connected worktree branches

### DIFF
--- a/src/main/ipc/worktree-handlers.ts
+++ b/src/main/ipc/worktree-handlers.ts
@@ -3,7 +3,8 @@ import { spawn } from 'child_process'
 import { existsSync } from 'fs'
 import { platform } from 'os'
 import { createGitService, createLogger } from '../services'
-import { ALL_BREED_NAMES, LEGACY_CITY_NAMES, type BreedType } from '../services/breed-names'
+import { type BreedType } from '../services/breed-names'
+import { isAutoNamedBranch } from '../services/git-service'
 import { scriptRunner } from '../services/script-runner'
 import { assignPort, releasePort } from '../services/port-registry'
 import { getDatabase } from '../db'
@@ -251,13 +252,7 @@ export function registerWorktreeHandlers(): void {
             // the old branch name OR is a city placeholder name (never meaningfully customized).
             const nameMatchesBranch = dbWorktree.name === dbWorktree.branch_name
             const worktreeName = dbWorktree.name.toLowerCase()
-            const isAutoName =
-              ALL_BREED_NAMES.some(
-                (b) => b === worktreeName || new RegExp(`^${b}-(?:v)?\\d+$`).test(worktreeName)
-              ) ||
-              LEGACY_CITY_NAMES.some(
-                (c) => c === worktreeName || new RegExp(`^${c}-(?:v)?\\d+$`).test(worktreeName)
-              )
+            const isAutoName = isAutoNamedBranch(worktreeName)
             const shouldUpdateName = nameMatchesBranch || isAutoName
             db.updateWorktree(dbWorktree.id, {
               branch_name: gitBranch,

--- a/test/phase-11/session-12/integration-verification.test.ts
+++ b/test/phase-11/session-12/integration-verification.test.ts
@@ -39,17 +39,17 @@ describe('Session 12: Integration & Verification', () => {
       // Title persistence
       expect(content).toContain('db.updateSession(hiveSessionId, { name: sessionTitle })')
 
-      // Auto-rename logic follows title persistence
+      // Auto-rename logic follows title persistence (now delegated to shared helper)
       const titlePersistIdx = content.indexOf(
         'db.updateSession(hiveSessionId, { name: sessionTitle })'
       )
-      const autoRenameIdx = content.indexOf('Auto-rename branch if still an auto-generated name')
+      const autoRenameIdx = content.indexOf('Auto-rename branch for the session')
       expect(autoRenameIdx).toBeGreaterThan(titlePersistIdx)
     })
 
-    test('auto-rename uses canonicalizeBranchName on the server title', () => {
+    test('auto-rename uses autoRenameWorktreeBranch helper', () => {
       const content = readSrc('main', 'services', 'opencode-service.ts')
-      expect(content).toContain('canonicalizeBranchName(sessionTitle)')
+      expect(content).toContain('autoRenameWorktreeBranch')
     })
 
     test('renderer receives both title update and branch rename events', () => {
@@ -87,19 +87,21 @@ describe('Session 12: Integration & Verification', () => {
       expect(content).toContain('!worktree.branch_renamed')
     })
 
-    test('auto-rename checks auto-generated name before proceeding', () => {
-      const content = readSrc('main', 'services', 'opencode-service.ts')
+    test('auto-rename checks auto-generated name via shared helper', () => {
+      // Auto-name detection now lives in isAutoNamedBranch in git-service.ts
+      const content = readSrc('main', 'services', 'git-service.ts')
+      expect(content).toContain('isAutoNamedBranch')
       expect(content).toContain('ALL_BREED_NAMES.some')
     })
 
     test('once branch_renamed=1 after manual rename, auto-rename skips', () => {
-      // Verify the control flow: branch_renamed check comes before rename attempt
+      // Verify the control flow: branch_renamed check comes before autoRenameWorktreeBranch call
       const content = readSrc('main', 'services', 'opencode-service.ts')
       const autoRenameBlock = content.slice(
-        content.indexOf('Auto-rename branch if still an auto-generated name')
+        content.indexOf('Auto-rename branch for the session')
       )
       const flagCheckIdx = autoRenameBlock.indexOf('!worktree.branch_renamed')
-      const renameCallIdx = autoRenameBlock.indexOf('gitService.renameBranch(')
+      const renameCallIdx = autoRenameBlock.indexOf('autoRenameWorktreeBranch')
       expect(flagCheckIdx).toBeGreaterThan(-1)
       expect(renameCallIdx).toBeGreaterThan(flagCheckIdx)
     })


### PR DESCRIPTION
## Summary

- **Extracted shared `autoRenameWorktreeBranch()` helper** into `git-service.ts` — consolidates the duplicated auto-rename logic that previously lived inline in both `opencode-service.ts` and `claude-code-implementer.ts` into a single, well-typed function with clear `AutoRenameParams` / `AutoRenameResult` interfaces
- **Extracted `isAutoNamedBranch()` utility** into `git-service.ts` — replaces three identical inline checks (in `worktree-handlers.ts`, `opencode-service.ts`, and `claude-code-implementer.ts`) that matched breed/city names with a single reusable function
- **Added connection-member branch renaming** — when a session title is generated, all worktrees belonging to the same connection (not just the session's direct worktree) now get their auto-named branches renamed to match the session title, with collision suffixing (-2, -3, …) handled automatically

### Files changed

| File | Change |
|------|--------|
| `src/main/services/git-service.ts` | Added `isAutoNamedBranch()`, `AutoRenameParams`, `AutoRenameResult`, and `autoRenameWorktreeBranch()` |
| `src/main/services/opencode-service.ts` | Replaced ~80 lines of inline rename logic with calls to the shared helper; added connection-member rename loop |
| `src/main/services/claude-code-implementer.ts` | Same refactor — replaced inline logic with shared helper; added connection-member rename loop |
| `src/main/ipc/worktree-handlers.ts` | Replaced inline auto-name check with `isAutoNamedBranch()` import |
| `test/claude-code-title-integration.test.ts` | Updated mocks to use `autoRenameWorktreeBranch` instead of individual `branchExists`/`renameBranch` |
| `test/phase-11/session-12/integration-verification.test.ts` | Updated assertions to reflect shared helper usage |
| `test/phase-11/session-4/auto-rename-branch.test.ts` | Updated assertions to point at `git-service.ts` where collision/failure logic now lives |

## Test plan

- [ ] Verify `pnpm test` passes — unit tests updated to mock `autoRenameWorktreeBranch`
- [ ] Create a new worktree with an auto-named branch (breed name), start a session, and confirm the branch renames on first title generation
- [ ] Create a connection with multiple worktrees, generate a title, and confirm all member worktrees' branches are renamed
- [ ] Manually rename a branch before title generation and confirm `branch_renamed=1` prevents auto-rename
- [ ] Verify collision suffixing works when the canonical branch name already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)