### PR TITLE
Auto-attach sessions to pre-assigned tickets when worktrees are selected

### DIFF
--- a/src/main/services/worktree-ops.ts
+++ b/src/main/services/worktree-ops.ts
@@ -350,20 +350,20 @@ export async function syncWorktreesOp(
         continue
       }
 
-      // Sync branch name if it was renamed outside of Hive
+      // Sync branch name if git reports a different one.
+      // branch_name is always updated to match git (source of truth).
+      // Display name is only updated when it's a breed/city placeholder or
+      // still matches the old branch name (never meaningfully customised).
       const gitBranch = gitBranchByPath.get(normalizedDbWorktreePath)
       if (
         gitBranch !== undefined &&
-        gitBranch !== dbWorktree.branch_name &&
-        !dbWorktree.branch_renamed
+        gitBranch !== dbWorktree.branch_name
       ) {
         log.info('Branch renamed externally, updating DB', {
           worktreeId: dbWorktree.id,
           oldBranch: dbWorktree.branch_name,
           newBranch: gitBranch
         })
-        // Update branch_name always. Also update display name if it still matches
-        // the old branch name OR is a city placeholder name (never meaningfully customized).
         const nameMatchesBranch = dbWorktree.name === dbWorktree.branch_name
         const worktreeName = dbWorktree.name.toLowerCase()
         const isAutoName = isAutoNamedBranch(worktreeName)
@@ -373,6 +373,14 @@ export async function syncWorktreesOp(
           branch_name: gitBranch,
           ...(shouldUpdateName ? { name: syncedName } : {})
         })
+      } else if (gitBranch !== undefined && dbWorktree.name !== dbWorktree.branch_name) {
+        // branch_name already matches git, but display name is stale (e.g. a
+        // breed/city placeholder left behind by a rename that didn't update it).
+        const isAutoName = isAutoNamedBranch(dbWorktree.name.toLowerCase())
+        if (isAutoName) {
+          const healedName = getImportedWorktreeName(dbWorktree.branch_name, dbWorktree.path)
+          db.updateWorktree(dbWorktree.id, { name: healedName })
+        }
       }
     }
 
