### PR TITLE
Add shutdown flag and Telegram notifications to release scripts

### DIFF
--- a/scripts/release-canary.sh
+++ b/scripts/release-canary.sh
@@ -17,6 +17,7 @@ fatal() { err "$1"; exit 1; }
 # ── Parse flags ───────────────────────────────────────────────────
 DRY_RUN=false
 SHUTDOWN_AFTER=false
+SUDO_KEEPALIVE_PID=""
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
@@ -76,6 +77,19 @@ source "$ENV_SIGNING"
 [[ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]  || fatal "APPLE_APP_SPECIFIC_PASSWORD not set in .env.signing"
 [[ -n "${APPLE_TEAM_ID:-}" ]]                || fatal "APPLE_TEAM_ID not set in .env.signing"
 ok "Signing credentials loaded"
+
+# Load .env for Telegram notifications (optional)
+if [[ -f "$PROJECT_DIR/.env" ]]; then
+  source "$PROJECT_DIR/.env"
+fi
+
+tg() {
+  if [[ -n "${MORIKO_TELEGRAM_BOT_TOKEN:-}" && -n "${MORIKO_TELEGRAM_OPERATOR_CHAT_ID:-}" ]]; then
+    curl -s -X POST "https://api.telegram.org/bot${MORIKO_TELEGRAM_BOT_TOKEN}/sendMessage" \
+      -d chat_id="${MORIKO_TELEGRAM_OPERATOR_CHAT_ID}" \
+      -d text="$1" > /dev/null 2>&1 || true
+  fi
+}
 
 # Acquire sudo credentials early if shutdown is requested
 if $SHUTDOWN_AFTER; then
@@ -194,6 +208,23 @@ echo ""
 read -rp "Proceed? [Y/n] " confirm
 [[ "$confirm" =~ ^[Nn]$ ]] && { info "Aborted."; exit 0; }
 
+# Arm EXIT trap AFTER user confirmation (so aborting doesn't trigger shutdown/notification)
+RELEASE_SUCCEEDED=false
+on_exit() {
+  if ! $RELEASE_SUCCEEDED; then
+    tg "❌ Hive canary v${NEW_VERSION} — release failed"
+  fi
+  if $SHUTDOWN_AFTER; then
+    kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
+    warn "Shutting down in 10 seconds... (Ctrl+C to cancel)"
+    sleep 10
+    sudo shutdown -h now
+  fi
+}
+trap on_exit EXIT
+
+tg "🚀 Hive canary v${NEW_VERSION} — starting release"
+
 # ── Phase 2: Version bump + git ──────────────────────────────────
 info "Bumping version to ${NEW_VERSION}..."
 
@@ -238,6 +269,7 @@ else
 fi
 
 # ── Phase 3: Build ────────────────────────────────────────────────
+tg "🔨 Hive canary v${NEW_VERSION} — building"
 # Build from the tagged commit
 info "Checking out tagged commit for build..."
 git checkout "v${NEW_VERSION}"
@@ -275,6 +307,7 @@ pnpm build
 ok "Electron build complete"
 
 # ── Phase 4: Package + Sign + Notarize + Publish ─────────────────
+tg "📦 Hive canary v${NEW_VERSION} — build complete, packaging & notarizing"
 info "Packaging, signing, notarizing, and publishing..."
 info "This will take several minutes (notarization is slow)."
 
@@ -381,10 +414,5 @@ if $DRY_RUN; then
   warn "This was a DRY RUN — nothing was actually published."
 fi
 
-# ── Shutdown (if requested) ─────────────────────────────────────
-if $SHUTDOWN_AFTER; then
-  kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
-  warn "Shutting down in 10 seconds... (Ctrl+C to cancel)"
-  sleep 10
-  sudo shutdown -h now
-fi
+RELEASE_SUCCEEDED=true
+tg "✅ Hive canary v${NEW_VERSION} — released successfully"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,6 +16,7 @@ fatal() { err "$1"; exit 1; }
 
 # ── Parse flags ──────────────────────────────────────────────────
 SHUTDOWN_AFTER=false
+SUDO_KEEPALIVE_PID=""
 for arg in "$@"; do
   case "$arg" in
     --shutdown) SHUTDOWN_AFTER=true ;;
