### PR TITLE
feat: flat git ls-files index for file search and @ mentions

### DIFF
--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -564,6 +564,12 @@ declare global {
         tree?: FileTreeNode[]
         error?: string
       }>
+      // Scan a directory and return a flat list of all files (via git ls-files)
+      scanFlat: (dirPath: string) => Promise<{
+        success: boolean
+        files?: FlatFile[]
+        error?: string
+      }>
       // Lazy load children for a directory
       loadChildren: (
         dirPath: string,
@@ -1038,6 +1044,14 @@ declare global {
     isSymlink?: boolean
     extension: string | null
     children?: FileTreeNode[]
+  }
+
+  // Flat file entry for search index (no tree structure)
+  interface FlatFile {
+    name: string
+    path: string
+    relativePath: string
+    extension: string | null
   }
 
   // File tree change event type

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -506,6 +506,14 @@ export interface FileTreeNode {
   children?: FileTreeNode[]
 }
 
+// Flat file entry for search index (no tree structure)
+export interface FlatFile {
+  name: string
+  path: string
+  relativePath: string
+  extension: string | null
+}
+
 // File tree change event type
 export interface FileTreeChangeEvent {
   worktreePath: string
@@ -545,6 +553,15 @@ const fileTreeOps = {
     tree?: FileTreeNode[]
     error?: string
   }> => ipcRenderer.invoke('file-tree:scan', dirPath),
+
+  // Scan a directory and return a flat list of all files (via git ls-files)
+  scanFlat: (
+    dirPath: string
+  ): Promise<{
+    success: boolean
+    files?: FlatFile[]
+    error?: string
+  }> => ipcRenderer.invoke('file-tree:scan-flat', dirPath),
 
   // Lazy load children for a directory
   loadChildren: (

--- a/src/renderer/src/hooks/useFileMentions.ts
+++ b/src/renderer/src/hooks/useFileMentions.ts
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
-import { flattenTree, scoreMatch, type FlatFile, type FileTreeNode } from '@/lib/file-search-utils'
+import { scoreMatch, type FlatFile } from '@/lib/file-search-utils'
 
 export interface FileMention {
   relativePath: string
@@ -92,14 +92,11 @@ function filterSuggestions(flatFiles: FlatFile[], query: string): FlatFile[] {
 export function useFileMentions(
   inputValue: string,
   cursorPosition: number,
-  fileTree: FileTreeNode[]
+  flatFiles: FlatFile[]
 ) {
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [mentions, setMentions] = useState<FileMention[]>([])
   const prevQueryRef = useRef('')
-
-  // Memoize flat file list — only recompute when fileTree reference changes
-  const flatFiles = useMemo(() => flattenTree(fileTree), [fileTree])
 
   // Detect trigger
   const trigger = useMemo(

--- a/test/file-mentions/session-3-mention-tracking.test.ts
+++ b/test/file-mentions/session-3-mention-tracking.test.ts
@@ -5,55 +5,13 @@ import {
   applyStripping,
   type FileMention
 } from '../../src/renderer/src/hooks/useFileMentions'
-import type { FileTreeNode } from '../../src/renderer/src/lib/file-search-utils'
+import type { FlatFile } from '../../src/renderer/src/lib/file-search-utils'
 
-const sampleTree: FileTreeNode[] = [
-  {
-    name: 'src',
-    path: '/project/src',
-    relativePath: 'src',
-    isDirectory: true,
-    extension: null,
-    children: [
-      {
-        name: 'utils',
-        path: '/project/src/utils',
-        relativePath: 'src/utils',
-        isDirectory: true,
-        extension: null,
-        children: [
-          {
-            name: 'helpers.ts',
-            path: '/project/src/utils/helpers.ts',
-            relativePath: 'src/utils/helpers.ts',
-            isDirectory: false,
-            extension: '.ts'
-          }
-        ]
-      },
-      {
-        name: 'index.ts',
-        path: '/project/src/index.ts',
-        relativePath: 'src/index.ts',
-        isDirectory: false,
-        extension: '.ts'
-      },
-      {
-        name: 'app.tsx',
-        path: '/project/src/app.tsx',
-        relativePath: 'src/app.tsx',
-        isDirectory: false,
-        extension: '.tsx'
-      }
-    ]
-  },
-  {
-    name: 'README.md',
-    path: '/project/README.md',
-    relativePath: 'README.md',
-    isDirectory: false,
-    extension: '.md'
-  }
+const sampleFiles: FlatFile[] = [
+  { name: 'helpers.ts', path: '/project/src/utils/helpers.ts', relativePath: 'src/utils/helpers.ts', extension: '.ts' },
+  { name: 'index.ts', path: '/project/src/index.ts', relativePath: 'src/index.ts', extension: '.ts' },
+  { name: 'app.tsx', path: '/project/src/app.tsx', relativePath: 'src/app.tsx', extension: '.tsx' },
+  { name: 'README.md', path: '/project/README.md', relativePath: 'README.md', extension: '.md' }
 ]
 
 describe('Session 3: Mention Tracking', () => {
@@ -61,7 +19,7 @@ describe('Session 3: Mention Tracking', () => {
     test('typing text BEFORE a mention shifts its indices forward', () => {
       // Start: select a file to create a mention
       const { result, rerender } = renderHook(
-        ({ input, cursor }) => useFileMentions(input, cursor, sampleTree),
+        ({ input, cursor }) => useFileMentions(input, cursor, sampleFiles),
         { initialProps: { input: '@help', cursor: 5 } }
       )
 
@@ -96,7 +54,7 @@ describe('Session 3: Mention Tracking', () => {
 
     test('typing text AFTER a mention does not change its indices', () => {
       const { result, rerender } = renderHook(
-        ({ input, cursor }) => useFileMentions(input, cursor, sampleTree),
+        ({ input, cursor }) => useFileMentions(input, cursor, sampleFiles),
         { initialProps: { input: '@help', cursor: 5 } }
       )
 
@@ -126,7 +84,7 @@ describe('Session 3: Mention Tracking', () => {
     test('deleting text BEFORE a mention shifts its indices backward', () => {
       // Start with 'Hello @help'
       const { result, rerender } = renderHook(
-        ({ input, cursor }) => useFileMentions(input, cursor, sampleTree),
+        ({ input, cursor }) => useFileMentions(input, cursor, sampleFiles),
         { initialProps: { input: 'Hello @help', cursor: 11 } }
       )
 
@@ -155,7 +113,7 @@ describe('Session 3: Mention Tracking', () => {
 
     test('editing text INSIDE a mention removes it from tracking', () => {
       const { result, rerender } = renderHook(
-        ({ input, cursor }) => useFileMentions(input, cursor, sampleTree),
+        ({ input, cursor }) => useFileMentions(input, cursor, sampleFiles),
         { initialProps: { input: '@help', cursor: 5 } }
       )
 
@@ -183,7 +141,7 @@ describe('Session 3: Mention Tracking', () => {
     test('multiple mentions adjust independently', () => {
       // Build up two mentions manually
       const { result, rerender } = renderHook(
-        ({ input, cursor }) => useFileMentions(input, cursor, sampleTree),
+        ({ input, cursor }) => useFileMentions(input, cursor, sampleFiles),
         { initialProps: { input: '@help', cursor: 5 } }
       )
 
@@ -288,7 +246,7 @@ describe('Session 3: Mention Tracking', () => {
   describe('getTextForSend', () => {
     test('with stripAtMentions=true, strips tracked mentions', () => {
       const { result, rerender } = renderHook(
-        ({ input, cursor }) => useFileMentions(input, cursor, sampleTree),
+        ({ input, cursor }) => useFileMentions(input, cursor, sampleFiles),
         { initialProps: { input: '@help', cursor: 5 } }
       )
 
@@ -307,7 +265,7 @@ describe('Session 3: Mention Tracking', () => {
 
     test('with stripAtMentions=false, returns text unchanged', () => {
       const { result, rerender } = renderHook(
-        ({ input, cursor }) => useFileMentions(input, cursor, sampleTree),
+        ({ input, cursor }) => useFileMentions(input, cursor, sampleFiles),
         { initialProps: { input: '@help', cursor: 5 } }
       )
 

--- a/test/phase-14/session-1/file-search-fix.test.tsx
+++ b/test/phase-14/session-1/file-search-fix.test.tsx
@@ -44,8 +44,8 @@ describe('Session 1: File Search Bug Fix', () => {
     })
   })
 
-  test('loads file tree when dialog opens with empty tree', () => {
-    const loadFileTree = vi.fn().mockResolvedValue(undefined)
+  test('loads file index when dialog opens with empty index', () => {
+    const loadFileIndex = vi.fn().mockResolvedValue(undefined)
 
     // Set up worktree store with a selected worktree
     useWorktreeStore.setState({
@@ -70,10 +70,10 @@ describe('Session 1: File Search Bug Fix', () => {
       ])
     })
 
-    // File tree store has no data for this worktree (empty tree)
+    // File tree store has no index for this worktree
     useFileTreeStore.setState({
-      fileTreeByWorktree: new Map(),
-      loadFileTree
+      fileIndexByWorktree: new Map(),
+      loadFileIndex
     })
 
     // Open the dialog
@@ -81,11 +81,11 @@ describe('Session 1: File Search Bug Fix', () => {
 
     render(<FileSearchDialog />)
 
-    expect(loadFileTree).toHaveBeenCalledWith('/test/worktree')
+    expect(loadFileIndex).toHaveBeenCalledWith('/test/worktree')
   })
 
-  test('does not reload file tree when already loaded', () => {
-    const loadFileTree = vi.fn().mockResolvedValue(undefined)
+  test('does not reload file index when already loaded', () => {
+    const loadFileIndex = vi.fn().mockResolvedValue(undefined)
 
     useWorktreeStore.setState({
       selectedWorktreeId: 'wt-1',
@@ -109,30 +109,29 @@ describe('Session 1: File Search Bug Fix', () => {
       ])
     })
 
-    // File tree store already has data for this worktree
-    const populatedTree = [
+    // File tree store already has index data for this worktree
+    const populatedIndex = [
       {
         name: 'index.ts',
         path: '/test/worktree/index.ts',
         relativePath: 'index.ts',
-        isDirectory: false,
         extension: '.ts'
       }
     ]
     useFileTreeStore.setState({
-      fileTreeByWorktree: new Map([['/test/worktree', populatedTree]]),
-      loadFileTree
+      fileIndexByWorktree: new Map([['/test/worktree', populatedIndex]]),
+      loadFileIndex
     })
 
     useFileSearchStore.setState({ isOpen: true })
 
     render(<FileSearchDialog />)
 
-    expect(loadFileTree).not.toHaveBeenCalled()
+    expect(loadFileIndex).not.toHaveBeenCalled()
   })
 
   test('does not load when dialog is closed', () => {
-    const loadFileTree = vi.fn().mockResolvedValue(undefined)
+    const loadFileIndex = vi.fn().mockResolvedValue(undefined)
 
     useWorktreeStore.setState({
       selectedWorktreeId: 'wt-1',
@@ -157,8 +156,8 @@ describe('Session 1: File Search Bug Fix', () => {
     })
 
     useFileTreeStore.setState({
-      fileTreeByWorktree: new Map(),
-      loadFileTree
+      fileIndexByWorktree: new Map(),
+      loadFileIndex
     })
 
     // Dialog is closed
@@ -166,6 +165,6 @@ describe('Session 1: File Search Bug Fix', () => {
 
     render(<FileSearchDialog />)
 
-    expect(loadFileTree).not.toHaveBeenCalled()
+    expect(loadFileIndex).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

- **New `scanFlat` IPC endpoint** — uses `git ls-files --cached --others --exclude-standard` to enumerate all tracked and untracked-but-not-ignored files as a flat list, replacing the recursive directory tree scan for search use-cases
- **Dedicated `fileIndexByWorktree` store state** — separates the flat search index from the tree-based sidebar data, with its own loading guard (`fileIndexLoadingByWorktree`) to prevent duplicate concurrent loads
- **Incremental file index updates** — `handleFileChange` now patches the flat index in-place on `add`, `unlink`, and `unlinkDir` events instead of re-scanning the entire project
- **`useFileMentions` simplified** — accepts `FlatFile[]` directly instead of `FileTreeNode[]`, removing the internal `flattenTree` call and an extra `useMemo`
- **`FileSearchDialog` and `SessionView` updated** — both now read from `fileIndexByWorktree` and call `loadFileIndex` instead of depending on the sidebar's tree data, so search/@ mentions work even when the file tree sidebar is collapsed or on a different worktree
- **File watcher subscription consolidated into store** — `startWatching`/`stopWatching` now own the `onChange` subscription lifecycle (with guard against duplicate subscriptions), removing manual ref-based subscribe/unsubscribe from `FileTree.tsx`
- **`QuestionPrompt` layout tweak** — moved dismiss button into the header bar and multi-question tabs below it for cleaner layout
- **All file mention tests updated** — test fixtures simplified from nested `FileTreeNode[]` trees to flat `FlatFile[]` arrays, matching the new API surface

## Test plan

- [ ] Open a project and use `Cmd+D` file search — verify all project files appear (not just files visible in the sidebar tree)
- [ ] Type `@` in the session input — verify file mention suggestions appear with full project coverage
- [ ] Collapse or switch the file tree sidebar tab, then use `@` mentions — verify suggestions still work
- [ ] Create a new file in the project — verify it appears in file search without manually refreshing
- [ ] Delete a file — verify it disappears from file search results
- [ ] Run `pnpm test` — all file mention and file search tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)