@@ -489,9 +497,19 @@ export async function renameWorktreeBranchOp(
       params.newBranch
     )
     if (result.success) {
+      // Also update display name if it still matches the old branch or is a
+      // breed/city placeholder (never meaningfully customised by the user).
+      const worktree = db.getWorktree(params.worktreeId)
+      const nameMatchesBranch = worktree?.name === params.oldBranch
+      const isAutoName = worktree ? isAutoNamedBranch(worktree.name.toLowerCase()) : false
+      const shouldUpdateName = nameMatchesBranch || isAutoName
+
       db.updateWorktree(params.worktreeId, {
         branch_name: params.newBranch,
-        branch_renamed: 1
+        branch_renamed: 1,
+        ...(shouldUpdateName
+          ? { name: getImportedWorktreeName(params.newBranch, params.worktreePath) }
+          : {})
       })
     }
     return result

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -457,7 +457,20 @@ export function WorktreePickerModal({
           return
         }
 
-        await updateTicket(ticket.id, projectId, { worktree_id: worktreeId })
+        // If the worktree already has sessions, auto-attach the most recent one
+        // so the ticket tracks session lifecycle (progress bar, auto-advance).
+        const existingSessions = useSessionStore.getState().sessionsByWorktree.get(worktreeId) || []
+        const activeSession = existingSessions[0]
+        if (activeSession) {
+          await updateTicket(ticket.id, projectId, {
+            worktree_id: worktreeId,
+            current_session_id: activeSession.id,
+            mode: (activeSession.mode as 'build' | 'plan') || 'build',
+            plan_ready: false
+          })
+        } else {
+          await updateTicket(ticket.id, projectId, { worktree_id: worktreeId })
+        }
         onOpenChange(false)
         toast.success('Worktree assigned')
         return

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -148,6 +148,7 @@ export function WorktreePickerModal({
   const updateTicket = useKanbanStore((state) => state.updateTicket)
   const createSession = useSessionStore((state) => state.createSession)
   const createWorktreeFromBranch = useWorktreeStore((state) => state.createWorktreeFromBranch)
+  const syncWorktrees = useWorktreeStore((state) => state.syncWorktrees)
 
   const project = useProjectStore(
     useCallback(
@@ -231,8 +232,12 @@ export function WorktreePickerModal({
       setBranches([])
       setBranchFilter('')
       setBranchPopoverOpen(false)
+      // Refresh worktree list from git so the picker shows current state
+      if (project?.path) {
+        syncWorktrees(projectId, project.path)
+      }
     }
-  }, [open, ticket, projectId])
+  }, [open, ticket, projectId, project?.path, syncWorktrees])
 
   // ── Branch filtering ───────────────────────────────────────────
   const filteredBranches = useMemo(() => {

--- a/src/renderer/src/stores/store-coordination.ts
+++ b/src/renderer/src/stores/store-coordination.ts
@@ -60,3 +60,21 @@ export function notifyKanbanSessionSync(
 ): void {
   _kanbanSessionSync?.(sessionId, event)
 }
+
+// ── Kanban ↔ Session: new session created in a worktree ──────────────
+type KanbanNewSessionFn = (sessionId: string, worktreeId: string, projectId: string, sessionMode: string) => void
+
+let _kanbanNewSession: KanbanNewSessionFn | null = null
+
+export function registerKanbanNewSession(fn: KanbanNewSessionFn): void {
+  _kanbanNewSession = fn
+}
+
+export function notifyKanbanNewSession(
+  sessionId: string,
+  worktreeId: string,
+  projectId: string,
+  sessionMode: string
+): void {
+  _kanbanNewSession?.(sessionId, worktreeId, projectId, sessionMode)
+}

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -593,8 +593,9 @@ export const useKanbanStore = create<KanbanState>()(
               }
 
               case 'session_working': {
-                // Session became active — if ticket is in review, move it to in_progress
-                if (ticket.column === 'review') {
+                // Session became active — move ticket to in_progress if it's in
+                // todo (pre-assigned, first activity) or review (returning to work).
+                if (ticket.column === 'todo' || ticket.column === 'review') {
                   get()
                     .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
                     .catch(() => {})

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../../main/db/types'
 import {
   registerKanbanSessionSync,
+  registerKanbanNewSession,
   type KanbanSessionEvent
 } from './store-coordination'
 import { isPlanLike } from '../lib/constants'
@@ -843,4 +844,32 @@ export const useKanbanStore = create<KanbanState>()(
 // ── Register coordination callback after store creation ──────────────
 registerKanbanSessionSync((sessionId, event) => {
   useKanbanStore.getState().syncTicketWithSession(sessionId, event)
+})
+
+// ── Register new-session callback: auto-attach pre-assigned tickets ──
+registerKanbanNewSession((sessionId, worktreeId, projectId, sessionMode) => {
+  const store = useKanbanStore.getState()
+  const tickets = store.tickets.get(projectId) ?? []
+
+  // Find the first ticket pre-assigned to this worktree with no active session
+  const orphan = tickets.find(
+    (t) => t.worktree_id === worktreeId && !t.current_session_id && !t.archived_at
+  )
+  if (!orphan) return
+
+  // Auto-attach: link session and move to in_progress.
+  // Setting `mode` is critical — the progress bar only renders when
+  // ticket.mode is truthy, and session_completed only advances tickets
+  // whose mode matches 'build' or a plan-like mode.
+  const sortOrder = store.computeSortOrder(
+    store.getTicketsByColumn(projectId, 'in_progress'),
+    0
+  )
+  store.updateTicket(orphan.id, projectId, {
+    current_session_id: sessionId,
+    column: 'in_progress',
+    sort_order: sortOrder,
+    mode: sessionMode as 'build' | 'plan',
+    plan_ready: false
+  })
 })

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import type { SelectedModel } from './useSettingsStore'
 import { useWorktreeStore } from './useWorktreeStore'
-import { notifyKanbanSessionSync } from './store-coordination'
+import { notifyKanbanSessionSync, notifyKanbanNewSession } from './store-coordination'
 import { useSettingsStore } from './useSettingsStore'
 
 export const BOARD_TAB_ID = '__board__'
@@ -475,6 +475,14 @@ export const useSessionStore = create<SessionState>()(
 
             return base
           })
+
+          // Notify kanban store — auto-attaches pre-assigned tickets to this session.
+          // Wrapped in its own try-catch so a handler error can never break session creation.
+          try {
+            notifyKanbanNewSession(session.id, worktreeId, projectId, session.mode || 'build')
+          } catch {
+            // Non-critical — session was created successfully regardless
+          }
 
           return { success: true, session }
         } catch (error) {


### PR DESCRIPTION
## Summary

- **Worktree sync improvements**: Enhanced `syncWorktreesOp` and `renameWorktreeBranchOp` to auto-update display names when branches are renamed externally, healing stale auto-generated names (breed/city placeholders)
- **Smart session attachment**: When assigning a worktree to a ticket via the picker modal, auto-attach the most recent session if one exists, linking ticket tracking to session lifecycle
- **Orphaned ticket resolution**: New store coordination callback (`registerKanbanNewSession`) auto-attaches pre-assigned tickets with no active session when a new session is created in their worktree
- **Automatic progression**: When sessions activate, pre-assigned tickets in `todo` now move to `in_progress` (previously only `review` tickets moved), enabling full progress tracking with the progress bar
- **Session sync integration**: Kanban store properly sets `mode` field on auto-attached tickets, ensuring progress bar rendering and session completion advances the ticket

## Testing

- Verified branch rename scenarios update both `branch_name` and `name` fields correctly
- Checked that auto-generated names are detected via `isAutoNamedBranch()` pattern
- Confirmed worktree picker calls `syncWorktrees()` before modal closes to reflect current state
- Validated that ticket selection captures `activeSession` and passes `mode` to `updateTicket`
- Tested session creation triggers kanban callback with correct worktreeId/projectId/sessionMode
- Confirmed orphan ticket matching finds unassigned tickets in correct worktree
- Verified `session_working` event moves `todo` → `in_progress` for pre-assigned tickets
- Checked error handling in session creation callback prevents session creation failure
- Not run: Integration test across worktree sync → picker selection → session creation flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes coordination between `useSessionStore` and `useKanbanStore` and alters ticket state updates/movement logic, which could mis-link tickets to sessions or move tickets to the wrong column if edge cases aren’t covered.
> 
> **Overview**
> Improves worktree and kanban/session coordination so tickets stay linked to the correct session lifecycle.
> 
> On the backend, `syncWorktreesOp` and `renameWorktreeBranchOp` now always treat git as the source of truth for `branch_name` and will also *heal/update* the worktree display `name` when it’s still an auto-generated placeholder or unchanged from the old branch name.
> 
> In the UI, the worktree picker now refreshes worktrees from git when opened, and when pre-assigning an existing worktree it auto-attaches the most recent existing session (setting `current_session_id` and `mode`). A new store-coordination hook (`registerKanbanNewSession`/`notifyKanbanNewSession`) lets session creation auto-attach an “orphan” pre-assigned ticket and move it to `in_progress`, and `session_working` now moves tickets from `todo` as well as `review` into `in_progress`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed97e692407b3e1d455b91800e0436240f2d5b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->