### PR TITLE
Optimize favicon detection by skipping projects with language badges

### DIFF
--- a/src/renderer/src/components/projects/LanguageIcon.tsx
+++ b/src/renderer/src/components/projects/LanguageIcon.tsx
@@ -43,7 +43,7 @@ const BUNDLED_ICONS: Record<string, string> = {
 }
 
 /** Fallback colored badges for languages without a bundled icon */
-const LANGUAGE_MAP: Record<string, LanguageConfig> = {
+export const LANGUAGE_MAP: Record<string, LanguageConfig> = {
   typescript: { label: 'TS', bg: 'bg-blue-600', text: 'text-white' },
   javascript: { label: 'JS', bg: 'bg-yellow-500', text: 'text-black' },
   python: { label: 'Py', bg: 'bg-sky-600', text: 'text-yellow-300' },

--- a/src/renderer/src/stores/useProjectStore.ts
+++ b/src/renderer/src/stores/useProjectStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { useKanbanStore } from './useKanbanStore'
+import { LANGUAGE_MAP } from '@/components/projects/LanguageIcon'
 
 // Project type matching the database schema
 interface Project {
@@ -83,8 +84,13 @@ export const useProjectStore = create<ProjectState>()(
           const projects = await window.db.project.getAll()
           set({ projects, isLoading: false })
 
-          // Backfill favicon detection sequentially to avoid SQLite write contention
-          const unscanned = projects.filter((p) => p.detected_icon === null || p.detected_icon === undefined)
+          // On startup, only scan projects that have no visual icon at all
+          const unscanned = projects.filter((p) => {
+            if (p.custom_icon) return false
+            if (p.detected_icon !== null && p.detected_icon !== undefined) return false
+            if (p.language && LANGUAGE_MAP[p.language]) return false
+            return true
+          })
           if (unscanned.length > 0) {
             ;(async () => {
               for (const project of unscanned) {


### PR DESCRIPTION
## Summary
- Export `LANGUAGE_MAP` from LanguageIcon component to enable reuse in project store
- Refine favicon detection logic to skip projects that already have a visual representation:
  - Projects with custom icons
  - Projects with previously detected icons
  - Projects with language badges (from LANGUAGE_MAP)
- Reduces unnecessary icon scanning on startup, improving performance
- Only scans projects that have no visual icon representation at all

## Testing
- Verify projects with language badges (TypeScript, Python, etc.) don't trigger favicon detection
- Verify projects with custom_icon set are skipped from scanning
- Verify projects with previously detected_icon values are skipped
- Verify projects with no icon representation are still scanned
- Check startup performance with large project lists
- Not run: Integration tests with backend favicon service

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to startup favicon backfill filtering and an export for reuse; main impact is potentially skipping favicon detection for projects that previously would have been scanned.
> 
> **Overview**
> Reduces startup favicon backfill work by only scanning projects that have *no* existing visual icon: it now skips favicon detection when a project already has a `custom_icon`, any `detected_icon` value, or a known language badge (`LANGUAGE_MAP`).
> 
> Exports `LANGUAGE_MAP` from `LanguageIcon` so the project store can reuse the same language-badge list when deciding whether to run favicon detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c95fafc1de58df83a5a567c08cb818ab05e9bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->