### PR TITLE
Fix preview of untracked and new files by reading from disk

### DIFF
--- a/src/renderer/src/components/diff/MonacoDiffView.tsx
+++ b/src/renderer/src/components/diff/MonacoDiffView.tsx
@@ -34,6 +34,7 @@ export default function MonacoDiffView({
   fileName,
   staged,
   isUntracked,
+  isNewFile,
   compareBranch,
   scrollToLine,
   scrollTrigger,
@@ -77,6 +78,14 @@ export default function MonacoDiffView({
     setError(null)
 
     try {
+      if (isNewFile || isUntracked) {
+        // Untracked/new files have no git history – read from disk
+        const modResult = await window.gitOps.getFileContent(worktreePath, filePath)
+        setOriginalContent('')
+        setModifiedContent(modResult.success ? (modResult.content ?? '') : '')
+        return
+      }
+
       if (compareBranch) {
         // Branch diff: original = merge-base content, modified = working tree.
         // Uses merge-base so only changes from commits ahead of the target branch
@@ -135,7 +144,7 @@ export default function MonacoDiffView({
       setIsLoading(false)
       isInitialLoad.current = false
     }
-  }, [worktreePath, filePath, staged, compareBranch])
+  }, [worktreePath, filePath, staged, isNewFile, isUntracked, compareBranch])
 
   // Fetch on mount and when refresh is triggered
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Added `isNewFile` parameter to MonacoDiffView component
- Implemented early return for untracked/new files that reads content directly from disk using `gitOps.getFileContent()`
- Sets original content to empty string and modified content from disk for new/untracked files
- Updated dependency array to include `isNewFile` and `isUntracked` to ensure proper re-renders
- Prevents git history lookup errors for files not yet staged in git

## Testing

- Verify untracked files can be previewed without errors
- Verify new files can be previewed without errors
- Verify modified content displays correctly from disk for untracked/new files
- Verify original content shows as empty for untracked/new files
- Verify existing diff functionality still works for tracked files
- Verify branch diff functionality still works when `compareBranch` is set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI diff-loading change; it only alters how content is sourced for `isUntracked`/`isNewFile` files and should not affect tracked-file diff logic beyond the updated re-fetch dependencies.
> 
> **Overview**
> Fixes Monaco diff preview for *untracked/new* files by bypassing git-history lookups and reading the modified content directly from disk via `gitOps.getFileContent`, with an empty original side.
> 
> Adds an `isNewFile` prop to `MonacoDiffView` and updates the `fetchContent` hook dependencies so the diff reloads correctly when `isNewFile`/`isUntracked` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01c6024afc69acc345fc86706f5d0c896bb8e014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->