### PR TITLE
Add Cmd+click support to open ticket worktree on Kanban cards

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -36,6 +36,7 @@ import type {
   KanbanTicketCreate,
   KanbanTicketUpdate,
   KanbanTicketColumn,
+  TicketMark,
   TicketFollowupMessage,
   TicketFollowupMessageCreate
 } from './types'
@@ -146,6 +147,7 @@ export class DatabaseService {
       external_url: (row.external_url as string) ?? null,
       github_pr_number: (row.github_pr_number as number) ?? null,
       github_pr_url: (row.github_pr_url as string) ?? null,
+      mark: (row.mark as TicketMark) ?? null,
       total_tokens: (row.total_tokens as number) ?? 0
     }
   }
@@ -251,6 +253,7 @@ export class DatabaseService {
     this.safeAddColumn('sessions', 'pinned_to_board', 'INTEGER NOT NULL DEFAULT 0')
     this.safeAddColumn('kanban_tickets', 'github_pr_number', 'INTEGER DEFAULT NULL')
     this.safeAddColumn('kanban_tickets', 'github_pr_url', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('kanban_tickets', 'mark', 'TEXT DEFAULT NULL')
 
     db.exec(`
       CREATE INDEX IF NOT EXISTS idx_sessions_connection ON sessions(connection_id);
@@ -1686,10 +1689,11 @@ export class DatabaseService {
     const externalUrl = data.external_url ?? null
     const githubPrNumber = data.github_pr_number ?? null
     const githubPrUrl = data.github_pr_url ?? null
+    const mark = data.mark ?? null
 
     db.prepare(
-      `INSERT INTO kanban_tickets (id, project_id, title, description, attachments, "column", sort_order, current_session_id, worktree_id, mode, plan_ready, external_provider, external_id, external_url, github_pr_number, github_pr_url, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO kanban_tickets (id, project_id, title, description, attachments, "column", sort_order, current_session_id, worktree_id, mode, plan_ready, external_provider, external_id, external_url, github_pr_number, github_pr_url, mark, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       id,
       data.project_id,
@@ -1707,6 +1711,7 @@ export class DatabaseService {
       externalUrl,
       githubPrNumber,
       githubPrUrl,
+      mark,
       now,
       now
     )
@@ -1728,6 +1733,7 @@ export class DatabaseService {
       external_url: externalUrl,
       github_pr_number: githubPrNumber,
       github_pr_url: githubPrUrl,
+      mark,
       total_tokens: 0,
       created_at: now,
       updated_at: now
@@ -1816,6 +1822,10 @@ export class DatabaseService {
     if (data.github_pr_url !== undefined) {
       updates.push('github_pr_url = ?')
       values.push(data.github_pr_url)
+    }
+    if (data.mark !== undefined) {
+      updates.push('mark = ?')
+      values.push(data.mark)
     }
 
     if (updates.length === 1) return existing // Only updated_at, nothing meaningful changed

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -28,5 +28,6 @@ export type {
   KanbanTicket,
   KanbanTicketCreate,
   KanbanTicketUpdate,
-  KanbanTicketColumn
+  KanbanTicketColumn,
+  TicketMark
 } from './types'

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 20
+export const CURRENT_SCHEMA_VERSION = 21
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -422,6 +422,12 @@ export const MIGRATIONS: Migration[] = [
     up: `ALTER TABLE sessions ADD COLUMN pinned_to_board INTEGER NOT NULL DEFAULT 0;
          ALTER TABLE kanban_tickets ADD COLUMN github_pr_number INTEGER DEFAULT NULL;
          ALTER TABLE kanban_tickets ADD COLUMN github_pr_url TEXT DEFAULT NULL;`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 21,
+    name: 'add_ticket_mark',
+    up: `ALTER TABLE kanban_tickets ADD COLUMN mark TEXT DEFAULT NULL`,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -338,6 +338,7 @@ export interface SessionSearchOptions {
 
 // Kanban ticket types
 export type KanbanTicketColumn = 'todo' | 'in_progress' | 'review' | 'done'
+export type TicketMark = 'common' | 'rare' | 'epic' | 'legendary'
 
 export interface KanbanTicket {
   id: string
@@ -359,6 +360,7 @@ export interface KanbanTicket {
   external_url: string | null
   github_pr_number: number | null
   github_pr_url: string | null
+  mark: TicketMark | null
   total_tokens: number
 }
 
@@ -379,6 +381,7 @@ export interface KanbanTicketCreate {
   external_url?: string | null
   github_pr_number?: number | null
   github_pr_url?: string | null
+  mark?: TicketMark | null
 }
 
 export interface KanbanTicketUpdate {
@@ -393,6 +396,7 @@ export interface KanbanTicketUpdate {
   plan_ready?: boolean
   github_pr_number?: number | null
   github_pr_url?: string | null
+  mark?: TicketMark | null
 }
 
 // Ticket followup message types

--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -253,6 +253,11 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
     ghosttyService.pasteText(worktreeId, text)
   })
 
+  // Diagnostic: inspect Ghostty view hierarchy and first responder state
+  ipcMain.handle('terminal:ghostty:focusDiagnostics', () => {
+    return ghosttyService.focusDiagnostics()
+  })
+
   // Destroy a Ghostty surface for a worktree
   ipcMain.handle('terminal:ghostty:destroySurface', (_event, worktreeId: string) => {
     log.info('IPC: terminal:ghostty:destroySurface', { worktreeId })

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,7 +1,9 @@
 import { BrowserWindow, Menu, app, clipboard, shell } from 'electron'
-import { getLogDir } from './services/logger'
+import { createLogger, getLogDir } from './services/logger'
 import { ghosttyService } from './services/ghostty-service'
 import { updaterService } from './services/updater'
+
+const log = createLogger({ component: 'Menu' })
 
 export interface MenuState {
   hasActiveSession: boolean
@@ -101,16 +103,31 @@ export function buildMenu(mainWindow: BrowserWindow, isDev: boolean): Menu {
           accelerator: 'CmdOrCtrl+V',
           click: (): void => {
             if (!_mainWindow || _mainWindow.isDestroyed()) return
-            // On macOS the Ghostty terminal is a native NSView overlay that
-            // can become the macOS first responder independently of Chromium.
-            // The menu accelerator intercepts Cmd+V before any NSView sees it.
-            // Query the native addon for the actual macOS first responder: if
-            // a Ghostty surface owns it, paste directly into that surface;
-            // otherwise fall through to the normal web content paste path.
+            // Three-tier paste routing for Ghostty + xterm coexistence.
+            //
+            // Tier 1: The native addon reports a Ghostty surface as macOS first
+            //         responder — paste directly into that surface (fast path).
+            // Tier 2: No Ghostty first responder AND web content is not focused
+            //         either — the native focus state is likely stale (e.g. after
+            //         overlay suppression race). Send 'edit:paste' IPC so the
+            //         renderer can route to whichever backend is actually active.
+            // Tier 3: Web content has focus — standard browser paste for xterm,
+            //         text inputs, and other Chromium-rendered elements.
             if (ghosttyService.focusedSurfaceId() > 0) {
               const text = clipboard.readText()
               if (text) {
                 ghosttyService.pasteToFocusedSurface(text)
+              }
+            } else if (!_mainWindow.webContents.isFocused() && ghosttyService.hasSurfaces()) {
+              // Tier 2 fallback — native focus query missed but Ghostty surfaces
+              // exist. Log diagnostics so users can send us the log file if paste
+              // still misbehaves (Help → Open Log Directory).
+              log.warn('Paste fallback: focusedSurfaceId() returned 0 with active surfaces', {
+                diagnostics: ghosttyService.focusDiagnostics()
+              })
+              const text = clipboard.readText()
+              if (text) {
+                _mainWindow.webContents.send('edit:paste', text)
               }
             } else {
               _mainWindow.webContents.paste()

--- a/src/main/services/ghostty-service.ts
+++ b/src/main/services/ghostty-service.ts
@@ -33,6 +33,14 @@ interface GhosttyAddon {
   ghosttySetFocus(surfaceId: number, focused: boolean): void
   ghosttyPasteText(surfaceId: number, text: string): void
   ghosttyFocusedSurfaceId(): number
+  ghosttyFocusDiagnostics(): Array<{
+    surfaceId: number
+    subviewCount: number
+    firstResponderClass: string
+    isHostView: boolean
+    isDescendant: boolean
+    hasWindow: boolean
+  }>
   ghosttyDestroySurface(surfaceId: number): void
   ghosttyShutdown(): void
 }
@@ -409,6 +417,35 @@ class GhosttyService {
         err instanceof Error ? err : new Error(String(err)),
         { worktreeId }
       )
+    }
+  }
+
+  /**
+   * Returns true if any Ghostty surfaces exist (regardless of focus state).
+   * Used by the menu paste handler to decide whether the IPC fallback should fire.
+   */
+  hasSurfaces(): boolean {
+    return this.surfaces.size > 0
+  }
+
+  /**
+   * Diagnostic: return info about the view hierarchy and first responder for
+   * each surface. Call from DevTools via terminalOps.ghosttyFocusDiagnostics()
+   * to debug paste routing issues.
+   */
+  focusDiagnostics(): Array<{
+    surfaceId: number
+    subviewCount: number
+    firstResponderClass: string
+    isHostView: boolean
+    isDescendant: boolean
+    hasWindow: boolean
+  }> {
+    if (!this.addon) return []
+    try {
+      return this.addon.ghosttyFocusDiagnostics()
+    } catch {
+      return []
     }
   }
 

--- a/src/native/src/addon.mm
+++ b/src/native/src/addon.mm
@@ -321,6 +321,28 @@ Napi::Value GhosttyFocusedSurfaceId(const Napi::CallbackInfo& info) {
 }
 
 // ---------------------------------------------------------------------------
+// ghosttyFocusDiagnostics() → Array<{surfaceId, subviewCount, firstResponderClass, isHostView, isDescendant, hasWindow}>
+// ---------------------------------------------------------------------------
+Napi::Value GhosttyFocusDiagnostics(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  auto diags = GhosttyBridge::instance().focusDiagnostics();
+
+  Napi::Array arr = Napi::Array::New(env, diags.size());
+  for (size_t i = 0; i < diags.size(); i++) {
+    Napi::Object obj = Napi::Object::New(env);
+    obj.Set("surfaceId", Napi::Number::New(env, diags[i].surfaceId));
+    obj.Set("subviewCount", Napi::Number::New(env, diags[i].subviewCount));
+    obj.Set("firstResponderClass", Napi::String::New(env, diags[i].firstResponderClass));
+    obj.Set("isHostView", Napi::Boolean::New(env, diags[i].isHostView));
+    obj.Set("isDescendant", Napi::Boolean::New(env, diags[i].isDescendant));
+    obj.Set("hasWindow", Napi::Boolean::New(env, diags[i].hasWindow));
+    arr[i] = obj;
+  }
+
+  return arr;
+}
+
+// ---------------------------------------------------------------------------
 // ghosttyDestroySurface(surfaceId: number) → void
 // ---------------------------------------------------------------------------
 void GhosttyDestroySurface(const Napi::CallbackInfo& info) {
@@ -366,6 +388,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
     Napi::Function::New(env, GhosttyPasteText));
   exports.Set("ghosttyFocusedSurfaceId",
     Napi::Function::New(env, GhosttyFocusedSurfaceId));
+  exports.Set("ghosttyFocusDiagnostics",
+    Napi::Function::New(env, GhosttyFocusDiagnostics));
   exports.Set("ghosttyDestroySurface",
     Napi::Function::New(env, GhosttyDestroySurface));
   exports.Set("ghosttyShutdown",

--- a/src/native/src/ghostty_bridge.h
+++ b/src/native/src/ghostty_bridge.h
@@ -12,6 +12,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 #include "ghostty.h"
 
 // Forward declaration for NSView*
@@ -116,6 +117,18 @@ public:
 
   // Update libghostty focus state only (no NSResponder changes).
   void setSurfaceFocus(uint32_t surfaceId, bool focused);
+
+  // Diagnostic: return info about the view hierarchy and first responder
+  // for each surface. Used to debug paste routing issues.
+  struct FocusDiagInfo {
+    uint32_t surfaceId;
+    int subviewCount;
+    std::string firstResponderClass;
+    bool isHostView;       // first responder == host view
+    bool isDescendant;     // first responder is a subview of host view
+    bool hasWindow;
+  };
+  std::vector<FocusDiagInfo> focusDiagnostics();
 
   // Request surface close (graceful)
   void requestClose(uint32_t surfaceId);

--- a/src/native/src/ghostty_bridge.mm
+++ b/src/native/src/ghostty_bridge.mm
@@ -344,10 +344,21 @@ void GhosttyBridge::setFocus(uint32_t surfaceId, bool focused) {
   // Do this outside the bridge mutex to avoid re-entrant deadlocks.
   if (view && [view window]) {
     NSWindow* window = [view window];
-    if (focused && [window firstResponder] != view) {
+    NSResponder* firstResponder = [window firstResponder];
+
+    // When focusing, always make the host view first responder.
+    if (focused && firstResponder != view) {
       [window makeFirstResponder:view];
-    } else if (!focused && [window firstResponder] == view) {
-      [window makeFirstResponder:nil];
+    }
+    // When unfocusing, resign if the host view OR any of its subviews is the
+    // first responder (Ghostty may have installed a child view for text input).
+    else if (!focused) {
+      bool ownsFocus = (firstResponder == view) ||
+        ([firstResponder isKindOfClass:[NSView class]] &&
+         [(NSView*)firstResponder isDescendantOf:view]);
+      if (ownsFocus) {
+        [window makeFirstResponder:nil];
+      }
     }
   }
 
@@ -386,11 +397,67 @@ uint32_t GhosttyBridge::focusedSurfaceId() {
   std::lock_guard<std::mutex> lock(mutex_);
   for (auto& [id, surface] : surfaces_) {
     NSView* view = surface.view;
-    if (view && view.window && [view.window firstResponder] == view) {
+    if (!view || !view.window) continue;
+
+    NSResponder* firstResponder = [view.window firstResponder];
+    // Check if the first responder is the host view itself.
+    if (firstResponder == view) return id;
+    // Also check if the first responder is a subview of the host view.
+    // Ghostty may install child views (e.g. for Metal rendering or IME text
+    // input) that become the first responder. Typing still works through the
+    // responder chain, but a strict identity check would miss them, causing
+    // focusedSurfaceId() to return 0 and breaking Cmd+V paste routing.
+    if ([firstResponder isKindOfClass:[NSView class]] &&
+        [(NSView*)firstResponder isDescendantOf:view]) {
       return id;
     }
   }
   return 0;
+}
+
+std::vector<GhosttyBridge::FocusDiagInfo> GhosttyBridge::focusDiagnostics() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<FocusDiagInfo> result;
+
+  for (auto& [id, surface] : surfaces_) {
+    FocusDiagInfo info;
+    info.surfaceId = id;
+    info.subviewCount = 0;
+    info.isHostView = false;
+    info.isDescendant = false;
+    info.hasWindow = false;
+
+    NSView* view = surface.view;
+    if (!view) {
+      info.firstResponderClass = "(no view)";
+      result.push_back(info);
+      continue;
+    }
+
+    info.subviewCount = static_cast<int>([view.subviews count]);
+    info.hasWindow = (view.window != nil);
+
+    if (!view.window) {
+      info.firstResponderClass = "(no window)";
+      result.push_back(info);
+      continue;
+    }
+
+    NSResponder* firstResponder = [view.window firstResponder];
+    if (!firstResponder) {
+      info.firstResponderClass = "(nil)";
+    } else {
+      info.firstResponderClass = [NSStringFromClass([firstResponder class]) UTF8String];
+      info.isHostView = (firstResponder == view);
+      info.isDescendant = !info.isHostView &&
+        [firstResponder isKindOfClass:[NSView class]] &&
+        [(NSView*)firstResponder isDescendantOf:view];
+    }
+
+    result.push_back(info);
+  }
+
+  return result;
 }
 
 void GhosttyBridge::requestClose(uint32_t surfaceId) {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -176,6 +176,7 @@ interface KanbanTicket {
   archived_at: string | null
   github_pr_number: number | null
   github_pr_url: string | null
+  mark: string | null
 }
 
 interface KanbanTicketCreate {
@@ -205,6 +206,7 @@ interface KanbanTicketUpdate {
   plan_ready?: boolean
   github_pr_number?: number | null
   github_pr_url?: string | null
+  mark?: string | null
 }
 
 declare global {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1881,6 +1881,7 @@ const kanban = {
         worktree_id?: string | null
         mode?: 'build' | 'plan' | null
         plan_ready?: boolean
+        mark?: string | null
       }
     ) => ipcRenderer.invoke('kanban:ticket:update', id, data),
     delete: (id: string) => ipcRenderer.invoke('kanban:ticket:delete', id),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1702,6 +1702,17 @@ const terminalOps = {
   ghosttyPasteText: (worktreeId: string, text: string): Promise<void> =>
     ipcRenderer.invoke('terminal:ghostty:pasteText', worktreeId, text),
 
+  ghosttyFocusDiagnostics: (): Promise<
+    Array<{
+      surfaceId: number
+      subviewCount: number
+      firstResponderClass: string
+      isHostView: boolean
+      isDescendant: boolean
+      hasWindow: boolean
+    }>
+  > => ipcRenderer.invoke('terminal:ghostty:focusDiagnostics'),
+
   ghosttyDestroySurface: (worktreeId: string): Promise<void> =>
     ipcRenderer.invoke('terminal:ghostty:destroySurface', worktreeId),
 

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -350,9 +350,21 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
   }, [])
 
   // ── Click handler — open ticket detail modal ───────────────────
-  const handleClick = useCallback(() => {
-    useKanbanStore.getState().setSelectedTicketId(ticket.id)
-  }, [ticket.id])
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      // Cmd+click (Mac) / Ctrl+click (Win/Linux) — select attached worktree
+      if ((e.metaKey || e.ctrlKey) && ticket.worktree_id && !isArchived) {
+        e.preventDefault()
+        useWorktreeStore.getState().selectWorktree(ticket.worktree_id)
+        useProjectStore.getState().selectProject(ticket.project_id)
+        useWorktreeStatusStore.getState().clearWorktreeUnread(ticket.worktree_id)
+        return
+      }
+
+      useKanbanStore.getState().setSelectedTicketId(ticket.id)
+    },
+    [ticket.id, ticket.worktree_id, ticket.project_id, isArchived]
+  )
 
   // ── Middle-click — select attached worktree (same as sidebar) ─
   const handleMouseDown = useCallback(

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
-import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2 } from 'lucide-react'
+import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles } from 'lucide-react'
 import { UpdateStatusModal } from './UpdateStatusModal'
 import { cn } from '@/lib/utils'
 import { ProviderIcon, getProviderLabel } from '@/components/ui/provider-icon'
@@ -9,7 +9,12 @@ import {
   ContextMenuTrigger,
   ContextMenuContent,
   ContextMenuItem,
-  ContextMenuSeparator
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem
 } from '@/components/ui/context-menu'
 import {
   AlertDialog,
@@ -40,7 +45,7 @@ import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import { useSessionTimer } from '@/hooks/useSessionTimer'
 import { useSessionTokenDelta } from '@/hooks/useSessionTokenDelta'
 import { formatTokenCount } from '@/lib/format-utils'
-import type { KanbanTicket } from '../../../../main/db/types'
+import type { KanbanTicket, TicketMark } from '../../../../main/db/types'
 
 // ── Project tag color palette ──────────────────────────────────────
 const PROJECT_TAG_COLORS = [
@@ -457,6 +462,16 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     useFileViewerStore.getState().openContextEditor(ticket.worktree_id)
   }, [ticket.worktree_id])
 
+  const handleMarkChange = useCallback(async (value: string) => {
+    try {
+      await useKanbanStore.getState().updateTicket(ticket.id, ticket.project_id, {
+        mark: value === 'none' ? null : value as TicketMark
+      })
+    } catch {
+      toast.error('Failed to update ticket mark')
+    }
+  }, [ticket.id, ticket.project_id])
+
   return (
     <>
       <Popover open={showPRPicker} onOpenChange={setShowPRPicker}>
@@ -477,7 +492,12 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                   isArchived && 'opacity-50 cursor-default',
                   borderState === 'default' && 'border-border/60',
                   borderState === 'blue' && 'border-blue-500/60',
-                  borderState === 'violet' && 'border-violet-500/60'
+                  borderState === 'violet' && 'border-violet-500/60',
+                  // Left accent stripe for marks
+                  ticket.mark === 'common' && 'border-l-4 !border-l-green-500',
+                  ticket.mark === 'rare' && 'border-l-4 !border-l-blue-500',
+                  ticket.mark === 'epic' && 'border-l-4 !border-l-purple-500',
+                  ticket.mark === 'legendary' && 'border-l-4 !border-l-orange-500'
                 )}
               >
             {/* Title + top-right indicators */}
@@ -729,6 +749,35 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
               Attach PR
             </ContextMenuItem>
           )}
+
+          <ContextMenuSeparator />
+          <ContextMenuSub>
+            <ContextMenuSubTrigger data-testid="ctx-mark-submenu" className="gap-2">
+              <Sparkles className="h-3.5 w-3.5" />
+              Mark
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              <ContextMenuRadioGroup value={ticket.mark ?? 'none'} onValueChange={handleMarkChange}>
+                <ContextMenuRadioItem value="none">No Mark</ContextMenuRadioItem>
+                <ContextMenuRadioItem value="common">
+                  <span className="h-2 w-2 rounded-full bg-green-500 inline-block mr-2" />
+                  Common
+                </ContextMenuRadioItem>
+                <ContextMenuRadioItem value="rare">
+                  <span className="h-2 w-2 rounded-full bg-blue-500 inline-block mr-2" />
+                  Rare
+                </ContextMenuRadioItem>
+                <ContextMenuRadioItem value="epic">
+                  <span className="h-2 w-2 rounded-full bg-purple-500 inline-block mr-2" />
+                  Epic
+                </ContextMenuRadioItem>
+                <ContextMenuRadioItem value="legendary">
+                  <span className="h-2 w-2 rounded-full bg-orange-500 inline-block mr-2" />
+                  Legendary
+                </ContextMenuRadioItem>
+              </ContextMenuRadioGroup>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
 
           <ContextMenuSeparator />
 

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -91,7 +91,11 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     return () => clearTimeout(timer)
   }, [themeId])
 
-  // Re-fit and focus when becoming visible
+  // Re-fit and focus when becoming visible.
+  // Note: GhosttyBackend.setVisible(true) already restores macOS first responder
+  // directly; the focus() call below is a belt-and-suspenders backup for Ghostty
+  // and the primary focus path for xterm. The xterm fit() requires the delayed
+  // call because layout dimensions need a frame to settle.
   useEffect(() => {
     if (!backendRef.current) return
 
@@ -109,20 +113,28 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     return () => clearTimeout(timer)
   }, [effectiveVisible])
 
-  // Ghostty paste: the Cmd+V menu accelerator intercepts the keystroke at the
-  // macOS application-menu level, before it can reach the native Ghostty NSView.
-  // The menu handler checks webContents.isFocused() — when the Ghostty NSView
-  // is the macOS first responder the web content is NOT focused, so the handler
-  // reads the clipboard and sends 'edit:paste' via IPC for us to forward here.
+  // Paste fallback: the Cmd+V menu accelerator intercepts the keystroke at the
+  // macOS application-menu level before it reaches any view. The menu handler
+  // uses a three-tier routing strategy:
+  //   Tier 1: Ghostty surface has macOS first responder → direct native paste
+  //   Tier 2: Neither Ghostty nor web content has focus (stale focus state) →
+  //           sends 'edit:paste' IPC here so we can route to the active backend
+  //   Tier 3: Web content has focus → webContents.paste() (xterm, inputs, etc.)
+  // This listener handles Tier 2 — it fires when the native focus detection
+  // failed but the terminal is still the intended paste target.
+  // Note: 'edit:paste' is an IPC broadcast — all registered listeners receive it.
+  // Only one TerminalView should have effectiveVisible=true at a time (enforced
+  // by TerminalManager's single-active invariant), so only one listener fires.
   useEffect(() => {
-    if (activeBackendTypeRef.current !== 'ghostty' || !effectiveVisible) return
+    if (!effectiveVisible) return
     if (!window.systemOps?.onEditPaste) return
 
     const cleanup = window.systemOps.onEditPaste((text) => {
-      // The main process already verified that webContents is NOT focused
-      // (i.e. a native NSView like Ghostty has macOS first responder), so
-      // we can unconditionally forward the text to the Ghostty surface.
-      window.terminalOps.ghosttyPasteText(worktreeId, text)
+      if (activeBackendTypeRef.current === 'ghostty') {
+        window.terminalOps.ghosttyPasteText(worktreeId, text)
+      } else if (activeBackendTypeRef.current === 'xterm') {
+        window.terminalOps.write(worktreeId, text)
+      }
     })
 
     return cleanup

--- a/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
@@ -206,6 +206,13 @@ export class GhosttyBackend implements TerminalBackend {
     }
 
     this.syncFrame()
+    // Restore macOS first responder so focusedSurfaceId() returns this surface
+    // and the menu paste handler routes Cmd+V correctly. Without this, focus
+    // restoration depends on a fragile setTimeout in TerminalView that can be
+    // cancelled by rapid effectiveVisible changes (e.g. overlay suppression race).
+    window.terminalOps.ghosttySetFocus(this.worktreeId, true).catch(() => {
+      // Ignore focus errors
+    })
   }
 
   clear(): void {

--- a/src/renderer/src/transport/graphql/adapters/kanban.ts
+++ b/src/renderer/src/transport/graphql/adapters/kanban.ts
@@ -27,6 +27,7 @@ interface GqlKanbanTicket {
   externalId: string | null
   externalUrl: string | null
   totalTokens: number
+  mark: string | null
 }
 
 interface GqlTicketFollowupMessage {
@@ -55,7 +56,8 @@ function mapTicket(t: GqlKanbanTicket) {
     external_provider: t.externalProvider ?? null,
     external_id: t.externalId ?? null,
     external_url: t.externalUrl ?? null,
-    total_tokens: t.totalTokens ?? 0
+    total_tokens: t.totalTokens ?? 0,
+    mark: t.mark ?? null
   }
 }
 
@@ -76,7 +78,7 @@ function mapFollowup(f: GqlTicketFollowupMessage) {
   }
 }
 
-const TICKET_FIELDS = `id projectId sessionId worktreeId title description column sortOrder archived createdAt updatedAt externalProvider externalId externalUrl totalTokens`
+const TICKET_FIELDS = `id projectId sessionId worktreeId title description column sortOrder archived createdAt updatedAt externalProvider externalId externalUrl totalTokens mark`
 const FOLLOWUP_FIELDS = `id ticketId message createdAt`
 
 export function createKanbanAdapter(): KanbanApi {
@@ -130,6 +132,7 @@ export function createKanbanAdapter(): KanbanApi {
         if (data.sort_order !== undefined) input.sortOrder = data.sort_order
         if (data.current_session_id !== undefined) input.sessionId = data.current_session_id
         if (data.worktree_id !== undefined) input.worktreeId = data.worktree_id
+        if (data.mark !== undefined) input.mark = data.mark
 
         const result = await graphqlQuery<{ kanbanUpdateTicket: GqlKanbanTicket | null }>(
           `mutation ($id: ID!, $input: KanbanUpdateTicketInput!) {

--- a/src/server/__generated__/resolvers-types.ts
+++ b/src/server/__generated__/resolvers-types.ts
@@ -542,6 +542,7 @@ export type KanbanTicket = {
   externalProvider?: Maybe<Scalars['String']['output']>;
   externalUrl?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
+  mark?: Maybe<Scalars['String']['output']>;
   projectId: Scalars['String']['output'];
   sessionId?: Maybe<Scalars['String']['output']>;
   sortOrder: Scalars['Float']['output'];
@@ -560,6 +561,7 @@ export type KanbanTicketColumn =
 export type KanbanUpdateTicketInput = {
   column?: InputMaybe<KanbanTicketColumn>;
   description?: InputMaybe<Scalars['String']['input']>;
+  mark?: InputMaybe<Scalars['String']['input']>;
   sessionId?: InputMaybe<Scalars['String']['input']>;
   sortOrder?: InputMaybe<Scalars['Float']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
@@ -3080,6 +3082,7 @@ export type KanbanTicketResolvers<ContextType = GraphQLContext, ParentType exten
   externalProvider?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   externalUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  mark?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   projectId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   sessionId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sortOrder?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;

--- a/src/server/resolvers/mutation/kanban.resolvers.ts
+++ b/src/server/resolvers/mutation/kanban.resolvers.ts
@@ -19,7 +19,8 @@ function mapKanbanTicket(row: any) {
     archived: !!row.archived_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
-    totalTokens: row.total_tokens ?? 0
+    totalTokens: row.total_tokens ?? 0,
+    mark: row.mark ?? null
   }
 }
 
@@ -53,6 +54,7 @@ export const kanbanMutationResolvers: Resolvers = {
       if (input.sortOrder !== undefined) data.sort_order = input.sortOrder
       if (input.sessionId !== undefined) data.current_session_id = input.sessionId
       if (input.worktreeId !== undefined) data.worktree_id = input.worktreeId
+      if (input.mark !== undefined) data.mark = input.mark
       return mapKanbanTicket(ctx.db.updateKanbanTicket(id, data))
     },
 

--- a/src/server/resolvers/query/kanban.resolvers.ts
+++ b/src/server/resolvers/query/kanban.resolvers.ts
@@ -22,7 +22,8 @@ function mapKanbanTicket(row: any) {
     externalProvider: row.external_provider ?? null,
     externalId: row.external_id ?? null,
     externalUrl: row.external_url ?? null,
-    totalTokens: row.total_tokens ?? 0
+    totalTokens: row.total_tokens ?? 0,
+    mark: row.mark ?? null
   }
 }
 

--- a/src/server/schema/types/kanban.graphql
+++ b/src/server/schema/types/kanban.graphql
@@ -21,6 +21,7 @@ type KanbanTicket {
   externalId: String
   externalUrl: String
   totalTokens: Int!
+  mark: String
 }
 
 input KanbanCreateTicketInput {
@@ -43,5 +44,6 @@ input KanbanUpdateTicketInput {
   sortOrder: Float
   sessionId: String
   worktreeId: String
+  mark: String
 }
 

--- a/test/terminal/ghostty-backend-visibility.test.ts
+++ b/test/terminal/ghostty-backend-visibility.test.ts
@@ -74,11 +74,17 @@ describe('GhosttyBackend visibility', () => {
     expect(hiddenFrame.h).toBe(360)
     expect(mockTerminalOps.ghosttyDestroySurface).not.toHaveBeenCalled()
 
+    mockTerminalOps.ghosttySetFocus.mockClear()
+
     visibilityBackend.setVisible(true)
 
     const visibleFrame = mockTerminalOps.ghosttySetFrame.mock.calls.at(-1)?.[1]
     expect(visibleFrame).toEqual({ x: 100, y: 80, w: 640, h: 360 })
     expect(mockTerminalOps.ghosttyDestroySurface).not.toHaveBeenCalled()
+
+    // Focus must be restored when becoming visible again so that
+    // focusedSurfaceId() returns this surface for the menu paste handler.
+    expect(mockTerminalOps.ghosttySetFocus).toHaveBeenCalledWith('wt-1', true)
 
     backend.dispose()
   })


### PR DESCRIPTION
## Summary

- Enhances `handleClick` in KanbanTicketCard to support Cmd+click (Mac) / Ctrl+click (Win/Linux) gestures
- When Cmd/Ctrl+clicking a ticket, automatically selects the associated worktree and project instead of opening the ticket detail modal
- Prevents opening ticket details for archived tickets with modifier key pressed
- Clears unread status for the selected worktree on activation
- Updates dependency array to include `ticket.worktree_id`, `ticket.project_id`, and `isArchived`

## Testing

- Verify Cmd+click (Mac) / Ctrl+click (Win/Linux) on a ticket card selects its worktree
- Verify regular click on a ticket still opens the detail modal
- Verify Cmd/Ctrl+click on an archived ticket has no effect
- Verify worktree is properly selected and unread count is cleared
- Verify project is properly selected alongside worktree selection
- Not run: E2E tests for cross-platform modifier key behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation plus core git/AI and SQLite migration paths; bugs here could affect release publishing, diff display, or session/ticket persistence, but changes are mostly additive with fallbacks.
> 
> **Overview**
> **Release + docs:** Updates the GitHub release workflow to add a `start` job that reads the version once, wires builds to it, and sends Telegram notifications for start/build/finalize outcomes; also updates Homebrew commands/docs to use `brew install --cask hive-app` and reflects macOS/Windows/Linux support across READMEs/FAQ/site.
> 
> **App behavior/data:** Adds a new nullable `mark` field to `kanban_tickets` (schema v21) and threads it through ticket create/update/mapping. Improves git comparison by diffing against a branch’s merge-base (and adds IPC endpoints to fetch merge-base file content, including base64), cleans up remote-tracking refs when archiving, and returns existing PR URL/number when `gh pr create` reports one already exists.
> 
> **AI/SDK reliability:** Adds structured JSON schema support to PR content generation and extends the text-generation router to pass output schemas to Codex (via temp schema files) and to use the configured Claude binary path. Fixes Claude/Codex streaming/title/tool-event handling (avoid duplicate or missing text, normalize tool names/commands, add snapshot tool_use reconstruction) and bumps related versions/models (package version, `@anthropic-ai/claude-agent-sdk`, Codex title model).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a533fe91f5c2f2fb5ccbf6d908e42ef5e53cbcb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->