### PR TITLE
Fix Claude agent context calculation and model ref parsing

### DIFF
--- a/test/phase-12/session-1/context-calculation.test.ts
+++ b/test/phase-12/session-1/context-calculation.test.ts
@@ -296,6 +296,50 @@ describe('Session 1: Context Calculation Fix', () => {
         cacheWrite: 0
       })
     })
+
+    test('parses Claude usage payload with raw *_tokens fields', () => {
+      const result = extractTokens({
+        info: {
+          usage: {
+            input_tokens: 42,
+            output_tokens: 7,
+            cache_read_input_tokens: 1000,
+            cache_creation_input_tokens: 500
+          }
+        }
+      })
+
+      expect(result).toEqual({
+        input: 42,
+        output: 7,
+        reasoning: 0,
+        cacheRead: 1000,
+        cacheWrite: 500
+      })
+    })
+
+    test('parses Claude statusline context_window.current_usage shape', () => {
+      const result = extractTokens({
+        context_window: {
+          total_input_tokens: 999999,
+          total_output_tokens: 888888,
+          current_usage: {
+            input_tokens: 1200,
+            output_tokens: 150,
+            cache_read_input_tokens: 300,
+            cache_creation_input_tokens: 200
+          }
+        }
+      })
+
+      expect(result).toEqual({
+        input: 1200,
+        output: 150,
+        reasoning: 0,
+        cacheRead: 300,
+        cacheWrite: 200
+      })
+    })
   })
 
   describe('extractCost', () => {
@@ -342,6 +386,19 @@ describe('Session 1: Context Calculation Fix', () => {
 
     test('returns null when model identity is missing', () => {
       expect(extractModelRef({})).toBeNull()
+    })
+
+    test('parses provider/model from info.model string', () => {
+      const result = extractModelRef({
+        info: {
+          model: 'anthropic/claude-sonnet-4-5-20250929'
+        }
+      })
+
+      expect(result).toEqual({
+        providerID: 'anthropic',
+        modelID: 'claude-sonnet-4-5-20250929'
+      })
     })
   })
 })

--- a/test/phase-21/session-5/claude-transcript-reader.test.ts
+++ b/test/phase-21/session-5/claude-transcript-reader.test.ts
@@ -372,5 +372,33 @@ describe('claude-transcript-reader', () => {
       const result = translateEntry(entry, 1) as any
       expect(result.role).toBe('assistant')
     })
+
+    it('preserves assistant usage/request metadata for token hydration', () => {
+      const entry = makeAssistantEntry({
+        requestId: 'req_123',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Done' }],
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_input_tokens: 100,
+            cache_creation_input_tokens: 20
+          },
+          model: 'anthropic/claude-sonnet-4-5-20250929'
+        } as any
+      } as any)
+
+      const result = translateEntry(entry as any, 2) as any
+
+      expect(result.requestId).toBe('req_123')
+      expect(result.usage).toEqual({
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 100,
+        cache_creation_input_tokens: 20
+      })
+      expect(result.model).toBe('anthropic/claude-sonnet-4-5-20250929')
+    })
   })
 })


### PR DESCRIPTION
## Summary

- **Transcript reader**: Extend `translateEntry()` to preserve `requestId`, `usage`, and `model` metadata on assistant JSONL entries, enabling downstream token hydration from Claude Code transcripts
- **Token extraction**: Add `firstFiniteNumber()` helper and broaden `extractTokens()` to handle Claude SDK field naming conventions (`input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, camelCase variants) and the `context_window.current_usage` payload shape
- **Model ref parsing**: Extend `extractModelRef()` to resolve model identity from a `model` object (`providerID`/`modelID`), or by splitting a `"provider/model"` string (e.g. `"anthropic/claude-sonnet-4-5-20250929"`)
- **Tests**: Add 4 new test cases covering raw `*_tokens` fields, `context_window.current_usage` shape, `info.model` string parsing, and assistant usage/request metadata preservation

## Changed files

| File | Change |
|------|--------|
| `src/main/services/claude-transcript-reader.ts` | Preserve `requestId`, `usage`, `model` on translated assistant entries |
| `src/renderer/src/lib/token-utils.ts` | Handle additional token field naming conventions and model ref formats |
| `test/phase-12/session-1/context-calculation.test.ts` | 3 new tests for token extraction and model ref parsing |
| `test/phase-21/session-5/claude-transcript-reader.test.ts` | 1 new test for assistant metadata preservation |

## Test plan

- [ ] Run `pnpm vitest run test/phase-12/session-1/context-calculation.test.ts` — all pass
- [ ] Run `pnpm vitest run test/phase-21/session-5/claude-transcript-reader.test.ts` — all pass
- [ ] Verify context calculation displays correctly for Claude Code sessions in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)