### PR TITLE
Fix duplicate breed name collisions in worktree creation

### DIFF
--- a/src/main/services/git-service.ts
+++ b/src/main/services/git-service.ts
@@ -1,7 +1,7 @@
 import simpleGit, { SimpleGit, BranchSummary } from 'simple-git'
 import { app } from 'electron'
 import { join, basename, dirname } from 'path'
-import { existsSync, mkdirSync, rmSync, cpSync, writeFileSync, unlinkSync } from 'fs'
+import { existsSync, mkdirSync, rmSync, cpSync, writeFileSync, unlinkSync, readdirSync } from 'fs'
 import { tmpdir } from 'os'
 import { selectUniqueBreedName, ALL_BREED_NAMES, LEGACY_CITY_NAMES, type BreedType } from './breed-names'
 import { createLogger } from './logger'
@@ -256,45 +256,64 @@ export class GitService {
     projectName: string,
     breedType: BreedType = 'dogs'
   ): Promise<CreateWorktreeResult> {
-    try {
-      // Get existing branches to avoid collisions
-      const existingBranches = await this.getAllBranches()
-      const existingWorktrees = await this.listWorktrees()
-      const existingWorktreeBranches = existingWorktrees.map((w) => w.branch)
+    const MAX_ATTEMPTS = 3
+    // Ensure worktrees directory exists and get base branch once — neither changes between retries
+    const projectWorktreesDir = this.ensureWorktreesDir(projectName)
+    const defaultBranch = await this.getCurrentBranch()
 
-      // Combine all existing names to avoid
-      const existingNames = new Set([...existingBranches, ...existingWorktreeBranches])
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        // Re-fetch on every attempt so retries see the latest state
+        const existingBranches = await this.getAllBranches()
+        const existingWorktrees = await this.listWorktrees()
+        const existingWorktreeBranches = existingWorktrees.map((w) => w.branch)
 
-      // Select a unique breed name
-      const breedName = selectUniqueBreedName(existingNames, breedType)
+        // Also scan the filesystem to catch path collisions from incomplete cleanups
+        let existingDirs: string[] = []
+        try {
+          existingDirs = readdirSync(projectWorktreesDir)
+        } catch {
+          // directory may not exist yet; ignore
+        }
 
-      // Ensure worktrees directory exists
-      const projectWorktreesDir = this.ensureWorktreesDir(projectName)
-      const worktreePath = join(projectWorktreesDir, breedName)
+        // Combine all existing names to avoid
+        const existingNames = new Set([...existingBranches, ...existingWorktreeBranches, ...existingDirs])
 
-      // Branch from whatever is checked out at the root of the repository
-      const defaultBranch = await this.getCurrentBranch()
+        // Select a unique breed name
+        const breedName = selectUniqueBreedName(existingNames, breedType)
+        const worktreePath = join(projectWorktreesDir, breedName)
 
-      // Create the worktree with a new branch
-      await this.git.raw(['worktree', 'add', '-b', breedName, worktreePath, defaultBranch])
+        // Create the worktree with a new branch
+        await this.git.raw(['worktree', 'add', '-b', breedName, worktreePath, defaultBranch])
 
-      return {
-        success: true,
-        name: breedName,
-        branchName: breedName,
-        path: worktreePath
+        return {
+          success: true,
+          name: breedName,
+          branchName: breedName,
+          path: worktreePath
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        if (message.toLowerCase().includes('already exists') && attempt < MAX_ATTEMPTS) {
+          log.warn(`createWorktree: name collision on attempt ${attempt}, retrying`, {
+            projectName,
+            attempt,
+            error: message
+          })
+          continue
+        }
+        log.error(
+          'Failed to create worktree',
+          error instanceof Error ? error : new Error(String(error)),
+          { projectName, repoPath: this.repoPath }
+        )
+        return { success: false, error: message }
       }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error'
-      log.error(
-        'Failed to create worktree',
-        error instanceof Error ? error : new Error(String(error)),
-        { projectName, repoPath: this.repoPath }
-      )
-      return {
-        success: false,
-        error: message
-      }
+    }
+
+    return {
+      success: false,
+      error: 'Failed to create worktree after 3 attempts due to name collisions'
     }
   }
 
@@ -983,27 +1002,54 @@ export class GitService {
     try {
       // 1. Extract base name (strip -vN suffix)
       const baseName = sourceBranch.replace(/-v\d+$/, '')
+      const projectWorktreesDir = this.ensureWorktreesDir(projectName)
+      const MAX_ATTEMPTS = 3
 
-      // 2. Find next version number
-      const allBranches = await this.getAllBranches()
-      const versionPattern = new RegExp(
-        `^${baseName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}-v(\\d+)$`
-      )
-      let maxVersion = 1 // means first dup will be v2
-      for (const branch of allBranches) {
-        const match = branch.match(versionPattern)
-        if (match) {
-          maxVersion = Math.max(maxVersion, parseInt(match[1], 10))
+      // 2-4. Find next version number and create worktree, with retry on collision
+      let newBranchName = ''
+      let worktreePath = ''
+      let created = false
+
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        // Re-fetch on every attempt so retries see the latest state
+        const allBranches = await this.getAllBranches()
+        const versionPattern = new RegExp(
+          `^${baseName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}-v(\\d+)$`
+        )
+        let maxVersion = 1 // means first dup will be v2
+        for (const branch of allBranches) {
+          const match = branch.match(versionPattern)
+          if (match) {
+            maxVersion = Math.max(maxVersion, parseInt(match[1], 10))
+          }
+        }
+        newBranchName = `${baseName}-v${maxVersion + 1}`
+        worktreePath = join(projectWorktreesDir, newBranchName)
+
+        try {
+          await this.git.raw(['worktree', 'add', '-b', newBranchName, worktreePath, sourceBranch])
+          created = true
+          break
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error'
+          if (message.toLowerCase().includes('already exists') && attempt < MAX_ATTEMPTS) {
+            log.warn(`duplicateWorktree: name collision on attempt ${attempt}, retrying`, {
+              newBranchName,
+              attempt,
+              error: message
+            })
+            continue
+          }
+          throw error
         }
       }
-      const newBranchName = `${baseName}-v${maxVersion + 1}`
 
-      // 3. Create worktree directory
-      const projectWorktreesDir = this.ensureWorktreesDir(projectName)
-      const worktreePath = join(projectWorktreesDir, newBranchName)
-
-      // 4. Create worktree from source branch
-      await this.git.raw(['worktree', 'add', '-b', newBranchName, worktreePath, sourceBranch])
+      if (!created) {
+        return {
+          success: false,
+          error: 'Failed to duplicate worktree after 3 attempts due to name collisions'
+        }
+      }
 
       // 5. Capture uncommitted state via stash create (non-destructive)
       const sourceGit = simpleGit(sourceWorktreePath)
@@ -1174,28 +1220,65 @@ export class GitService {
         }
       }
 
-      // Get existing branches to avoid name collisions
-      const existingBranches = await this.getAllBranches()
-      const existingWorktrees = await this.listWorktrees()
-      const existingWorktreeBranches = existingWorktrees.map((w) => w.branch)
-      const existingNames = new Set([...existingBranches, ...existingWorktreeBranches])
-
-      // Select a unique breed name
-      const breedName = selectUniqueBreedName(existingNames, breedType)
-
       const projectWorktreesDir = this.ensureWorktreesDir(projectName)
-      const worktreePath = join(projectWorktreesDir, breedName)
+      const MAX_ATTEMPTS = 3
 
       if (prNumber != null) {
-        // Fetch the PR ref directly — works for both fork and same-repo PRs
+        // Fetch the PR ref once — FETCH_HEAD stays valid for subsequent retries
         await this.git.raw(['fetch', 'origin', `pull/${prNumber}/head`])
-        await this.git.raw(['worktree', 'add', '-b', breedName, worktreePath, 'FETCH_HEAD'])
-      } else {
-        // Create a new breed-named branch derived from the selected branch
-        await this.git.raw(['worktree', 'add', '-b', breedName, worktreePath, branchName])
       }
 
-      return { success: true, path: worktreePath, branchName: breedName, name: breedName }
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        // Re-fetch on every attempt so retries see the latest state
+        const existingBranches = await this.getAllBranches()
+        const existingWorktrees = await this.listWorktrees()
+        const existingWorktreeBranches = existingWorktrees.map((w) => w.branch)
+
+        // Also scan the filesystem to catch path collisions from incomplete cleanups
+        let existingDirs: string[] = []
+        try {
+          existingDirs = readdirSync(projectWorktreesDir)
+        } catch {
+          // directory may not exist yet; ignore
+        }
+
+        const existingNames = new Set([
+          ...existingBranches,
+          ...existingWorktreeBranches,
+          ...existingDirs
+        ])
+
+        // Select a unique breed name
+        const breedName = selectUniqueBreedName(existingNames, breedType)
+        const worktreePath = join(projectWorktreesDir, breedName)
+
+        try {
+          if (prNumber != null) {
+            await this.git.raw(['worktree', 'add', '-b', breedName, worktreePath, 'FETCH_HEAD'])
+          } else {
+            // Create a new breed-named branch derived from the selected branch
+            await this.git.raw(['worktree', 'add', '-b', breedName, worktreePath, branchName])
+          }
+          return { success: true, path: worktreePath, branchName: breedName, name: breedName }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error'
+          if (message.toLowerCase().includes('already exists') && attempt < MAX_ATTEMPTS) {
+            log.warn(`createWorktreeFromBranch: name collision on attempt ${attempt}, retrying`, {
+              projectName,
+              branchName,
+              attempt,
+              error: message
+            })
+            continue
+          }
+          throw error
+        }
+      }
+
+      return {
+        success: false,
+        error: 'Failed to create worktree from branch after 3 attempts due to name collisions'
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
       log.error(

--- a/test/phase-21/session-7/worktree-breed-collision-retry.test.ts
+++ b/test/phase-21/session-7/worktree-breed-collision-retry.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Mock electron's app module so importing git-service doesn't crash in jsdom
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue('/tmp/mock-home')
+  }
+}))
+
+// Mock fs so readdirSync can be controlled per-test
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    readdirSync: vi.fn().mockReturnValue([]),
+    existsSync: vi.fn().mockReturnValue(false),
+    mkdirSync: vi.fn()
+  }
+})
+
+// Mock simple-git — we will configure per-test
+const mockRaw = vi.fn()
+const mockBranch = vi.fn()
+vi.mock('simple-git', () => ({
+  default: vi.fn().mockReturnValue({
+    branch: mockBranch,
+    raw: mockRaw
+  })
+}))
+
+describe('Worktree breed-name collision retry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('createWorktree retries when git reports "already exists"', async () => {
+    // Import after mocks are set up
+    const { GitService } = await import('../../../src/main/services/git-service')
+
+    // getAllBranches() returns [] (simulating silent failure / empty state)
+    mockBranch.mockResolvedValue({ all: [], current: 'main' })
+
+    // First git worktree add call fails with "already exists",
+    // second call succeeds
+    mockRaw
+      .mockImplementationOnce(async (args: string[]) => {
+        // getCurrentBranch raw call — not used directly (branch() is)
+        return ''
+      })
+      .mockRejectedValueOnce(new Error("fatal: 'labrador' already exists"))
+      .mockResolvedValueOnce('')
+
+    const service = new GitService('/tmp/mock-repo')
+
+    // Spy on getAllBranches and listWorktrees to track call counts
+    const getAllBranchesSpy = vi.spyOn(service, 'getAllBranches').mockResolvedValue([])
+    const listWorktreesSpy = vi.spyOn(service, 'listWorktrees').mockResolvedValue([])
+    const getCurrentBranchSpy = vi.spyOn(service, 'getCurrentBranch').mockResolvedValue('main')
+
+    // Capture args to the underlying git.raw for worktree add calls
+    const rawCalls: string[][] = []
+    const gitInstance = (service as unknown as { git: { raw: typeof mockRaw } }).git
+    gitInstance.raw = vi.fn().mockImplementation(async (args: string[]) => {
+      rawCalls.push(args)
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        if (rawCalls.filter((c) => c[0] === 'worktree').length === 1) {
+          throw new Error("fatal: 'somename' already exists")
+        }
+      }
+      return ''
+    })
+
+    const result = await service.createWorktree('my-project', 'dogs')
+
+    expect(result.success).toBe(true)
+    expect(result.branchName).toBeTruthy()
+    expect(result.path).toBeTruthy()
+
+    // getAllBranches should have been called at least twice (once per attempt)
+    expect(getAllBranchesSpy.mock.calls.length).toBeGreaterThanOrEqual(2)
+    expect(listWorktreesSpy.mock.calls.length).toBeGreaterThanOrEqual(2)
+
+    // getCurrentBranch should only be called once (outside the loop)
+    expect(getCurrentBranchSpy.mock.calls.length).toBe(1)
+  })
+
+  test('createWorktree returns failure after 3 collisions', async () => {
+    const { GitService } = await import('../../../src/main/services/git-service')
+
+    const service = new GitService('/tmp/mock-repo')
+
+    vi.spyOn(service, 'getAllBranches').mockResolvedValue([])
+    vi.spyOn(service, 'listWorktrees').mockResolvedValue([])
+    vi.spyOn(service, 'getCurrentBranch').mockResolvedValue('main')
+
+    const gitInstance = (service as unknown as { git: { raw: typeof mockRaw } }).git
+    gitInstance.raw = vi.fn().mockRejectedValue(new Error("fatal: 'somename' already exists"))
+
+    const result = await service.createWorktree('my-project', 'dogs')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeTruthy()
+  })
+
+  test('createWorktree does not retry on non-collision errors', async () => {
+    const { GitService } = await import('../../../src/main/services/git-service')
+
+    const service = new GitService('/tmp/mock-repo')
+
+    const getAllBranchesSpy = vi.spyOn(service, 'getAllBranches').mockResolvedValue([])
+    vi.spyOn(service, 'listWorktrees').mockResolvedValue([])
+    vi.spyOn(service, 'getCurrentBranch').mockResolvedValue('main')
+
+    const gitInstance = (service as unknown as { git: { raw: typeof mockRaw } }).git
+    gitInstance.raw = vi.fn().mockRejectedValue(new Error('fatal: not a git repository'))
+
+    const result = await service.createWorktree('my-project', 'dogs')
+
+    expect(result.success).toBe(false)
+    // getAllBranches should only be called once — no retry on non-collision errors
+    expect(getAllBranchesSpy.mock.calls.length).toBe(1)
+  })
+
+  test('createWorktree succeeds on first attempt with no collision', async () => {
+    const { GitService } = await import('../../../src/main/services/git-service')
+
+    const service = new GitService('/tmp/mock-repo')
+
+    const getAllBranchesSpy = vi.spyOn(service, 'getAllBranches').mockResolvedValue(['main'])
+    vi.spyOn(service, 'listWorktrees').mockResolvedValue([])
+    vi.spyOn(service, 'getCurrentBranch').mockResolvedValue('main')
+
+    const gitInstance = (service as unknown as { git: { raw: typeof mockRaw } }).git
+    gitInstance.raw = vi.fn().mockResolvedValue('')
+
+    const result = await service.createWorktree('my-project', 'dogs')
+
+    expect(result.success).toBe(true)
+    expect(getAllBranchesSpy.mock.calls.length).toBe(1)
+  })
+
+  test('git-service.ts createWorktree contains retry loop logic', async () => {
+    const { readFileSync } = await import('fs')
+    const { join } = await import('path')
+    const content = readFileSync(
+      join(__dirname, '..', '..', '..', 'src', 'main', 'services', 'git-service.ts'),
+      'utf-8'
+    )
+    expect(content).toContain('MAX_ATTEMPTS')
+    expect(content).toContain('already exists')
+    expect(content).toContain('readdirSync')
+    expect(content).toContain('createWorktree: name collision on attempt')
+    expect(content).toContain('duplicateWorktree: name collision on attempt')
+    expect(content).toContain('createWorktreeFromBranch: name collision on attempt')
+  })
+})


