### PR TITLE
Add review session status tracking and visual indicator on kanban cards

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -199,6 +199,17 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     )
   )
 
+  // ── Review session active on this ticket's worktree ────────────
+  const isBeingReviewed = useWorktreeStatusStore(
+    useCallback(
+      (state) => {
+        if (!ticket.worktree_id || ticket.column !== 'review') return false
+        return ticket.worktree_id in state.reviewSessionByWorktree
+      },
+      [ticket.worktree_id, ticket.column]
+    )
+  )
+
   // ── Detect pending questions for this ticket's session ─────────
   const isAsking = useQuestionStore(
     useCallback(
@@ -496,7 +507,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isArchived || isRunProcessAlive || ticket.github_pr_number || isCreatingPR) && (
+            {(hasAttachments || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isBeingReviewed || isArchived || isRunProcessAlive || ticket.github_pr_number || isCreatingPR) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
@@ -599,6 +610,13 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                         Question
                       </span>
                     )}
+                  </span>
+                )}
+
+                {/* Review active but ticket's own session is NOT busy — show green bar */}
+                {isBeingReviewed && !(isBusy || isAsking) && (
+                  <span data-testid="kanban-ticket-reviewing" className="ml-auto flex items-center gap-1.5">
+                    <IndeterminateProgressBar mode={ticket.mode || 'build'} isReviewing className="w-20" />
                   </span>
                 )}
               </div>

--- a/src/renderer/src/components/sessions/IndeterminateProgressBar.tsx
+++ b/src/renderer/src/components/sessions/IndeterminateProgressBar.tsx
@@ -6,6 +6,7 @@ interface IndeterminateProgressBarProps {
   mode: SessionMode
   isAsking?: boolean
   isCompacting?: boolean
+  isReviewing?: boolean
   className?: string
 }
 
