### PR TITLE
Add SDK rate_limit_event logging

### DIFF
--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -578,6 +578,12 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
           continue // No materialization/accumulation needed for partials
         }
 
+        if (msgType === 'rate_limit_event') {
+          log.info('Prompt: rate_limit_event received', {
+            fullMessage: sdkMessage
+          })
+        }
+
         log.info('Prompt: received SDK message', {
           type: msgType,
           index: messageIndex,


### PR DESCRIPTION
## Summary

- Adds explicit logging for `rate_limit_event` messages received from the Claude Agent SDK in the `ClaudeCodeImplementer` prompt message stream
- When a `rate_limit_event` SDK message is received, it is now logged at `info` level with the full message payload before the general SDK message logging
- This provides better observability into rate limiting behavior during AI coding sessions

## Changes

- **`src/main/services/claude-code-implementer.ts`**: Added a dedicated `rate_limit_event` check in the SDK message processing loop that logs the full message content when rate limit events are encountered

## Test plan

- [ ] Verify the app builds successfully (`pnpm build`)
- [ ] Trigger a rate-limited scenario and confirm the `rate_limit_event` log entry appears in the Hive logs (`~/Library/Logs/hive/`)
- [ ] Verify normal (non-rate-limited) SDK message processing is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved handling and logging of rate limit events for better diagnostics and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->