### PR TITLE
Fix Codex early-stop via collaborative subagent tracking

### DIFF
--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -156,6 +156,7 @@ export interface CodexManagerEvent {
   requestId?: string
   textDelta?: string
   payload?: unknown
+  childThreadId?: string
 }
 
 export interface CodexAppServerManagerEvents {
@@ -974,20 +975,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     context: CodexSessionContext,
     notification: ServerNotification
   ): void {
-    // DEBUG: Log all server notifications to discover title events
-    if (
-      notification.method !== 'item/agentMessage/delta' &&
-      notification.method !== 'item/reasoning/textDelta'
-    ) {
-      log.info('DEBUG handleServerNotification: received', {
-        method: notification.method,
-        paramsKeys: notification.params
-          ? Object.keys(notification.params as Record<string, unknown>)
-          : [],
-        paramsSnapshot: toJsonSnapshot(notification.params, 500)
-      })
-    }
-
     const route = this.readRouteFields(notification.params)
 
     // Track collab subagent spawns (must run before child detection)
@@ -1008,6 +995,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         ? asString(asObject(notification.params)?.delta)
         : undefined
 
+    const providerConversationId = this.readProviderConversationId(notification.params)
+
     // Emit event — child events get parent's turnId for proper attribution
     this.emitEvent({
       id: randomUUID(),
@@ -1019,6 +1008,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       ...((childParentTurnId ?? route.turnId) ? { turnId: childParentTurnId ?? route.turnId } : {}),
       ...(route.itemId ? { itemId: route.itemId } : {}),
       textDelta,
+      ...(isChildConversation && providerConversationId
+        ? { childThreadId: providerConversationId }
+        : {}),
       payload: notification.params
     })
 
@@ -1052,6 +1044,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     // Detect if this request is from a child thread — use parent's turnId for attribution
     const childParentTurnId = this.readChildParentTurnId(context, request.params)
     const effectiveTurnId = childParentTurnId ?? route.turnId
+    const providerConversationId = this.readProviderConversationId(request.params)
+    const isChildConversation = childParentTurnId !== undefined
 
     // Track approval requests
     if (
@@ -1097,6 +1091,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       ...(effectiveTurnId ? { turnId: effectiveTurnId } : {}),
       ...(route.itemId ? { itemId: route.itemId } : {}),
       requestId,
+      ...(isChildConversation && providerConversationId
+        ? { childThreadId: providerConversationId }
+        : {}),
       payload: request.params
     })
   }

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -629,6 +629,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       params.effort = input.reasoningEffort
     }
 
+    // Enable reasoning summary streaming so reasoning deltas appear in the UI.
+    // Without this parameter the server sends no reasoning deltas at all.
+    params.summary = 'auto'
+
     if (input.serviceTier !== undefined) {
       params.serviceTier = input.serviceTier
     }

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -107,6 +107,7 @@ export interface CodexSessionContext {
   pending: Map<string, PendingRequest>
   pendingApprovals: Map<string, PendingApprovalRequest>
   pendingUserInputs: Map<string, PendingUserInputRequest>
+  collabReceiverTurns: Map<string, string> // childThreadId → parentTurnId
   nextRequestId: number
   stopping: boolean
 }
@@ -415,6 +416,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         pending: new Map(),
         pendingApprovals: new Map(),
         pendingUserInputs: new Map(),
+        collabReceiverTurns: new Map(),
         nextRequestId: 1,
         stopping: false
       }
@@ -601,6 +603,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     if (!context.session.threadId) {
       throw new Error('sendTurn: session has no threadId')
     }
+
+    // Reset child tracking for new turn
+    context.collabReceiverTurns.clear()
 
     // Build the turn input array
     const turnInput =
@@ -985,12 +990,25 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
     const route = this.readRouteFields(notification.params)
 
+    // Track collab subagent spawns (must run before child detection)
+    this.rememberCollabReceiverTurns(context, notification.params, route.turnId)
+
+    // Detect if this notification is from a child thread
+    const childParentTurnId = this.readChildParentTurnId(context, notification.params)
+    const isChildConversation = childParentTurnId !== undefined
+
+    // Suppress lifecycle notifications from child threads
+    if (isChildConversation && this.shouldSuppressChildConversationNotification(notification.method)) {
+      return
+    }
+
     // Extract textDelta for streaming text notifications (matches t3code pattern)
     const textDelta =
       notification.method === 'item/agentMessage/delta'
         ? asString(asObject(notification.params)?.delta)
         : undefined
 
