### PR TITLE
Add right-click context menu on plus button for provider selection

### DIFF
--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -512,6 +512,8 @@ export function SessionTabs(): React.JSX.Element | null {
   // Auto-start runs as a direct follow-up to loadSessions (not a separate effect) to
   // eliminate race conditions between the two async operations.
   const autoStartSession = useSettingsStore((state) => state.autoStartSession)
+  const availableAgentSdks = useSettingsStore((state) => state.availableAgentSdks)
+  const showProviderMenu = availableAgentSdks?.opencode && availableAgentSdks?.claude
   const autoStartedRef = useRef<string | null>(null)
 
   useEffect(() => {
@@ -663,6 +665,24 @@ export function SessionTabs(): React.JSX.Element | null {
     }
   }
 
+  // Handle creating a new session with a specific agent SDK (from context menu)
+  const handleCreateSessionWithSdk = async (sdk: 'opencode' | 'claude-code') => {
+    if (isConnectionMode && selectedConnectionId) {
+      const result = await createConnectionSession(selectedConnectionId, sdk)
+      if (!result.success) {
+        toast.error(result.error || 'Failed to create session')
+      }
+      return
+    }
+
+    if (!selectedWorktreeId || !project) return
+
+    const result = await createSession(selectedWorktreeId, project.id, sdk)
+    if (!result.success) {
+      toast.error(result.error || 'Failed to create session')
+    }
+  }
+
   // Handle closing a session
   const handleCloseSession = async (e: React.MouseEvent, sessionId: string) => {
     e.stopPropagation()
@@ -808,14 +828,38 @@ export function SessionTabs(): React.JSX.Element | null {
       data-testid="session-tabs"
     >
       {/* New session button - on the left */}
-      <button
-        onClick={handleCreateSession}
-        className="p-1.5 hover:bg-accent transition-colors shrink-0 border-r border-border"
-        data-testid="create-session"
-        title="Create new session"
-      >
-        <Plus className="h-4 w-4" />
-      </button>
+      {/* Right-click shows provider menu when both SDKs are available */}
+      {showProviderMenu ? (
+        <ContextMenu>
+          <ContextMenuTrigger asChild>
+            <button
+              onClick={handleCreateSession}
+              className="p-1.5 hover:bg-accent transition-colors shrink-0 border-r border-border"
+              data-testid="create-session"
+              title="Create new session (right-click for provider options)"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('opencode')}>
+              New OpenCode Session
+            </ContextMenuItem>
+            <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('claude-code')}>
+              New Claude Code Session
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      ) : (
+        <button
+          onClick={handleCreateSession}
+          className="p-1.5 hover:bg-accent transition-colors shrink-0 border-r border-border"
+          data-testid="create-session"
+          title="Create new session"
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      )}
 
       {/* Left scroll arrow */}
       {showLeftArrow && (


### PR DESCRIPTION
## Summary

- **Right-click provider selection on the "+" button**: When both OpenCode and Claude Code SDKs are detected as available, right-clicking the new session button reveals a context menu letting users explicitly choose which agent SDK to use for the new session. Left-click continues to use the default SDK as before.
- **Agent SDK override support in session creation**: `createSession` and `createConnectionSession` in the session store now accept an optional `agentSdkOverride` parameter, allowing callers to bypass the default SDK setting and create a session with a specific provider.
- **SDK availability detection on startup**: The settings store gains `availableAgentSdks` state and a `detectAvailableAgentSdks()` action that calls `window.systemOps.detectAgentSdks()` after settings load. The context menu only renders when both SDKs are present, so single-SDK setups see no UI change.

## Changed Files

| File | Change |
|------|--------|
| `src/renderer/src/components/sessions/SessionTabs.tsx` | Wrap "+" button in `<ContextMenu>` when both SDKs available; add `handleCreateSessionWithSdk` handler |
| `src/renderer/src/stores/useSessionStore.ts` | Add `agentSdkOverride` param to `createSession` and `createConnectionSession` |
| `src/renderer/src/stores/useSettingsStore.ts` | Add `availableAgentSdks` state, `detectAvailableAgentSdks` action, and startup detection |

## Test plan

- [ ] With both OpenCode and Claude Code installed: right-click the "+" button → context menu shows "New OpenCode Session" and "New Claude Code Session"
- [ ] Select each option → session is created with the correct agent SDK
- [ ] Left-click the "+" button still creates a session with the default SDK
- [ ] With only one SDK installed: no context menu appears; "+" button works as before
- [ ] Connection mode: right-click provider selection works for connection sessions too

🤖 Generated with [Claude Code](https://claude.com/claude-code)