### PR TITLE
Fix auto-update toast z-index by repositioning to bottom-left

### DIFF
--- a/src/renderer/src/components/ui/sonner.tsx
+++ b/src/renderer/src/components/ui/sonner.tsx
@@ -3,6 +3,7 @@ import { Toaster as Sonner, type ToasterProps } from 'sonner'
 function Toaster({ ...props }: ToasterProps) {
   return (
     <Sonner
+      position="bottom-left"
       theme="dark"
       className="toaster group"
       toastOptions={{


### PR DESCRIPTION
## Summary

- **Fix auto-update toast visibility**: Repositioned the Sonner toast notification from the default position to `bottom-left` to resolve a z-index issue where auto-update toasts were being obscured by other UI elements.

## Changes

- `src/renderer/src/components/ui/sonner.tsx`: Added `position="bottom-left"` prop to the `<Sonner>` `<Toaster>` component, ensuring update notifications are visible and not blocked by overlapping UI layers.

## Test plan

- [ ] Trigger an auto-update toast notification and verify it appears at the bottom-left of the window
- [ ] Confirm the toast is fully visible and not hidden behind any other UI elements (sidebars, panels, modals)
- [ ] Verify other toast notifications (e.g., error messages, success confirmations) also render correctly at the new position

🤖 Generated with [Claude Code](https://claude.com/claude-code)