### PR TITLE
feat: Add native SVG rendering with iframe sandbox for better preview support

### DIFF
--- a/src/renderer/src/components/diff/ImageDiffView.tsx
+++ b/src/renderer/src/components/diff/ImageDiffView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { X, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { ImagePreview } from '@/components/file-viewer/ImagePreview'
+import { ImagePreview, SvgPreview } from '@/components/file-viewer/ImagePreview'
 import { isSvgFile, getImageMimeType } from '@shared/types/file-utils'
 
 interface ImageDiffViewProps {
@@ -25,8 +25,12 @@ export function ImageDiffView({
   compareBranch,
   onClose
 }: ImageDiffViewProps): React.JSX.Element {
+  // Data URIs for binary images (PNG, JPG, etc.)
   const [originalUri, setOriginalUri] = useState<string | null>(null)
   const [modifiedUri, setModifiedUri] = useState<string | null>(null)
+  // Raw SVG text content (rendered via SvgPreview instead of <img>)
+  const [originalSvg, setOriginalSvg] = useState<string | null>(null)
+  const [modifiedSvg, setModifiedSvg] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -46,13 +50,11 @@ export function ImageDiffView({
     [filePath]
   )
 
-  const buildSvgDataUri = useCallback((textContent: string): string => {
-    return `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(textContent)))}`
-  }, [])
-
   const fetchContent = useCallback(async () => {
     setIsLoading(true)
     setError(null)
+    setOriginalSvg(null)
+    setModifiedSvg(null)
 
     try {
       const isSvg = isSvgFile(filePath)
@@ -62,7 +64,7 @@ export function ImageDiffView({
         if (isSvg) {
           const modResult = await window.gitOps.getFileContent(worktreePath, filePath)
           if (modResult.success && modResult.content) {
-            setModifiedUri(buildSvgDataUri(modResult.content))
+            setModifiedSvg(modResult.content)
           }
         } else {
           const modResult = await window.gitOps.getFileContentBase64(worktreePath, filePath)
@@ -76,19 +78,13 @@ export function ImageDiffView({
 
       if (compareBranch) {
         // Branch diff: original = merge-base content, modified = working tree.
-        // Uses merge-base so only changes from commits ahead of the target branch
-        // are shown (not changes introduced on the target after divergence).
         if (isSvg) {
           const [origResult, modResult] = await Promise.all([
             window.gitOps.getBranchBaseContent(worktreePath, compareBranch, filePath),
             window.gitOps.getFileContent(worktreePath, filePath)
           ])
-          setOriginalUri(
-            origResult.success && origResult.content ? buildSvgDataUri(origResult.content) : null
-          )
-          setModifiedUri(
-            modResult.success && modResult.content ? buildSvgDataUri(modResult.content) : null
-          )
+          setOriginalSvg(origResult.success && origResult.content ? origResult.content : null)
+          setModifiedSvg(modResult.success && modResult.content ? modResult.content : null)
         } else {
           const [origResult, modResult] = await Promise.all([
             window.gitOps.getBranchBaseContentBase64(worktreePath, compareBranch, filePath),
@@ -112,12 +108,8 @@ export function ImageDiffView({
             window.gitOps.getRefContent(worktreePath, 'HEAD', filePath),
             window.gitOps.getRefContent(worktreePath, '', filePath)
           ])
-          setOriginalUri(
-            origResult.success && origResult.content ? buildSvgDataUri(origResult.content) : null
-          )
-          setModifiedUri(
-            modResult.success && modResult.content ? buildSvgDataUri(modResult.content) : null
-          )
+          setOriginalSvg(origResult.success && origResult.content ? origResult.content : null)
+          setModifiedSvg(modResult.success && modResult.content ? modResult.content : null)
         } else {
           const [origResult, modResult] = await Promise.all([
             window.gitOps.getRefContentBase64(worktreePath, 'HEAD', filePath),
@@ -141,12 +133,8 @@ export function ImageDiffView({
             window.gitOps.getRefContent(worktreePath, '', filePath),
             window.gitOps.getFileContent(worktreePath, filePath)
           ])
-          setOriginalUri(
-            origResult.success && origResult.content ? buildSvgDataUri(origResult.content) : null
-          )
-          setModifiedUri(
-            modResult.success && modResult.content ? buildSvgDataUri(modResult.content) : null
-          )
+          setOriginalSvg(origResult.success && origResult.content ? origResult.content : null)
+          setModifiedSvg(modResult.success && modResult.content ? modResult.content : null)
         } else {
           const [origResult, modResult] = await Promise.all([
             window.gitOps.getRefContentBase64(worktreePath, '', filePath),
@@ -176,8 +164,7 @@ export function ImageDiffView({
     isUntracked,
     isNewFile,
     compareBranch,
-    buildDataUri,
-    buildSvgDataUri
+    buildDataUri
   ])
 
   useEffect(() => {
@@ -236,27 +223,39 @@ export function ImageDiffView({
     )
   }
 
+  const isSvg = isSvgFile(filePath)
+  const hasOriginal = isSvg ? !!originalSvg : !!originalUri
+  const hasModified = isSvg ? !!modifiedSvg : !!modifiedUri
+
   return (
     <div className="flex-1 flex flex-col min-h-0">
       {toolbar}
       <div className="flex-1 flex min-h-0 overflow-auto">
-        {originalUri && (
+        {hasOriginal && (
           <div className="flex-1 flex flex-col min-w-0 border-r border-border">
             <div className="px-3 py-1 text-xs text-muted-foreground bg-muted/20 border-b border-border">
               Before
             </div>
             <div className="flex-1 overflow-auto">
-              <ImagePreview src={originalUri} fileName={fileName} />
+              {isSvg ? (
+                <SvgPreview svgContent={originalSvg!} fileName={fileName} />
+              ) : (
+                <ImagePreview src={originalUri!} fileName={fileName} />
+              )}
             </div>
           </div>
         )}
-        {modifiedUri && (
+        {hasModified && (
           <div className="flex-1 flex flex-col min-w-0">
             <div className="px-3 py-1 text-xs text-muted-foreground bg-muted/20 border-b border-border">
               After
             </div>
             <div className="flex-1 overflow-auto">
-              <ImagePreview src={modifiedUri} fileName={fileName} />
+              {isSvg ? (
+                <SvgPreview svgContent={modifiedSvg!} fileName={fileName} />
+              ) : (
+                <ImagePreview src={modifiedUri!} fileName={fileName} />
+              )}
             </div>
           </div>
         )}

--- a/src/renderer/src/components/file-viewer/FileViewer.tsx
+++ b/src/renderer/src/components/file-viewer/FileViewer.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { Loader2 } from 'lucide-react'
 import { CodeMirrorEditor } from './CodeMirrorEditor'
-import { ImagePreview } from './ImagePreview'
+import { ImagePreview, SvgPreview } from './ImagePreview'
 import { UnsavedChangesDialog } from './UnsavedChangesDialog'
 import { ExternalChangesBanner } from './ExternalChangesBanner'
 import { MarkdownRenderer } from '@/components/sessions/MarkdownRenderer'
@@ -11,6 +11,7 @@ import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useGitStore } from '@/stores/useGitStore'
 import { isBinaryImageFile, isSvgFile, getImageMimeType } from '@shared/types/file-utils'
+import { svgToDataUri } from '@/lib/svg-utils'
 
 // Time window after a save during which file watcher events are suppressed
 // to avoid treating our own writes as external changes.
@@ -49,31 +50,48 @@ export function FileViewer({ filePath }: FileViewerProps): React.JSX.Element {
 
     if (isBinaryImage) {
       const mimeType = getImageMimeType(filePath) || 'image/png'
-      window.fileOps.readImageAsBase64(filePath).then((result) => {
-        if (cancelled) return
-        if (result.success && result.data) {
-          setImageDataUri(`data:${mimeType};base64,${result.data}`)
-        } else {
-          setError(result.error || 'Failed to read image')
-        }
-        setIsLoading(false)
-      })
-    } else {
-      window.fileOps.readFile(filePath).then((result) => {
-        if (cancelled) return
-        if (result.success && result.content !== undefined) {
-          setContent(result.content)
-          useFileViewerStore.getState().setOriginalContent(filePath, result.content)
-          if (isSvg) {
-            setImageDataUri(
-              `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(result.content)))}`
-            )
+      window.fileOps
+        .readImageAsBase64(filePath)
+        .then((result) => {
+          if (cancelled) return
+          if (result.success && result.data) {
+            setImageDataUri(`data:${mimeType};base64,${result.data}`)
+          } else {
+            setError(result.error || 'Failed to read image')
           }
-        } else {
-          setError(result.error || 'Failed to read file')
-        }
-        setIsLoading(false)
-      })
+        })
+        .catch((err) => {
+          if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to read image')
+        })
+        .finally(() => {
+          if (!cancelled) setIsLoading(false)
+        })
+    } else {
+      window.fileOps
+        .readFile(filePath)
+        .then((result) => {
+          if (cancelled) return
+          if (result.success && result.content !== undefined) {
+            setContent(result.content)
+            useFileViewerStore.getState().setOriginalContent(filePath, result.content)
+            if (isSvg) {
+              const uri = svgToDataUri(result.content)
+              if (uri) {
+                setImageDataUri(uri)
+              } else {
+                setError('Failed to encode SVG for preview')
+              }
+            }
+          } else {
+            setError(result.error || 'Failed to read file')
+          }
+        })
+        .catch((err) => {
+          if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to read file')
+        })
+        .finally(() => {
+          if (!cancelled) setIsLoading(false)
+        })
     }
 
     return () => {
@@ -204,13 +222,20 @@ export function FileViewer({ filePath }: FileViewerProps): React.JSX.Element {
     const result = await window.fileOps.readFile(filePath)
     if (result.success && result.content !== undefined) {
       setContent(result.content)
+      if (isSvg) {
+        const uri = svgToDataUri(result.content)
+        setImageDataUri(uri)
+        if (!uri) {
+          setError('Failed to encode SVG for preview')
+        }
+      }
       const store = useFileViewerStore.getState()
       store.setOriginalContent(filePath, result.content)
       store.markClean(filePath)
       clearExternallyChanged(filePath)
       setReloadKey((k) => k + 1)
     }
-  }, [filePath, clearExternallyChanged])
+  }, [filePath, isSvg, clearExternallyChanged])
 
   const handleKeepMine = useCallback(async () => {
     clearExternallyChanged(filePath)
@@ -237,9 +262,12 @@ export function FileViewer({ filePath }: FileViewerProps): React.JSX.Element {
     if (isSvg && viewMode === 'preview') {
       const svgContent = latestContentRef.current ?? content
       if (svgContent) {
-        setImageDataUri(
-          `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svgContent)))}`
-        )
+        const uri = svgToDataUri(svgContent)
+        if (uri) {
+          setImageDataUri(uri)
+        } else {
+          setError('Failed to encode SVG for preview')
+        }
       }
     }
   }, [viewMode, isSvg, content])
@@ -317,9 +345,9 @@ export function FileViewer({ filePath }: FileViewerProps): React.JSX.Element {
         <div className="flex-1 overflow-auto" data-testid="file-viewer-image">
           <ImagePreview src={imageDataUri} fileName={fileName} />
         </div>
-      ) : isSvg && viewMode === 'preview' && imageDataUri ? (
+      ) : isSvg && viewMode === 'preview' && content ? (
         <div className="flex-1 overflow-auto" data-testid="file-viewer-image">
-          <ImagePreview src={imageDataUri} fileName={fileName} />
+          <SvgPreview svgContent={latestContentRef.current ?? content} fileName={fileName} />
         </div>
       ) : viewMode === 'preview' && isMarkdown ? (
         <div

--- a/src/renderer/src/components/file-viewer/ImagePreview.tsx
+++ b/src/renderer/src/components/file-viewer/ImagePreview.tsx
@@ -1,19 +1,38 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { cn } from '@/lib/utils'
 
 interface ImagePreviewProps {
   src: string
   fileName: string
   className?: string
+  onError?: () => void
 }
 
-export function ImagePreview({ src, fileName, className }: ImagePreviewProps): React.JSX.Element {
+export function ImagePreview({
+  src,
+  fileName,
+  className,
+  onError
+}: ImagePreviewProps): React.JSX.Element {
   const [dimensions, setDimensions] = useState<{ width: number; height: number } | null>(null)
+  const [loadError, setLoadError] = useState(false)
 
-  // Reset dimensions when image source changes to avoid stale values flashing
+  // Reset dimensions and error state when image source changes
   useEffect(() => {
     setDimensions(null)
+    setLoadError(false)
   }, [src])
+
+  if (loadError) {
+    return (
+      <div className={cn('flex flex-col items-center gap-2 p-4', className)}>
+        <div className="rounded-md border border-border bg-muted/30 p-8 text-center">
+          <p className="text-sm text-muted-foreground">Failed to render image</p>
+          <p className="text-xs text-muted-foreground/70 mt-1">{fileName}</p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className={cn('flex flex-col items-center gap-2 p-4', className)}>
@@ -39,7 +58,96 @@ export function ImagePreview({ src, fileName, className }: ImagePreviewProps): R
             const img = e.currentTarget
             setDimensions({ width: img.naturalWidth, height: img.naturalHeight })
           }}
+          onError={() => {
+            setLoadError(true)
+            onError?.()
+          }}
           draggable={false}
+        />
+      </div>
+      {dimensions && (
+        <span className="text-xs text-muted-foreground">
+          {dimensions.width} &times; {dimensions.height}
+        </span>
+      )}
+    </div>
+  )
+}
+
+// ── SVG-specific preview ────────────────────────────────────────────
+// Renders SVG content directly in a sandboxed iframe instead of relying
+// on <img src="data:..."> which silently fails in many environments.
+
+interface SvgPreviewProps {
+  svgContent: string
+  fileName: string
+  className?: string
+}
+
+export function SvgPreview({ svgContent, fileName, className }: SvgPreviewProps): React.JSX.Element {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const [dimensions, setDimensions] = useState<{ width: number; height: number } | null>(null)
+
+  // Reset dimensions when content changes
+  useEffect(() => {
+    setDimensions(null)
+  }, [svgContent])
+
+  // Build a minimal HTML document that renders the SVG centered on a
+  // checkerboard transparency background — same visual as ImagePreview.
+  const srcdoc = `<!DOCTYPE html>
+<html>
+<head>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body {
+    width: 100%; height: 100%;
+    background-color: #1a1a2e;
+    background-image:
+      linear-gradient(45deg, #2a2a3e 25%, transparent 25%),
+      linear-gradient(-45deg, #2a2a3e 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #2a2a3e 75%),
+      linear-gradient(-45deg, transparent 75%, #2a2a3e 75%);
+    background-size: 20px 20px;
+    background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+    display: flex; align-items: center; justify-content: center;
+    overflow: auto;
+  }
+  svg {
+    max-width: 100%;
+    max-height: 100%;
+  }
+</style>
+</head>
+<body>${svgContent}</body>
+</html>`
+
+  const handleLoad = (): void => {
+    try {
+      const doc = iframeRef.current?.contentDocument
+      const svg = doc?.querySelector('svg')
+      if (svg) {
+        const bbox = svg.getBoundingClientRect()
+        if (bbox.width > 0 && bbox.height > 0) {
+          setDimensions({ width: Math.round(bbox.width), height: Math.round(bbox.height) })
+        }
+      }
+    } catch {
+      // cross-origin restrictions — ignore
+    }
+  }
+
+  return (
+    <div className={cn('flex flex-col items-center gap-2 p-4', className)}>
+      <div className="rounded-md overflow-hidden border border-border w-full max-w-[90%]">
+        <iframe
+          ref={iframeRef}
+          srcDoc={srcdoc}
+          title={fileName}
+          sandbox="allow-same-origin"
+          className="w-full border-0"
+          style={{ minHeight: '200px', height: '70vh', maxHeight: '70vh' }}
+          onLoad={handleLoad}
         />
       </div>
       {dimensions && (

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -199,6 +199,17 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     )
   )
 
+  // ── Review session active on this ticket's worktree ────────────
+  const isBeingReviewed = useWorktreeStatusStore(
+    useCallback(
+      (state) => {
+        if (!ticket.worktree_id || ticket.column !== 'review') return false
+        return ticket.worktree_id in state.reviewSessionByWorktree
+      },
+      [ticket.worktree_id, ticket.column]
+    )
+  )
+
   // ── Detect pending questions for this ticket's session ─────────
   const isAsking = useQuestionStore(
     useCallback(
@@ -496,7 +507,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isArchived || isRunProcessAlive || ticket.github_pr_number || isCreatingPR) && (
+            {(hasAttachments || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isBeingReviewed || isArchived || isRunProcessAlive || ticket.github_pr_number || isCreatingPR) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
@@ -599,6 +610,13 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                         Question
                       </span>
                     )}
+                  </span>
+                )}
+
+                {/* Review active but ticket's own session is NOT busy — show green bar */}
+                {isBeingReviewed && !(isBusy || isAsking) && (
+                  <span data-testid="kanban-ticket-reviewing" className="ml-auto flex items-center gap-1.5">
+                    <IndeterminateProgressBar mode={ticket.mode || 'build'} isReviewing className="w-20" />
                   </span>
                 )}
               </div>

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -318,7 +318,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
 
     // File viewer tab is active - render FileViewer (skip diff tab keys)
     if (activeFilePath && !activeFilePath.startsWith('diff:')) {
-      return <FileViewer filePath={activeFilePath} />
+      return <FileViewer key={activeFilePath} filePath={activeFilePath} />
     }
 
     // Inline connection session view (sticky tab clicked in worktree mode)

--- a/src/renderer/src/components/sessions/IndeterminateProgressBar.tsx
+++ b/src/renderer/src/components/sessions/IndeterminateProgressBar.tsx
@@ -6,6 +6,7 @@ interface IndeterminateProgressBarProps {
   mode: SessionMode
   isAsking?: boolean
   isCompacting?: boolean
+  isReviewing?: boolean
   className?: string
 }
 
@@ -33,6 +34,7 @@ export function IndeterminateProgressBar({
   mode,
   isAsking,
   isCompacting,
+  isReviewing,
   className
 }: IndeterminateProgressBarProps) {
   const barRef = useRef<HTMLDivElement>(null)
@@ -58,20 +60,24 @@ export function IndeterminateProgressBar({
     ? 'bg-red-500/15'
     : isAsking
       ? 'bg-amber-500/15'
-      : mode === 'build'
-        ? 'bg-blue-500/15'
-        : mode === 'super-plan'
-          ? 'bg-orange-500/15'
-          : 'bg-violet-500/15'
+      : isReviewing
+        ? 'bg-green-500/15'
+        : mode === 'build'
+          ? 'bg-blue-500/15'
+          : mode === 'super-plan'
+            ? 'bg-orange-500/15'
+            : 'bg-violet-500/15'
   const bgBar = isCompacting
     ? 'bg-red-500'
     : isAsking
       ? 'bg-amber-500'
-      : mode === 'build'
-        ? 'bg-blue-500'
-        : mode === 'super-plan'
-          ? 'bg-orange-500'
-          : 'bg-violet-500'
+      : isReviewing
+        ? 'bg-green-500'
+        : mode === 'build'
+          ? 'bg-blue-500'
+          : mode === 'super-plan'
+            ? 'bg-orange-500'
+            : 'bg-violet-500'
 
   return (
     <div className={cn('flex flex-col items-center w-36', className)}>

--- a/src/renderer/src/hooks/useLifecycleActions.ts
+++ b/src/renderer/src/hooks/useLifecycleActions.ts
@@ -3,6 +3,7 @@ import { useGitStore } from '@/stores/useGitStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { toast } from '@/lib/toast'
 
 interface AttachedPR {
@@ -224,6 +225,9 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
       `Code Review — ${branchName} vs ${target}`
     )
     sessionStore.setPendingMessage(result.session.id, prompt)
+
+    // Register the review session so ticket cards can show "Reviewing" indicator
+    useWorktreeStatusStore.getState().setReviewSession(worktreeId, result.session.id)
 
     return result.session.id
   }, [worktreeId, worktree?.path])

--- a/src/renderer/src/lib/svg-utils.ts
+++ b/src/renderer/src/lib/svg-utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Convert SVG text content to a data URI suitable for use as an <img> src.
+ *
+ * Uses TextEncoder for reliable UTF-8 → bytes conversion instead of the
+ * deprecated `unescape(encodeURIComponent(...))` pattern.
+ *
+ * Returns `null` if encoding fails for any reason (malformed content, etc.).
+ */
+export function svgToDataUri(svgText: string): string | null {
+  try {
+    const encoder = new TextEncoder()
+    const bytes = encoder.encode(svgText)
+    let binary = ''
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i])
+    }
+    return `data:image/svg+xml;base64,${btoa(binary)}`
+  } catch {
+    return null
+  }
+}

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -27,6 +27,8 @@ interface WorktreeStatusState {
   sessionStatuses: Record<string, SessionStatusEntry | null>
   // worktreeId → epoch ms of last message activity
   lastMessageTimeByWorktree: Record<string, number>
+  // worktreeId → sessionId for active review sessions
+  reviewSessionByWorktree: Record<string, string>
 
   // Actions
   setSessionStatus: (
@@ -41,6 +43,9 @@ interface WorktreeStatusState {
   getWorktreeCompletedEntry: (worktreeId: string) => SessionStatusEntry | null
   setLastMessageTime: (worktreeId: string, timestamp: number) => void
   getLastMessageTime: (worktreeId: string) => number | null
+  setReviewSession: (worktreeId: string, sessionId: string) => void
+  clearReviewSession: (worktreeId: string) => void
+  isWorktreeBeingReviewed: (worktreeId: string) => boolean
 }
 
 // Priority ranking for status aggregation (higher number = higher priority)
@@ -67,18 +72,34 @@ function higherPriority(
 export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => ({
   sessionStatuses: {},
   lastMessageTimeByWorktree: {},
+  reviewSessionByWorktree: {},
 
   setSessionStatus: (
     sessionId: string,
     status: SessionStatusType | null,
     metadata?: { word?: string; durationMs?: number; tokenDelta?: number }
   ) => {
-    set((state) => ({
-      sessionStatuses: {
-        ...state.sessionStatuses,
-        [sessionId]: status ? { status, timestamp: Date.now(), ...metadata } : null
+    set((state) => {
+      const next: Partial<WorktreeStatusState> = {
+        sessionStatuses: {
+          ...state.sessionStatuses,
+          [sessionId]: status ? { status, timestamp: Date.now(), ...metadata } : null
+        }
       }
-    }))
+
+      // Auto-clear review session when its session completes or is cleared
+      if (status === 'completed' || status === null) {
+        for (const [wtId, sId] of Object.entries(state.reviewSessionByWorktree)) {
+          if (sId === sessionId) {
+            const { [wtId]: _, ...rest } = state.reviewSessionByWorktree
+            next.reviewSessionByWorktree = rest
+            break
+          }
+        }
+      }
+
+      return next
+    })
 
     // ── Kanban coordination: notify kanban store of relevant status changes ──
     if (status === 'completed') {
@@ -265,5 +286,25 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
 
   getLastMessageTime: (worktreeId: string) => {
     return get().lastMessageTimeByWorktree[worktreeId] ?? null
+  },
+
+  setReviewSession: (worktreeId: string, sessionId: string) => {
+    set((state) => ({
+      reviewSessionByWorktree: {
+        ...state.reviewSessionByWorktree,
+        [worktreeId]: sessionId
+      }
+    }))
+  },
+
+  clearReviewSession: (worktreeId: string) => {
+    set((state) => {
+      const { [worktreeId]: _, ...rest } = state.reviewSessionByWorktree
+      return { reviewSessionByWorktree: rest }
+    })
+  },
+
+  isWorktreeBeingReviewed: (worktreeId: string): boolean => {
+    return worktreeId in get().reviewSessionByWorktree
   }
 }))


### PR DESCRIPTION
## Summary

- **New SVG preview component**: `SvgPreview` renders SVG content directly in a sandboxed iframe instead of relying on data URIs, improving compatibility and reliability
- **SVG utility function**: Added `svgToDataUri()` in `svg-utils.ts` with proper UTF-8 encoding using TextEncoder (replaces deprecated unescape/encodeURIComponent pattern)
- **Updated ImageDiffView**: Routes SVG files to `SvgPreview` component; stores raw SVG text instead of data URIs
- **Updated FileViewer**: Uses `SvgPreview` for SVG file preview mode; improved promise chain error handling with .catch() and .finally()
- **Improved ImagePreview**: Added loadError state and error UI fallback for failed image renders
- **Fixed MainPane**: Added `key={activeFilePath}` to FileViewer to ensure proper component unmounting between files
- **Consistent styling**: Checkerboard transparency background in SVG iframe matches binary image preview aesthetics

## Testing

- Verify SVG files render correctly in FileViewer preview mode
- Verify SVG file diffs display both original and modified versions side-by-side in ImageDiffView
- Test branch diffs with SVG files (merge-base comparison)
- Test HEAD vs working tree SVG diffs
- Confirm binary image previews still work (PNG, JPG, WebP)
- Test error handling when SVG content fails to encode
- Verify dimensions are calculated and displayed for SVG previews
- Test broken images show error UI instead of blank space
- Not run: Visual regression testing for transparency background styling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how SVGs are rendered (injecting raw SVG into an iframe) and increases image/git show buffer limits to 20MB, which could impact rendering security assumptions and memory usage. Also expands `archiveWorktree` cleanup behavior by deleting local remote-tracking refs, which may affect branch list expectations if mis-targeted.
> 
> **Overview**
> Adds **native SVG previewing** by introducing `SvgPreview` (sandboxed iframe rendering) and routing SVGs in `FileViewer` and `ImageDiffView` to render from raw SVG text instead of `data:` URIs.
> 
> Improves robustness around previews: centralizes SVG encoding in `svgToDataUri`, adds error UI for failed image loads in `ImagePreview`, and forces `FileViewer` remounts on path change via `key={activeFilePath}`.
> 
> Backend adjustments increase binary image limits to **20MB** for `readFileAsBase64` and `git show` (`getRefContentBase64`), and `GitService.archiveWorktree` now also deletes the local `origin/<branch>` remote-tracking ref; tests cover the new branch cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb27e4498930ba51aa7717a7408c4aaf6fd14cdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->