### PR TITLE
Defer title generation for /using-superpowers hook prompts

### DIFF
--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -12,10 +12,7 @@ import { generateSessionTitle } from './claude-session-title'
 import { autoRenameWorktreeBranch } from './git-service'
 import { getEventBus } from '../../server/event-bus'
 import { Options, PermissionMode } from '@anthropic-ai/claude-agent-sdk'
-import {
-  CommandFilterService,
-  type CommandFilterSettings
-} from './command-filter-service'
+import { CommandFilterService, type CommandFilterSettings } from './command-filter-service'
 import { createLspMcpServerConfig, LspService } from './lsp'
 import { APP_SETTINGS_DB_KEY } from '@shared/types/settings'
 
@@ -116,6 +113,9 @@ export interface ClaudeSessionState {
   /** SDK assistant UUID to pass as resumeSessionAt on the forked prompt.
    *  Ensures the fork's context excludes undone messages and throwaway entries. */
   pendingResumeSessionAt: string | null
+  /** Title generation was skipped for the first prompt (e.g. /using-superpowers);
+   *  fire on the next real user message instead. */
+  titleDeferred: boolean
 }
 
 export class ClaudeCodeImplementer implements AgentSdkImplementer {
@@ -201,7 +201,8 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       revertCheckpointUuid: null,
       revertDiff: null,
       pendingFork: false,
-      pendingResumeSessionAt: null
+      pendingResumeSessionAt: null,
+      titleDeferred: false
     }
     this.sessions.set(key, state)
 
@@ -251,7 +252,8 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       revertCheckpointUuid: null,
       revertDiff: null,
       pendingFork: false,
-      pendingResumeSessionAt: null
+      pendingResumeSessionAt: null,
+      titleDeferred: false
     }
     this.sessions.set(key, state)
 
@@ -294,9 +296,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     this.cachedSlashCommands.delete(worktreePath)
 
     // Shut down LSP service if no remaining sessions use this worktree
-    const stillUsed = [...this.sessions.values()].some(
-      (s) => s.worktreePath === worktreePath
-    )
+    const stillUsed = [...this.sessions.values()].some((s) => s.worktreePath === worktreePath)
     if (!stillUsed) {
       const lsp = this.lspServices.get(worktreePath)
       if (lsp) {
@@ -405,6 +405,21 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         promptLength: prompt.length,
         promptPreview: prompt.slice(0, 100)
       })
+
+      // If title generation was deferred (e.g. first prompt was /using-superpowers),
+      // fire it now on the first real user message.
+      if (
+        session.materialized &&
+        session.titleDeferred &&
+        !prompt.trimStart().startsWith('/using-superpowers')
+      ) {
+        session.titleDeferred = false
+        this.handleTitleGeneration(session, prompt).catch(() => {})
+        log.info('Prompt: firing deferred title generation', {
+          hiveSessionId: session.hiveSessionId,
+          promptPreview: prompt.slice(0, 80)
+        })
+      }
 
       // After undo, the fork creates a new session branch.  Clear the
       // in-memory messages so the new branch starts fresh — the SDK will
@@ -733,9 +748,16 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
           // Fire-and-forget: generate a title for brand-new sessions only.
           // wasPending is only true on initial materialization, not forks.
           if (wasPending) {
-            this.handleTitleGeneration(session, prompt).catch(() => {
-              // Swallowed — handleTitleGeneration already logs internally
-            })
+            if (prompt.trimStart().startsWith('/using-superpowers')) {
+              session.titleDeferred = true
+              log.info('Prompt: deferring title generation (superpowers hook)', {
+                hiveSessionId: session.hiveSessionId
+              })
+            } else {
+              this.handleTitleGeneration(session, prompt).catch(() => {
+                // Swallowed — handleTitleGeneration already logs internally
+              })
+            }
           }
         }
 
@@ -1465,11 +1487,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
 
   // ── Commands ─────────────────────────────────────────────────────
 
