### PR TITLE
Clear plan ready status when superpowers completes

### DIFF
--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -3,6 +3,7 @@ import { motion } from 'motion/react'
 import { ChevronRight, ChevronDown, Plus, Zap, Archive } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { toast } from '@/lib/toast'
+import { lastSendMode } from '@/lib/message-send-times'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { KanbanTicketCard } from '@/components/kanban/KanbanTicketCard'
@@ -358,6 +359,7 @@ export function KanbanColumn({ column, tickets, archivedTickets, projectId, conn
           completed_at: new Date().toISOString()
         })
         useWorktreeStatusStore.getState().clearSessionStatus(draggedTicket.current_session_id)
+        lastSendMode.delete(draggedTicket.current_session_id)
       }
 
       // Clear session link on the ticket

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1389,6 +1389,7 @@ function PlanReviewModeContent({
       const sessionId = ticket.current_session_id
       useSessionStore.getState().clearPendingPlan(sessionId)
       useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+      lastSendMode.delete(sessionId)
 
       const sessionStore = useSessionStore.getState()
       const result = await sessionStore.createSession(ticket.worktree_id, ticket.project_id)
@@ -1468,6 +1469,7 @@ function PlanReviewModeContent({
       const sessionId = ticket.current_session_id
       useSessionStore.getState().clearPendingPlan(sessionId)
       useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+      lastSendMode.delete(sessionId)
 
       // Abort the original backend session so it stops spinning
       if (worktreePath && opcSessionId) {
@@ -1539,6 +1541,7 @@ function PlanReviewModeContent({
       const sessionId = ticket.current_session_id
       useSessionStore.getState().clearPendingPlan(sessionId)
       useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+      lastSendMode.delete(sessionId)
 
       // Abort the original backend session so it stops spinning
       if (worktreePath && opcSessionId) {

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -4023,6 +4023,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
     useSessionStore.getState().clearPendingPlan(sessionId)
     useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+    lastSendMode.delete(sessionId)
 
     // Abort the original backend session so it stops spinning
     if (worktreePath && opencodeSessionId) {
@@ -4082,6 +4083,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
     useSessionStore.getState().clearPendingPlan(sessionId)
     useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+    lastSendMode.delete(sessionId)
 
     // Abort the original backend session so it stops spinning
     if (worktreePath && opencodeSessionId) {
@@ -4183,6 +4185,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
     useSessionStore.getState().clearPendingPlan(sessionId)
     useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+    lastSendMode.delete(sessionId)
 
     // Abort the original backend session so it stops spinning
     if (worktreePath && opencodeSessionId) {

--- a/test/phase-18/session-3/plan-ready-status.test.ts
+++ b/test/phase-18/session-3/plan-ready-status.test.ts
@@ -121,6 +121,20 @@ describe('Session 3: Plan Ready Status', () => {
       getState().setSessionStatus('session-2', 'completed', { word: 'Built', durationMs: 3000 })
       expect(getState().getWorktreeStatus('wt-1')).toBe('plan_ready')
     })
+
+    test('clearing lastSendMode for old session prevents plan_ready after supercharge', () => {
+      // Simulate: old session planned, new session built (supercharge scenario)
+      lastSendMode.set('session-1', 'plan')
+      lastSendMode.set('session-2', 'build')
+      getState().setSessionStatus('session-1', 'completed', { word: 'Crafted', durationMs: 5000 })
+      getState().setSessionStatus('session-2', 'completed', { word: 'Built', durationMs: 3000 })
+      // Before fix: would return 'plan_ready'
+      expect(getState().getWorktreeStatus('wt-1')).toBe('plan_ready')
+
+      // Supercharge clears lastSendMode for old session
+      lastSendMode.delete('session-1')
+      expect(getState().getWorktreeStatus('wt-1')).toBe('completed')
+    })
   })
 
   describe('priority ordering', () => {


### PR DESCRIPTION
## Summary

- Removes the stale `plan_ready` status when superpowers completes by deleting the `lastSendMode` entry for the old session
- Prevents incorrect state where a worktree shows `plan_ready` after supercharging to a new session
- Clears session tracking in 5 locations: KanbanColumn (drag-drop completion), KanbanTicketModal (3 restart handlers), and SessionView (3 abort handlers)
- Adds test case demonstrating the fix: old session's lastSendMode deletion correctly transitions status to `completed`

## Testing

- New test: `clearing lastSendMode for old session prevents plan_ready after supercharge` validates that deleting lastSendMode for the old session removes the spurious `plan_ready` status
- Test simulates supercharge scenario: plan old session, build new session, then delete old session's lastSendMode tracking
- Verified test passes and correctly asserts status transitions from `plan_ready` to `completed`
- Manual verification recommended in UI for superpowers workflow with plan→build transitions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small state-cleanup changes that only affect derived UI status (`plan_ready` vs `completed`) when sessions are aborted/restarted/supercharged.
> 
> **Overview**
> Prevents worktrees from incorrectly showing **`plan_ready`** after a handoff/supercharge or when completing a session via kanban drag actions by deleting the stale `lastSendMode` entry for the old session whenever session tracking is cleared.
> 
> Updates the kanban backward-drag stop flow, kanban plan-review restart actions (`handleHandoff`, `handleSupercharge`, `handleSuperchargeLocal`), and SessionView abort/restart handlers to call `lastSendMode.delete(sessionId)`, and adds a regression test covering the supercharge scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 158de1f3bc16edb35c7970ec72e0b4e80a104917. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->