### PR TITLE
Persist slash commands to DB and fix init message detection

### DIFF
--- a/src/main/ipc/opencode-handlers.ts
+++ b/src/main/ipc/opencode-handlers.ts
@@ -332,6 +332,17 @@ export function registerOpenCodeHandlers(
             return { success: true, commands }
           }
         }
+
+        // For pending:: sessions (not yet materialized in DB), try Claude Code
+        // implementer first — it has a DB cache fallback from previous sessions.
+        if (sdkManager && sessionId?.startsWith('pending::')) {
+          const impl = sdkManager.getImplementer('claude-code')
+          const commands = await impl.listCommands(worktreePath)
+          if (commands.length > 0) {
+            return { success: true, commands }
+          }
+        }
+
         // Fall through to existing OpenCode path
         const commands = await openCodeService.listCommands(worktreePath)
         return { success: true, commands }


### PR DESCRIPTION
## Summary

- **Fix SDK init message detection**: The SDK sends init as `{ type: 'system', subtype: 'init' }`, not `{ type: 'init' }`. Updated the condition to match on `type === 'system' && subtype === 'init'`, which was preventing slash commands from being cached during session initialization.
- **Persist slash commands to SQLite**: Cached slash commands are now saved to the database (via `persistCommandsToDb`) whenever they are populated from the SDK init message or from `supportedCommands()`. This allows commands to survive across app restarts / session boundaries.
- **DB fallback in `listCommands`**: When the in-memory cache is empty (e.g. fresh app start before a session is created), `listCommands` now falls back to loading persisted commands from the DB cache written by a previous session.
- **Support `pending::` sessions**: Added a code path in `opencode-handlers.ts` so that pending sessions (not yet materialized in the DB) can route through the Claude Code implementer to serve slash commands from its DB cache, rather than falling through to an empty result.
- **Enhanced logging**: Slash command cache log messages now include command names for easier debugging.

## Changed files

- `src/main/ipc/opencode-handlers.ts` — Route `pending::` sessions through Claude Code implementer for command listing
- `src/main/services/claude-code-implementer.ts` — Fix init detection, add DB persistence/fallback, refactor `listCommands`, add `toHiveCommandFormat` and `persistCommandsToDb` helpers

## Test plan

- [ ] Start the app, open a worktree, verify slash commands appear in the command input
- [ ] Restart the app without starting a new session — verify slash commands still appear (loaded from DB cache)
- [ ] Open a worktree with a `pending::` session — verify slash commands are available
- [ ] Check logs for `persistCommandsToDb: saved to DB` and `listCommands: loaded from DB cache` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)