### PR TITLE
Fix 'todos.filter is not a function' runtime error

### DIFF
--- a/src/renderer/src/components/sessions/ToolCard.tsx
+++ b/src/renderer/src/components/sessions/ToolCard.tsx
@@ -127,7 +127,7 @@ function getToolLabel(name: string, input: Record<string, unknown>, cwd?: string
 
   // Show summary for todowrite (must be before 'write' check)
   if (isTodoWriteTool(lowerName)) {
-    const todos = (input.todos || []) as Array<{ status: string }>
+    const todos = Array.isArray(input.todos) ? input.todos as Array<{ status: string }> : []
     const completed = todos.filter((t) => t.status === 'completed').length
     return `${completed}/${todos.length} completed`
   }
@@ -338,7 +338,7 @@ function CollapsedContent({
 
   // TodoWrite (must be before 'write' check since name contains 'write')
   if (isTodoWriteTool(lowerName)) {
-    const todos = (input.todos || []) as Array<{ status: string }>
+    const todos = Array.isArray(input.todos) ? input.todos as Array<{ status: string }> : []
     const completed = todos.filter((t) => t.status === 'completed').length
     const inProgress = todos.filter((t) => t.status === 'in_progress').length
     return (
@@ -474,7 +474,7 @@ function CollapsedContent({
 
   // Question
   if (lowerName.includes('question')) {
-    const questions = (input.questions || []) as Array<{ header: string; question: string }>
+    const questions = Array.isArray(input.questions) ? input.questions as Array<{ header: string; question: string }> : []
     const questionCount = questions.length
     const firstHeader = questions[0]?.header || 'Question'
     return (

--- a/src/renderer/src/components/sessions/tools/TodoWriteToolView.tsx
+++ b/src/renderer/src/components/sessions/tools/TodoWriteToolView.tsx
@@ -51,7 +51,7 @@ function PriorityBadge({ priority }: { priority: TodoItem['priority'] }) {
 
 export function TodoWriteToolView({ input, error }: ToolViewProps) {
   const todoInput = input as unknown as TodoInput
-  const todos = useMemo(() => todoInput?.todos || [], [todoInput?.todos])
+  const todos = useMemo(() => Array.isArray(todoInput?.todos) ? todoInput.todos : [], [todoInput?.todos])
 
   if (todos.length === 0) {
     return (


### PR DESCRIPTION
## Summary

- **Fix runtime crash** where `todos.filter is not a function` error occurred when `input.todos` was a non-array truthy value (e.g., a string or object). The previous pattern `(input.todos || [])` only guards against falsy values but doesn't ensure the value is actually an array.
- **Replace unsafe fallback pattern** `(value || []) as Array<T>` with explicit `Array.isArray()` checks across all 4 occurrences in `ToolCard.tsx` and `TodoWriteToolView.tsx`, ensuring `.filter()` and `.length` are only called on actual arrays.

## Changes

### `src/renderer/src/components/sessions/ToolCard.tsx`
- `getToolLabel()`: Safely handle `input.todos` for TodoWrite tool summary line
- `CollapsedContent`: Safely handle `input.todos` for TodoWrite collapsed view
- `CollapsedContent`: Safely handle `input.questions` for Question tool collapsed view

### `src/renderer/src/components/sessions/tools/TodoWriteToolView.tsx`
- `TodoWriteToolView`: Safely handle `todoInput.todos` in the `useMemo` initializer

## Test plan

- [ ] Open a session with TodoWrite tool calls and verify they render correctly
- [ ] Open a session with Question tool calls and verify they render correctly
- [ ] Verify no runtime errors in the console when viewing sessions with these tool types
- [ ] Verify edge cases where tool input may have unexpected shapes (e.g., `todos` as a string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)