@@ -71,6 +72,19 @@ source "$ENV_SIGNING"
 [[ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]  || fatal "APPLE_APP_SPECIFIC_PASSWORD not set in .env.signing"
 [[ -n "${APPLE_TEAM_ID:-}" ]]                || fatal "APPLE_TEAM_ID not set in .env.signing"
 ok "Signing credentials loaded"
+
+# Load .env for Telegram notifications (optional)
+if [[ -f "$PROJECT_DIR/.env" ]]; then
+  source "$PROJECT_DIR/.env"
+fi
+
+tg() {
+  if [[ -n "${MORIKO_TELEGRAM_BOT_TOKEN:-}" && -n "${MORIKO_TELEGRAM_OPERATOR_CHAT_ID:-}" ]]; then
+    curl -s -X POST "https://api.telegram.org/bot${MORIKO_TELEGRAM_BOT_TOKEN}/sendMessage" \
+      -d chat_id="${MORIKO_TELEGRAM_OPERATOR_CHAT_ID}" \
+      -d text="$1" > /dev/null 2>&1 || true
+  fi
+}
 
 # Acquire sudo credentials early if shutdown is requested
 if $SHUTDOWN_AFTER; then
@@ -177,6 +191,23 @@ echo ""
 read -rp "Proceed? [Y/n] " confirm
 [[ "$confirm" =~ ^[Nn]$ ]] && { info "Aborted."; exit 0; }
 
+# Arm EXIT trap AFTER user confirmation (so aborting doesn't trigger shutdown/notification)
+RELEASE_SUCCEEDED=false
+on_exit() {
+  if ! $RELEASE_SUCCEEDED; then
+    tg "❌ Hive release v${NEW_VERSION} — release failed"
+  fi
+  if $SHUTDOWN_AFTER; then
+    kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
+    warn "Shutting down in 10 seconds... (Ctrl+C to cancel)"
+    sleep 10
+    sudo shutdown -h now
+  fi
+}
+trap on_exit EXIT
+
+tg "🚀 Hive release v${NEW_VERSION} — starting release"
+
 # ── Phase 2: Version bump + git ──────────────────────────────────
 info "Bumping version to ${NEW_VERSION}..."
 
@@ -199,6 +230,7 @@ git push origin "v${NEW_VERSION}"
 ok "Pushed commit and tag"
 
 # ── Phase 3: Build ────────────────────────────────────────────────
+tg "🔨 Hive release v${NEW_VERSION} — building"
 # Resolve libghostty.a — check local paths first, download as last resort
 LOCAL_GHOSTTY="$HOME/Documents/dev/ghostty/macos/GhosttyKit.xcframework/macos-arm64_x86_64/libghostty.a"
 VENDOR_GHOSTTY="$PROJECT_DIR/vendor/libghostty.a"
@@ -232,6 +264,7 @@ pnpm build
 ok "Electron build complete"
 
 # ── Phase 4: Package + Sign + Notarize + Publish ─────────────────
+tg "📦 Hive release v${NEW_VERSION} — build complete, packaging & notarizing"
 info "Packaging, signing, notarizing, and publishing..."
 info "This will take several minutes (notarization is slow)."
 
@@ -331,10 +364,5 @@ echo "    • Hive-${NEW_VERSION}-mac.zip"
 echo "    • latest-mac.yml (auto-updater)"
 echo ""
 
-# ── Shutdown (if requested) ─────────────────────────────────────
-if $SHUTDOWN_AFTER; then
-  kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
-  warn "Shutting down in 10 seconds... (Ctrl+C to cancel)"
-  sleep 10
-  sudo shutdown -h now
-fi
+RELEASE_SUCCEEDED=true
+tg "✅ Hive release v${NEW_VERSION} — released successfully"


### PR DESCRIPTION
## Summary

- **`--shutdown` flag**: Both `release.sh` and `release-canary.sh` now accept a `--shutdown` flag that automatically shuts down the computer after the release completes. This is useful for kicking off long-running release builds (notarization, packaging) and walking away. Sudo credentials are acquired upfront and kept alive via a background keepalive loop so the shutdown can execute unattended.
- **Telegram notifications**: Both scripts now send Telegram messages at key milestones — release start, building, packaging/notarizing, success, and failure — via an optional `tg()` helper. Credentials are loaded from `.env` (`MORIKO_TELEGRAM_BOT_TOKEN`, `MORIKO_TELEGRAM_OPERATOR_CHAT_ID`); notifications are silently skipped if not configured.
- **EXIT trap for failure handling**: An `on_exit` trap is armed *after* user confirmation so that aborting the release summary prompt doesn't trigger false failure notifications or an unwanted shutdown. On failure, a Telegram notification is sent; on `--shutdown`, the computer powers off after a 10-second grace period.
- **`--dry-run` + `--shutdown` guard** (canary only): The canary script validates that `--dry-run` and `--shutdown` are not used together, since a dry run should never trigger a real shutdown.

## Files changed

| File | Change |
|------|--------|
| `scripts/release-canary.sh` | Added `--shutdown` flag, Telegram notifications, EXIT trap, `--dry-run`/`--shutdown` conflict guard |
| `scripts/release.sh` | Added `--shutdown` flag, Telegram notifications, EXIT trap |

## Test plan

- [ ] Run `./scripts/release-canary.sh --dry-run` — should work as before with no Telegram or shutdown behavior
- [ ] Run `./scripts/release-canary.sh --dry-run --shutdown` — should fail with error about combining flags
- [ ] Verify Telegram notifications fire at each stage when `.env` credentials are configured
- [ ] Verify no errors when `.env` credentials are missing (notifications silently skipped)
- [ ] Verify `--shutdown` acquires sudo upfront and shuts down after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release automation flow by adding an `EXIT` trap, background `sudo` keepalive, and optional `shutdown`, which could affect developer machines and release execution if misused or if the trap/keepalive behaves unexpectedly.
> 
> **Overview**
> Adds an optional `--shutdown` flag to `scripts/release.sh` and `scripts/release-canary.sh` that acquires `sudo` up front, keeps credentials alive during the run, and powers off the machine on exit after a 10s grace period.
> 
> Introduces optional Telegram milestone notifications (start/build/package/success/failure) via a `tg()` helper sourced from `.env`, and wires an `EXIT` trap (armed only after user confirmation) to send failure notifications and perform the shutdown cleanup. The canary script also blocks combining `--dry-run` with `--shutdown`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e350437a43645f5cfe6c5a8db6b614583fed7873. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional automatic shutdown capability after release completion
  * Added Telegram notification support for real-time release status and progress updates

* **Chores**
  * Improved credential management during the release process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->