### PR TITLE
Add 'Go to review' button to completed review sessions on kanban cards

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -215,6 +215,16 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     )
   )
 
+  const completedReviewSessionId = useWorktreeStatusStore(
+    useCallback(
+      (state) => {
+        if (!ticket.worktree_id) return null
+        return state.completedReviewSessionByWorktree[ticket.worktree_id] ?? null
+      },
+      [ticket.worktree_id]
+    )
+  )
+
   // ── Detect pending questions for this ticket's session ─────────
   const isAsking = useQuestionStore(
     useCallback(
@@ -445,6 +455,18 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     }
   }, [ticket.current_session_id, ticket.worktree_id, ticket.project_id, connectionId, connectionSession, isPinnedMode])
 
+  const handleGoToReview = useCallback(() => {
+    if (!completedReviewSessionId) return
+    const kanbanStore = useKanbanStore.getState()
+    if (kanbanStore.isBoardViewActive) kanbanStore.toggleBoardView()
+    if (kanbanStore.isPinnedBoardActive) kanbanStore.togglePinnedBoard()
+    if (ticket.worktree_id) {
+      useWorktreeStore.getState().selectWorktree(ticket.worktree_id)
+      useSessionStore.getState().setActiveWorktree(ticket.worktree_id)
+    }
+    useSessionStore.getState().setActiveSession(completedReviewSessionId)
+  }, [completedReviewSessionId, ticket.worktree_id])
+
   const isSimpleTicket = ticket.current_session_id === null
   const isFlowTicket = ticket.current_session_id !== null
   const isTodo = ticket.column === 'todo'
