### PR TITLE
Put codex.jsonl logging behind feature flag in settings

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -46,6 +46,7 @@ import { setClaudeBinaryPath as setRouterClaudeBinaryPath } from './services/tex
 import type { AgentSdkImplementer } from './services/agent-sdk-types'
 import { telemetryService } from './services/telemetry-service'
 import { perfDiagnostics } from './services/perf-diagnostics'
+import { configure as configureCodexDebugLogger } from './services/codex-debug-logger'
 import { ptyService } from './services/pty-service'
 import { scriptRunner } from './services/script-runner'
 import { registerTicketImportHandlers } from './ipc/ticket-import-handlers'
@@ -478,6 +479,11 @@ app.whenReady().then(async () => {
     return perfDiagnostics.getSnapshot()
   })
 
+  // Codex debug logger IPC
+  ipcMain.handle('codex-debug-logger:configure', (_event, enabled: boolean, resetPerSession: boolean) => {
+    configureCodexDebugLogger({ enabled, resetPerSession })
+  })
+
   // Register response logging handlers only when --log is active
   if (isLogMode) {
     log.info('Registering response logging handlers')
@@ -589,6 +595,26 @@ app.whenReady().then(async () => {
         if (settings.perfDiagnosticsEnabled) {
           log.info('Auto-starting performance diagnostics (setting enabled)')
           perfDiagnostics.start()
+        }
+      }
+    } catch {
+      // ignore — setting may not exist yet
+    }
+
+    // Auto-enable codex JSONL logging if setting is enabled
+    try {
+      const raw = getDatabase().getSetting(APP_SETTINGS_DB_KEY)
+      if (raw) {
+        const settings = JSON.parse(raw) as {
+          codexJsonlLoggingEnabled?: boolean
+          codexJsonlResetPerSession?: boolean
+        }
+        if (settings.codexJsonlLoggingEnabled) {
+          log.info('Auto-enabling codex JSONL logging (setting enabled)')
+          configureCodexDebugLogger({
+            enabled: true,
+            resetPerSession: settings.codexJsonlResetPerSession ?? true
+          })
         }
       }
     } catch {

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'node:events'
 import readline from 'node:readline'
 
 import { createLogger } from './logger'
-import { logCodexMessage, logCodexLifecycleEvent } from './codex-debug-logger'
+import { logCodexMessage, logCodexLifecycleEvent, resetSession } from './codex-debug-logger'
 import { asObject, asString, toJsonSnapshot } from './codex-utils'
 import { CODEX_DEFAULT_MODEL } from './codex-models'
 import { getDatabase } from '../db'
@@ -403,6 +403,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         stdio: ['pipe', 'pipe', 'pipe'],
         shell: process.platform === 'win32'
       })
+      resetSession() // Truncate codex.jsonl if reset-per-session is enabled
       const output = readline.createInterface({ input: child.stdout! })
 
       // Generate a temporary thread ID for session tracking

--- a/src/main/services/codex-debug-logger.ts
+++ b/src/main/services/codex-debug-logger.ts
@@ -6,6 +6,8 @@ const LOG_FILE_NAME = 'codex.jsonl'
 
 let logFilePath: string | null = null
 let initialized = false
