### PR TITLE
Background follow-up dispatch and session init abort guards

### DIFF
--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -461,7 +461,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   // rely on the FileTree sidebar component having already populated the store
   // (sidebar may be collapsed, on a different tab, or targeting a different worktree).
   const fileIndex = useFileTreeStore((state) =>
-    worktreePath ? (state.fileIndexByWorktree.get(worktreePath) ?? EMPTY_FILE_INDEX) : EMPTY_FILE_INDEX
+    worktreePath
+      ? (state.fileIndexByWorktree.get(worktreePath) ?? EMPTY_FILE_INDEX)
+      : EMPTY_FILE_INDEX
   )
   useEffect(() => {
     if (worktreePath && fileIndex === EMPTY_FILE_INDEX) {
@@ -1010,10 +1012,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         for (const msg of loadedMessages) {
           if (msg.parts) {
             for (const part of msg.parts) {
-              if (
-                part.type === 'tool_use' &&
-                part.toolUse?.id === pendingPlanForLoad.toolUseID
-              ) {
+              if (part.type === 'tool_use' && part.toolUse?.id === pendingPlanForLoad.toolUseID) {
                 part.toolUse.status = 'pending'
               }
             }
@@ -1142,6 +1141,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     // instances process events concurrently during tab transitions.
     streamGenerationRef.current += 1
     const currentGeneration = streamGenerationRef.current
+    let isEffectActive = true
+
+    const shouldAbortInit = (): boolean => {
+      return !isEffectActive || streamGenerationRef.current !== currentGeneration
+    }
 
     // Clear streaming display state. The key={sessionId} on SessionView forces a
     // full remount on session change, so this always starts fresh.
@@ -1765,13 +1769,14 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                 lastSentPromptRef.current = followUp
                 const wtPath = transcriptSourceRef.current.worktreePath
                 const opcSid = transcriptSourceRef.current.opencodeSessionId
+                if (!wtPath || !opcSid) {
+                  useSessionStore.getState().requeueFollowUpMessageFront(sessionId, followUp)
+                  useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+                  setIsSending(false)
+                  return
+                }
                 window.opencodeOps
-                  .prompt(
-                    wtPath,
-                    opcSid,
-                    [{ type: 'text', text: followUp }],
-                    getModelForRequests()
-                  )
+                  .prompt(wtPath, opcSid, [{ type: 'text', text: followUp }], getModelForRequests())
                   .then((result) => {
                     if (!result.success) {
                       console.error('Failed to send follow-up message:', result.error)
@@ -1821,6 +1826,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       : () => {}
 
     const initializeSession = async (): Promise<void> => {
+      if (shouldAbortInit()) return
+
       setViewState({ status: 'connecting' })
       setSessionRetry(null)
       setSessionErrorMessage(null)
@@ -1838,6 +1845,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       try {
         // 1. Resolve session/worktree metadata so transcript loading can prefer OpenCode
         const session = (await window.db.session.get(sessionId)) as DbSession | null
+        if (shouldAbortInit()) return
         if (!session) {
           throw new Error('Session not found')
         }
@@ -1859,6 +1867,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         if (session.worktree_id) {
           setWorktreeId(session.worktree_id)
           const worktree = (await window.db.worktree.get(session.worktree_id)) as DbWorktree | null
+          if (shouldAbortInit()) return
           if (worktree) {
             wtPath = worktree.path
             setWorktreePath(wtPath)
@@ -1869,6 +1878,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           setConnectionId(session.connection_id)
           try {
             const connResult = await window.connectionOps.get(session.connection_id)
+            if (shouldAbortInit()) return
             if (connResult.success && connResult.connection) {
               wtPath = connResult.connection.path
               setWorktreePath(wtPath)
@@ -1890,6 +1900,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         if (wtPath && existingOpcSessionId && window.opencodeOps?.sessionInfo) {
           try {
             const sessionInfo = await window.opencodeOps.sessionInfo(wtPath, existingOpcSessionId)
+            if (shouldAbortInit()) return
             if (sessionInfo.success) {
               setRevertMessageID(sessionInfo.revertMessageID ?? null)
               revertDiffRef.current = sessionInfo.revertDiff ?? null
@@ -1904,6 +1915,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           worktreePath: wtPath,
           opencodeSessionId: existingOpcSessionId
         })
+        if (shouldAbortInit()) return
 
         // 2b. Restore streaming parts from the last persisted assistant message,
         // but ONLY when the session is actively busy. For idle sessions the
@@ -2075,8 +2087,16 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
         // Send any pending initial message (e.g., from code review)
         const sendPendingMessage = async (path: string, opcId: string): Promise<void> => {
-          const pendingMsg = useSessionStore.getState().consumePendingMessage(sessionId)
+          if (shouldAbortInit()) return
+          const pendingMsg = useSessionStore.getState().dequeuePendingMessage(sessionId)
           if (!pendingMsg) return
+
+          const restorePendingAfterFailure = (): void => {
+            useSessionStore.getState().requeuePendingMessage(sessionId, pendingMsg)
+            newPromptPendingRef.current = false
+            useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+          }
+
           try {
             // Mirror handleSend: set streaming/sending state BEFORE the prompt call
             // so the UI shows the correct state and finalizeResponse behaves correctly.
@@ -2108,14 +2128,23 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
               { type: 'text' as const, text: promptMessage }
             ]
             const result = await window.opencodeOps.prompt(path, opcId, parts, model)
+            if (shouldAbortInit()) {
+              if (!result.success) {
+                restorePendingAfterFailure()
+              }
+              setIsSending(false)
+              return
+            }
             if (!result.success) {
               console.error('Failed to send pending message:', result.error)
               toast.error('Failed to send review prompt')
+              restorePendingAfterFailure()
               setIsSending(false)
             }
           } catch (err) {
             console.error('Failed to send pending message:', err)
             toast.error('Failed to send review prompt')
+            restorePendingAfterFailure()
             setIsSending(false)
           }
         }
@@ -2127,6 +2156,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
             existingOpcSessionId,
             sessionId
           )
+          if (shouldAbortInit()) return
           if (reconnectResult.success) {
             setOpencodeSessionId(existingOpcSessionId)
             useSessionStore.getState().setOpenCodeSessionId(sessionId, existingOpcSessionId)
@@ -2154,9 +2184,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
             // Corrects Part A if the session finished while we were away,
             // or confirms busy if the store was accurate.
             // Don't overwrite plan_ready — session is blocked waiting for plan approval.
-            const hasPendingPlanOnReconnect = useSessionStore
-              .getState()
-              .getPendingPlan(sessionId)
+            const hasPendingPlanOnReconnect = useSessionStore.getState().getPendingPlan(sessionId)
             if (reconnectResult.sessionStatus === 'busy') {
               if (!hasPendingPlanOnReconnect) {
                 setSessionRetry(null)
@@ -2166,10 +2194,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                 const currentMode = useSessionStore.getState().getSessionMode(sessionId)
                 useWorktreeStatusStore
                   .getState()
-                  .setSessionStatus(
-                    sessionId,
-                    currentMode === 'plan' ? 'planning' : 'working'
-                  )
+                  .setSessionStatus(sessionId, currentMode === 'plan' ? 'planning' : 'working')
               }
             } else if (reconnectResult.sessionStatus === 'idle') {
               if (!hasPendingPlanOnReconnect) {
@@ -2179,14 +2204,10 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                 setSessionErrorMessage(null)
                 // If the session was previously busy, the agent finished while we
                 // were away — show a completion badge instead of clearing to "Ready".
-                if (
-                  storedStatus?.status === 'working' ||
-                  storedStatus?.status === 'planning'
-                ) {
+                if (storedStatus?.status === 'working' || storedStatus?.status === 'planning') {
                   const sendTime = messageSendTimes.get(sessionId)
                   const durationMs = sendTime ? Date.now() - sendTime : 0
-                  const word =
-                    COMPLETION_WORDS[Math.floor(Math.random() * COMPLETION_WORDS.length)]
+                  const word = COMPLETION_WORDS[Math.floor(Math.random() * COMPLETION_WORDS.length)]
                   useWorktreeStatusStore
                     .getState()
                     .setSessionStatus(sessionId, 'completed', { word, durationMs })
@@ -2203,6 +2224,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
             // Refresh transcript using the confirmed live OpenCode session ID.
             // This avoids keeping a stale/partial pre-connect transcript.
             await loadMessages({ worktreePath: wtPath, opencodeSessionId: existingOpcSessionId })
+            if (shouldAbortInit()) return
 
             await sendPendingMessage(wtPath, existingOpcSessionId)
             return
@@ -2211,6 +2233,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
         // Create new OpenCode session
         const connectResult = await window.opencodeOps.connect(wtPath, sessionId)
+        if (shouldAbortInit()) return
         if (connectResult.success && connectResult.sessionId) {
           setOpencodeSessionId(connectResult.sessionId)
           useSessionStore.getState().setOpenCodeSessionId(sessionId, connectResult.sessionId)
@@ -2241,6 +2264,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
           // Refresh transcript after establishing the active OpenCode session.
           await loadMessages({ worktreePath: wtPath, opencodeSessionId: connectResult.sessionId })
+          if (shouldAbortInit()) return
 
           await sendPendingMessage(wtPath, connectResult.sessionId)
         } else {
@@ -2259,6 +2283,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
     // Cleanup on unmount or session change
     return () => {
+      isEffectActive = false
       unsubscribe()
       // DO NOT clear questions or permissions — they must persist across tab switches.
       // They are removed individually when answered/rejected via removeQuestion/removePermission.
@@ -3051,7 +3076,15 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     await useSessionStore.getState().setSessionMode(sessionId, 'build')
     lastSendMode.set(sessionId, 'build')
     await handleSend('Implement')
-  }, [sessionId, handleSend, worktreePath, pendingPlan, isClaudeCode, updateStreamingPartsRef, immediateFlush])
+  }, [
+    sessionId,
+    handleSend,
+    worktreePath,
+    pendingPlan,
+    isClaudeCode,
+    updateStreamingPartsRef,
+    immediateFlush
+  ])
 
   const handlePlanReject = useCallback(
     async (feedback: string) => {
@@ -3152,9 +3185,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     // 1. Extract plan content
     const planContent =
       pendingPlan?.planContent ??
-      [...messages]
-        .reverse()
-        .find((m) => m.role === 'assistant' && m.content.trim().length > 0)?.content
+      [...messages].reverse().find((m) => m.role === 'assistant' && m.content.trim().length > 0)
+        ?.content
     if (!planContent) {
       toast.error('No plan content found to supercharge')
       return
@@ -3234,9 +3266,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     // 1. Extract plan content
     const planContent =
       pendingPlan?.planContent ??
-      [...messages]
-        .reverse()
-        .find((m) => m.role === 'assistant' && m.content.trim().length > 0)?.content
+      [...messages].reverse().find((m) => m.role === 'assistant' && m.content.trim().length > 0)
+        ?.content
     if (!planContent) {
       toast.error('No plan content found to supercharge')
       return

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
@@ -11,6 +11,145 @@ import { extractTokens, extractCost, extractModelRef, extractModelUsage } from '
 import { COMPLETION_WORDS } from '@/lib/format-utils'
 import { messageSendTimes } from '@/lib/message-send-times'
 
+interface PromptDispatchContext {
+  worktreePath: string
+  opencodeSessionId: string
+}
+
+function resolvePromptDispatchContextFromStores(sessionId: string): PromptDispatchContext | null {
+  const sessionState = useSessionStore.getState()
+
+  for (const [worktreeId, sessions] of sessionState.sessionsByWorktree) {
+    const session = sessions.find((s) => s.id === sessionId)
+    if (!session?.opencode_session_id) continue
+
+    const worktreesByProject = useWorktreeStore.getState().worktreesByProject
+    for (const worktrees of worktreesByProject.values()) {
+      const worktree = worktrees.find((w) => w.id === worktreeId)
+      if (worktree?.path) {
+        return {
+          worktreePath: worktree.path,
+          opencodeSessionId: session.opencode_session_id
+        }
+      }
+    }
+  }
+
+  for (const [connectionId, sessions] of sessionState.sessionsByConnection) {
+    const session = sessions.find((s) => s.id === sessionId)
+    if (!session?.opencode_session_id) continue
+
+    const connection = useConnectionStore
+      .getState()
+      .connections.find((item) => item.id === connectionId)
+    if (connection?.path) {
+      return {
+        worktreePath: connection.path,
+        opencodeSessionId: session.opencode_session_id
+      }
+    }
+  }
+
+  return null
+}
+
+async function resolvePromptDispatchContext(
+  sessionId: string
+): Promise<PromptDispatchContext | null> {
+  const storeContext = resolvePromptDispatchContextFromStores(sessionId)
+
+  if (!window.db?.session?.get) {
+    return storeContext
+  }
+
+  try {
+    const dbSession = (await window.db.session.get(sessionId)) as {
+      worktree_id?: string | null
+      connection_id?: string | null
+      opencode_session_id?: string | null
+    } | null
+
+    const dbOpcSessionId = dbSession?.opencode_session_id ?? null
+    if (!dbOpcSessionId) {
+      return storeContext
+    }
+
+    if (dbSession?.worktree_id && window.db?.worktree?.get) {
+      const dbWorktree = (await window.db.worktree.get(dbSession.worktree_id)) as {
+        path?: string | null
+      } | null
+      if (dbWorktree?.path) {
+        return {
+          worktreePath: dbWorktree.path,
+          opencodeSessionId: dbOpcSessionId
+        }
+      }
+    }
+
+    if (dbSession?.connection_id && window.connectionOps?.get) {
+      const connectionResult = await window.connectionOps.get(dbSession.connection_id)
+      if (connectionResult.success && connectionResult.connection?.path) {
+        return {
+          worktreePath: connectionResult.connection.path,
+          opencodeSessionId: dbOpcSessionId
+        }
+      }
+    }
+
+    if (storeContext) {
+      return { ...storeContext, opencodeSessionId: dbOpcSessionId }
+    }
+  } catch {
+    // DB lookup failed — fall through to store context
+  }
+
+  return storeContext
+}
+
+function markBackgroundSessionCompleted(sessionId: string): void {
+  const sendTime = messageSendTimes.get(sessionId)
+  const durationMs = sendTime ? Date.now() - sendTime : 0
+  const word = COMPLETION_WORDS[Math.floor(Math.random() * COMPLETION_WORDS.length)]
+  useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'completed', { word, durationMs })
+
+  const now = Date.now()
+  const sessions = useSessionStore.getState().sessionsByWorktree
+  let found = false
+  for (const [worktreeId, wSessions] of sessions) {
+    if (wSessions.some((s) => s.id === sessionId)) {
+      useWorktreeStatusStore.getState().setLastMessageTime(worktreeId, now)
+      useRecentStore.getState().addWorktreeToRecent(worktreeId)
+      found = true
+      break
+    }
+  }
+
+  const connectionSessions = useSessionStore.getState().sessionsByConnection
+  for (const [connectionId, cSessions] of connectionSessions) {
+    if (cSessions.some((s) => s.id === sessionId)) {
+      useRecentStore.getState().addConnectionToRecent(connectionId)
+      break
+    }
+  }
+
+  if (!found) {
+    const connSessions = useSessionStore.getState().sessionsByConnection
+    for (const [connectionId, cSessions] of connSessions) {
+      if (cSessions.some((s) => s.id === sessionId)) {
+        const connection = useConnectionStore
+          .getState()
+          .connections.find((c) => c.id === connectionId)
+        if (connection) {
+          for (const member of connection.members) {
+            useWorktreeStatusStore.getState().setLastMessageTime(member.worktree_id, now)
+          }
+        }
+        break
+      }
+    }
+  }
+}
+
 /**
  * Persistent global listener for OpenCode stream events.
  *
@@ -21,6 +160,9 @@ import { messageSendTimes } from '@/lib/message-send-times'
  * - Branch auto-rename notifications from the main process
  */
 export function useOpenCodeGlobalListener(): void {
+  const backgroundFollowUpDispatchingRef = useRef<Set<string>>(new Set())
+  const deferredIdleWhileDispatchingRef = useRef<Set<string>>(new Set())
+
   // Listen for branch auto-rename events from the main process
   useEffect(() => {
     const unsubscribe = window.worktreeOps?.onBranchRenamed
@@ -233,55 +375,86 @@ export function useOpenCodeGlobalListener(): void {
           // Active session is handled by SessionView.
           if (sessionId === activeId) return
 
-          // Set completion badge — duration measured from when user sent the message
-          const sendTime = messageSendTimes.get(sessionId)
-          const durationMs = sendTime ? Date.now() - sendTime : 0
-          const word = COMPLETION_WORDS[Math.floor(Math.random() * COMPLETION_WORDS.length)]
-          useWorktreeStatusStore
-            .getState()
-            .setSessionStatus(sessionId, 'completed', { word, durationMs })
+          const dispatchBackgroundFollowUp = (message: string): void => {
+            backgroundFollowUpDispatchingRef.current.add(sessionId)
 
-          // Update last message time for the worktree (or connection member worktrees)
-          const now = Date.now()
-          const sessions = useSessionStore.getState().sessionsByWorktree
-          let found = false
-          for (const [worktreeId, wSessions] of sessions) {
-            if (wSessions.some((s) => s.id === sessionId)) {
-              useWorktreeStatusStore.getState().setLastMessageTime(worktreeId, now)
-              // Always track recent activity so data is fresh when toggled on (Fix #6)
-              useRecentStore.getState().addWorktreeToRecent(worktreeId)
-              found = true
-              break
-            }
-          }
-
-          // Also check connection sessions for recent tracking
-          const connectionSessions = useSessionStore.getState().sessionsByConnection
-          for (const [connectionId, cSessions] of connectionSessions) {
-            if (cSessions.some((s) => s.id === sessionId)) {
-              useRecentStore.getState().addConnectionToRecent(connectionId)
-              break
-            }
-          }
-          // If the session belongs to a connection, update all member worktrees
-          if (!found) {
-            const connSessions = useSessionStore.getState().sessionsByConnection
-            for (const [connectionId, cSessions] of connSessions) {
-              if (cSessions.some((s) => s.id === sessionId)) {
-                const connection = useConnectionStore
-                  .getState()
-                  .connections.find((c) => c.id === connectionId)
-                if (connection) {
-                  for (const member of connection.members) {
-                    useWorktreeStatusStore
-                      .getState()
-                      .setLastMessageTime(member.worktree_id, now)
-                  }
+            void (async () => {
+              let dispatchSucceeded = false
+              try {
+                const context = await resolvePromptDispatchContext(sessionId)
+                if (!context || !window.opencodeOps?.prompt) {
+                  useSessionStore.getState().requeueFollowUpMessageFront(sessionId, message)
+                  markBackgroundSessionCompleted(sessionId)
+                  return
                 }
-                break
+
+                if (context.opencodeSessionId.startsWith('pending::')) {
+                  useSessionStore.getState().requeueFollowUpMessageFront(sessionId, message)
+                  markBackgroundSessionCompleted(sessionId)
+                  return
+                }
+
+                const mode = useSessionStore.getState().getSessionMode(sessionId)
+                useWorktreeStatusStore
+                  .getState()
+                  .setSessionStatus(sessionId, mode === 'plan' ? 'planning' : 'working')
+
+                const result = await window.opencodeOps.prompt(
+                  context.worktreePath,
+                  context.opencodeSessionId,
+                  [{ type: 'text', text: message }]
+                )
+
+                if (!result.success) {
+                  useSessionStore.getState().requeueFollowUpMessageFront(sessionId, message)
+                  markBackgroundSessionCompleted(sessionId)
+                  return
+                }
+
+                dispatchSucceeded = true
+              } catch {
+                useSessionStore.getState().requeueFollowUpMessageFront(sessionId, message)
+                markBackgroundSessionCompleted(sessionId)
+              } finally {
+                backgroundFollowUpDispatchingRef.current.delete(sessionId)
+
+                if (!deferredIdleWhileDispatchingRef.current.has(sessionId)) {
+                  return
+                }
+
+                deferredIdleWhileDispatchingRef.current.delete(sessionId)
+
+                // If dispatch failed, we've already requeued + set completed above.
+                if (!dispatchSucceeded) return
+
+                // Don't overwrite plan_ready — session is blocked waiting for plan approval
+                if (useSessionStore.getState().getPendingPlan(sessionId)) return
+
+                const nextFollowUp = useSessionStore.getState().dequeueFollowUpMessage(sessionId)
+                if (nextFollowUp) {
+                  dispatchBackgroundFollowUp(nextFollowUp)
+                  return
+                }
+
+                markBackgroundSessionCompleted(sessionId)
               }
-            }
+            })()
           }
+
+          // Background queued follow-ups should be dispatched here so they survive tab switches.
+          if (backgroundFollowUpDispatchingRef.current.has(sessionId)) {
+            deferredIdleWhileDispatchingRef.current.add(sessionId)
+            return
+          }
+
+          const followUp = useSessionStore.getState().dequeueFollowUpMessage(sessionId)
+          if (followUp) {
+            dispatchBackgroundFollowUp(followUp)
+
+            return
+          }
+
+          markBackgroundSessionCompleted(sessionId)
         })
       : () => {}
 

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -95,8 +95,12 @@ interface SessionState {
   setSessionModel: (sessionId: string, model: SelectedModel) => Promise<void>
   setOpenCodeSessionId: (sessionId: string, opencodeSessionId: string | null) => void
   setPendingMessage: (sessionId: string, message: string) => void
+  dequeuePendingMessage: (sessionId: string) => string | null
+  requeuePendingMessage: (sessionId: string, message: string) => void
   consumePendingMessage: (sessionId: string) => string | null
   setPendingFollowUpMessages: (sessionId: string, messages: string[]) => void
+  dequeueFollowUpMessage: (sessionId: string) => string | null
+  requeueFollowUpMessageFront: (sessionId: string, message: string) => void
   consumeFollowUpMessage: (sessionId: string) => string | null
   closeOtherSessions: (worktreeId: string, keepSessionId: string) => Promise<void>
   closeSessionsToRight: (worktreeId: string, fromSessionId: string) => Promise<void>
@@ -265,7 +269,8 @@ export const useSessionStore = create<SessionState>()(
         try {
           // Resolve default agent SDK from settings
           const { useSettingsStore } = await import('./useSettingsStore')
-          const defaultAgentSdk = agentSdkOverride ?? useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
+          const defaultAgentSdk =
+            agentSdkOverride ?? useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
 
           const isTerminal = defaultAgentSdk === 'terminal'
 
@@ -591,7 +596,11 @@ export const useSessionStore = create<SessionState>()(
 
         if (worktreeId === state.activeWorktreeId) return
 
-        set({ activeWorktreeId: worktreeId, activeConnectionId: null, inlineConnectionSessionId: null })
+        set({
+          activeWorktreeId: worktreeId,
+          activeConnectionId: null,
+          inlineConnectionSessionId: null
+        })
 
         if (worktreeId) {
           // Check if we already have sessions for this worktree
@@ -893,8 +902,8 @@ export const useSessionStore = create<SessionState>()(
         })
       },
 
-      // Consume (get and remove) a pending message for a session
-      consumePendingMessage: (sessionId: string): string | null => {
+      // Dequeue (get and remove) a pending message for a session
+      dequeuePendingMessage: (sessionId: string): string | null => {
         const message = get().pendingMessages.get(sessionId) || null
         if (message) {
           set((state) => {
@@ -906,19 +915,35 @@ export const useSessionStore = create<SessionState>()(
         return message
       },
 
+      // Restore a pending message for a session (used when auto-send fails)
+      requeuePendingMessage: (sessionId: string, message: string) => {
+        set((state) => {
+          const newMap = new Map(state.pendingMessages)
+          newMap.set(sessionId, message)
+          return { pendingMessages: newMap }
+        })
+      },
+
+      // Consume (get and remove) a pending message for a session
+      consumePendingMessage: (sessionId: string): string | null => {
+        return get().dequeuePendingMessage(sessionId)
+      },
+
       // Set follow-up messages queue for a session (ordered, auto-sent after each idle)
       setPendingFollowUpMessages: (sessionId: string, messages: string[]) => {
         set((state) => {
           const newMap = new Map(state.pendingFollowUpMessages)
-          newMap.set(sessionId, messages)
+          newMap.set(sessionId, [...messages])
           return { pendingFollowUpMessages: newMap }
         })
       },
 
-      // Consume (pop first) a follow-up message for a session
-      consumeFollowUpMessage: (sessionId: string): string | null => {
+      // Dequeue (pop first) a follow-up message for a session
+      dequeueFollowUpMessage: (sessionId: string): string | null => {
         const messages = get().pendingFollowUpMessages.get(sessionId)
-        if (!messages || messages.length === 0) return null
+        if (!messages || messages.length === 0) {
+          return null
+        }
         const [first, ...rest] = messages
         set((state) => {
           const newMap = new Map(state.pendingFollowUpMessages)
@@ -930,6 +955,21 @@ export const useSessionStore = create<SessionState>()(
           return { pendingFollowUpMessages: newMap }
         })
         return first
+      },
+
+      // Requeue a follow-up message at the front (used on transient send failure)
+      requeueFollowUpMessageFront: (sessionId: string, message: string) => {
+        set((state) => {
+          const existing = state.pendingFollowUpMessages.get(sessionId) || []
+          const newMap = new Map(state.pendingFollowUpMessages)
+          newMap.set(sessionId, [message, ...existing])
+          return { pendingFollowUpMessages: newMap }
+        })
+      },
+
+      // Consume (pop first) a follow-up message for a session
+      consumeFollowUpMessage: (sessionId: string): string | null => {
+        return get().dequeueFollowUpMessage(sessionId)
       },
 
       // Close all sessions except the kept one

--- a/test/phase-16/session-4/global-listener-busy.test.ts
+++ b/test/phase-16/session-4/global-listener-busy.test.ts
@@ -56,6 +56,27 @@ vi.mock('@/stores/useQuestionStore', () => ({
   }
 }))
 
+// Mock usePermissionStore
+vi.mock('@/stores/usePermissionStore', () => ({
+  usePermissionStore: {
+    getState: () => ({
+      addPermission: vi.fn(),
+      removePermission: vi.fn(),
+      pendingBySession: new Map()
+    })
+  }
+}))
+
+// Mock useRecentStore
+vi.mock('@/stores/useRecentStore', () => ({
+  useRecentStore: {
+    getState: () => ({
+      addWorktreeToRecent: vi.fn(),
+      addConnectionToRecent: vi.fn()
+    })
+  }
+}))
+
 // Mock useContextStore (imported by the listener)
 const setSessionTokensSpy = vi.fn()
 const addSessionCostSpy = vi.fn()
@@ -97,8 +118,11 @@ vi.mock('@/stores/useSessionStore', () => ({
       activeSessionId: 'session-A',
       getSessionMode: getSessionModeSpy,
       getPendingPlan: vi.fn(() => null),
+      dequeueFollowUpMessage: vi.fn(() => null),
+      requeueFollowUpMessageFront: vi.fn(),
       updateSessionName: updateSessionNameSpy,
-      sessionsByWorktree: new Map([['wt-1', [{ id: 'session-B' }]]])
+      sessionsByWorktree: new Map([['wt-1', [{ id: 'session-B', opencode_session_id: 'opc-1' }]]]),
+      sessionsByConnection: new Map()
     })
   }
 }))

--- a/test/phase-16/session-4/global-listener-follow-up-dispatch.test.ts
+++ b/test/phase-16/session-4/global-listener-follow-up-dispatch.test.ts
@@ -1,0 +1,403 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, renderHook } from '@testing-library/react'
+import { useOpenCodeGlobalListener } from '@/hooks/useOpenCodeGlobalListener'
+
+let streamCallback: ((event: Record<string, unknown>) => void) | null = null
+
+const mockPrompt = vi.fn<
+  (
+    path: string,
+    opencodeSessionId: string,
+    message: Array<{ type: 'text'; text: string }>
+  ) => Promise<{
+    success: boolean
+    error?: string
+  }>
+>()
+
+const mockOnStream = vi.fn((cb: (event: Record<string, unknown>) => void) => {
+  streamCallback = cb
+  return () => {
+    streamCallback = null
+  }
+})
+
+const mockOnBranchRenamed = vi.fn(() => () => {})
+const mockDbSessionGet = vi.fn()
+const mockDbWorktreeGet = vi.fn()
+const mockConnectionGet = vi.fn()
+
+Object.defineProperty(window, 'opencodeOps', {
+  writable: true,
+  value: {
+    onStream: mockOnStream,
+    prompt: mockPrompt
+  }
+})
+
+Object.defineProperty(window, 'worktreeOps', {
+  writable: true,
+  value: { onBranchRenamed: mockOnBranchRenamed }
+})
+
+Object.defineProperty(window, 'db', {
+  writable: true,
+  value: {
+    session: {
+      get: mockDbSessionGet
+    },
+    worktree: {
+      get: mockDbWorktreeGet
+    }
+  }
+})
+
+Object.defineProperty(window, 'connectionOps', {
+  writable: true,
+  value: {
+    get: mockConnectionGet
+  }
+})
+
+const setSessionStatusSpy = vi.fn()
+const setLastMessageTimeSpy = vi.fn()
+const addWorktreeToRecentSpy = vi.fn()
+const addConnectionToRecentSpy = vi.fn()
+
+const followUpQueues = new Map<string, string[]>()
+
+const sessionStoreState = {
+  activeSessionId: 'session-A',
+  getSessionMode: vi.fn(() => 'build'),
+  getPendingPlan: vi.fn(() => null),
+  updateSessionName: vi.fn(),
+  sessionsByWorktree: new Map<string, Array<{ id: string; opencode_session_id: string | null }>>(),
+  sessionsByConnection: new Map<
+    string,
+    Array<{ id: string; opencode_session_id: string | null }>
+  >(),
+  dequeueFollowUpMessage: vi.fn((sessionId: string) => {
+    const queue = followUpQueues.get(sessionId)
+    if (!queue || queue.length === 0) return null
+    const [head, ...rest] = queue
+    if (rest.length === 0) {
+      followUpQueues.delete(sessionId)
+    } else {
+      followUpQueues.set(sessionId, rest)
+    }
+    return head
+  }),
+  requeueFollowUpMessageFront: vi.fn((sessionId: string, message: string) => {
+    const queue = followUpQueues.get(sessionId) || []
+    followUpQueues.set(sessionId, [message, ...queue])
+  })
+}
+
+const worktreeStoreState = {
+  worktreesByProject: new Map<string, Array<{ id: string; path: string }>>(),
+  updateWorktreeBranch: vi.fn()
+}
+
+const connectionStoreState = {
+  connections: [] as Array<{ id: string; path: string; members: Array<{ worktree_id: string }> }>
+}
+
+vi.mock('@/stores/useSessionStore', () => ({
+  useSessionStore: {
+    getState: () => sessionStoreState
+  }
+}))
+
+vi.mock('@/stores/useWorktreeStore', () => ({
+  useWorktreeStore: {
+    getState: () => worktreeStoreState
+  }
+}))
+
+vi.mock('@/stores/useConnectionStore', () => ({
+  useConnectionStore: {
+    getState: () => connectionStoreState
+  }
+}))
+
+vi.mock('@/stores/useWorktreeStatusStore', () => ({
+  useWorktreeStatusStore: {
+    getState: () => ({
+      setSessionStatus: setSessionStatusSpy,
+      setLastMessageTime: setLastMessageTimeSpy,
+      clearSessionStatus: vi.fn(),
+      sessionStatuses: {}
+    })
+  }
+}))
+
+vi.mock('@/stores/useRecentStore', () => ({
+  useRecentStore: {
+    getState: () => ({
+      addWorktreeToRecent: addWorktreeToRecentSpy,
+      addConnectionToRecent: addConnectionToRecentSpy
+    })
+  }
+}))
+
+vi.mock('@/stores/useQuestionStore', () => ({
+  useQuestionStore: {
+    getState: () => ({
+      addQuestion: vi.fn(),
+      removeQuestion: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@/stores/usePermissionStore', () => ({
+  usePermissionStore: {
+    getState: () => ({
+      addPermission: vi.fn(),
+      removePermission: vi.fn(),
+      pendingBySession: new Map()
+    })
+  }
+}))
+
+vi.mock('@/stores/useContextStore', () => ({
+  useContextStore: {
+    getState: () => ({
+      setSessionTokens: vi.fn(),
+      addSessionCost: vi.fn(),
+      setModelLimit: vi.fn()
+    })
+  }
+}))
+
+function hasCompletedStatus(sessionId: string): boolean {
+  return setSessionStatusSpy.mock.calls.some((call) => {
+    const calledSessionId = call[0]
+    const status = call[1]
+    return calledSessionId === sessionId && status === 'completed'
+  })
+}
+
+async function flushAsync(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+describe('Global listener background follow-up dispatcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    streamCallback = null
+    followUpQueues.clear()
+    sessionStoreState.activeSessionId = 'session-A'
+    sessionStoreState.getSessionMode.mockReturnValue('build')
+    sessionStoreState.sessionsByWorktree = new Map()
+    sessionStoreState.sessionsByConnection = new Map()
+    worktreeStoreState.worktreesByProject = new Map()
+    connectionStoreState.connections = []
+    mockPrompt.mockResolvedValue({ success: true })
+    mockDbSessionGet.mockResolvedValue(null)
+    mockDbWorktreeGet.mockResolvedValue(null)
+    mockConnectionGet.mockResolvedValue({ success: false, error: 'not found' })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  function mountAndGetCallback() {
+    renderHook(() => useOpenCodeGlobalListener())
+    expect(streamCallback).not.toBeNull()
+    return streamCallback!
+  }
+
+  test('background idle with queued follow-up dispatches prompt and skips completed status', async () => {
+    followUpQueues.set('session-B', ['follow-up 2'])
+    sessionStoreState.sessionsByWorktree = new Map([
+      ['wt-1', [{ id: 'session-B', opencode_session_id: 'opc-123' }]]
+    ])
+    worktreeStoreState.worktreesByProject = new Map([
+      ['proj-1', [{ id: 'wt-1', path: '/tmp/worktree-1' }]]
+    ])
+
+    const cb = mountAndGetCallback()
+    cb({
+      type: 'session.status',
+      sessionId: 'session-B',
+      statusPayload: { type: 'idle' }
+    })
+    await flushAsync()
+
+    expect(mockPrompt).toHaveBeenCalledWith('/tmp/worktree-1', 'opc-123', [
+      { type: 'text', text: 'follow-up 2' }
+    ])
+    expect(setSessionStatusSpy).toHaveBeenCalledWith('session-B', 'working')
+    expect(hasCompletedStatus('session-B')).toBe(false)
+    expect(followUpQueues.has('session-B')).toBe(false)
+  })
+
+  test('prompt send failure requeues follow-up at front', async () => {
+    followUpQueues.set('session-B', ['follow-up 2'])
+    sessionStoreState.sessionsByWorktree = new Map([
+      ['wt-1', [{ id: 'session-B', opencode_session_id: 'opc-123' }]]
+    ])
+    worktreeStoreState.worktreesByProject = new Map([
+      ['proj-1', [{ id: 'wt-1', path: '/tmp/worktree-1' }]]
+    ])
+    mockPrompt.mockResolvedValue({ success: false, error: 'network failure' })
+
+    const cb = mountAndGetCallback()
+    cb({
+      type: 'session.status',
+      sessionId: 'session-B',
+      statusPayload: { type: 'idle' }
+    })
+    await flushAsync()
+
+    expect(mockPrompt).toHaveBeenCalledTimes(1)
+    expect(followUpQueues.get('session-B')).toEqual(['follow-up 2'])
+    expect(setSessionStatusSpy).toHaveBeenCalledWith('session-B', 'working')
+    expect(hasCompletedStatus('session-B')).toBe(true)
+  })
+
+  test('duplicate idle events while dispatch in-flight do not double-dispatch', async () => {
+    followUpQueues.set('session-B', ['follow-up 2'])
+    sessionStoreState.sessionsByWorktree = new Map([
+      ['wt-1', [{ id: 'session-B', opencode_session_id: 'opc-123' }]]
+    ])
+    worktreeStoreState.worktreesByProject = new Map([
+      ['proj-1', [{ id: 'wt-1', path: '/tmp/worktree-1' }]]
+    ])
+
+    const deferred = createDeferred<{ success: boolean }>()
+    mockPrompt.mockReturnValue(deferred.promise)
+
+    const cb = mountAndGetCallback()
+    cb({
+      type: 'session.status',
+      sessionId: 'session-B',
+      statusPayload: { type: 'idle' }
+    })
+    cb({
+      type: 'session.status',
+      sessionId: 'session-B',
+      statusPayload: { type: 'idle' }
+    })
+    await flushAsync()
+
+    expect(mockPrompt).toHaveBeenCalledTimes(1)
+    expect(sessionStoreState.dequeueFollowUpMessage).toHaveBeenCalledTimes(1)
+    expect(followUpQueues.has('session-B')).toBe(false)
+
+    deferred.resolve({ success: true })
+    await flushAsync()
+
+    expect(mockPrompt).toHaveBeenCalledTimes(1)
+    // One dequeue for initial dispatch, one dequeue when processing deferred idle.
+    expect(sessionStoreState.dequeueFollowUpMessage).toHaveBeenCalledTimes(2)
+    expect(hasCompletedStatus('session-B')).toBe(true)
+  })
+
+  test('background idle with no follow-up keeps existing completed behavior', () => {
+    sessionStoreState.sessionsByWorktree = new Map([
+      ['wt-1', [{ id: 'session-B', opencode_session_id: 'opc-123' }]]
+    ])
+    worktreeStoreState.worktreesByProject = new Map([
+      ['proj-1', [{ id: 'wt-1', path: '/tmp/worktree-1' }]]
+    ])
+
+    const cb = mountAndGetCallback()
+    cb({
+      type: 'session.status',
+      sessionId: 'session-B',
+      statusPayload: { type: 'idle' }
+    })
+
+    expect(mockPrompt).not.toHaveBeenCalled()
+    expect(hasCompletedStatus('session-B')).toBe(true)
+  })
+
+  test('active session idle is ignored by global listener even with queued follow-up', async () => {
+    followUpQueues.set('session-A', ['should not dispatch'])
+    sessionStoreState.activeSessionId = 'session-A'
+    sessionStoreState.sessionsByWorktree = new Map([
+      ['wt-1', [{ id: 'session-A', opencode_session_id: 'opc-active' }]]
+    ])
+    worktreeStoreState.worktreesByProject = new Map([
+      ['proj-1', [{ id: 'wt-1', path: '/tmp/worktree-active' }]]
+    ])
+
+    const cb = mountAndGetCallback()
+    cb({
+      type: 'session.status',
+      sessionId: 'session-A',
+      statusPayload: { type: 'idle' }
+    })
+    await flushAsync()
+
+    expect(mockPrompt).not.toHaveBeenCalled()
+    expect(followUpQueues.get('session-A')).toEqual(['should not dispatch'])
+    expect(setSessionStatusSpy).not.toHaveBeenCalled()
+  })
+
+  test('connection session follow-up uses connection path', async () => {
+    followUpQueues.set('session-C', ['follow-up connection'])
+    sessionStoreState.sessionsByConnection = new Map([
+      ['conn-1', [{ id: 'session-C', opencode_session_id: 'opc-conn' }]]
+    ])
+    connectionStoreState.connections = [
+      { id: 'conn-1', path: '/tmp/connection-root', members: [{ worktree_id: 'wt-1' }] }
+    ]
+
+    const cb = mountAndGetCallback()
+    cb({
+      type: 'session.status',
+      sessionId: 'session-C',
+      statusPayload: { type: 'idle' }
+    })
+    await flushAsync()
+
+    expect(mockPrompt).toHaveBeenCalledWith('/tmp/connection-root', 'opc-conn', [
+      { type: 'text', text: 'follow-up connection' }
+    ])
+    expect(setSessionStatusSpy).toHaveBeenCalledWith('session-C', 'working')
+    expect(hasCompletedStatus('session-C')).toBe(false)
+  })
+
+  test('background follow-up prefers DB materialized session id over store pending id', async () => {
+    followUpQueues.set('session-B', ['follow-up 2'])
+    sessionStoreState.sessionsByWorktree = new Map([
+      ['wt-1', [{ id: 'session-B', opencode_session_id: 'pending::abc' }]]
+    ])
+    worktreeStoreState.worktreesByProject = new Map([
+      ['proj-1', [{ id: 'wt-1', path: '/tmp/worktree-1' }]]
+    ])
+
+    mockDbSessionGet.mockResolvedValue({
+      id: 'session-B',
+      worktree_id: 'wt-1',
+      connection_id: null,
+      opencode_session_id: 'opc-real-123'
+    })
+    mockDbWorktreeGet.mockResolvedValue({ id: 'wt-1', path: '/tmp/worktree-1' })
+
+    const cb = mountAndGetCallback()
+    cb({
+      type: 'session.status',
+      sessionId: 'session-B',
+      statusPayload: { type: 'idle' }
+    })
+    await flushAsync()
+
+    expect(mockPrompt).toHaveBeenCalledWith('/tmp/worktree-1', 'opc-real-123', [
+      { type: 'text', text: 'follow-up 2' }
+    ])
+    expect(followUpQueues.has('session-B')).toBe(false)
+  })
+})

--- a/test/phase-7/session-4/code-review.test.ts
+++ b/test/phase-7/session-4/code-review.test.ts
@@ -122,18 +122,14 @@ describe('Session 4: Code Review', () => {
   // ---------------------------------------------------------------------------
   describe('Session store pending messages', () => {
     test('setPendingMessage stores message', async () => {
-      const { useSessionStore } = await import(
-        '../../../src/renderer/src/stores/useSessionStore'
-      )
+      const { useSessionStore } = await import('../../../src/renderer/src/stores/useSessionStore')
 
       useSessionStore.getState().setPendingMessage('session-1', 'Review prompt text')
       expect(useSessionStore.getState().pendingMessages.get('session-1')).toBe('Review prompt text')
     })
 
     test('consumePendingMessage returns and removes message', async () => {
-      const { useSessionStore } = await import(
-        '../../../src/renderer/src/stores/useSessionStore'
-      )
+      const { useSessionStore } = await import('../../../src/renderer/src/stores/useSessionStore')
 
       useSessionStore.getState().setPendingMessage('session-2', 'Another prompt')
 
@@ -146,12 +142,32 @@ describe('Session 4: Code Review', () => {
     })
 
     test('consumePendingMessage returns null for unknown session', async () => {
-      const { useSessionStore } = await import(
-        '../../../src/renderer/src/stores/useSessionStore'
-      )
+      const { useSessionStore } = await import('../../../src/renderer/src/stores/useSessionStore')
 
       const message = useSessionStore.getState().consumePendingMessage('nonexistent')
       expect(message).toBeNull()
+    })
+
+    test('dequeuePendingMessage returns and removes message', async () => {
+      const { useSessionStore } = await import('../../../src/renderer/src/stores/useSessionStore')
+
+      useSessionStore.getState().setPendingMessage('session-3', 'Dequeued prompt')
+
+      const message = useSessionStore.getState().dequeuePendingMessage('session-3')
+      expect(message).toBe('Dequeued prompt')
+      expect(useSessionStore.getState().pendingMessages.get('session-3')).toBeUndefined()
+    })
+
+    test('requeuePendingMessage restores a failed auto-send prompt', async () => {
+      const { useSessionStore } = await import('../../../src/renderer/src/stores/useSessionStore')
+
+      useSessionStore.getState().setPendingMessage('session-4', 'Failed prompt')
+      const dequeued = useSessionStore.getState().dequeuePendingMessage('session-4')
+      expect(dequeued).toBe('Failed prompt')
+
+      useSessionStore.getState().requeuePendingMessage('session-4', dequeued!)
+
+      expect(useSessionStore.getState().consumePendingMessage('session-4')).toBe('Failed prompt')
     })
   })
 
@@ -217,18 +233,14 @@ describe('Session 4: Code Review', () => {
   // ---------------------------------------------------------------------------
   describe('Review target branch store', () => {
     test('setReviewTargetBranch stores branch for worktree', async () => {
-      const { useGitStore } = await import(
-        '../../../src/renderer/src/stores/useGitStore'
-      )
+      const { useGitStore } = await import('../../../src/renderer/src/stores/useGitStore')
 
       useGitStore.getState().setReviewTargetBranch('wt-1', 'origin/develop')
       expect(useGitStore.getState().reviewTargetBranch.get('wt-1')).toBe('origin/develop')
     })
 
     test('setReviewTargetBranch updates existing branch', async () => {
-      const { useGitStore } = await import(
-        '../../../src/renderer/src/stores/useGitStore'
-      )
+      const { useGitStore } = await import('../../../src/renderer/src/stores/useGitStore')
 
       useGitStore.getState().setReviewTargetBranch('wt-1', 'origin/develop')
       useGitStore.getState().setReviewTargetBranch('wt-1', 'origin/main')
@@ -236,9 +248,7 @@ describe('Session 4: Code Review', () => {
     })
 
     test('reviewTargetBranch returns undefined for unknown worktree', async () => {
-      const { useGitStore } = await import(
-        '../../../src/renderer/src/stores/useGitStore'
-      )
+      const { useGitStore } = await import('../../../src/renderer/src/stores/useGitStore')
 
       expect(useGitStore.getState().reviewTargetBranch.get('nonexistent')).toBeUndefined()
     })


### PR DESCRIPTION
## Summary

- **Background follow-up dispatching in global listener**: When a background (non-active) session goes idle and has queued follow-up messages, the global listener now automatically dispatches the next follow-up prompt. This ensures follow-up chains survive tab switches and continue executing without requiring the session tab to be active. Includes deduplication guards (`backgroundFollowUpDispatchingRef` / `deferredIdleWhileDispatchingRef`) to prevent double-dispatch from rapid idle events.

- **Session init abort guards in SessionView**: Added a `shouldAbortInit()` check throughout the entire async initialization chain in `SessionView`. Every `await` point now verifies the effect is still active and the stream generation hasn't changed, preventing stale async operations from clobbering state when users rapidly switch sessions/tabs during initialization.

- **Pending message requeue on failure**: When auto-sending a pending message (e.g., code review prompt) fails, the message is now requeued via `requeuePendingMessage()` instead of being silently dropped. Similarly, follow-up messages that fail to send are requeued at the front of the queue via `requeueFollowUpMessageFront()` so they can be retried.

- **Extracted helper functions in global listener**: Refactored the idle-handler in `useOpenCodeGlobalListener` by extracting `resolvePromptDispatchContext()` (resolves worktree path + OpenCode session ID from stores and DB, preferring materialized DB session IDs over `pending::` prefixed ones), `resolvePromptDispatchContextFromStores()`, and `markBackgroundSessionCompleted()` into standalone functions for clarity and testability.

- **Session store API additions**: Added `dequeuePendingMessage()`, `requeuePendingMessage()`, `dequeueFollowUpMessage()`, and `requeueFollowUpMessageFront()` to the session store. The existing `consumePendingMessage()` and `consumeFollowUpMessage()` methods are preserved as aliases for backward compatibility.

- **Comprehensive test coverage**: Added new test file `global-listener-follow-up-dispatch.test.ts` covering background follow-up dispatch scenarios (success, failure with requeue, duplicate idle dedup, connection session paths, DB-preferred session ID resolution). Updated existing tests (`global-listener-busy.test.ts`, `code-review.test.ts`) with new store mocks and tests for the new dequeue/requeue methods.

## Test plan

- [ ] Verify background sessions with queued follow-ups auto-dispatch when going idle
- [ ] Verify follow-up messages survive tab switches (switch away and back during follow-up chain)
- [ ] Verify failed prompt sends requeue the message for retry
- [ ] Verify rapid session/tab switching during init doesn't cause stale state updates
- [ ] Verify code review pending messages are restored on send failure
- [ ] Run `pnpm test` to confirm all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session stability with abort guards to prevent stale operations during rapid session changes.
  * Improved error recovery through intelligent requeuing and state restoration on failed operations.
  * Reduced race conditions in async flows and refined message dispatch logic.
  * Fixed streaming state synchronization to prevent inconsistent UI during tab switches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->