### PR TITLE
feat: add Pull Requests tab to branch picker dialog

### DIFF
--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -904,6 +904,17 @@ declare global {
         worktreePath: string,
         branchName: string
       ) => Promise<{ success: boolean; error?: string }>
+      // List open pull requests from GitHub via gh CLI
+      listPRs: (projectPath: string) => Promise<{
+        success: boolean
+        prs: Array<{
+          number: number
+          title: string
+          author: string
+          headRefName: string
+        }>
+        error?: string
+      }>
     }
     updaterOps: {
       checkForUpdate: () => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -852,7 +852,21 @@ const gitOps = {
     worktreePath: string,
     branchName: string
   ): Promise<{ success: boolean; error?: string }> =>
-    ipcRenderer.invoke('git:deleteBranch', worktreePath, branchName)
+    ipcRenderer.invoke('git:deleteBranch', worktreePath, branchName),
+
+  // List open pull requests from GitHub via gh CLI
+  listPRs: (
+    projectPath: string
+  ): Promise<{
+    success: boolean
+    prs: Array<{
+      number: number
+      title: string
+      author: string
+      headRefName: string
+    }>
+    error?: string
+  }> => ipcRenderer.invoke('git:listPRs', { projectPath })
 }
 
 const opencodeOps = {

--- a/src/renderer/src/components/worktrees/BranchPickerDialog.tsx
+++ b/src/renderer/src/components/worktrees/BranchPickerDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import { Loader2, Search, GitBranch, Globe, CheckCircle2 } from 'lucide-react'
+import { Loader2, Search, GitBranch, GitPullRequest, Globe, CheckCircle2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   Dialog,
@@ -16,6 +16,15 @@ interface BranchInfo {
   isCheckedOut: boolean
   worktreePath?: string
 }
+
+interface PullRequestInfo {
+  number: number
+  title: string
+  author: string
+  headRefName: string
+}
+
+type TabValue = 'branches' | 'prs'
 
 interface BranchPickerDialogProps {
   open: boolean
@@ -35,10 +44,18 @@ export function BranchPickerDialog({
   const [filter, setFilter] = useState('')
   const [error, setError] = useState<string | null>(null)
 
+  const [activeTab, setActiveTab] = useState<TabValue>('branches')
+  const [prs, setPrs] = useState<PullRequestInfo[]>([])
+  const [prsLoading, setPrsLoading] = useState(false)
+  const [prsError, setPrsError] = useState<string | null>(null)
+
   // Fetch branches when dialog opens
   useEffect(() => {
     if (!open) {
       setFilter('')
+      setActiveTab('branches')
+      setPrs([])
+      setPrsError(null)
       return
     }
 
@@ -62,6 +79,30 @@ export function BranchPickerDialog({
       })
   }, [open, projectPath])
 
+  // Fetch PRs when PRs tab is selected (lazy)
+  useEffect(() => {
+    if (!open || activeTab !== 'prs') return
+
+    setPrsLoading(true)
+    setPrsError(null)
+
+    window.gitOps
+      .listPRs(projectPath)
+      .then((result) => {
+        if (result.success) {
+          setPrs(result.prs)
+        } else {
+          setPrsError(result.error || 'Failed to load pull requests')
+        }
+      })
+      .catch((err) => {
+        setPrsError(err instanceof Error ? err.message : 'Failed to load pull requests')
+      })
+      .finally(() => {
+        setPrsLoading(false)
+      })
+  }, [open, projectPath, activeTab])
+
   // Filter and sort branches
   const filteredBranches = useMemo(() => {
     const lowerFilter = filter.toLowerCase()
@@ -74,23 +115,72 @@ export function BranchPickerDialog({
     })
   }, [branches, filter])
 
+  // Filter PRs
+  const filteredPRs = useMemo(() => {
+    const lowerFilter = filter.toLowerCase()
+    return prs.filter(
+      (pr) =>
+        pr.title.toLowerCase().includes(lowerFilter) ||
+        pr.headRefName.toLowerCase().includes(lowerFilter) ||
+        `#${pr.number}`.includes(lowerFilter)
+    )
+  }, [prs, filter])
+
   const handleSelect = (branch: BranchInfo): void => {
     onSelect(branch.name)
+  }
+
+  const handlePRSelect = (pr: PullRequestInfo): void => {
+    onSelect(pr.headRefName)
   }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>New Workspace From Branch</DialogTitle>
-          <DialogDescription>Select a branch to create a new workspace from.</DialogDescription>
+          <DialogTitle>New Workspace</DialogTitle>
+          <DialogDescription>
+            Select a branch or pull request to create a new workspace from.
+          </DialogDescription>
         </DialogHeader>
+
+        {/* Tab bar */}
+        <div className="flex gap-1 border-b">
+          <button
+            className={cn(
+              'px-3 py-1.5 text-sm font-medium transition-colors',
+              'border-b-2 -mb-px',
+              activeTab === 'branches'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+            onClick={() => setActiveTab('branches')}
+          >
+            <GitBranch className="inline h-3.5 w-3.5 mr-1.5 -mt-0.5" />
+            Branches
+          </button>
+          <button
+            className={cn(
+              'px-3 py-1.5 text-sm font-medium transition-colors',
+              'border-b-2 -mb-px',
+              activeTab === 'prs'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+            onClick={() => setActiveTab('prs')}
+          >
+            <GitPullRequest className="inline h-3.5 w-3.5 mr-1.5 -mt-0.5" />
+            PRs
+          </button>
+        </div>
 
         {/* Search/Filter */}
         <div className="relative">
           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="Filter branches..."
+            placeholder={
+              activeTab === 'branches' ? 'Filter branches...' : 'Filter pull requests...'
+            }
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
             className="pl-9"
@@ -98,55 +188,112 @@ export function BranchPickerDialog({
           />
         </div>
 
-        {/* Branch List */}
-        <div className="max-h-[300px] overflow-y-auto border rounded-md">
-          {loading ? (
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-              <span className="ml-2 text-sm text-muted-foreground">Loading branches...</span>
-            </div>
-          ) : error ? (
-            <div className="px-4 py-8 text-center text-sm text-destructive">{error}</div>
-          ) : filteredBranches.length === 0 ? (
-            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-              {filter ? 'No branches match your filter' : 'No branches found'}
-            </div>
-          ) : (
-            <div className="py-1">
-              {filteredBranches.map((branch) => (
-                <button
-                  key={`${branch.name}-${branch.isRemote}`}
-                  className={cn(
-                    'flex items-center gap-2 w-full px-3 py-2 text-sm text-left',
-                    'hover:bg-accent hover:text-accent-foreground transition-colors',
-                    'focus:bg-accent focus:text-accent-foreground focus:outline-none'
-                  )}
-                  onClick={() => handleSelect(branch)}
-                >
-                  <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                  <span className="flex-1 truncate">{branch.name}</span>
-                  {branch.isRemote && (
-                    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded bg-muted text-muted-foreground shrink-0">
-                      <Globe className="h-2.5 w-2.5" />
-                      remote
+        {/* Branches List */}
+        {activeTab === 'branches' && (
+          <div className="max-h-[300px] overflow-y-auto border rounded-md">
+            {loading ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                <span className="ml-2 text-sm text-muted-foreground">Loading branches...</span>
+              </div>
+            ) : error ? (
+              <div className="px-4 py-8 text-center text-sm text-destructive">{error}</div>
+            ) : filteredBranches.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                {filter ? 'No branches match your filter' : 'No branches found'}
+              </div>
+            ) : (
+              <div className="py-1">
+                {filteredBranches.map((branch) => (
+                  <button
+                    key={`${branch.name}-${branch.isRemote}`}
+                    className={cn(
+                      'flex items-center gap-2 w-full px-3 py-2 text-sm text-left',
+                      'hover:bg-accent hover:text-accent-foreground transition-colors',
+                      'focus:bg-accent focus:text-accent-foreground focus:outline-none'
+                    )}
+                    onClick={() => handleSelect(branch)}
+                  >
+                    <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    <span className="flex-1 truncate">{branch.name}</span>
+                    {branch.isRemote && (
+                      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded bg-muted text-muted-foreground shrink-0">
+                        <Globe className="h-2.5 w-2.5" />
+                        remote
+                      </span>
+                    )}
+                    {branch.isCheckedOut && (
+                      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded bg-primary/10 text-primary shrink-0">
+                        <CheckCircle2 className="h-2.5 w-2.5" />
+                        active
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* PRs List */}
+        {activeTab === 'prs' && (
+          <div className="max-h-[300px] overflow-y-auto border rounded-md">
+            {prsLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                <span className="ml-2 text-sm text-muted-foreground">
+                  Loading pull requests...
+                </span>
+              </div>
+            ) : prsError ? (
+              <div className="px-4 py-8 text-center text-sm text-destructive">{prsError}</div>
+            ) : filteredPRs.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                {filter ? 'No pull requests match your filter' : 'No open pull requests'}
+              </div>
+            ) : (
+              <div className="py-1">
+                {filteredPRs.map((pr) => (
+                  <button
+                    key={pr.number}
+                    className={cn(
+                      'flex items-center gap-2 w-full px-3 py-2 text-sm text-left',
+                      'hover:bg-accent hover:text-accent-foreground transition-colors',
+                      'focus:bg-accent focus:text-accent-foreground focus:outline-none'
+                    )}
+                    onClick={() => handlePRSelect(pr)}
+                  >
+                    <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    <span className="flex-1 min-w-0">
+                      <span className="font-medium text-muted-foreground mr-1.5">
+                        #{pr.number}
+                      </span>
+                      <span className="truncate">{pr.title}</span>
                     </span>
-                  )}
-                  {branch.isCheckedOut && (
-                    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded bg-primary/10 text-primary shrink-0">
-                      <CheckCircle2 className="h-2.5 w-2.5" />
-                      active
+                    <span className="text-[10px] text-muted-foreground shrink-0 max-w-[120px] truncate">
+                      {pr.author}
                     </span>
-                  )}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+                    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded bg-muted text-muted-foreground shrink-0 max-w-[140px] truncate">
+                      <GitBranch className="h-2.5 w-2.5 shrink-0" />
+                      {pr.headRefName}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Footer info */}
-        {!loading && !error && filteredBranches.length > 0 && (
+        {activeTab === 'branches' && !loading && !error && filteredBranches.length > 0 && (
           <p className="text-xs text-muted-foreground">
             {filteredBranches.length} branch{filteredBranches.length !== 1 ? 'es' : ''}
+            {filter && ` matching "${filter}"`}
+          </p>
+        )}
+        {activeTab === 'prs' && !prsLoading && !prsError && filteredPRs.length > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {filteredPRs.length} pull request{filteredPRs.length !== 1 ? 's' : ''}
             {filter && ` matching "${filter}"`}
           </p>
         )}


### PR DESCRIPTION
## Summary

- **New `git:listPRs` IPC handler** — Uses `gh pr list` CLI to fetch open pull requests for a project, with structured error handling for missing CLI, non-GitHub repos, and auth issues. Includes `git fetch origin` to ensure PR branches are available locally for worktree creation.
- **Preload bridge & types** — Exposes `window.gitOps.listPRs()` with full TypeScript declarations in `index.d.ts` for the PR data shape (`number`, `title`, `author`, `headRefName`).
- **Tabbed BranchPickerDialog** — Refactors the dialog from a single branch list into a two-tab layout (**Branches** / **PRs**) with a custom tab bar using Tailwind styles. PRs are lazy-loaded only when the tab is activated.
- **PR filtering & selection** — Filter pull requests by title, branch name, or `#number`. Selecting a PR passes its `headRefName` to the existing `onSelect` callback, creating a workspace from the PR branch.
- **UI polish** — Updated dialog title/description, tab-aware search placeholder, and per-tab footer counts with filter context.

## Test plan

- [ ] Open the branch picker dialog and verify the **Branches** tab loads as before
- [ ] Switch to the **PRs** tab and verify open pull requests load (requires `gh` CLI authenticated)
- [ ] Filter PRs by title, branch name, and PR number
- [ ] Select a PR and verify a workspace is created from the correct branch
- [ ] Test error states: no `gh` CLI installed, non-GitHub repo, unauthenticated
- [ ] Verify switching tabs resets filter and dialog state resets on close

🤖 Generated with [Claude Code](https://claude.com/claude-code)