### PR TITLE
Add attachment support to followup messages in ticket modals

### DIFF
--- a/src/renderer/src/components/kanban/FollowupInput.tsx
+++ b/src/renderer/src/components/kanban/FollowupInput.tsx
@@ -1,0 +1,169 @@
+import { useCallback } from 'react'
+import { Hammer, Map, Sparkles, Send } from 'lucide-react'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { AttachmentButton } from '@/components/sessions/AttachmentButton'
+import { AttachmentPreview } from '@/components/sessions/AttachmentPreview'
+import type { Attachment } from '@/components/sessions/AttachmentPreview'
+import { cn } from '@/lib/utils'
+import { MAX_ATTACHMENTS } from '@/lib/file-attachment-utils'
+import { toast } from '@/lib/toast'
+
+type FollowUpMode = 'build' | 'plan' | 'super-plan'
+
+interface FollowupInputProps {
+  text: string
+  onTextChange: (text: string) => void
+  attachments: Attachment[]
+  onAttach: (file: Omit<Attachment, 'id'>) => void
+  onRemoveAttachment: (id: string) => void
+  followUpMode: FollowUpMode
+  onToggleMode: () => void
+  onSend: () => void
+  isSending: boolean
+  placeholder: string
+  testIdPrefix: string
+  showInlineSendButton?: boolean
+  textareaRef?: React.RefObject<HTMLTextAreaElement>
+}
+
+export function FollowupInput({
+  text,
+  onTextChange,
+  attachments,
+  onAttach,
+  onRemoveAttachment,
+  followUpMode,
+  onToggleMode,
+  onSend,
+  isSending,
+  placeholder,
+  testIdPrefix,
+  showInlineSendButton = false,
+  textareaRef
+}: FollowupInputProps) {
+  const hasContent = text.trim().length > 0 || attachments.length > 0
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const items = e.clipboardData?.items
+      if (!items) return
+      for (const item of Array.from(items)) {
+        if (item.type.startsWith('image/')) {
+          e.preventDefault()
+          const file = item.getAsFile()
+          if (!file) continue
+          if (attachments.length >= MAX_ATTACHMENTS) {
+            toast.warning(`Maximum ${MAX_ATTACHMENTS} attachments reached`)
+            return
+          }
+          const reader = new FileReader()
+          reader.onload = () => {
+            onAttach({
+              kind: 'data',
+              name: file.name || 'pasted-image.png',
+              mime: file.type,
+              dataUrl: reader.result as string
+            })
+          }
+          reader.readAsDataURL(file)
+        }
+      }
+    },
+    [onAttach, attachments.length]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault()
+        if (hasContent) {
+          onSend()
+        }
+      }
+    },
+    [onSend, hasContent]
+  )
+
+  const handleAttachWithLimit = useCallback(
+    (file: Omit<Attachment, 'id'>) => {
+      if (attachments.length >= MAX_ATTACHMENTS) {
+        toast.warning(`Maximum ${MAX_ATTACHMENTS} attachments reached`)
+        return
+      }
+      onAttach(file)
+    },
+    [onAttach, attachments.length]
+  )
+
+  const ModeIcon = followUpMode === 'build' ? Hammer : followUpMode === 'plan' ? Map : Sparkles
+  const modeLabel = followUpMode === 'build' ? 'Build' : followUpMode === 'plan' ? 'Plan' : 'Super Plan'
+
+  return (
+    <div className="space-y-1.5 flex-shrink-0">
+      {/* Label row: Followup label + mode toggle */}
+      <div className="flex items-center gap-2">
+        <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Followup
+        </label>
+        <button
+          data-testid={`${testIdPrefix}-mode-toggle`}
+          data-mode={followUpMode}
+          type="button"
+          onClick={onToggleMode}
+          className={cn(
+            'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
+            'border select-none',
+            followUpMode === 'build'
+              ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
+              : followUpMode === 'plan'
+                ? 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
+                : 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20'
+          )}
+        >
+          <ModeIcon className="h-3 w-3" />
+          <span>{modeLabel}</span>
+        </button>
+      </div>
+
+      {/* Attachment previews */}
+      <AttachmentPreview attachments={attachments} onRemove={onRemoveAttachment} />
+
+      {/* Textarea row + optional inline Send button */}
+      <div className="flex gap-2 items-end">
+        <div className="flex-1 relative">
+          <Textarea
+            ref={textareaRef}
+            data-testid={`${testIdPrefix}-followup-input`}
+            value={text}
+            onChange={(e) => onTextChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+            rows={2}
+            placeholder={placeholder}
+            className="resize-y font-mono text-xs leading-relaxed pr-8"
+          />
+          {/* Paperclip button positioned inside the textarea area */}
+          <div className="absolute right-1 bottom-1">
+            <AttachmentButton
+              onAttach={handleAttachWithLimit}
+              disabled={isSending}
+            />
+          </div>
+        </div>
+        {showInlineSendButton && (
+          <Button
+            type="button"
+            data-testid={`${testIdPrefix}-send-followup-btn`}
+            disabled={isSending || !hasContent}
+            onClick={onSend}
+            size="icon"
+            className="shrink-0 h-8 w-8"
+          >
+            <Send className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -10,8 +10,6 @@ import {
   Trash2,
   ExternalLink,
   Hammer,
-  Map,
-  Sparkles,
   Send,
   Zap,
   ArrowRight,
@@ -26,7 +24,8 @@ import {
   Loader2,
   Github,
   FileUp,
-  File as FileIcon
+  File as FileIcon,
+  Upload
 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -69,6 +68,10 @@ import { toast } from '@/lib/toast'
 import { useScriptStore, fireRunScript, killRunScript } from '@/stores/useScriptStore'
 import { useQuestionStore, type QuestionRequest } from '@/stores/useQuestionStore'
 import { QuestionPrompt } from '@/components/sessions/QuestionPrompt'
+import { FollowupInput } from './FollowupInput'
+import type { Attachment } from '@/components/sessions/AttachmentPreview'
+import { buildMessageParts, isImageMime, MAX_ATTACHMENTS } from '@/lib/file-attachment-utils'
+import { useDropZone } from '@/hooks/useDropZone'
 import { SessionStreamPanel } from './SessionStreamPanel'
 import {
   ReviewTicketDiffSummary,
@@ -207,6 +210,7 @@ async function sendFollowupToSession(opts: {
   prompt: string
   followUpMode: FollowUpMode
   ticketId: string
+  attachments?: Attachment[]
 }): Promise<void> {
   const result = await findSessionById(opts.sessionId)
   if (!result) {
@@ -255,19 +259,6 @@ async function sendFollowupToSession(opts: {
   // Resolve model AFTER setSessionMode (which may have applied a mode-specific default)
   const model = resolveSessionModel(opts.sessionId, result.session)
 
-  // Persist the followup message (non-critical — API may not be wired up yet)
-  try {
-    window.kanban?.followup?.create({
-      ticket_id: opts.ticketId,
-      content: opts.prompt,
-      mode: opts.followUpMode,
-      session_id: opts.sessionId,
-      source: 'direct'
-    })?.catch(() => {})
-  } catch {
-    // followup persistence is best-effort
-  }
-
   // Ensure the session is loaded in the agent SDK implementer's in-memory map.
   // SessionView does this on mount via initializeSession(), but the kanban
   // followup path bypasses SessionView entirely.  Without this, the Claude Code
@@ -277,9 +268,12 @@ async function sendFollowupToSession(opts: {
     throw new Error(`Failed to reconnect to session: ${opts.sessionId}`)
   }
 
-  const promptResult = await window.opencodeOps.prompt(workingPath, session.opencode_session_id, [
-    { type: 'text', text: fullPrompt }
-  ], model)
+  const messageParts = opts.attachments?.length
+    ? buildMessageParts(opts.attachments, fullPrompt)
+    : [{ type: 'text' as const, text: fullPrompt }]
+
+  const promptResult = await window.opencodeOps.prompt(workingPath, session.opencode_session_id,
+    messageParts, model)
 
   if (promptResult && !promptResult.success) {
     console.error(`[KanbanTicketModal] sendFollowupToSession: prompt returned failure — error=${promptResult.error}`)
@@ -1179,9 +1173,55 @@ function PlanReviewModeContent({
   const [followUpText, setFollowUpText] = useState('')
   const [followUpMode, setFollowUpMode] = useState<FollowUpMode>('plan')
   const [isSending, setIsSending] = useState(false)
+  const [attachments, setAttachments] = useState<Attachment[]>([])
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const dropZoneRef = useRef<HTMLDivElement>(null)
 
   const planContent = pendingPlan?.planContent ?? ticket.description ?? ''
+
+  const handleAttach = useCallback((file: Omit<Attachment, 'id'>) => {
+    setAttachments((prev) => {
+      if (prev.length >= MAX_ATTACHMENTS) {
+        toast.warning(`Maximum ${MAX_ATTACHMENTS} attachments reached`)
+        return prev
+      }
+      return [...prev, { id: crypto.randomUUID(), ...file }]
+    })
+  }, [])
+
+  const handleRemoveAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id))
+  }, [])
+
+  const handleDropFiles = useCallback((files: FileList) => {
+    for (const file of Array.from(files)) {
+      if (attachments.length >= MAX_ATTACHMENTS) {
+        toast.warning(`Maximum ${MAX_ATTACHMENTS} attachments reached`)
+        break
+      }
+      if (isImageMime(file.type)) {
+        const reader = new FileReader()
+        reader.onload = () => {
+          handleAttach({
+            kind: 'data',
+            name: file.name,
+            mime: file.type,
+            dataUrl: reader.result as string
+          })
+        }
+        reader.readAsDataURL(file)
+      } else {
+        handleAttach({
+          kind: 'path',
+          name: file.name,
+          mime: file.type || 'application/octet-stream',
+          filePath: window.fileOps.getPathForFile(file)
+        })
+      }
+    }
+  }, [handleAttach, attachments.length])
+
+  const { isDragging } = useDropZone({ onDrop: handleDropFiles, containerRef: dropZoneRef })
 
   const toggleMode = useCallback(() => {
     setFollowUpMode((prev) => prev === 'build' ? 'plan' : 'build')
@@ -1205,7 +1245,7 @@ function PlanReviewModeContent({
 
   // ── Send followup (reject pending plan + iterate) ────────────────
   const handleSendFollowup = useCallback(async () => {
-    if (!followUpText.trim() || !ticket.current_session_id || isSending) return
+    if ((!followUpText.trim() && attachments.length === 0) || !ticket.current_session_id || isSending) return
     setIsSending(true)
 
     try {
@@ -1251,6 +1291,7 @@ function PlanReviewModeContent({
             prompt: feedback,
             followUpMode,
             ticketId: ticket.id,
+            attachments,
           }).catch((err) => {
             console.error('[KanbanTicketModal] sendFollowupToSession failed:', err)
             const reason = err instanceof Error ? err.message : String(err)
@@ -1283,6 +1324,7 @@ function PlanReviewModeContent({
         prompt: feedback,
         followUpMode,
         ticketId: ticket.id,
+        attachments,
       }).catch((err) => {
         console.error('[KanbanTicketModal] sendFollowupToSession failed:', err)
         const reason = err instanceof Error ? err.message : String(err)
@@ -1295,19 +1337,9 @@ function PlanReviewModeContent({
       toast.error(`Failed to send followup: ${reason}`)
     } finally {
       setIsSending(false)
+      setAttachments([])
     }
-  }, [followUpText, followUpMode, ticket, isSending, pendingPlan, sessionRecord, updateTicket, onClose])
-
-  // Enter sends, Shift+Enter for newline
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault()
-        handleSendFollowup()
-      }
-    },
-    [handleSendFollowup]
-  )
+  }, [followUpText, followUpMode, ticket, isSending, pendingPlan, sessionRecord, updateTicket, onClose, attachments])
 
   // ── Implement handler ─────────────────────────────────────────────
   const handleImplement = useCallback(async () => {
@@ -1582,7 +1614,7 @@ function PlanReviewModeContent({
   }, [ticket, isActioning, planContent, onClose, eagerSuperchargeStart, worktreePath, opcSessionId])
 
   return (
-    <>
+    <div ref={dropZoneRef} className="relative contents">
       <DialogHeader>
         <div className="flex items-center justify-between">
           <DialogTitle className="flex items-center gap-2">
@@ -1604,53 +1636,31 @@ function PlanReviewModeContent({
       </div>
 
       {/* Followup input — iterate on the plan */}
-      <div className="space-y-1.5 flex-shrink-0">
-        <div className="flex items-center gap-2">
-          <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-            Followup
-          </label>
-          <button
-            data-testid="plan-review-mode-toggle"
-            data-mode={followUpMode}
-            type="button"
-            onClick={toggleMode}
-            className={cn(
-              'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
-              'border select-none',
-              followUpMode === 'build'
-                ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
-                : followUpMode === 'plan'
-                  ? 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
-                  : 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20'
-            )}
-          >
-            {followUpMode === 'build' ? <Hammer className="h-3 w-3" /> : followUpMode === 'plan' ? <Map className="h-3 w-3" /> : <Sparkles className="h-3 w-3" />}
-            <span>{followUpMode === 'build' ? 'Build' : followUpMode === 'plan' ? 'Plan' : 'Super Plan'}</span>
-          </button>
+      <FollowupInput
+        text={followUpText}
+        onTextChange={setFollowUpText}
+        attachments={attachments}
+        onAttach={handleAttach}
+        onRemoveAttachment={handleRemoveAttachment}
+        followUpMode={followUpMode}
+        onToggleMode={toggleMode}
+        onSend={handleSendFollowup}
+        isSending={isSending}
+        placeholder="Iterate on the plan... (Enter to send)"
+        testIdPrefix="plan-review"
+        showInlineSendButton
+        textareaRef={textareaRef}
+      />
+
+      {/* Drag-and-drop overlay */}
+      {isDragging && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm rounded-lg border-2 border-dashed border-primary/50">
+          <div className="flex flex-col items-center gap-2 text-primary">
+            <Upload className="h-8 w-8" />
+            <span className="text-sm font-medium">Drop files here</span>
+          </div>
         </div>
-        <div className="flex gap-2 items-end">
-          <Textarea
-            ref={textareaRef}
-            data-testid="plan-review-followup-input"
-            value={followUpText}
-            onChange={(e) => setFollowUpText(e.target.value)}
-            onKeyDown={handleKeyDown}
-            rows={2}
-            placeholder="Iterate on the plan… (Enter to send)"
-            className="resize-y font-mono text-xs leading-relaxed flex-1"
-          />
-          <Button
-            type="button"
-            data-testid="plan-review-send-followup-btn"
-            disabled={isSending || !followUpText.trim()}
-            onClick={handleSendFollowup}
-            size="icon"
-            className="shrink-0 h-8 w-8"
-          >
-            <Send className="h-3.5 w-3.5" />
-          </Button>
-        </div>
-      </div>
+      )}
 
       {/* Action buttons only visible when ExitPlanMode is awaiting approval
           (matches SessionView's showPlanReadyImplementFab gating on !!pendingPlan) */}
@@ -1700,7 +1710,7 @@ function PlanReviewModeContent({
           </Button>
         </DialogFooter>
       )}
-    </>
+    </div>
   )
 }
 
@@ -1728,12 +1738,58 @@ function ReviewModeContent({
   const [followUpText, setFollowUpText] = useState('')
   const [followUpMode, setFollowUpMode] = useState<FollowUpMode>('build')
   const [isSending, setIsSending] = useState(false)
+  const [attachments, setAttachments] = useState<Attachment[]>([])
   const [resolvedWorktree, setResolvedWorktree] = useState<Worktree | null>(worktree)
   const [resolvedBaseBranch, setResolvedBaseBranch] = useState<string | null>(null)
   const [diffSummary, setDiffSummary] = useState<ReviewTicketDiffFile[]>([])
   const [diffSummaryLoading, setDiffSummaryLoading] = useState(false)
   const [diffSummaryError, setDiffSummaryError] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const dropZoneRef = useRef<HTMLDivElement>(null)
+
+  const handleAttach = useCallback((file: Omit<Attachment, 'id'>) => {
+    setAttachments((prev) => {
+      if (prev.length >= MAX_ATTACHMENTS) {
+        toast.warning(`Maximum ${MAX_ATTACHMENTS} attachments reached`)
+        return prev
+      }
+      return [...prev, { id: crypto.randomUUID(), ...file }]
+    })
+  }, [])
+
+  const handleRemoveAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id))
+  }, [])
+
+  const handleDropFiles = useCallback((files: FileList) => {
+    for (const file of Array.from(files)) {
+      if (attachments.length >= MAX_ATTACHMENTS) {
+        toast.warning(`Maximum ${MAX_ATTACHMENTS} attachments reached`)
+        break
+      }
+      if (isImageMime(file.type)) {
+        const reader = new FileReader()
+        reader.onload = () => {
+          handleAttach({
+            kind: 'data',
+            name: file.name,
+            mime: file.type,
+            dataUrl: reader.result as string
+          })
+        }
+        reader.readAsDataURL(file)
+      } else {
+        handleAttach({
+          kind: 'path',
+          name: file.name,
+          mime: file.type || 'application/octet-stream',
+          filePath: window.fileOps.getPathForFile(file)
+        })
+      }
+    }
+  }, [handleAttach, attachments.length])
+
+  const { isDragging } = useDropZone({ onDrop: handleDropFiles, containerRef: dropZoneRef })
   const lifecycle = useLifecycleActions(ticket.worktree_id)
   const isCreatingPR = useGitStore((s) =>
     ticket.worktree_id ? s.creatingPRByWorktreeId.get(ticket.worktree_id) === true : false
@@ -1887,7 +1943,7 @@ function ReviewModeContent({
 
   // ── Send followup ─────────────────────────────────────────────────
   const handleSendFollowup = useCallback(async () => {
-    if (!followUpText.trim() || !ticket.current_session_id || isSending) return
+    if ((!followUpText.trim() && attachments.length === 0) || !ticket.current_session_id || isSending) return
     setIsSending(true)
 
     try {
@@ -1903,6 +1959,7 @@ function ReviewModeContent({
       const mode = followUpMode
       const ticketId = ticket.id
       const projectId = ticket.project_id
+      const currentAttachments = [...attachments]
 
       // Mark the session as busy NOW so the kanban card shows the progress bar
       // the moment the modal closes (sendFollowupToSession would set this too,
@@ -1927,6 +1984,7 @@ function ReviewModeContent({
         prompt,
         followUpMode: mode,
         ticketId,
+        attachments: currentAttachments,
       }).catch((err) => {
         console.error('[KanbanTicketModal] sendFollowupToSession failed:', err)
         const reason = err instanceof Error ? err.message : String(err)
@@ -1939,19 +1997,9 @@ function ReviewModeContent({
       toast.error(`Failed to move ticket: ${reason}`)
     } finally {
       setIsSending(false)
+      setAttachments([])
     }
-  }, [followUpText, followUpMode, ticket, isSending, moveTicket, updateTicket, onClose])
-
-  // Enter sends, Shift+Enter for newline
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault()
-        handleSendFollowup()
-      }
-    },
-    [handleSendFollowup]
-  )
+  }, [followUpText, followUpMode, ticket, isSending, moveTicket, updateTicket, onClose, attachments])
 
   // ── Move to Done ──────────────────────────────────────────────────
   const handleMoveToDone = useCallback(async () => {
@@ -2027,11 +2075,8 @@ function ReviewModeContent({
     return () => window.removeEventListener('keydown', handler, true)
   }, [hasRunScript, runRunning, handleRunScript, handleStopScript])
 
-  const ModeIcon = followUpMode === 'build' ? Hammer : followUpMode === 'plan' ? Map : Sparkles
-  const modeLabel = followUpMode === 'build' ? 'Build' : followUpMode === 'plan' ? 'Plan' : 'Super Plan'
-
   return (
-    <>
+    <div ref={dropZoneRef} className="relative contents">
       <DialogHeader>
         <div className="flex items-center justify-between">
           <DialogTitle>{dualPane ? 'Review' : ticket.title}</DialogTitle>
@@ -2079,41 +2124,30 @@ function ReviewModeContent({
       )}
 
       {/* Followup input area */}
-      <div className="space-y-2 flex-shrink-0">
-        <div className="flex items-center gap-2">
-          <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-            Followup
-          </label>
-          <button
-            data-testid="review-mode-toggle"
-            data-mode={followUpMode}
-            type="button"
-            onClick={toggleMode}
-            className={cn(
-              'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
-              'border select-none',
-              followUpMode === 'build'
-                ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
-                : followUpMode === 'plan'
-                  ? 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
-                  : 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20'
-            )}
-          >
-            <ModeIcon className="h-3 w-3" />
-            <span>{modeLabel}</span>
-          </button>
+      <FollowupInput
+        text={followUpText}
+        onTextChange={setFollowUpText}
+        attachments={attachments}
+        onAttach={handleAttach}
+        onRemoveAttachment={handleRemoveAttachment}
+        followUpMode={followUpMode}
+        onToggleMode={toggleMode}
+        onSend={handleSendFollowup}
+        isSending={isSending}
+        placeholder="Provide followup instructions... (Enter to send)"
+        testIdPrefix="review"
+        textareaRef={textareaRef}
+      />
+
+      {/* Drag-and-drop overlay */}
+      {isDragging && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm rounded-lg border-2 border-dashed border-primary/50">
+          <div className="flex flex-col items-center gap-2 text-primary">
+            <Upload className="h-8 w-8" />
+            <span className="text-sm font-medium">Drop files here</span>
+          </div>
         </div>
-        <Textarea
-          ref={textareaRef}
-          data-testid="review-followup-input"
-          value={followUpText}
-          onChange={(e) => setFollowUpText(e.target.value)}
-          onKeyDown={handleKeyDown}
-          rows={2}
-          placeholder="Provide followup instructions… (Enter to send)"
-          className="resize-y font-mono text-xs leading-relaxed"
-        />
-      </div>
+      )}
 
       <DialogFooter className="flex-shrink-0 flex-wrap gap-y-2">
         <Button
@@ -2215,7 +2249,7 @@ function ReviewModeContent({
         <Button
           type="button"
           data-testid="review-send-followup-btn"
-          disabled={!followUpText.trim() || isSending}
+          disabled={(!followUpText.trim() && attachments.length === 0) || isSending}
           onClick={handleSendFollowup}
           className={cn(
             'gap-1.5',
@@ -2228,7 +2262,7 @@ function ReviewModeContent({
           {isSending ? 'Sending...' : 'Send'}
         </Button>
       </DialogFooter>
-    </>
+    </div>
   )
 }
 
@@ -2248,7 +2282,9 @@ function ErrorModeContent({
   const [followUpText, setFollowUpText] = useState('')
   const [followUpMode, setFollowUpMode] = useState<FollowUpMode>('build')
   const [isSending, setIsSending] = useState(false)
+  const [attachments, setAttachments] = useState<Attachment[]>([])
   const updateTicket = useKanbanStore((s) => s.updateTicket)
+  const dropZoneRef = useRef<HTMLDivElement>(null)
 
   // Look up session status entry for error details
   const sessionStatusEntry = useWorktreeStatusStore(
@@ -2261,13 +2297,57 @@ function ErrorModeContent({
     )
   )
 
+  const handleAttach = useCallback((file: Omit<Attachment, 'id'>) => {
+    setAttachments((prev) => {
+      if (prev.length >= MAX_ATTACHMENTS) {
+        toast.warning(`Maximum ${MAX_ATTACHMENTS} attachments reached`)
+        return prev
+      }
+      return [...prev, { id: crypto.randomUUID(), ...file }]
+    })
+  }, [])
+
+  const handleRemoveAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id))
+  }, [])
+
+  const handleDropFiles = useCallback((files: FileList) => {
+    for (const file of Array.from(files)) {
+      if (attachments.length >= MAX_ATTACHMENTS) {
+        toast.warning(`Maximum ${MAX_ATTACHMENTS} attachments reached`)
+        break
+      }
+      if (isImageMime(file.type)) {
+        const reader = new FileReader()
+        reader.onload = () => {
+          handleAttach({
+            kind: 'data',
+            name: file.name,
+            mime: file.type,
+            dataUrl: reader.result as string
+          })
+        }
+        reader.readAsDataURL(file)
+      } else {
+        handleAttach({
+          kind: 'path',
+          name: file.name,
+          mime: file.type || 'application/octet-stream',
+          filePath: window.fileOps.getPathForFile(file)
+        })
+      }
+    }
+  }, [handleAttach, attachments.length])
+
+  const { isDragging } = useDropZone({ onDrop: handleDropFiles, containerRef: dropZoneRef })
+
   const toggleMode = useCallback(() => {
     setFollowUpMode((prev) => prev === 'build' ? 'plan' : 'build')
   }, [])
 
   // ── Send followup for error retry ─────────────────────────────────
   const handleSendFollowup = useCallback(async () => {
-    if (!followUpText.trim() || !ticket.current_session_id || isSending) return
+    if ((!followUpText.trim() && attachments.length === 0) || !ticket.current_session_id || isSending) return
     setIsSending(true)
 
     try {
@@ -2276,6 +2356,7 @@ function ErrorModeContent({
         prompt: followUpText.trim(),
         followUpMode,
         ticketId: ticket.id,
+        attachments,
       })
 
       await updateTicket(ticket.id, ticket.project_id, { mode: followUpMode, plan_ready: false })
@@ -2289,25 +2370,12 @@ function ErrorModeContent({
       }
     } finally {
       setIsSending(false)
+      setAttachments([])
     }
-  }, [followUpText, followUpMode, ticket, isSending, updateTicket, onClose])
-
-  // Enter sends, Shift+Enter for newline
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault()
-        handleSendFollowup()
-      }
-    },
-    [handleSendFollowup]
-  )
-
-  const ModeIcon = followUpMode === 'build' ? Hammer : followUpMode === 'plan' ? Map : Sparkles
-  const modeLabel = followUpMode === 'build' ? 'Build' : followUpMode === 'plan' ? 'Plan' : 'Super Plan'
+  }, [followUpText, followUpMode, ticket, isSending, updateTicket, onClose, attachments])
 
   return (
-    <>
+    <div ref={dropZoneRef} className="relative contents">
       <DialogHeader>
         <div className="flex items-center justify-between">
           <DialogTitle className="flex items-center gap-2">
@@ -2341,40 +2409,29 @@ function ErrorModeContent({
       </div>
 
       {/* Followup input */}
-      <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-            Followup
-          </label>
-          <button
-            data-testid="error-mode-toggle"
-            data-mode={followUpMode}
-            type="button"
-            onClick={toggleMode}
-            className={cn(
-              'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
-              'border select-none',
-              followUpMode === 'build'
-                ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
-                : followUpMode === 'plan'
-                  ? 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
-                  : 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20'
-            )}
-          >
-            <ModeIcon className="h-3 w-3" />
-            <span>{modeLabel}</span>
-          </button>
+      <FollowupInput
+        text={followUpText}
+        onTextChange={setFollowUpText}
+        attachments={attachments}
+        onAttach={handleAttach}
+        onRemoveAttachment={handleRemoveAttachment}
+        followUpMode={followUpMode}
+        onToggleMode={toggleMode}
+        onSend={handleSendFollowup}
+        isSending={isSending}
+        placeholder="Describe the fix or retry instructions... (Enter to send)"
+        testIdPrefix="error"
+      />
+
+      {/* Drag-and-drop overlay */}
+      {isDragging && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm rounded-lg border-2 border-dashed border-primary/50">
+          <div className="flex flex-col items-center gap-2 text-primary">
+            <Upload className="h-8 w-8" />
+            <span className="text-sm font-medium">Drop files here</span>
+          </div>
         </div>
-        <Textarea
-          data-testid="error-followup-input"
-          value={followUpText}
-          onChange={(e) => setFollowUpText(e.target.value)}
-          onKeyDown={handleKeyDown}
-          rows={2}
-          placeholder="Describe the fix or retry instructions… (Enter to send)"
-          className="resize-y font-mono text-xs leading-relaxed"
-        />
-      </div>
+      )}
 
       <DialogFooter>
         <Button
@@ -2388,7 +2445,7 @@ function ErrorModeContent({
         <Button
           type="button"
           data-testid="error-send-followup-btn"
-          disabled={!followUpText.trim() || isSending}
+          disabled={(!followUpText.trim() && attachments.length === 0) || isSending}
           onClick={handleSendFollowup}
           className={cn(
             'gap-1.5',
@@ -2401,7 +2458,7 @@ function ErrorModeContent({
           {isSending ? 'Sending...' : 'Send'}
         </Button>
       </DialogFooter>
-    </>
+    </div>
   )
 }
 

--- a/src/renderer/src/hooks/useDropZone.ts
+++ b/src/renderer/src/hooks/useDropZone.ts
@@ -2,9 +2,11 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 interface UseDropZoneProps {
   onDrop: (files: FileList) => void
+  /** When provided, listen on this element instead of `window` (scoped drop zone). */
+  containerRef?: React.RefObject<HTMLElement>
 }
 
-export function useDropZone({ onDrop }: UseDropZoneProps) {
+export function useDropZone({ onDrop, containerRef }: UseDropZoneProps) {
   const [isDragging, setIsDragging] = useState(false)
   const dragCounterRef = useRef(0)
 
@@ -47,18 +49,19 @@ export function useDropZone({ onDrop }: UseDropZoneProps) {
   )
 
   useEffect(() => {
-    window.addEventListener('dragenter', handleDragEnter)
-    window.addEventListener('dragleave', handleDragLeave)
-    window.addEventListener('dragover', handleDragOver)
-    window.addEventListener('drop', handleDrop)
+    const target: Window | HTMLElement = containerRef?.current ?? window
+    target.addEventListener('dragenter', handleDragEnter as EventListener)
+    target.addEventListener('dragleave', handleDragLeave as EventListener)
+    target.addEventListener('dragover', handleDragOver as EventListener)
+    target.addEventListener('drop', handleDrop as EventListener)
 
     return () => {
-      window.removeEventListener('dragenter', handleDragEnter)
-      window.removeEventListener('dragleave', handleDragLeave)
-      window.removeEventListener('dragover', handleDragOver)
-      window.removeEventListener('drop', handleDrop)
+      target.removeEventListener('dragenter', handleDragEnter as EventListener)
+      target.removeEventListener('dragleave', handleDragLeave as EventListener)
+      target.removeEventListener('dragover', handleDragOver as EventListener)
+      target.removeEventListener('drop', handleDrop as EventListener)
     }
-  }, [handleDragEnter, handleDragLeave, handleDragOver, handleDrop])
+  }, [handleDragEnter, handleDragLeave, handleDragOver, handleDrop, containerRef])
 
   return { isDragging }
 }


### PR DESCRIPTION
## Summary

- Extracted followup input UI into reusable `FollowupInput` component with attachment support
- Added file attachment handling (images as data URLs, other files as paths) across Review, Plan, and Error modes
- Integrated drag-and-drop zones with scoped detection per modal using updated `useDropZone` hook
- Enhanced `sendFollowupToSession` to build and send message parts with attachments
- Added visual feedback with drag-and-drop overlay and attachment previews
- Enforced `MAX_ATTACHMENTS` limit with user-facing toast warnings
- Updated Send button logic to allow sending with attachments only (no text required)

## Testing

- Verified attachment button renders in all three modes (Review, Plan, Error)
- Tested image paste into textarea with FileReader conversion to data URL
- Confirmed drag-and-drop overlay appears when dragging files over modal
- Validated MAX_ATTACHMENTS limit prevents exceeding configured limit
- Checked attachment preview displays and remove functionality works
- Tested Send button disabled state: enabled with attachments-only, disabled when empty
- Verified message parts correctly built with `buildMessageParts` utility
- Confirmed `useDropZone` scoped to containerRef prevents global drag interference
- Validated attachments cleared after successful send
- Tested mode toggle (Build/Plan/Super Plan) preserved during attachment workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI+prompting changes: followups can now include pasted/dropped files and are sent as multi-part messages, which could affect agent prompt formatting and file handling. Risk is mitigated by size limits (`MAX_ATTACHMENTS`) and mostly localized to kanban modal flows.
> 
> **Overview**
> Adds attachment support to kanban ticket followups across *Plan Review*, *Review*, and *Error* modals, including paperclip uploads, image paste-to-attachment, preview/removal UI, and drag-and-drop with an in-modal overlay.
> 
> Updates `sendFollowupToSession` to accept optional attachments and send them via `buildMessageParts` (multi-part prompt), and relaxes send gating so users can send attachments without text; attachments are cleared after send.
> 
> Enhances `useDropZone` to optionally scope listeners to a `containerRef` instead of always attaching to `window`, reducing interference with global drag/drop handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b5d5bc58441378bedc8e78c2717dc39a29f3da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->