### PR TITLE
Add Shift+Tab keyboard shortcut for Super Plan mode toggle

### DIFF
--- a/src/renderer/src/components/kanban/FollowupInput.tsx
+++ b/src/renderer/src/components/kanban/FollowupInput.tsx
@@ -8,6 +8,7 @@ import type { Attachment } from '@/components/sessions/AttachmentPreview'
 import { cn } from '@/lib/utils'
 import { MAX_ATTACHMENTS } from '@/lib/file-attachment-utils'
 import { toast } from '@/lib/toast'
+import { Tip } from '@/components/ui/Tip'
 
 type FollowUpMode = 'build' | 'plan' | 'super-plan'
 
@@ -106,24 +107,26 @@ export function FollowupInput({
         <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
           Followup
         </label>
-        <button
-          data-testid={`${testIdPrefix}-mode-toggle`}
-          data-mode={followUpMode}
-          type="button"
-          onClick={onToggleMode}
-          className={cn(
-            'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
-            'border select-none',
-            followUpMode === 'build'
-              ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
-              : followUpMode === 'plan'
-                ? 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
-                : 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20'
-          )}
-        >
-          <ModeIcon className="h-3 w-3" />
-          <span>{modeLabel}</span>
-        </button>
+        <Tip tipId="super-plan-shortcut" enabled={followUpMode === 'super-plan'}>
+          <button
+            data-testid={`${testIdPrefix}-mode-toggle`}
+            data-mode={followUpMode}
+            type="button"
+            onClick={onToggleMode}
+            className={cn(
+              'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
+              'border select-none',
+              followUpMode === 'build'
+                ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
+                : followUpMode === 'plan'
+                  ? 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
+                  : 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20'
+            )}
+          >
+            <ModeIcon className="h-3 w-3" />
+            <span>{modeLabel}</span>
+          </button>
+        </Tip>
       </div>
 
       {/* Attachment previews */}

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1104,21 +1104,29 @@ function PlanReviewModeContent({
     setFollowUpMode((prev) => prev === 'build' ? 'plan' : 'build')
   }, [])
 
-  // Tab key toggles mode
+  const toggleSuperMode = useCallback(() => {
+    setFollowUpMode((prev) => prev === 'super-plan' ? 'plan' : 'super-plan')
+  }, [])
+
+  // Tab key toggles mode, Shift+Tab toggles super-plan
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {
-      if (e.key === 'Tab' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (e.key === 'Tab' && !e.ctrlKey && !e.metaKey && !e.altKey) {
         const modal = document.querySelector('[data-testid="kanban-ticket-modal"]')
         if (modal?.contains(document.activeElement)) {
           e.preventDefault()
           e.stopImmediatePropagation()
-          toggleMode()
+          if (e.shiftKey) {
+            toggleSuperMode()
+          } else {
+            toggleMode()
+          }
         }
       }
     }
     window.addEventListener('keydown', handler, true)
     return () => window.removeEventListener('keydown', handler, true)
-  }, [toggleMode])
+  }, [toggleMode, toggleSuperMode])
 
   // ── Send followup (reject pending plan + iterate) ────────────────
   const handleSendFollowup = useCallback(async () => {
@@ -1804,22 +1812,30 @@ function ReviewModeContent({
     setFollowUpMode((prev) => prev === 'build' ? 'plan' : 'build')
   }, [])
 
-  // Tab key toggles mode
+  const toggleSuperMode = useCallback(() => {
+    setFollowUpMode((prev) => prev === 'super-plan' ? 'plan' : 'super-plan')
+  }, [])
+
+  // Tab key toggles mode, Shift+Tab toggles super-plan
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {
-      if (e.key === 'Tab' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (e.key === 'Tab' && !e.ctrlKey && !e.metaKey && !e.altKey) {
         // Only intercept when the modal is focused
         const modal = document.querySelector('[data-testid="kanban-ticket-modal"]')
         if (modal?.contains(document.activeElement)) {
           e.preventDefault()
           e.stopImmediatePropagation()
-          toggleMode()
+          if (e.shiftKey) {
+            toggleSuperMode()
+          } else {
+            toggleMode()
+          }
         }
       }
     }
     window.addEventListener('keydown', handler, true)
     return () => window.removeEventListener('keydown', handler, true)
-  }, [toggleMode])
+  }, [toggleMode, toggleSuperMode])
 
   // ── Send followup ─────────────────────────────────────────────────
   const handleSendFollowup = useCallback(async () => {
@@ -2224,6 +2240,30 @@ function ErrorModeContent({
   const toggleMode = useCallback(() => {
     setFollowUpMode((prev) => prev === 'build' ? 'plan' : 'build')
   }, [])
+
+  const toggleSuperMode = useCallback(() => {
+    setFollowUpMode((prev) => prev === 'super-plan' ? 'plan' : 'super-plan')
+  }, [])
+
+  // Tab key toggles mode, Shift+Tab toggles super-plan
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Tab' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        const modal = document.querySelector('[data-testid="kanban-ticket-modal"]')
+        if (modal?.contains(document.activeElement)) {
+          e.preventDefault()
+          e.stopImmediatePropagation()
+          if (e.shiftKey) {
+            toggleSuperMode()
+          } else {
+            toggleMode()
+          }
+        }
+      }
+    }
+    window.addEventListener('keydown', handler, true)
+    return () => window.removeEventListener('keydown', handler, true)
+  }, [toggleMode, toggleSuperMode])
 
   // ── Send followup for error retry ─────────────────────────────────
   const handleSendFollowup = useCallback(async () => {

--- a/src/renderer/src/components/kanban/TicketCreateModal.tsx
+++ b/src/renderer/src/components/kanban/TicketCreateModal.tsx
@@ -80,7 +80,7 @@ export function TicketCreateModal({ open, onOpenChange, projectId, connectionId,
   useEffect(() => {
     if (!open) return
     const handler = (e: KeyboardEvent): void => {
-      if (e.key === 'Tab' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (e.key === 'Tab' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
         const modal = document.querySelector('[data-testid="ticket-create-modal"]')
         if (modal?.contains(document.activeElement)) {
           e.stopImmediatePropagation()

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -280,28 +280,42 @@ export function WorktreePickerModal({
     }
   }, [mode])
 
-  // ── Handle Tab key: toggle mode + focus prompt textarea ────────
+  // ── Handle Shift+Tab super-plan shortcut ─────────────────────
+  const toggleSuperShortcut = useCallback(() => {
+    setMode((prev) => {
+      const next: PickerMode = prev === 'super-plan' ? 'plan' : 'super-plan'
+      setPromptText((current) => swapModePrefix(current, prev, next))
+      return next
+    })
+  }, [])
+
+  // ── Handle Tab / Shift+Tab keys ─────────────────────────────────
   // Must use window-level capture-phase listener to beat SessionView's
   // global Tab handler which also uses capture and stops propagation.
+  // Tab = toggle build↔plan, Shift+Tab = toggle ±super-plan.
   useEffect(() => {
     if (!open || preAssignOnly) return
     const handler = (e: KeyboardEvent): void => {
-      if (e.key === 'Tab' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
-        if (branchPopoverOpen) return  // Don't toggle mode while picking a branch
-        e.preventDefault()
-        e.stopImmediatePropagation()
+      if (e.key !== 'Tab' || e.ctrlKey || e.metaKey || e.altKey) return
+      if (branchPopoverOpen) return  // Don't toggle mode while picking a branch
+      e.preventDefault()
+      e.stopImmediatePropagation()
+
+      if (e.shiftKey) {
+        toggleSuperShortcut()
+      } else {
         toggleMode()
-        // Also focus the prompt textarea if it isn't already focused
-        if (document.activeElement !== promptRef.current) {
-          promptRef.current?.focus()
-        }
+      }
+      // Also focus the prompt textarea if it isn't already focused
+      if (document.activeElement !== promptRef.current) {
+        promptRef.current?.focus()
       }
     }
     window.addEventListener('keydown', handler, true) // capture phase
     return () => {
       window.removeEventListener('keydown', handler, true)
     }
-  }, [open, toggleMode, branchPopoverOpen, preAssignOnly])
+  }, [open, toggleMode, toggleSuperShortcut, branchPopoverOpen, preAssignOnly])
 
   // Keep React keydown for test compatibility (jsdom doesn't have capture-phase issues)
   const handleKeyDown = useCallback(
@@ -309,14 +323,18 @@ export function WorktreePickerModal({
       if (e.key === 'Tab' && !preAssignOnly) {
         if (branchPopoverOpen) return
         e.preventDefault()
-        toggleMode()
+        if (e.shiftKey) {
+          toggleSuperShortcut()
+        } else {
+          toggleMode()
+        }
         // Also focus the prompt textarea if it isn't already focused
         if (document.activeElement !== promptRef.current) {
           promptRef.current?.focus()
         }
       }
     },
-    [toggleMode, branchPopoverOpen, preAssignOnly]
+    [toggleMode, toggleSuperShortcut, branchPopoverOpen, preAssignOnly]
   )
 
   // ── Handle worktree selection ───────────────────────────────────

--- a/src/renderer/src/components/sessions/ModeToggle.tsx
+++ b/src/renderer/src/components/sessions/ModeToggle.tsx
@@ -46,7 +46,7 @@ export function ModeToggle({ sessionId }: ModeToggleProps): React.JSX.Element {
           ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
           : 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
       )}
-      title={`${config.description} (Tab to toggle)`}
+      title={`${config.description} (Tab to toggle, Shift+Tab for Super Plan)`}
       aria-label={`Current mode: ${config.label}. Click to switch to ${mode === 'build' ? 'Plan' : 'Build'} mode`}
       data-testid="mode-toggle"
       data-mode={mode}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -4787,10 +4787,10 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     const handler = (e: KeyboardEvent): void => {
       if (e.key !== 'Tab' || e.ctrlKey || e.metaKey || e.altKey) return
 
-      // Don't intercept Tab inside the ticket creation modal — it needs
-      // natural tab navigation between title / description fields.
+      // Don't intercept plain Tab inside the ticket creation modal — it needs
+      // natural tab navigation. Shift+Tab still toggles super-plan mode.
       const createModal = document.querySelector('[data-testid="ticket-create-modal"]')
-      if (createModal?.contains(document.activeElement)) return
+      if (createModal?.contains(document.activeElement) && !e.shiftKey) return
 
       // Don't intercept Tab when the xterm terminal is focused — it needs
       // to reach the shell for tab completion.

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -4780,23 +4780,29 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     [handleAttach]
   )
 
-  // Global Tab key handler — toggles Build/Plan mode, blocks tab character insertion
+  // Global Tab/Shift+Tab key handler — toggles Build/Plan mode or Super-Plan
   const toggleSessionMode = useSessionStore((state) => state.toggleSessionMode)
+  const toggleSuperPlanShortcut = useSessionStore((state) => state.toggleSuperPlanShortcut)
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {
-      if (e.key === 'Tab' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
-        // Don't intercept Tab inside the ticket creation modal — it needs
-        // natural tab navigation between title / description fields.
-        const createModal = document.querySelector('[data-testid="ticket-create-modal"]')
-        if (createModal?.contains(document.activeElement)) return
+      if (e.key !== 'Tab' || e.ctrlKey || e.metaKey || e.altKey) return
 
-        // Don't intercept Tab when the xterm terminal is focused — it needs
-        // to reach the shell for tab completion.
-        const terminalContainer = document.querySelector('[data-testid="terminal-view-container"]')
-        if (terminalContainer?.contains(document.activeElement)) return
+      // Don't intercept Tab inside the ticket creation modal — it needs
+      // natural tab navigation between title / description fields.
+      const createModal = document.querySelector('[data-testid="ticket-create-modal"]')
+      if (createModal?.contains(document.activeElement)) return
 
-        e.preventDefault()
-        e.stopPropagation()
+      // Don't intercept Tab when the xterm terminal is focused — it needs
+      // to reach the shell for tab completion.
+      const terminalContainer = document.querySelector('[data-testid="terminal-view-container"]')
+      if (terminalContainer?.contains(document.activeElement)) return
+
+      e.preventDefault()
+      e.stopPropagation()
+
+      if (e.shiftKey) {
+        toggleSuperPlanShortcut(sessionId)
+      } else {
         toggleSessionMode(sessionId)
       }
     }
@@ -4804,7 +4810,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     return () => {
       window.removeEventListener('keydown', handler, true)
     }
-  }, [sessionId, toggleSessionMode])
+  }, [sessionId, toggleSessionMode, toggleSuperPlanShortcut])
 
   // Listen for undo/redo turn events from the application menu
   useEffect(() => {

--- a/src/renderer/src/components/sessions/SuperToggle.tsx
+++ b/src/renderer/src/components/sessions/SuperToggle.tsx
@@ -25,7 +25,8 @@ export function SuperToggle({ sessionId }: SuperToggleProps): React.JSX.Element 
         type="button"
         onClick={() => toggleSuperMode(sessionId)}
         aria-pressed={isOn}
-        aria-label={`Super mode ${isOn ? 'enabled' : 'disabled'}`}
+        aria-label={`Super mode ${isOn ? 'enabled' : 'disabled'} (Shift+Tab to toggle)`}
+        title="Toggle super-plan mode (Shift+Tab)"
         data-testid="super-toggle"
         className={cn(
           'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',

--- a/src/renderer/src/components/sessions/SuperToggle.tsx
+++ b/src/renderer/src/components/sessions/SuperToggle.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils'
 import { useSessionStore } from '@/stores/useSessionStore'
+import { Tip } from '@/components/ui/Tip'
 
 interface SuperToggleProps {
   sessionId: string
@@ -21,23 +22,25 @@ export function SuperToggle({ sessionId }: SuperToggleProps): React.JSX.Element 
           : 'opacity-0 -translate-x-2 max-w-0 pointer-events-none'
       )}
     >
-      <button
-        type="button"
-        onClick={() => toggleSuperMode(sessionId)}
-        aria-pressed={isOn}
-        aria-label={`Super mode ${isOn ? 'enabled' : 'disabled'} (Shift+Tab to toggle)`}
-        title="Toggle super-plan mode (Shift+Tab)"
-        data-testid="super-toggle"
-        className={cn(
-          'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
-          'border select-none whitespace-nowrap',
-          isOn
-            ? 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20 super-sparkle'
-            : 'bg-muted/50 border-border text-muted-foreground hover:bg-muted hover:text-foreground'
-        )}
-      >
-        SUPER
-      </button>
+      <Tip tipId="super-plan-shortcut" enabled={isOn}>
+        <button
+          type="button"
+          onClick={() => toggleSuperMode(sessionId)}
+          aria-pressed={isOn}
+          aria-label={`Super mode ${isOn ? 'enabled' : 'disabled'} (Shift+Tab to toggle)`}
+          title="Toggle super-plan mode (Shift+Tab)"
+          data-testid="super-toggle"
+          className={cn(
+            'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
+            'border select-none whitespace-nowrap',
+            isOn
+              ? 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20 super-sparkle'
+              : 'bg-muted/50 border-border text-muted-foreground hover:bg-muted hover:text-foreground'
+          )}
+        >
+          SUPER
+        </button>
+      </Tip>
     </div>
   )
 }

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -186,7 +186,7 @@ export function useKeyboardShortcuts(): void {
       for (const { binding, handler, allowInInput } of shortcuts) {
         if (!binding) continue
         if (isInputFocused && !allowInInput) continue
-        if (isTerminalFocused && binding.modifiers.length === 0) continue
+        if (isTerminalFocused && (binding.modifiers.length === 0 || binding.key?.toLowerCase() === 'tab')) continue
 
         if (eventMatchesBinding(event, binding)) {
           event.preventDefault()
@@ -358,6 +358,16 @@ function getShortcutHandlers(
         const { activeSessionId } = useSessionStore.getState()
         if (!activeSessionId) return
         useSessionStore.getState().toggleSessionMode(activeSessionId)
+      }
+    },
+    {
+      id: 'session:super-plan-toggle',
+      binding: getEffectiveBinding('session:super-plan-toggle'),
+      allowInInput: true,
+      handler: () => {
+        const { activeSessionId } = useSessionStore.getState()
+        if (!activeSessionId) return
+        useSessionStore.getState().toggleSuperPlanShortcut(activeSessionId)
       }
     },
     {

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -49,6 +49,13 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     defaultBinding: { key: 'Tab', modifiers: [] }
   },
   {
+    id: 'session:super-plan-toggle',
+    label: 'Toggle Super Plan',
+    description: 'Toggle super-plan mode (Shift+Tab)',
+    category: 'session',
+    defaultBinding: { key: 'Tab', modifiers: ['shift'] }
+  },
+  {
     id: 'project:run',
     label: 'Run Project',
     description: 'Start or stop the project run script',

--- a/src/renderer/src/lib/tip-definitions.ts
+++ b/src/renderer/src/lib/tip-definitions.ts
@@ -46,5 +46,12 @@ export const TIP_DEFINITIONS: Record<string, TipDefinition> = {
     priority: 5,
     side: 'bottom',
     align: 'end'
+  },
+  'super-plan-shortcut': {
+    id: 'super-plan-shortcut',
+    description: 'Press Shift+Tab to toggle Super Plan mode.',
+    trigger: 'action',
+    priority: 6,
+    side: 'top'
   }
 }

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -122,6 +122,7 @@ interface SessionState {
   getSuperArmed: (sessionId: string) => boolean
   toggleSessionMode: (sessionId: string) => Promise<void>
   toggleSuperMode: (sessionId: string) => Promise<void>
+  toggleSuperPlanShortcut: (sessionId: string) => Promise<void>
   setSessionMode: (sessionId: string, mode: SessionMode) => Promise<void>
   setSessionModel: (
     sessionId: string,
@@ -1113,6 +1114,28 @@ export const useSessionStore = create<SessionState>()(
         await get().applyModeDefaultModel(sessionId, newMode)
 
         // Notify Kanban board of mode change
+        notifyKanbanSessionSync(sessionId, { type: 'mode_change', sessionMode: newMode })
+      },
+
+      // Toggle super-plan shortcut: super-plan → plan, everything else → super-plan
+      // Unlike toggleSuperMode, this does NOT mutate superArmedBySession
+      toggleSuperPlanShortcut: async (sessionId: string) => {
+        const currentMode = get().modeBySession.get(sessionId) || 'build'
+        const newMode: SessionMode = currentMode === 'super-plan' ? 'plan' : 'super-plan'
+
+        set((state) => {
+          const newModeMap = new Map(state.modeBySession)
+          newModeMap.set(sessionId, newMode)
+          return { modeBySession: newModeMap }
+        })
+
+        try {
+          await window.db.session.update(sessionId, { mode: newMode })
+        } catch (error) {
+          console.error('Failed to persist session mode:', error)
+        }
+
+        await get().applyModeDefaultModel(sessionId, newMode)
         notifyKanbanSessionSync(sessionId, { type: 'mode_change', sessionMode: newMode })
       },
 

--- a/test/phase-3/session-6/integration-polish.test.tsx
+++ b/test/phase-3/session-6/integration-polish.test.tsx
@@ -231,7 +231,7 @@ This document tests all markdown features for performance.`
     test('Mode toggle has descriptive title', () => {
       render(<ModeToggle sessionId="test-session" />)
       const toggle = screen.getByTestId('mode-toggle')
-      expect(toggle.getAttribute('title')).toContain('Shift+Tab to toggle')
+      expect(toggle.getAttribute('title')).toContain('Shift+Tab')
     })
 
     test('Mode toggle icon is hidden from screen readers', () => {

--- a/test/phase-5/session-10/integration-polish.test.tsx
+++ b/test/phase-5/session-10/integration-polish.test.tsx
@@ -167,6 +167,7 @@ describe('Shortcut Registration', () => {
       'session:new',
       'session:close',
       'session:mode-toggle',
+      'session:super-plan-toggle',
       'nav:command-palette',
       'nav:session-history',
       'nav:new-worktree',


### PR DESCRIPTION
## Summary

- Implement `toggleSuperPlanShortcut()` store method that toggles between super-plan and plan modes (unlike `toggleSuperMode` which also arms super mode)
- Add Shift+Tab keyboard handlers across SessionView, KanbanTicketModal, WorktreePickerModal, and FollowupInput
- Register `session:super-plan-toggle` shortcut with default binding Shift+Tab
- Add tooltip hints and tip definitions to surface the Shift+Tab shortcut to users
- Update UI labels and aria descriptions to mention the new keyboard binding
- Preserve existing Tab behavior for mode toggling (build ↔ plan)
- Fix TicketCreateModal to explicitly exclude Shift+Tab from its mode toggle (allowing normal browser tab navigation)

## Testing

- Test Shift+Tab toggles super-plan mode on/off in SessionView
- Test plain Tab still toggles build ↔ plan mode
- Test Shift+Tab works inside active KanbanTicketModal
- Test Shift+Tab works inside active WorktreePickerModal
- Test shortcut does not activate when terminal or non-modal inputs are focused
- Test `session:super-plan-toggle` shortcut is registered in shortcuts list
- Test tooltip/title attributes display Shift+Tab instruction
- Verify test suite updated: `integration-polish.test.tsx` expects new shortcut in registration list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new global and modal-level Tab/Shift+Tab key handlers plus a new session-store toggle path that persists mode changes, which could impact focus/navigation behavior and mode state consistency across views.
> 
> **Overview**
> Adds a dedicated **Shift+Tab** shortcut to toggle `super-plan` mode (while keeping plain Tab as the Build↔Plan toggle) across `SessionView`, `KanbanTicketModal`, and `WorktreePickerModal`.
> 
> Introduces `useSessionStore.toggleSuperPlanShortcut()` (super-plan↔plan, otherwise→super-plan) and registers it as `session:super-plan-toggle` with a default `Shift+Tab` binding; updates keyboard handling to avoid interfering with terminal focus and to preserve normal Tab navigation in `TicketCreateModal`.
> 
> Surfaces the shortcut in the UI via updated titles/aria labels and a new `super-plan-shortcut` tip, wrapping relevant toggles (`SuperToggle`, `FollowupInput`) in `Tip`; updates integration tests to expect the new shortcut and copy changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 227512f0fa9ea78e8e6cf2bcb07512df7420ed01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->