### PR TITLE
Add elapsed timer to session input area

### DIFF
--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -41,8 +41,8 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useFileTreeStore } from '@/stores/useFileTreeStore'
 import { mapOpencodeMessagesToSessionViewMessages } from '@/lib/opencode-transcript'
-import { COMPLETION_WORDS, formatCompletionDuration } from '@/lib/format-utils'
-import { messageSendTimes, lastSendMode } from '@/lib/message-send-times'
+import { COMPLETION_WORDS, formatCompletionDuration, formatElapsedTimer } from '@/lib/format-utils'
+import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import beeIcon from '@/assets/bee.png'
 
 // Stable empty array to avoid creating new references in selectors
@@ -352,6 +352,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const [sessionRetry, setSessionRetry] = useState<SessionRetryState | null>(null)
   const [sessionErrorMessage, setSessionErrorMessage] = useState<string | null>(null)
   const [retryTickMs, setRetryTickMs] = useState<number>(Date.now())
+  const [elapsedTickMs, setElapsedTickMs] = useState(Date.now())
 
   // Prompt history key: works for both worktree and connection sessions
   const historyKey = worktreeId ?? connectionId
@@ -2736,6 +2737,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
           // Start completion badge timer
           messageSendTimes.set(sessionId, Date.now())
+          userExplicitSendTimes.set(sessionId, Date.now())
           lastSendMode.set(sessionId, 'ask')
           useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
 
@@ -2825,6 +2827,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
       // Start the completion badge timer from when the user sends the message
       messageSendTimes.set(sessionId, Date.now())
+      userExplicitSendTimes.set(sessionId, Date.now())
 
       // Record the mode at send time — used to derive "Plan ready" vs "Ready"
       const currentModeForStatus = useSessionStore.getState().getSessionMode(sessionId)
@@ -3078,6 +3081,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
         setIsStreaming(true)
         setIsSending(true)
+        userExplicitSendTimes.set(sessionId, Date.now())
 
         // Transition the ExitPlanMode tool card to "accepted" state
         updateStreamingPartsRef((parts) =>
@@ -3113,6 +3117,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const handlePlanReject = useCallback(
     async (feedback: string) => {
       if (!worktreePath || !pendingPlan) return
+      userExplicitSendTimes.set(sessionId, Date.now())
       const pendingBeforeAction = pendingPlan
       useSessionStore.getState().clearPendingPlan(sessionId)
       useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
@@ -3726,6 +3731,20 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     }
   }, [sessionRetry?.next])
 
+  const isActive = isStreaming || isSending
+  useEffect(() => {
+    if (!isActive) return
+    setElapsedTickMs(Date.now())
+    const timer = window.setInterval(() => setElapsedTickMs(Date.now()), 1000)
+    return () => window.clearInterval(timer)
+  }, [isActive])
+
+  const elapsedTimerText = useMemo(() => {
+    const sendTime = userExplicitSendTimes.get(sessionId)
+    if (!sendTime) return null
+    return formatElapsedTimer(elapsedTickMs - sendTime)
+  }, [sessionId, elapsedTickMs])
+
   // Render based on view state
   if (viewState.status === 'connecting') {
     return (
@@ -4048,10 +4067,22 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                   modelId={currentModelId}
                   providerId={currentProviderId}
                 />
-                <span className="text-xs text-muted-foreground">
-                  {pendingPlan
-                    ? 'Enter to send feedback to revise the plan'
-                    : 'Enter to send, Shift+Enter for new line'}
+                <span
+                  className={cn(
+                    'text-xs tabular-nums',
+                    elapsedTimerText && isActive
+                      ? activeQuestion
+                        ? 'text-amber-500 font-semibold'
+                        : mode === 'build'
+                          ? 'text-blue-500 font-semibold'
+                          : 'text-violet-500 font-semibold'
+                      : 'text-muted-foreground'
+                  )}
+                >
+                  {elapsedTimerText
+                    ?? (pendingPlan
+                      ? 'Enter to send feedback to revise the plan'
+                      : 'Enter to send, Shift+Enter for new line')}
                 </span>
               </div>
               <div className="flex items-center gap-1.5">

--- a/src/renderer/src/lib/format-utils.ts
+++ b/src/renderer/src/lib/format-utils.ts
@@ -22,6 +22,13 @@ export function formatCompletionDuration(ms: number): string {
   return `${hours}h`
 }
 
+export function formatElapsedTimer(ms: number): string {
+  const totalSeconds = Math.floor(Math.max(0, ms) / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}
+
 export const COMPLETION_WORDS = [
   'Swarmed',
   'Buzzed',

--- a/src/renderer/src/lib/message-send-times.ts
+++ b/src/renderer/src/lib/message-send-times.ts
@@ -13,3 +13,11 @@ export const messageSendTimes = new Map<string, number>()
  * "Plan ready" or "Ready" in the sidebar.
  */
 export const lastSendMode = new Map<string, 'plan' | 'build'>()
+
+/**
+ * Tracks when the user last *explicitly* sent a message for each session.
+ * Unlike messageSendTimes (which tracks ALL sends including auto follow-ups
+ * and pending messages for the completion badge), this only records sends
+ * triggered by actual user action — used for the elapsed timer in the input area.
+ */
+export const userExplicitSendTimes = new Map<string, number>()


### PR DESCRIPTION
## Summary

- **Live elapsed timer** in the session input area showing `m:ss` while a session is actively streaming or sending
- **New `userExplicitSendTimes` map** that tracks only user-initiated actions (message send, plan accept, plan reject), separate from `messageSendTimes` which also counts auto follow-ups — ensures the timer reflects actual user wait time
- **New `formatElapsedTimer()` utility** in `format-utils.ts` that converts milliseconds to a `m:ss` display string
- **Color-coded timer text** based on session context:
  - **Amber** when an active question is pending (tool approval, etc.)
  - **Blue** in build mode
  - **Violet** in plan/ask mode
- Timer replaces the default hint text ("Enter to send…") while active, and reverts to the hint when idle
- Uses a 1-second interval (`setInterval`) that starts/stops based on `isStreaming || isSending` state to avoid unnecessary re-renders when idle

## Files changed

| File | Change |
|------|--------|
| `src/renderer/src/components/sessions/SessionView.tsx` | Timer state, effect, display logic; record `userExplicitSendTimes` on all user-initiated sends |
| `src/renderer/src/lib/format-utils.ts` | New `formatElapsedTimer()` function |
| `src/renderer/src/lib/message-send-times.ts` | New `userExplicitSendTimes` map with documentation |

## Test plan

- [ ] Send a message and verify the timer appears in the input area counting up in `m:ss` format
- [ ] Verify the timer is amber when a tool approval question is pending
- [ ] Verify the timer is blue in build mode and violet in plan/ask mode
- [ ] Verify the timer resets when sending a new message
- [ ] Verify the timer disappears and hint text returns when the session finishes responding
- [ ] Accept and reject plans — verify the timer starts on each action
- [ ] Confirm no performance issues from the 1-second interval (no ticking when idle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a 1s ticking timer and a new per-session timestamp map; main risk is minor extra re-renders/interval lifecycle issues while sending/streaming.
> 
> **Overview**
> Adds a live elapsed timer to `SessionView` that replaces the input hint text while `isStreaming || isSending`, updating once per second and color-coding the timer based on context (question pending vs build vs plan/ask).
> 
> Introduces `userExplicitSendTimes` (separate from `messageSendTimes`) to track only user-triggered sends/plan accept/reject for the timer, and adds `formatElapsedTimer()` in `format-utils.ts` to render `m:ss`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f257fcf032320640231440515439f15e930020f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->