### PR TITLE
Fix Windows startup hang by force-showing window after timeout + add renderer diagnostics

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -161,8 +161,34 @@ function createWindow(): void {
     mainWindow.maximize()
   }
 
+  let windowShown = false
+
   mainWindow.on('ready-to-show', () => {
-    mainWindow.show()
+    windowShown = true
+    log.info('Window ready-to-show fired, showing window')
+    mainWindow!.show()
+  })
+
+  // Safety timeout — on Windows the renderer can take 10+ seconds to fire ready-to-show.
+  // Force-show the window after 3 seconds so the user sees something while it finishes loading.
+  setTimeout(() => {
+    if (!windowShown && mainWindow && !mainWindow.isDestroyed()) {
+      log.warn('Window ready-to-show did not fire within 3s — force-showing window')
+      mainWindow.show()
+    }
+  }, 3_000)
+
+  // Log renderer failures that would silently prevent ready-to-show
+  mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
+    log.error('Renderer failed to load', new Error(errorDescription), { errorCode, validatedURL })
+  })
+
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    log.error('Renderer process gone', new Error(details.reason), { exitCode: details.exitCode })
+  })
+
+  mainWindow.on('unresponsive', () => {
+    log.warn('Window became unresponsive')
   })
 
   // Emit focus event to renderer for git refresh on window focus
@@ -232,9 +258,12 @@ function createWindow(): void {
   // HMR for renderer based on electron-vite cli.
   // Load the remote URL for development or the local html file for production.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
+    log.info('Loading renderer URL (dev)', { url: process.env['ELECTRON_RENDERER_URL'] })
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    const rendererPath = join(__dirname, '../renderer/index.html')
+    log.info('Loading renderer file', { path: rendererPath })
+    mainWindow.loadFile(rendererPath)
   }
 }
 
@@ -575,7 +604,9 @@ app.whenReady().then(async () => {
     registerLoggingHandlers()
   }
 
+  log.info('Creating main window')
   createWindow()
+  log.info('Main window created, waiting for renderer to load')
 
   // Register OpenCode handlers after window is created
   if (mainWindow) {
@@ -668,6 +699,9 @@ app.whenReady().then(async () => {
     // dock icon is clicked and there are no other windows open.
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
+}).catch((error) => {
+  log.error('Fatal error during app startup', error instanceof Error ? error : new Error(String(error)))
+  app.quit()
 })
 
 // Quit when all windows are closed, except on macOS. There, it's common


### PR DESCRIPTION
## Summary

- **Problem**: On Windows, the renderer's `ready-to-show` event can take 10+ seconds to fire, leaving users staring at a blank window
- **Solution**: Implement a 3-second safety timeout that force-shows the window if `ready-to-show` hasn't fired
- **Diagnostics**: Add logging and event handlers to capture renderer failures:
  - `did-fail-load` handler logs network/file load errors
  - `render-process-gone` handler logs renderer process crashes
  - `unresponsive` handler logs UI thread hangs
- **UX**: Window now appears within 3 seconds on Windows, while the renderer continues loading in the background
- **Dev logging**: Added log statements at key startup points (window creation, renderer loading) to aid debugging
- **Error handling**: Wrap `app.whenReady()` in `.catch()` to log fatal startup errors before quitting

## Testing

- Test on Windows 10/11: Launch app and verify window appears within 3 seconds (not blank)
- Verify on macOS/Linux that `ready-to-show` still fires normally and timeout doesn't interfere
- Simulate renderer load failure: check that `did-fail-load` events are logged with error details
- Test renderer process crash: verify `render-process-gone` is logged
- Verify unresponsive window detection logs (if applicable)
- Check that startup logs appear in app logs with `Loading renderer URL/file` and `Window created` messages
- Test fatal startup error handling: intentionally corrupt app config and verify error is logged before exit
- Not run: Full load-time profiling across Windows variants

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app startup/window-show behavior and adds new timeout-based rendering fallback, which could affect perceived UX and timing on slower machines. Logging and fatal startup error handling are low risk but touch the main process boot path.
> 
> **Overview**
> Reduces Windows startup hangs by tracking whether `ready-to-show` fired and **force-showing the main window after 3s** if it doesn’t.
> 
> Adds renderer diagnostics (`did-fail-load`, `render-process-gone`, and `unresponsive`) and more startup logs around window creation and renderer URL/file loading, and wraps `app.whenReady()` with a `.catch()` to log *fatal startup errors* before quitting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2654da036cea6d8e5f8eb6550c5ad40c3000b421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->