### PR TITLE
Fix: Prevent permission status from being overwritten by OpenCode listener

### DIFF
--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -2498,7 +2498,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                 sessionId,
                 isBlocked: () => {
                   const currentStatus = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-                  return currentStatus?.status === 'command_approval'
+                  return currentStatus?.status === 'command_approval' || currentStatus?.status === 'permission'
                 },
                 dequeueFollowUp: () => useSessionStore.getState().consumeFollowUpMessage(sessionId),
                 requeueFollowUp: (message) =>

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -472,6 +472,9 @@ export function useOpenCodeGlobalListener(): void {
             const currentStatus = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
             if (currentStatus?.status === 'command_approval') return
 
+            // Don't overwrite permission — session is blocked waiting for permission approval
+            if (currentStatus?.status === 'permission') return
+
             if (sessionId !== activeId) {
               const currentMode = useSessionStore.getState().getSessionMode(sessionId)
               useWorktreeStatusStore
@@ -542,6 +545,9 @@ export function useOpenCodeGlobalListener(): void {
           const statusForIdle = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
           if (statusForIdle?.status === 'command_approval') return
 
+          // Don't overwrite permission — session is blocked waiting for permission approval
+          if (statusForIdle?.status === 'permission') return
+
           // Active session is handled by SessionView.
           if (sessionId === activeId) return
 
@@ -550,7 +556,7 @@ export function useOpenCodeGlobalListener(): void {
             isBlocked: () => {
               if (useSessionStore.getState().getPendingPlan(sessionId)) return true
               const current = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-              return current?.status === 'command_approval'
+              return current?.status === 'command_approval' || current?.status === 'permission'
             },
             dequeueFollowUp: () => useSessionStore.getState().dequeueFollowUpMessage(sessionId),
             requeueFollowUp: (message) =>


### PR DESCRIPTION
## Summary

- Add checks to prevent overwriting 'permission' status when OpenCode listener processes session updates
- Mark sessions as blocked when awaiting permission approval in both SessionView and idle session handlers
- Ensures permission prompts aren't cleared prematurely when new command approvals or mode changes occur
- Fixes race condition where 'permission' status could be replaced with other status values

## Testing

- Verify permission approval dialog displays and persists when OpenCode requests file/command permissions
- Test that permission status blocks further processing until user approval
- Confirm sessions in 'permission' status show as blocked in both active and idle session views
- Validate that switching to other sessions doesn't clear pending permission requests
- Check that normal command_approval flow still works correctly
- Not run: Automated tests (no test files modified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session status transitions in `SessionView` and the global OpenCode listener; mistakes could block follow-up dispatch or leave sessions stuck in the wrong UI state, but scope is limited to status-gating logic.
> 
> **Overview**
> Prevents OpenCode `session.status` handling from overwriting a session’s `permission`-blocked state.
> 
> The global listener now skips restoring `working`/`planning` and skips idle follow-up processing when the current status is `permission`, and both `SessionView` and background idle follow-up dispatch treat `permission` the same as `command_approval` for blocking queued follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 819bb819ca5c85963d5b25f8b54466b0b1a83d55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->