### PR TITLE
Codex streaming: canonical message path with debounced persistence and renderer dedup

### DIFF
--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -933,16 +933,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         ? asString(asObject(notification.params)?.delta)
         : undefined
 
-    if (textDelta) {
-      log.info('CODEX_STREAM_RAW_DELTA', {
-        threadId: context.session.threadId,
-        turnId: route.turnId,
-        itemId: route.itemId,
-        len: textDelta.length,
-        preview: textDelta.slice(0, 120)
-      })
-    }
-
     this.emitEvent({
       id: randomUUID(),
       kind: 'notification',

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -933,6 +933,16 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         ? asString(asObject(notification.params)?.delta)
         : undefined
 
+    if (textDelta) {
+      log.info('CODEX_STREAM_RAW_DELTA', {
+        threadId: context.session.threadId,
+        turnId: route.turnId,
+        itemId: route.itemId,
+        len: textDelta.length,
+        preview: textDelta.slice(0, 120)
+      })
+    }
+
     this.emitEvent({
       id: randomUUID(),
       kind: 'notification',

--- a/src/main/services/codex-event-mapper.ts
+++ b/src/main/services/codex-event-mapper.ts
@@ -261,6 +261,9 @@ export function mapCodexEventToStreamEvents(
   event: CodexManagerEvent,
   hiveSessionId: string
 ): OpenCodeStreamEvent[] {
+  // Attach Codex event ID for renderer-side dedup (seenCodexEventIds in
+  // SessionView). Placed on stream event `data`; does NOT flow into canonical
+  // message parts — extraction functions pick specific fields only.
   const annotateData = <T extends Record<string, unknown>>(data: T): T & { _codexEventId: string } => ({
     ...data,
     _codexEventId: event.id

--- a/src/main/services/codex-event-mapper.ts
+++ b/src/main/services/codex-event-mapper.ts
@@ -261,6 +261,11 @@ export function mapCodexEventToStreamEvents(
   event: CodexManagerEvent,
   hiveSessionId: string
 ): OpenCodeStreamEvent[] {
+  const annotateData = <T extends Record<string, unknown>>(data: T): T & { _codexEventId: string } => ({
+    ...data,
+    _codexEventId: event.id
+  })
+
   const { method } = event
 
   // ── Content deltas — actual Codex notification methods ───────
@@ -273,10 +278,11 @@ export function mapCodexEventToStreamEvents(
       {
         type: 'message.part.updated',
         sessionId: hiveSessionId,
-        data:
+        data: annotateData(
           streamKind === 'reasoning' || streamKind === 'reasoning_summary'
             ? toReasoningPart(delta.text)
             : toTextPart(delta.text)
+        )
       }
     ]
   }
@@ -287,7 +293,7 @@ export function mapCodexEventToStreamEvents(
       {
         type: 'session.status',
         sessionId: hiveSessionId,
-        data: { status: { type: 'busy' } },
+        data: annotateData({ status: { type: 'busy' } }),
         statusPayload: { type: 'busy' }
       }
     ]
@@ -302,7 +308,7 @@ export function mapCodexEventToStreamEvents(
       events.push({
         type: 'session.error',
         sessionId: hiveSessionId,
-        data: { error: info.error ?? 'Turn failed' }
+        data: annotateData({ error: info.error ?? 'Turn failed' })
       })
     }
 
@@ -311,10 +317,10 @@ export function mapCodexEventToStreamEvents(
       events.push({
         type: 'message.updated',
         sessionId: hiveSessionId,
-        data: {
+        data: annotateData({
           ...(info.usage ? { usage: info.usage } : {}),
           ...(info.cost !== undefined ? { cost: info.cost } : {})
-        }
+        })
       })
     }
 
@@ -322,7 +328,7 @@ export function mapCodexEventToStreamEvents(
     events.push({
       type: 'session.status',
       sessionId: hiveSessionId,
-      data: { status: { type: 'idle' } },
+      data: annotateData({ status: { type: 'idle' } }),
       statusPayload: { type: 'idle' }
     })
 
@@ -338,7 +344,7 @@ export function mapCodexEventToStreamEvents(
       {
         type: 'message.part.updated',
         sessionId: hiveSessionId,
-        data: {
+        data: annotateData({
           part: {
             type: 'tool',
             callID: item.callId,
@@ -348,7 +354,7 @@ export function mapCodexEventToStreamEvents(
               ...(item.input !== undefined ? { input: item.input } : {})
             }
           }
-        }
+        })
       }
     ]
   }
@@ -362,7 +368,7 @@ export function mapCodexEventToStreamEvents(
       {
         type: 'message.part.updated',
         sessionId: hiveSessionId,
-        data: {
+        data: annotateData({
           part: {
             type: 'tool',
             callID: item.callId,
@@ -372,7 +378,7 @@ export function mapCodexEventToStreamEvents(
               ...(item.input !== undefined ? { input: item.input } : {})
             }
           }
-        }
+        })
       }
     ]
   }
@@ -386,7 +392,7 @@ export function mapCodexEventToStreamEvents(
       {
         type: 'message.part.updated',
         sessionId: hiveSessionId,
-        data: {
+        data: annotateData({
           part: {
             type: 'tool',
             callID: item.callId,
@@ -401,7 +407,7 @@ export function mapCodexEventToStreamEvents(
                 : {})
             }
           }
-        }
+        })
       }
     ]
   }

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -20,6 +20,7 @@ import { autoRenameWorktreeBranch } from './git-service'
 import { normalizeCodexToolName, stripShellPrefix } from '@shared/codex-tool-normalizer'
 
 const log = createLogger({ component: 'CodexImplementer' })
+const PERSIST_DEBOUNCE_MS = 2000
 
 // ── Session state ─────────────────────────────────────────────────
 
@@ -36,6 +37,7 @@ export interface CodexSessionState {
   revertDiff: string | null
   titleGenerated: boolean
   titleGenerationStarted: boolean
+  persistDebounceTimer: ReturnType<typeof setTimeout> | null
 }
 
 interface CodexLiveToolPart {
@@ -413,7 +415,8 @@ export class CodexImplementer implements AgentSdkImplementer {
       revertMessageID: null,
       revertDiff: null,
       titleGenerated: false,
-      titleGenerationStarted: false
+      titleGenerationStarted: false,
+      persistDebounceTimer: null
     }
     this.sessions.set(key, state)
 
@@ -1805,32 +1808,12 @@ export class CodexImplementer implements AgentSdkImplementer {
     const partType = asString(part.type)
     if (partType === 'text') {
       const delta = asString(data?.delta) ?? asString(part.text) ?? ''
-      if (delta) {
-        log.info('CODEX_STREAM_CANONICAL_TEXT_APPEND', {
-          hiveSessionId: session.hiveSessionId,
-          threadId: session.threadId,
-          turnId: event.turnId ?? session.currentTurnId,
-          currentAssistantMessageId: session.currentAssistantMessageId,
-          len: delta.length,
-          preview: delta.slice(0, 120)
-        })
-      }
       this.appendCanonicalAssistantText(session, 'text', delta, event.turnId ?? session.currentTurnId ?? undefined)
       return delta.length > 0
     }
 
     if (partType === 'reasoning') {
       const delta = asString(data?.delta) ?? asString(part.text) ?? ''
-      if (delta) {
-        log.info('CODEX_STREAM_CANONICAL_REASONING_APPEND', {
-          hiveSessionId: session.hiveSessionId,
-          threadId: session.threadId,
-          turnId: event.turnId ?? session.currentTurnId,
-          currentAssistantMessageId: session.currentAssistantMessageId,
-          len: delta.length,
-          preview: delta.slice(0, 120)
-        })
-      }
       this.appendCanonicalAssistantText(
         session,
         'reasoning',

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -20,6 +20,7 @@ import { autoRenameWorktreeBranch } from './git-service'
 import { normalizeCodexToolName, stripShellPrefix } from '@shared/codex-tool-normalizer'
 
 const log = createLogger({ component: 'CodexImplementer' })
+// Balances write coalescing during rapid streaming against data freshness for crash recovery.
 const PERSIST_DEBOUNCE_MS = 2000
 
 // ── Session state ─────────────────────────────────────────────────
@@ -524,6 +525,9 @@ export class CodexImplementer implements AgentSdkImplementer {
     // Stop the manager session
     this.manager.stopSession(agentSessionId)
 
+    // Flush any pending debounced persist before removing the session
+    this.flushPendingPersist(session)
+
     // Clean up local state
     this.sessions.delete(key)
     this.cleanupPendingForThread(agentSessionId)
@@ -536,6 +540,14 @@ export class CodexImplementer implements AgentSdkImplementer {
 
     // Stop all manager sessions
     this.manager.stopAll()
+
+    // Clear pending debounce timers (don't flush — avoid DB writes during teardown)
+    for (const session of this.sessions.values()) {
+      if (session.persistDebounceTimer) {
+        clearTimeout(session.persistDebounceTimer)
+        session.persistDebounceTimer = null
+      }
+    }
 
     // Clear local state
     this.sessions.clear()
@@ -855,6 +867,7 @@ export class CodexImplementer implements AgentSdkImplementer {
       })
       this.emitStatus(session.hiveSessionId, 'idle')
     } finally {
+      this.flushPendingPersist(session)
       session.currentTurnId = null
       session.currentAssistantMessageId = null
       this.manager.removeListener('event', handleEvent)

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -487,7 +487,8 @@ export class CodexImplementer implements AgentSdkImplementer {
         revertMessageID: null,
         revertDiff: null,
         titleGenerated: true,
-        titleGenerationStarted: true
+        titleGenerationStarted: true,
+        persistDebounceTimer: null
       }
       this.sessions.set(newKey, state)
 
@@ -623,6 +624,9 @@ export class CodexImplementer implements AgentSdkImplementer {
 
     // Set up event listener for streaming
     let interactionMode: 'default' | 'plan' = 'default'
+    // Fallback accumulators: only populated when canonical path is not active.
+    // Used for: (1) fallback message if canonical path fails, (2) plan extraction
+    // last resort, (3) logging. Stay empty when canonical path is active.
     let assistantText = ''
     let reasoningText = ''
     let pendingPlanText: string | null = null
@@ -646,24 +650,26 @@ export class CodexImplementer implements AgentSdkImplementer {
         this.sendToRenderer('opencode:stream', streamEvent)
         this.updateLiveAssistantDraftFromStreamEvent(session, streamEvent)
         if (this.synchronizeCanonicalAssistantFromStreamEvent(session, event, streamEvent)) {
-          this.persistCanonicalMessages(session)
+          this.persistCanonicalMessagesDebounced(session)
         }
       }
 
-      // Accumulate text for message history
-      const streamKind = contentStreamKindFromMethod(event.method)
-      if (streamKind) {
-        const payload = event.payload as Record<string, unknown> | undefined
-        const deltaText =
-          event.textDelta ??
-          asString(asObject(payload)?.delta) ??
-          asString(asObject(payload)?.text) ??
-          ''
+      // Accumulate text for message history (only when canonical path is not active)
+      if (!session.currentAssistantMessageId) {
+        const streamKind = contentStreamKindFromMethod(event.method)
+        if (streamKind) {
+          const payload = event.payload as Record<string, unknown> | undefined
+          const deltaText =
+            event.textDelta ??
+            asString(asObject(payload)?.delta) ??
+            asString(asObject(payload)?.text) ??
+            ''
 
-        if (streamKind === 'reasoning' || streamKind === 'reasoning_summary') {
-          reasoningText += deltaText
-        } else {
-          assistantText += deltaText
+          if (streamKind === 'reasoning' || streamKind === 'reasoning_summary') {
+            reasoningText += deltaText
+          } else {
+            assistantText += deltaText
+          }
         }
       }
 
@@ -738,6 +744,7 @@ export class CodexImplementer implements AgentSdkImplementer {
 
       // Persist the canonical streamed transcript first. This keeps reload
       // aligned with the exact structure that was rendered during streaming.
+      this.flushPendingPersist(session)
       if (session.currentAssistantMessageId) {
         this.persistCanonicalMessages(session)
         session.liveAssistantDraft = null
@@ -876,6 +883,7 @@ export class CodexImplementer implements AgentSdkImplementer {
     session.liveAssistantDraft = null
     session.currentTurnId = null
     session.currentAssistantMessageId = null
+    this.flushPendingPersist(session)
     this.persistCanonicalMessages(session)
     this.emitStatus(session.hiveSessionId, 'idle')
     return true
@@ -1538,6 +1546,22 @@ export class CodexImplementer implements AgentSdkImplementer {
     }
   }
 
+  private persistCanonicalMessagesDebounced(session: CodexSessionState): void {
+    if (session.persistDebounceTimer) clearTimeout(session.persistDebounceTimer)
+    session.persistDebounceTimer = setTimeout(() => {
+      session.persistDebounceTimer = null
+      this.persistCanonicalMessages(session)
+    }, PERSIST_DEBOUNCE_MS)
+  }
+
+  private flushPendingPersist(session: CodexSessionState): void {
+    if (session.persistDebounceTimer) {
+      clearTimeout(session.persistDebounceTimer)
+      session.persistDebounceTimer = null
+      this.persistCanonicalMessages(session)
+    }
+  }
+
   private persistCanonicalMessages(session: CodexSessionState): void {
     if (!this.dbService) return
 
@@ -2142,7 +2166,8 @@ export class CodexImplementer implements AgentSdkImplementer {
         revertMessageID: null,
         revertDiff: null,
         titleGenerated: true,
-        titleGenerationStarted: true
+        titleGenerationStarted: true,
+        persistDebounceTimer: null
       }
 
       this.sessions.set(this.getSessionKey(worktreePath, threadId), recovered)

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -1,4 +1,5 @@
 import type { BrowserWindow } from 'electron'
+import { randomUUID } from 'node:crypto'
 
 import type { AgentSdkCapabilities, AgentSdkImplementer, PromptOptions } from './agent-sdk-types'
 import { CODEX_CAPABILITIES } from './agent-sdk-types'
@@ -29,6 +30,8 @@ export interface CodexSessionState {
   status: 'connecting' | 'ready' | 'running' | 'error' | 'closed'
   messages: unknown[]
   liveAssistantDraft?: CodexLiveAssistantDraft | null
+  currentTurnId: string | null
+  currentAssistantMessageId: string | null
   revertMessageID: string | null
   revertDiff: string | null
   titleGenerated: boolean
@@ -153,6 +156,23 @@ function buildSnapshotToolInput(itemObj: Record<string, unknown>): Record<string
     ...(command ? { command } : {}),
     ...(changes ? { changes } : {})
   }
+}
+
+function extractMessageText(parts: unknown[]): string {
+  const segments: string[] = []
+
+  for (const part of parts) {
+    const partObj = asObject(part)
+    if (!partObj) continue
+
+    const type = asString(partObj.type)
+    if (type === 'text' || type === 'reasoning') {
+      const text = asString(partObj.text)
+      if (text) segments.push(text)
+    }
+  }
+
+  return segments.join('')
 }
 
 export class CodexImplementer implements AgentSdkImplementer {
@@ -388,6 +408,8 @@ export class CodexImplementer implements AgentSdkImplementer {
       status: this.mapProviderStatus(providerSession.status),
       messages: [],
       liveAssistantDraft: null,
+      currentTurnId: null,
+      currentAssistantMessageId: null,
       revertMessageID: null,
       revertDiff: null,
       titleGenerated: false,
@@ -457,6 +479,8 @@ export class CodexImplementer implements AgentSdkImplementer {
         status: this.mapProviderStatus(providerSession.status),
         messages: [],
         liveAssistantDraft: null,
+        currentTurnId: null,
+        currentAssistantMessageId: null,
         revertMessageID: null,
         revertDiff: null,
         titleGenerated: true,
@@ -573,12 +597,15 @@ export class CodexImplementer implements AgentSdkImplementer {
     // Inject synthetic user message so getMessages() returns it
     const syntheticTimestamp = new Date().toISOString()
     session.messages.push({
+      id: `user-${randomUUID()}`,
       role: 'user',
       parts: [{ type: 'text', text, timestamp: syntheticTimestamp }],
       timestamp: syntheticTimestamp
     })
     this.persistCanonicalMessages(session)
     this.resetLiveAssistantDraft(session)
+    session.currentTurnId = null
+    session.currentAssistantMessageId = null
 
     // Emit busy status
     session.status = 'running'
@@ -615,6 +642,9 @@ export class CodexImplementer implements AgentSdkImplementer {
         }
         this.sendToRenderer('opencode:stream', streamEvent)
         this.updateLiveAssistantDraftFromStreamEvent(session, streamEvent)
+        if (this.synchronizeCanonicalAssistantFromStreamEvent(session, event, streamEvent)) {
+          this.persistCanonicalMessages(session)
+        }
       }
 
       // Accumulate text for message history
@@ -703,20 +733,12 @@ export class CodexImplementer implements AgentSdkImplementer {
       // events stream asynchronously via the manager's event emitter)
       await this.waitForTurnCompletion(session, () => turnCompleted)
 
-      // Read canonical thread for properly separated messages
-      try {
-        const threadSnapshot = await this.manager.readThread(session.threadId)
-        const parsed = this.parseThreadSnapshot(threadSnapshot)
-        if (parsed.length > 0) {
-          session.messages = parsed
-        }
+      // Persist the canonical streamed transcript first. This keeps reload
+      // aligned with the exact structure that was rendered during streaming.
+      if (session.currentAssistantMessageId) {
         this.persistCanonicalMessages(session)
         session.liveAssistantDraft = null
-      } catch (readError) {
-        log.warn('prompt: readThread after turn failed, falling back to accumulated text', {
-          agentSessionId,
-          error: readError instanceof Error ? readError.message : String(readError)
-        })
+      } else {
         // Fallback: use accumulated text as single message
         const assistantParts: unknown[] = []
         if (assistantText) {
@@ -735,6 +757,7 @@ export class CodexImplementer implements AgentSdkImplementer {
         }
         if (assistantParts.length > 0) {
           session.messages.push({
+            id: `assistant-${completedTurnId ?? randomUUID()}`,
             role: 'assistant',
             parts: assistantParts,
             timestamp: new Date().toISOString()
@@ -822,6 +845,8 @@ export class CodexImplementer implements AgentSdkImplementer {
       })
       this.emitStatus(session.hiveSessionId, 'idle')
     } finally {
+      session.currentTurnId = null
+      session.currentAssistantMessageId = null
       this.manager.removeListener('event', handleEvent)
     }
   }
@@ -846,6 +871,9 @@ export class CodexImplementer implements AgentSdkImplementer {
 
     session.status = 'ready'
     session.liveAssistantDraft = null
+    session.currentTurnId = null
+    session.currentAssistantMessageId = null
+    this.persistCanonicalMessages(session)
     this.emitStatus(session.hiveSessionId, 'idle')
     return true
   }
@@ -865,9 +893,7 @@ export class CodexImplementer implements AgentSdkImplementer {
 
     // Return in-memory messages if available
     if (session.messages.length > 0) {
-      const liveDraftMessage =
-        session.status === 'running' ? this.cloneLiveAssistantDraftMessage(session) : null
-      return liveDraftMessage ? [...session.messages, liveDraftMessage] : [...session.messages]
+      return [...session.messages]
     }
 
     if (session.status === 'running') {
@@ -882,9 +908,10 @@ export class CodexImplementer implements AgentSdkImplementer {
         const persistedMessages = this.dbService.getSessionMessages(session.hiveSessionId)
         if (persistedMessages.length > 0) {
           const parsed = persistedMessages.flatMap((message) => {
-            if (!message.opencode_message_json) return []
+            const raw = message.opencode_message_json ?? message.opencode_timeline_json
+            if (!raw) return []
             try {
-              return [JSON.parse(message.opencode_message_json)]
+              return [JSON.parse(raw)]
             } catch {
               return []
             }
@@ -1521,20 +1548,24 @@ export class CodexImplementer implements AgentSdkImplementer {
         if (role !== 'user' && role !== 'assistant' && role !== 'system') return []
 
         const parts = Array.isArray(record.parts) ? record.parts : []
-        const textContent = parts
-          .map((part) => asObject(part))
-          .filter((part) => part?.type === 'text' || part?.type === 'reasoning')
-          .map((part) => asString(part?.text) ?? '')
-          .join('')
+        const textContent = extractMessageText(parts)
+        const canonicalMessage = {
+          ...record,
+          id: asString(record.id) ?? `${role}-${randomUUID()}`,
+          role,
+          parts,
+          timestamp
+        }
 
         return [
           {
             session_id: session.hiveSessionId,
             role,
             content: textContent,
-            opencode_message_id: asString(record.id) ?? null,
-            opencode_message_json: JSON.stringify(message),
+            opencode_message_id: canonicalMessage.id,
+            opencode_message_json: JSON.stringify(canonicalMessage),
             opencode_parts_json: JSON.stringify(parts),
+            opencode_timeline_json: JSON.stringify(canonicalMessage),
             created_at: timestamp
           }
         ]
@@ -1591,6 +1622,248 @@ export class CodexImplementer implements AgentSdkImplementer {
       this.resetLiveAssistantDraft(session)
     }
     return session.liveAssistantDraft!
+  }
+
+  private getAssistantMessageId(session: CodexSessionState, turnId?: string): string {
+    if (turnId) return `${turnId}:assistant`
+    if (session.currentAssistantMessageId) return session.currentAssistantMessageId
+    return `codex-live-${session.threadId}`
+  }
+
+  private getOrCreateCanonicalAssistantMessage(
+    session: CodexSessionState,
+    turnId?: string
+  ): Record<string, unknown> {
+    const messageId = this.getAssistantMessageId(session, turnId)
+    session.currentAssistantMessageId = messageId
+    if (turnId) session.currentTurnId = turnId
+
+    const existingIndex = session.messages.findIndex((message) => {
+      const record = asObject(message)
+      return asString(record?.id) === messageId
+    })
+
+    if (existingIndex >= 0) {
+      const existing = asObject(session.messages[existingIndex])
+      if (existing) {
+        if (typeof existing.timestamp !== 'string') {
+          existing.timestamp = new Date().toISOString()
+        }
+        return existing
+      }
+    }
+
+    const timestamp = new Date().toISOString()
+    const message: Record<string, unknown> = {
+      id: messageId,
+      role: 'assistant',
+      parts: [],
+      timestamp
+    }
+    session.messages.push(message)
+    return message
+  }
+
+  private renameCanonicalAssistantMessage(
+    session: CodexSessionState,
+    nextMessageId: string
+  ): Record<string, unknown> {
+    const currentId = session.currentAssistantMessageId
+    if (!currentId || currentId === nextMessageId) {
+      session.currentAssistantMessageId = nextMessageId
+      return this.getOrCreateCanonicalAssistantMessage(session, session.currentTurnId ?? undefined)
+    }
+
+    const existingIndex = session.messages.findIndex((message) => {
+      const record = asObject(message)
+      return asString(record?.id) === currentId
+    })
+
+    if (existingIndex >= 0) {
+      const record = asObject(session.messages[existingIndex])
+      if (record) {
+        record.id = nextMessageId
+        session.currentAssistantMessageId = nextMessageId
+        return record
+      }
+    }
+
+    session.currentAssistantMessageId = nextMessageId
+    return this.getOrCreateCanonicalAssistantMessage(session, session.currentTurnId ?? undefined)
+  }
+
+  private appendCanonicalAssistantText(
+    session: CodexSessionState,
+    kind: 'text' | 'reasoning',
+    text: string,
+    turnId?: string
+  ): void {
+    if (!text) return
+
+    const message = this.getOrCreateCanonicalAssistantMessage(session, turnId)
+    const parts = Array.isArray(message.parts) ? (message.parts as Array<Record<string, unknown>>) : []
+    const lastPart = parts[parts.length - 1]
+    const timestamp = new Date().toISOString()
+
+    if (lastPart && asString(lastPart.type) === kind) {
+      lastPart.text = `${asString(lastPart.text) ?? ''}${text}`
+    } else {
+      parts.push({ type: kind, text, timestamp })
+    }
+
+    message.parts = parts
+    message.timestamp = asString(message.timestamp) ?? timestamp
+  }
+
+  private upsertCanonicalAssistantTool(
+    session: CodexSessionState,
+    tool: {
+      callID: string
+      tool: string
+      state: {
+        status: 'running' | 'completed' | 'error'
+        input?: unknown
+        output?: unknown
+        error?: unknown
+      }
+    },
+    turnId?: string
+  ): void {
+    if (!tool.callID) return
+
+    const message = this.getOrCreateCanonicalAssistantMessage(session, turnId)
+    const parts = Array.isArray(message.parts) ? (message.parts as Array<Record<string, unknown>>) : []
+    const existingIndex = parts.findIndex((part) => {
+      const partObj = asObject(part)
+      const toolUse = asObject(partObj?.toolUse)
+      return asString(partObj?.type) === 'tool_use' && asString(toolUse?.id) === tool.callID
+    })
+
+    const nextToolUse = {
+      id: tool.callID,
+      name: tool.tool || 'unknown',
+      input:
+        tool.state.input && typeof tool.state.input === 'object' && !Array.isArray(tool.state.input)
+          ? (tool.state.input as Record<string, unknown>)
+          : {},
+      status:
+        tool.state.status === 'completed'
+          ? 'success'
+          : tool.state.status === 'error'
+            ? 'error'
+            : 'running',
+      startTime: Date.now(),
+      ...(tool.state.output !== undefined ? { output: tool.state.output } : {}),
+      ...(tool.state.error !== undefined ? { error: tool.state.error } : {}),
+      ...(tool.state.status !== 'running' ? { endTime: Date.now() } : {})
+    }
+
+    if (existingIndex >= 0) {
+      const existingToolUse = asObject(asObject(parts[existingIndex])?.toolUse)
+      parts[existingIndex] = {
+        type: 'tool_use',
+        toolUse: {
+          ...(existingToolUse ?? {}),
+          ...nextToolUse,
+          startTime:
+            typeof existingToolUse?.startTime === 'number'
+              ? existingToolUse.startTime
+              : nextToolUse.startTime
+        }
+      }
+    } else {
+      parts.push({ type: 'tool_use', toolUse: nextToolUse })
+    }
+
+    message.parts = parts
+  }
+
+  private synchronizeCanonicalAssistantFromStreamEvent(
+    session: CodexSessionState,
+    event: CodexManagerEvent,
+    streamEvent: { type?: string; data?: unknown }
+  ): boolean {
+    if (event.method === 'turn/started' && event.turnId) {
+      const previousId = session.currentAssistantMessageId
+      session.currentTurnId = event.turnId
+      if (!previousId) {
+        session.currentAssistantMessageId = `${event.turnId}:assistant`
+        return false
+      }
+
+      const nextId = this.getAssistantMessageId(session, event.turnId)
+      this.renameCanonicalAssistantMessage(session, nextId)
+      return previousId !== nextId
+    }
+
+    if (streamEvent.type !== 'message.part.updated') return false
+
+    const data = asObject(streamEvent.data)
+    const part = asObject(data?.part)
+    if (!part) return false
+
+    const partType = asString(part.type)
+    if (partType === 'text') {
+      const delta = asString(data?.delta) ?? asString(part.text) ?? ''
+      if (delta) {
+        log.info('CODEX_STREAM_CANONICAL_TEXT_APPEND', {
+          hiveSessionId: session.hiveSessionId,
+          threadId: session.threadId,
+          turnId: event.turnId ?? session.currentTurnId,
+          currentAssistantMessageId: session.currentAssistantMessageId,
+          len: delta.length,
+          preview: delta.slice(0, 120)
+        })
+      }
+      this.appendCanonicalAssistantText(session, 'text', delta, event.turnId ?? session.currentTurnId ?? undefined)
+      return delta.length > 0
+    }
+
+    if (partType === 'reasoning') {
+      const delta = asString(data?.delta) ?? asString(part.text) ?? ''
+      if (delta) {
+        log.info('CODEX_STREAM_CANONICAL_REASONING_APPEND', {
+          hiveSessionId: session.hiveSessionId,
+          threadId: session.threadId,
+          turnId: event.turnId ?? session.currentTurnId,
+          currentAssistantMessageId: session.currentAssistantMessageId,
+          len: delta.length,
+          preview: delta.slice(0, 120)
+        })
+      }
+      this.appendCanonicalAssistantText(
+        session,
+        'reasoning',
+        delta,
+        event.turnId ?? session.currentTurnId ?? undefined
+      )
+      return delta.length > 0
+    }
+
+    if (partType === 'tool') {
+      const state = asObject(part.state)
+      const statusValue = asString(state?.status)
+      const status =
+        statusValue === 'completed' || statusValue === 'error' ? statusValue : 'running'
+
+      this.upsertCanonicalAssistantTool(
+        session,
+        {
+          callID: asString(part.callID) ?? asString(part.id) ?? '',
+          tool: asString(part.tool) ?? 'unknown',
+          state: {
+            status,
+            ...(state?.input !== undefined ? { input: state.input } : {}),
+            ...(state?.output !== undefined ? { output: state.output } : {}),
+            ...(state?.error !== undefined ? { error: state.error } : {})
+          }
+        },
+        event.turnId ?? session.currentTurnId ?? undefined
+      )
+      return true
+    }
+
+    return false
   }
 
   private appendLiveAssistantText(
@@ -1881,6 +2154,8 @@ export class CodexImplementer implements AgentSdkImplementer {
         status: this.mapProviderStatus(providerSession.status),
         messages: [],
         liveAssistantDraft: null,
+        currentTurnId: null,
+        currentAssistantMessageId: null,
         revertMessageID: null,
         revertDiff: null,
         titleGenerated: true,

--- a/src/renderer/src/components/sessions/AssistantCanvas.tsx
+++ b/src/renderer/src/components/sessions/AssistantCanvas.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 import { ToolCard } from './ToolCard'
 import { StreamingCursor } from './StreamingCursor'
 import { MarkdownRenderer } from './MarkdownRenderer'
@@ -65,12 +65,11 @@ function normalizeRenderableParts(parts: StreamingPart[]): StreamingPart[] {
 
 /** Render interleaved parts (text + tool cards) */
 function renderParts(
-  parts: StreamingPart[],
+  normalizedParts: StreamingPart[],
   isStreaming: boolean,
   cwd?: string | null,
   forceCompactTools = false
 ): React.JSX.Element {
-  const normalizedParts = normalizeRenderableParts(parts)
   const renderedParts: React.JSX.Element[] = []
   let index = 0
 
@@ -178,6 +177,10 @@ export const AssistantCanvas = memo(function AssistantCanvas({
   cwd
 }: AssistantCanvasProps): React.JSX.Element {
   const hasParts = parts && parts.length > 0
+  const normalizedParts = useMemo(
+    () => (hasParts ? normalizeRenderableParts(parts!) : undefined),
+    [hasParts, parts]
+  )
   const shouldUseCompactToolSpacing = hasToolParts(parts)
 
   return (
@@ -187,7 +190,7 @@ export const AssistantCanvas = memo(function AssistantCanvas({
     >
       <div className="text-sm text-foreground leading-relaxed">
         {hasParts ? (
-          renderParts(parts, isStreaming, cwd, shouldUseCompactToolSpacing)
+          renderParts(normalizedParts!, isStreaming, cwd, shouldUseCompactToolSpacing)
         ) : (
           <>
             <MarkdownRenderer content={content} />

--- a/src/renderer/src/components/sessions/AssistantCanvas.tsx
+++ b/src/renderer/src/components/sessions/AssistantCanvas.tsx
@@ -88,10 +88,10 @@ function renderParts(
         continue
       }
       renderedParts.push(
-        <span key={`part-${index}`}>
+        <div key={`part-${index}`}>
           <MarkdownRenderer content={text} />
           {isStreaming && isLastPart && <StreamingCursor />}
-        </span>
+        </div>
       )
       index += 1
       continue
@@ -182,10 +182,10 @@ export const AssistantCanvas = memo(function AssistantCanvas({
 
   return (
     <div
-      className={cn('px-6', shouldUseCompactToolSpacing ? 'py-1' : 'py-5')}
+      className={cn('px-6', shouldUseCompactToolSpacing ? 'py-3' : 'py-5')}
       data-testid="message-assistant"
     >
-      <div className="text-sm text-foreground leading-relaxed">
+      <div className="text-sm text-foreground leading-relaxed space-y-2">
         {hasParts ? (
           renderParts(parts, isStreaming, cwd, shouldUseCompactToolSpacing)
         ) : (

--- a/src/renderer/src/components/sessions/AssistantCanvas.tsx
+++ b/src/renderer/src/components/sessions/AssistantCanvas.tsx
@@ -35,6 +35,34 @@ function hasToolParts(parts: StreamingPart[] | undefined): boolean {
   return false
 }
 
+function normalizeRenderableParts(parts: StreamingPart[]): StreamingPart[] {
+  const normalized: StreamingPart[] = []
+
+  for (const part of parts) {
+    const previous = normalized[normalized.length - 1]
+
+    if (part.type === 'text' && previous?.type === 'text') {
+      normalized[normalized.length - 1] = {
+        ...previous,
+        text: `${previous.text ?? ''}${part.text ?? ''}`
+      }
+      continue
+    }
+
+    if (part.type === 'reasoning' && previous?.type === 'reasoning') {
+      normalized[normalized.length - 1] = {
+        ...previous,
+        reasoning: `${previous.reasoning ?? ''}${part.reasoning ?? ''}`
+      }
+      continue
+    }
+
+    normalized.push(part)
+  }
+
+  return normalized
+}
+
 /** Render interleaved parts (text + tool cards) */
 function renderParts(
   parts: StreamingPart[],
@@ -42,15 +70,16 @@ function renderParts(
   cwd?: string | null,
   forceCompactTools = false
 ): React.JSX.Element {
+  const normalizedParts = normalizeRenderableParts(parts)
   const renderedParts: React.JSX.Element[] = []
   let index = 0
 
-  while (index < parts.length) {
-    const part = parts[index]
+  while (index < normalizedParts.length) {
+    const part = normalizedParts[index]
 
     if (part.type === 'text') {
       const text = part.text ?? ''
-      const isLastPart = index === parts.length - 1
+      const isLastPart = index === normalizedParts.length - 1
       if (!hasMeaningfulText(text)) {
         if (isStreaming && isLastPart) {
           renderedParts.push(<StreamingCursor key={`cursor-${index}`} />)
@@ -92,7 +121,7 @@ function renderParts(
     if (part.type === 'reasoning' && part.reasoning) {
       // Reasoning is still streaming only if the overall message is streaming
       // AND there are no meaningful parts after this one (text with content, tool_use, etc.)
-      const hasContentAfter = parts.slice(index + 1).some((p) => {
+      const hasContentAfter = normalizedParts.slice(index + 1).some((p) => {
         if (p.type === 'tool_use') return true
         if (p.type === 'text' && hasMeaningfulText(p.text)) return true
         if (p.type === 'reasoning') return true
@@ -132,9 +161,11 @@ function renderParts(
     <>
       {renderedParts}
       {/* Show streaming cursor at end if last part is a tool (text will come after) */}
-      {isStreaming && parts.length > 0 && parts[parts.length - 1].type === 'tool_use' && (
-        <StreamingCursor />
-      )}
+      {isStreaming &&
+        normalizedParts.length > 0 &&
+        normalizedParts[normalizedParts.length - 1].type === 'tool_use' && (
+          <StreamingCursor />
+        )}
     </>
   )
 }

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -731,8 +731,6 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const codexRefreshRafRef = useRef<number | null>(null)
   const codexRefreshInFlightRef = useRef(false)
   const codexRefreshPendingRef = useRef(false)
-  const isStreamingRef = useRef(isStreaming)
-  useEffect(() => { isStreamingRef.current = isStreaming }, [isStreaming])
   const codexStreamingMessageIdRef = useRef<string | null>(null)
   const seenCodexEventIdsRef = useRef<Set<string>>(new Set())
   const seenCodexEventIdsQueueRef = useRef<string[]>([])

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -505,8 +505,6 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     sessionCapabilitiesRef.current = sessionCapabilities
   }, [sessionCapabilities])
 
-  useEffect(() => { isStreamingRef.current = isStreaming }, [isStreaming])
-
   const allSlashCommands = useMemo(() => {
     const seen = new Set<string>()
     const ordered = [...BUILT_IN_SLASH_COMMANDS, ...slashCommands]
@@ -732,6 +730,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const codexRefreshInFlightRef = useRef(false)
   const codexRefreshPendingRef = useRef(false)
   const isStreamingRef = useRef(isStreaming)
+  useEffect(() => { isStreamingRef.current = isStreaming }, [isStreaming])
   const codexStreamingMessageIdRef = useRef<string | null>(null)
   const seenCodexEventIdsRef = useRef<Set<string>>(new Set())
   const seenCodexEventIdsQueueRef = useRef<string[]>([])
@@ -3306,7 +3305,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           opencodeSessionId
         )
         if (transcriptResult.success) {
-          const isIdle = !isStreaming
+          const isIdle = !isStreamingRef.current
           const liveMessages = mergeCodexActivityMessages(
             mapOpencodeMessagesToSessionViewMessages(
               Array.isArray(transcriptResult.messages) ? transcriptResult.messages : []
@@ -3338,7 +3337,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     )
     setMessages(loadedMessages)
     return true
-  }, [isStreaming, opencodeSessionId, sessionId, sessionRecord?.agent_sdk, worktreePath])
+  }, [opencodeSessionId, sessionId, sessionRecord?.agent_sdk, worktreePath])
 
   const refreshCodexStreamingMessages = useCallback(async (): Promise<void> => {
     if (sessionRecord?.agent_sdk !== 'codex') return

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -1604,11 +1604,6 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
             if (codexEventId) {
               if (seenCodexEventIdsRef.current.includes(codexEventId)) {
-                console.debug('[CODEX_STREAM_DUPLICATE_EVENT_DROPPED]', {
-                  sessionId,
-                  codexEventId,
-                  eventType: event.type
-                })
                 return
               }
 
@@ -3353,13 +3348,6 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       durableState.activities,
       !isStreaming
     )
-    const lastAssistant = [...liveMessages].reverse().find((message) => message.role === 'assistant')
-    console.debug('[CODEX_STREAM_RENDER_REFRESH]', {
-      sessionId,
-      messageCount: liveMessages.length,
-      lastAssistantId: lastAssistant?.id,
-      lastAssistantPreview: lastAssistant?.content.slice(0, 120)
-    })
     setMessages(liveMessages)
   }, [isStreaming, opencodeSessionId, sessionId, sessionRecord?.agent_sdk, worktreePath])
 
@@ -3391,29 +3379,6 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
   const applyCodexStreamingPart = useCallback(
     (part: StreamingPart) => {
-      if (part.type === 'text' && part.text) {
-        console.debug('[CODEX_STREAM_RENDER_APPLY_TEXT]', {
-          sessionId,
-          len: part.text.length,
-          preview: part.text.slice(0, 120)
-        })
-      }
-      if (part.type === 'reasoning' && part.reasoning) {
-        console.debug('[CODEX_STREAM_RENDER_APPLY_REASONING]', {
-          sessionId,
-          len: part.reasoning.length,
-          preview: part.reasoning.slice(0, 120)
-        })
-      }
-      if (part.type === 'tool_use' && part.toolUse) {
-        console.debug('[CODEX_STREAM_RENDER_APPLY_TOOL]', {
-          sessionId,
-          toolId: part.toolUse.id,
-          name: part.toolUse.name,
-          status: part.toolUse.status
-        })
-      }
-
       setMessages((currentMessages) => {
         const messageId =
           codexStreamingMessageIdRef.current ?? `codex-streaming-${crypto.randomUUID()}`
@@ -3515,7 +3480,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         return [...nextMessages, nextMessage]
       })
     },
-    [sessionId, setMessages]
+    [setMessages]
   )
 
   const handleForkFromAssistantMessage = useCallback(

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -726,6 +726,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const finalizedMessageIdsRef = useRef<Set<string>>(new Set())
   const hasFinalizedCurrentResponseRef = useRef(false)
   const sessionModelHydratedRef = useRef(false)
+  const codexRefreshRafRef = useRef<number | null>(null)
+  const codexRefreshInFlightRef = useRef(false)
+  const codexRefreshPendingRef = useRef(false)
+  const codexStreamingMessageIdRef = useRef<string | null>(null)
+  const seenCodexEventIdsRef = useRef<string[]>([])
 
   // Guard: tracks whether a new prompt was sent during the current streaming cycle.
   // When true, finalizeResponse skips the full reload to avoid
@@ -1053,6 +1058,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     return () => {
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current)
+      }
+      if (codexRefreshRafRef.current !== null) {
+        cancelAnimationFrame(codexRefreshRafRef.current)
       }
       if (programmaticScrollResetRef.current !== null) {
         cancelAnimationFrame(programmaticScrollResetRef.current)
@@ -1549,6 +1557,14 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     streamingPartsRef.current = []
     streamingContentRef.current = ''
     childToSubtaskIndexRef.current = new Map()
+    codexStreamingMessageIdRef.current = null
+    seenCodexEventIdsRef.current = []
+    codexRefreshPendingRef.current = false
+    codexRefreshInFlightRef.current = false
+    if (codexRefreshRafRef.current !== null) {
+      cancelAnimationFrame(codexRefreshRafRef.current)
+      codexRefreshRafRef.current = null
+    }
     setStreamingParts([])
     setStreamingContent('')
     hasFinalizedCurrentResponseRef.current = false
@@ -1576,6 +1592,32 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           // Guard: generation check — prevents stale closures from processing
           // events when the user has already switched to a different session.
           if (streamGenerationRef.current !== currentGeneration) return
+
+          if (sessionRecord?.agent_sdk === 'codex') {
+            const codexEventId =
+              event.data &&
+              typeof event.data === 'object' &&
+              !Array.isArray(event.data) &&
+              typeof (event.data as Record<string, unknown>)._codexEventId === 'string'
+                ? ((event.data as Record<string, unknown>)._codexEventId as string)
+                : null
+
+            if (codexEventId) {
+              if (seenCodexEventIdsRef.current.includes(codexEventId)) {
+                console.debug('[CODEX_STREAM_DUPLICATE_EVENT_DROPPED]', {
+                  sessionId,
+                  codexEventId,
+                  eventType: event.type
+                })
+                return
+              }
+
+              seenCodexEventIdsRef.current.push(codexEventId)
+              if (seenCodexEventIdsRef.current.length > 500) {
+                seenCodexEventIdsRef.current = seenCodexEventIdsRef.current.slice(-250)
+              }
+            }
+          }
 
           // Log event if response logging is active
           if (isLogModeRef.current && logFilePathRef.current) {
@@ -1865,6 +1907,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                 planContent: planText,
                 toolUseID: data.toolUseID ?? ''
               })
+              if (sessionRecord?.agent_sdk === 'codex') {
+                scheduleCodexStreamingRefresh()
+              }
               setIsStreaming(false)
               setIsSending(false)
               setQueuedMessages([])
@@ -1875,6 +1920,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
           if (event.type === 'plan.resolved') {
             useSessionStore.getState().clearPendingPlan(sessionId)
+            if (sessionRecord?.agent_sdk === 'codex') {
+              scheduleCodexStreamingRefresh()
+            }
             return
           }
 
@@ -2011,6 +2059,44 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
               }
               // First non-matching text means assistant response has started
               lastSentPromptRef.current = null
+            }
+
+            if (sessionRecord?.agent_sdk === 'codex') {
+              if (part.type === 'text') {
+                const delta = event.data?.delta || part.text || ''
+                if (delta) {
+                  applyCodexStreamingPart({ type: 'text', text: delta })
+                }
+              } else if (part.type === 'reasoning') {
+                const delta = event.data?.delta || part.text || ''
+                if (delta) {
+                  applyCodexStreamingPart({ type: 'reasoning', reasoning: delta })
+                }
+              } else if (part.type === 'tool') {
+                const state = part.state || {}
+                const statusMap: Record<string, ToolStatus> = {
+                  pending: 'pending',
+                  running: 'running',
+                  completed: 'success',
+                  error: 'error'
+                }
+                applyCodexStreamingPart({
+                  type: 'tool_use',
+                  toolUse: {
+                    id: part.callID || part.id || `tool-${Date.now()}`,
+                    name: part.tool || 'Unknown',
+                    input: state.input || {},
+                    status: statusMap[state.status] || 'running',
+                    startTime: state.time?.start || Date.now(),
+                    endTime: state.time?.end,
+                    output: state.status === 'completed' ? state.output : undefined,
+                    error: state.status === 'error' ? state.error : undefined
+                  }
+                })
+              }
+
+              setIsStreaming(true)
+              return
             }
 
             // New stream content means we're processing a new assistant response.
@@ -2387,6 +2473,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
               setSessionErrorStderr(null)
               setIsCompacting(false)
               setIsStreaming(true)
+              codexStreamingMessageIdRef.current = null
               hasFinalizedCurrentResponseRef.current = false
               newPromptPendingRef.current = false
               planXmlDetectionRef.current = { state: 'scanning', buffer: '', cardId: null }
@@ -3249,7 +3336,187 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     )
     setMessages(loadedMessages)
     return true
-  }, [opencodeSessionId, sessionId, sessionRecord?.agent_sdk, worktreePath])
+  }, [isStreaming, opencodeSessionId, sessionId, sessionRecord?.agent_sdk, worktreePath])
+
+  const refreshCodexStreamingMessages = useCallback(async (): Promise<void> => {
+    if (sessionRecord?.agent_sdk !== 'codex') return
+    if (!worktreePath || !opencodeSessionId) return
+
+    const durableState = await loadCodexDurableState(sessionId)
+    const transcriptResult = await window.opencodeOps.getMessages(worktreePath, opencodeSessionId)
+    if (!transcriptResult.success) return
+
+    const liveMessages = mergeCodexActivityMessages(
+      mapOpencodeMessagesToSessionViewMessages(
+        Array.isArray(transcriptResult.messages) ? transcriptResult.messages : []
+      ),
+      durableState.activities,
+      !isStreaming
+    )
+    const lastAssistant = [...liveMessages].reverse().find((message) => message.role === 'assistant')
+    console.debug('[CODEX_STREAM_RENDER_REFRESH]', {
+      sessionId,
+      messageCount: liveMessages.length,
+      lastAssistantId: lastAssistant?.id,
+      lastAssistantPreview: lastAssistant?.content.slice(0, 120)
+    })
+    setMessages(liveMessages)
+  }, [isStreaming, opencodeSessionId, sessionId, sessionRecord?.agent_sdk, worktreePath])
+
+  const scheduleCodexStreamingRefresh = useCallback(() => {
+    if (sessionRecord?.agent_sdk !== 'codex') return
+    if (codexRefreshRafRef.current !== null) return
+
+    codexRefreshRafRef.current = requestAnimationFrame(() => {
+      codexRefreshRafRef.current = null
+      if (codexRefreshInFlightRef.current) {
+        codexRefreshPendingRef.current = true
+        return
+      }
+
+      codexRefreshInFlightRef.current = true
+      refreshCodexStreamingMessages()
+        .catch(() => {
+          // Best effort; finalization path still does a full refresh.
+        })
+        .finally(() => {
+          codexRefreshInFlightRef.current = false
+          if (codexRefreshPendingRef.current) {
+            codexRefreshPendingRef.current = false
+            scheduleCodexStreamingRefresh()
+          }
+        })
+    })
+  }, [refreshCodexStreamingMessages, sessionRecord?.agent_sdk])
+
+  const applyCodexStreamingPart = useCallback(
+    (part: StreamingPart) => {
+      if (part.type === 'text' && part.text) {
+        console.debug('[CODEX_STREAM_RENDER_APPLY_TEXT]', {
+          sessionId,
+          len: part.text.length,
+          preview: part.text.slice(0, 120)
+        })
+      }
+      if (part.type === 'reasoning' && part.reasoning) {
+        console.debug('[CODEX_STREAM_RENDER_APPLY_REASONING]', {
+          sessionId,
+          len: part.reasoning.length,
+          preview: part.reasoning.slice(0, 120)
+        })
+      }
+      if (part.type === 'tool_use' && part.toolUse) {
+        console.debug('[CODEX_STREAM_RENDER_APPLY_TOOL]', {
+          sessionId,
+          toolId: part.toolUse.id,
+          name: part.toolUse.name,
+          status: part.toolUse.status
+        })
+      }
+
+      setMessages((currentMessages) => {
+        const messageId =
+          codexStreamingMessageIdRef.current ?? `codex-streaming-${crypto.randomUUID()}`
+        codexStreamingMessageIdRef.current = messageId
+
+        const existingIndex = currentMessages.findIndex((message) => message.id === messageId)
+        const nextMessages = [...currentMessages]
+        const existingMessage =
+          existingIndex >= 0
+            ? {
+                ...nextMessages[existingIndex],
+                parts: nextMessages[existingIndex].parts
+                  ? nextMessages[existingIndex].parts!.map((existingPart) => {
+                      if (existingPart.type === 'tool_use' && existingPart.toolUse) {
+                        return {
+                          ...existingPart,
+                          toolUse: { ...existingPart.toolUse }
+                        }
+                      }
+                      if (existingPart.type === 'subtask' && existingPart.subtask) {
+                        return {
+                          ...existingPart,
+                          subtask: {
+                            ...existingPart.subtask,
+                            parts: [...existingPart.subtask.parts]
+                          }
+                        }
+                      }
+                      return { ...existingPart }
+                    })
+                  : ([] as StreamingPart[])
+              }
+            : {
+                id: messageId,
+                role: 'assistant' as const,
+                content: '',
+                timestamp: new Date().toISOString(),
+                parts: [] as StreamingPart[]
+              }
+
+        const nextParts = [...(existingMessage.parts ?? [])]
+
+        if (part.type === 'text') {
+          const lastPart = nextParts[nextParts.length - 1]
+          if (lastPart?.type === 'text') {
+            nextParts[nextParts.length - 1] = {
+              ...lastPart,
+              text: `${lastPart.text ?? ''}${part.text ?? ''}`
+            }
+          } else {
+            nextParts.push({ type: 'text', text: part.text ?? '' })
+          }
+        } else if (part.type === 'reasoning') {
+          const lastPart = nextParts[nextParts.length - 1]
+          if (lastPart?.type === 'reasoning') {
+            nextParts[nextParts.length - 1] = {
+              ...lastPart,
+              reasoning: `${lastPart.reasoning ?? ''}${part.reasoning ?? ''}`
+            }
+          } else {
+            nextParts.push({ type: 'reasoning', reasoning: part.reasoning ?? '' })
+          }
+        } else if (part.type === 'tool_use' && part.toolUse) {
+          const existingToolIndex = nextParts.findIndex(
+            (candidate) =>
+              candidate.type === 'tool_use' && candidate.toolUse?.id === part.toolUse?.id
+          )
+          if (existingToolIndex >= 0) {
+            nextParts[existingToolIndex] = {
+              type: 'tool_use',
+              toolUse: {
+                ...nextParts[existingToolIndex].toolUse!,
+                ...part.toolUse
+              }
+            }
+          } else {
+            nextParts.push(part)
+          }
+        } else {
+          nextParts.push(part)
+        }
+
+        const nextContent = nextParts
+          .filter((candidate) => candidate.type === 'text')
+          .map((candidate) => candidate.text ?? '')
+          .join('')
+
+        const nextMessage: OpenCodeMessage = {
+          ...existingMessage,
+          content: nextContent,
+          parts: nextParts
+        }
+
+        if (existingIndex >= 0) {
+          nextMessages[existingIndex] = nextMessage
+          return nextMessages
+        }
+
+        return [...nextMessages, nextMessage]
+      })
+    },
+    [sessionId, setMessages]
+  )
 
   const handleForkFromAssistantMessage = useCallback(
     async (message: OpenCodeMessage) => {
@@ -3924,6 +4191,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     worktreePath,
     pendingPlan,
     isClaudeCode,
+    sessionRecord?.agent_sdk,
     updateStreamingPartsRef,
     immediateFlush
   ])
@@ -4678,10 +4946,17 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   }, [sessionId, messages, sessionRecord?.agent_sdk])
 
   // Determine if there's streaming content to show
-  const hasStreamingContent = streamingParts.length > 0 || streamingContent.length > 0
+  const hasStreamingContent =
+    sessionRecord?.agent_sdk === 'codex'
+      ? false
+      : streamingParts.length > 0 || streamingContent.length > 0
 
   const streamingStartTimeRef = useRef<string>('')
   const streamingMessage = useMemo(() => {
+    if (sessionRecord?.agent_sdk === 'codex') {
+      streamingStartTimeRef.current = ''
+      return null
+    }
     if (!hasStreamingContent) {
       streamingStartTimeRef.current = ''
       return null
@@ -4696,7 +4971,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       timestamp: streamingStartTimeRef.current,
       parts: streamingParts
     }
-  }, [hasStreamingContent, streamingContent, streamingParts])
+  }, [hasStreamingContent, sessionRecord?.agent_sdk, streamingContent, streamingParts])
 
   const handleRedoRevert = useCallback(() => {
     setInputValue('/redo')
@@ -4708,12 +4983,21 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   // Parts like reasoning, step_start, step_finish, compaction don't show it.
   // When those are the only parts, we still need the 3-dot loading indicator.
   const hasVisibleWritingCursor =
-    hasStreamingContent &&
-    isStreaming &&
-    (streamingContent.length > 0 ||
-      (streamingParts.length > 0 &&
-        (streamingParts[streamingParts.length - 1].type === 'text' ||
-          streamingParts[streamingParts.length - 1].type === 'tool_use')))
+    sessionRecord?.agent_sdk === 'codex'
+      ? isStreaming &&
+        (() => {
+          const lastAssistant = [...visibleMessages].reverse().find((message) => message.role === 'assistant')
+          if (!lastAssistant) return false
+          const lastPart = lastAssistant.parts?.[lastAssistant.parts.length - 1]
+          if (lastPart?.type === 'tool_use') return true
+          return Boolean(lastAssistant.content.trim())
+        })()
+      : hasStreamingContent &&
+        isStreaming &&
+        (streamingContent.length > 0 ||
+          (streamingParts.length > 0 &&
+            (streamingParts[streamingParts.length - 1].type === 'text' ||
+              streamingParts[streamingParts.length - 1].type === 'tool_use')))
 
   const codexPlanCandidate = useMemo(() => {
     const pendingPlanText = pendingPlan?.planContent?.trim()

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -505,6 +505,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     sessionCapabilitiesRef.current = sessionCapabilities
   }, [sessionCapabilities])
 
+  useEffect(() => { isStreamingRef.current = isStreaming }, [isStreaming])
+
   const allSlashCommands = useMemo(() => {
     const seen = new Set<string>()
     const ordered = [...BUILT_IN_SLASH_COMMANDS, ...slashCommands]
@@ -729,8 +731,10 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const codexRefreshRafRef = useRef<number | null>(null)
   const codexRefreshInFlightRef = useRef(false)
   const codexRefreshPendingRef = useRef(false)
+  const isStreamingRef = useRef(isStreaming)
   const codexStreamingMessageIdRef = useRef<string | null>(null)
-  const seenCodexEventIdsRef = useRef<string[]>([])
+  const seenCodexEventIdsRef = useRef<Set<string>>(new Set())
+  const seenCodexEventIdsQueueRef = useRef<string[]>([])
 
   // Guard: tracks whether a new prompt was sent during the current streaming cycle.
   // When true, finalizeResponse skips the full reload to avoid
@@ -1558,7 +1562,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     streamingContentRef.current = ''
     childToSubtaskIndexRef.current = new Map()
     codexStreamingMessageIdRef.current = null
-    seenCodexEventIdsRef.current = []
+    seenCodexEventIdsRef.current = new Set()
+    seenCodexEventIdsQueueRef.current = []
     codexRefreshPendingRef.current = false
     codexRefreshInFlightRef.current = false
     if (codexRefreshRafRef.current !== null) {
@@ -1603,13 +1608,15 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                 : null
 
             if (codexEventId) {
-              if (seenCodexEventIdsRef.current.includes(codexEventId)) {
+              if (seenCodexEventIdsRef.current.has(codexEventId)) {
                 return
               }
-
-              seenCodexEventIdsRef.current.push(codexEventId)
-              if (seenCodexEventIdsRef.current.length > 500) {
-                seenCodexEventIdsRef.current = seenCodexEventIdsRef.current.slice(-250)
+              seenCodexEventIdsRef.current.add(codexEventId)
+              seenCodexEventIdsQueueRef.current.push(codexEventId)
+              if (seenCodexEventIdsQueueRef.current.length > 500) {
+                const recentIds = seenCodexEventIdsQueueRef.current.slice(-250)
+                seenCodexEventIdsRef.current = new Set(recentIds)
+                seenCodexEventIdsQueueRef.current = recentIds
               }
             }
           }
@@ -3346,10 +3353,10 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         Array.isArray(transcriptResult.messages) ? transcriptResult.messages : []
       ),
       durableState.activities,
-      !isStreaming
+      !isStreamingRef.current
     )
     setMessages(liveMessages)
-  }, [isStreaming, opencodeSessionId, sessionId, sessionRecord?.agent_sdk, worktreePath])
+  }, [opencodeSessionId, sessionId, sessionRecord?.agent_sdk, worktreePath])
 
   const scheduleCodexStreamingRefresh = useCallback(() => {
     if (sessionRecord?.agent_sdk !== 'codex') return
@@ -4947,16 +4954,22 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   // The StreamingCursor (blinking cursor) only renders after text or tool_use parts.
   // Parts like reasoning, step_start, step_finish, compaction don't show it.
   // When those are the only parts, we still need the 3-dot loading indicator.
+  const codexHasWritingCursor = useMemo(() => {
+    if (sessionRecord?.agent_sdk !== 'codex' || !isStreaming) return false
+    for (let i = visibleMessages.length - 1; i >= 0; i--) {
+      if (visibleMessages[i].role === 'assistant') {
+        const msg = visibleMessages[i]
+        const lastPart = msg.parts?.[msg.parts.length - 1]
+        if (lastPart?.type === 'tool_use') return true
+        return Boolean(msg.content.trim())
+      }
+    }
+    return false
+  }, [visibleMessages, isStreaming, sessionRecord?.agent_sdk])
+
   const hasVisibleWritingCursor =
     sessionRecord?.agent_sdk === 'codex'
-      ? isStreaming &&
-        (() => {
-          const lastAssistant = [...visibleMessages].reverse().find((message) => message.role === 'assistant')
-          if (!lastAssistant) return false
-          const lastPart = lastAssistant.parts?.[lastAssistant.parts.length - 1]
-          if (lastPart?.type === 'tool_use') return true
-          return Boolean(lastAssistant.content.trim())
-        })()
+      ? codexHasWritingCursor
       : hasStreamingContent &&
         isStreaming &&
         (streamingContent.length > 0 ||

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -534,6 +534,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const [connectionId, setConnectionId] = useState<string | null>(null)
   const [opencodeSessionId, setOpencodeSessionId] = useState<string | null>(null)
   const [isStreaming, setIsStreaming] = useState(false)
+  const isStreamingRef = useRef(isStreaming)
+  useEffect(() => { isStreamingRef.current = isStreaming }, [isStreaming])
   const [isCompacting, setIsCompacting] = useState(false)
   const [sessionRetry, setSessionRetry] = useState<SessionRetryState | null>(null)
   const [sessionErrorMessage, setSessionErrorMessage] = useState<string | null>(null)
@@ -730,7 +732,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const codexRefreshInFlightRef = useRef(false)
   const codexRefreshPendingRef = useRef(false)
   const codexStreamingMessageIdRef = useRef<string | null>(null)
-  const seenCodexEventIdsRef = useRef<string[]>([])
+  const seenCodexEventIdsRef = useRef<Set<string>>(new Set())
+  const seenCodexEventIdsQueueRef = useRef<string[]>([])
 
   // Guard: tracks whether a new prompt was sent during the current streaming cycle.
   // When true, finalizeResponse skips the full reload to avoid
@@ -1558,7 +1561,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     streamingContentRef.current = ''
     childToSubtaskIndexRef.current = new Map()
     codexStreamingMessageIdRef.current = null
-    seenCodexEventIdsRef.current = []
+    seenCodexEventIdsRef.current = new Set()
+    seenCodexEventIdsQueueRef.current = []
     codexRefreshPendingRef.current = false
     codexRefreshInFlightRef.current = false
     if (codexRefreshRafRef.current !== null) {
@@ -1603,13 +1607,15 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                 : null
 
             if (codexEventId) {
-              if (seenCodexEventIdsRef.current.includes(codexEventId)) {
+              if (seenCodexEventIdsRef.current.has(codexEventId)) {
                 return
               }
-
-              seenCodexEventIdsRef.current.push(codexEventId)
-              if (seenCodexEventIdsRef.current.length > 500) {
-                seenCodexEventIdsRef.current = seenCodexEventIdsRef.current.slice(-250)
+              seenCodexEventIdsRef.current.add(codexEventId)
+              seenCodexEventIdsQueueRef.current.push(codexEventId)
+              if (seenCodexEventIdsQueueRef.current.length > 500) {
+                const recentIds = seenCodexEventIdsQueueRef.current.slice(-250)
+                seenCodexEventIdsRef.current = new Set(recentIds)
+                seenCodexEventIdsQueueRef.current = recentIds
               }
             }
           }
@@ -3346,10 +3352,10 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         Array.isArray(transcriptResult.messages) ? transcriptResult.messages : []
       ),
       durableState.activities,
-      !isStreaming
+      !isStreamingRef.current
     )
     setMessages(liveMessages)
-  }, [isStreaming, opencodeSessionId, sessionId, sessionRecord?.agent_sdk, worktreePath])
+  }, [opencodeSessionId, sessionId, sessionRecord?.agent_sdk, worktreePath])
 
   const scheduleCodexStreamingRefresh = useCallback(() => {
     if (sessionRecord?.agent_sdk !== 'codex') return
@@ -4947,16 +4953,22 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   // The StreamingCursor (blinking cursor) only renders after text or tool_use parts.
   // Parts like reasoning, step_start, step_finish, compaction don't show it.
   // When those are the only parts, we still need the 3-dot loading indicator.
+  const codexHasWritingCursor = useMemo(() => {
+    if (sessionRecord?.agent_sdk !== 'codex' || !isStreaming) return false
+    for (let i = visibleMessages.length - 1; i >= 0; i--) {
+      if (visibleMessages[i].role === 'assistant') {
+        const msg = visibleMessages[i]
+        const lastPart = msg.parts?.[msg.parts.length - 1]
+        if (lastPart?.type === 'tool_use') return true
+        return Boolean(msg.content.trim())
+      }
+    }
+    return false
+  }, [visibleMessages, isStreaming, sessionRecord?.agent_sdk])
+
   const hasVisibleWritingCursor =
     sessionRecord?.agent_sdk === 'codex'
-      ? isStreaming &&
-        (() => {
-          const lastAssistant = [...visibleMessages].reverse().find((message) => message.role === 'assistant')
-          if (!lastAssistant) return false
-          const lastPart = lastAssistant.parts?.[lastAssistant.parts.length - 1]
-          if (lastPart?.type === 'tool_use') return true
-          return Boolean(lastAssistant.content.trim())
-        })()
+      ? codexHasWritingCursor
       : hasStreamingContent &&
         isStreaming &&
         (streamingContent.length > 0 ||

--- a/src/renderer/src/components/sessions/ToolCard.tsx
+++ b/src/renderer/src/components/sessions/ToolCard.tsx
@@ -777,7 +777,7 @@ const CompactFileToolCard = memo(function CompactFileToolCard({
       <button
         onClick={() => hasExpandableContent && setIsExpanded(!isExpanded)}
         className={cn(
-          'flex items-center gap-1.5 w-full py-0.5 text-left text-xs',
+          'flex items-center gap-1.5 w-full py-1 text-left text-xs',
           hasExpandableContent && 'cursor-pointer hover:bg-accent/50 transition-colors rounded-sm',
           !hasExpandableContent && !isRunning && 'cursor-default'
         )}
@@ -892,7 +892,7 @@ export const ToolCard = memo(function ToolCard({
         <div
           className={cn(
             compact
-              ? 'my-0 rounded-md border border-l-2 text-xs'
+              ? 'my-1 rounded-md border border-l-2 text-xs'
               : 'my-1 rounded-md border border-l-2 text-xs',
             toolUse.status === 'running' && 'animate-pulse',
             'border-border bg-muted/30'
@@ -951,7 +951,7 @@ export const ToolCard = memo(function ToolCard({
           <div
             className={cn(
               compact
-                ? 'my-0 rounded-md border border-l-2 text-xs'
+                ? 'my-1 rounded-md border border-l-2 text-xs'
                 : 'my-1 rounded-md border border-l-2 text-xs',
               planRejected ? 'border-red-500/30 bg-red-500/5' : 'border-border bg-primary/[0.04]'
             )}
@@ -1023,7 +1023,7 @@ export const ToolCard = memo(function ToolCard({
       <div
         className={cn(
           compact
-            ? 'my-0 rounded-md border border-l-2 text-xs'
+            ? 'my-1 rounded-md border border-l-2 text-xs'
             : 'my-1 rounded-md border border-l-2 text-xs',
           toolUse.status === 'running' && 'animate-pulse',
           toolUse.status === 'error'

--- a/src/renderer/src/lib/codex-timeline.ts
+++ b/src/renderer/src/lib/codex-timeline.ts
@@ -95,10 +95,6 @@ function parsePlanPart(activity: SessionActivity): StreamingPart | null {
   }
 }
 
-function hasCanonicalTurnScopedId(messageId: string | null | undefined): boolean {
-  return typeof messageId === 'string' && /:user(?::|$)|:assistant(?::|$)/.test(messageId)
-}
-
 function extractAssistantTurnId(messageId: string): string | null {
   const assistantMatch = messageId.match(/^(.*):assistant(?::.*)?$/)
   return assistantMatch?.[1] ?? null
@@ -289,6 +285,20 @@ export function mapDbSessionMessagesToOpenCodeMessages(
   messages: SessionMessage[]
 ): OpenCodeMessage[] {
   return messages.map((message) => {
+    const serializedMessage =
+      parseJson<OpenCodeMessage>(message.opencode_message_json) ??
+      parseJson<OpenCodeMessage>(message.opencode_timeline_json)
+
+    if (serializedMessage) {
+      return {
+        id: serializedMessage.id ?? message.opencode_message_id ?? message.id,
+        role: serializedMessage.role ?? message.role,
+        content: serializedMessage.content ?? message.content,
+        timestamp: serializedMessage.timestamp ?? message.created_at,
+        parts: serializedMessage.parts
+      }
+    }
+
     const parsedParts = parseJson<unknown[]>(message.opencode_parts_json)
     const parts = Array.isArray(parsedParts)
       ? parsedParts

--- a/test/phase-2/session-10/tool-messages.test.tsx
+++ b/test/phase-2/session-10/tool-messages.test.tsx
@@ -469,7 +469,7 @@ describe('Session 10: Tool Message Rendering', () => {
       render(<AssistantCanvas content="" timestamp={new Date().toISOString()} parts={parts} />)
 
       const assistantCanvas = screen.getByTestId('message-assistant')
-      expect(assistantCanvas.className.split(/\s+/)).toContain('py-1')
+      expect(assistantCanvas.className.split(/\s+/)).toContain('py-3')
 
       // Read is a file tool → compact layout (no my-0 class assertion)
       expect(screen.getByTestId('compact-file-tool')).toBeInTheDocument()
@@ -494,7 +494,7 @@ describe('Session 10: Tool Message Rendering', () => {
       render(<AssistantCanvas content="" timestamp={new Date().toISOString()} parts={parts} />)
 
       const assistantCanvas = screen.getByTestId('message-assistant')
-      expect(assistantCanvas.className.split(/\s+/)).toContain('py-1')
+      expect(assistantCanvas.className.split(/\s+/)).toContain('py-3')
     })
 
     test('Assistant messages without tools keep standard vertical spacing', () => {


### PR DESCRIPTION
## Summary

- **Canonical message building during streaming**: `synchronizeCanonicalAssistantFromStreamEvent()` constructs properly-structured assistant messages with text, reasoning, and tool parts from Codex stream events
- **Debounced persistence**: `persistCanonicalMessagesDebounced()` coalesces rapid DB writes during streaming with 2000ms debounce window, `flushPendingPersist()` ensures final flush on turn completion
- **Renderer-side dedup**: Stream events annotated with `_codexEventId` in `codex-event-mapper.ts`; SessionView tracks seen event IDs in `seenCodexEventIdsRef` to prevent duplicate rendering
- **Message spacing improvements**: AssistantCanvas normalized parts memoization prevents consecutive text/reasoning fragments; py-3 spacing on tool containers, space-y-2 on inner divs
- **Turn tracking**: `currentTurnId` and `currentAssistantMessageId` maintain canonical message identity across streaming; fallback to accumulated text only when canonical path inactive
- **Renderer refresh loop**: `scheduleCodexStreamingRefresh()` and RAF-debounced `refreshCodexStreamingMessages()` sync in-flight streaming state with new messages from transcript

## Testing

- Manual verification of Codex streaming with proper message separation (text + reasoning + tools) — Not run
- Verify no duplicate parts render when `_codexEventId` dedup is active — Not run
- Confirm DB persist calls coalesce during 2s debounce window, single final write on completion — Not run
- Check message spacing between tool cards and text (py-3 vs py-5) on different viewport sizes — Not run
- Verify `seenCodexEventIdsRef` queue limits at 500 (retains last 250) prevents unbounded memory growth — Not run
- Test turn renaming path: verify message ID transitions correctly when `turn/started` event arrives — Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Codex streaming, message persistence, and renderer event handling; mistakes could cause missing/duplicated transcript content or extra DB writes, but changes are scoped to the Codex path with fallbacks retained.
> 
> **Overview**
> Codex streaming now builds a **canonical assistant message** incrementally from stream events (text, reasoning, tool updates) using turn-scoped message IDs, instead of relying on post-turn `thread/read` snapshots or concatenated deltas.
> 
> To reduce churn, canonical transcript persistence is **debounced** during streaming and explicitly flushed on turn completion/abort/disconnect; persisted rows now store a normalized message envelope (with stable IDs) in both `opencode_message_json` and `opencode_timeline_json`, and reads fall back to either field.
> 
> On the renderer side, Codex stream events are annotated with `_codexEventId` and `SessionView` dedups repeated events, adds a RAF-coalesced refresh to reconcile in-flight streaming with transcript reloads, and updates `AssistantCanvas`/`ToolCard` spacing plus part-normalization to avoid consecutive text/reasoning fragments rendering as separate blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5bccbdf764bff463d5516db63a15f2c73640a89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->