### PR TITLE
Extract title from JSON response in title-generation flow

### DIFF
--- a/src/main/services/opencode-service.ts
+++ b/src/main/services/opencode-service.ts
@@ -6,6 +6,7 @@ import { getDatabase } from '../db'
 import { autoRenameWorktreeBranch } from './git-service'
 import { getEventBus } from '../../server/event-bus'
 import { getUserEnvironmentVariables } from './env-vars'
+import { maybeExtractJsonTitle } from '@shared/title-utils'
 
 const log = createLogger({ component: 'OpenCodeService' })
 
@@ -1155,7 +1156,8 @@ class OpenCodeService {
     // The SDK event structure is: { properties: { info: Session } } where Session has { id, title, ... }
     if (eventType === 'session.updated') {
       const sessionInfo = event.properties?.info
-      const sessionTitle = sessionInfo?.title || event.properties?.title
+      const rawSessionTitle = sessionInfo?.title || event.properties?.title
+      const sessionTitle = rawSessionTitle ? maybeExtractJsonTitle(rawSessionTitle) : rawSessionTitle
       if (hiveSessionId && sessionTitle) {
         try {
           const db = getDatabase()

--- a/src/main/services/title-generation-shared.ts
+++ b/src/main/services/title-generation-shared.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import { createLogger } from './logger'
+import { maybeExtractJsonTitle } from '@shared/title-utils'
 
 const log = createLogger({ component: 'TitleGenerationShared' })
 
@@ -40,8 +41,12 @@ const MAX_SANITIZED_LENGTH = 50
  * Returns null if the result is empty.
  */
 export function sanitizeTitle(raw: string): string | null {
+  // If the title value is itself a JSON string with a "title" field, extract it.
+  // This handles cases where the model double-wraps: structured_output.title = '{"title": "..."}'
+  let title = maybeExtractJsonTitle(raw)
+
   // First line only
-  let title = raw.split('\n')[0] ?? ''
+  title = title.split('\n')[0] ?? ''
 
   // Strip surrounding quotes and backticks
   title = title.replace(/^[`"']+|[`"']+$/g, '')

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -28,6 +28,7 @@ import type { FlatFile } from '@/lib/file-search-utils'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useContextStore } from '@/stores/useContextStore'
+import { maybeExtractJsonTitle } from '@shared/title-utils'
 import type { TokenInfo, SessionModelRef } from '@/stores/useContextStore'
 import {
   extractTokens,
@@ -1603,7 +1604,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           // Handle session.updated events — update session title in store
           // The SDK event structure is: { data: { info: { title, ... } } }
           if (event.type === 'session.updated') {
-            const sessionTitle = event.data?.info?.title || event.data?.title
+            const rawTitle = event.data?.info?.title || event.data?.title
+            const sessionTitle = rawTitle ? maybeExtractJsonTitle(rawTitle) : rawTitle
             console.log('[TITLE_DEBUG] SessionView received session.updated', {
               eventSessionId: event.sessionId,
               componentSessionId: sessionId,

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -18,6 +18,7 @@ import { checkAutoApprove } from '@/lib/permissionUtils'
 import { isPlanLike } from '@/lib/constants'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
 import { useKanbanStore } from '@/stores/useKanbanStore'
+import { maybeExtractJsonTitle } from '@shared/title-utils'
 
 interface PromptDispatchContext {
   worktreePath: string
@@ -301,7 +302,8 @@ export function useOpenCodeGlobalListener(): void {
             })
           }
           if (event.type === 'session.updated' && sessionId !== activeId) {
-            const sessionTitle = event.data?.info?.title || event.data?.title
+            const rawTitle = event.data?.info?.title || event.data?.title
+            const sessionTitle = rawTitle ? maybeExtractJsonTitle(rawTitle) : rawTitle
             // Skip OpenCode default placeholder titles like "New session - 2026-02-12T21:33:03.013Z"
             const isOpenCodeDefault = /^New session\s*-?\s*\d{4}-\d{2}-\d{2}/i.test(
               sessionTitle || ''

--- a/src/shared/title-utils.ts
+++ b/src/shared/title-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * If the input is a JSON string containing a "title" field, extract and return it.
+ * Otherwise return the input unchanged. Safe to call on any string.
+ */
+export function maybeExtractJsonTitle(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed.startsWith('{')) return raw
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (typeof parsed?.title === 'string' && parsed.title.trim()) {
+      return parsed.title.trim()
+    }
+  } catch {
+    // Not valid JSON
+  }
+  return raw
+}

--- a/test/title-generation-shared.test.ts
+++ b/test/title-generation-shared.test.ts
@@ -62,6 +62,18 @@ describe('sanitizeTitle', () => {
     const short = 'A'.repeat(30)
     expect(sanitizeTitle(short)).toBe(short)
   })
+
+  it('extracts title from double-wrapped JSON (the bug case)', () => {
+    expect(sanitizeTitle('{"title": "Codex vs t3"}')).toBe('Codex vs t3')
+  })
+
+  it('extracts title from double-wrapped JSON with extra fields', () => {
+    expect(sanitizeTitle('{"title": "Fix auth bug", "confidence": 0.9}')).toBe('Fix auth bug')
+  })
+
+  it('passes through JSON without title field unchanged', () => {
+    expect(sanitizeTitle('{"other": "value"}')).toBe('{"other": "value"}')
+  })
 })
 
 // ── extractTitleFromJSON ─────────────────────────────────────────────

--- a/test/title-real-output.test.ts
+++ b/test/title-real-output.test.ts
@@ -164,6 +164,17 @@ describe('generateSessionTitle — real parsing, mocked spawn', () => {
     expect(title).toBeNull()
   })
 
+  it('extracts title when structured_output.title is double-wrapped JSON (the bug)', async () => {
+    mockSpawnCLI.mockResolvedValue(JSON.stringify({
+      type: 'result',
+      result: '',
+      structured_output: { title: '{"title": "Codex vs t3"}' }
+    }))
+
+    const title = await generateSessionTitle('compare codex and t3')
+    expect(title).toBe('Codex vs t3')
+  })
+
   it('sanitizes quotes from title', async () => {
     mockSpawnCLI.mockResolvedValue(JSON.stringify({
       structured_output: { title: '"Fix auth bug"' }

--- a/test/title-utils.test.ts
+++ b/test/title-utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { maybeExtractJsonTitle } from '../src/shared/title-utils'
+
+describe('maybeExtractJsonTitle', () => {
+  it('extracts title from JSON object (the bug case)', () => {
+    expect(maybeExtractJsonTitle('{"title": "Codex vs t3"}')).toBe('Codex vs t3')
+  })
+
+  it('trims whitespace from extracted title', () => {
+    expect(maybeExtractJsonTitle('{"title": "  spaced  "}')).toBe('spaced')
+  })
+
+  it('returns plain string titles unchanged', () => {
+    expect(maybeExtractJsonTitle('Plain title')).toBe('Plain title')
+  })
+
+  it('returns JSON without title field unchanged', () => {
+    const input = '{"other": "value"}'
+    expect(maybeExtractJsonTitle(input)).toBe(input)
+  })
+
+  it('returns invalid JSON starting with { unchanged', () => {
+    expect(maybeExtractJsonTitle('{not json')).toBe('{not json')
+  })
+
+  it('returns empty string unchanged', () => {
+    expect(maybeExtractJsonTitle('')).toBe('')
+  })
+
+  it('handles whitespace around JSON', () => {
+    expect(maybeExtractJsonTitle('  { "title": "padded" }  ')).toBe('padded')
+  })
+
+  it('returns JSON with empty title field unchanged', () => {
+    const input = '{"title": ""}'
+    expect(maybeExtractJsonTitle(input)).toBe(input)
+  })
+
+  it('returns JSON with whitespace-only title field unchanged', () => {
+    const input = '{"title": "   "}'
+    expect(maybeExtractJsonTitle(input)).toBe(input)
+  })
+
+  it('handles title with extra JSON fields', () => {
+    expect(maybeExtractJsonTitle('{"title": "Fix auth bug", "confidence": 0.9}')).toBe('Fix auth bug')
+  })
+
+  it('does not try to parse strings that do not start with {', () => {
+    expect(maybeExtractJsonTitle('title: Fix auth bug')).toBe('title: Fix auth bug')
+  })
+
+  it('handles numeric title values gracefully (returns original)', () => {
+    const input = '{"title": 42}'
+    expect(maybeExtractJsonTitle(input)).toBe(input)
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes double-wrapped JSON in `structured_output.title` where the title field itself contains a JSON string (e.g., `{"title": "..."}`)
- Adds `maybeExtractJsonTitle()` utility function in `src/shared/title-utils.ts` to safely extract title strings from JSON objects
- Updates title sanitization and session event handlers to call the extraction function before processing
- Applies extraction in three locations:
  - `opencode-service.ts` — session.updated events from main process
  - `title-generation-shared.ts` — sanitizeTitle function
  - `SessionView.tsx` and `useOpenCodeGlobalListener.ts` — session.updated events in renderer

## Testing

- ✅ Added comprehensive unit tests for `maybeExtractJsonTitle()` covering:
  - JSON object extraction with title field
  - Whitespace trimming
  - Plain strings (pass-through)
  - JSON without title field (pass-through)
  - Invalid JSON and edge cases
- ✅ Added integration tests in `title-generation-shared.test.ts` for double-wrapped JSON scenarios
- ✅ Added real-output test case in `title-real-output.test.ts` demonstrating the bug fix with mocked spawn
- All tests verify correct extraction and safe fallback behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session title handling in both main and renderer processes, which can affect persisted session names and auto branch-renaming behavior if parsing is wrong. Changes are small and guarded with safe fallback parsing plus added tests.
> 
> **Overview**
> Fixes a bug where session titles could arrive as *double-wrapped JSON strings* (e.g. `"{\"title\":\"...\"}"`) and end up displayed/persisted incorrectly.
> 
> Adds a shared `maybeExtractJsonTitle()` helper and applies it when sanitizing generated titles and when handling `session.updated` events in the main process (`opencode-service`) and renderer (`SessionView`, `useOpenCodeGlobalListener`) so DB updates, UI updates, and branch rename logic use the extracted plain title.
> 
> Extends test coverage with new unit tests for the helper and additional cases validating the double-wrapped title flow end-to-end in the title generation tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e807d5ae8c9e86e2bc84643fb5b1d13f11eb645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->