### PR DESCRIPTION
## Summary

- **Added retry logic (up to 3 attempts) for worktree breed-name collisions** in `GitService` across all three worktree creation methods: `createWorktree`, `duplicateWorktree`, and `createWorktreeFromBranch`
- **Added filesystem directory scanning** (`readdirSync`) to detect path collisions from incomplete worktree cleanups that git branches/worktrees alone wouldn't catch
- **Moved invariant setup outside retry loops** — `ensureWorktreesDir()`, `getCurrentBranch()`, and PR `fetch` calls execute once before the retry loop since they don't change between attempts
- **Re-fetch branch/worktree state on each retry** so subsequent attempts see the latest git state after a collision
- **Only retry on "already exists" errors** — non-collision errors (e.g. "not a git repository") propagate immediately without wasting retries
- **Added comprehensive test suite** (`worktree-breed-collision-retry.test.ts`) with 5 tests covering: successful retry after collision, failure after 3 collisions, no retry on non-collision errors, success on first attempt, and source code verification of retry patterns

## Changed Files

- `src/main/services/git-service.ts` — Refactored `createWorktree`, `duplicateWorktree`, and `createWorktreeFromBranch` with retry-on-collision loops and filesystem-level collision detection
- `test/phase-21/session-7/worktree-breed-collision-retry.test.ts` — New test file validating retry behavior

