### PR TITLE
Update usage when sending a ticket to work

### DIFF
--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -26,6 +26,8 @@ import {
 } from '@/components/ui/context-menu'
 import { useKanbanStore, getKanbanDragData, setKanbanDragData, suppressLayoutAnimation, isLayoutAnimationSuppressed } from '@/stores/useKanbanStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
 import type { KanbanTicket, KanbanTicketColumn as ColumnType } from '../../../../main/db/types'
 
 // ── Layout animation spring ─────────────────────────────────────────
@@ -305,6 +307,12 @@ export function KanbanColumn({ column, tickets, archivedTickets, projectId, conn
         // Default: move directly
         const sortOrder = store.computeSortOrder(tickets, targetIndex)
         store.moveTicket(ticketId, ticketProjectId, column, sortOrder)
+
+        // Trigger usage refresh when simple-mode drops a ticket into In Progress
+        if (column === 'in_progress') {
+          const sdk = useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
+          useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(sdk))
+        }
       } else {
         // ── Same-column reorder ───────────────────────────────
         const ticketProjectId = findTicketProjectId(ticketId)

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -20,6 +20,7 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
 import { ModelSelector } from '@/components/sessions/ModelSelector'
 import { CodexFastToggle } from '@/components/sessions/CodexFastToggle'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
@@ -375,6 +376,9 @@ export function WorktreePickerModal({
           plan_ready: false
         })
 
+        // Trigger usage refresh so the board shows up-to-date usage (debounced in store)
+        useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(agentSdk))
+
         // Close modal
         onSendComplete?.()
         onOpenChange(false)
@@ -526,6 +530,9 @@ export function WorktreePickerModal({
         sort_order: sortOrder,
         plan_ready: false
       })
+
+      // Trigger usage refresh so the board shows up-to-date usage (debounced in store)
+      useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(agentSdk))
 
       // In sticky-tab mode, stay on the board instead of switching to the new session
       if (useSettingsStore.getState().boardMode === 'sticky-tab') {


### PR DESCRIPTION
## Summary

- Refresh usage metrics when dragging a ticket into "In Progress" column (simple-mode)
- Refresh usage metrics when sending a ticket to a worktree via WorktreePickerModal
- Imports `useUsageStore` and `resolveDefaultUsageProvider` to trigger debounced usage updates
- Updates usage for the resolved SDK provider (based on configured defaultAgentSdk)
- Ensures the kanban board displays current usage stats immediately after ticket assignments

## Testing

- Drag a ticket to "In Progress" column and verify usage metrics are refreshed
- Send a ticket to a worktree using WorktreePickerModal and verify usage updates
- Verify that usage refresh is debounced in the store (no excessive API calls)
- Test with different SDK configurations (opencode, claude, etc.) and confirm correct provider resolution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change that adds extra usage-fetch calls after ticket moves/session creation; calls are debounced in `useUsageStore` to limit API churn.
> 
> **Overview**
> Ensures the kanban board shows **up-to-date usage** immediately after starting work on a ticket.
> 
> On simple-mode drag/drop into `in_progress`, `KanbanColumn` now triggers `useUsageStore.fetchUsageForProvider(...)` based on the configured default SDK. `WorktreePickerModal` similarly triggers a debounced usage refresh after successfully updating the ticket/session into `in_progress` (including connection-mode sends).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82e74d771b0edc1e703766ee8f79a09ef68ff6b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->