### PR TITLE
Fix intermittent terminal paste bug with Ghostty focus detection

### DIFF
--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -253,6 +253,11 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
     ghosttyService.pasteText(worktreeId, text)
   })
 
+  // Diagnostic: inspect Ghostty view hierarchy and first responder state
+  ipcMain.handle('terminal:ghostty:focusDiagnostics', () => {
+    return ghosttyService.focusDiagnostics()
+  })
+
   // Destroy a Ghostty surface for a worktree
   ipcMain.handle('terminal:ghostty:destroySurface', (_event, worktreeId: string) => {
     log.info('IPC: terminal:ghostty:destroySurface', { worktreeId })

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -101,16 +101,25 @@ export function buildMenu(mainWindow: BrowserWindow, isDev: boolean): Menu {
           accelerator: 'CmdOrCtrl+V',
           click: (): void => {
             if (!_mainWindow || _mainWindow.isDestroyed()) return
-            // On macOS the Ghostty terminal is a native NSView overlay that
-            // can become the macOS first responder independently of Chromium.
-            // The menu accelerator intercepts Cmd+V before any NSView sees it.
-            // Query the native addon for the actual macOS first responder: if
-            // a Ghostty surface owns it, paste directly into that surface;
-            // otherwise fall through to the normal web content paste path.
+            // Three-tier paste routing for Ghostty + xterm coexistence.
+            //
+            // Tier 1: The native addon reports a Ghostty surface as macOS first
+            //         responder — paste directly into that surface (fast path).
+            // Tier 2: No Ghostty first responder AND web content is not focused
+            //         either — the native focus state is likely stale (e.g. after
+            //         overlay suppression race). Send 'edit:paste' IPC so the
+            //         renderer can route to whichever backend is actually active.
+            // Tier 3: Web content has focus — standard browser paste for xterm,
+            //         text inputs, and other Chromium-rendered elements.
             if (ghosttyService.focusedSurfaceId() > 0) {
               const text = clipboard.readText()
               if (text) {
                 ghosttyService.pasteToFocusedSurface(text)
+              }
+            } else if (!_mainWindow.webContents.isFocused() && ghosttyService.hasSurfaces()) {
+              const text = clipboard.readText()
+              if (text) {
+                _mainWindow.webContents.send('edit:paste', text)
               }
             } else {
               _mainWindow.webContents.paste()

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,7 +1,9 @@
 import { BrowserWindow, Menu, app, clipboard, shell } from 'electron'
-import { getLogDir } from './services/logger'
+import { createLogger, getLogDir } from './services/logger'
 import { ghosttyService } from './services/ghostty-service'
 import { updaterService } from './services/updater'
+
+const log = createLogger({ component: 'Menu' })
 
 export interface MenuState {
   hasActiveSession: boolean
@@ -117,6 +119,12 @@ export function buildMenu(mainWindow: BrowserWindow, isDev: boolean): Menu {
                 ghosttyService.pasteToFocusedSurface(text)
               }
             } else if (!_mainWindow.webContents.isFocused() && ghosttyService.hasSurfaces()) {
+              // Tier 2 fallback — native focus query missed but Ghostty surfaces
+              // exist. Log diagnostics so users can send us the log file if paste
+              // still misbehaves (Help → Open Log Directory).
+              log.warn('Paste fallback: focusedSurfaceId() returned 0 with active surfaces', {
+                diagnostics: ghosttyService.focusDiagnostics()
+              })
               const text = clipboard.readText()
               if (text) {
                 _mainWindow.webContents.send('edit:paste', text)

--- a/src/main/services/ghostty-service.ts
+++ b/src/main/services/ghostty-service.ts
@@ -33,6 +33,14 @@ interface GhosttyAddon {
   ghosttySetFocus(surfaceId: number, focused: boolean): void
   ghosttyPasteText(surfaceId: number, text: string): void
   ghosttyFocusedSurfaceId(): number
+  ghosttyFocusDiagnostics(): Array<{
+    surfaceId: number
+    subviewCount: number
+    firstResponderClass: string
+    isHostView: boolean
+    isDescendant: boolean
+    hasWindow: boolean
+  }>
   ghosttyDestroySurface(surfaceId: number): void
   ghosttyShutdown(): void
 }
@@ -409,6 +417,35 @@ class GhosttyService {
         err instanceof Error ? err : new Error(String(err)),
         { worktreeId }
       )
+    }
+  }
+
+  /**
+   * Returns true if any Ghostty surfaces exist (regardless of focus state).
+   * Used by the menu paste handler to decide whether the IPC fallback should fire.
+   */
+  hasSurfaces(): boolean {
+    return this.surfaces.size > 0
+  }
+
+  /**
+   * Diagnostic: return info about the view hierarchy and first responder for
+   * each surface. Call from DevTools via terminalOps.ghosttyFocusDiagnostics()
+   * to debug paste routing issues.
+   */
+  focusDiagnostics(): Array<{
+    surfaceId: number
+    subviewCount: number
+    firstResponderClass: string
+    isHostView: boolean
+    isDescendant: boolean
+    hasWindow: boolean
+  }> {
+    if (!this.addon) return []
+    try {
+      return this.addon.ghosttyFocusDiagnostics()
+    } catch {
+      return []
     }
   }
 

--- a/src/native/src/addon.mm
+++ b/src/native/src/addon.mm
@@ -321,6 +321,28 @@ Napi::Value GhosttyFocusedSurfaceId(const Napi::CallbackInfo& info) {
 }
 
 // ---------------------------------------------------------------------------
+// ghosttyFocusDiagnostics() → Array<{surfaceId, subviewCount, firstResponderClass, isHostView, isDescendant, hasWindow}>
+// ---------------------------------------------------------------------------
+Napi::Value GhosttyFocusDiagnostics(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  auto diags = GhosttyBridge::instance().focusDiagnostics();
+
+  Napi::Array arr = Napi::Array::New(env, diags.size());
+  for (size_t i = 0; i < diags.size(); i++) {
+    Napi::Object obj = Napi::Object::New(env);
+    obj.Set("surfaceId", Napi::Number::New(env, diags[i].surfaceId));
+    obj.Set("subviewCount", Napi::Number::New(env, diags[i].subviewCount));
+    obj.Set("firstResponderClass", Napi::String::New(env, diags[i].firstResponderClass));
+    obj.Set("isHostView", Napi::Boolean::New(env, diags[i].isHostView));
+    obj.Set("isDescendant", Napi::Boolean::New(env, diags[i].isDescendant));
+    obj.Set("hasWindow", Napi::Boolean::New(env, diags[i].hasWindow));
+    arr[i] = obj;
+  }
+
+  return arr;
+}
+
+// ---------------------------------------------------------------------------
 // ghosttyDestroySurface(surfaceId: number) → void
 // ---------------------------------------------------------------------------
 void GhosttyDestroySurface(const Napi::CallbackInfo& info) {
@@ -366,6 +388,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
     Napi::Function::New(env, GhosttyPasteText));
   exports.Set("ghosttyFocusedSurfaceId",
     Napi::Function::New(env, GhosttyFocusedSurfaceId));
+  exports.Set("ghosttyFocusDiagnostics",
+    Napi::Function::New(env, GhosttyFocusDiagnostics));
   exports.Set("ghosttyDestroySurface",
     Napi::Function::New(env, GhosttyDestroySurface));
   exports.Set("ghosttyShutdown",

--- a/src/native/src/ghostty_bridge.h
+++ b/src/native/src/ghostty_bridge.h
@@ -12,6 +12,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 #include "ghostty.h"
 
 // Forward declaration for NSView*
@@ -116,6 +117,18 @@ public:
 
   // Update libghostty focus state only (no NSResponder changes).
   void setSurfaceFocus(uint32_t surfaceId, bool focused);
+
+  // Diagnostic: return info about the view hierarchy and first responder
+  // for each surface. Used to debug paste routing issues.
+  struct FocusDiagInfo {
+    uint32_t surfaceId;
+    int subviewCount;
+    std::string firstResponderClass;
+    bool isHostView;       // first responder == host view
+    bool isDescendant;     // first responder is a subview of host view
+    bool hasWindow;
+  };
+  std::vector<FocusDiagInfo> focusDiagnostics();
 
   // Request surface close (graceful)
   void requestClose(uint32_t surfaceId);

--- a/src/native/src/ghostty_bridge.mm
+++ b/src/native/src/ghostty_bridge.mm
@@ -344,10 +344,21 @@ void GhosttyBridge::setFocus(uint32_t surfaceId, bool focused) {
   // Do this outside the bridge mutex to avoid re-entrant deadlocks.
   if (view && [view window]) {
     NSWindow* window = [view window];
-    if (focused && [window firstResponder] != view) {
+    NSResponder* firstResponder = [window firstResponder];
+
+    // When focusing, always make the host view first responder.
+    if (focused && firstResponder != view) {
       [window makeFirstResponder:view];
-    } else if (!focused && [window firstResponder] == view) {
-      [window makeFirstResponder:nil];
+    }
+    // When unfocusing, resign if the host view OR any of its subviews is the
+    // first responder (Ghostty may have installed a child view for text input).
+    else if (!focused) {
+      bool ownsFocus = (firstResponder == view) ||
+        ([firstResponder isKindOfClass:[NSView class]] &&
+         [(NSView*)firstResponder isDescendantOf:view]);
+      if (ownsFocus) {
+        [window makeFirstResponder:nil];
+      }
     }
   }
 
@@ -386,11 +397,67 @@ uint32_t GhosttyBridge::focusedSurfaceId() {
   std::lock_guard<std::mutex> lock(mutex_);
   for (auto& [id, surface] : surfaces_) {
     NSView* view = surface.view;
-    if (view && view.window && [view.window firstResponder] == view) {
+    if (!view || !view.window) continue;
+
+    NSResponder* firstResponder = [view.window firstResponder];
+    // Check if the first responder is the host view itself.
+    if (firstResponder == view) return id;
+    // Also check if the first responder is a subview of the host view.
+    // Ghostty may install child views (e.g. for Metal rendering or IME text
+    // input) that become the first responder. Typing still works through the
+    // responder chain, but a strict identity check would miss them, causing
+    // focusedSurfaceId() to return 0 and breaking Cmd+V paste routing.
+    if ([firstResponder isKindOfClass:[NSView class]] &&
+        [(NSView*)firstResponder isDescendantOf:view]) {
       return id;
     }
   }
   return 0;
+}
+
+std::vector<GhosttyBridge::FocusDiagInfo> GhosttyBridge::focusDiagnostics() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<FocusDiagInfo> result;
+
+  for (auto& [id, surface] : surfaces_) {
+    FocusDiagInfo info;
+    info.surfaceId = id;
+    info.subviewCount = 0;
+    info.isHostView = false;
+    info.isDescendant = false;
+    info.hasWindow = false;
+
+    NSView* view = surface.view;
+    if (!view) {
+      info.firstResponderClass = "(no view)";
+      result.push_back(info);
+      continue;
+    }
+
+    info.subviewCount = static_cast<int>([view.subviews count]);
+    info.hasWindow = (view.window != nil);
+
+    if (!view.window) {
+      info.firstResponderClass = "(no window)";
+      result.push_back(info);
+      continue;
+    }
+
+    NSResponder* firstResponder = [view.window firstResponder];
+    if (!firstResponder) {
+      info.firstResponderClass = "(nil)";
+    } else {
+      info.firstResponderClass = [NSStringFromClass([firstResponder class]) UTF8String];
+      info.isHostView = (firstResponder == view);
+      info.isDescendant = !info.isHostView &&
+        [firstResponder isKindOfClass:[NSView class]] &&
+        [(NSView*)firstResponder isDescendantOf:view];
+    }
+
+    result.push_back(info);
+  }
+
+  return result;
 }
 
 void GhosttyBridge::requestClose(uint32_t surfaceId) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1679,6 +1679,17 @@ const terminalOps = {
   ghosttyPasteText: (worktreeId: string, text: string): Promise<void> =>
     ipcRenderer.invoke('terminal:ghostty:pasteText', worktreeId, text),
 
+  ghosttyFocusDiagnostics: (): Promise<
+    Array<{
+      surfaceId: number
+      subviewCount: number
+      firstResponderClass: string
+      isHostView: boolean
+      isDescendant: boolean
+      hasWindow: boolean
+    }>
+  > => ipcRenderer.invoke('terminal:ghostty:focusDiagnostics'),
+
   ghosttyDestroySurface: (worktreeId: string): Promise<void> =>
     ipcRenderer.invoke('terminal:ghostty:destroySurface', worktreeId),
 

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -91,7 +91,11 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     return () => clearTimeout(timer)
   }, [themeId])
 
-  // Re-fit and focus when becoming visible
+  // Re-fit and focus when becoming visible.
+  // Note: GhosttyBackend.setVisible(true) already restores macOS first responder
+  // directly; the focus() call below is a belt-and-suspenders backup for Ghostty
+  // and the primary focus path for xterm. The xterm fit() requires the delayed
+  // call because layout dimensions need a frame to settle.
   useEffect(() => {
     if (!backendRef.current) return
 
@@ -109,20 +113,28 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     return () => clearTimeout(timer)
   }, [effectiveVisible])
 
-  // Ghostty paste: the Cmd+V menu accelerator intercepts the keystroke at the
-  // macOS application-menu level, before it can reach the native Ghostty NSView.
-  // The menu handler checks webContents.isFocused() — when the Ghostty NSView
-  // is the macOS first responder the web content is NOT focused, so the handler
-  // reads the clipboard and sends 'edit:paste' via IPC for us to forward here.
+  // Paste fallback: the Cmd+V menu accelerator intercepts the keystroke at the
+  // macOS application-menu level before it reaches any view. The menu handler
+  // uses a three-tier routing strategy:
+  //   Tier 1: Ghostty surface has macOS first responder → direct native paste
+  //   Tier 2: Neither Ghostty nor web content has focus (stale focus state) →
+  //           sends 'edit:paste' IPC here so we can route to the active backend
+  //   Tier 3: Web content has focus → webContents.paste() (xterm, inputs, etc.)
+  // This listener handles Tier 2 — it fires when the native focus detection
+  // failed but the terminal is still the intended paste target.
+  // Note: 'edit:paste' is an IPC broadcast — all registered listeners receive it.
+  // Only one TerminalView should have effectiveVisible=true at a time (enforced
+  // by TerminalManager's single-active invariant), so only one listener fires.
   useEffect(() => {
-    if (activeBackendTypeRef.current !== 'ghostty' || !effectiveVisible) return
+    if (!effectiveVisible) return
     if (!window.systemOps?.onEditPaste) return
 
     const cleanup = window.systemOps.onEditPaste((text) => {
-      // The main process already verified that webContents is NOT focused
-      // (i.e. a native NSView like Ghostty has macOS first responder), so
-      // we can unconditionally forward the text to the Ghostty surface.
-      window.terminalOps.ghosttyPasteText(worktreeId, text)
+      if (activeBackendTypeRef.current === 'ghostty') {
+        window.terminalOps.ghosttyPasteText(worktreeId, text)
+      } else if (activeBackendTypeRef.current === 'xterm') {
+        window.terminalOps.write(worktreeId, text)
+      }
     })
 
     return cleanup

--- a/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
@@ -206,6 +206,13 @@ export class GhosttyBackend implements TerminalBackend {
     }
 
     this.syncFrame()
+    // Restore macOS first responder so focusedSurfaceId() returns this surface
+    // and the menu paste handler routes Cmd+V correctly. Without this, focus
+    // restoration depends on a fragile setTimeout in TerminalView that can be
+    // cancelled by rapid effectiveVisible changes (e.g. overlay suppression race).
+    window.terminalOps.ghosttySetFocus(this.worktreeId, true).catch(() => {
+      // Ignore focus errors
+    })
   }
 
   clear(): void {

--- a/test/terminal/ghostty-backend-visibility.test.ts
+++ b/test/terminal/ghostty-backend-visibility.test.ts
@@ -74,11 +74,17 @@ describe('GhosttyBackend visibility', () => {
     expect(hiddenFrame.h).toBe(360)
     expect(mockTerminalOps.ghosttyDestroySurface).not.toHaveBeenCalled()
 
+    mockTerminalOps.ghosttySetFocus.mockClear()
+
     visibilityBackend.setVisible(true)
 
     const visibleFrame = mockTerminalOps.ghosttySetFrame.mock.calls.at(-1)?.[1]
     expect(visibleFrame).toEqual({ x: 100, y: 80, w: 640, h: 360 })
     expect(mockTerminalOps.ghosttyDestroySurface).not.toHaveBeenCalled()
+
+    // Focus must be restored when becoming visible again so that
+    // focusedSurfaceId() returns this surface for the menu paste handler.
+    expect(mockTerminalOps.ghosttySetFocus).toHaveBeenCalledWith('wt-1', true)
 
     backend.dispose()
   })


### PR DESCRIPTION
## Summary

- **Root cause**: The menu paste handler's macOS first responder detection failed intermittently when Ghostty subviews (not the host view itself) owned focus, causing `focusedSurfaceId()` to return 0 and routing Cmd+V to webContents instead
- **Native fix**: Updated `focusedSurfaceId()` to detect both the host view AND any descendant NSView as Ghostty focus owners, matching how the responder chain actually works
- **Focus restoration**: GhosttyBackend now explicitly restores macOS first responder when `setVisible(true)` is called, eliminating race conditions in the setTimeout fallback
- **Three-tier paste routing**: Implemented in menu handler with clear fallback logic:
  - Tier 1: Ghostty surface detected as first responder → native direct paste
  - Tier 2: No Ghostty focus detected but surfaces exist (stale state) → send `edit:paste` IPC for renderer to route
  - Tier 3: Web content has focus → standard webContents.paste() for xterm/inputs
- **Diagnostics**: Added `focusDiagnostics()` method to inspect view hierarchy and first responder state per surface (useful for future debugging)
- **Xterm support**: Paste fallback now handles both Ghostty and xterm backends in TerminalView listener

## Testing

- Manual verification: Tested rapid Cmd+V pasting with Ghostty surface active
- Focus detection: Verified first responder detection logic handles subviews correctly
- Ghostty backend visibility test updated to assert `ghosttySetFocus(true)` is called on `setVisible(true)`
- Fallback path: Tested with `edit:paste` IPC trigger to ensure renderer correctly routes to active backend
- Not run: Full integration test with xterm backend swap during active paste

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS-native focus/first-responder handling and cross-process paste routing, so regressions could impact terminal input/focus behavior. Changes are scoped to Ghostty/xterm paste paths and add diagnostics to aid debugging.
> 
> **Overview**
> Fixes intermittent terminal paste failures on macOS by updating Ghostty focus detection to treat *descendant* NSViews as focus owners (not just the host view), and by resigning focus when either the host view or its subviews are first responder.
> 
> Updates the Edit → Paste menu handler to a **three-tier routing strategy** (direct native paste when Ghostty is focused, IPC fallback when focus state appears stale but surfaces exist, otherwise `webContents.paste()`), with warning logs that include new `focusDiagnostics()` output.
> 
> Adds a `ghosttyFocusDiagnostics` IPC/API surface (main, preload, native addon) and adjusts renderer behavior so the IPC paste fallback routes to the currently active backend (Ghostty or xterm). Also restores Ghostty focus when `setVisible(true)` runs and updates the visibility test to assert that focus restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84375e7d9ee6dabc1242664f3a5dea1cb100fc72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->