+    // Emit event — child events get parent's turnId for proper attribution
     this.emitEvent({
       id: randomUUID(),
       kind: 'notification',
@@ -998,14 +1016,15 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       threadId: context.session.threadId ?? '',
       createdAt: new Date().toISOString(),
       method: notification.method,
-      turnId: route.turnId,
-      itemId: route.itemId,
+      ...((childParentTurnId ?? route.turnId) ? { turnId: childParentTurnId ?? route.turnId } : {}),
+      ...(route.itemId ? { itemId: route.itemId } : {}),
       textDelta,
       payload: notification.params
     })
 
-    // Handle session lifecycle notifications
+    // Handle session lifecycle notifications — only for parent thread
     if (notification.method === 'turn/started') {
+      if (isChildConversation) return
       const turnId = notification.params.turn.id
       this.updateSession(context, {
         status: 'running',
@@ -1015,6 +1034,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
 
     if (notification.method === 'turn/completed') {
+      if (isChildConversation) return
+      context.collabReceiverTurns.clear()
       const status = notification.params.turn.status
       this.updateSession(context, {
         status: status === 'failed' ? 'error' : 'ready',
@@ -1026,6 +1047,11 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
   private handleServerRequest(context: CodexSessionContext, request: ServerRequest): void {
     const requestId = randomUUID()
+    const route = this.readRouteFields(request.params)
+
+    // Detect if this request is from a child thread — use parent's turnId for attribution
+    const childParentTurnId = this.readChildParentTurnId(context, request.params)
+    const effectiveTurnId = childParentTurnId ?? route.turnId
 
     // Track approval requests
     if (
@@ -1043,7 +1069,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         method: request.method,
         threadId: context.session.threadId ?? '',
         payload: request.params,
-        ...('turnId' in params ? { turnId: params.turnId } : {}),
+        ...(effectiveTurnId ? { turnId: effectiveTurnId } : {}),
         ...('itemId' in params ? { itemId: params.itemId } : {})
       })
     }
@@ -1061,8 +1087,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       })
     }
 
-    const route = this.readRouteFields(request.params)
-
     this.emitEvent({
       id: randomUUID(),
       kind: 'request',
@@ -1070,8 +1094,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       threadId: context.session.threadId ?? '',
       createdAt: new Date().toISOString(),
       method: request.method,
-      turnId: route.turnId,
-      itemId: route.itemId,
+      ...(effectiveTurnId ? { turnId: effectiveTurnId } : {}),
+      ...(route.itemId ? { itemId: route.itemId } : {}),
       requestId,
       payload: request.params
     })
@@ -1184,6 +1208,66 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
   }
 
   // ── Protocol helpers ──────────────────────────────────────────
+
+  // ── Collab subagent tracking helpers ────────────────────────
+
+  private readProviderConversationId(params: unknown): string | undefined {
+    const p = asObject(params)
+    return (
+      asString(p?.threadId) ??
+      asString(asObject(p?.thread)?.id) ??
+      asString(p?.conversationId)
+    )
+  }
+
+  private readChildParentTurnId(
+    context: CodexSessionContext,
+    params: unknown
+  ): string | undefined {
+    const providerConversationId = this.readProviderConversationId(params)
+    if (!providerConversationId) return undefined
+    return context.collabReceiverTurns.get(providerConversationId)
+  }
+
+  private rememberCollabReceiverTurns(
+    context: CodexSessionContext,
+    params: unknown,
+    parentTurnId: string | undefined
+  ): void {
+    if (!parentTurnId) return
+    const payload = asObject(params)
+    const item = asObject(payload?.item) ?? payload
+    const itemType = asString(item?.type) ?? asString(item?.kind)
+    if (itemType !== 'collabAgentToolCall') return
+
+    const receiverThreadIds =
+      (item?.receiverThreadIds as string[] | undefined) ?? []
+    for (const id of receiverThreadIds) {
+      if (typeof id === 'string') {
+        context.collabReceiverTurns.set(id, parentTurnId)
+      }
+    }
+  }
+
+  private shouldSuppressChildConversationNotification(method: string): boolean {
+    return (
+      method === 'thread/started' ||
+      method === 'thread/status/changed' ||
+      method === 'thread/archived' ||
+      method === 'thread/unarchived' ||
+      method === 'thread/closed' ||
+      method === 'thread/compacted' ||
+      method === 'thread/name/updated' ||
+      method === 'thread/tokenUsage/updated' ||
+      method === 'turn/started' ||
+      method === 'turn/completed' ||
+      method === 'turn/aborted' ||
+      method === 'turn/plan/updated' ||
+      method === 'item/plan/delta'
+    )
+  }
+
+  // ── Route field extraction ─────────────────────────────────
 
   private readRouteFields(params: unknown): {
     turnId?: string

--- a/src/main/services/codex-event-mapper.ts
+++ b/src/main/services/codex-event-mapper.ts
@@ -364,6 +364,21 @@ export function mapCodexEventToStreamEvents(
   event: CodexManagerEvent,
   hiveSessionId: string
 ): OpenCodeStreamEvent[] {
+  const events = mapCodexEventToStreamEventsInner(event, hiveSessionId)
+
+  if (event.childThreadId) {
+    for (const e of events) {
+      e.childSessionId = event.childThreadId
+    }
+  }
+
+  return events
+}
+
+function mapCodexEventToStreamEventsInner(
+  event: CodexManagerEvent,
+  hiveSessionId: string
+): OpenCodeStreamEvent[] {
   // Attach Codex event ID for renderer-side dedup (seenCodexEventIds in
   // SessionView). Placed on stream event `data`; does NOT flow into canonical
   // message parts — extraction functions pick specific fields only.

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -225,16 +225,6 @@ export class CodexImplementer implements AgentSdkImplementer {
   }
 
   private handleManagerEvent(event: CodexManagerEvent): void {
-    // DEBUG: Log ALL notification events to discover title-related methods
-    if (event.kind === 'notification') {
-      log.info('DEBUG handleManagerEvent: notification received', {
-        method: event.method,
-        threadId: event.threadId,
-        payloadKeys: event.payload ? Object.keys(event.payload as Record<string, unknown>) : [],
-        payloadSnapshot: toJsonSnapshot(event.payload, 500)
-      })
-    }
-
     const targetSession = this.findSessionByThreadId(event.threadId)
     if (targetSession) {
       this.persistActivity(targetSession, event)
@@ -373,16 +363,9 @@ export class CodexImplementer implements AgentSdkImplementer {
 
   private async handleProviderTitleUpdate(event: CodexManagerEvent): Promise<void> {
     const payload = asObject(event.payload)
-    log.info('DEBUG handleProviderTitleUpdate: raw payload', {
-      payloadKeys: payload ? Object.keys(payload) : [],
-      fullPayload: toJsonSnapshot(event.payload, 1000)
-    })
     const typed = event.payload as ThreadNameUpdatedNotification | undefined
     const title = typed?.threadName ?? asString(payload?.threadName)
     if (!title) {
-      log.warn(
-        'DEBUG handleProviderTitleUpdate: threadName field empty/missing, tried payload?.threadName'
-      )
       return
     }
 
@@ -2058,13 +2041,24 @@ export class CodexImplementer implements AgentSdkImplementer {
     if (isComplete()) return Promise.resolve()
 
     return new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => {
+      let timer = setTimeout(() => {
         cleanup()
         reject(new Error('Turn timed out'))
       }, timeoutMs)
 
+      const resetTimer = () => {
+        clearTimeout(timer)
+        timer = setTimeout(() => {
+          cleanup()
+          reject(new Error('Turn timed out'))
+        }, timeoutMs)
+      }
+
       const checkEvent = (event: CodexManagerEvent) => {
         if (event.threadId !== session.threadId) return
+
+        // Reset timeout on any activity from this thread
+        resetTimer()
 
         if (event.method === 'turn/completed') {
           cleanup()

--- a/test/phase-22/session-4/codex-app-server-manager.test.ts
+++ b/test/phase-22/session-4/codex-app-server-manager.test.ts
@@ -113,6 +113,7 @@ function createTestContext(overrides?: Partial<CodexProviderSession>): {
     pending: new Map(),
     pendingApprovals: new Map(),
     pendingUserInputs: new Map(),
+    collabReceiverTurns: new Map(),
     nextRequestId: 1,
     stopping: false
   }

--- a/test/phase-22/session-5/codex-app-server-manager.test.ts
+++ b/test/phase-22/session-5/codex-app-server-manager.test.ts
@@ -71,6 +71,7 @@ function createTestContext(overrides?: Partial<CodexProviderSession>): {
     pending: new Map(),
     pendingApprovals: new Map(),
     pendingUserInputs: new Map(),
+    collabReceiverTurns: new Map(),
     nextRequestId: 1,
     stopping: false
   }

--- a/test/phase-22/session-6/codex-abort-getmessages.test.ts
+++ b/test/phase-22/session-6/codex-abort-getmessages.test.ts
@@ -89,6 +89,7 @@ function createTestContext(overrides?: Partial<CodexProviderSession>): {
     pending: new Map(),
     pendingApprovals: new Map(),
     pendingUserInputs: new Map(),
+    collabReceiverTurns: new Map(),
     nextRequestId: 1,
     stopping: false
   }

--- a/test/phase-22/session-6/codex-permission-requests.test.ts
+++ b/test/phase-22/session-6/codex-permission-requests.test.ts
@@ -94,6 +94,7 @@ function createTestContext(overrides?: Partial<CodexProviderSession>): {
     pending: new Map(),
     pendingApprovals: new Map(),
     pendingUserInputs: new Map(),
+    collabReceiverTurns: new Map(),
     nextRequestId: 1,
     stopping: false
   }

--- a/test/phase-22/session-6/codex-question-prompts.test.ts
+++ b/test/phase-22/session-6/codex-question-prompts.test.ts
@@ -89,6 +89,7 @@ function createTestContext(overrides?: Partial<CodexProviderSession>): {
     pending: new Map(),
     pendingApprovals: new Map(),
     pendingUserInputs: new Map(),
+    collabReceiverTurns: new Map(),
     nextRequestId: 1,
     stopping: false
   }

--- a/test/phase-22/session-6/codex-thread-turn-params.test.ts
+++ b/test/phase-22/session-6/codex-thread-turn-params.test.ts
@@ -71,6 +71,7 @@ function createTestContext(overrides?: Partial<CodexProviderSession>): {
     pending: new Map(),
     pendingApprovals: new Map(),
     pendingUserInputs: new Map(),
+    collabReceiverTurns: new Map(),
     nextRequestId: 1,
     stopping: false
   }

--- a/test/phase-22/session-7/codex-undo-redo.test.ts
+++ b/test/phase-22/session-7/codex-undo-redo.test.ts
@@ -89,6 +89,7 @@ function createTestContext(overrides?: Partial<CodexProviderSession>): {
     pending: new Map(),
     pendingApprovals: new Map(),
     pendingUserInputs: new Map(),
+    collabReceiverTurns: new Map(),
     nextRequestId: 1,
     stopping: false
   }


### PR DESCRIPTION
## Summary

- Add `collabReceiverTurns` tracking to map child thread IDs to parent turn IDs for proper attribution of collaborative subagent messages
- Detect child conversation notifications and suppress lifecycle events (`thread/started`, `turn/started`, etc.) to prevent premature turn completion
- Enable reasoning summary streaming with `summary: 'auto'` parameter so reasoning deltas appear in the UI
- Reset timeout on any thread activity in `waitForTurnCompletion()` to prevent early timeout while subagents are working
- Add `childThreadId` to events and map it to `childSessionId` in stream events for renderer-side tracking
- Clear child tracking map on turn completion and at the start of each new turn

## Testing

- Updated all 7 test context factories to include `collabReceiverTurns: new Map()` initialization
- Verify subagent-spawned messages appear correctly attributed to parent turn
- Verify child thread lifecycle notifications don't trigger parent turn completion
- Verify timeout doesn't fire while collaborative subagents are processing
- Manual test: Send prompt that triggers collab subagent, confirm reasoning summary appears and turn completes after all children finish

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Codex session/turn event handling and attribution, which could affect turn completion, approvals, and UI streaming behavior if child-thread detection is wrong. Scope is moderate and covered by test updates, but impacts runtime session lifecycle.
> 
> **Overview**
> Prevents Codex turns from *ending early* when collaborative subagents spawn child threads by tracking `childThreadId → parentTurnId`, attributing child requests/notifications to the parent `turnId`, and suppressing child-thread lifecycle notifications from driving session state.
> 
> `sendTurn` now forces reasoning summary streaming via `summary: 'auto'`, and child-thread tracking is reset at turn start and cleared on `turn/completed`. Stream event mapping propagates `childThreadId` to renderer events (`childSessionId`), and `waitForTurnCompletion()` now resets its timeout on any same-thread activity to avoid timing out while work is still streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7c7e68cc4c61e2f69fd2ba2e2de77206450c73b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->