### PR TITLE
feat: Add ticket dependency management with visual dependency graph

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -39,7 +39,8 @@ import type {
   KanbanTicketColumn,
   TicketMark,
   TicketFollowupMessage,
-  TicketFollowupMessageCreate
+  TicketFollowupMessageCreate,
+  TicketDependency
 } from './types'
 
 export class DatabaseService {
@@ -149,7 +150,8 @@ export class DatabaseService {
       github_pr_number: (row.github_pr_number as number) ?? null,
       github_pr_url: (row.github_pr_url as string) ?? null,
       mark: (row.mark as TicketMark) ?? null,
-      total_tokens: (row.total_tokens as number) ?? 0
+      total_tokens: (row.total_tokens as number) ?? 0,
+      pending_launch_config: (row.pending_launch_config as string) ?? null
     }
   }
 
@@ -1828,6 +1830,10 @@ export class DatabaseService {
       updates.push('mark = ?')
       values.push(data.mark)
     }
+    if (data.pending_launch_config !== undefined) {
+      updates.push('pending_launch_config = ?')
+      values.push(data.pending_launch_config)
+    }
 
     if (updates.length === 1) return existing // Only updated_at, nothing meaningful changed
 
@@ -1963,6 +1969,115 @@ export class DatabaseService {
     const result = db.prepare(
       'UPDATE kanban_tickets SET worktree_id = NULL, updated_at = ? WHERE worktree_id = ?'
     ).run(now, worktreeId)
+    return result.changes
+  }
+
+  addTicketDependency(
+    dependentId: string,
+    blockerId: string
+  ): { success: boolean; error?: string } {
+    return this.transaction(() => {
+      const db = this.getDb()
+
+      // Validate same project
+      const dependentTicket = db
+        .prepare('SELECT project_id FROM kanban_tickets WHERE id = ?')
+        .get(dependentId) as { project_id: string } | undefined
+      const blockerTicket = db
+        .prepare('SELECT project_id FROM kanban_tickets WHERE id = ?')
+        .get(blockerId) as { project_id: string } | undefined
+
+      if (!dependentTicket || !blockerTicket) {
+        return { success: false, error: 'Tickets must be in the same project' }
+      }
+      if (dependentTicket.project_id !== blockerTicket.project_id) {
+        return { success: false, error: 'Tickets must be in the same project' }
+      }
+
+      // BFS cycle detection: check if dependentId is reachable from blockerId
+      const visited = new Set<string>()
+      const queue: string[] = [blockerId]
+      visited.add(blockerId)
+
+      while (queue.length > 0) {
+        const node = queue.shift()!
+        const dependents = db
+          .prepare('SELECT dependent_id FROM ticket_dependencies WHERE blocker_id = ?')
+          .all(node) as { dependent_id: string }[]
+
+        for (const row of dependents) {
+          if (row.dependent_id === dependentId) {
+            return {
+              success: false,
+              error: 'Adding this dependency would create a circular dependency'
+            }
+          }
+          if (!visited.has(row.dependent_id)) {
+            visited.add(row.dependent_id)
+            queue.push(row.dependent_id)
+          }
+        }
+      }
+
+      // Safe to insert
+      const now = new Date().toISOString()
+      db.prepare(
+        'INSERT INTO ticket_dependencies (dependent_id, blocker_id, created_at) VALUES (?, ?, ?)'
+      ).run(dependentId, blockerId, now)
+
+      return { success: true }
+    })
+  }
+
+  removeTicketDependency(dependentId: string, blockerId: string): boolean {
+    const db = this.getDb()
+    const result = db
+      .prepare('DELETE FROM ticket_dependencies WHERE dependent_id = ? AND blocker_id = ?')
+      .run(dependentId, blockerId)
+    return result.changes > 0
+  }
+
+  getBlockersForTicket(ticketId: string): KanbanTicket[] {
+    const db = this.getDb()
+    const rows = db
+      .prepare(
+        `SELECT kt.* FROM kanban_tickets kt
+         JOIN ticket_dependencies td ON td.blocker_id = kt.id
+         WHERE td.dependent_id = ?`
+      )
+      .all(ticketId) as Record<string, unknown>[]
+    return rows.map((row) => this.mapKanbanTicketRow(row))
+  }
+
+  getDependentsOfTicket(ticketId: string): KanbanTicket[] {
+    const db = this.getDb()
+    const rows = db
+      .prepare(
+        `SELECT kt.* FROM kanban_tickets kt
+         JOIN ticket_dependencies td ON td.dependent_id = kt.id
+         WHERE td.blocker_id = ?`
+      )
+      .all(ticketId) as Record<string, unknown>[]
+    return rows.map((row) => this.mapKanbanTicketRow(row))
+  }
+
+  getDependenciesForProject(projectId: string): TicketDependency[] {
+    const db = this.getDb()
+    return db
+      .prepare(
+        `SELECT td.* FROM ticket_dependencies td
+         JOIN kanban_tickets kt1 ON kt1.id = td.dependent_id
+         JOIN kanban_tickets kt2 ON kt2.id = td.blocker_id
+         WHERE kt1.project_id = ? AND kt2.project_id = ?`
+      )
+      .all(projectId, projectId) as TicketDependency[]
+  }
+
+  removeAllDependenciesForTicket(ticketId: string): number {
+    const db = this.getDb()
+    const result = db
+      .prepare('DELETE FROM ticket_dependencies WHERE dependent_id = ? OR blocker_id = ?')
+      .run(ticketId, ticketId)
     return result.changes
   }
 

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -1976,6 +1976,11 @@ export class DatabaseService {
     dependentId: string,
     blockerId: string
   ): { success: boolean; error?: string } {
+    // Fix 1: Self-dependency check (CRITICAL)
+    if (dependentId === blockerId) {
+      return { success: false, error: 'A ticket cannot depend on itself' }
+    }
+
     return this.transaction(() => {
       const db = this.getDb()
 
@@ -1987,8 +1992,9 @@ export class DatabaseService {
         .prepare('SELECT project_id FROM kanban_tickets WHERE id = ?')
         .get(blockerId) as { project_id: string } | undefined
 
+      // Fix 3: Separate error messages for non-existent tickets vs same project
       if (!dependentTicket || !blockerTicket) {
-        return { success: false, error: 'Tickets must be in the same project' }
+        return { success: false, error: 'One or both tickets do not exist' }
       }
       if (dependentTicket.project_id !== blockerTicket.project_id) {
         return { success: false, error: 'Tickets must be in the same project' }
@@ -2017,6 +2023,14 @@ export class DatabaseService {
             queue.push(row.dependent_id)
           }
         }
+      }
+
+      // Fix 2: Check for existing dependency
+      const existing = db.prepare(
+        'SELECT 1 FROM ticket_dependencies WHERE dependent_id = ? AND blocker_id = ?'
+      ).get(dependentId, blockerId)
+      if (existing) {
+        return { success: true } // Idempotent - already exists
       }
 
       // Safe to insert

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 21
+export const CURRENT_SCHEMA_VERSION = 22
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -428,6 +428,20 @@ export const MIGRATIONS: Migration[] = [
     version: 21,
     name: 'add_ticket_mark',
     up: `ALTER TABLE kanban_tickets ADD COLUMN mark TEXT DEFAULT NULL`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 22,
+    name: 'add_ticket_dependencies',
+    up: `CREATE TABLE IF NOT EXISTS ticket_dependencies (
+  dependent_id TEXT NOT NULL REFERENCES kanban_tickets(id) ON DELETE CASCADE,
+  blocker_id TEXT NOT NULL REFERENCES kanban_tickets(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (dependent_id, blocker_id)
+);
+CREATE INDEX idx_ticket_deps_dependent ON ticket_dependencies(dependent_id);
+CREATE INDEX idx_ticket_deps_blocker ON ticket_dependencies(blocker_id);
+ALTER TABLE kanban_tickets ADD COLUMN pending_launch_config TEXT DEFAULT NULL;`,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -362,6 +362,7 @@ export interface KanbanTicket {
   github_pr_url: string | null
   mark: TicketMark | null
   total_tokens: number
+  pending_launch_config: string | null
 }
 
 export interface KanbanTicketCreate {
@@ -397,6 +398,24 @@ export interface KanbanTicketUpdate {
   github_pr_number?: number | null
   github_pr_url?: string | null
   mark?: TicketMark | null
+  pending_launch_config?: string | null
+}
+
+export interface TicketDependency {
+  dependent_id: string
+  blocker_id: string
+  created_at: string
+}
+
+export interface PendingLaunchConfig {
+  worktree:
+    | { type: 'new'; sourceBranch: string }
+    | { type: 'existing'; worktreeId: string }
+  prompt: string
+  mode: 'build' | 'plan' | 'super-plan'
+  model: { providerID: string; modelID: string; variant?: string } | null
+  sdk: 'opencode' | 'claude-code' | 'codex'
+  codexFastMode: boolean
 }
 
 // Ticket followup message types

--- a/src/main/ipc/kanban-handlers.ts
+++ b/src/main/ipc/kanban-handlers.ts
@@ -85,6 +85,31 @@ export function registerKanbanHandlers(): void {
     return getDatabase().updateProjectSimpleMode(projectId, enabled)
   })
 
+  // Dependency handlers
+  ipcMain.handle('kanban:dependency:add', (_event, dependentId: string, blockerId: string) => {
+    return getDatabase().addTicketDependency(dependentId, blockerId)
+  })
+
+  ipcMain.handle('kanban:dependency:remove', (_event, dependentId: string, blockerId: string) => {
+    return getDatabase().removeTicketDependency(dependentId, blockerId)
+  })
+
+  ipcMain.handle('kanban:dependency:getBlockers', (_event, ticketId: string) => {
+    return getDatabase().getBlockersForTicket(ticketId)
+  })
+
+  ipcMain.handle('kanban:dependency:getDependents', (_event, ticketId: string) => {
+    return getDatabase().getDependentsOfTicket(ticketId)
+  })
+
+  ipcMain.handle('kanban:dependency:getForProject', (_event, projectId: string) => {
+    return getDatabase().getDependenciesForProject(projectId)
+  })
+
+  ipcMain.handle('kanban:dependency:removeAll', (_event, ticketId: string) => {
+    return getDatabase().removeAllDependenciesForTicket(ticketId)
+  })
+
   ipcMain.handle(
     'kanban:board:export',
     async (_event, projectId: string, projectName: string) => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1410,6 +1410,14 @@ declare global {
       simpleMode: {
         toggle: (projectId: string, enabled: boolean) => Promise<void>
       }
+      dependency: {
+        add: (dependentId: string, blockerId: string) => Promise<{ success: boolean; error?: string }>
+        remove: (dependentId: string, blockerId: string) => Promise<boolean>
+        getBlockers: (ticketId: string) => Promise<KanbanTicket[]>
+        getDependents: (ticketId: string) => Promise<KanbanTicket[]>
+        getForProject: (projectId: string) => Promise<Array<{ dependent_id: string; blocker_id: string; created_at: string }>>
+        removeAll: (ticketId: string) => Promise<number>
+      }
       board: {
         export: (projectId: string, projectName: string) => Promise<{ success: boolean; ticketCount: number; path?: string }>
         openImportFile: () => Promise<{

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1923,6 +1923,20 @@ const kanban = {
     toggle: (projectId: string, enabled: boolean) =>
       ipcRenderer.invoke('kanban:simpleMode:toggle', projectId, enabled)
   },
+  dependency: {
+    add: (dependentId: string, blockerId: string): Promise<{ success: boolean; error?: string }> =>
+      ipcRenderer.invoke('kanban:dependency:add', dependentId, blockerId),
+    remove: (dependentId: string, blockerId: string): Promise<boolean> =>
+      ipcRenderer.invoke('kanban:dependency:remove', dependentId, blockerId),
+    getBlockers: (ticketId: string) =>
+      ipcRenderer.invoke('kanban:dependency:getBlockers', ticketId),
+    getDependents: (ticketId: string) =>
+      ipcRenderer.invoke('kanban:dependency:getDependents', ticketId),
+    getForProject: (projectId: string) =>
+      ipcRenderer.invoke('kanban:dependency:getForProject', projectId),
+    removeAll: (ticketId: string): Promise<number> =>
+      ipcRenderer.invoke('kanban:dependency:removeAll', ticketId),
+  },
   board: {
     export: (projectId: string, projectName: string): Promise<{ success: boolean; ticketCount: number; path?: string }> =>
       ipcRenderer.invoke('kanban:board:export', projectId, projectName),

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { LayoutGroup, motion } from 'motion/react'
 import { Pin } from 'lucide-react'
 import { useKanbanStore } from '@/stores/useKanbanStore'
@@ -9,6 +9,7 @@ import { KanbanTicketModal } from '@/components/kanban/KanbanTicketModal'
 import { BoardChatDrawer } from '@/components/kanban/BoardChatDrawer'
 import { BoardChatLauncher } from '@/components/kanban/BoardChatLauncher'
 import { MergeOnDoneDialog } from './MergeOnDoneDialog'
+import { toast } from '@/lib/toast'
 import type { KanbanTicketColumn } from '../../../../main/db/types'
 
 const COLUMNS: KanbanTicketColumn[] = ['todo', 'in_progress', 'review', 'done']
@@ -35,10 +36,37 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
   const boardChatStatus = useBoardChatStore((state) => state.status)
   const openBoardChat = useBoardChatStore((state) => state.openDrawer)
 
+  // Dependency mode subscriptions
+  const dependencyMode = useKanbanStore((state) => state.dependencyMode)
+  const exitDependencyMode = useKanbanStore((state) => state.exitDependencyMode)
+  const addDependency = useKanbanStore((state) => state.addDependency)
+  const removeDependency = useKanbanStore((state) => state.removeDependency)
+  const dependencyMap = useKanbanStore((state) => state.dependencyMap)
+  const hoveredBlockedTicketId = useKanbanStore((state) => state.hoveredBlockedTicketId)
+
   // Subscribe to the multi-project archive toggle ('' key used by pinned/connection boards)
   const showArchivedAll = useKanbanStore(
     useCallback((s) => s.showArchivedByProject[''] ?? false, [])
   )
+
+  // Derived: source ticket title for dependency mode overlay
+  const sourceTicketTitle = useKanbanStore(
+    useCallback((state) => {
+      if (!dependencyMode?.sourceTicketId) return ''
+      for (const [, projectTickets] of state.tickets) {
+        const found = projectTickets.find(t => t.id === dependencyMode.sourceTicketId)
+        if (found) return found.title
+      }
+      return ''
+    }, [dependencyMode?.sourceTicketId])
+  )
+
+  // Ref for board container (SVG line rendering)
+  const boardRef = useRef<HTMLDivElement>(null)
+
+  // SVG dependency line state
+  const [svgPaths, setSvgPaths] = useState<Array<{ key: string; d: string }>>([])
+  const [svgSize, setSvgSize] = useState({ width: 0, height: 0 })
 
   useKanbanStore((state) => state.tickets)
 
@@ -54,6 +82,107 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
     }
   }, [projectId, connectionId, isConnectionMode, isPinnedMode, pinnedProjectIds, showArchivedAll, loadTickets, loadTicketsForConnection, loadTicketsForPinnedProjects])
 
+  // ESC key handler for dependency mode
+  useEffect(() => {
+    if (!dependencyMode?.active) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') exitDependencyMode()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [dependencyMode?.active, exitDependencyMode])
+
+  // Click handler for toggling dependencies during dependency mode
+  const handleBoardClick = useCallback((e: React.MouseEvent) => {
+    if (!dependencyMode?.active || !dependencyMode.sourceTicketId) return
+
+    // Find the closest ticket card element
+    const ticketEl = (e.target as HTMLElement).closest('[data-ticket-id]')
+    if (!ticketEl) return
+
+    const targetTicketId = ticketEl.getAttribute('data-ticket-id')
+    if (!targetTicketId || targetTicketId === dependencyMode.sourceTicketId) return
+
+    e.stopPropagation()
+    e.preventDefault()
+
+    // Toggle: if already a dep, remove; otherwise add
+    const existingBlockers = dependencyMap.get(dependencyMode.sourceTicketId)
+    if (existingBlockers?.has(targetTicketId)) {
+      removeDependency(dependencyMode.sourceTicketId, targetTicketId)
+    } else {
+      addDependency(dependencyMode.sourceTicketId, targetTicketId).then(result => {
+        if (!result.success && result.error) {
+          toast.error(result.error)
+        }
+      })
+    }
+  }, [dependencyMode, dependencyMap, addDependency, removeDependency])
+
+  // Compute SVG bezier paths between dependent tickets
+  const computePaths = useCallback(() => {
+    if (!boardRef.current) return
+
+    const activeTicketId = hoveredBlockedTicketId || (dependencyMode?.active ? dependencyMode.sourceTicketId : null)
+    if (!activeTicketId) {
+      setSvgPaths([])
+      return
+    }
+
+    const boardRect = boardRef.current.getBoundingClientRect()
+    setSvgSize({ width: boardRect.width, height: boardRect.height })
+
+    // Get blocker IDs for this ticket
+    const blockerIds = dependencyMap.get(activeTicketId)
+    if (!blockerIds?.size) {
+      setSvgPaths([])
+      return
+    }
+
+    const sourceEl = boardRef.current.querySelector(`[data-ticket-id="${activeTicketId}"]`)
+    if (!sourceEl) {
+      setSvgPaths([])
+      return
+    }
+
+    const sourceRect = sourceEl.getBoundingClientRect()
+    const sx = sourceRect.left + sourceRect.width / 2 - boardRect.left
+    const sy = sourceRect.top + sourceRect.height / 2 - boardRect.top
+
+    const paths: Array<{ key: string; d: string }> = []
+
+    for (const blockerId of blockerIds) {
+      const targetEl = boardRef.current.querySelector(`[data-ticket-id="${blockerId}"]`)
+      if (!targetEl) continue
+
+      const targetRect = targetEl.getBoundingClientRect()
+      const tx = targetRect.left + targetRect.width / 2 - boardRect.left
+      const ty = targetRect.top + targetRect.height / 2 - boardRect.top
+
+      // Cubic bezier with horizontal-aware control points
+      const cx = (sx + tx) / 2
+      const d = `M ${sx},${sy} C ${cx},${sy} ${cx},${ty} ${tx},${ty}`
+
+      paths.push({ key: `${activeTicketId}-${blockerId}`, d })
+    }
+
+    setSvgPaths(paths)
+  }, [hoveredBlockedTicketId, dependencyMode, dependencyMap])
+
+  // Recompute paths when relevant state changes
+  useEffect(() => {
+    computePaths()
+  }, [computePaths])
+
+  // Recompute on scroll
+  useEffect(() => {
+    const el = boardRef.current
+    if (!el) return
+    const handler = () => computePaths()
+    el.addEventListener('scroll', handler)
+    return () => el.removeEventListener('scroll', handler)
+  }, [computePaths])
+
   // Aggregate archived tickets across all connection member projects for the done column
   const connectionArchivedDoneTickets = isConnectionMode
     ? getConnectionProjectIds(connectionId!).flatMap((pid) => getArchivedTicketsByColumn(pid, 'done'))
@@ -68,6 +197,24 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
   return (
     <LayoutGroup>
       <div className="relative flex min-h-0 flex-1 flex-col">
+        {dependencyMode?.active && (
+          <>
+            {/* Dark overlay */}
+            <div className="fixed inset-0 bg-black/40 z-30 pointer-events-none" />
+            {/* Floating instruction bar */}
+            <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50 bg-card border border-border rounded-lg shadow-lg px-4 py-2 flex items-center gap-3">
+              <span className="text-sm">
+                Selecting dependencies for: <strong>{sourceTicketTitle}</strong> — click tickets to toggle
+              </span>
+              <button
+                onClick={exitDependencyMode}
+                className="px-3 py-1 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
         {isPinnedMode && (
           <div className="flex items-center gap-2 px-3 pt-3 pb-0">
             <Pin className="h-4 w-4 text-muted-foreground" />
@@ -86,9 +233,11 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
           </div>
         ) : (
           <motion.div
+            ref={boardRef}
             layoutScroll
             data-testid="kanban-board"
             className="flex flex-1 min-h-0 gap-3 overflow-x-auto p-3"
+            onClick={handleBoardClick}
           >
             {COLUMNS.map((column) => {
               const tickets = isPinnedMode
@@ -123,6 +272,27 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
             })}
             <KanbanTicketModal />
             <MergeOnDoneDialog />
+            {/* SVG dependency lines */}
+            {svgPaths.length > 0 && (
+              <svg
+                className="absolute inset-0 pointer-events-none z-25"
+                width={svgSize.width}
+                height={svgSize.height}
+                style={{ overflow: 'visible' }}
+              >
+                {svgPaths.map(({ key, d }) => (
+                  <path
+                    key={key}
+                    d={d}
+                    stroke="rgb(245, 158, 11)"
+                    strokeWidth="2"
+                    fill="none"
+                    strokeDasharray="6 3"
+                    opacity="0.7"
+                  />
+                ))}
+              </svg>
+            )}
           </motion.div>
         )}
         <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 flex justify-end p-4">

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -103,6 +103,27 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
     const targetTicketId = ticketEl.getAttribute('data-ticket-id')
     if (!targetTicketId || targetTicketId === dependencyMode.sourceTicketId) return
 
+    // Same-project check: only allow dependencies within the same project
+    const sourceTicket = (() => {
+      for (const [, projectTickets] of useKanbanStore.getState().tickets) {
+        const found = projectTickets.find(t => t.id === dependencyMode.sourceTicketId)
+        if (found) return found
+      }
+      return null
+    })()
+
+    const targetTicket = (() => {
+      for (const [, projectTickets] of useKanbanStore.getState().tickets) {
+        const found = projectTickets.find(t => t.id === targetTicketId)
+        if (found) return found
+      }
+      return null
+    })()
+
+    if (!sourceTicket || !targetTicket || sourceTicket.project_id !== targetTicket.project_id) {
+      return // Different projects — ignore click
+    }
+
     e.stopPropagation()
     e.preventDefault()
 

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -167,7 +167,7 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
     }
 
     const sourceRect = sourceEl.getBoundingClientRect()
-    const sx = sourceRect.left - boardRect.left
+    const sourceCx = sourceRect.left + sourceRect.width / 2 - boardRect.left
     const sy = sourceRect.top + sourceRect.height / 2 - boardRect.top
 
     const paths: Array<{ key: string; d: string }> = []
@@ -177,8 +177,16 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
       if (!targetEl) continue
 
       const targetRect = targetEl.getBoundingClientRect()
-      const tx = targetRect.left - boardRect.left
+      const targetCx = targetRect.left + targetRect.width / 2 - boardRect.left
       const ty = targetRect.top + targetRect.height / 2 - boardRect.top
+
+      // Use the closest side: if target is to the right, exit from source's right → target's left
+      const sx = targetCx > sourceCx
+        ? sourceRect.right - boardRect.left
+        : sourceRect.left - boardRect.left
+      const tx = targetCx > sourceCx
+        ? targetRect.left - boardRect.left
+        : targetRect.right - boardRect.left
 
       // Cubic bezier with horizontal-aware control points
       const cx = (sx + tx) / 2

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -182,10 +182,13 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
 
       let sx: number, tx: number, d: string
 
-      if (Math.abs(sourceCx - targetCx) < 50) {
+      // Treat tickets as same-column when their centers are within half a card-width
+      const SAME_COLUMN_THRESHOLD_PX = 50
+      if (Math.abs(sourceCx - targetCx) < SAME_COLUMN_THRESHOLD_PX) {
         // Same-column case: both endpoints exit from the left edge, arc leftward
         sx = sourceRect.left - boardRect.left
         tx = targetRect.left - boardRect.left
+        // Arc depth: at least 40px, scaling to 40% of vertical distance
         const offset = Math.max(40, Math.abs(ty - sy) * 0.4)
         d = `M ${sx},${sy} C ${sx - offset},${sy} ${tx - offset},${ty} ${tx},${ty}`
       } else {

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -228,7 +228,10 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
                 Selecting dependencies for: <strong>{sourceTicketTitle}</strong> — click tickets to toggle
               </span>
               <button
-                onClick={exitDependencyMode}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  exitDependencyMode()
+                }}
                 className="px-3 py-1 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
               >
                 Done

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -167,7 +167,7 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
     }
 
     const sourceRect = sourceEl.getBoundingClientRect()
-    const sx = sourceRect.left + sourceRect.width / 2 - boardRect.left
+    const sx = sourceRect.left - boardRect.left
     const sy = sourceRect.top + sourceRect.height / 2 - boardRect.top
 
     const paths: Array<{ key: string; d: string }> = []
@@ -177,7 +177,7 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
       if (!targetEl) continue
 
       const targetRect = targetEl.getBoundingClientRect()
-      const tx = targetRect.left + targetRect.width / 2 - boardRect.left
+      const tx = targetRect.left - boardRect.left
       const ty = targetRect.top + targetRect.height / 2 - boardRect.top
 
       // Cubic bezier with horizontal-aware control points
@@ -222,8 +222,11 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
           <>
             {/* Dark overlay */}
             <div className="fixed inset-0 bg-black/40 z-30 pointer-events-none" />
-            {/* Floating instruction bar */}
-            <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50 bg-card border border-border rounded-lg shadow-lg px-4 py-2 flex items-center gap-3">
+            {/* Floating instruction bar — no-drag overrides Electron header drag region */}
+            <div
+              className="fixed top-4 left-1/2 -translate-x-1/2 z-50 bg-card border border-border rounded-lg shadow-lg px-4 py-2 flex items-center gap-3"
+              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+            >
               <span className="text-sm">
                 Selecting dependencies for: <strong>{sourceTicketTitle}</strong> — click tickets to toggle
               </span>

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -180,17 +180,27 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
       const targetCx = targetRect.left + targetRect.width / 2 - boardRect.left
       const ty = targetRect.top + targetRect.height / 2 - boardRect.top
 
-      // Use the closest side: if target is to the right, exit from source's right → target's left
-      const sx = targetCx > sourceCx
-        ? sourceRect.right - boardRect.left
-        : sourceRect.left - boardRect.left
-      const tx = targetCx > sourceCx
-        ? targetRect.left - boardRect.left
-        : targetRect.right - boardRect.left
+      let sx: number, tx: number, d: string
 
-      // Cubic bezier with horizontal-aware control points
-      const cx = (sx + tx) / 2
-      const d = `M ${sx},${sy} C ${cx},${sy} ${cx},${ty} ${tx},${ty}`
+      if (Math.abs(sourceCx - targetCx) < 50) {
+        // Same-column case: both endpoints exit from the left edge, arc leftward
+        sx = sourceRect.left - boardRect.left
+        tx = targetRect.left - boardRect.left
+        const offset = Math.max(40, Math.abs(ty - sy) * 0.4)
+        d = `M ${sx},${sy} C ${sx - offset},${sy} ${tx - offset},${ty} ${tx},${ty}`
+      } else {
+        // Use the closest side: if target is to the right, exit from source's right → target's left
+        sx = targetCx > sourceCx
+          ? sourceRect.right - boardRect.left
+          : sourceRect.left - boardRect.left
+        tx = targetCx > sourceCx
+          ? targetRect.left - boardRect.left
+          : targetRect.right - boardRect.left
+
+        // Cubic bezier with horizontal-aware control points
+        const cx = (sx + tx) / 2
+        d = `M ${sx},${sy} C ${cx},${sy} ${cx},${ty} ${tx},${ty}`
+      }
 
       paths.push({ key: `${activeTicketId}-${blockerId}`, d })
     }

--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -63,6 +63,7 @@ export function KanbanColumn({ column, tickets, archivedTickets, projectId, conn
   const [dropIndex, setDropIndex] = useState<number | null>(null)
   const dropIndexRef = useRef<number | null>(null)
   const [worktreePickerTicket, setWorktreePickerTicket] = useState<KanbanTicket | null>(null)
+  const [saveConfigTicket, setSaveConfigTicket] = useState<KanbanTicket | null>(null)
   const [pendingBackwardDrag, setPendingBackwardDrag] = useState<{
     ticketId: string
     targetIndex: number
@@ -246,7 +247,28 @@ export function KanbanColumn({ column, tickets, archivedTickets, projectId, conn
         if (isInProgressColumn && !isSimpleMode) {
           const draggedTicket = findTicket(ticketId)
           if (draggedTicket) {
-            setWorktreePickerTicket(draggedTicket)
+            // Check if ticket has unresolved blockers
+            const blockerIds = store.dependencyMap.get(ticketId)
+            let isBlocked = false
+            if (blockerIds?.size) {
+              for (const [, projTickets] of store.tickets) {
+                for (const t of projTickets) {
+                  if (blockerIds.has(t.id) && t.column !== 'done') {
+                    isBlocked = true
+                    break
+                  }
+                }
+                if (isBlocked) break
+              }
+            }
+
+            if (isBlocked) {
+              // Blocked ticket — open picker in save-config-only mode
+              setSaveConfigTicket(draggedTicket)
+            } else {
+              // Normal unblocked ticket — open regular picker
+              setWorktreePickerTicket(draggedTicket)
+            }
             return // Don't move yet — modal handles the move
           }
         }
@@ -596,6 +618,17 @@ export function KanbanColumn({ column, tickets, archivedTickets, projectId, conn
             if (!open) setWorktreePickerTicket(null)
           }}
           connectionId={connectionId}
+        />
+      )}
+
+      {/* Worktree picker modal — save-config-only for blocked tickets */}
+      {saveConfigTicket && (
+        <WorktreePickerModal
+          ticket={saveConfigTicket}
+          projectId={saveConfigTicket.project_id}
+          open={!!saveConfigTicket}
+          onOpenChange={(open) => { if (!open) setSaveConfigTicket(null) }}
+          saveConfigOnly
         />
       )}
 

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -127,7 +127,11 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     }, [ticket.id])
   )
 
-  const isBlocked = unresolvedBlockerCount > 0
+  const isSimpleMode = useKanbanStore(
+    useCallback((state) => state.simpleModeByProject[ticket.project_id] ?? false, [ticket.project_id])
+  )
+
+  const isBlocked = !isSimpleMode && unresolvedBlockerCount > 0
 
   // ── Lookup worktree name ────────────────────────────────────────
   const worktreeName = useWorktreeStore(

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles, Lock, Link2, Plus } from 'lucide-react'
 import { UpdateStatusModal } from './UpdateStatusModal'
 import { cn } from '@/lib/utils'
@@ -99,8 +100,10 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
   const dragCloneRef = useRef<HTMLElement | null>(null)
 
   // ── Dependency selectors ────────────────────────────────────────
+  // useShallow prevents infinite re-render loops by doing shallow equality
+  // comparison on the returned array instead of Object.is reference check.
   const blockerTickets = useKanbanStore(
-    useCallback((state) => {
+    useShallow((state) => {
       const blockerIds = state.dependencyMap.get(ticket.id)
       if (!blockerIds?.size) return EMPTY_ARRAY as unknown as KanbanTicket[]
       const result: KanbanTicket[] = []
@@ -110,7 +113,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
         }
       }
       return result
-    }, [ticket.id])
+    })
   )
 
   const unresolvedBlockerCount = useKanbanStore(

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
-import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles } from 'lucide-react'
+import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles, Lock, Link2, Plus } from 'lucide-react'
 import { UpdateStatusModal } from './UpdateStatusModal'
 import { cn } from '@/lib/utils'
 import { ProviderIcon, getProviderLabel } from '@/components/ui/provider-icon'
@@ -66,6 +66,8 @@ function getProjectColor(projectId: string, connectionProjectIds: string[]): str
   return PROJECT_TAG_COLORS[idx % PROJECT_TAG_COLORS.length]
 }
 
+const EMPTY_ARRAY: readonly never[] = []
+
 interface KanbanTicketCardProps {
   ticket: KanbanTicket
   /** Position index within the column (used for drag transfer data) */
@@ -95,6 +97,37 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
   const [showPRPicker, setShowPRPicker] = useState(false)
   const isExternalTicket = !!ticket.external_provider
   const dragCloneRef = useRef<HTMLElement | null>(null)
+
+  // ── Dependency selectors ────────────────────────────────────────
+  const blockerTickets = useKanbanStore(
+    useCallback((state) => {
+      const blockerIds = state.dependencyMap.get(ticket.id)
+      if (!blockerIds?.size) return EMPTY_ARRAY as unknown as KanbanTicket[]
+      const result: KanbanTicket[] = []
+      for (const [, projectTickets] of state.tickets) {
+        for (const t of projectTickets) {
+          if (blockerIds.has(t.id)) result.push(t)
+        }
+      }
+      return result
+    }, [ticket.id])
+  )
+
+  const unresolvedBlockerCount = useKanbanStore(
+    useCallback((state) => {
+      const blockers = state.dependencyMap.get(ticket.id)
+      if (!blockers?.size) return 0
+      let count = 0
+      for (const [, projectTickets] of state.tickets) {
+        for (const t of projectTickets) {
+          if (blockers.has(t.id) && t.column !== 'done') count++
+        }
+      }
+      return count
+    }, [ticket.id])
+  )
+
+  const isBlocked = unresolvedBlockerCount > 0
 
   // ── Lookup worktree name ────────────────────────────────────────
   const worktreeName = useWorktreeStore(
@@ -392,6 +425,16 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     [ticket.worktree_id, ticket.project_id, isArchived]
   )
 
+  const handleMouseEnter = useCallback(() => {
+    if (isBlocked) {
+      useKanbanStore.getState().setHoveredBlockedTicketId(ticket.id)
+    }
+  }, [isBlocked, ticket.id])
+
+  const handleMouseLeave = useCallback(() => {
+    useKanbanStore.getState().setHoveredBlockedTicketId(null)
+  }, [])
+
   const isDone = ticket.column === 'done'
 
   // ── Context menu handlers ─────────────────────────────────────
@@ -514,16 +557,20 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             <PopoverAnchor asChild>
               <div
                 data-testid={`kanban-ticket-${ticket.id}`}
+                data-ticket-id={ticket.id}
                 draggable={!isArchived}
                 onDragStart={handleDragStart}
                 onDragEnd={handleDragEnd}
                 onClick={handleClick}
                 onMouseDown={handleMouseDown}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
                 className={cn(
                   'group cursor-pointer rounded-md border bg-card shadow-sm p-2 transition-all duration-200',
                   'hover:bg-muted/40',
                   isDragging && 'invisible',
                   isArchived && 'opacity-50 cursor-default',
+                  isBlocked && 'opacity-60',
                   borderState === 'default' && 'border-border/60',
                   borderState === 'blue' && 'border-blue-500/60',
                   borderState === 'violet' && 'border-violet-500/60',
@@ -561,13 +608,20 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isBeingReviewed || completedReviewSessionId || isArchived || isRunProcessAlive || ticket.github_pr_number || isCreatingPR) && (
+            {(hasAttachments || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isBeingReviewed || completedReviewSessionId || isArchived || isBlocked || isRunProcessAlive || ticket.github_pr_number || isCreatingPR) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
                   <span className="inline-flex items-center gap-1 rounded-full bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
                     <Archive className="h-3 w-3" />
                     Archived
+                  </span>
+                )}
+                {/* Blocked badge */}
+                {isBlocked && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 border border-amber-500/30 px-2 py-0.5 text-[11px] font-medium text-amber-500">
+                    <Lock className="h-3 w-3" />
+                    {unresolvedBlockerCount}
                   </span>
                 )}
                 {/* Attachment badge */}
@@ -644,7 +698,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                   </span>
                 )}
 
-                {(isBusy || isAsking) && ticket.mode && (
+                {(isBusy || isAsking) && ticket.mode && !isBlocked && (
                   <span data-testid="kanban-ticket-progress" className="ml-auto flex items-center gap-1.5">
                     {timerText && (
                       <span className={cn(
@@ -821,6 +875,42 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                   Legendary
                 </ContextMenuRadioItem>
               </ContextMenuRadioGroup>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+
+          <ContextMenuSub>
+            <ContextMenuSubTrigger data-testid="ctx-dependencies-submenu" className="gap-2">
+              <Link2 className="h-3.5 w-3.5" />
+              Dependencies
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              <ContextMenuItem
+                data-testid="ctx-add-dependency"
+                onClick={() => useKanbanStore.getState().enterDependencyMode(ticket.id)}
+                className="gap-2"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add dependency...
+              </ContextMenuItem>
+              {blockerTickets.length > 0 && <ContextMenuSeparator />}
+              {blockerTickets.map(blocker => (
+                <ContextMenuItem
+                  key={blocker.id}
+                  className="gap-2 justify-between"
+                  onSelect={(e) => {
+                    e.preventDefault()
+                    useKanbanStore.getState().removeDependency(ticket.id, blocker.id)
+                  }}
+                >
+                  <span className="truncate max-w-[180px]">{blocker.title}</span>
+                  <X className="h-3 w-3 shrink-0 text-muted-foreground hover:text-foreground" />
+                </ContextMenuItem>
+              ))}
+              {blockerTickets.length === 0 && (
+                <ContextMenuItem disabled className="text-muted-foreground text-xs">
+                  (No dependencies)
+                </ContextMenuItem>
+              )}
             </ContextMenuSubContent>
           </ContextMenuSub>
 

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -402,6 +402,10 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
   // ── Click handler — open ticket detail modal ───────────────────
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
+      // In dependency mode, don't open the modal — let click bubble
+      // to the board's handleBoardClick which toggles the dependency
+      if (useKanbanStore.getState().dependencyMode?.active) return
+
       // Cmd+click (Mac) / Ctrl+click (Win/Linux) — select attached worktree
       if ((e.metaKey || e.ctrlKey) && ticket.worktree_id && !isArchived) {
         e.preventDefault()

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -134,6 +134,16 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     useCallback((state) => state.simpleModeByProject[ticket.project_id] ?? false, [ticket.project_id])
   )
 
+  // True when another blocked ticket is hovered and THIS ticket is one of its blockers
+  const isHighlightedAsBlocker = useKanbanStore(
+    useCallback((state) => {
+      const hoveredId = state.hoveredBlockedTicketId
+      if (!hoveredId) return false
+      const blockers = state.dependencyMap.get(hoveredId)
+      return blockers?.has(ticket.id) ?? false
+    }, [ticket.id])
+  )
+
   const isBlocked = !isSimpleMode && unresolvedBlockerCount > 0
 
   // ── Lookup worktree name ────────────────────────────────────────
@@ -582,9 +592,11 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                   isDragging && 'invisible',
                   isArchived && 'opacity-50 cursor-default',
                   isBlocked && 'opacity-60',
-                  borderState === 'default' && 'border-border/60',
-                  borderState === 'blue' && 'border-blue-500/60',
-                  borderState === 'violet' && 'border-violet-500/60',
+                  // Highlighted as a blocker of the currently hovered ticket
+                  isHighlightedAsBlocker && 'border-dashed !border-amber-500/70 ring-1 ring-amber-500/30',
+                  !isHighlightedAsBlocker && borderState === 'default' && 'border-border/60',
+                  !isHighlightedAsBlocker && borderState === 'blue' && 'border-blue-500/60',
+                  !isHighlightedAsBlocker && borderState === 'violet' && 'border-violet-500/60',
                   // Left accent stripe for marks
                   ticket.mark === 'common' && 'border-l-4 !border-l-green-500',
                   ticket.mark === 'rare' && 'border-l-4 !border-l-blue-500',

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -764,18 +764,21 @@ function EditModeContent({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
   // ── Dependency selectors ──────────────────────────────────────────
+  // Stable empty array to avoid referential-inequality loops in Zustand selectors
+  const EMPTY_TICKETS: readonly KanbanTicket[] = useMemo(() => [], [])
+
   const blockerTickets = useKanbanStore(
     useCallback((state) => {
       const blockerIds = state.dependencyMap.get(ticket.id)
-      if (!blockerIds?.size) return [] as KanbanTicket[]
+      if (!blockerIds?.size) return EMPTY_TICKETS as KanbanTicket[]
       const result: KanbanTicket[] = []
       for (const [, projectTickets] of state.tickets) {
         for (const t of projectTickets) {
           if (blockerIds.has(t.id)) result.push(t)
         }
       }
-      return result
-    }, [ticket.id])
+      return result.length > 0 ? result : EMPTY_TICKETS as KanbanTicket[]
+    }, [ticket.id, EMPTY_TICKETS])
   )
 
   const dependentTickets = useKanbanStore(
@@ -789,8 +792,8 @@ function EditModeContent({
           }
         }
       }
-      return result
-    }, [ticket.id])
+      return result.length > 0 ? result : EMPTY_TICKETS as KanbanTicket[]
+    }, [ticket.id, EMPTY_TICKETS])
   )
 
   // Load live PR state so merge-button guard works (hide if already merged/closed)

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -21,7 +21,9 @@ import {
   Github,
   FileUp,
   File as FileIcon,
-  Upload
+  Upload,
+  Lock,
+  Plus
 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -761,6 +763,36 @@ function EditModeContent({
   const { pinAndActivate: pinAndActivateSession, lifecycleLoading } = usePinAndActivateSession(onClose)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
+  // ── Dependency selectors ──────────────────────────────────────────
+  const blockerTickets = useKanbanStore(
+    useCallback((state) => {
+      const blockerIds = state.dependencyMap.get(ticket.id)
+      if (!blockerIds?.size) return [] as KanbanTicket[]
+      const result: KanbanTicket[] = []
+      for (const [, projectTickets] of state.tickets) {
+        for (const t of projectTickets) {
+          if (blockerIds.has(t.id)) result.push(t)
+        }
+      }
+      return result
+    }, [ticket.id])
+  )
+
+  const dependentTickets = useKanbanStore(
+    useCallback((state) => {
+      const result: KanbanTicket[] = []
+      for (const [depId, blockerIds] of state.dependencyMap) {
+        if (blockerIds.has(ticket.id)) {
+          for (const [, projectTickets] of state.tickets) {
+            const t = projectTickets.find(pt => pt.id === depId)
+            if (t) result.push(t)
+          }
+        }
+      }
+      return result
+    }, [ticket.id])
+  )
+
   // Load live PR state so merge-button guard works (hide if already merged/closed)
   useEffect(() => {
     if (lifecycle.hasAttachedPR) lifecycle.loadPRState()
@@ -914,6 +946,76 @@ function EditModeContent({
           onChange={setAttachments}
           testIdPrefix="ticket-edit"
         />
+
+        {/* Dependencies section */}
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-foreground">
+            Dependencies
+          </label>
+          <div className="space-y-2">
+            {/* Blockers */}
+            {blockerTickets.length > 0 && (
+              <div className="space-y-1">
+                <span className="text-xs text-muted-foreground">Blocked by:</span>
+                {blockerTickets.map(blocker => (
+                  <div key={blocker.id} className="flex items-center justify-between gap-2 px-2 py-1 rounded-md bg-muted/30">
+                    <div className="flex items-center gap-2 min-w-0">
+                      {blocker.column === 'done' ? (
+                        <span className="text-green-500 text-xs">&#10003;</span>
+                      ) : (
+                        <Lock className="h-3 w-3 text-amber-500" />
+                      )}
+                      <span className="text-sm truncate">{blocker.title}</span>
+                    </div>
+                    <button
+                      onClick={() => useKanbanStore.getState().removeDependency(ticket.id, blocker.id)}
+                      className="text-muted-foreground hover:text-foreground shrink-0"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Dependents */}
+            {dependentTickets.length > 0 && (
+              <div className="space-y-1">
+                <span className="text-xs text-muted-foreground">Depended on by:</span>
+                {dependentTickets.map(dep => (
+                  <div key={dep.id} className="flex items-center gap-2 px-2 py-1 rounded-md bg-muted/30">
+                    <span className="text-sm truncate">{dep.title}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Add dependency button */}
+            <button
+              type="button"
+              onClick={() => {
+                useKanbanStore.getState().enterDependencyMode(ticket.id)
+                onClose() // Close modal
+              }}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Plus className="h-3 w-3" />
+              Add dependency...
+            </button>
+
+            {/* Auto-launch indicator */}
+            {ticket.pending_launch_config && (
+              <div className="flex items-center gap-1.5 text-xs text-amber-500">
+                <Zap className="h-3 w-3" />
+                Auto-launch queued: {(() => {
+                  try {
+                    return JSON.parse(ticket.pending_launch_config).mode
+                  } catch { return 'unknown' }
+                })()} mode
+              </div>
+            )}
+          </div>
+        </div>
       </div>
 
       <DialogFooter className="flex items-center justify-between sm:justify-between flex-wrap gap-y-2">

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import {
   Eye,
   EyeOff,
@@ -764,25 +765,24 @@ function EditModeContent({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
   // ── Dependency selectors ──────────────────────────────────────────
-  // Stable empty array to avoid referential-inequality loops in Zustand selectors
-  const EMPTY_TICKETS: readonly KanbanTicket[] = useMemo(() => [], [])
-
+  // useShallow prevents infinite re-render loops by doing shallow equality
+  // comparison on the returned array instead of Object.is reference check.
   const blockerTickets = useKanbanStore(
-    useCallback((state) => {
+    useShallow((state) => {
       const blockerIds = state.dependencyMap.get(ticket.id)
-      if (!blockerIds?.size) return EMPTY_TICKETS as KanbanTicket[]
+      if (!blockerIds?.size) return [] as KanbanTicket[]
       const result: KanbanTicket[] = []
       for (const [, projectTickets] of state.tickets) {
         for (const t of projectTickets) {
           if (blockerIds.has(t.id)) result.push(t)
         }
       }
-      return result.length > 0 ? result : EMPTY_TICKETS as KanbanTicket[]
-    }, [ticket.id, EMPTY_TICKETS])
+      return result
+    })
   )
 
   const dependentTickets = useKanbanStore(
-    useCallback((state) => {
+    useShallow((state) => {
       const result: KanbanTicket[] = []
       for (const [depId, blockerIds] of state.dependencyMap) {
         if (blockerIds.has(ticket.id)) {
@@ -792,8 +792,8 @@ function EditModeContent({
           }
         }
       }
-      return result.length > 0 ? result : EMPTY_TICKETS as KanbanTicket[]
-    }, [ticket.id, EMPTY_TICKETS])
+      return result
+    })
   )
 
   // Load live PR state so merge-button guard works (hide if already merged/closed)

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -54,6 +54,8 @@ interface WorktreePickerModalProps {
   preAssignOnly?: boolean
   /** When set, operates in connection mode — no worktree selection, uses connection path */
   connectionId?: string
+  /** When true, serializes config as JSON on the ticket instead of creating a session */
+  saveConfigOnly?: boolean
 }
 
 /** In-memory: last-chosen source branch per project (resets on app restart) */
@@ -112,7 +114,8 @@ export function WorktreePickerModal({
   onOpenChange,
   onSendComplete,
   preAssignOnly = false,
-  connectionId
+  connectionId,
+  saveConfigOnly = false
 }: WorktreePickerModalProps) {
   const isConnectionMode = !!connectionId
   const [mode, setMode] = useState<PickerMode>('build')
@@ -431,6 +434,38 @@ export function WorktreePickerModal({
     try {
       let worktreeId = selectedWorktreeId
 
+      // ── Save config only path: serialize config, don't create session ─
+      if (saveConfigOnly) {
+        const pendingConfig = {
+          worktree: isNewWorktree
+            ? { type: 'new' as const, sourceBranch: sourceBranch ?? defaultBranchName }
+            : { type: 'existing' as const, worktreeId: worktreeId! },
+          prompt: promptText.trim() || buildPrompt(mode, ticket),
+          mode,
+          model: selectedModel ?? null,
+          sdk: agentSdk,
+          codexFastMode
+        }
+
+        const sortOrder = useKanbanStore.getState().computeSortOrder(
+          useKanbanStore.getState().getTicketsByColumn(projectId, 'in_progress'),
+          0
+        )
+
+        await updateTicket(ticket.id, projectId, {
+          pending_launch_config: JSON.stringify(pendingConfig),
+          column: 'in_progress',
+          sort_order: sortOrder,
+          mode
+        })
+
+        onSendComplete?.()
+        onOpenChange(false)
+        toast.success('Launch config saved — will auto-launch when dependencies resolve')
+        setIsSending(false)
+        return
+      }
+
       // ── Pre-assign path: only set worktree_id, no session ────────
       if (preAssignOnly) {
         // Create new worktree if needed
@@ -629,6 +664,7 @@ export function WorktreePickerModal({
     onSendComplete,
     onOpenChange,
     preAssignOnly,
+    saveConfigOnly,
     selectedModel,
     autoResolvedModel,
     codexFastMode,
@@ -649,7 +685,7 @@ export function WorktreePickerModal({
       >
         <DialogHeader className="space-y-2.5 pb-1">
           <DialogTitle className="text-base">
-            {preAssignOnly ? 'Assign Worktree' : 'Start Session'}
+            {saveConfigOnly ? 'Pre-configure Launch' : preAssignOnly ? 'Assign Worktree' : 'Start Session'}
           </DialogTitle>
           <DialogDescription>
             {preAssignOnly ? 'Pre-assign a worktree to' : isConnectionMode ? 'Start a session for' : 'Pick a worktree for'}{' '}
@@ -981,6 +1017,11 @@ export function WorktreePickerModal({
               <>
                 <GitBranch className="h-3.5 w-3.5" />
                 {isSending ? 'Assigning...' : 'Assign'}
+              </>
+            ) : saveConfigOnly ? (
+              <>
+                <Send className="h-3.5 w-3.5" />
+                {isSending ? 'Saving...' : 'Save & Queue'}
               </>
             ) : (
               <>

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -55,7 +55,8 @@ export async function autoLaunchTicket(ticket: KanbanTicket): Promise<void> {
       worktreeId,
       ticket.project_id,
       config.sdk,
-      config.mode
+      config.mode,
+      { autoFocus: false }
     )
     if (!sessionResult.success || !sessionResult.session) {
       toast.error(`Auto-launch failed: ${sessionResult.error || 'Could not create session'}`)

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -1,0 +1,132 @@
+import type { KanbanTicket } from '../../../../main/db/types'
+import type { PendingLaunchConfig } from '../../../../main/db/types'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
+import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
+import { snapshotTokenBaseline } from '@/lib/token-baselines'
+import { PLAN_MODE_PREFIX, SUPER_PLAN_MODE_PREFIX, isPlanLike } from '@/lib/constants'
+import { toast } from '@/lib/toast'
+import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
+
+export async function autoLaunchTicket(ticket: KanbanTicket): Promise<void> {
+  if (!ticket.pending_launch_config) return
+
+  let config: PendingLaunchConfig
+  try {
+    config = JSON.parse(ticket.pending_launch_config) as PendingLaunchConfig
+  } catch {
+    console.error('Failed to parse pending_launch_config for ticket:', ticket.id)
+    return
+  }
+
+  const project = useProjectStore.getState().projects.find(p => p.id === ticket.project_id)
+  if (!project) {
+    console.error('Project not found for auto-launch:', ticket.project_id)
+    return
+  }
+
+  try {
+    // 1. Resolve worktree
+    let worktreeId: string
+    if (config.worktree.type === 'new') {
+      const nameHint = canonicalizeTicketTitle(ticket.title)
+      const result = await useWorktreeStore.getState().createWorktreeFromBranch(
+        ticket.project_id,
+        project.path,
+        project.name,
+        config.worktree.sourceBranch,
+        nameHint || undefined
+      )
+      if (!result.success || !result.worktree?.id) {
+        toast.error(`Auto-launch failed: ${result.error || 'Could not create worktree'}`)
+        return
+      }
+      worktreeId = result.worktree.id
+    } else {
+      worktreeId = config.worktree.worktreeId
+    }
+
+    // 2. Create session
+    const sessionResult = await useSessionStore.getState().createSession(
+      worktreeId,
+      ticket.project_id,
+      config.sdk,
+      config.mode
+    )
+    if (!sessionResult.success || !sessionResult.session) {
+      toast.error(`Auto-launch failed: ${sessionResult.error || 'Could not create session'}`)
+      return
+    }
+
+    const sessionId = sessionResult.session.id
+    const sessionAgentSdk = sessionResult.session.agent_sdk
+
+    // 3. Set status tracking
+    messageSendTimes.set(sessionId, Date.now())
+    userExplicitSendTimes.set(sessionId, Date.now())
+    snapshotTokenBaseline(sessionId)
+    lastSendMode.set(sessionId, config.mode)
+    useWorktreeStatusStore.getState().setSessionStatus(
+      sessionId,
+      isPlanLike(config.mode) ? 'planning' : 'working'
+    )
+
+    // 4. Apply model override
+    const effectiveModel = config.model ?? undefined
+    if (config.model) {
+      await useSessionStore.getState().setSessionModel(sessionId, config.model)
+    }
+
+    // 5. Update ticket: clear pending config, set session + worktree
+    await useKanbanStore.getState().updateTicket(ticket.id, ticket.project_id, {
+      pending_launch_config: null,
+      current_session_id: sessionId,
+      worktree_id: worktreeId,
+      mode: config.mode
+    })
+
+    // 6. Trigger usage refresh
+    useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(config.sdk))
+
+    // 7. Toast notification
+    toast.success(`Auto-launched: ${ticket.title}`)
+
+    // 8. Connect to OpenCode and send prompt
+    const allWorktrees = Array.from(useWorktreeStore.getState().worktreesByProject.values()).flat()
+    const worktree = allWorktrees.find(w => w.id === worktreeId)
+    if (!worktree?.path) return
+
+    const connectResult = await window.opencodeOps.connect(worktree.path, sessionId)
+    if (!connectResult.success || !connectResult.sessionId) return
+
+    useSessionStore.getState().setOpenCodeSessionId(sessionId, connectResult.sessionId)
+    await window.db.session.update(sessionId, { opencode_session_id: connectResult.sessionId })
+
+    // 9. Send prompt
+    if (config.prompt.trim()) {
+      const skipPrefix = sessionAgentSdk === 'claude-code' || sessionAgentSdk === 'codex'
+      const modePrefix =
+        config.mode === 'super-plan' ? SUPER_PLAN_MODE_PREFIX
+        : config.mode === 'plan' && !skipPrefix ? PLAN_MODE_PREFIX
+        : ''
+      const fullPrompt = modePrefix + config.prompt.trim()
+      const promptOptions =
+        sessionAgentSdk === 'codex' ? { codexFastMode: config.codexFastMode } : undefined
+
+      if (config.mode === 'super-plan') {
+        useSessionStore.getState().setSessionMode(sessionId, 'plan')
+      }
+
+      await window.opencodeOps.prompt(worktree.path, connectResult.sessionId, [
+        { type: 'text', text: fullPrompt }
+      ], effectiveModel, promptOptions)
+    }
+  } catch (err) {
+    console.error('Auto-launch failed for ticket:', ticket.id, err)
+    toast.error(`Auto-launch failed for: ${ticket.title}`)
+  }
+}

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -950,8 +950,8 @@ export const useKanbanStore = create<KanbanState>()(
         if (result.success) {
           set((state) => {
             const newMap = new Map(state.dependencyMap)
-            const existing = new Map(newMap.get(dependentId)?.entries() ?? [])
-            const newSet = new Set(existing.values())
+            const existing = newMap.get(dependentId) ?? new Set()
+            const newSet = new Set(existing)
             newSet.add(blockerId)
             newMap.set(dependentId, newSet)
             return { dependencyMap: newMap }

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -263,6 +263,26 @@ export const useKanbanStore = create<KanbanState>()(
 
         try {
           await window.kanban.ticket.delete(ticketId)
+
+          // Remove all dependency links for deleted ticket
+          window.kanban.dependency.removeAll(ticketId).catch(() => {})
+          // Update local dependency map
+          set((state) => {
+            const newMap = new Map(state.dependencyMap)
+            newMap.delete(ticketId)
+            for (const [depId, blockers] of newMap) {
+              if (blockers.has(ticketId)) {
+                const newSet = new Set(blockers)
+                newSet.delete(ticketId)
+                if (newSet.size === 0) {
+                  newMap.delete(depId)
+                } else {
+                  newMap.set(depId, newSet)
+                }
+              }
+            }
+            return { dependencyMap: newMap }
+          })
         } catch (err) {
           // Revert on failure
           set((state) => {

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -152,6 +152,19 @@ interface KanbanState {
 
   // ── Helpers ────────────────────────────────────────────────────────
   computeSortOrder: (tickets: KanbanTicket[], targetIndex: number) => number
+
+  // ── Dependency tracking ────────────────────────────────────────────
+  dependencyMap: Map<string, Set<string>>  // Map<dependent_id, Set<blocker_id>>
+  dependencyMode: { active: boolean; sourceTicketId: string | null } | null
+  hoveredBlockedTicketId: string | null
+
+  // ── Dependency actions ─────────────────────────────────────────────
+  loadDependencies: (projectId: string) => Promise<void>
+  addDependency: (dependentId: string, blockerId: string) => Promise<{ success: boolean; error?: string }>
+  removeDependency: (dependentId: string, blockerId: string) => Promise<void>
+  enterDependencyMode: (sourceTicketId: string) => void
+  exitDependencyMode: () => void
+  setHoveredBlockedTicketId: (ticketId: string | null) => void
 }
 
 // ── Store ──────────────────────────────────────────────────────────────
@@ -168,6 +181,9 @@ export const useKanbanStore = create<KanbanState>()(
       draggingTicketId: null,
       showArchivedByProject: {} as Record<string, boolean>,
       pendingDoneMove: null,
+      dependencyMap: new Map(),
+      dependencyMode: null,
+      hoveredBlockedTicketId: null,
 
       // ── setSelectedTicketId ────────────────────────────────────────
       setSelectedTicketId: (id: string | null) => {
@@ -185,6 +201,8 @@ export const useKanbanStore = create<KanbanState>()(
             next.set(projectId, tickets)
             return { tickets: next, isLoading: false }
           })
+          // Load dependencies for this project
+          get().loadDependencies(projectId)
         } catch {
           set({ isLoading: false })
         }
@@ -274,6 +292,28 @@ export const useKanbanStore = create<KanbanState>()(
 
         try {
           await window.kanban.ticket.archive(ticketId)
+
+          // Remove all dependency links for archived ticket
+          await window.kanban.dependency.removeAll(ticketId)
+          // Update local dependency map
+          set((state) => {
+            const newMap = new Map(state.dependencyMap)
+            // Remove as dependent
+            newMap.delete(ticketId)
+            // Remove from blockers of other tickets
+            for (const [depId, blockers] of newMap) {
+              if (blockers.has(ticketId)) {
+                const newSet = new Set(blockers)
+                newSet.delete(ticketId)
+                if (newSet.size === 0) {
+                  newMap.delete(depId)
+                } else {
+                  newMap.set(depId, newSet)
+                }
+              }
+            }
+            return { dependencyMap: newMap }
+          })
         } catch (err) {
           // Revert on failure
           set((state) => {
@@ -436,6 +476,40 @@ export const useKanbanStore = create<KanbanState>()(
 
         try {
           await window.kanban.ticket.move(ticketId, column, sortOrder)
+
+          // When a ticket moves to done, check if any dependents can be auto-launched
+          if (column === 'done') {
+            const { dependencyMap, tickets: allTickets } = get()
+            // Find tickets that list this ticket as a blocker
+            for (const [depId, blockers] of dependencyMap) {
+              if (!blockers.has(ticketId)) continue
+              // Check if ALL blockers of this dependent are now done
+              let allDone = true
+              for (const bid of blockers) {
+                // Find the blocker ticket across all projects
+                for (const [, projTickets] of allTickets) {
+                  const bt = projTickets.find(t => t.id === bid)
+                  if (bt && bt.column !== 'done') { allDone = false; break }
+                }
+                if (!allDone) break
+              }
+              if (allDone) {
+                // Find the dependent ticket and auto-launch if it has pending config
+                for (const [, projTickets] of allTickets) {
+                  const depTicket = projTickets.find(t => t.id === depId)
+                  if (depTicket?.pending_launch_config) {
+                    // Auto-launch will be handled by the auto-launch module (Task 5)
+                    import('../lib/auto-launch').then(({ autoLaunchTicket }) => {
+                      autoLaunchTicket(depTicket).catch(err => {
+                        console.error('Auto-launch failed for ticket:', depTicket.id, err)
+                      })
+                    }).catch(() => {})
+                    break
+                  }
+                }
+              }
+            }
+          }
         } catch (err) {
           // Revert on failure
           set((state) => {
@@ -683,6 +757,10 @@ export const useKanbanStore = create<KanbanState>()(
             })
             return { tickets: newTickets }
           })
+          // Load dependencies for each project
+          for (const pid of projectIds) {
+            get().loadDependencies(pid)
+          }
         } catch (error) {
           console.error('Failed to load tickets for connection:', error)
         } finally {
@@ -723,6 +801,10 @@ export const useKanbanStore = create<KanbanState>()(
             })
             return { tickets: newTickets }
           })
+          // Load dependencies for each project
+          for (const pid of projectIds) {
+            get().loadDependencies(pid)
+          }
         } catch (error) {
           console.error('Failed to load tickets for pinned projects:', error)
         } finally {
@@ -835,6 +917,81 @@ export const useKanbanStore = create<KanbanState>()(
         const before = tickets[targetIndex - 1]
         const after = tickets[targetIndex]
         return (before.sort_order + after.sort_order) / 2
+      },
+
+      // ── loadDependencies ────────────────────────────────────────────
+      loadDependencies: async (projectId: string) => {
+        try {
+          const deps = await window.kanban.dependency.getForProject(projectId)
+          set((state) => {
+            const newMap = new Map(state.dependencyMap)
+            // Clear existing entries for this project's tickets
+            const projectTickets = state.tickets.get(projectId) ?? []
+            const projectTicketIds = new Set(projectTickets.map(t => t.id))
+            for (const [depId] of newMap) {
+              if (projectTicketIds.has(depId)) newMap.delete(depId)
+            }
+            // Populate from fetched data
+            for (const dep of deps) {
+              const existing = newMap.get(dep.dependent_id) ?? new Set()
+              existing.add(dep.blocker_id)
+              newMap.set(dep.dependent_id, existing)
+            }
+            return { dependencyMap: newMap }
+          })
+        } catch (err) {
+          console.error('Failed to load dependencies:', err)
+        }
+      },
+
+      // ── addDependency ───────────────────────────────────────────────
+      addDependency: async (dependentId: string, blockerId: string) => {
+        const result = await window.kanban.dependency.add(dependentId, blockerId)
+        if (result.success) {
+          set((state) => {
+            const newMap = new Map(state.dependencyMap)
+            const existing = new Map(newMap.get(dependentId)?.entries() ?? [])
+            const newSet = new Set(existing.values())
+            newSet.add(blockerId)
+            newMap.set(dependentId, newSet)
+            return { dependencyMap: newMap }
+          })
+        }
+        return result
+      },
+
+      // ── removeDependency ────────────────────────────────────────────
+      removeDependency: async (dependentId: string, blockerId: string) => {
+        await window.kanban.dependency.remove(dependentId, blockerId)
+        set((state) => {
+          const newMap = new Map(state.dependencyMap)
+          const existing = newMap.get(dependentId)
+          if (existing) {
+            const newSet = new Set(existing)
+            newSet.delete(blockerId)
+            if (newSet.size === 0) {
+              newMap.delete(dependentId)
+            } else {
+              newMap.set(dependentId, newSet)
+            }
+          }
+          return { dependencyMap: newMap }
+        })
+      },
+
+      // ── enterDependencyMode ─────────────────────────────────────────
+      enterDependencyMode: (sourceTicketId: string) => {
+        set({ dependencyMode: { active: true, sourceTicketId } })
+      },
+
+      // ── exitDependencyMode ──────────────────────────────────────────
+      exitDependencyMode: () => {
+        set({ dependencyMode: null })
+      },
+
+      // ── setHoveredBlockedTicketId ───────────────────────────────────
+      setHoveredBlockedTicketId: (ticketId: string | null) => {
+        set({ hoveredBlockedTicketId: ticketId })
       }
     }),
     {


### PR DESCRIPTION
## Summary

- **Database schema migration (v22)**: Add `ticket_dependencies` table with BFS cycle detection and `pending_launch_config` column on `kanban_tickets`
- **Dependency API**: Add 6 IPC handlers for add/remove/query operations with same-project enforcement and self-dependency validation
- **Dependency mode UI**: Interactive overlay with dark background and floating instruction bar to select/toggle dependencies
- **SVG bezier lines**: Render dashed amber dependency lines between tickets with smart curve logic:
  - **Same-column case**: Exit/enter from left edges with leftward arc (offset scales to 40% of vertical distance)
  - **Different columns**: Exit/enter from closest sides with cubic bezier control points
- **Blocked ticket state**: Blocked tickets show lock badge with unresolved blocker count, reduced opacity, and prevent launch until all blockers are done
- **Context menu integration**: "Dependencies" submenu to add/remove blockers, plus blocker highlighting with dashed amber border when hovering blocked tickets
- **Ticket modal enhancements**: "Blocked by" and "Depended on by" sections in edit mode, status indicator (✓ for done blockers, 🔒 for pending)
- **WorktreePickerModal saveConfigOnly mode**: Blocked tickets can save launch config without moving, deferring launch until unblocked
- **Auto-launch integration**: Pass `{ autoFocus: false }` to `createSession()` to prevent focus stealing

## Testing

- Add ticket A → B (B blocks A): Verify A shows blocker badge, reduced opacity, cannot launch
- SVG curves render correctly for same/different column cases: Check bezier paths visually
- Circular dependency prevention: Add A → B → C, attempt C → A, verify error message
- Self-dependency check: Attempt A → A, verify error message
- Same-project enforcement: Attempt dependency across projects, verify silently ignored
- Archive/delete cleanup: Delete blocker ticket, verify dependency removed from dependent
- Dependency mode escape: Press ESC in dependency mode, verify overlay closes
- Blocked ticket context menu: Verify "Add dependency..." enters mode, existing blockers list deletable
- Not run: Full end-to-end launch flow with saved pending config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new DB table/migration plus new client-side dependency/auto-launch flows that can affect ticket movement and session creation; primary risk is data migration correctness and edge cases in cycle detection/auto-launch triggering.
> 
> **Overview**
> Adds **ticket dependency management** end-to-end: a schema v22 migration creates `ticket_dependencies` and adds `kanban_tickets.pending_launch_config`, with `DatabaseService` methods to add/remove/query dependencies (including self-dependency, same-project enforcement, idempotency, and BFS circular-dependency prevention).
> 
> Exposes this via new `kanban:dependency:*` IPC + preload APIs and extends `useKanbanStore` with a dependency map, dependency selection mode, and cleanup on ticket archive/delete.
> 
> Updates the Kanban UI to support an interactive *dependency mode* (overlay + click-to-toggle), renders dashed SVG dependency lines, shows/flags blocked tickets (badges, highlighting, disabled progress display), and adds dependency controls in the ticket context menu and modal.
> 
> Introduces a `saveConfigOnly` path in `WorktreePickerModal` to persist a pending launch config for blocked tickets, plus a new `autoLaunchTicket` helper that triggers session/worktree creation and prompt sending once blockers resolve (invoked when a blocker moves to `done`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75956e9c4817e1008a8727334f840dc376d34b09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->