### PR TITLE
Fix settings pane scrolling issue

### DIFF
--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -45,7 +45,7 @@ export function SettingsModal(): React.JSX.Element {
         className="max-w-3xl h-[70vh] p-0 gap-0 overflow-hidden"
         data-testid="settings-modal"
       >
-        <div className="flex h-full">
+        <div className="flex h-full min-h-0">
           {/* Left navigation */}
           <nav className="w-48 border-r bg-muted/30 p-3 flex flex-col gap-1 shrink-0">
             <div className="flex items-center gap-2 px-2 py-1.5 mb-2">


### PR DESCRIPTION
## Summary

- **Fix settings modal content overflow**: Added `min-h-0` to the flex container inside the settings modal (`SettingsModal.tsx`). Without this, the flex child could grow beyond the modal's `h-[70vh]` constraint, preventing the settings content pane from scrolling when its content exceeds the available height. The `min-h-0` override allows the flex layout to properly constrain and enable overflow scrolling within the settings panels.

## Changes

- `src/renderer/src/components/settings/SettingsModal.tsx` — Added `min-h-0` class to the top-level `<div className="flex h-full">` container to fix a common flexbox overflow issue where children ignore the parent's fixed height.

## Test plan

- [ ] Open the Settings modal
- [ ] Navigate to a settings tab with enough content to overflow (or resize the window smaller)
- [ ] Verify the settings content area scrolls properly and does not overflow beyond the modal boundaries
- [ ] Verify the left navigation sidebar remains visible and does not scroll away

🤖 Generated with [Claude Code](https://claude.com/claude-code)