@@ -33,6 +34,7 @@ export function IndeterminateProgressBar({
   mode,
   isAsking,
   isCompacting,
+  isReviewing,
   className
 }: IndeterminateProgressBarProps) {
   const barRef = useRef<HTMLDivElement>(null)
@@ -58,20 +60,24 @@ export function IndeterminateProgressBar({
     ? 'bg-red-500/15'
     : isAsking
       ? 'bg-amber-500/15'
-      : mode === 'build'
-        ? 'bg-blue-500/15'
-        : mode === 'super-plan'
-          ? 'bg-orange-500/15'
-          : 'bg-violet-500/15'
+      : isReviewing
+        ? 'bg-green-500/15'
+        : mode === 'build'
+          ? 'bg-blue-500/15'
+          : mode === 'super-plan'
+            ? 'bg-orange-500/15'
+            : 'bg-violet-500/15'
   const bgBar = isCompacting
     ? 'bg-red-500'
     : isAsking
       ? 'bg-amber-500'
-      : mode === 'build'
-        ? 'bg-blue-500'
-        : mode === 'super-plan'
-          ? 'bg-orange-500'
-          : 'bg-violet-500'
+      : isReviewing
+        ? 'bg-green-500'
+        : mode === 'build'
+          ? 'bg-blue-500'
+          : mode === 'super-plan'
+            ? 'bg-orange-500'
+            : 'bg-violet-500'
 
   return (
     <div className={cn('flex flex-col items-center w-36', className)}>

--- a/src/renderer/src/hooks/useLifecycleActions.ts
+++ b/src/renderer/src/hooks/useLifecycleActions.ts
@@ -3,6 +3,7 @@ import { useGitStore } from '@/stores/useGitStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { toast } from '@/lib/toast'
 
 interface AttachedPR {
@@ -224,6 +225,9 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
       `Code Review — ${branchName} vs ${target}`
     )
     sessionStore.setPendingMessage(result.session.id, prompt)
+
+    // Register the review session so ticket cards can show "Reviewing" indicator
+    useWorktreeStatusStore.getState().setReviewSession(worktreeId, result.session.id)
 
     return result.session.id
   }, [worktreeId, worktree?.path])

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -27,6 +27,8 @@ interface WorktreeStatusState {
   sessionStatuses: Record<string, SessionStatusEntry | null>
   // worktreeId → epoch ms of last message activity
   lastMessageTimeByWorktree: Record<string, number>
+  // worktreeId → sessionId for active review sessions
+  reviewSessionByWorktree: Record<string, string>
 
   // Actions
   setSessionStatus: (
@@ -41,6 +43,9 @@ interface WorktreeStatusState {
   getWorktreeCompletedEntry: (worktreeId: string) => SessionStatusEntry | null
   setLastMessageTime: (worktreeId: string, timestamp: number) => void
   getLastMessageTime: (worktreeId: string) => number | null
+  setReviewSession: (worktreeId: string, sessionId: string) => void
+  clearReviewSession: (worktreeId: string) => void
+  isWorktreeBeingReviewed: (worktreeId: string) => boolean
 }
 
 // Priority ranking for status aggregation (higher number = higher priority)
@@ -67,18 +72,34 @@ function higherPriority(
 export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => ({
   sessionStatuses: {},
   lastMessageTimeByWorktree: {},
+  reviewSessionByWorktree: {},
 
   setSessionStatus: (
     sessionId: string,
     status: SessionStatusType | null,
     metadata?: { word?: string; durationMs?: number; tokenDelta?: number }
   ) => {
-    set((state) => ({
-      sessionStatuses: {
-        ...state.sessionStatuses,
-        [sessionId]: status ? { status, timestamp: Date.now(), ...metadata } : null
+    set((state) => {
+      const next: Partial<WorktreeStatusState> = {
+        sessionStatuses: {
+          ...state.sessionStatuses,
+          [sessionId]: status ? { status, timestamp: Date.now(), ...metadata } : null
+        }
       }
-    }))
+
+      // Auto-clear review session when its session completes or is cleared
+      if (status === 'completed' || status === null) {
+        for (const [wtId, sId] of Object.entries(state.reviewSessionByWorktree)) {
+          if (sId === sessionId) {
+            const { [wtId]: _, ...rest } = state.reviewSessionByWorktree
+            next.reviewSessionByWorktree = rest
+            break
+          }
+        }
+      }
+
+      return next
+    })
 
     // ── Kanban coordination: notify kanban store of relevant status changes ──
     if (status === 'completed') {
@@ -265,5 +286,25 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
 
   getLastMessageTime: (worktreeId: string) => {
     return get().lastMessageTimeByWorktree[worktreeId] ?? null
+  },
+
+  setReviewSession: (worktreeId: string, sessionId: string) => {
+    set((state) => ({
+      reviewSessionByWorktree: {
+        ...state.reviewSessionByWorktree,
+        [worktreeId]: sessionId
+      }
+    }))
+  },
+
+  clearReviewSession: (worktreeId: string) => {
+    set((state) => {
+      const { [worktreeId]: _, ...rest } = state.reviewSessionByWorktree
+      return { reviewSessionByWorktree: rest }
+    })
+  },
+
+  isWorktreeBeingReviewed: (worktreeId: string): boolean => {
+    return worktreeId in get().reviewSessionByWorktree
   }
 }))


### PR DESCRIPTION
## Summary

- Added `reviewSessionByWorktree` map to track active review sessions per worktree in `useWorktreeStatusStore`
- Implemented `setReviewSession()`, `clearReviewSession()`, and `isWorktreeBeingReviewed()` store actions
- Auto-clear review sessions when parent session reaches 'completed' or null status
- Enhanced `KanbanTicketCard` to detect and display review status via new `isBeingReviewed` selector
- Updated `IndeterminateProgressBar` with `isReviewing` prop to render green progress bar for reviewing state
- Register review session in `useLifecycleActions` when review starts

## Testing

- Verify review sessions register correctly when review action is triggered
- Confirm green progress bar appears on kanban cards when worktree has active review session
- Verify progress bar only displays when ticket's own session is not busy or asking
- Confirm review session indicator clears when session completes
- Check review status persists correctly across store subscriptions
- Verify ticket remains in 'review' column while being reviewed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it extends shared Zustand state (`useWorktreeStatusStore`) and couples review-session lifecycle to `setSessionStatus`, which could impact status updates if edge cases clear mappings unexpectedly.
> 
> **Overview**
> Adds explicit tracking of *active code review sessions per worktree* via a new `reviewSessionByWorktree` map in `useWorktreeStatusStore`, with helpers to set/clear it and auto-cleanup when the underlying session is cleared or reaches `completed`.
> 
> Wires review-session registration into `useLifecycleActions.createCodeReview`, and updates `KanbanTicketCard` to detect review activity (only in the `review` column) and render a new green `IndeterminateProgressBar` state via an `isReviewing` prop when the ticket itself isn’t already busy/asking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d072f0b1165df2770dd254ccd739aef26a847da0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->