### PR TITLE
Fix: clear conflict fix flow when conflicts are resolved

### DIFF
--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -133,6 +133,13 @@ export function Header(): React.JSX.Element {
       : null
   )
 
+  // Clear conflict fix flow as soon as conflicts are resolved
+  useEffect(() => {
+    if (!hasConflicts && conflictFixFlow) {
+      setConflictFixFlow(null)
+    }
+  }, [hasConflicts, conflictFixFlow])
+
   useEffect(() => {
     if (!conflictFixFlow || conflictFixFlow.phase !== 'running') return
 


### PR DESCRIPTION
## Summary
- Adds a `useEffect` in `Header.tsx` that automatically resets `conflictFixFlow` state to `null` once merge conflicts are resolved (`hasConflicts` becomes `false`)
- Prevents stale conflict-fix UI (e.g. progress indicators, conflict-related buttons) from persisting after the user has already resolved all merge conflicts
- Placed before the existing conflict-fix polling effect so the cleanup runs first

## Changes
- **`src/renderer/src/components/layout/Header.tsx`** — New `useEffect` hook that watches `hasConflicts` and `conflictFixFlow`, clearing the flow state as soon as conflicts are gone

## Test plan
- [ ] Trigger a merge conflict in a worktree
- [ ] Enter the conflict fix flow in the Header UI
- [ ] Resolve all conflicts externally (e.g. in an editor)
- [ ] Verify the conflict fix flow UI resets automatically without manual dismissal
- [ ] Verify normal (non-conflict) workflows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)