### PR TITLE
fix: simplify Claude effort variants and remove max effort level

### DIFF
--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -15,29 +15,28 @@ import { Options, PermissionMode } from '@anthropic-ai/claude-agent-sdk'
 
 const log = createLogger({ component: 'ClaudeCodeImplementer' })
 
-const CLAUDE_EFFORT_VARIANTS_FULL = { low: {}, medium: {}, high: {}, max: {} }
-const CLAUDE_EFFORT_VARIANTS_STANDARD = { low: {}, medium: {}, high: {} }
+const CLAUDE_EFFORT_VARIANTS = { low: {}, medium: {}, high: {} }
 
 const CLAUDE_MODELS = [
   {
     id: 'opus',
     name: 'Opus 4.6',
     limit: { context: 200000, output: 32000 },
-    variants: CLAUDE_EFFORT_VARIANTS_FULL,
-    defaultVariant: 'max'
+    variants: CLAUDE_EFFORT_VARIANTS,
+    defaultVariant: 'high'
   },
   {
     id: 'sonnet',
     name: 'Sonnet 4.6',
     limit: { context: 200000, output: 16000 },
-    variants: CLAUDE_EFFORT_VARIANTS_STANDARD,
+    variants: CLAUDE_EFFORT_VARIANTS,
     defaultVariant: 'high'
   },
   {
     id: 'haiku',
     name: 'Haiku 4.5',
     limit: { context: 200000, output: 8192 },
-    variants: CLAUDE_EFFORT_VARIANTS_STANDARD,
+    variants: CLAUDE_EFFORT_VARIANTS,
     defaultVariant: 'high'
   }
 ]


### PR DESCRIPTION
## Summary

- **Consolidated effort variant configs**: Merged `CLAUDE_EFFORT_VARIANTS_FULL` (low/medium/high/max) and `CLAUDE_EFFORT_VARIANTS_STANDARD` (low/medium/high) into a single unified `CLAUDE_EFFORT_VARIANTS` constant with three levels: low, medium, and high
- **Standardized Opus default**: Changed the Opus 4.6 model's default variant from `max` to `high`, making it consistent with Sonnet 4.6 and Haiku 4.5
- **Removed `max` effort level**: The `max` effort tier is no longer available as a variant for any model, simplifying the effort configuration across the board

## Motivation

The `max` effort variant was only available on Opus and created an inconsistency across model configurations. By removing it and unifying the variant definitions, the code is simpler, more maintainable, and all models now share the same effort levels and default behavior.

## Test plan

- [ ] Verify Opus model sessions start with `high` effort (previously `max`)
- [ ] Verify Sonnet and Haiku models are unaffected (already defaulted to `high`)
- [ ] Confirm effort level selector in the UI only shows low/medium/high options for all models
- [ ] Test switching between models to ensure effort variants update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)