### PR TITLE
Add Recent Activity panel to left sidebar

### DIFF
--- a/src/renderer/src/components/file-tree/ChangesView.tsx
+++ b/src/renderer/src/components/file-tree/ChangesView.tsx
@@ -500,6 +500,7 @@ export function ChangesView({
                   key={`conflict-${file.relativePath}`}
                   file={file}
                   onViewDiff={handleViewDiff}
+                  onStageToggle={handleStageFile}
                   contextMenu={
                     <ContextMenuContent>
                       <ContextMenuItem onClick={() => handleStageFile(file)}>
@@ -544,6 +545,7 @@ export function ChangesView({
                   key={`staged-${file.relativePath}`}
                   file={file}
                   onViewDiff={handleViewDiff}
+                  onStageToggle={handleUnstageFile}
                   contextMenu={
                     <ContextMenuContent>
                       <ContextMenuItem onClick={() => handleUnstageFile(file)}>
@@ -588,6 +590,7 @@ export function ChangesView({
                   key={`modified-${file.relativePath}`}
                   file={file}
                   onViewDiff={handleViewDiff}
+                  onStageToggle={handleStageFile}
                   contextMenu={
                     <ContextMenuContent>
                       <ContextMenuItem onClick={() => handleStageFile(file)}>
@@ -627,6 +630,7 @@ export function ChangesView({
                   key={`untracked-${file.relativePath}`}
                   file={file}
                   onViewDiff={handleViewDiff}
+                  onStageToggle={handleStageFile}
                   contextMenu={
                     <ContextMenuContent>
                       <ContextMenuItem onClick={() => handleStageFile(file)}>
@@ -764,12 +768,14 @@ interface FileRowProps {
   file: GitFileStatus
   onViewDiff: (file: GitFileStatus) => void
   contextMenu: React.ReactNode
+  onStageToggle?: (file: GitFileStatus) => void
 }
 
 const FileRow = memo(function FileRow({
   file,
   onViewDiff,
-  contextMenu
+  contextMenu,
+  onStageToggle
 }: FileRowProps): React.JSX.Element {
   const fileName = file.relativePath.split('/').pop() || file.relativePath
   const ext = fileName.includes('.') ? '.' + fileName.split('.').pop() : null
@@ -782,7 +788,37 @@ const FileRow = memo(function FileRow({
           onClick={() => onViewDiff(file)}
           data-testid={`changes-file-${file.relativePath}`}
         >
-          <FileIcon name={fileName} extension={ext} isDirectory={false} className="h-3.5 w-3.5" />
+          {onStageToggle ? (
+            <div className="relative h-3.5 w-3.5 flex-shrink-0">
+              <FileIcon
+                name={fileName}
+                extension={ext}
+                isDirectory={false}
+                className="h-3.5 w-3.5 group-hover:invisible"
+              />
+              <button
+                className="absolute inset-0 hidden group-hover:flex items-center justify-center text-muted-foreground hover:text-foreground"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onStageToggle(file)
+                }}
+                title={file.staged ? 'Unstage' : 'Stage'}
+              >
+                {file.staged ? (
+                  <Minus className="h-3.5 w-3.5" />
+                ) : (
+                  <Plus className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </div>
+          ) : (
+            <FileIcon
+              name={fileName}
+              extension={ext}
+              isDirectory={false}
+              className="h-3.5 w-3.5"
+            />
+          )}
           <span className="text-xs truncate flex-1" title={file.relativePath}>
             {file.relativePath}
           </span>
@@ -846,6 +882,20 @@ const MemberChanges = memo(function MemberChanges({
 
   const wp = member.worktree_path
 
+  const handleStageToggle = useCallback(
+    (file: GitFileStatus) => {
+      onStageFile(wp, file.relativePath)
+    },
+    [onStageFile, wp]
+  )
+
+  const handleUnstageToggle = useCallback(
+    (file: GitFileStatus) => {
+      onUnstageFile(wp, file.relativePath)
+    },
+    [onUnstageFile, wp]
+  )
+
   return (
     <div className="pl-3 pb-1">
       {/* Staged */}
@@ -873,6 +923,7 @@ const MemberChanges = memo(function MemberChanges({
               key={`staged-${file.relativePath}`}
               file={file}
               onViewDiff={handleViewDiff}
+              onStageToggle={handleUnstageToggle}
               contextMenu={
                 <ContextMenuContent>
                   <ContextMenuItem onClick={() => onUnstageFile(wp, file.relativePath)}>
@@ -911,6 +962,7 @@ const MemberChanges = memo(function MemberChanges({
               key={`modified-${file.relativePath}`}
               file={file}
               onViewDiff={handleViewDiff}
+              onStageToggle={handleStageToggle}
               contextMenu={
                 <ContextMenuContent>
                   <ContextMenuItem onClick={() => onStageFile(wp, file.relativePath)}>
@@ -945,6 +997,7 @@ const MemberChanges = memo(function MemberChanges({
               key={`untracked-${file.relativePath}`}
               file={file}
               onViewDiff={handleViewDiff}
+              onStageToggle={handleStageToggle}
               contextMenu={
                 <ContextMenuContent>
                   <ContextMenuItem onClick={() => onStageFile(wp, file.relativePath)}>


### PR DESCRIPTION
## Summary

- **New "Recent" section** in the left sidebar that shows worktrees and connections with AI activity in the last hour, sorted by most recent first
- **RecentList component** (`src/renderer/src/components/layout/RecentList.tsx`) — displays recently active worktrees (with branch name, model icon, and live status) and connections (with color dot, status icons, and member project names), including unread indicators
- **RecentToggleButton** (`src/renderer/src/components/projects/RecentToggleButton.tsx`) — toggle button (⚡ icon) in the Projects header to show/hide the Recent panel, with visibility persisted to localStorage
- **useRecentStore** (`src/renderer/src/stores/useRecentStore.ts`) — Zustand store managing recent worktree/connection ID sets, toggle state, and population logic; queries the DB on toggle-on and auto-populates on mount via a `useEffect` in RecentList
- **New DB query** `getRecentlyActiveWorktrees(cutoffMs)` in `database.ts` — fetches active worktrees with `last_message_at` newer than a cutoff timestamp, enabling discovery of recent activity across all projects (including collapsed ones)
- **New IPC channel** `db:worktree:getRecentlyActive` wired through `database-handlers.ts` → `preload/index.ts` → `preload/index.d.ts`
- **Live tracking in useOpenCodeGlobalListener** — session events (status changes and new messages) now call `addWorktreeToRecent` / `addConnectionToRecent` so the Recent panel stays fresh in real-time without polling
- **Connection type update** — added `custom_name` field to the `Connection` interface in `preload/index.d.ts`
- **Version bump** from 1.0.29 → 1.0.30

## Test plan

- [ ] Toggle the Recent panel on/off via the ⚡ button in the Projects header — verify visibility persists across app restarts (localStorage)
- [ ] With the panel visible, verify worktrees with AI activity in the last hour appear sorted by most recent
- [ ] Start an AI session in a worktree — verify it appears in the Recent list in real-time with correct status (Working/Planning/Ready)
- [ ] Verify connections with recent session activity also appear with correct display name and status
- [ ] Click a recent worktree item — verify it selects the worktree, expands the parent project, and clears unread status
- [ ] Click a recent connection item — verify it selects the connection
- [ ] Verify unread dots appear for worktrees/connections with unread messages
- [ ] Toggle Recent off — verify the list clears and disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)