### PR TITLE
Skip worktree context injection for Supercharge sessions

### DIFF
--- a/src/main/ipc/opencode-handlers.ts
+++ b/src/main/ipc/opencode-handlers.ts
@@ -147,40 +147,52 @@ export function registerOpenCodeHandlers(
     // sessions start with a pending:: ID that materializes to a real ID after
     // the first prompt — tracking by session ID would miss the transition.
     if (!injectedWorktrees.has(worktreePath) && dbService) {
-      try {
-        const worktree = dbService.getWorktreeByPath(worktreePath)
-        if (worktree?.context) {
-          log.info('Injecting worktree context into first prompt', {
-            worktreePath,
-            opencodeSessionId,
-            contextLength: worktree.context.length
-          })
-          const contextPrefix = `[Worktree Context]\n${worktree.context}\n\n[User Message]\n`
-          if (typeof messageOrParts === 'string') {
-            messageOrParts = contextPrefix + messageOrParts
-          } else if (Array.isArray(messageOrParts)) {
-            // Find the first text part and prepend context
-            const textPartIndex = messageOrParts.findIndex((p) => p.type === 'text')
-            if (textPartIndex >= 0) {
-              const textPart = messageOrParts[textPartIndex]
-              if (textPart.type === 'text' && textPart.text) {
-                messageOrParts = [...messageOrParts]
-                messageOrParts[textPartIndex] = {
-                  ...textPart,
-                  text: contextPrefix + textPart.text
+      // Skip worktree context injection for Supercharge sessions — the plan
+      // content that follows already has full context and the worktree context
+      // just pollutes it.
+      const firstTextPart = Array.isArray(messageOrParts)
+        ? messageOrParts.find((p) => p.type === 'text')?.text?.trim()
+        : typeof messageOrParts === 'string'
+          ? messageOrParts.trim()
+          : undefined
+      if (firstTextPart?.startsWith('/using-superpowers')) {
+        injectedWorktrees.add(worktreePath)
+      } else {
+        try {
+          const worktree = dbService.getWorktreeByPath(worktreePath)
+          if (worktree?.context) {
+            log.info('Injecting worktree context into first prompt', {
+              worktreePath,
+              opencodeSessionId,
+              contextLength: worktree.context.length
+            })
+            const contextPrefix = `[Worktree Context]\n${worktree.context}\n\n[User Message]\n`
+            if (typeof messageOrParts === 'string') {
+              messageOrParts = contextPrefix + messageOrParts
+            } else if (Array.isArray(messageOrParts)) {
+              // Find the first text part and prepend context
+              const textPartIndex = messageOrParts.findIndex((p) => p.type === 'text')
+              if (textPartIndex >= 0) {
+                const textPart = messageOrParts[textPartIndex]
+                if (textPart.type === 'text' && textPart.text) {
+                  messageOrParts = [...messageOrParts]
+                  messageOrParts[textPartIndex] = {
+                    ...textPart,
+                    text: contextPrefix + textPart.text
+                  }
                 }
               }
             }
           }
+          // Mark as injected after successful lookup (even if no context to inject)
+          injectedWorktrees.add(worktreePath)
+        } catch (err) {
+          // Don't add to injectedWorktrees — allow retry on next prompt
+          log.warn('Failed to inject worktree context', {
+            worktreePath,
+            error: err instanceof Error ? err.message : String(err)
+          })
         }
-        // Mark as injected after successful lookup (even if no context to inject)
-        injectedWorktrees.add(worktreePath)
-      } catch (err) {
-        // Don't add to injectedWorktrees — allow retry on next prompt
-        log.warn('Failed to inject worktree context', {
-          worktreePath,
-          error: err instanceof Error ? err.message : String(err)
-        })
       }
     }
 


### PR DESCRIPTION
## Summary

- **Skip worktree context for Supercharge sessions**: When a session's first message starts with `/using-superpowers`, the worktree context injection is bypassed entirely. Supercharge sessions already carry full plan context, so prepending the worktree context just adds noise and pollutes the prompt.
- **Detection logic**: Extracts the first text part from either a plain string message or an array of message parts, then checks if it starts with `/using-superpowers`. If so, the worktree path is immediately marked as "already injected" without performing a DB lookup.
- **No change to normal sessions**: Non-Supercharge sessions continue to get worktree context injected on the first prompt exactly as before — the existing DB lookup, context prepend, and error-handling logic is preserved.

## Changes

- `src/main/ipc/opencode-handlers.ts`: Added early detection of Supercharge session messages before the worktree context injection block. Restructured the injection logic with a conditional branch that skips context for superpowers prompts while preserving the existing behavior for all other sessions.

## Test plan

- [ ] Verify normal worktree sessions still receive injected context on first prompt
- [ ] Verify Supercharge sessions (starting with `/using-superpowers`) do **not** receive worktree context injection
- [ ] Verify error handling still works — failed DB lookups should allow retry on next prompt
- [ ] Verify both string and array message formats are handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to prompt pre-processing that only bypasses context injection when the first message starts with `/using-superpowers`; other sessions retain the same injection and retry behavior.
> 
> **Overview**
> Supercharge sessions whose first prompt begins with `/using-superpowers` no longer get worktree context prepended on their initial message, avoiding polluting the plan-driven prompt.
> 
> `opencode:prompt` now detects the first text content (from either a string message or multipart `parts`) and, when it matches, marks the worktree as injected without doing the worktree DB lookup; non-supercharge flows keep the existing context-injection and error-handling behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6b0f985d295ab6d983394015c5d326bcdb8d28e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and handling of prompts containing planning information to prevent unnecessary context injection
  * Implemented robust error handling for prompt processing operations with graceful fallback
  * Fixed idempotent behavior for prompt submissions to prevent redundant processing on retries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->