### PR TITLE
feat: add connection color system with sticky tabs in worktree mode

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -150,6 +150,7 @@ export class DatabaseService {
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
         path TEXT NOT NULL,
+        color TEXT DEFAULT NULL,
         status TEXT NOT NULL DEFAULT 'active',
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
@@ -177,6 +178,7 @@ export class DatabaseService {
       'TEXT DEFAULT NULL REFERENCES connections(id) ON DELETE SET NULL'
     )
     this.safeAddColumn('sessions', 'agent_sdk', "TEXT NOT NULL DEFAULT 'opencode'")
+    this.safeAddColumn('connections', 'color', 'TEXT DEFAULT NULL')
 
     db.exec(`
       CREATE INDEX IF NOT EXISTS idx_sessions_connection ON sessions(connection_id);
@@ -924,18 +926,20 @@ export class DatabaseService {
       id: randomUUID(),
       name: data.name,
       path: data.path,
+      color: data.color ?? null,
       status: 'active',
       created_at: now,
       updated_at: now
     }
 
     db.prepare(
-      `INSERT INTO connections (id, name, path, status, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?)`
+      `INSERT INTO connections (id, name, path, color, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
     ).run(
       connection.id,
       connection.name,
       connection.path,
+      connection.color,
       connection.status,
       connection.created_at,
       connection.updated_at
@@ -1009,6 +1013,10 @@ export class DatabaseService {
     if (data.status !== undefined) {
       updates.push('status = ?')
       values.push(data.status)
+    }
+    if (data.color !== undefined) {
+      updates.push('color = ?')
+      values.push(data.color)
     }
 
     values.push(id)

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 3
+export const CURRENT_SCHEMA_VERSION = 4
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -189,5 +189,12 @@ export const MIGRATIONS: Migration[] = [
       DROP TABLE IF EXISTS connection_members;
       DROP TABLE IF EXISTS connections;
     `
+  },
+  {
+    version: 4,
+    name: 'add_connection_color',
+    up: `-- NOTE: ALTER TABLE for color is handled idempotently by
+         -- ensureConnectionTables() in database.ts to avoid "duplicate column" errors.`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -194,11 +194,15 @@ export interface ProjectSpaceAssignment {
   space_id: string
 }
 
+// Connection color quad: [inactiveBg, activeBg, inactiveText, activeText] stored as JSON string
+export type ConnectionColorQuad = [string, string, string, string]
+
 // Connection types
 export interface Connection {
   id: string
   name: string
   path: string
+  color: string | null // JSON-serialised ConnectionColorQuad
   status: 'active' | 'archived'
   created_at: string
   updated_at: string
@@ -207,11 +211,13 @@ export interface Connection {
 export interface ConnectionCreate {
   name: string
   path: string
+  color?: string | null
 }
 
 export interface ConnectionUpdate {
   name?: string
   path?: string
+  color?: string | null
   status?: 'active' | 'archived'
 }
 

--- a/src/main/ipc/connection-handlers.ts
+++ b/src/main/ipc/connection-handlers.ts
@@ -11,7 +11,8 @@ import {
   removeSymlink,
   deleteConnectionDir,
   generateConnectionInstructions,
-  deriveSymlinkName
+  deriveSymlinkName,
+  generateConnectionColor
 } from '../services/connection-service'
 import { getDatabase } from '../db'
 import type { ConnectionWithMembers } from '../db/types'
@@ -62,8 +63,9 @@ export function registerConnectionHandlers(): void {
         const dirName = randomUUID().slice(0, 8)
         const dirPath = createConnectionDir(dirName)
 
-        // Create the DB connection record with placeholder name
-        const connection = db.createConnection({ name: dirName, path: dirPath })
+        // Create the DB connection record with placeholder name and random color
+        const color = generateConnectionColor()
+        const connection = db.createConnection({ name: dirName, path: dirPath, color })
 
         // For each worktree, look up its data, derive symlink name, create symlink + member
         const existingSymlinkNames: string[] = []

--- a/src/main/services/connection-service.ts
+++ b/src/main/services/connection-service.ts
@@ -117,5 +117,108 @@ ${sections.join('\n\n')}
   })
 }
 
+/**
+ * Connection color quad: [inactiveBg, activeBg, inactiveText, activeText]
+ * ~50 visually distinct presets to minimise duplicate chance and guarantee contrast.
+ */
+export type ConnectionColorQuad = [string, string, string, string]
+
+const CONNECTION_COLOR_QUADS: ConnectionColorQuad[] = [
+  // ── Reds ───────────────────────────────────────────────
+  ['#fecaca', '#dc2626', '#991b1b', '#ffffff'], // red light
+  ['#fee2e2', '#ef4444', '#7f1d1d', '#ffffff'], // red medium
+  ['#fca5a5', '#b91c1c', '#450a0a', '#fecaca'], // red deep
+
+  // ── Oranges ────────────────────────────────────────────
+  ['#fed7aa', '#ea580c', '#9a3412', '#ffffff'], // orange light
+  ['#ffedd5', '#f97316', '#7c2d12', '#ffffff'], // orange medium
+  ['#fdba74', '#c2410c', '#431407', '#fed7aa'], // orange deep
+
+  // ── Ambers ─────────────────────────────────────────────
+  ['#fde68a', '#d97706', '#78350f', '#ffffff'], // amber light
+  ['#fef3c7', '#f59e0b', '#713f12', '#ffffff'], // amber medium
+  ['#fcd34d', '#b45309', '#451a03', '#fef3c7'], // amber deep
+
+  // ── Yellows ────────────────────────────────────────────
+  ['#fef08a', '#ca8a04', '#713f12', '#ffffff'], // yellow light
+  ['#fef9c3', '#eab308', '#422006', '#ffffff'], // yellow medium
+
+  // ── Limes ──────────────────────────────────────────────
+  ['#d9f99d', '#65a30d', '#1a2e05', '#ffffff'], // lime light
+  ['#ecfccb', '#84cc16', '#365314', '#ffffff'], // lime medium
+
+  // ── Greens ─────────────────────────────────────────────
+  ['#bbf7d0', '#16a34a', '#14532d', '#ffffff'], // green light
+  ['#dcfce7', '#22c55e', '#166534', '#ffffff'], // green medium
+  ['#86efac', '#15803d', '#052e16', '#dcfce7'], // green deep
+
+  // ── Emeralds ───────────────────────────────────────────
+  ['#a7f3d0', '#059669', '#064e3b', '#ffffff'], // emerald light
+  ['#d1fae5', '#10b981', '#065f46', '#ffffff'], // emerald medium
+  ['#6ee7b7', '#047857', '#022c22', '#d1fae5'], // emerald deep
+
+  // ── Teals ──────────────────────────────────────────────
+  ['#99f6e4', '#0d9488', '#134e4a', '#ffffff'], // teal light
+  ['#ccfbf1', '#14b8a6', '#115e59', '#ffffff'], // teal medium
+  ['#5eead4', '#0f766e', '#042f2e', '#ccfbf1'], // teal deep
+
+  // ── Cyans ──────────────────────────────────────────────
+  ['#a5f3fc', '#0891b2', '#164e63', '#ffffff'], // cyan light
+  ['#cffafe', '#06b6d4', '#155e75', '#ffffff'], // cyan medium
+  ['#67e8f9', '#0e7490', '#083344', '#cffafe'], // cyan deep
+
+  // ── Skys ───────────────────────────────────────────────
+  ['#bae6fd', '#0284c7', '#0c4a6e', '#ffffff'], // sky light
+  ['#e0f2fe', '#0ea5e9', '#075985', '#ffffff'], // sky medium
+
+  // ── Blues ───────────────────────────────────────────────
+  ['#bfdbfe', '#2563eb', '#1e3a5f', '#ffffff'], // blue light
+  ['#dbeafe', '#3b82f6', '#1e40af', '#ffffff'], // blue medium
+  ['#93c5fd', '#1d4ed8', '#172554', '#dbeafe'], // blue deep
+
+  // ── Indigos ────────────────────────────────────────────
+  ['#c7d2fe', '#4f46e5', '#312e81', '#ffffff'], // indigo light
+  ['#e0e7ff', '#6366f1', '#3730a3', '#ffffff'], // indigo medium
+  ['#a5b4fc', '#4338ca', '#1e1b4b', '#e0e7ff'], // indigo deep
+
+  // ── Violets ────────────────────────────────────────────
+  ['#ddd6fe', '#7c3aed', '#4c1d95', '#ffffff'], // violet light
+  ['#ede9fe', '#8b5cf6', '#5b21b6', '#ffffff'], // violet medium
+  ['#c4b5fd', '#6d28d9', '#2e1065', '#ede9fe'], // violet deep
+
+  // ── Purples ────────────────────────────────────────────
+  ['#e9d5ff', '#9333ea', '#581c87', '#ffffff'], // purple light
+  ['#f3e8ff', '#a855f7', '#6b21a8', '#ffffff'], // purple medium
+  ['#d8b4fe', '#7e22ce', '#3b0764', '#f3e8ff'], // purple deep
+
+  // ── Fuchsias ───────────────────────────────────────────
+  ['#f5d0fe', '#c026d3', '#701a75', '#ffffff'], // fuchsia light
+  ['#fae8ff', '#d946ef', '#86198f', '#ffffff'], // fuchsia medium
+  ['#e879f9', '#a21caf', '#4a044e', '#fae8ff'], // fuchsia deep
+
+  // ── Pinks ──────────────────────────────────────────────
+  ['#fbcfe8', '#db2777', '#831843', '#ffffff'], // pink light
+  ['#fce7f3', '#ec4899', '#9d174d', '#ffffff'], // pink medium
+  ['#f9a8d4', '#be185d', '#500724', '#fce7f3'], // pink deep
+
+  // ── Roses ──────────────────────────────────────────────
+  ['#fecdd3', '#e11d48', '#881337', '#ffffff'], // rose light
+  ['#ffe4e6', '#f43f5e', '#9f1239', '#ffffff'], // rose medium
+  ['#fda4af', '#be123c', '#4c0519', '#ffe4e6'], // rose deep
+
+  // ── Slates (neutral) ──────────────────────────────────
+  ['#cbd5e1', '#475569', '#0f172a', '#ffffff'], // slate light
+  ['#e2e8f0', '#64748b', '#1e293b', '#ffffff'], // slate medium
+
+  // ── Stones (warm neutral) ─────────────────────────────
+  ['#d6d3d1', '#57534e', '#1c1917', '#ffffff'], // stone light
+  ['#e7e5e4', '#78716c', '#292524', '#ffffff']  // stone medium
+]
+
+export function generateConnectionColor(): string {
+  const quad = CONNECTION_COLOR_QUADS[Math.floor(Math.random() * CONNECTION_COLOR_QUADS.length)]
+  return JSON.stringify(quad)
+}
+
 /** @deprecated Use generateConnectionInstructions instead */
 export const generateAgentsMd = generateConnectionInstructions

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -4,6 +4,7 @@ interface Connection {
   name: string
   status: 'active' | 'archived'
   path: string
+  color: string | null // JSON-serialised ConnectionColorQuad
   created_at: string
   updated_at: string
 }

--- a/src/renderer/src/components/connections/ConnectionItem.tsx
+++ b/src/renderer/src/components/connections/ConnectionItem.tsx
@@ -12,7 +12,7 @@ import {
   Terminal,
   Trash2
 } from 'lucide-react'
-import { cn } from '@/lib/utils'
+import { cn, parseColorQuad } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import {
   ContextMenu,
@@ -50,6 +50,7 @@ interface Connection {
   name: string
   status: 'active' | 'archived'
   path: string
+  color: string | null
   created_at: string
   updated_at: string
   members: ConnectionMemberEnriched[]
@@ -204,7 +205,18 @@ export function ConnectionItem({
           onClick={handleClick}
           data-testid={`connection-item-${connection.id}`}
         >
-          {/* Status icon */}
+          {/* Connection color indicator — always visible */}
+          {connection.color ? (
+            <span
+              className="h-2.5 w-2.5 rounded-full flex-shrink-0"
+              style={{ backgroundColor: parseColorQuad(connection.color)[1] }}
+              aria-hidden="true"
+            />
+          ) : (
+            <Link className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          )}
+
+          {/* Status icon (shown alongside color) */}
           {(connectionStatus === 'working' || connectionStatus === 'planning') && (
             <Loader2 className="h-3.5 w-3.5 text-primary shrink-0 animate-spin" />
           )}
@@ -214,13 +226,6 @@ export function ConnectionItem({
           {connectionStatus === 'plan_ready' && (
             <Map className="h-3.5 w-3.5 text-blue-400 shrink-0" />
           )}
-          {connectionStatus !== 'working' &&
-            connectionStatus !== 'planning' &&
-            connectionStatus !== 'answering' &&
-            connectionStatus !== 'permission' &&
-            connectionStatus !== 'plan_ready' && (
-              <Link className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-            )}
 
           {/* Name and status */}
           <div className="flex-1 min-w-0">

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -17,6 +17,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const selectedConnectionId = useConnectionStore((state) => state.selectedConnectionId)
   const activeSessionId = useSessionStore((state) => state.activeSessionId)
   const isLoading = useSessionStore((state) => state.isLoading)
+  const inlineConnectionSessionId = useSessionStore((state) => state.inlineConnectionSessionId)
   const activeFilePath = useFileViewerStore((state) => state.activeFilePath)
   const activeDiff = useFileViewerStore((state) => state.activeDiff)
 
@@ -77,6 +78,11 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     // File viewer tab is active - render FileViewer (skip diff tab keys)
     if (activeFilePath && !activeFilePath.startsWith('diff:')) {
       return <FileViewer filePath={activeFilePath} />
+    }
+
+    // Inline connection session view (sticky tab clicked in worktree mode)
+    if (inlineConnectionSessionId) {
+      return <SessionView key={inlineConnectionSessionId} sessionId={inlineConnectionSessionId} />
     }
 
     // Worktree or connection selected but no session - show create session prompt

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -4,3 +4,30 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs))
 }
+
+/** Default color quad when connection has no color: gray */
+const DEFAULT_COLOR_QUAD: ConnectionColorQuad = ['#e5e7eb', '#6b7280', '#374151', '#ffffff']
+
+/**
+ * Parse a connection's `color` field (JSON string) into a quad.
+ * Returns a safe gray default if null or malformed.
+ */
+export function parseColorQuad(color: string | null): ConnectionColorQuad {
+  if (!color) return DEFAULT_COLOR_QUAD
+  try {
+    const parsed = JSON.parse(color)
+    if (Array.isArray(parsed) && parsed.length === 4 && parsed.every((c) => typeof c === 'string')) {
+      return parsed as ConnectionColorQuad
+    }
+    // Legacy single-color string (e.g. "#3b82f6") — treat as activeBg with white text
+    if (typeof color === 'string' && color.startsWith('#') && !color.startsWith('[')) {
+      return [`${color}33`, color, '#1f2937', '#ffffff']
+    }
+  } catch {
+    // Legacy single-color string fallback
+    if (typeof color === 'string' && color.startsWith('#')) {
+      return [`${color}33`, color, '#1f2937', '#ffffff']
+    }
+  }
+  return DEFAULT_COLOR_QUAD
+}

--- a/src/renderer/src/stores/useConnectionStore.ts
+++ b/src/renderer/src/stores/useConnectionStore.ts
@@ -22,6 +22,7 @@ interface Connection {
   name: string
   status: 'active' | 'archived'
   path: string
+  color: string | null
   created_at: string
   updated_at: string
   members: ConnectionMemberEnriched[]

--- a/test/worktree-connection/session-3/connection-handlers.test.ts
+++ b/test/worktree-connection/session-3/connection-handlers.test.ts
@@ -52,6 +52,8 @@ const mockConnectionService = vi.hoisted(() => ({
   removeSymlink: vi.fn(),
   deleteConnectionDir: vi.fn(),
   generateAgentsMd: vi.fn(),
+  generateConnectionInstructions: vi.fn(),
+  generateConnectionColor: vi.fn(() => JSON.stringify(['#bfdbfe', '#2563eb', '#1e3a5f', '#ffffff'])),
   deriveSymlinkName: vi.fn((name: string) => name.toLowerCase().replace(/[^a-z0-9-]/g, '-')),
   renameConnectionDir: vi.fn(),
   getConnectionsBaseDir: vi.fn(() => '/mock/.hive/connections')
@@ -133,6 +135,7 @@ function makeConnection(overrides: Record<string, unknown> = {}) {
     id: 'conn-1',
     name: 'golden-retriever',
     path: '/mock/.hive/connections/golden-retriever',
+    color: JSON.stringify(['#bfdbfe', '#2563eb', '#1e3a5f', '#ffffff']),
     status: 'active',
     created_at: '2025-01-01T00:00:00.000Z',
     updated_at: '2025-01-01T00:00:00.000Z',

--- a/test/worktree-connection/session-5/connection-store.test.ts
+++ b/test/worktree-connection/session-5/connection-store.test.ts
@@ -64,6 +64,7 @@ function makeConnection(overrides: Record<string, unknown> = {}) {
     name: 'golden-retriever',
     status: 'active' as const,
     path: '/home/.hive/connections/golden-retriever',
+    color: JSON.stringify(['#bfdbfe', '#2563eb', '#1e3a5f', '#ffffff']),
     created_at: '2025-01-01T00:00:00.000Z',
     updated_at: '2025-01-01T00:00:00.000Z',
     members: [

--- a/test/worktree-connection/session-6/session-store-connections.test.ts
+++ b/test/worktree-connection/session-6/session-store-connections.test.ts
@@ -131,6 +131,7 @@ function makeConnection() {
     name: 'golden-retriever',
     status: 'active' as const,
     path: '/home/.hive/connections/golden-retriever',
+    color: JSON.stringify(['#bfdbfe', '#2563eb', '#1e3a5f', '#ffffff']),
     created_at: '2025-01-01T00:00:00.000Z',
     updated_at: '2025-01-01T00:00:00.000Z',
     members: [

--- a/test/worktree-connection/session-7/connect-dialog.test.tsx
+++ b/test/worktree-connection/session-7/connect-dialog.test.tsx
@@ -114,6 +114,7 @@ function makeConnection(overrides: Record<string, unknown> = {}) {
     name: 'golden-retriever',
     status: 'active' as const,
     path: '/home/.hive/connections/golden-retriever',
+    color: JSON.stringify(['#bfdbfe', '#2563eb', '#1e3a5f', '#ffffff']),
     created_at: '2025-01-01T00:00:00.000Z',
     updated_at: '2025-01-01T00:00:00.000Z',
     members: [

--- a/test/worktree-connection/session-8/sidebar-connections.test.tsx
+++ b/test/worktree-connection/session-8/sidebar-connections.test.tsx
@@ -87,6 +87,7 @@ function makeConnection(overrides: Record<string, unknown> = {}) {
     name: 'golden-retriever',
     status: 'active' as const,
     path: '/home/.hive/connections/golden-retriever',
+    color: JSON.stringify(['#bfdbfe', '#2563eb', '#1e3a5f', '#ffffff']),
     created_at: '2025-01-01T00:00:00.000Z',
     updated_at: '2025-01-01T00:00:00.000Z',
     members: [

--- a/test/worktree-connection/session-9/session-view-connections.test.tsx
+++ b/test/worktree-connection/session-9/session-view-connections.test.tsx
@@ -69,6 +69,7 @@ const mockConnectionOps = {
       id: 'conn-1',
       name: 'golden-retriever',
       path: '/home/.hive/connections/golden-retriever',
+      color: JSON.stringify(['#bfdbfe', '#2563eb', '#1e3a5f', '#ffffff']),
       status: 'active',
       created_at: '2025-01-01T00:00:00.000Z',
       updated_at: '2025-01-01T00:00:00.000Z',


### PR DESCRIPTION
## Summary

- **Connection color property**: Adds a `color` column to the `connections` table (schema v4 migration) storing a JSON-serialized quad `[inactiveBg, activeBg, inactiveText, activeText]`. ~50 visually distinct color presets are randomly assigned on connection creation via `generateConnectionColor()`.
- **Color indicator in sidebar**: `ConnectionItem` now shows a colored dot (using the quad's `activeBg`) next to each connection, replacing the generic link icon for the idle state.
- **Sticky connection session tabs in worktree mode**: When viewing a worktree that belongs to one or more connections, `SessionTabs` renders non-closable, color-styled "sticky" tabs for those connection sessions — enabling cross-connection session visibility without switching context. Clicking a sticky tab sets `inlineConnectionSessionId` in the session store, which `MainPane` renders as an inline `SessionView`.
- **`parseColorQuad` utility**: New renderer utility in `lib/utils.ts` that safely parses the JSON color string with fallback to a neutral gray default and legacy single-color string support.
- **Session store additions**: `inlineConnectionSessionId` state, `setInlineConnectionSession` / `clearInlineConnectionSession` actions, and `loadConnectionSessionsBackground()` to pre-load connection sessions without entering connection mode.
- **Full-stack type updates**: `Connection` type updated in `db/types.ts`, `preload/index.d.ts`, and `useConnectionStore.ts` to include the `color` field. `ConnectionCreate` and `ConnectionUpdate` support optional color.
- **Test updates**: All 6 affected test suites updated with `color` field in mock connection factories.

## Test plan

- [ ] Create a new connection and verify it gets a random color dot in the sidebar
- [ ] Verify the color dot displays correctly for existing connections (null color → gray fallback)
- [ ] Switch to a worktree that belongs to a connection — sticky colored tabs should appear in the tab bar
- [ ] Click a sticky connection tab — the session view should render inline without leaving worktree mode
- [ ] Click a regular worktree session tab — inline connection session should clear
- [ ] Switch worktrees — sticky tabs should update to reflect the new worktree's connections
- [ ] Run `pnpm test` — all existing and updated tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)