### PR TITLE
feat: command filter system for Claude tool use approval

### DIFF
--- a/src/main/services/command-filter-service.ts
+++ b/src/main/services/command-filter-service.ts
@@ -1,0 +1,276 @@
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'CommandFilterService' })
+
+export interface CommandFilterSettings {
+  allowlist: string[]
+  blocklist: string[]
+  defaultBehavior: 'ask' | 'allow' | 'block'
+  enabled: boolean
+}
+
+/**
+ * Service for evaluating tool uses against allowlist/blocklist patterns
+ * with wildcard support (* and **)
+ */
+export class CommandFilterService {
+  /**
+   * Evaluate a tool use and determine if it should be allowed, blocked, or require approval
+   */
+  evaluateToolUse(
+    toolName: string,
+    input: Record<string, unknown>,
+    settings: CommandFilterSettings
+  ): 'allow' | 'block' | 'ask' {
+    if (!settings.enabled) {
+      return 'allow'
+    }
+
+    const commandStr = this.formatCommandString(toolName, input)
+
+    log.info('CommandFilter: evaluating tool use', {
+      toolName,
+      commandStr,
+      allowlist: settings.allowlist,
+      blocklist: settings.blocklist,
+      defaultBehavior: settings.defaultBehavior,
+      enabled: settings.enabled
+    })
+
+    // Check blocklist first (highest priority — security rules always win)
+    if (this.matchesAnyPattern(commandStr, settings.blocklist)) {
+      log.info('CommandFilter: BLOCKED by blocklist', { commandStr })
+      return 'block'
+    }
+
+    // Check allowlist second
+    if (this.matchesAnyPattern(commandStr, settings.allowlist)) {
+      log.info('CommandFilter: allowed by allowlist', { commandStr })
+      return 'allow'
+    }
+
+    // Not on either list - use default behavior
+    log.info('CommandFilter: no match, using default behavior', {
+      commandStr,
+      defaultBehavior: settings.defaultBehavior
+    })
+    return settings.defaultBehavior
+  }
+
+  /**
+   * Check if a command matches any pattern in a list
+   */
+  matchesAnyPattern(command: string, patterns: string[]): boolean {
+    return patterns.some((pattern) => this.matchPattern(command, pattern))
+  }
+
+  /**
+   * Match a single pattern against a command string with wildcard support
+   *
+   * Wildcards:
+   * - * matches any sequence except /
+   * - ** matches any sequence including /
+   *
+   * Examples:
+   * - "bash: npm *" matches "bash: npm install", "bash: npm test"
+   * - "read: src/**" matches "read: src/main/db/schema.ts"
+   * - "edit: *.env" matches "edit: .env", "edit: production.env"
+   */
+  private matchPattern(command: string, pattern: string): boolean {
+    try {
+      // Escape special regex characters except our wildcards
+      const regexPattern = pattern
+        // First, protect ** by replacing with placeholder
+        .replace(/\*\*/g, '__DOUBLESTAR__')
+        // Escape other special regex chars
+        .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+        // Convert * to regex (matches any sequence except /)
+        .replace(/\*/g, '[^/]*')
+        // Convert ** back to regex (matches any sequence)
+        .replace(/__DOUBLESTAR__/g, '.*')
+
+      const regex = new RegExp(`^${regexPattern}$`, 'i')
+      const matches = regex.test(command)
+
+      if (matches) {
+        log.info('CommandFilter: pattern matched', { command, pattern })
+      }
+
+      return matches
+    } catch (error) {
+      log.error('CommandFilter: invalid pattern', { pattern, error })
+      return false
+    }
+  }
+
+  /**
+   * Format a tool use into a searchable command string
+   *
+   * Format: "{tool}: {primary_identifier}"
+   *
+   * Examples:
+   * - Bash: "bash: npm install"
+   * - Edit: "edit: src/main.ts"
+   * - Read: "read: /path/to/file"
+   */
+  formatCommandString(toolName: string, input: Record<string, unknown>): string {
+    const tool = toolName.toLowerCase()
+
+    switch (tool) {
+      case 'bash':
+        return `bash: ${input.command || ''}`
+
+      case 'edit':
+        return `edit: ${input.file_path || input.path || ''}`
+
+      case 'write':
+        return `write: ${input.file_path || input.path || ''}`
+
+      case 'read':
+        return `read: ${input.file_path || input.path || ''}`
+
+      case 'grep':
+        return `grep: ${input.pattern || ''} in ${input.path || 'cwd'}`
+
+      case 'glob':
+        return `glob: ${input.pattern || ''}`
+
+      case 'webfetch':
+        return `webfetch: ${input.url || ''}`
+
+      case 'websearch':
+        return `websearch: ${input.query || ''}`
+
+      case 'task':
+        return `task: ${input.description || 'subtask'}`
+
+      case 'skill':
+        return `skill: ${input.skill || ''}`
+
+      case 'notebookedit':
+        return `notebookedit: ${input.notebook_path || ''}`
+
+      default:
+        // For unknown tools, use tool name and JSON representation
+        return `${tool}: ${JSON.stringify(input)}`
+    }
+  }
+
+  /**
+   * Generate pattern suggestions at varying granularity levels for a tool use.
+   * Returns patterns from most specific (exact match) to most broad.
+   *
+   * For bash commands: splits by words and progressively replaces tail with wildcard
+   * For file tools: generates filename and extension patterns
+   * For other tools: returns the exact command string
+   */
+  generatePatternSuggestions(toolName: string, input: Record<string, unknown>): string[] {
+    const commandStr = this.formatCommandString(toolName, input)
+    const tool = toolName.toLowerCase()
+
+    if (tool === 'bash') {
+      return this.generateBashSuggestions(commandStr)
+    }
+
+    if (tool === 'edit' || tool === 'write' || tool === 'read') {
+      return this.generateFileSuggestions(commandStr, tool)
+    }
+
+    // For other tools (webfetch, websearch, task, skill, etc.), just the exact command
+    return [commandStr]
+  }
+
+  /**
+   * Generate progressive bash command pattern suggestions
+   */
+  private generateBashSuggestions(commandStr: string): string[] {
+    // commandStr format: "bash: some command args"
+    const prefix = 'bash: '
+    if (!commandStr.startsWith(prefix)) return [commandStr]
+
+    const command = commandStr.slice(prefix.length).trim()
+    if (!command) return [commandStr]
+
+    const parts = command.split(/\s+/)
+    if (parts.length <= 1) return [commandStr]
+
+    const suggestions: string[] = [commandStr]
+
+    // Generate progressively broader patterns by trimming from the right
+    // e.g. "gcloud compute list --project x" → "gcloud compute list *" → "gcloud compute *" → "gcloud *"
+    for (let i = parts.length - 1; i >= 1; i--) {
+      const pattern = `${prefix}${parts.slice(0, i).join(' ')} *`
+      // Avoid duplicates
+      if (!suggestions.includes(pattern)) {
+        suggestions.push(pattern)
+      }
+    }
+
+    return suggestions
+  }
+
+  /**
+   * Generate file-based pattern suggestions (filename, extension)
+   */
+  private generateFileSuggestions(commandStr: string, tool: string): string[] {
+    // commandStr format: "edit: /some/path/to/file.ts"
+    const prefix = `${tool}: `
+    if (!commandStr.startsWith(prefix)) return [commandStr]
+
+    const filePath = commandStr.slice(prefix.length).trim()
+    if (!filePath) return [commandStr]
+
+    const suggestions: string[] = []
+
+    // Extract filename and extension
+    const lastSlash = filePath.lastIndexOf('/')
+    const fileName = lastSlash >= 0 ? filePath.slice(lastSlash + 1) : filePath
+    const dotIndex = fileName.lastIndexOf('.')
+    const ext = dotIndex >= 0 ? fileName.slice(dotIndex) : null
+
+    // Pattern: match this exact filename anywhere (e.g. "edit: **/db.ts")
+    if (fileName) {
+      suggestions.push(`${prefix}**/${fileName}`)
+    }
+
+    // Pattern: match any file with this extension (e.g. "edit: **/*.ts")
+    if (ext) {
+      const extPattern = `${prefix}**/*${ext}`
+      if (!suggestions.includes(extPattern)) {
+        suggestions.push(extPattern)
+      }
+    }
+
+    return suggestions
+  }
+
+  /**
+   * Validate a pattern string
+   * Returns null if valid, error message if invalid
+   */
+  validatePattern(pattern: string): string | null {
+    if (!pattern || pattern.trim().length === 0) {
+      return 'Pattern cannot be empty'
+    }
+
+    // Check if pattern would create invalid regex
+    try {
+      const testCommand = 'test: test'
+      this.matchPattern(testCommand, pattern)
+      return null
+    } catch (error) {
+      return `Invalid pattern: ${error instanceof Error ? error.message : String(error)}`
+    }
+  }
+
+  /**
+   * Check if a pattern is overly broad (matches everything)
+   */
+  isOverlyBroadPattern(pattern: string): boolean {
+    const broadPatterns = ['*', '**', '*: *', '*: **', '**: *', '**: **']
+    return broadPatterns.some((broad) => pattern.trim() === broad)
+  }
+}
+
+// Singleton instance
+export const commandFilterService = new CommandFilterService()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -503,6 +503,14 @@ declare global {
       permissionList: (
         worktreePath?: string
       ) => Promise<{ success: boolean; permissions: PermissionRequest[]; error?: string }>
+      // Reply to a pending command approval request (approve or deny, optionally add to allowlist/blocklist)
+      commandApprovalReply: (
+        requestId: string,
+        approved: boolean,
+        remember?: 'allow' | 'block',
+        pattern?: string,
+        worktreePath?: string
+      ) => Promise<{ success: boolean; error?: string }>
       // Get session info (revert state)
       sessionInfo: (
         worktreePath: string,
@@ -638,6 +646,7 @@ declare global {
         success: boolean
         error?: string
       }>
+      onSettingsUpdated: (callback: (data: unknown) => void) => () => void
     }
     scriptOps: {
       runSetup: (
@@ -1066,6 +1075,20 @@ declare global {
     patterns: string[]
     metadata: Record<string, unknown>
     always: string[]
+    tool?: {
+      messageID: string
+      callID: string
+    }
+  }
+
+  // Command approval request type (for command filter system)
+  interface CommandApprovalRequest {
+    id: string
+    sessionID: string
+    toolName: string
+    commandStr: string
+    input: Record<string, unknown>
+    patternSuggestions: string[]
     tool?: {
       messageID: string
       callID: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1090,6 +1090,22 @@ const opencodeOps = {
   ): Promise<{ success: boolean; permissions: unknown[]; error?: string }> =>
     ipcRenderer.invoke('opencode:permission:list', { worktreePath }),
 
+  // Reply to a pending command approval request (for command filter system)
+  commandApprovalReply: (
+    requestId: string,
+    approved: boolean,
+    remember?: 'allow' | 'block',
+    pattern?: string,
+    worktreePath?: string
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('opencode:commandApprovalReply', {
+      requestId,
+      approved,
+      remember,
+      pattern,
+      worktreePath
+    }),
+
   // Get session info (revert state)
   sessionInfo: (
     worktreePath: string,
@@ -1301,7 +1317,16 @@ const settingsOps = {
     terminalId: string,
     customCommand?: string
   ): Promise<{ success: boolean; error?: string }> =>
-    ipcRenderer.invoke('settings:openWithTerminal', worktreePath, terminalId, customCommand)
+    ipcRenderer.invoke('settings:openWithTerminal', worktreePath, terminalId, customCommand),
+
+  // Listen for settings updates from main process
+  onSettingsUpdated: (callback: (data: unknown) => void): (() => void) => {
+    const handler = (_event: unknown, data: unknown): void => callback(data)
+    ipcRenderer.on('settings:updated', handler)
+    return () => {
+      ipcRenderer.removeListener('settings:updated', handler)
+    }
+  }
 }
 
 // Terminal operations API (PTY management)

--- a/src/renderer/src/components/sessions/CommandApprovalPrompt.tsx
+++ b/src/renderer/src/components/sessions/CommandApprovalPrompt.tsx
@@ -1,0 +1,252 @@
+import { useState, useCallback } from 'react'
+import {
+  Shield,
+  Terminal,
+  FileEdit,
+  Eye,
+  Search,
+  Globe,
+  Zap,
+  FileCode,
+  FileDown,
+  ChevronDown,
+  Check
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import type { CommandApprovalRequest } from '@/stores/useCommandApprovalStore'
+
+interface CommandApprovalPromptProps {
+  request: CommandApprovalRequest
+  onReply: (
+    requestId: string,
+    approved: boolean,
+    remember?: 'allow' | 'block',
+    pattern?: string
+  ) => void
+}
+
+function getToolDisplay(toolName: string): {
+  icon: React.ElementType
+  label: string
+  color: string
+} {
+  const tool = toolName.toLowerCase()
+  switch (tool) {
+    case 'bash':
+      return { icon: Terminal, label: 'Execute Command', color: 'text-orange-400' }
+    case 'edit':
+      return { icon: FileEdit, label: 'Edit File', color: 'text-yellow-400' }
+    case 'write':
+      return { icon: FileDown, label: 'Write File', color: 'text-yellow-400' }
+    case 'read':
+      return { icon: Eye, label: 'Read File', color: 'text-blue-400' }
+    case 'glob':
+    case 'grep':
+      return { icon: Search, label: 'Search Files', color: 'text-blue-400' }
+    case 'webfetch':
+    case 'websearch':
+      return { icon: Globe, label: 'Web Access', color: 'text-purple-400' }
+    case 'task':
+      return { icon: Zap, label: 'Run Sub-task', color: 'text-cyan-400' }
+    case 'skill':
+      return { icon: FileCode, label: 'Execute Skill', color: 'text-green-400' }
+    case 'notebookedit':
+      return { icon: FileEdit, label: 'Edit Notebook', color: 'text-yellow-400' }
+    default:
+      return { icon: Shield, label: toolName, color: 'text-yellow-400' }
+  }
+}
+
+export function CommandApprovalPrompt({ request, onReply }: CommandApprovalPromptProps) {
+  const [sending, setSending] = useState(false)
+  const [patternPickerMode, setPatternPickerMode] = useState<'allow' | 'block' | null>(null)
+  const [selectedPattern, setSelectedPattern] = useState<string>(
+    request.patternSuggestions?.[0] || request.commandStr
+  )
+
+  const { icon: Icon, label, color } = getToolDisplay(request.toolName)
+
+  const suggestions = request.patternSuggestions || [request.commandStr]
+
+  const handleAllow = useCallback(() => {
+    if (sending) return
+    setSending(true)
+    onReply(request.id, true)
+  }, [sending, onReply, request.id])
+
+  const handleDeny = useCallback(() => {
+    if (sending) return
+    setSending(true)
+    onReply(request.id, false)
+  }, [sending, onReply, request.id])
+
+  const handleConfirmPattern = useCallback(() => {
+    if (sending || !patternPickerMode) return
+    setSending(true)
+    if (patternPickerMode === 'allow') {
+      onReply(request.id, true, 'allow', selectedPattern)
+    } else {
+      onReply(request.id, false, 'block', selectedPattern)
+    }
+  }, [sending, patternPickerMode, onReply, request.id, selectedPattern])
+
+  const handleCancelPicker = useCallback(() => {
+    setPatternPickerMode(null)
+  }, [])
+
+  return (
+    <div
+      className="rounded-md border border-border bg-zinc-900/50 overflow-hidden"
+      data-testid="command-approval-prompt"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/30">
+        <Shield className={cn('h-4 w-4 shrink-0', color)} />
+        <span className="text-xs font-medium text-foreground">Command Approval Required</span>
+        <span className="text-xs text-muted-foreground">—</span>
+        <Icon className={cn('h-3.5 w-3.5 shrink-0', color)} />
+        <span className="text-xs text-muted-foreground">{label}</span>
+      </div>
+
+      <div className="px-3 py-2.5">
+        {/* Command display */}
+        <div className="mb-3">
+          <div className="text-xs font-semibold mb-1 text-muted-foreground">
+            Tool: {request.toolName}
+          </div>
+          <div
+            className={cn(
+              'text-xs font-mono px-2 py-1.5 rounded',
+              'bg-muted/50 text-foreground',
+              'break-all max-h-32 overflow-y-auto'
+            )}
+          >
+            {request.commandStr}
+          </div>
+        </div>
+
+        {/* Pattern picker (shown when Allow always / Block always clicked) */}
+        {patternPickerMode && (
+          <div className="mb-3 rounded-md border border-border bg-muted/20 p-2.5">
+            <div className="text-xs font-medium mb-2 text-foreground">
+              {patternPickerMode === 'allow'
+                ? 'Choose pattern to always allow:'
+                : 'Choose pattern to always block:'}
+            </div>
+            <div className="space-y-1">
+              {suggestions.map((pattern) => (
+                <button
+                  key={pattern}
+                  onClick={() => setSelectedPattern(pattern)}
+                  className={cn(
+                    'w-full flex items-center gap-2 px-2 py-1.5 rounded text-left text-xs font-mono transition-colors',
+                    selectedPattern === pattern
+                      ? 'bg-primary/20 border border-primary/40 text-foreground'
+                      : 'bg-muted/30 border border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+                  )}
+                >
+                  <Check
+                    className={cn(
+                      'h-3 w-3 shrink-0',
+                      selectedPattern === pattern ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                  <span className="break-all">{pattern}</span>
+                </button>
+              ))}
+            </div>
+            <div className="flex items-center gap-2 mt-2.5">
+              <Button
+                size="sm"
+                onClick={handleConfirmPattern}
+                disabled={sending}
+                className={cn(
+                  patternPickerMode === 'block' &&
+                    'bg-destructive hover:bg-destructive/90 text-destructive-foreground'
+                )}
+                data-testid="confirm-pattern"
+              >
+                {sending
+                  ? 'Saving...'
+                  : patternPickerMode === 'allow'
+                    ? 'Allow always'
+                    : 'Block always'}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={handleCancelPicker}
+                disabled={sending}
+                data-testid="cancel-pattern"
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Action buttons */}
+        {!patternPickerMode && (
+          <div className="flex items-center gap-2 flex-wrap">
+            <Button
+              size="sm"
+              onClick={handleAllow}
+              disabled={sending}
+              data-testid="command-approve-once"
+            >
+              {sending ? 'Sending...' : 'Allow once'}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() =>
+                suggestions.length > 1
+                  ? setPatternPickerMode('allow')
+                  : (() => {
+                      setSending(true)
+                      onReply(request.id, true, 'allow', suggestions[0])
+                    })()
+              }
+              disabled={sending}
+              title="Always allow this command pattern"
+              data-testid="command-approve-always"
+            >
+              Allow always
+              {suggestions.length > 1 && <ChevronDown className="h-3 w-3 ml-1" />}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() =>
+                suggestions.length > 1
+                  ? setPatternPickerMode('block')
+                  : (() => {
+                      setSending(true)
+                      onReply(request.id, false, 'block', suggestions[0])
+                    })()
+              }
+              disabled={sending}
+              className="text-destructive hover:text-destructive"
+              title="Always block this command pattern"
+              data-testid="command-block-always"
+            >
+              Block always
+              {suggestions.length > 1 && <ChevronDown className="h-3 w-3 ml-1" />}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleDeny}
+              disabled={sending}
+              className="text-destructive hover:text-destructive"
+              data-testid="command-deny"
+            >
+              Deny
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Settings, Palette, Monitor, Code, Terminal, Keyboard, Download } from 'lucide-react'
+import { Settings, Palette, Monitor, Code, Terminal, Keyboard, Download, Shield } from 'lucide-react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { SettingsAppearance } from './SettingsAppearance'
@@ -8,6 +8,7 @@ import { SettingsEditor } from './SettingsEditor'
 import { SettingsTerminal } from './SettingsTerminal'
 import { SettingsShortcuts } from './SettingsShortcuts'
 import { SettingsUpdates } from './SettingsUpdates'
+import { SettingsSecurity } from './SettingsSecurity'
 import { cn } from '@/lib/utils'
 
 const SECTIONS = [
@@ -15,6 +16,7 @@ const SECTIONS = [
   { id: 'general', label: 'General', icon: Monitor },
   { id: 'editor', label: 'Editor', icon: Code },
   { id: 'terminal', label: 'Terminal', icon: Terminal },
+  { id: 'security', label: 'Security', icon: Shield },
   { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
   { id: 'updates', label: 'Updates', icon: Download }
 ] as const
@@ -77,6 +79,7 @@ export function SettingsModal(): React.JSX.Element {
             {activeSection === 'general' && <SettingsGeneral />}
             {activeSection === 'editor' && <SettingsEditor />}
             {activeSection === 'terminal' && <SettingsTerminal />}
+            {activeSection === 'security' && <SettingsSecurity />}
             {activeSection === 'shortcuts' && <SettingsShortcuts />}
             {activeSection === 'updates' && <SettingsUpdates />}
           </div>

--- a/src/renderer/src/components/settings/SettingsSecurity.tsx
+++ b/src/renderer/src/components/settings/SettingsSecurity.tsx
@@ -1,0 +1,308 @@
+import { useState } from 'react'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { Trash2, Plus, Info } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { toast } from '@/lib/toast'
+
+export function SettingsSecurity(): React.JSX.Element {
+  const { commandFilter, updateSetting } = useSettingsStore()
+  const [newPattern, setNewPattern] = useState('')
+  const [activeTab, setActiveTab] = useState<'allowlist' | 'blocklist'>('allowlist')
+
+  const handleToggleEnabled = () => {
+    updateSetting('commandFilter', {
+      ...commandFilter,
+      enabled: !commandFilter.enabled
+    })
+  }
+
+  const handleSetDefaultBehavior = (behavior: 'ask' | 'allow' | 'block') => {
+    updateSetting('commandFilter', {
+      ...commandFilter,
+      defaultBehavior: behavior
+    })
+  }
+
+  const handleAddPattern = () => {
+    const pattern = newPattern.trim()
+    if (!pattern) {
+      toast.error('Pattern cannot be empty')
+      return
+    }
+
+    const list = activeTab === 'allowlist' ? commandFilter.allowlist : commandFilter.blocklist
+
+    if (list.includes(pattern)) {
+      toast.error('Pattern already exists in this list')
+      return
+    }
+
+    const updated =
+      activeTab === 'allowlist'
+        ? { ...commandFilter, allowlist: [...commandFilter.allowlist, pattern] }
+        : { ...commandFilter, blocklist: [...commandFilter.blocklist, pattern] }
+
+    updateSetting('commandFilter', updated)
+    setNewPattern('')
+    toast.success(`Pattern added to ${activeTab}`)
+  }
+
+  const handleRemovePattern = (pattern: string, listType: 'allowlist' | 'blocklist') => {
+    const updated =
+      listType === 'allowlist'
+        ? {
+            ...commandFilter,
+            allowlist: commandFilter.allowlist.filter((p) => p !== pattern)
+          }
+        : {
+            ...commandFilter,
+            blocklist: commandFilter.blocklist.filter((p) => p !== pattern)
+          }
+
+    updateSetting('commandFilter', updated)
+    toast.success(`Pattern removed from ${listType}`)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-base font-medium mb-1">Security</h3>
+        <p className="text-sm text-muted-foreground">Control which commands Claude can execute</p>
+      </div>
+
+      {/* Enable/Disable */}
+      <div className="flex items-center justify-between">
+        <div>
+          <label className="text-sm font-medium">Enable command filtering</label>
+          <p className="text-xs text-muted-foreground">
+            Control which tools and commands Claude can use during sessions
+          </p>
+        </div>
+        <button
+          role="switch"
+          aria-checked={commandFilter.enabled}
+          onClick={handleToggleEnabled}
+          className={cn(
+            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+            commandFilter.enabled ? 'bg-primary' : 'bg-muted'
+          )}
+          data-testid="command-filter-toggle"
+        >
+          <span
+            className={cn(
+              'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+              commandFilter.enabled ? 'translate-x-4' : 'translate-x-0'
+            )}
+          />
+        </button>
+      </div>
+
+      {/* Default Behavior */}
+      <div className={cn('space-y-2', !commandFilter.enabled && 'opacity-50 pointer-events-none')}>
+        <label className="text-sm font-medium">Default behavior for unlisted commands</label>
+        <p className="text-xs text-muted-foreground">
+          How to handle commands not on either list
+        </p>
+        <div className="flex gap-2">
+          <button
+            onClick={() => handleSetDefaultBehavior('ask')}
+            disabled={!commandFilter.enabled}
+            className={cn(
+              'px-3 py-1.5 rounded-md text-sm border transition-colors',
+              commandFilter.defaultBehavior === 'ask'
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+            )}
+            data-testid="default-behavior-ask"
+          >
+            Ask for approval
+          </button>
+          <button
+            onClick={() => handleSetDefaultBehavior('allow')}
+            disabled={!commandFilter.enabled}
+            className={cn(
+              'px-3 py-1.5 rounded-md text-sm border transition-colors',
+              commandFilter.defaultBehavior === 'allow'
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+            )}
+            data-testid="default-behavior-allow"
+          >
+            Allow silently
+          </button>
+          <button
+            onClick={() => handleSetDefaultBehavior('block')}
+            disabled={!commandFilter.enabled}
+            className={cn(
+              'px-3 py-1.5 rounded-md text-sm border transition-colors',
+              commandFilter.defaultBehavior === 'block'
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+            )}
+            data-testid="default-behavior-block"
+          >
+            Block silently
+          </button>
+        </div>
+      </div>
+
+      {/* Info box */}
+      <div
+        className={cn(
+          'rounded-md border border-border bg-muted/30 p-3',
+          !commandFilter.enabled && 'opacity-50'
+        )}
+      >
+        <div className="flex gap-2">
+          <Info className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+          <div className="text-xs text-muted-foreground space-y-1">
+            <p className="font-medium text-foreground">Pattern matching with wildcards:</p>
+            <ul className="list-disc list-inside space-y-0.5">
+              <li>
+                <code className="text-xs bg-muted px-1 py-0.5 rounded">*</code> matches any sequence
+                except /
+              </li>
+              <li>
+                <code className="text-xs bg-muted px-1 py-0.5 rounded">**</code> matches any
+                sequence including /
+              </li>
+              <li>
+                Example: <code className="text-xs bg-muted px-1 py-0.5 rounded">bash: npm *</code>{' '}
+                matches all npm commands
+              </li>
+              <li>
+                Example: <code className="text-xs bg-muted px-1 py-0.5 rounded">read: src/**</code>{' '}
+                matches any file in src/
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {/* Priority note */}
+      <div
+        className={cn(
+          'rounded-md border border-border bg-muted/30 p-3',
+          !commandFilter.enabled && 'opacity-50'
+        )}
+      >
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Priority:</span> Blocklist takes precedence
+          over allowlist. If a command matches both, it will be blocked.
+        </p>
+      </div>
+
+      {/* Tabs */}
+      <div className={cn('space-y-3', !commandFilter.enabled && 'opacity-50 pointer-events-none')}>
+        <div className="flex gap-2 border-b border-border">
+          <button
+            onClick={() => setActiveTab('allowlist')}
+            disabled={!commandFilter.enabled}
+            className={cn(
+              'px-3 py-1.5 text-sm font-medium transition-colors border-b-2',
+              activeTab === 'allowlist'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Allowlist ({commandFilter.allowlist.length})
+          </button>
+          <button
+            onClick={() => setActiveTab('blocklist')}
+            disabled={!commandFilter.enabled}
+            className={cn(
+              'px-3 py-1.5 text-sm font-medium transition-colors border-b-2',
+              activeTab === 'blocklist'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Blocklist ({commandFilter.blocklist.length})
+          </button>
+        </div>
+
+        {/* Add pattern input */}
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={newPattern}
+            onChange={(e) => setNewPattern(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && commandFilter.enabled) {
+                handleAddPattern()
+              }
+            }}
+            disabled={!commandFilter.enabled}
+            placeholder={
+              activeTab === 'allowlist'
+                ? 'e.g., bash: git status or read: src/**'
+                : 'e.g., bash: rm -rf * or edit: .env'
+            }
+            className="flex-1 px-3 py-1.5 text-sm rounded-md border border-border bg-background"
+            data-testid="pattern-input"
+          />
+          <Button
+            size="sm"
+            onClick={handleAddPattern}
+            disabled={!newPattern.trim() || !commandFilter.enabled}
+            data-testid="add-pattern-button"
+          >
+            <Plus className="h-3.5 w-3.5 mr-1" />
+            Add
+          </Button>
+        </div>
+
+        {/* Pattern list with scrolling */}
+        <div className="space-y-2 max-h-48 overflow-y-auto pr-1">
+          {activeTab === 'allowlist' && commandFilter.allowlist.length === 0 && (
+            <div className="text-xs text-muted-foreground text-center py-4">
+              No patterns in allowlist. Commands will follow the default behavior.
+            </div>
+          )}
+          {activeTab === 'blocklist' && commandFilter.blocklist.length === 0 && (
+            <div className="text-xs text-muted-foreground text-center py-4">
+              No patterns in blocklist. Default dangerous patterns are included on first launch.
+            </div>
+          )}
+          {activeTab === 'allowlist' &&
+            commandFilter.allowlist.map((pattern) => (
+              <div
+                key={pattern}
+                className="flex items-center justify-between px-3 py-2 rounded-md border border-border bg-muted/30"
+              >
+                <code className="text-xs font-mono">{pattern}</code>
+                <button
+                  onClick={() => handleRemovePattern(pattern, 'allowlist')}
+                  disabled={!commandFilter.enabled}
+                  className="text-destructive hover:text-destructive/80 transition-colors"
+                  title="Remove pattern"
+                  data-testid="remove-allowlist-pattern"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            ))}
+          {activeTab === 'blocklist' &&
+            commandFilter.blocklist.map((pattern) => (
+              <div
+                key={pattern}
+                className="flex items-center justify-between px-3 py-2 rounded-md border border-border bg-muted/30"
+              >
+                <code className="text-xs font-mono">{pattern}</code>
+                <button
+                  onClick={() => handleRemovePattern(pattern, 'blocklist')}
+                  disabled={!commandFilter.enabled}
+                  className="text-destructive hover:text-destructive/80 transition-colors"
+                  title="Remove pattern"
+                  data-testid="remove-blocklist-pattern"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/stores/index.ts
+++ b/src/renderer/src/stores/index.ts
@@ -31,6 +31,10 @@ export { useContextStore } from './useContextStore'
 export { useFileSearchStore } from './useFileSearchStore'
 export { useQuestionStore } from './useQuestionStore'
 export { usePermissionStore } from './usePermissionStore'
+export {
+  useCommandApprovalStore,
+  type CommandApprovalRequest
+} from './useCommandApprovalStore'
 export { usePromptHistoryStore } from './usePromptHistoryStore'
 export { useSpaceStore } from './useSpaceStore'
 export { useTerminalStore, type TerminalStatus, type TerminalInfo } from './useTerminalStore'

--- a/src/renderer/src/stores/useCommandApprovalStore.ts
+++ b/src/renderer/src/stores/useCommandApprovalStore.ts
@@ -1,0 +1,63 @@
+import { create } from 'zustand'
+
+export interface CommandApprovalRequest {
+  id: string
+  sessionID: string
+  toolName: string
+  commandStr: string
+  input: Record<string, unknown>
+  patternSuggestions: string[]
+  tool?: {
+    messageID: string
+    callID: string
+  }
+}
+
+interface CommandApprovalStore {
+  pendingBySession: Map<string, CommandApprovalRequest[]>
+  addApproval: (sessionId: string, request: CommandApprovalRequest) => void
+  removeApproval: (sessionId: string, requestId: string) => void
+  getApprovals: (sessionId: string) => CommandApprovalRequest[]
+  getActiveApproval: (sessionId: string) => CommandApprovalRequest | null
+  clearSession: (sessionId: string) => void
+}
+
+export const useCommandApprovalStore = create<CommandApprovalStore>((set, get) => ({
+  pendingBySession: new Map(),
+
+  addApproval: (sessionId, request) =>
+    set((state) => {
+      const map = new Map(state.pendingBySession)
+      const existing = map.get(sessionId) || []
+      if (existing.some((a) => a.id === request.id)) return state
+      map.set(sessionId, [...existing, request])
+      return { pendingBySession: map }
+    }),
+
+  removeApproval: (sessionId, requestId) =>
+    set((state) => {
+      const map = new Map(state.pendingBySession)
+      const existing = map.get(sessionId) || []
+      const filtered = existing.filter((a) => a.id !== requestId)
+      if (filtered.length === 0) {
+        map.delete(sessionId)
+      } else {
+        map.set(sessionId, filtered)
+      }
+      return { pendingBySession: map }
+    }),
+
+  getApprovals: (sessionId) => get().pendingBySession.get(sessionId) || [],
+
+  getActiveApproval: (sessionId) => {
+    const approvals = get().pendingBySession.get(sessionId) || []
+    return approvals[0] || null
+  },
+
+  clearSession: (sessionId) =>
+    set((state) => {
+      const map = new Map(state.pendingBySession)
+      map.delete(sessionId)
+      return { pendingBySession: map }
+    })
+}))


### PR DESCRIPTION
## Summary

- **New command filter security system** that intercepts Claude's tool uses (Bash, Edit, Write, Read, Grep, Glob, WebFetch, WebSearch, Task, Skill, NotebookEdit) and evaluates them against configurable allowlist/blocklist patterns before execution
- **Wildcard pattern matching** (`*` matches any non-slash sequence, `**` matches anything including slashes) for flexible rule definitions like `bash: npm *`, `edit: src/**`, `bash: rm -rf *`
- **In-session approval prompt UI** (`CommandApprovalPrompt`) shown inline when a command needs user approval, with options: Allow once, Allow always (with pattern picker), Block always (with pattern picker), and Deny
- **Settings > Security panel** (`SettingsSecurity`) for managing allowlist/blocklist patterns, toggling the filter on/off, and setting the default behavior for unlisted commands (ask/allow/block)
- **Smart pattern suggestions** — when approving or blocking, the system generates progressively broader pattern suggestions (e.g., exact command → `bash: gcloud compute *` → `bash: gcloud *`)
- **Blocklist takes priority** over allowlist for security; default blocklist includes dangerous patterns like `bash: rm -rf *`, `bash: sudo *`, `edit: **/.env`, `write: **/*.key`
- **Persistent rules** — "Allow always" and "Block always" choices are persisted to the database and synced back to the renderer settings store via a new `settings:updated` IPC channel
- **Abort-safe** — pending approvals are auto-denied when a session is aborted, and stale approvals are cleared on session idle/send

### Files changed

| Area | Files | What |
|------|-------|------|
| **New service** | `command-filter-service.ts` | Core pattern matching engine with `evaluateToolUse()`, `formatCommandString()`, `generatePatternSuggestions()`, and wildcard regex support |
| **Main process** | `claude-code-implementer.ts` | Integrates command filter into `canUseTool()` hook; adds `handleCommandApproval()` blocking flow, settings persistence, and `handleApprovalReply()` IPC handler |
| **IPC** | `opencode-handlers.ts` | New `opencode:commandApprovalReply` channel for routing approval responses |
| **Preload** | `index.ts`, `index.d.ts` | Expose `commandApprovalReply()` API and `onSettingsUpdated` listener; add `CommandApprovalRequest` type |
| **New component** | `CommandApprovalPrompt.tsx` | Inline approval prompt with tool-aware icons, pattern picker, and allow/deny/remember actions |
| **New component** | `SettingsSecurity.tsx` | Settings panel with enable toggle, default behavior selector, allowlist/blocklist tabs, pattern add/remove UI, and wildcard docs |
| **Store** | `useCommandApprovalStore.ts` | Zustand store managing pending approval requests per session |
| **Store** | `useSettingsStore.ts` | Added `CommandFilterSettings` type and default values; listens for `settings:updated` events |
| **Integration** | `SessionView.tsx` | Handles `command.approval_needed` stream events, renders `CommandApprovalPrompt`, clears approvals on idle/abort/send |
| **Settings** | `SettingsModal.tsx` | Added Security tab with Shield icon |
| **Exports** | `stores/index.ts` | Re-exports `useCommandApprovalStore` and `CommandApprovalRequest` |

## Test plan

- [ ] Start a Claude Code session and trigger a bash command — verify the approval prompt appears inline
- [ ] Click "Allow once" — verify the command runs and the prompt disappears
- [ ] Click "Deny" — verify the command is rejected with an appropriate message
- [ ] Click "Allow always" with pattern picker — verify the pattern is saved to Settings > Security allowlist
- [ ] Click "Block always" — verify the pattern is saved to blocklist and future matching commands are auto-blocked
- [ ] Open Settings > Security — verify allowlist/blocklist are editable, toggle works, default behavior selector functions
- [ ] Add a custom pattern manually (e.g., `bash: git *`) and verify matching commands are auto-allowed
- [ ] Abort a session while an approval prompt is showing — verify the prompt disappears and the command is auto-denied
- [ ] Disable the command filter toggle — verify all commands pass through without prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)