### PR TITLE
Make terminal quick action configurable

### DIFF
--- a/src/renderer/src/hooks/useCommands.ts
+++ b/src/renderer/src/hooks/useCommands.ts
@@ -5,7 +5,8 @@ import {
   useSessionStore,
   useThemeStore,
   useSessionHistoryStore,
-  useLayoutStore
+  useLayoutStore,
+  useSettingsStore
 } from '@/stores'
 import { THEME_PRESETS } from '@/lib/themes'
 import { useGitStore } from '@/stores/useGitStore'
@@ -308,7 +309,12 @@ export function useCommands() {
             return
           }
           try {
-            await window.worktreeOps.openInTerminal(worktreePath)
+            const { defaultTerminal, customTerminalCommand } = useSettingsStore.getState()
+            await window.settingsOps.openWithTerminal(
+              worktreePath,
+              defaultTerminal,
+              defaultTerminal === 'custom' ? customTerminalCommand : undefined
+            )
             toast.success('Opened in terminal')
           } catch {
             toast.error('Failed to open in terminal')

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -22,7 +22,7 @@ export interface SelectedModel {
   variant?: string
 }
 
-export type QuickActionType = 'cursor' | 'ghostty' | 'copy-path' | 'finder'
+export type QuickActionType = 'cursor' | 'terminal' | 'copy-path' | 'finder'
 
 export interface AppSettings {
   // General

--- a/test/phase-10/session-6/show-in-finder.test.ts
+++ b/test/phase-10/session-6/show-in-finder.test.ts
@@ -20,7 +20,7 @@ describe('Session 6: Show in Finder', () => {
     })
 
     test('all expected quick action types exist', () => {
-      const actions: QuickActionType[] = ['cursor', 'ghostty', 'copy-path', 'finder']
+      const actions: QuickActionType[] = ['cursor', 'terminal', 'copy-path', 'finder']
       expect(actions).toHaveLength(4)
       expect(actions).toContain('finder')
     })
@@ -33,7 +33,7 @@ describe('Session 6: Show in Finder', () => {
       const finderAction: QuickActionType = 'finder'
       expect(finderAction).toBe('finder')
       // Verify all 4 action types are valid
-      const allActions: QuickActionType[] = ['cursor', 'ghostty', 'copy-path', 'finder']
+      const allActions: QuickActionType[] = ['cursor', 'terminal', 'copy-path', 'finder']
       expect(allActions).toHaveLength(4)
     })
   })
