### PR TITLE
Fix context calculation: filter subagent messages and reset tokens on compaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ vendor/
 *.cert
 *.crt
 *.pfx
+
+# Local debug/playground scripts
+scripts/

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -680,7 +680,16 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
             isSubagentMessage
           })
 
-          if (isToolResultOnly) {
+          // Skip subagent messages from accumulation — they belong to the child
+          // session's transcript and should not appear in the main conversation.
+          // The renderer routes subagent content into SubtaskCards via childSessionId
+          // on stream events; the in-memory cache must not include them either.
+          if (isSubagentMessage) {
+            log.debug('Skipping subagent message from session.messages accumulation', {
+              msgType,
+              parentToolUseId: (sdkMessage as Record<string, unknown>).parent_tool_use_id
+            })
+          } else if (isToolResultOnly) {
             // Instead of creating an empty user message, merge tool_result
             // output/error into the preceding assistant message's tool_use parts.
             const toolResults = msgContent as {

--- a/src/main/services/claude-transcript-reader.ts
+++ b/src/main/services/claude-transcript-reader.ts
@@ -201,9 +201,16 @@ export async function readClaudeTranscript(
     }
   }
 
-  // Pass 3: Translate entries, skipping tool_result-only user messages
+  // Pass 3: Translate entries, skipping tool_result-only and subagent messages
   const messages: unknown[] = []
   for (const entry of entries) {
+    // Skip subagent messages — they have parent_tool_use_id set and belong
+    // to child session transcripts, not the main conversation.
+    const rawEntry = entry as Record<string, unknown>
+    if (rawEntry.parent_tool_use_id) {
+      continue
+    }
+
     // Skip user messages that only contain tool_result blocks
     if (entry.type === 'user') {
       const content = Array.isArray(entry.message?.content) ? entry.message!.content : []

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -1578,6 +1578,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                 ...parts,
                 { type: 'compaction' as const, compactionAuto: part.auto === true }
               ])
+              // Reset stale token snapshot — compaction truncates the context window.
+              // The next assistant message.updated will carry accurate post-compaction tokens.
+              // Use clearSessionTokenSnapshot (not resetSessionTokens) to preserve
+              // the accumulated cost and model identity for the session.
+              useContextStore.getState().clearSessionTokenSnapshot(sessionId)
               immediateFlush()
               setIsStreaming(true)
             }

--- a/src/renderer/src/stores/useContextStore.ts
+++ b/src/renderer/src/stores/useContextStore.ts
@@ -39,6 +39,7 @@ interface ContextState {
   addSessionCost: (sessionId: string, cost: number) => void
   setSessionCost: (sessionId: string, cost: number) => void
   resetSessionTokens: (sessionId: string) => void
+  clearSessionTokenSnapshot: (sessionId: string) => void
   setModelLimit: (modelId: string, limit: number, providerID?: string) => void
   // Derived
   getContextUsage: (
@@ -107,6 +108,14 @@ export const useContextStore = create<ContextState>()((set, get) => ({
         modelBySession: restModel,
         costBySession: restCost
       }
+    })
+  },
+
+  clearSessionTokenSnapshot: (sessionId: string) => {
+    set((state) => {
+      const { [sessionId]: _removed, ...rest } = state.tokensBySession
+      void _removed
+      return { tokensBySession: rest }
     })
   },
 


### PR DESCRIPTION
## Summary

- **Filter subagent messages from main conversation**: Both the live streaming accumulator (`claude-code-implementer.ts`) and the transcript reader (`claude-transcript-reader.ts`) now skip messages with `parent_tool_use_id`, preventing child-session content from inflating the parent session's message list and token counts.
- **Reset stale token snapshot on compaction**: When a compaction event fires in `SessionView`, the context store's token snapshot for that session is cleared via a new `clearSessionTokenSnapshot` method, so the next assistant update carries accurate post-compaction values instead of stale pre-compaction ones.
- **New `clearSessionTokenSnapshot` action in `useContextStore`**: Unlike `resetSessionTokens` (which wipes cost and model too), this only removes the token snapshot entry, preserving accumulated cost and model identity.
- **Gitignore local debug scripts**: Added `scripts/` to `.gitignore` for local playground/debug utilities.

## Changed Files

| File | Change |
|------|--------|
| `src/main/services/claude-code-implementer.ts` | Skip subagent messages from `session.messages` accumulation during streaming |
| `src/main/services/claude-transcript-reader.ts` | Skip entries with `parent_tool_use_id` in transcript Pass 3 translation |
| `src/renderer/src/components/sessions/SessionView.tsx` | Call `clearSessionTokenSnapshot` on compaction events |
| `src/renderer/src/stores/useContextStore.ts` | Add `clearSessionTokenSnapshot` action |
| `.gitignore` | Ignore `scripts/` directory |

## Test plan

- [ ] Start a session that spawns subagents — verify subagent messages do not appear in the parent session's message list
- [ ] Trigger a compaction event — verify the context usage bar resets and updates with accurate post-compaction token values
- [ ] Reload a transcript containing subagent messages — verify they are filtered out
- [ ] Verify accumulated session cost and model identity persist after compaction reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)