### PR TITLE
Fix QuestionPrompt custom answer display after selection

### DIFF
--- a/src/renderer/src/components/sessions/QuestionPrompt.tsx
+++ b/src/renderer/src/components/sessions/QuestionPrompt.tsx
@@ -119,6 +119,11 @@ export function QuestionPrompt({ request, onReply, onReject }: QuestionPromptPro
   const currentAnswers = answers[currentTab] || []
   const hasCurrentAnswer = currentAnswers.length > 0
 
+  // Detect a custom answer (one not matching any predefined option label)
+  const customAnswer = isCustomAllowed
+    ? currentAnswers.find((a) => !currentQuestion?.options.some((o) => o.label === a))
+    : undefined
+
   // For multi-question: check all questions have at least one answer
   const allAnswered = isMultiQuestion ? answers.every((a) => a.length > 0) : false
 
@@ -213,8 +218,26 @@ export function QuestionPrompt({ request, onReply, onReject }: QuestionPromptPro
             )
           })}
 
-          {/* Custom text option */}
-          {isCustomAllowed && !editingCustom && (
+          {/* Custom answer display (when a custom answer has been entered) */}
+          {isCustomAllowed && !editingCustom && customAnswer && (
+            <button
+              onClick={() => {
+                setEditingCustom(true)
+                handleCustomInputChange(customAnswer)
+              }}
+              disabled={sending}
+              className="w-full text-left px-3 py-2 rounded-md border border-blue-500/50 bg-blue-500/10 transition-colors disabled:opacity-50"
+              data-testid="custom-answer-display"
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <Pencil className="h-3.5 w-3.5 shrink-0 text-blue-400" />
+                <span className="text-sm font-medium truncate">{customAnswer}</span>
+              </div>
+            </button>
+          )}
+
+          {/* Custom text option (when no custom answer yet) */}
+          {isCustomAllowed && !editingCustom && !customAnswer && (
             <button
               onClick={() => setEditingCustom(true)}
               disabled={sending}


### PR DESCRIPTION
## Summary

- **Improved custom answer UX in `QuestionPrompt`**: After a user types and submits a custom answer (the "Other" option), the component now displays the custom answer text as a styled, editable button instead of continuing to show the generic "Other — type your own response" prompt.
- **Added custom answer detection logic**: Computes a `customAnswer` value by finding any selected answer that doesn't match a predefined option label, enabling the component to distinguish between predefined selections and user-typed custom text.
- **Editable custom answer display**: Clicking the displayed custom answer re-opens the text input pre-filled with the existing value, allowing users to revise their custom response. Styled with a blue border/background and a pencil icon for visual clarity.
- **Conditional rendering split**: The original single "Custom text option" block is now split into two mutually exclusive renders — one for when a custom answer exists (shows the answer with edit affordance) and one for when no custom answer has been entered yet (shows the original "Other" prompt).

## Changed files

- `src/renderer/src/components/sessions/QuestionPrompt.tsx` — 25 additions, 2 deletions

## Test plan

- [ ] Open a session with a question prompt that includes the "Other" custom input option
- [ ] Type a custom answer and submit — verify the custom text displays as a styled button with pencil icon
- [ ] Click the displayed custom answer — verify the text input reopens pre-filled with the previous value
- [ ] Edit the custom answer and re-submit — verify the display updates
- [ ] Verify predefined option selection still works normally (no custom answer display shown)
- [ ] Verify multi-select questions with custom answers behave correctly
- [ ] Verify disabled state (sending) dims the custom answer display button

🤖 Generated with [Claude Code](https://claude.com/claude-code)