### PR TITLE
Update modification time for connection sessions

### DIFF
--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -34,6 +34,7 @@ import { useQuestionStore } from '@/stores/useQuestionStore'
 import { usePermissionStore } from '@/stores/usePermissionStore'
 import { usePromptHistoryStore } from '@/stores/usePromptHistoryStore'
 import { useWorktreeStore } from '@/stores'
+import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useFileTreeStore } from '@/stores/useFileTreeStore'
 import { mapOpencodeMessagesToSessionViewMessages } from '@/lib/opencode-transcript'
 import { COMPLETION_WORDS, formatCompletionDuration } from '@/lib/format-utils'
@@ -2603,6 +2604,17 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         }
         if (worktreeId) {
           useWorktreeStatusStore.getState().setLastMessageTime(worktreeId, Date.now())
+        } else if (connectionId) {
+          // Connection session — update all member worktrees
+          const connection = useConnectionStore
+            .getState()
+            .connections.find((c) => c.id === connectionId)
+          if (connection) {
+            const now = Date.now()
+            for (const member of connection.members) {
+              useWorktreeStatusStore.getState().setLastMessageTime(member.worktree_id, now)
+            }
+          }
         }
         setHistoryIndex(null)
         savedDraftRef.current = ''


### PR DESCRIPTION
## Summary

- **Connection session support for last-message timestamps**: When a session belongs to a connection (multi-worktree), the last message time is now updated for **all member worktrees** in the connection, not just a single worktree.
- **SessionView.tsx**: After sending a message in a connection session, iterates over all connection members and calls `setLastMessageTime` for each member's worktree.
- **useOpenCodeGlobalListener.ts**: When a background session completes, checks if the session belongs to a connection (via `sessionsByConnection`). If so, updates the last message time for all member worktrees in that connection. Falls back from worktree-based lookup to connection-based lookup to cover both cases.

These changes ensure that activity in a connection session is properly reflected across all worktrees that are part of that connection, keeping the sidebar modification indicators accurate.

## Test plan

- [ ] Open a connection session that spans multiple worktrees
- [ ] Send a message and verify all member worktrees show updated modification time in the sidebar
- [ ] Verify background session completion also updates all member worktree timestamps
- [ ] Verify regular (non-connection) worktree sessions still update their modification time correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)