### PR TITLE
Fix auto-focus on rename input fields across all item components

### DIFF
--- a/src/renderer/src/components/connections/ConnectionItem.tsx
+++ b/src/renderer/src/components/connections/ConnectionItem.tsx
@@ -121,10 +121,13 @@ export function ConnectionItem({
   const [nameInput, setNameInput] = useState('')
   const renameInputRef = useRef<HTMLInputElement>(null)
 
+  // Focus rename input when it appears (deferred to run after menu closes)
   useEffect(() => {
-    if (isRenaming && renameInputRef.current) {
-      renameInputRef.current.focus()
-      renameInputRef.current.select()
+    if (isRenaming) {
+      requestAnimationFrame(() => {
+        renameInputRef.current?.focus()
+        renameInputRef.current?.select()
+      })
     }
   }, [isRenaming])
 
@@ -307,6 +310,7 @@ export function ConnectionItem({
             {isRenaming ? (
               <input
                 ref={renameInputRef}
+                autoFocus
                 value={nameInput}
                 onChange={(e) => setNameInput(e.target.value)}
                 onKeyDown={handleRenameKeyDown}

--- a/src/renderer/src/components/layout/PinnedList.tsx
+++ b/src/renderer/src/components/layout/PinnedList.tsx
@@ -174,10 +174,13 @@ function PinnedWorktreeItem({ worktreeId }: { worktreeId: string }): React.JSX.E
   const [branchNameInput, setBranchNameInput] = useState('')
   const renameInputRef = useRef<HTMLInputElement>(null)
 
+  // Focus rename input when it appears (deferred to run after menu closes)
   useEffect(() => {
-    if (isRenamingBranch && renameInputRef.current) {
-      renameInputRef.current.focus()
-      renameInputRef.current.select()
+    if (isRenamingBranch) {
+      requestAnimationFrame(() => {
+        renameInputRef.current?.focus()
+        renameInputRef.current?.select()
+      })
     }
   }, [isRenamingBranch])
 
@@ -524,6 +527,7 @@ function PinnedWorktreeItem({ worktreeId }: { worktreeId: string }): React.JSX.E
             {isRenamingBranch ? (
               <input
                 ref={renameInputRef}
+                autoFocus
                 value={branchNameInput}
                 onChange={(e) => setBranchNameInput(e.target.value)}
                 onKeyDown={(e) => {
@@ -650,10 +654,13 @@ function PinnedConnectionItem({
   // Manage worktrees dialog state
   const [manageConnectionId, setManageConnectionId] = useState<string | null>(null)
 
+  // Focus rename input when it appears (deferred to run after menu closes)
   useEffect(() => {
-    if (isRenaming && renameInputRef.current) {
-      renameInputRef.current.focus()
-      renameInputRef.current.select()
+    if (isRenaming) {
+      requestAnimationFrame(() => {
+        renameInputRef.current?.focus()
+        renameInputRef.current?.select()
+      })
     }
   }, [isRenaming])
 
@@ -845,6 +852,7 @@ function PinnedConnectionItem({
             {isRenaming ? (
               <input
                 ref={renameInputRef}
+                autoFocus
                 value={nameInput}
                 onChange={(e) => setNameInput(e.target.value)}
                 onKeyDown={handleRenameKeyDown}

--- a/src/renderer/src/components/projects/ProjectItem.tsx
+++ b/src/renderer/src/components/projects/ProjectItem.tsx
@@ -117,11 +117,13 @@ export function ProjectItem({
   const isExpanded = expandedProjectIds.has(project.id)
   const isEditing = editingProjectId === project.id
 
-  // Focus input when editing starts
+  // Focus input when editing starts (deferred to run after menu closes)
   useEffect(() => {
-    if (isEditing && inputRef.current) {
-      inputRef.current.focus()
-      inputRef.current.select()
+    if (isEditing) {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus()
+        inputRef.current?.select()
+      })
     }
   }, [isEditing])
 
@@ -274,6 +276,7 @@ export function ProjectItem({
             {isEditing ? (
               <Input
                 ref={inputRef}
+                autoFocus
                 value={editName}
                 onChange={(e) => setEditName(e.target.value)}
                 onBlur={handleSaveEdit}

--- a/src/renderer/src/components/worktrees/WorktreeItem.tsx
+++ b/src/renderer/src/components/worktrees/WorktreeItem.tsx
@@ -217,11 +217,13 @@ export function WorktreeItem({
   const [branchNameInput, setBranchNameInput] = useState('')
   const renameInputRef = useRef<HTMLInputElement>(null)
 
-  // Auto-focus the rename input when it appears
+  // Auto-focus the rename input when it appears (deferred to run after menu closes)
   useEffect(() => {
-    if (isRenamingBranch && renameInputRef.current) {
-      renameInputRef.current.focus()
-      renameInputRef.current.select()
+    if (isRenamingBranch) {
+      requestAnimationFrame(() => {
+        renameInputRef.current?.focus()
+        renameInputRef.current?.select()
+      })
     }
   }, [isRenamingBranch])
 
@@ -499,6 +501,7 @@ export function WorktreeItem({
             {isRenamingBranch ? (
               <input
                 ref={renameInputRef}
+                autoFocus
                 value={branchNameInput}
                 onChange={(e) => setBranchNameInput(e.target.value)}
                 onKeyDown={(e) => {


### PR DESCRIPTION
## Summary

- **Fixed rename input focus reliability** across all item components (`ConnectionItem`, `PinnedList`, `ProjectItem`, `WorktreeItem`)
- The rename/edit input fields were not consistently receiving focus when triggered from context menus, because the focus call would fire while the menu was still closing
- Applied a two-pronged fix in all 5 rename input locations:
  1. **Deferred focus via `requestAnimationFrame`** — the `useEffect` that fires on rename state change now wraps `focus()` + `select()` in `requestAnimationFrame()`, ensuring the call runs after the context menu has fully closed and the input is mounted in the DOM
  2. **Added `autoFocus` prop** — as a belt-and-suspenders measure, the input elements now also carry `autoFocus` so the browser natively attempts focus on mount

## Files Changed

| File | Change |
|------|--------|
| `ConnectionItem.tsx` | Deferred focus + `autoFocus` on rename input |
| `PinnedList.tsx` (PinnedWorktreeItem) | Deferred focus + `autoFocus` on branch rename input |
| `PinnedList.tsx` (PinnedConnectionItem) | Deferred focus + `autoFocus` on rename input |
| `ProjectItem.tsx` | Deferred focus + `autoFocus` on project name edit input |
| `WorktreeItem.tsx` | Deferred focus + `autoFocus` on branch rename input |

## Test plan

- [ ] Right-click a project → Rename → verify input is focused and text is selected
- [ ] Right-click a worktree → Rename Branch → verify input is focused and text is selected
- [ ] Right-click a connection → Rename → verify input is focused and text is selected
- [ ] Right-click a pinned worktree → Rename Branch → verify input is focused and text is selected
- [ ] Right-click a pinned connection → Rename → verify input is focused and text is selected
- [ ] Verify no regressions in normal click/navigation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced focus handling for rename input fields across connections, projects, branches, and worktrees, ensuring inputs reliably receive focus after menu transitions and UI updates complete for a smoother renaming experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->