### PR TITLE
Upgrade Claude Agent SDK to ^0.2.62

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "codegen": "graphql-codegen --config src/shared/codegen.ts"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.50",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.62",
     "@electron-toolkit/utils": "^3.0.0",
     "@monaco-editor/react": "^4.7.0",
     "@opencode-ai/sdk": "^1.1.51",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.50
-        version: 0.2.50(zod@3.25.76)
+        specifier: ^0.2.62
+        version: 0.2.62(zod@3.25.76)
       '@electron-toolkit/utils':
         specifier: ^3.0.0
         version: 3.0.0(electron@33.4.11)
@@ -268,8 +268,8 @@ packages:
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
     hasBin: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.50':
-    resolution: {integrity: sha512-zVQzJbicfTmvS6uarFQYYVYiYedKE0FgXmhiGC1oSLm6OkIbuuKM7XV4fXEFxPZHcWQc7ZYv6HA2/P5HOE7b2Q==}
+  '@anthropic-ai/claude-agent-sdk@0.2.62':
+    resolution: {integrity: sha512-exRJ2djKP6erRpUrtnVf5iXzqeS9dAie9d1ghODZVVXdLqieSqCpaAhZhe0hL1yvP33OL0J5CgT9RAyPzhYY9A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -5240,6 +5240,10 @@ packages:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -6971,7 +6975,7 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
 
-  '@anthropic-ai/claude-agent-sdk@0.2.50(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.2.62(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -12773,6 +12777,10 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
@@ -13472,7 +13480,7 @@ snapshots:
 
   readdir-glob@1.1.3:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 5.1.9
 
   readdirp@3.6.0:
     dependencies:


### PR DESCRIPTION
## Summary

- **Bumps `@anthropic-ai/claude-agent-sdk`** from `^0.2.50` to `^0.2.62` in `package.json`
- **Updates `pnpm-lock.yaml`** to resolve the new SDK version (`0.2.62`) along with transitive dependency changes:
  - Adds `minimatch@5.1.9` (replacing `5.1.6` usage in `readdir-glob`)
  - Updates integrity hashes for the SDK package

## Why

Picks up the latest fixes and improvements in the Claude Agent SDK (versions 0.2.51 through 0.2.62).

## Test plan

- [ ] Verify `pnpm install` completes without errors
- [ ] Verify `pnpm dev` starts successfully
- [ ] Verify Claude Agent SDK functionality works as expected in the app
- [ ] Run `pnpm build` to confirm production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to the latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->