### PR TITLE
Update session input helper text with variant shortcut

### DIFF
--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -4082,7 +4082,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                   {elapsedTimerText
                     ?? (pendingPlan
                       ? 'Enter to send feedback to revise the plan'
-                      : 'Enter to send, Shift+Enter for new line')}
+                      : `${navigator.platform.includes('Mac') ? '⌃' : 'Ctrl+'}T to change variant, Shift+Enter for new line`)}
                 </span>
               </div>
               <div className="flex items-center gap-1.5">

--- a/test/session-8/session-view.test.tsx
+++ b/test/session-8/session-view.test.tsx
@@ -1402,7 +1402,7 @@ describe('Session 8: Session View', () => {
       render(<SessionView sessionId="test-session-1" />)
 
       await waitFor(() => {
-        expect(screen.getByText(/Enter to send/i)).toBeInTheDocument()
+        expect(screen.getByText(/to change variant/i)).toBeInTheDocument()
       })
     })
 


### PR DESCRIPTION
## Summary

- **Replaced session input helper text**: Changed the default hint from `Enter to send, Shift+Enter for new line` to show the platform-aware keyboard shortcut for changing variant (`⌃T` on Mac, `Ctrl+T` on other platforms), keeping the `Shift+Enter for new line` hint.
- **Platform-aware rendering**: Uses `navigator.platform` to detect macOS and display the appropriate modifier symbol (`⌃` vs `Ctrl+`).
- **Updated test**: Adjusted the session view test assertion to match the new helper text (`/to change variant/i` instead of `/Enter to send/i`).

## Changed Files

- `src/renderer/src/components/sessions/SessionView.tsx` — Updated helper text in the input area
- `test/session-8/session-view.test.tsx` — Updated test to assert against new text

## Test plan

- [ ] Verify the session input shows `⌃T to change variant, Shift+Enter for new line` on macOS
- [ ] Verify the session input shows `Ctrl+T to change variant, Shift+Enter for new line` on non-Mac platforms
- [ ] Verify the pending plan state still shows `Enter to send feedback to revise the plan`
- [ ] Verify the elapsed timer text still takes priority when present
- [ ] Run `pnpm test` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI copy change that only affects the session input hint text; main behavioral risk is minor test/JSdom differences around `navigator.platform`.
> 
> **Overview**
> Updates the `SessionView` input helper text to advertise the platform-specific keyboard shortcut for changing model variant (`⌃T` on macOS, `Ctrl+T` elsewhere) while keeping the `Shift+Enter` newline hint, and preserves the existing pending-plan helper message.
> 
> Adjusts the `SessionView` accessibility test to assert on the new helper text wording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faa62d9928e7e7a5f80346e227e8095ad0b034af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->