### PR TITLE
Fix PlanReadyImplementFab button background for local theme

### DIFF
--- a/src/renderer/src/components/sessions/PlanReadyImplementFab.tsx
+++ b/src/renderer/src/components/sessions/PlanReadyImplementFab.tsx
@@ -49,7 +49,7 @@ export function PlanReadyImplementFab({
           className={cn(
             'h-8 rounded-full px-3',
             'text-xs font-medium',
-            'border border-violet-600 text-violet-600 bg-transparent hover:bg-violet-600/10',
+            'border border-violet-600 text-violet-600 bg-background hover:bg-violet-600/10',
             'shadow-md transition-colors duration-200',
             'cursor-pointer',
             visible ? 'opacity-100' : 'opacity-0'


### PR DESCRIPTION
## Summary

- **Fixed transparent background on the "Supercharge Locally" button** in the `PlanReadyImplementFab` component
- Changed `bg-transparent` → `bg-background` so the button picks up the current theme's background color instead of being fully transparent, ensuring proper visual contrast and consistency across all themes

## Changes

**`src/renderer/src/components/sessions/PlanReadyImplementFab.tsx`**
- Replaced `bg-transparent` with `bg-background` in the button's Tailwind class list, ensuring the bordered button renders with the correct background color from the active theme's CSS variables

## Test plan

- [ ] Verify the "Supercharge Locally" FAB button renders with the correct theme background color (not transparent)
- [ ] Toggle between light and dark themes and confirm the button background adapts correctly
- [ ] Confirm hover state (`hover:bg-violet-600/10`) still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified the visual appearance of the "Supercharge locally" button with a background color update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->