## Test plan

- [ ] Run `pnpm vitest run test/phase-21/session-7/worktree-breed-collision-retry.test.ts` — all 5 tests pass
- [ ] Create a new worktree in the app — verify it succeeds normally
- [ ] Duplicate an existing worktree — verify versioned naming works
- [ ] Create a worktree from a branch/PR — verify breed name assignment works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes worktree creation/duplication control flow to add retries and filesystem collision checks, which could affect branch/worktree naming and error handling in a frequently used workflow. Risk is mitigated by limiting retries to "already exists" failures and adding targeted tests.
> 
> **Overview**
> **Worktree creation is now resilient to breed-name/path collisions.** `GitService.createWorktree`, `duplicateWorktree`, and `createWorktreeFromBranch` retry up to 3 times when `git worktree add` fails with an "already exists" error, reloading branch/worktree state each attempt and (for breed-named worktrees) also scanning the worktrees directory via `readdirSync` to avoid leftover on-disk directory collisions.
> 
> Invariant setup (e.g., `ensureWorktreesDir()`, `getCurrentBranch()`, PR `fetch`) is moved outside retry loops, and a new `worktree-breed-collision-retry.test.ts` suite validates retry vs non-retry behavior and the presence of the new collision-handling logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec036322e50f217f1c28e9f3255550c1d1b6ba25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Worktree creation now automatically retries on name conflicts instead of failing immediately
* Collision detection improved to check both repository branches and on-disk directories
* Enhanced error handling with more descriptive failure messages

## Tests
* Added comprehensive test coverage for worktree creation retry scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->