+let enabled = false
+let resetPerSession = true
 
 function getLogFilePath(): string {
   if (!logFilePath) {
@@ -21,10 +23,22 @@ function getLogFilePath(): string {
 function ensureInitialized(): void {
   if (initialized) return
   initialized = true
-  writeFileSync(getLogFilePath(), '') // truncate on first write per process
+  getLogFilePath() // ensure directory exists
+}
+
+export function configure(opts: { enabled: boolean; resetPerSession: boolean }): void {
+  enabled = opts.enabled
+  resetPerSession = opts.resetPerSession
+}
+
+export function resetSession(): void {
+  if (!enabled || !resetPerSession) return
+  writeFileSync(getLogFilePath(), '')
+  initialized = false
 }
 
 export function logCodexMessage(direction: 'outgoing' | 'incoming', rawData: unknown): void {
+  if (!enabled) return
   ensureInitialized()
   const entry = {
     ts: new Date().toISOString(),
@@ -35,6 +49,7 @@ export function logCodexMessage(direction: 'outgoing' | 'incoming', rawData: unk
 }
 
 export function logCodexLifecycleEvent(event: string, detail?: Record<string, unknown>): void {
+  if (!enabled) return
   ensureInitialized()
   const entry = {
     ts: new Date().toISOString(),

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1397,6 +1397,9 @@ declare global {
         eventLoopLagMs: number
       }>
     }
+    codexDebugLoggerOps: {
+      configure: (enabled: boolean, resetPerSession: boolean) => Promise<void>
+    }
     kanban: {
       ticket: {
         create: (data: KanbanTicketCreate) => Promise<KanbanTicket>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1862,6 +1862,11 @@ const perfDiagnosticsOps = {
   getSnapshot: () => ipcRenderer.invoke('perf-diagnostics:snapshot')
 }
 
+const codexDebugLoggerOps = {
+  configure: (enabled: boolean, resetPerSession: boolean) =>
+    ipcRenderer.invoke('codex-debug-logger:configure', enabled, resetPerSession)
+}
+
 const analyticsOps = {
   track: (event: string, properties?: Record<string, unknown>) =>
     ipcRenderer.invoke('telemetry:track', event, properties),
@@ -2038,6 +2043,7 @@ if (process.contextIsolated) {
     contextBridge.exposeInMainWorld('usageOps', usageOps)
     contextBridge.exposeInMainWorld('analyticsOps', analyticsOps)
     contextBridge.exposeInMainWorld('perfDiagnosticsOps', perfDiagnosticsOps)
+    contextBridge.exposeInMainWorld('codexDebugLoggerOps', codexDebugLoggerOps)
     contextBridge.exposeInMainWorld('kanban', kanban)
     contextBridge.exposeInMainWorld('ticketImport', ticketImport)
   } catch (error) {
@@ -2078,6 +2084,8 @@ if (process.contextIsolated) {
   window.analyticsOps = analyticsOps
   // @ts-expect-error (define in dts)
   window.perfDiagnosticsOps = perfDiagnosticsOps
+  // @ts-expect-error (define in dts)
+  window.codexDebugLoggerOps = codexDebugLoggerOps
   // @ts-expect-error (define in dts)
   window.kanban = kanban
   // @ts-expect-error (define in dts)

--- a/src/renderer/src/components/settings/SettingsAdvanced.tsx
+++ b/src/renderer/src/components/settings/SettingsAdvanced.tsx
@@ -21,7 +21,7 @@ export function SettingsAdvanced(): React.JSX.Element {
   const [errors, setErrors] = useState<Record<number, string | null>>({})
 
   // Store access
-  const { environmentVariables: rawEnvVars, perfDiagnosticsEnabled, updateSetting } = useSettingsStore()
+  const { environmentVariables: rawEnvVars, perfDiagnosticsEnabled, codexJsonlLoggingEnabled, codexJsonlResetPerSession, updateSetting } = useSettingsStore()
   const envVars = rawEnvVars ?? []
 
   const handlePerfDiagnosticsToggle = (): void => {
@@ -29,6 +29,20 @@ export function SettingsAdvanced(): React.JSX.Element {
     updateSetting('perfDiagnosticsEnabled', newValue)
     window.perfDiagnosticsOps.enable(newValue)
     toast.success(newValue ? 'Performance diagnostics enabled' : 'Performance diagnostics disabled')
+  }
+
+  const handleCodexJsonlLoggingToggle = (): void => {
+    const newValue = !codexJsonlLoggingEnabled
+    updateSetting('codexJsonlLoggingEnabled', newValue)
+    window.codexDebugLoggerOps.configure(newValue, codexJsonlResetPerSession)
+    toast.success(newValue ? 'Codex JSONL logging enabled' : 'Codex JSONL logging disabled')
+  }
+
+  const handleCodexJsonlResetToggle = (): void => {
+    const newValue = !codexJsonlResetPerSession
+    updateSetting('codexJsonlResetPerSession', newValue)
+    window.codexDebugLoggerOps.configure(codexJsonlLoggingEnabled, newValue)
+    toast.success(newValue ? 'Log will reset each Codex session' : 'Log will append across sessions')
   }
 
   const handleAdd = () => {
@@ -97,6 +111,58 @@ export function SettingsAdvanced(): React.JSX.Element {
             className={cn(
               'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
               perfDiagnosticsEnabled ? 'translate-x-4' : 'translate-x-0'
+            )}
+          />
+        </button>
+      </div>
+
+      {/* Codex JSONL Logging toggle */}
+      <div className="flex items-center justify-between">
+        <div>
+          <label className="text-sm font-medium">Codex JSONL Logging</label>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Log all Codex JSON-RPC messages to ~/.hive/logs/codex.jsonl
+          </p>
+        </div>
+        <button
+          role="switch"
+          aria-checked={codexJsonlLoggingEnabled}
+          onClick={handleCodexJsonlLoggingToggle}
+          className={cn(
+            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+            codexJsonlLoggingEnabled ? 'bg-primary' : 'bg-muted'
+          )}
+        >
+          <span
+            className={cn(
+              'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+              codexJsonlLoggingEnabled ? 'translate-x-4' : 'translate-x-0'
+            )}
+          />
+        </button>
+      </div>
+
+      {/* Reset log each session sub-toggle */}
+      <div className={cn('flex items-center justify-between pl-4', !codexJsonlLoggingEnabled && 'opacity-50 pointer-events-none')}>
+        <div>
+          <label className="text-sm font-medium">Reset log each session</label>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Truncate the log file when a new Codex session starts. When off, logs append across sessions.
+          </p>
+        </div>
+        <button
+          role="switch"
+          aria-checked={codexJsonlResetPerSession}
+          onClick={handleCodexJsonlResetToggle}
+          className={cn(
+            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+            codexJsonlResetPerSession ? 'bg-primary' : 'bg-muted'
+          )}
+        >
+          <span
+            className={cn(
+              'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+              codexJsonlResetPerSession ? 'translate-x-4' : 'translate-x-0'
             )}
           />
         </button>

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -120,6 +120,8 @@ export interface AppSettings {
 
   // Diagnostics
   perfDiagnosticsEnabled: boolean
+  codexJsonlLoggingEnabled: boolean
+  codexJsonlResetPerSession: boolean
 
   // Review
   reviewPromptType: ReviewPromptType
@@ -181,6 +183,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   tipsEnabled: true,
   environmentVariables: [],
   perfDiagnosticsEnabled: false,
+  codexJsonlLoggingEnabled: false,
+  codexJsonlResetPerSession: true,
   reviewPromptType: 'superpowers',
   _boardModeMigratedToStickyTab: false
 }
@@ -314,6 +318,8 @@ function extractSettings(state: SettingsState): AppSettings {
     tipsEnabled: state.tipsEnabled,
     environmentVariables: state.environmentVariables,
     perfDiagnosticsEnabled: state.perfDiagnosticsEnabled,
+    codexJsonlLoggingEnabled: state.codexJsonlLoggingEnabled,
+    codexJsonlResetPerSession: state.codexJsonlResetPerSession,
     reviewPromptType: state.reviewPromptType,
     _boardModeMigratedToStickyTab: state._boardModeMigratedToStickyTab
   }
@@ -569,6 +575,8 @@ export const useSettingsStore = create<SettingsState>()(
         tipsEnabled: state.tipsEnabled,
         environmentVariables: state.environmentVariables,
         perfDiagnosticsEnabled: state.perfDiagnosticsEnabled,
+        codexJsonlLoggingEnabled: state.codexJsonlLoggingEnabled,
+        codexJsonlResetPerSession: state.codexJsonlResetPerSession,
         reviewPromptType: state.reviewPromptType,
         _boardModeMigratedToStickyTab: state._boardModeMigratedToStickyTab
       })


### PR DESCRIPTION
## Summary

- Add feature flag to Advanced Settings for Codex JSON-RPC message logging
- Implement `codex-debug-logger:configure` IPC handler to enable/disable logging at runtime
- Add sub-toggle for "Reset log each session" to control whether codex.jsonl is truncated on session start
- Auto-enable logging on app startup if setting is persisted in app database
- Export `resetSession()` from codex-debug-logger and call it when new Codex session spawns
- Update settings store with `codexJsonlLoggingEnabled` and `codexJsonlResetPerSession` fields
- Expose `codexDebugLoggerOps.configure()` via preload bridge for renderer access

## Testing

- Verify toggle in Advanced Settings enables/disables logging to ~/.hive/logs/codex.jsonl
- Confirm "Reset log each session" is disabled when main logging toggle is off
- Check that enabling "Reset log each session" truncates the log file when a new Codex session starts
- Verify logging persists across sessions when "Reset log each session" is disabled
- Test that settings are persisted and re-applied on app restart
- Confirm codex.jsonl contains valid JSONL format with `ts`, `direction`/`event`, and `data` fields
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new IPC and persisted settings that affect Codex session startup behavior (including truncating `~/.hive/logs/codex.jsonl`) and could impact debugging/diagnostics flows if misconfigured.
> 
> **Overview**
> Adds an **Advanced Settings feature flag** to enable/disable Codex JSON-RPC JSONL logging to `~/.hive/logs/codex.jsonl`, plus a sub-toggle to control whether the log is truncated at the start of each Codex session.
> 
> Wires this through a new `codex-debug-logger:configure` IPC handler exposed via preload (`window.codexDebugLoggerOps.configure`), persists the new settings (`codexJsonlLoggingEnabled`, `codexJsonlResetPerSession`), auto-applies them on app startup, and updates `codex-debug-logger` to be disabled by default with optional per-session reset via `resetSession()` called when the Codex app-server process is spawned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea6b2966d3a461b2aeba8b138af761a8eca14cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->