### PR TITLE
Fix input field height on worktree navigation

### DIFF
--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
+import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo } from 'react'
 import { Send, ListPlus, Loader2, AlertCircle, RefreshCw, Square } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -684,13 +684,13 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   ])
 
   // Auto-resize textarea (depends on sessionId to handle pre-populated drafts)
-  useEffect(() => {
+  // Uses useLayoutEffect to measure and set height synchronously before paint,
+  // ensuring correct height when drafts are loaded on worktree navigation.
+  useLayoutEffect(() => {
     const textarea = textareaRef.current
     if (textarea) {
-      requestAnimationFrame(() => {
-        textarea.style.height = 'auto'
-        textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`
-      })
+      textarea.style.height = 'auto'
+      textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`
     }
   }, [inputValue, sessionId])
 


### PR DESCRIPTION
## Summary

- **Fixes textarea input height not adjusting correctly when navigating between worktrees** with pre-populated drafts in `SessionView`
- Replaces `useEffect` + `requestAnimationFrame` with `useLayoutEffect` for the textarea auto-resize logic, ensuring the height is measured and set synchronously before the browser paints
- Removes the unnecessary `requestAnimationFrame` wrapper since `useLayoutEffect` already runs synchronously after DOM mutations

## Details

When switching between worktrees, the session input field could briefly render with an incorrect height because `useEffect` fires asynchronously after paint. The `requestAnimationFrame` inside it added further delay. By switching to `useLayoutEffect`, the textarea height is calculated and applied before the browser paints, eliminating the visual flicker and ensuring correct height for loaded drafts.

### Changes

- **`src/renderer/src/components/sessions/SessionView.tsx`**:
  - Import `useLayoutEffect` from React
  - Replace `useEffect` → `useLayoutEffect` for the textarea auto-resize effect
  - Remove `requestAnimationFrame` wrapper (no longer needed with synchronous layout effect)

## Test plan

- [ ] Navigate between worktrees that have saved input drafts — verify the textarea renders at the correct height immediately without flicker
- [ ] Type multi-line text in the input field — verify auto-resize still works correctly
- [ ] Clear the input field — verify it shrinks back to single-line height
- [ ] Verify no console warnings about `useLayoutEffect` during SSR (N/A for Electron, but good to confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts when textarea resizing runs; main potential issue is `useLayoutEffect` timing causing minor layout/perf impacts, but behavior is otherwise unchanged.
> 
> **Overview**
> Fixes the session input textarea briefly rendering at the wrong height when switching between worktrees with pre-populated drafts.
> 
> The textarea auto-resize logic in `SessionView` now runs in `useLayoutEffect` (synchronously before paint) and directly updates height without an extra `requestAnimationFrame`, improving initial sizing consistency on navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cf82fbde94929f2548ae435fe2be9759d7fac37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved textarea auto-resize responsiveness to better align height adjustments with browser rendering for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->