### PR TITLE
Add indeterminate progress bar for agent working status

### DIFF
--- a/src/renderer/src/components/sessions/IndeterminateProgressBar.tsx
+++ b/src/renderer/src/components/sessions/IndeterminateProgressBar.tsx
@@ -1,0 +1,31 @@
+import { cn } from '@/lib/utils'
+import type { SessionMode } from '@/stores/useSessionStore'
+
+interface IndeterminateProgressBarProps {
+  mode: SessionMode
+  className?: string
+}
+
+export function IndeterminateProgressBar({ mode, className }: IndeterminateProgressBarProps) {
+  const isBuild = mode === 'build'
+
+  return (
+    <div
+      role="progressbar"
+      aria-label="Agent is working"
+      className={cn(
+        'relative w-36 h-4 rounded-full overflow-hidden',
+        isBuild ? 'bg-blue-500/15' : 'bg-violet-500/15',
+        className
+      )}
+    >
+      <div
+        className={cn(
+          'progress-bounce-bar absolute top-0 bottom-0 rounded-full',
+          isBuild ? 'bg-blue-500' : 'bg-violet-500'
+        )}
+        style={{ animation: 'progress-bounce 3s linear infinite' }}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -15,6 +15,7 @@ import { SlashCommandPopover } from './SlashCommandPopover'
 import { FileMentionPopover } from './FileMentionPopover'
 import { ScrollToBottomFab } from './ScrollToBottomFab'
 import { PlanReadyImplementFab } from './PlanReadyImplementFab'
+import { IndeterminateProgressBar } from './IndeterminateProgressBar'
 import { useFileMentions } from '@/hooks/useFileMentions'
 import type { FlatFile } from '@/lib/file-search-utils'
 import { useSessionStore } from '@/stores/useSessionStore'
@@ -4038,6 +4039,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                 </span>
               </div>
               <div className="flex items-center gap-1.5">
+                {isStreaming && <IndeterminateProgressBar mode={mode} />}
                 {isStreaming && !inputValue.trim() ? (
                   <Button
                     onClick={handleAbort}

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -360,3 +360,46 @@
     transform: translateX(var(--scroll-distance));
   }
 }
+
+/* Indeterminate progress bar bounce animation for agent working indicator.
+   6-phase bouncing worm: grow → slide → shrink → grow → slide back → shrink.
+   Uses left/right on position:absolute to animate width + position together. */
+@keyframes progress-bounce {
+  0% {
+    left: 0;
+    right: 100%;
+  }
+  12% {
+    left: 0;
+    right: 75%;
+  }
+  38% {
+    left: 75%;
+    right: 0;
+  }
+  50% {
+    left: 100%;
+    right: 0;
+  }
+  62% {
+    left: 75%;
+    right: 0;
+  }
+  88% {
+    left: 0;
+    right: 75%;
+  }
+  100% {
+    left: 0;
+    right: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-bounce-bar {
+    animation: none !important;
+    left: 37.5%;
+    right: 37.5%;
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
## Summary

- **New `IndeterminateProgressBar` component** (`src/renderer/src/components/sessions/IndeterminateProgressBar.tsx`): A compact animated progress indicator that displays while the AI agent is actively working (streaming). Uses a bouncing worm animation that slides back and forth across a rounded track.
- **Color-coded by session mode**: Renders in blue (`bg-blue-500`) during `build` mode and violet (`bg-violet-500`) otherwise, matching the existing mode theming.
- **Integrated into `SessionView`**: The progress bar appears inline next to the input area controls whenever `isStreaming` is true, providing clear visual feedback that the agent is processing.
- **CSS keyframe animation** (`progress-bounce`): A 6-phase animation using `left`/`right` on an absolutely-positioned element to smoothly grow, slide, shrink, and reverse — creating a fluid bouncing worm effect over a 3-second cycle.
- **Accessibility**: Includes `role="progressbar"` and `aria-label="Agent is working"` for screen readers. Respects `prefers-reduced-motion` by disabling the animation and showing a static centered bar instead.

## Files changed

| File | Change |
|------|--------|
| `IndeterminateProgressBar.tsx` | New component (31 lines) |
| `SessionView.tsx` | Import + render progress bar when streaming |
| `globals.css` | `@keyframes progress-bounce` + reduced-motion fallback |

## Test plan

- [ ] Start an AI session and verify the progress bar appears in the input area while the agent is streaming
- [ ] Confirm the bar animates with a smooth bouncing worm effect
- [ ] Switch to build mode and verify the bar color changes from violet to blue
- [ ] Enable "Reduce motion" in OS accessibility settings and verify the animation stops, showing a static bar
- [ ] Verify the bar disappears when streaming ends
- [ ] Check screen reader announces "Agent is working" for the progress bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a new animated indicator and CSS keyframes; main concern is minor layout/animation performance or styling regressions in the input toolbar.
> 
> **Overview**
> Adds a new `IndeterminateProgressBar` component and shows it inline in `SessionView` whenever `isStreaming` is true to visually indicate the agent is working.
> 
> Introduces a global `progress-bounce` keyframe animation (with `prefers-reduced-motion` fallback) and mode-based theming (blue for `build`, violet otherwise) for the indicator.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd10d22562df367341829c26b7c7bde7ee127d45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->