### PR TITLE
Increase auto-update check interval from 4 to 5 hours

### DIFF
--- a/src/main/services/updater.ts
+++ b/src/main/services/updater.ts
@@ -20,7 +20,7 @@ function getUpdateChannel(): 'stable' | 'canary' {
   return 'stable'
 }
 
-const CHECK_INTERVAL = 4 * 60 * 60 * 1000 // 4 hours
+const CHECK_INTERVAL = 5 * 60 * 60 * 1000 // 5 hours
 const INITIAL_DELAY = 10 * 1000 // 10 seconds
 
 autoUpdater.autoDownload = false


### PR DESCRIPTION
## Summary

- Updates the update check interval from 4 hours to 5 hours
- Changes `CHECK_INTERVAL` constant in `src/main/services/updater.ts`
- Reduces update check frequency while maintaining startup checks via `INITIAL_DELAY`

## Testing

- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only reduces background auto-update polling frequency from 4h to 5h; no change to update logic or startup check timing.
> 
> **Overview**
> In `src/main/services/updater.ts`, increases the periodic auto-update polling interval by changing `CHECK_INTERVAL` from 4 hours to 5 hours, reducing how often the app checks for updates during runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b25fac6c841fd317734e8cc5be96cb540400e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->