@@ -539,7 +561,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isBeingReviewed || isArchived || isRunProcessAlive || ticket.github_pr_number || isCreatingPR) && (
+            {(hasAttachments || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isBeingReviewed || completedReviewSessionId || isArchived || isRunProcessAlive || ticket.github_pr_number || isCreatingPR) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
@@ -650,6 +672,17 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                   <span data-testid="kanban-ticket-reviewing" className="ml-auto flex items-center gap-1.5">
                     <IndeterminateProgressBar mode={ticket.mode || 'build'} isReviewing className="w-20" />
                   </span>
+                )}
+
+                {/* Completed review — show "Go to review" link */}
+                {!isBeingReviewed && !(isBusy || isAsking) && completedReviewSessionId && (
+                  <button
+                    data-testid="kanban-ticket-go-to-review"
+                    onClick={(e) => { e.stopPropagation(); handleGoToReview() }}
+                    className="ml-auto text-green-500 hover:text-green-400 text-xs cursor-pointer"
+                  >
+                    Go to review
+                  </button>
                 )}
               </div>
             )}

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -13,6 +13,7 @@ import {
 import { isPlanLike } from '../lib/constants'
 import { useConnectionStore } from './useConnectionStore'
 import { usePinnedStore } from './usePinnedStore'
+import { useWorktreeStatusStore } from './useWorktreeStatusStore'
 
 // ── Shared drag state (module-level, avoids DataTransfer issues in Electron) ──
 export interface KanbanDragData {
@@ -425,6 +426,12 @@ export const useKanbanStore = create<KanbanState>()(
           next.set(projectId, tickets)
           return { tickets: next }
         })
+
+        // Clear "Go to review" indicator when ticket moves columns (optimistic)
+        const movedTicket = prev.find((t) => t.id === ticketId)
+        if (movedTicket?.worktree_id) {
+          useWorktreeStatusStore.getState().clearCompletedReviewSession(movedTicket.worktree_id)
+        }
 
         try {
           await window.kanban.ticket.move(ticketId, column, sortOrder)

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -29,6 +29,8 @@ interface WorktreeStatusState {
   lastMessageTimeByWorktree: Record<string, number>
   // worktreeId → sessionId for active review sessions
   reviewSessionByWorktree: Record<string, string>
+  // worktreeId → sessionId for completed review sessions (in-memory only)
+  completedReviewSessionByWorktree: Record<string, string>
 
   // Actions
   setSessionStatus: (
@@ -45,6 +47,7 @@ interface WorktreeStatusState {
   getLastMessageTime: (worktreeId: string) => number | null
   setReviewSession: (worktreeId: string, sessionId: string) => void
   clearReviewSession: (worktreeId: string) => void
+  clearCompletedReviewSession: (worktreeId: string) => void
   isWorktreeBeingReviewed: (worktreeId: string) => boolean
 }
 
@@ -73,6 +76,7 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
   sessionStatuses: {},
   lastMessageTimeByWorktree: {},
   reviewSessionByWorktree: {},
+  completedReviewSessionByWorktree: {},
 
   setSessionStatus: (
     sessionId: string,
@@ -93,6 +97,13 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
           if (sId === sessionId) {
             const { [wtId]: _, ...rest } = state.reviewSessionByWorktree
             next.reviewSessionByWorktree = rest
+            // When a review completes, save its session ID so the card can show "Go to review"
+            if (status === 'completed') {
+              next.completedReviewSessionByWorktree = {
+                ...state.completedReviewSessionByWorktree,
+                [wtId]: sessionId
+              }
+            }
             break
           }
         }
@@ -289,18 +300,30 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
   },
 
   setReviewSession: (worktreeId: string, sessionId: string) => {
-    set((state) => ({
-      reviewSessionByWorktree: {
-        ...state.reviewSessionByWorktree,
-        [worktreeId]: sessionId
+    set((state) => {
+      // Clear any completed review for this worktree when a new review starts
+      const { [worktreeId]: _, ...restCompleted } = state.completedReviewSessionByWorktree
+      return {
+        reviewSessionByWorktree: {
+          ...state.reviewSessionByWorktree,
+          [worktreeId]: sessionId
+        },
+        completedReviewSessionByWorktree: restCompleted
       }
-    }))
+    })
   },
 
   clearReviewSession: (worktreeId: string) => {
     set((state) => {
       const { [worktreeId]: _, ...rest } = state.reviewSessionByWorktree
       return { reviewSessionByWorktree: rest }
+    })
+  },
+
+  clearCompletedReviewSession: (worktreeId: string) => {
+    set((state) => {
+      const { [worktreeId]: _, ...rest } = state.completedReviewSessionByWorktree
+      return { completedReviewSessionByWorktree: rest }
     })
   },
 


### PR DESCRIPTION
## Summary

- Display a "Go to review" link on kanban ticket cards when a review session has completed
- Clicking the link navigates to the completed review session and closes board/pinned views
- Add `completedReviewSessionByWorktree` tracking to `useWorktreeStatusStore` for in-memory storage of completed review session IDs
- Clear completed review indicator when ticket is moved to a different column (optimistic update)
- Clear completed review state when a new review session starts for the same worktree
- Style the button with green text color and hover state for visibility

## Testing

- Verify "Go to review" button appears on kanban cards after a review session completes
- Verify clicking "Go to review" navigates to the review session view and closes board/pinned views
- Verify completed review indicator clears when ticket is moved to a different column
- Verify completed review state is cleared when a new review session starts
- Verify button is hidden while review is in progress or when other busy states exist (e.g., asking, building)
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state change that adds in-memory tracking for completed review sessions and a navigation button; main risk is stale/incorrect session IDs causing confusing navigation.
> 
> **Overview**
> Kanban ticket cards now show a **"Go to review"** link when a worktree’s review session completes, and clicking it navigates to that completed session while closing board/pinned views.
> 
> This introduces in-memory `completedReviewSessionByWorktree` tracking in `useWorktreeStatusStore`, records the completed review session ID when a review session status becomes `completed`, and clears the indicator when a new review starts or when the ticket is moved to another column (optimistic update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c6f96866e758ffffddc4033407a323a5dbc401c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->