### PR TITLE
fix: clear file viewer when creating or switching sessions

### DIFF
--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -329,6 +329,11 @@ export const useSessionStore = create<SessionState>()(
               : {})
           })
 
+          // Clear file viewer so the new session takes focus in MainPane
+          const { useFileViewerStore } = await import('./useFileViewerStore')
+          useFileViewerStore.getState().setActiveFile(null)
+          useFileViewerStore.getState().clearActiveDiff()
+
           set((state) => {
             const newSessionsMap = new Map(state.sessionsByWorktree)
             const existingSessions = newSessionsMap.get(worktreeId) || []
@@ -569,6 +574,14 @@ export const useSessionStore = create<SessionState>()(
 
       // Set active session
       setActiveSession: (sessionId: string | null) => {
+        // Clear file viewer so the session takes focus in MainPane
+        if (sessionId) {
+          import('./useFileViewerStore').then(({ useFileViewerStore }) => {
+            useFileViewerStore.getState().setActiveFile(null)
+            useFileViewerStore.getState().clearActiveDiff()
+          })
+        }
+
         const state = get()
         const worktreeId = state.activeWorktreeId
         const connectionId = state.activeConnectionId


### PR DESCRIPTION
## Summary

- **Clears the file viewer when creating a new session** — after a new session is created via `createSession`, the `useFileViewerStore` is reset (`setActiveFile(null)` + `clearActiveDiff()`) so the session panel takes focus in `MainPane` instead of showing a stale file or diff view.
- **Clears the file viewer when switching sessions** — when `setActiveSession` is called with a non-null session ID, the file viewer is similarly cleared so the newly selected session is immediately visible.
- Both changes use dynamic `import('./useFileViewerStore')` to avoid circular dependency issues between stores.

## Test plan

- [ ] Create a new session while a file or diff is open in the main pane — verify the session view takes focus immediately
- [ ] Switch between sessions while a file is open — verify the file viewer is cleared and the session is shown
- [ ] Switch to a null session (deselect) — verify the file viewer is NOT cleared (only clears when selecting a session)
- [ ] Verify no circular dependency warnings in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change: resets file/diff viewer when a session is created or selected to avoid showing stale content. Main risk is unintended clearing of the viewer in flows that programmatically set the active session.
> 
> **Overview**
> Ensures `MainPane` focuses on the session view by clearing the file viewer state (`setActiveFile(null)` and `clearActiveDiff()`) after `createSession` completes and whenever `setActiveSession` selects a non-null session.
> 
> The file viewer store is loaded via dynamic `import('./useFileViewerStore')` to avoid introducing store dependency cycles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06c078c1156a4279455cfdc4831310faee2c2c5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->