-  private toHiveCommandFormat(cmd: {
-    name: string
-    description: string
-    argumentHint: string
-  }) {
+  private toHiveCommandFormat(cmd: { name: string; description: string; argumentHint: string }) {
     return {
       name: cmd.name,
       description: cmd.description || undefined,
@@ -1513,10 +1531,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     return []
   }
 
-  private persistCommandsToDb(
-    worktreePath: string,
-    commands?: unknown[]
-  ): void {
+  private persistCommandsToDb(worktreePath: string, commands?: unknown[]): void {
     if (!this.dbService) return
 
     // If no pre-mapped commands provided, map from the in-memory cache
@@ -1987,10 +2002,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       hiveSessionId: session.hiveSessionId
     })
 
-    const patternSuggestions = this.commandFilterService.generatePatternSuggestions(
-      toolName,
-      input
-    )
+    const patternSuggestions = this.commandFilterService.generatePatternSuggestions(toolName, input)
     const subCommandPatterns = this.commandFilterService.generateSubCommandSuggestions(
       toolName,
       input
@@ -2130,10 +2142,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
   /**
    * Update command filter settings by adding a pattern to allowlist or blocklist
    */
-  private async updateCommandFilter(
-    pattern: string,
-    action: 'allow' | 'block'
-  ): Promise<void> {
+  private async updateCommandFilter(pattern: string, action: 'allow' | 'block'): Promise<void> {
     if (!this.dbService) {
       log.error('updateCommandFilter: no database service available')
       return
@@ -2152,7 +2161,8 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         }
       }
 
-      const list = action === 'allow' ? settings.commandFilter.allowlist : settings.commandFilter.blocklist
+      const list =
+        action === 'allow' ? settings.commandFilter.allowlist : settings.commandFilter.blocklist
 
       if (!list.includes(pattern)) {
         list.push(pattern)

--- a/test/claude-code-title-integration.test.ts
+++ b/test/claude-code-title-integration.test.ts
@@ -75,6 +75,7 @@ function createMockSession(overrides: Partial<ClaudeSessionState> = {}): ClaudeS
     revertDiff: null,
     pendingFork: false,
     pendingResumeSessionAt: null,
+    titleDeferred: false,
     ...overrides
   }
 }
@@ -263,9 +264,7 @@ describe('handleTitleGeneration', () => {
     ;(impl as any).dbService = null
 
     // Should not throw
-    await expect(
-      (impl as any).handleTitleGeneration(session, 'message')
-    ).resolves.toBeUndefined()
+    await expect((impl as any).handleTitleGeneration(session, 'message')).resolves.toBeUndefined()
   })
 
   it('handles missing mainWindow gracefully', async () => {
@@ -273,9 +272,7 @@ describe('handleTitleGeneration', () => {
     ;(impl as any).mainWindow = null
 
     // Should not throw — DB still gets updated
-    await expect(
-      (impl as any).handleTitleGeneration(session, 'message')
-    ).resolves.toBeUndefined()
+    await expect((impl as any).handleTitleGeneration(session, 'message')).resolves.toBeUndefined()
     expect(mockDb.updateSession).toHaveBeenCalledWith('hive-session-456', { name: 'Some title' })
   })
 
@@ -283,9 +280,7 @@ describe('handleTitleGeneration', () => {
     mockGenerateSessionTitle.mockRejectedValue(new Error('Unexpected error'))
 
     // Should not throw
-    await expect(
-      (impl as any).handleTitleGeneration(session, 'message')
-    ).resolves.toBeUndefined()
+    await expect((impl as any).handleTitleGeneration(session, 'message')).resolves.toBeUndefined()
   })
 
   // ── Branch rename failure handling ───────────────────────────────


### PR DESCRIPTION
## Summary

- **Deferred title generation**: When a session's first prompt is the `/using-superpowers` skill hook, title generation is now deferred until the next real user message. This prevents generating meaningless or broken titles from system hook prompts that don't reflect the user's actual intent.
- **New `titleDeferred` state flag**: Added `titleDeferred: boolean` to `ClaudeSessionState` to track when title generation has been postponed. On initial session materialization, if the prompt starts with `/using-superpowers`, the flag is set to `true` instead of firing title generation immediately. On subsequent prompts, if the flag is set and the prompt is a real user message, deferred title generation fires automatically.
- **Code formatting cleanup**: Minor formatting adjustments (collapsed multi-line function signatures, import reformatting) applied by the formatter across several methods in `claude-code-implementer.ts`.
- **Test updates**: Updated `claude-code-title-integration.test.ts` to include the new `titleDeferred` field in mock session state and reformatted assertion lines.

## Changed Files

- `src/main/services/claude-code-implementer.ts` — Core logic for deferred title generation + formatting
- `test/claude-code-title-integration.test.ts` — Test mock updates + formatting

## Test plan

- [ ] Verify that starting a new session with `/using-superpowers` as the first prompt does NOT immediately generate a title
- [ ] Verify that the next real user message after `/using-superpowers` triggers title generation
- [ ] Verify that sessions starting with a normal prompt still generate titles immediately as before
- [ ] Run existing test suite: `pnpm vitest run test/claude-code-title-integration.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when `handleTitleGeneration` runs in the core `prompt()` flow, which can affect session titles and auto-branch renaming timing. Logic is small and gated, but touches session lifecycle state.
> 
> **Overview**
> Prevents meaningless session titles by **deferring title generation** when a brand-new session’s first prompt starts with `/using-superpowers`, then triggering `handleTitleGeneration()` on the next non-hook user prompt.
> 
> Adds a `titleDeferred` flag to `ClaudeSessionState` to track this behavior, and updates the title-generation integration tests/mocks accordingly (plus minor formatter-driven refactors in `claude-code-implementer.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9784ed92c0d40b0b26d34f0ee0028fa52de1f81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->