### PR TITLE
Multiline custom answer input in QuestionPrompt

### DIFF
--- a/src/renderer/src/components/sessions/QuestionPrompt.tsx
+++ b/src/renderer/src/components/sessions/QuestionPrompt.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef, useLayoutEffect } from 'react'
 import { MessageCircleQuestion, Check, X, ChevronRight, Pencil } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -17,11 +17,22 @@ export function QuestionPrompt({ request, onReply, onReject }: QuestionPromptPro
   const [editingCustom, setEditingCustom] = useState(false)
   const [sending, setSending] = useState(false)
 
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
   const isMultiQuestion = request.questions.length > 1
   const currentQuestion = request.questions[currentTab]
   const isMultiple = currentQuestion?.multiple ?? false
   const isCustomAllowed = currentQuestion?.custom !== false
   const isLastTab = currentTab === request.questions.length - 1
+
+  // Auto-resize the custom answer textarea
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = 'auto'
+      textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`
+    }
+  }, [customInputs, currentTab])
 
   const handleSubmit = useCallback(
     (finalAnswers?: QuestionAnswer[]) => {
@@ -231,7 +242,7 @@ export function QuestionPrompt({ request, onReply, onReject }: QuestionPromptPro
             >
               <div className="flex items-center gap-2 min-w-0">
                 <Pencil className="h-3.5 w-3.5 shrink-0 text-blue-400" />
-                <span className="text-sm font-medium truncate">{customAnswer}</span>
+                <span className="text-sm font-medium whitespace-pre-wrap line-clamp-3">{customAnswer}</span>
               </div>
             </button>
           )}
@@ -258,12 +269,20 @@ export function QuestionPrompt({ request, onReply, onReject }: QuestionPromptPro
               className="flex gap-2"
               data-testid="custom-input-form"
             >
-              <input
+              <textarea
+                ref={textareaRef}
                 autoFocus
                 value={customInputs[currentTab] || ''}
                 onChange={(e) => handleCustomInputChange(e.target.value)}
-                className="flex-1 bg-background border border-border rounded px-2 py-1.5 text-sm focus:outline-none focus:border-blue-500/50 transition-colors"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault()
+                    handleCustomSubmit(e)
+                  }
+                }}
+                className="flex-1 bg-background border border-border rounded px-2 py-1.5 text-sm focus:outline-none focus:border-blue-500/50 transition-colors resize-none min-h-[36px] max-h-[200px]"
                 placeholder="Type your answer..."
+                rows={1}
                 disabled={sending}
               />
               <Button


### PR DESCRIPTION
## Summary

- **Converted the custom answer input from a single-line `<input>` to a multiline `<textarea>`** in `QuestionPrompt.tsx`, allowing users to enter multi-line responses when providing custom answers to AI questions
- **Added auto-resize behavior** using `useLayoutEffect` that dynamically adjusts the textarea height based on content, capped at 200px max height
- **Added `Shift+Enter` support** for inserting newlines, while plain `Enter` still submits the answer
- **Updated the custom answer display** to use `whitespace-pre-wrap` and `line-clamp-3` so multiline answers render properly (with truncation after 3 lines) when shown as a selected option

## Changes

**`src/renderer/src/components/sessions/QuestionPrompt.tsx`**
- Import `useRef` and `useLayoutEffect` from React
- Add `textareaRef` for the textarea element
- Add `useLayoutEffect` hook that auto-resizes the textarea on content/tab changes (max 200px)
- Replace `<input>` with `<textarea>` including `onKeyDown` handler for Enter/Shift+Enter behavior
- Add `resize-none`, `min-h-[36px]`, `max-h-[200px]` styling and `rows={1}` for proper initial sizing
- Update custom answer display span to use `whitespace-pre-wrap line-clamp-3` instead of `truncate`

## Test plan

- [ ] Open a session with AI questions that allow custom answers
- [ ] Verify the custom input appears as a single-line field initially
- [ ] Type a long multi-line answer using Shift+Enter — textarea should auto-expand up to 200px
- [ ] Press Enter (without Shift) to submit — should submit the answer
- [ ] Verify the submitted custom answer displays with preserved line breaks (up to 3 lines visible)
- [ ] Switch between question tabs and verify auto-resize recalculates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced custom answer input with multi-line textarea support and auto-resizing.
  * Improved display of long answers with preserved formatting and line clamping.
  * Added direct Enter key submission for custom answers (Shift+Enter for new lines).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->