### PR TITLE
Move question titles to header bar

### DIFF
--- a/src/renderer/src/components/sessions/QuestionPrompt.tsx
+++ b/src/renderer/src/components/sessions/QuestionPrompt.tsx
@@ -132,20 +132,8 @@ export function QuestionPrompt({ request, onReply, onReject }: QuestionPromptPro
       {/* Header */}
       <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/30">
         <MessageCircleQuestion className="h-4 w-4 text-blue-400 shrink-0" />
-        <button
-          onClick={handleDismiss}
-          disabled={sending}
-          className="ml-auto text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
-          aria-label="Dismiss"
-        >
-          <X className="h-3.5 w-3.5" />
-        </button>
-      </div>
-
-      <div className="px-3 py-2.5">
-        {/* Multi-question tabs */}
-        {isMultiQuestion && (
-          <div className="flex gap-1 mb-3" data-testid="question-tabs">
+        {isMultiQuestion ? (
+          <div className="flex gap-1 flex-1 min-w-0" data-testid="question-tabs">
             {request.questions.map((q, i) => (
               <button
                 key={i}
@@ -161,12 +149,28 @@ export function QuestionPrompt({ request, onReply, onReject }: QuestionPromptPro
                 )}
               >
                 {q.header}
-                {answers[i]?.length > 0 && <Check className="h-3 w-3 ml-1 inline text-green-500" />}
+                {answers[i]?.length > 0 && (
+                  <Check className="h-3 w-3 ml-1 inline text-green-500" />
+                )}
               </button>
             ))}
           </div>
+        ) : (
+          <span className="text-sm font-medium text-foreground truncate flex-1">
+            {currentQuestion.header}
+          </span>
         )}
+        <button
+          onClick={handleDismiss}
+          disabled={sending}
+          className="ml-auto text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 shrink-0"
+          aria-label="Dismiss"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
 
+      <div className="px-3 py-2.5">
         {/* Question text */}
         <p className="text-sm text-foreground mb-3">{currentQuestion.question}</p>
 


### PR DESCRIPTION
## Summary

- **Relocated question header/tabs into the header bar** of the `QuestionPrompt` component, consolidating the title area with the dismiss button into a single row
- For **multi-question prompts**, the tab buttons now sit inline in the header bar next to the icon and dismiss button, instead of being in a separate section below the header
- For **single-question prompts**, the question header text is now displayed directly in the header bar as a truncated label
- Moved the **dismiss (X) button** to stay at the far right of the header, after the tabs/title, with `shrink-0` to prevent it from collapsing
- Removed the extra `div` wrapper that previously separated the header from the question tabs, reducing nesting and vertical space

## Test plan

- [ ] Verify single-question prompts show the header text inline in the top bar
- [ ] Verify multi-question prompts show tab buttons inline in the top bar
- [ ] Verify the dismiss (X) button remains accessible and aligned to the right
- [ ] Verify answered tab indicators (green checkmark) still display correctly
- [ ] Verify layout doesn't break with long header text (truncation works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)