@@ -56,7 +56,7 @@ describe('Session 6: Show in Finder', () => {
     })
 
     test('lastOpenAction can cycle between all action types', () => {
-      const types: QuickActionType[] = ['cursor', 'ghostty', 'copy-path', 'finder']
+      const types: QuickActionType[] = ['cursor', 'terminal', 'copy-path', 'finder']
       for (const type of types) {
         useSettingsStore.getState().updateSetting('lastOpenAction', type)
         expect(useSettingsStore.getState().lastOpenAction).toBe(type)
@@ -88,9 +88,10 @@ describe('Session 6: Show in Finder', () => {
       expect(copyToClipboard).not.toHaveBeenCalled()
     })
 
-    test('non-finder actions still route to openInApp', async () => {
+    test('non-finder actions still route correctly', async () => {
       const showInFolder = vi.fn()
       const openInApp = vi.fn()
+      const openWithTerminal = vi.fn()
       const copyToClipboard = vi.fn()
       const worktreePath = '/path/to/worktree'
 
@@ -99,6 +100,8 @@ describe('Session 6: Show in Finder', () => {
           await copyToClipboard(worktreePath)
         } else if (actionId === 'finder') {
           await showInFolder(worktreePath)
+        } else if (actionId === 'terminal') {
+          await openWithTerminal(worktreePath, 'ghostty')
         } else {
           await openInApp(actionId, worktreePath)
         }
@@ -108,8 +111,8 @@ describe('Session 6: Show in Finder', () => {
       expect(openInApp).toHaveBeenCalledWith('cursor', '/path/to/worktree')
       expect(showInFolder).not.toHaveBeenCalled()
 
-      await executeAction('ghostty')
-      expect(openInApp).toHaveBeenCalledWith('ghostty', '/path/to/worktree')
+      await executeAction('terminal')
+      expect(openWithTerminal).toHaveBeenCalledWith('/path/to/worktree', 'ghostty')
     })
 
     test('copy-path action still routes to copyToClipboard', async () => {

--- a/test/phase-13/session-9/integration-verification.test.ts
+++ b/test/phase-13/session-9/integration-verification.test.ts
@@ -236,7 +236,7 @@ describe('Session 9: Integration & Verification', () => {
     test('has four individual buttons with data-testid attributes', () => {
       const source = readSource('src/renderer/src/components/layout/QuickActions.tsx')
       expect(source).toContain('data-testid="quick-action-cursor"')
-      expect(source).toContain('data-testid="quick-action-ghostty"')
+      expect(source).toContain('data-testid="quick-action-terminal"')
       expect(source).toContain('data-testid="quick-action-copy-path"')
       expect(source).toContain('data-testid="quick-action-finder"')
     })
@@ -249,10 +249,10 @@ describe('Session 9: Integration & Verification', () => {
       expect(source).not.toContain('ChevronDown')
     })
 
-    test('Cursor and Ghostty buttons have labels', () => {
+    test('Cursor button has label and terminal label is dynamic', () => {
       const source = readSource('src/renderer/src/components/layout/QuickActions.tsx')
       expect(source).toContain('<span>Cursor</span>')
-      expect(source).toContain('<span>Ghostty</span>')
+      expect(source).toContain('<span>{terminalLabel}</span>')
     })
 
     test('Copy Path shows check icon after copying', () => {
@@ -266,7 +266,7 @@ describe('Session 9: Integration & Verification', () => {
     test('buttons are disabled when no worktree path', () => {
       const source = readSource('src/renderer/src/components/layout/QuickActions.tsx')
       expect(source).toContain('disabled={disabled}')
-      expect(source).toContain('const disabled = !worktreePath')
+      expect(source).toContain('const disabled = !activePath')
     })
   })
 

--- a/test/phase-15/session-5/copy-branch-name.test.tsx
+++ b/test/phase-15/session-5/copy-branch-name.test.tsx
@@ -214,7 +214,7 @@ describe('Session 5: Copy Branch Name', () => {
     render(<QuickActions />)
 
     expect(screen.getByTestId('quick-action-cursor')).toBeInTheDocument()
-    expect(screen.getByTestId('quick-action-ghostty')).toBeInTheDocument()
+    expect(screen.getByTestId('quick-action-terminal')).toBeInTheDocument()
     expect(screen.getByTestId('quick-action-copy-path')).toBeInTheDocument()
     expect(screen.getByTestId('quick-action-finder')).toBeInTheDocument()
     expect(screen.getByTestId('quick-action-copy-branch')).toBeInTheDocument()


### PR DESCRIPTION
## Summary

Replaces hardcoded Ghostty integration with user-configurable terminal preference. Users can now select their preferred terminal app from Settings, and the QuickActions button will dynamically display and launch the configured terminal.

## Key Changes

- **Dynamic Terminal Integration**: Quick action button now displays the icon and label for the user's configured default terminal
- **Multi-Terminal Support**: Added support for Terminal, iTerm, Warp, Alacritty, Kitty, Ghostty, and custom terminal commands
- **Settings Integration**: Terminal quick action now reads from `defaultTerminal` and `customTerminalCommand` settings
- **API Updates**: Uses `settingsOps.openWithTerminal` instead of hardcoded `systemOps.openInApp('ghostty')`
- **Command Palette**: Updated "Open in Terminal" command to use configured terminal preference
- **Type Updates**: Changed `QuickActionType` from `'ghostty'` to `'terminal'` for better generalization

## Files Changed

- **`QuickActions.tsx`**: Added dynamic icon/label rendering with `TerminalIcon` component and `TERMINAL_LABELS` mapping. Added Warp icon component.
- **`useCommands.ts`**: Updated "Open in Terminal" command to use settings store for terminal preferences
- **`useSettingsStore.ts`**: Updated `QuickActionType` definition from `'ghostty'` to `'terminal'`
- **Test files**: Comprehensive updates across 4 test files to reflect new `'terminal'` action type and test multiple terminal configurations

## Test Coverage

- ✅ Dynamic label rendering based on `defaultTerminal` setting
- ✅ Support for switching between different terminal applications (Ghostty, Warp, etc.)
- ✅ Proper API routing to `openWithTerminal` vs `openInApp`
- ✅ Backward compatibility with existing functionality
- ✅ All existing tests updated and passing

## Technical Details

The implementation uses a mapping approach for terminal labels and a switch-based icon renderer that currently supports custom icons for Ghostty and Warp, falling back to the generic Terminal icon for other terminal types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)