### PR TITLE
Add 'Install hive-server' command to command palette

### DIFF
--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -389,6 +389,9 @@ declare global {
         canRedo?: boolean
       }) => Promise<void>
       onMenuAction: (channel: string, callback: () => void) => () => void
+      isPackaged: () => Promise<boolean>
+      installServerToPath: () => Promise<{ success: boolean; path?: string; error?: string }>
+      uninstallServerFromPath: () => Promise<{ success: boolean; error?: string }>
     }
     loggingOps: {
       createResponseLog: (sessionId: string) => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -467,7 +467,18 @@ const systemOps = {
     return () => {
       ipcRenderer.removeListener(channel, handler)
     }
-  }
+  },
+
+  // Check if the app is running in packaged mode (not dev)
+  isPackaged: (): Promise<boolean> => ipcRenderer.invoke('system:isPackaged'),
+
+  // Install hive-server CLI wrapper to /usr/local/bin (requires admin elevation)
+  installServerToPath: (): Promise<{ success: boolean; path?: string; error?: string }> =>
+    ipcRenderer.invoke('system:installServerToPath'),
+
+  // Uninstall hive-server CLI from /usr/local/bin (requires admin elevation)
+  uninstallServerFromPath: (): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('system:uninstallServerFromPath')
 }
 
 // Response logging operations API (only functional when --log is active)


### PR DESCRIPTION
## Summary

Adds the ability to install and uninstall the `hive-server` CLI wrapper directly from the command palette (⌘P), enabling users to launch Hive in headless mode from their terminal.

- **New IPC handlers** in the main process (`system:isPackaged`, `system:installServerToPath`, `system:uninstallServerFromPath`) that manage a shell wrapper script at `/usr/local/bin/hive-server`
- **Preload bridge** exposes all three new channels to the renderer via `window.systemOps`
- **Type declarations** added to `index.d.ts` for full type safety across processes
- **Two new command palette commands**: "Install 'hive-server' Command in PATH" and "Uninstall 'hive-server' Command from PATH", only visible when the app is running in packaged mode (not dev)

## Details

### Install flow
1. Writes a bash wrapper script to a temp file that executes the packaged Electron binary with `--headless` and passes through all arguments
2. Uses macOS `osascript` with `administrator privileges` to move the script to `/usr/local/bin/hive-server` and set it executable — prompts the user for admin credentials via the native macOS dialog
3. Shows a toast on success or failure (including user cancellation)

### Uninstall flow
1. Checks if `/usr/local/bin/hive-server` exists
2. Uses the same `osascript` elevation pattern to remove the file
3. Shows appropriate toast feedback

### Visibility
- Both commands are gated behind `isPackaged` — they only appear in the command palette when running from a production build, not during development

## Files changed

| File | Changes |
|------|---------|
| `src/main/index.ts` | Added `system:isPackaged`, `system:installServerToPath`, and `system:uninstallServerFromPath` IPC handlers |
| `src/preload/index.ts` | Exposed new IPC channels via `systemOps` |
| `src/preload/index.d.ts` | Added type declarations for the three new `systemOps` methods |
| `src/renderer/src/hooks/useCommands.ts` | Added install/uninstall server commands with `isPackaged` visibility gate |

## Test plan

- [ ] Verify commands do **not** appear in command palette during dev mode (`pnpm dev`)
- [ ] Build packaged app and verify both commands appear in ⌘P
- [ ] Test install — confirm admin prompt appears, script is written to `/usr/local/bin/hive-server`
- [ ] Test `hive-server` from terminal launches the app in headless mode
- [ ] Test uninstall — confirm `/usr/local/bin/hive-server` is removed
- [ ] Test cancelling the admin dialog shows appropriate toast message
- [ ] Run `pnpm lint` and `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)