### PR TITLE
Fix run tab lag: reduce buffer limits, line-split output, optimize URL detection

### DIFF
--- a/src/renderer/src/lib/format-utils.ts
+++ b/src/renderer/src/lib/format-utils.ts
@@ -45,9 +45,8 @@ export const COMPLETION_WORDS = [
 const DEV_SERVER_URL_PATTERN = /https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0):\d{3,5}\/?/
 
 export function extractDevServerUrl(output: string[]): string | null {
-  // Scan last 50 chunks for a dev server URL.
-  // Each chunk may contain multiple lines (raw process output),
-  // so we search the full text of each chunk.
+  // Scan last 50 entries for a dev server URL.
+  // Each entry is a single line of output after line splitting.
   for (let i = output.length - 1; i >= Math.max(0, output.length - 50); i--) {
     const match = output[i].match(DEV_SERVER_URL_PATTERN)
     if (match) return match[0]

--- a/src/renderer/src/lib/output-ring-buffer.ts
+++ b/src/renderer/src/lib/output-ring-buffer.ts
@@ -1,5 +1,5 @@
-const MAX_CHARS = 500_000
-const BUFFER_CAPACITY = 50_000 // max entries (50K * ~10 chars avg = 500K)
+export const MAX_CHARS = 200_000
+export const BUFFER_CAPACITY = 10_000
 const TRUNCATION_MARKER = '\x00TRUNC:[older output truncated]'
 
 export class OutputRingBuffer {

--- a/src/renderer/src/stores/useScriptStore.ts
+++ b/src/renderer/src/stores/useScriptStore.ts
@@ -238,7 +238,12 @@ export function fireRunScript(worktreeId: string, commands: string[], cwd: strin
         s.appendRunOutput(worktreeId, `\x00CMD:${event.command}`)
         break
       case 'output':
-        if (event.data) s.appendRunOutput(worktreeId, event.data)
+        if (event.data) {
+          const lines = event.data.split('\n')
+          for (const line of lines) {
+            if (line !== '') s.appendRunOutput(worktreeId, line)
+          }
+        }
         break
       case 'error':
         s.appendRunOutput(

--- a/src/renderer/src/stores/useWorktreeStore.ts
+++ b/src/renderer/src/stores/useWorktreeStore.ts
@@ -32,7 +32,12 @@ export function fireSetupScript(projectId: string, worktreeId: string, cwd: stri
         s.appendSetupOutput(worktreeId, `\x00CMD:${event.command}`)
         break
       case 'output':
-        if (event.data) s.appendSetupOutput(worktreeId, event.data)
+        if (event.data) {
+          const lines = event.data.split('\n')
+          for (const line of lines) {
+            if (line !== '') s.appendSetupOutput(worktreeId, line)
+          }
+        }
         break
       case 'error':
         s.appendSetupOutput(


### PR DESCRIPTION
## Summary

Fixes performance issues causing the Run tab to become laggy during high-output script execution.

- **Reduced ring buffer limits**: Lowered `MAX_CHARS` from 500K → 200K and `BUFFER_CAPACITY` from 50K → 10K entries to reduce memory pressure and improve rendering performance
- **Line-split output before buffering**: Script output (`event.data`) is now split by newlines before appending to the ring buffer — each entry is a single line instead of a raw multi-line chunk. Applied to both `useScriptStore` (run scripts) and `useWorktreeStore` (setup scripts)
- **Optimized dev server URL detection**: Replaced `useMemo` with `useEffect` + `useState` in `BottomPanel` — once a URL is detected, scanning stops entirely with zero cost per subsequent output version bump. Resets on run stop so the next run can detect a fresh URL
- **Updated tests**: Adjusted buffer limit assertions to match new 200K cap; exported `MAX_CHARS` constant from `output-ring-buffer.ts` for DRY test assertions

## Test plan

- [ ] Run a script with high output volume (e.g., `yes | head -100000`) and verify the Run tab stays responsive
- [ ] Verify dev server URL detection still works (e.g., `pnpm dev` shows the detected URL in the bottom panel)
- [ ] Verify URL detection stops scanning after first detection (no perf cost on subsequent output)
- [ ] Stop and restart a run — verify URL resets and is re-detected
- [ ] Run `pnpm test` — all unit tests pass with updated buffer limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script and setup script output processing to handle content line-by-line, providing cleaner output display and avoiding empty line artifacts during execution.

* **Chores**
  * Refined output buffer capacity settings to optimize performance and resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->