### PR TITLE
Per-worktree dev server URL detection for Open in Chrome

### DIFF
--- a/src/renderer/src/components/layout/BottomPanel.tsx
+++ b/src/renderer/src/components/layout/BottomPanel.tsx
@@ -42,23 +42,31 @@ export function BottomPanel({ terminalSlot, isConnectionMode }: BottomPanelProps
   )
   const customChromeCommand = useSettingsStore((s) => s.customChromeCommand)
 
-  const [detectedUrl, setDetectedUrl] = useState<string | null>(null)
+  // Per-worktree detected URLs so switching worktrees shows the correct port instantly.
+  const [detectedUrls, setDetectedUrls] = useState<Record<string, string>>({})
+  const detectedUrl = selectedWorktreeId ? (detectedUrls[selectedWorktreeId] ?? null) : null
 
   // Scan for dev server URL only while running and not yet found.
-  // Once a URL is detected, scanning stops entirely (zero cost per subsequent version bump).
-  // When runRunning becomes false, the URL resets so the next run can detect a new one.
+  // Once a URL is detected for a worktree, scanning stops (zero cost per subsequent version bump).
+  // When runRunning becomes false, the URL for that worktree is cleared so the next run can detect a new one.
   useEffect(() => {
     if (!selectedWorktreeId || !scriptState?.runRunning) {
-      setDetectedUrl(null)
+      if (selectedWorktreeId) {
+        setDetectedUrls((prev) => {
+          if (!(selectedWorktreeId in prev)) return prev
+          const { [selectedWorktreeId]: _, ...rest } = prev
+          return rest
+        })
+      }
       return
     }
-    // Already found — stop scanning
+    // Already found for this worktree — stop scanning
     if (detectedUrl) return
 
     const output = getOrCreateBuffer(selectedWorktreeId).toRecentArray(80)
     if (!output.length) return
     const url = extractDevServerUrl(output)
-    if (url) setDetectedUrl(url)
+    if (url) setDetectedUrls((prev) => ({ ...prev, [selectedWorktreeId]: url }))
   }, [selectedWorktreeId, scriptState?.runRunning, runOutputVersion, detectedUrl])
 
   const [chromeConfigOpen, setChromeConfigOpen] = useState(false)


### PR DESCRIPTION
## Summary

- **Per-worktree URL tracking**: Replaced the single shared `detectedUrl` state with a `detectedUrls` record keyed by worktree ID. Switching between worktrees now instantly displays the correct dev server port for each worktree instead of losing/resetting the detected URL.
- **Scoped cleanup**: When a worktree's run script stops (`runRunning` becomes false), only that worktree's detected URL is cleared — other worktrees retain their detected URLs.
- **Zero-cost scanning**: Once a URL is detected for a given worktree, scanning stops for that worktree (unchanged behavior, now correctly scoped per worktree).
- **No-op state updates avoided**: The cleanup effect checks whether the worktree ID exists in the record before updating state, preventing unnecessary re-renders.

## Changed Files

- `src/renderer/src/components/layout/BottomPanel.tsx` — Refactored dev server URL detection from single `useState<string | null>` to per-worktree `useState<Record<string, string>>` with a derived `detectedUrl` for the currently selected worktree.

## Test plan

- [ ] Start a dev server (run script) in one worktree — verify the "Open in Chrome" button appears with the correct URL
- [ ] Switch to another worktree with its own running dev server — verify the detected URL updates immediately to that worktree's port
- [ ] Switch back to the first worktree — verify its URL is still shown without re-scanning
- [ ] Stop a worktree's run script — verify only that worktree's URL is cleared
- [ ] Start the run script again — verify URL is re-detected from fresh output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI state change that only affects how the dev-server URL is cached/cleared for the "Open in Chrome" button; main risk is minor regressions in URL detection/cleanup when switching worktrees.
> 
> **Overview**
> **Fixes "Open in Chrome" URL detection when switching worktrees** by replacing the single `detectedUrl` state with a per-worktree `detectedUrls` map keyed by worktree ID.
> 
> URL scanning/caching is now scoped to the active worktree: once a URL is found, scanning stops for that worktree, and when `runRunning` becomes false only that worktree’s cached URL is cleared (avoiding no-op state updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf6a1d974f01dd75f4d9cda99c854d1e1ab0ea0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dev-server URL detection to correctly track and maintain URLs independently when working with multiple workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->