### PR TITLE
Add Codex streaming plan for coherent conversations and subagent deltas

### DIFF
--- a/src/main/services/codex-event-mapper.ts
+++ b/src/main/services/codex-event-mapper.ts
@@ -2,7 +2,14 @@ import type { OpenCodeStreamEvent } from '@shared/types/opencode'
 import { normalizeCodexToolName, stripShellPrefix } from '@shared/codex-tool-normalizer'
 import type { CodexManagerEvent } from './codex-app-server-manager'
 import { asObject, asString, asNumber } from './codex-utils'
-import type { ThreadNameUpdatedNotification, TurnCompletedNotification, ThreadItem, CommandExecutionRequestApprovalParams, FileChangeRequestApprovalParams, TerminalInteractionNotification } from '@shared/codex-schemas/v2'
+import type {
+  ThreadNameUpdatedNotification,
+  TurnCompletedNotification,
+  ThreadItem,
+  CommandExecutionRequestApprovalParams,
+  FileChangeRequestApprovalParams,
+  TerminalInteractionNotification
+} from '@shared/codex-schemas/v2'
 
 // ── Content stream kind classification ───────────────────────────
 
@@ -103,10 +110,16 @@ function normalizeToolInput(
 function extractContentDelta(event: CodexManagerEvent): ContentDelta | null {
   // ── Typed fast-path: generated notification types all have `delta: string` ──
   const streamKind = contentStreamKindFromMethod(event.method)
-  if (streamKind && event.payload && typeof event.payload === 'object' && 'delta' in event.payload) {
+  if (
+    streamKind &&
+    event.payload &&
+    typeof event.payload === 'object' &&
+    'delta' in event.payload
+  ) {
     const typed = event.payload as { delta: string }
     if (typeof typed.delta === 'string') {
-      const kind = (streamKind === 'reasoning' || streamKind === 'reasoning_summary') ? 'reasoning' : 'assistant'
+      const kind =
+        streamKind === 'reasoning' || streamKind === 'reasoning_summary' ? 'reasoning' : 'assistant'
       return { kind, text: typed.delta }
     }
   }
@@ -173,11 +186,14 @@ function extractTurnCompletedInfo(event: CodexManagerEvent): TurnCompletedInfo {
   const typed = event.payload as TurnCompletedNotification | undefined
   if (typed?.turn && typeof typed.turn === 'object' && typeof typed.turn.status === 'string') {
     const turn = typed.turn
-    const errorMsg = typeof turn.error === 'object' && turn.error !== null
-      ? turn.error.message
-      // Defensive: handle legacy servers that may send error as a plain string
-      // inside the typed turn structure (generated type says TurnError | null)
-      : typeof turn.error === 'string' ? turn.error as unknown as string : undefined
+    const errorMsg =
+      typeof turn.error === 'object' && turn.error !== null
+        ? turn.error.message
+        : // Defensive: handle legacy servers that may send error as a plain string
+          // inside the typed turn structure (generated type says TurnError | null)
+          typeof turn.error === 'string'
+          ? (turn.error as unknown as string)
+          : undefined
     // usage/cost are not on the Turn type — check at payload level and inside turn (legacy extension)
     const payload = asObject(event.payload)
     const turnObj = asObject(payload?.turn)
@@ -262,7 +278,13 @@ function extractItemInfo(event: CodexManagerEvent): ItemInfo {
   // ── Typed path: ItemStartedNotification / ItemCompletedNotification ──
   const typed = event.payload as { item?: ThreadItem } | undefined
   const candidate = typed?.item
-  if (candidate && typeof candidate === 'object' && typeof candidate.type === 'string' && typeof candidate.id === 'string' && isWellFormedThreadItem(candidate as { type: string; id: string; [k: string]: unknown })) {
+  if (
+    candidate &&
+    typeof candidate === 'object' &&
+    typeof candidate.type === 'string' &&
+    typeof candidate.id === 'string' &&
+    isWellFormedThreadItem(candidate as { type: string; id: string; [k: string]: unknown })
+  ) {
     const item = candidate
     const itemType = item.type
     const toolName = normalizeCodexToolName(item.type)
@@ -287,10 +309,10 @@ function extractItemInfo(event: CodexManagerEvent): ItemInfo {
 
   const toolName = normalizeCodexToolName(
     asString(item?.toolName) ??
-    asString(item?.name) ??
-    asString(item?.type) ??
-    asString(payload?.toolName) ??
-    'unknown'
+      asString(item?.name) ??
+      asString(item?.type) ??
+      asString(payload?.toolName) ??
+      'unknown'
   )
 
   const callId = asString(item?.id) ?? asString(event.itemId) ?? asString(payload?.itemId) ?? ''
@@ -332,6 +354,7 @@ interface TaskInfo {
   status: string
   message?: string
   progress?: number
+  sessionId?: string
 }
 
 function extractTaskInfo(event: CodexManagerEvent): TaskInfo {
@@ -347,8 +370,25 @@ function extractTaskInfo(event: CodexManagerEvent): TaskInfo {
     taskId,
     status,
     ...(message ? { message } : {}),
-    ...(progress !== undefined ? { progress } : {})
+    ...(progress !== undefined ? { progress } : {}),
+    ...((asString(task?.threadId) ?? asString(payload?.threadId))
+      ? { sessionId: asString(task?.threadId) ?? asString(payload?.threadId) }
+      : {})
   }
+}
+
+function mapTaskStatusToSubtaskStatus(status: string): 'running' | 'completed' | 'error' {
+  if (status === 'completed') return 'completed'
+  if (status === 'failed' || status === 'error') return 'error'
+  return 'running'
+}
+
+function formatTaskDescription(task: TaskInfo): string {
+  if (task.message) return task.message
+  if (typeof task.progress === 'number' && Number.isFinite(task.progress)) {
+    return `Progress ${(task.progress * 100).toFixed(0)}%`
+  }
+  return ''
 }
 
 // ── Main mapper ───────────────────────────────────────────────────
@@ -382,7 +422,9 @@ function mapCodexEventToStreamEventsInner(
   // Attach Codex event ID for renderer-side dedup (seenCodexEventIds in
   // SessionView). Placed on stream event `data`; does NOT flow into canonical
   // message parts — extraction functions pick specific fields only.
-  const annotateData = <T extends Record<string, unknown>>(data: T): T & { _codexEventId: string } => ({
+  const annotateData = <T extends Record<string, unknown>>(
+    data: T
+  ): T & { _codexEventId: string } => ({
     ...data,
     _codexEventId: event.id
   })
@@ -395,46 +437,52 @@ function mapCodexEventToStreamEventsInner(
       const params = event.payload as CommandExecutionRequestApprovalParams | undefined
       const payload = asObject(event.payload)
       const item = asObject(payload?.item)
-      const callId = event.itemId ?? params?.itemId ?? asString(item?.id) ?? asString(payload?.itemId) ?? ''
+      const callId =
+        event.itemId ?? params?.itemId ?? asString(item?.id) ?? asString(payload?.itemId) ?? ''
       if (!callId) return []
       const command = params?.command ? stripShellPrefix(params.command) : undefined
       // Typed path: build input from top-level params; fallback to normalizeToolInput for legacy
       const input = command ? { command } : normalizeToolInput(item, payload)
-      return [{
-        type: 'message.part.updated',
-        sessionId: hiveSessionId,
-        data: annotateData({
-          part: {
-            type: 'tool',
-            callID: callId,
-            tool: 'Bash',
-            state: {
-              status: 'running',
-              ...(input !== undefined ? { input } : {})
+      return [
+        {
+          type: 'message.part.updated',
+          sessionId: hiveSessionId,
+          data: annotateData({
+            part: {
+              type: 'tool',
+              callID: callId,
+              tool: 'Bash',
+              state: {
+                status: 'running',
+                ...(input !== undefined ? { input } : {})
+              }
             }
-          }
-        })
-      }]
+          })
+        }
+      ]
     }
 
     if (method === 'item/fileChange/requestApproval') {
       const params = event.payload as FileChangeRequestApprovalParams | undefined
       const fcPayload = asObject(event.payload)
       const fcItem = asObject(fcPayload?.item)
-      const callId = event.itemId ?? params?.itemId ?? asString(fcItem?.id) ?? asString(fcPayload?.itemId) ?? ''
+      const callId =
+        event.itemId ?? params?.itemId ?? asString(fcItem?.id) ?? asString(fcPayload?.itemId) ?? ''
       if (!callId) return []
-      return [{
-        type: 'message.part.updated',
-        sessionId: hiveSessionId,
-        data: annotateData({
-          part: {
-            type: 'tool',
-            callID: callId,
-            tool: 'fileChange',
-            state: { status: 'running' }
-          }
-        })
-      }]
+      return [
+        {
+          type: 'message.part.updated',
+          sessionId: hiveSessionId,
+          data: annotateData({
+            part: {
+              type: 'tool',
+              callID: callId,
+              tool: 'fileChange',
+              state: { status: 'running' }
+            }
+          })
+        }
+      ]
     }
 
     if (method === 'item/fileRead/requestApproval') {
@@ -444,21 +492,23 @@ function mapCodexEventToStreamEventsInner(
       const callId = event.itemId ?? asString(item?.id) ?? asString(payload?.itemId) ?? ''
       if (!callId) return []
       const input = normalizeToolInput(item, payload)
-      return [{
-        type: 'message.part.updated',
-        sessionId: hiveSessionId,
-        data: annotateData({
-          part: {
-            type: 'tool',
-            callID: callId,
-            tool: 'Read',
-            state: {
-              status: 'running',
-              ...(input !== undefined ? { input } : {})
+      return [
+        {
+          type: 'message.part.updated',
+          sessionId: hiveSessionId,
+          data: annotateData({
+            part: {
+              type: 'tool',
+              callID: callId,
+              tool: 'Read',
+              state: {
+                status: 'running',
+                ...(input !== undefined ? { input } : {})
+              }
             }
-          }
-        })
-      }]
+          })
+        }
+      ]
     }
 
     return []
@@ -471,22 +521,21 @@ function mapCodexEventToStreamEventsInner(
     if (!delta) return []
 
     // Route command/file-change output to the tool card as outputDelta
-    if (
-      (streamKind === 'command_output' || streamKind === 'file_change_output') &&
-      event.itemId
-    ) {
-      return [{
-        type: 'message.part.updated',
-        sessionId: hiveSessionId,
-        data: annotateData({
-          part: {
-            type: 'tool',
-            callID: event.itemId,
-            tool: streamKind === 'command_output' ? 'Bash' : 'fileChange',
-            state: { status: 'running', outputDelta: delta.text }
-          }
-        })
-      }]
+    if ((streamKind === 'command_output' || streamKind === 'file_change_output') && event.itemId) {
+      return [
+        {
+          type: 'message.part.updated',
+          sessionId: hiveSessionId,
+          data: annotateData({
+            part: {
+              type: 'tool',
+              callID: event.itemId,
+              tool: streamKind === 'command_output' ? 'Bash' : 'fileChange',
+              state: { status: 'running', outputDelta: delta.text }
+            }
+          })
+        }
+      ]
     }
 
     return [
@@ -642,13 +691,17 @@ function mapCodexEventToStreamEventsInner(
       {
         type: 'message.part.updated',
         sessionId: hiveSessionId,
-        data: {
-          type: 'task',
-          taskId: task.taskId,
-          status: task.status,
-          ...(task.message ? { message: task.message } : {}),
-          ...(task.progress !== undefined ? { progress: task.progress } : {})
-        }
+        data: annotateData({
+          part: {
+            type: 'subtask',
+            id: task.taskId,
+            sessionID: task.sessionId ?? event.childThreadId ?? task.taskId,
+            prompt: '',
+            description: formatTaskDescription(task),
+            agent: 'task',
+            status: mapTaskStatusToSubtaskStatus(task.status)
+          }
+        })
       }
     ]
   }
@@ -751,7 +804,8 @@ function mapCodexEventToStreamEventsInner(
     const typed = event.payload as TerminalInteractionNotification | undefined
     const tiPayload = asObject(event.payload)
     const tiItem = asObject(tiPayload?.item)
-    const callId = event.itemId ?? typed?.itemId ?? asString(tiItem?.id) ?? asString(tiPayload?.itemId) ?? ''
+    const callId =
+      event.itemId ?? typed?.itemId ?? asString(tiItem?.id) ?? asString(tiPayload?.itemId) ?? ''
     if (!callId) return []
 
     return [

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -28,6 +28,7 @@ import type { ToolRequestUserInputAnswer } from '@shared/codex-schemas/v2/ToolRe
 import type { CommandExecutionRequestApprovalParams } from '@shared/codex-schemas/v2/CommandExecutionRequestApprovalParams'
 import type { ThreadItem } from '@shared/codex-schemas/v2/ThreadItem'
 import type { Thread } from '@shared/codex-schemas/v2/Thread'
+import type { OpenCodeStreamEvent } from '@shared/types/opencode'
 
 const log = createLogger({ component: 'CodexImplementer' })
 // Balances write coalescing during rapid streaming against data freshness for crash recovery.
@@ -66,6 +67,16 @@ interface CodexLiveToolPart {
 type CodexLiveDraftPart =
   | { type: 'text'; text: string; timestamp: string }
   | { type: 'reasoning'; text: string; timestamp: string }
+  | {
+      type: 'subtask'
+      id: string
+      sessionID: string
+      prompt: string
+      description: string
+      agent: string
+      parts: Array<{ type: 'text'; text: string; timestamp?: string } | CodexLiveToolPart>
+      status: 'running' | 'completed' | 'error'
+    }
   | CodexLiveToolPart
 
 interface CodexLiveAssistantDraft {
@@ -109,8 +120,7 @@ function isDefaultSessionTitle(title: string | null | undefined): boolean {
   if (!normalized) return true
 
   return (
-    /^Session \d+$/.test(normalized) ||
-    /^New session\s*-?\s*\d{4}-\d{2}-\d{2}/i.test(normalized)
+    /^Session \d+$/.test(normalized) || /^New session\s*-?\s*\d{4}-\d{2}-\d{2}/i.test(normalized)
   )
 }
 
@@ -318,9 +328,10 @@ export class CodexImplementer implements AgentSdkImplementer {
       })
 
       // Typed payload available for known methods
-      const _typedApproval = event.method === 'item/commandExecution/requestApproval'
-        ? event.payload as CommandExecutionRequestApprovalParams
-        : undefined
+      const _typedApproval =
+        event.method === 'item/commandExecution/requestApproval'
+          ? (event.payload as CommandExecutionRequestApprovalParams)
+          : undefined
       const payload = asObject(event.payload)
       this.sendToRenderer('opencode:stream', {
         type: 'permission.asked',
@@ -347,7 +358,8 @@ export class CodexImplementer implements AgentSdkImplementer {
       })
 
       const typed = event.payload as ToolRequestUserInputParams | undefined
-      const questions = typed?.questions ?? ((asObject(event.payload)?.questions ?? []) as unknown[])
+      const questions =
+        typed?.questions ?? ((asObject(event.payload)?.questions ?? []) as unknown[])
 
       this.sendToRenderer('opencode:stream', {
         type: 'question.asked',
@@ -1741,7 +1753,9 @@ export class CodexImplementer implements AgentSdkImplementer {
     if (!text) return
 
     const message = this.getOrCreateCanonicalAssistantMessage(session, turnId)
-    const parts = Array.isArray(message.parts) ? (message.parts as Array<Record<string, unknown>>) : []
+    const parts = Array.isArray(message.parts)
+      ? (message.parts as Array<Record<string, unknown>>)
+      : []
     const lastPart = parts[parts.length - 1]
     const timestamp = new Date().toISOString()
 
@@ -1772,7 +1786,9 @@ export class CodexImplementer implements AgentSdkImplementer {
     if (!tool.callID) return
 
     const message = this.getOrCreateCanonicalAssistantMessage(session, turnId)
-    const parts = Array.isArray(message.parts) ? (message.parts as Array<Record<string, unknown>>) : []
+    const parts = Array.isArray(message.parts)
+      ? (message.parts as Array<Record<string, unknown>>)
+      : []
     const existingIndex = parts.findIndex((part) => {
       const partObj = asObject(part)
       const toolUse = asObject(partObj?.toolUse)
@@ -1828,10 +1844,310 @@ export class CodexImplementer implements AgentSdkImplementer {
     message.parts = parts
   }
 
+  private mapSubtaskStatus(status: string | undefined): 'running' | 'completed' | 'error' {
+    if (status === 'completed') return 'completed'
+    if (status === 'failed' || status === 'error') return 'error'
+    return 'running'
+  }
+
+  private extractSubtaskDescriptor(
+    part: Record<string, unknown>,
+    childSessionId?: string
+  ): {
+    id: string
+    sessionID: string
+    prompt: string
+    description: string
+    agent: string
+    status: 'running' | 'completed' | 'error'
+  } {
+    const id =
+      asString(part.id) ?? asString(part.sessionID) ?? childSessionId ?? `subtask-${randomUUID()}`
+    const sessionID = asString(part.sessionID) ?? childSessionId ?? id
+    return {
+      id,
+      sessionID,
+      prompt: asString(part.prompt) ?? '',
+      description: asString(part.description) ?? '',
+      agent: asString(part.agent) ?? 'task',
+      status: this.mapSubtaskStatus(asString(part.status))
+    }
+  }
+
+  private getOrCreateLiveAssistantSubtask(
+    session: CodexSessionState,
+    descriptor: {
+      id: string
+      sessionID: string
+      prompt: string
+      description: string
+      agent: string
+      status: 'running' | 'completed' | 'error'
+    }
+  ): Extract<CodexLiveDraftPart, { type: 'subtask' }> {
+    const draft = this.ensureLiveAssistantDraft(session)
+    const existing = draft.parts.find(
+      (part) =>
+        part.type === 'subtask' &&
+        (part.id === descriptor.id || part.sessionID === descriptor.sessionID)
+    ) as Extract<CodexLiveDraftPart, { type: 'subtask' }> | undefined
+
+    if (existing) {
+      existing.prompt = descriptor.prompt || existing.prompt
+      existing.description = descriptor.description || existing.description
+      existing.agent = descriptor.agent || existing.agent
+      if (descriptor.status === 'completed' || descriptor.status === 'error') {
+        existing.status = descriptor.status
+      }
+      return existing
+    }
+
+    const subtask: Extract<CodexLiveDraftPart, { type: 'subtask' }> = {
+      type: 'subtask',
+      id: descriptor.id,
+      sessionID: descriptor.sessionID,
+      prompt: descriptor.prompt,
+      description: descriptor.description,
+      agent: descriptor.agent,
+      parts: [],
+      status: descriptor.status
+    }
+    draft.parts.push(subtask)
+    return subtask
+  }
+
+  private appendLiveAssistantSubtaskText(
+    session: CodexSessionState,
+    childSessionId: string,
+    text: string
+  ): void {
+    if (!text) return
+    const subtask = this.getOrCreateLiveAssistantSubtask(session, {
+      id: childSessionId,
+      sessionID: childSessionId,
+      prompt: '',
+      description: '',
+      agent: 'task',
+      status: 'running'
+    })
+    const lastPart = subtask.parts[subtask.parts.length - 1]
+    if (lastPart?.type === 'text') {
+      lastPart.text += text
+      return
+    }
+    subtask.parts.push({ type: 'text', text, timestamp: new Date().toISOString() })
+  }
+
+  private upsertLiveAssistantSubtaskTool(
+    session: CodexSessionState,
+    childSessionId: string,
+    tool: {
+      callID: string
+      tool: string
+      state: {
+        status: 'running' | 'completed' | 'error'
+        input?: unknown
+        output?: unknown
+        error?: unknown
+        outputDelta?: unknown
+      }
+    }
+  ): void {
+    if (!tool.callID) return
+    const subtask = this.getOrCreateLiveAssistantSubtask(session, {
+      id: childSessionId,
+      sessionID: childSessionId,
+      prompt: '',
+      description: '',
+      agent: 'task',
+      status: 'running'
+    })
+    const existingIndex = subtask.parts.findIndex(
+      (part) => part.type === 'tool' && part.callID === tool.callID
+    )
+
+    if (existingIndex >= 0) {
+      const existing = subtask.parts[existingIndex] as CodexLiveToolPart
+      const appendedOutput = tool.state.outputDelta
+        ? ((existing.state.output as string) ?? '') + String(tool.state.outputDelta)
+        : undefined
+      existing.tool = tool.tool || existing.tool
+      existing.state = {
+        ...existing.state,
+        ...tool.state,
+        ...(tool.state.input === undefined ? { input: existing.state.input } : {}),
+        ...(appendedOutput !== undefined
+          ? { output: appendedOutput }
+          : tool.state.output === undefined
+            ? { output: existing.state.output }
+            : {}),
+        ...(tool.state.error === undefined ? { error: existing.state.error } : {})
+      }
+      delete (existing.state as any).outputDelta
+      return
+    }
+
+    subtask.parts.push({
+      type: 'tool',
+      callID: tool.callID,
+      tool: tool.tool,
+      state: { ...tool.state }
+    })
+    delete ((subtask.parts[subtask.parts.length - 1] as CodexLiveToolPart).state as any).outputDelta
+  }
+
+  private getOrCreateCanonicalAssistantSubtask(
+    session: CodexSessionState,
+    descriptor: {
+      id: string
+      sessionID: string
+      prompt: string
+      description: string
+      agent: string
+      status: 'running' | 'completed' | 'error'
+    },
+    turnId?: string
+  ): Record<string, unknown> {
+    const message = this.getOrCreateCanonicalAssistantMessage(session, turnId)
+    const parts = Array.isArray(message.parts)
+      ? (message.parts as Array<Record<string, unknown>>)
+      : []
+    let existing = parts.find((part) => {
+      if (asString(part.type) !== 'subtask') return false
+      return (
+        asString(part.id) === descriptor.id || asString(part.sessionID) === descriptor.sessionID
+      )
+    })
+
+    if (!existing) {
+      existing = {
+        type: 'subtask',
+        id: descriptor.id,
+        sessionID: descriptor.sessionID,
+        prompt: descriptor.prompt,
+        description: descriptor.description,
+        agent: descriptor.agent,
+        parts: [],
+        status: descriptor.status
+      }
+      parts.push(existing)
+      message.parts = parts
+      return existing
+    }
+
+    existing.prompt = descriptor.prompt || asString(existing.prompt) || ''
+    existing.description = descriptor.description || asString(existing.description) || ''
+    existing.agent = descriptor.agent || asString(existing.agent) || 'task'
+    if (descriptor.status === 'completed' || descriptor.status === 'error') {
+      existing.status = descriptor.status
+    } else if (!asString(existing.status)) {
+      existing.status = descriptor.status
+    }
+    if (!Array.isArray(existing.parts)) {
+      existing.parts = []
+    }
+    message.parts = parts
+    return existing
+  }
+
+  private appendCanonicalAssistantSubtaskText(
+    session: CodexSessionState,
+    childSessionId: string,
+    text: string,
+    turnId?: string
+  ): void {
+    if (!text) return
+    const subtask = this.getOrCreateCanonicalAssistantSubtask(
+      session,
+      {
+        id: childSessionId,
+        sessionID: childSessionId,
+        prompt: '',
+        description: '',
+        agent: 'task',
+        status: 'running'
+      },
+      turnId
+    )
+    const parts = Array.isArray(subtask.parts)
+      ? (subtask.parts as Array<Record<string, unknown>>)
+      : []
+    const lastPart = parts[parts.length - 1]
+    if (lastPart && asString(lastPart.type) === 'text') {
+      lastPart.text = `${asString(lastPart.text) ?? ''}${text}`
+    } else {
+      parts.push({ type: 'text', text })
+    }
+    subtask.parts = parts
+  }
+
+  private upsertCanonicalAssistantSubtaskTool(
+    session: CodexSessionState,
+    childSessionId: string,
+    tool: {
+      callID: string
+      tool: string
+      state: {
+        status: 'running' | 'completed' | 'error'
+        input?: unknown
+        output?: unknown
+        error?: unknown
+        outputDelta?: unknown
+      }
+    },
+    turnId?: string
+  ): void {
+    if (!tool.callID) return
+    const subtask = this.getOrCreateCanonicalAssistantSubtask(
+      session,
+      {
+        id: childSessionId,
+        sessionID: childSessionId,
+        prompt: '',
+        description: '',
+        agent: 'task',
+        status: 'running'
+      },
+      turnId
+    )
+    const parts = Array.isArray(subtask.parts)
+      ? (subtask.parts as Array<Record<string, unknown>>)
+      : []
+    const existingIndex = parts.findIndex(
+      (part) => asString(part.type) === 'tool' && asString(part.callID) === tool.callID
+    )
+    const nextState = { ...tool.state }
+    delete (nextState as any).outputDelta
+
+    if (existingIndex >= 0) {
+      const existing = parts[existingIndex]
+      const existingState = asObject(existing.state) ?? {}
+      const appendedOutput = tool.state.outputDelta
+        ? `${asString(existingState.output) ?? ''}${String(tool.state.outputDelta)}`
+        : undefined
+      existing.tool = tool.tool || asString(existing.tool) || 'unknown'
+      existing.state = {
+        ...existingState,
+        ...nextState,
+        ...(tool.state.input === undefined ? { input: existingState.input } : {}),
+        ...(appendedOutput !== undefined
+          ? { output: appendedOutput }
+          : tool.state.output === undefined
+            ? { output: existingState.output }
+            : {}),
+        ...(tool.state.error === undefined ? { error: existingState.error } : {})
+      }
+    } else {
+      parts.push({ type: 'tool', callID: tool.callID, tool: tool.tool, state: nextState })
+    }
+
+    subtask.parts = parts
+  }
+
   private synchronizeCanonicalAssistantFromStreamEvent(
     session: CodexSessionState,
     event: CodexManagerEvent,
-    streamEvent: { type?: string; data?: unknown }
+    streamEvent: OpenCodeStreamEvent
   ): boolean {
     if (event.method === 'turn/started' && event.turnId) {
       const previousId = session.currentAssistantMessageId
@@ -1853,20 +2169,64 @@ export class CodexImplementer implements AgentSdkImplementer {
     if (!part) return false
 
     const partType = asString(part.type)
+    const targetTurnId = event.turnId ?? session.currentTurnId ?? undefined
+
+    if (streamEvent.childSessionId) {
+      if (partType === 'text' || partType === 'reasoning') {
+        const delta = asString(data?.delta) ?? asString(part.text) ?? ''
+        this.appendCanonicalAssistantSubtaskText(
+          session,
+          streamEvent.childSessionId,
+          delta,
+          targetTurnId
+        )
+        return delta.length > 0
+      }
+
+      if (partType === 'tool') {
+        const state = asObject(part.state)
+        const statusValue = asString(state?.status)
+        const status =
+          statusValue === 'completed' || statusValue === 'error' ? statusValue : 'running'
+
+        this.upsertCanonicalAssistantSubtaskTool(
+          session,
+          streamEvent.childSessionId,
+          {
+            callID: asString(part.callID) ?? asString(part.id) ?? '',
+            tool: asString(part.tool) ?? 'unknown',
+            state: {
+              status,
+              ...(state?.input !== undefined ? { input: state.input } : {}),
+              ...(state?.output !== undefined ? { output: state.output } : {}),
+              ...(state?.error !== undefined ? { error: state.error } : {}),
+              ...(state?.outputDelta !== undefined ? { outputDelta: state.outputDelta } : {})
+            } as any
+          },
+          targetTurnId
+        )
+        return true
+      }
+
+      if (partType === 'subtask') {
+        this.getOrCreateCanonicalAssistantSubtask(
+          session,
+          this.extractSubtaskDescriptor(part, streamEvent.childSessionId),
+          targetTurnId
+        )
+        return true
+      }
+    }
+
     if (partType === 'text') {
       const delta = asString(data?.delta) ?? asString(part.text) ?? ''
-      this.appendCanonicalAssistantText(session, 'text', delta, event.turnId ?? session.currentTurnId ?? undefined)
+      this.appendCanonicalAssistantText(session, 'text', delta, targetTurnId)
       return delta.length > 0
     }
 
     if (partType === 'reasoning') {
       const delta = asString(data?.delta) ?? asString(part.text) ?? ''
-      this.appendCanonicalAssistantText(
-        session,
-        'reasoning',
-        delta,
-        event.turnId ?? session.currentTurnId ?? undefined
-      )
+      this.appendCanonicalAssistantText(session, 'reasoning', delta, targetTurnId)
       return delta.length > 0
     }
 
@@ -1889,7 +2249,16 @@ export class CodexImplementer implements AgentSdkImplementer {
             ...(state?.outputDelta !== undefined ? { outputDelta: state.outputDelta } : {})
           } as any
         },
-        event.turnId ?? session.currentTurnId ?? undefined
+        targetTurnId
+      )
+      return true
+    }
+
+    if (partType === 'subtask') {
+      this.getOrCreateCanonicalAssistantSubtask(
+        session,
+        this.extractSubtaskDescriptor(part),
+        targetTurnId
       )
       return true
     }
@@ -1947,7 +2316,9 @@ export class CodexImplementer implements AgentSdkImplementer {
           ...(tool.state.input === undefined ? { input: existing.state.input } : {}),
           ...(appendedOutput !== undefined
             ? { output: appendedOutput }
-            : tool.state.output === undefined ? { output: existing.state.output } : {}),
+            : tool.state.output === undefined
+              ? { output: existing.state.output }
+              : {}),
           ...(tool.state.error === undefined ? { error: existing.state.error } : {})
         }
         // Remove outputDelta from persisted state — it's transient
@@ -1964,12 +2335,12 @@ export class CodexImplementer implements AgentSdkImplementer {
       state: tool.state
     })
     // Remove outputDelta from persisted state — it's transient (new-tool path)
-    delete (draft.parts[draft.parts.length - 1].state as any).outputDelta
+    delete ((draft.parts[draft.parts.length - 1] as CodexLiveToolPart).state as any).outputDelta
   }
 
   private updateLiveAssistantDraftFromStreamEvent(
     session: CodexSessionState,
-    streamEvent: { type?: string; data?: unknown }
+    streamEvent: OpenCodeStreamEvent
   ): void {
     if (streamEvent.type !== 'message.part.updated') return
 
@@ -1978,6 +2349,42 @@ export class CodexImplementer implements AgentSdkImplementer {
     if (!part) return
 
     const partType = asString(part.type)
+    if (streamEvent.childSessionId) {
+      if (partType === 'text' || partType === 'reasoning') {
+        const delta = asString(data?.delta) ?? asString(part.text) ?? ''
+        this.appendLiveAssistantSubtaskText(session, streamEvent.childSessionId, delta)
+        return
+      }
+
+      if (partType === 'tool') {
+        const state = asObject(part.state)
+        const statusValue = asString(state?.status)
+        const status =
+          statusValue === 'completed' || statusValue === 'error' ? statusValue : 'running'
+
+        this.upsertLiveAssistantSubtaskTool(session, streamEvent.childSessionId, {
+          callID: asString(part.callID) ?? asString(part.id) ?? '',
+          tool: asString(part.tool) ?? 'unknown',
+          state: {
+            status,
+            ...(state?.input !== undefined ? { input: state.input } : {}),
+            ...(state?.output !== undefined ? { output: state.output } : {}),
+            ...(state?.error !== undefined ? { error: state.error } : {}),
+            ...(state?.outputDelta !== undefined ? { outputDelta: state.outputDelta } : {})
+          } as any
+        })
+        return
+      }
+
+      if (partType === 'subtask') {
+        this.getOrCreateLiveAssistantSubtask(
+          session,
+          this.extractSubtaskDescriptor(part, streamEvent.childSessionId)
+        )
+        return
+      }
+    }
+
     if (partType === 'text') {
       const delta = asString(data?.delta) ?? asString(part.text) ?? ''
       this.appendLiveAssistantText(session, 'text', delta)
@@ -2007,6 +2414,11 @@ export class CodexImplementer implements AgentSdkImplementer {
           ...(state?.outputDelta !== undefined ? { outputDelta: state.outputDelta } : {})
         } as any
       })
+      return
+    }
+
+    if (partType === 'subtask') {
+      this.getOrCreateLiveAssistantSubtask(session, this.extractSubtaskDescriptor(part))
     }
   }
 
@@ -2020,6 +2432,29 @@ export class CodexImplementer implements AgentSdkImplementer {
       parts: draft.parts.map((part) => {
         if (part.type === 'text' || part.type === 'reasoning') {
           return { ...part }
+        }
+
+        if (part.type === 'subtask') {
+          return {
+            type: 'subtask',
+            id: part.id,
+            sessionID: part.sessionID,
+            prompt: part.prompt,
+            description: part.description,
+            agent: part.agent,
+            parts: part.parts.map((subtaskPart) => {
+              if (subtaskPart.type === 'text') {
+                return { ...subtaskPart }
+              }
+              return {
+                type: 'tool',
+                callID: subtaskPart.callID,
+                tool: subtaskPart.tool,
+                state: { ...(subtaskPart as CodexLiveToolPart).state }
+              }
+            }),
+            status: part.status
+          }
         }
 
         return {

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -1,5 +1,16 @@
 import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo } from 'react'
-import { Send, ListPlus, Loader2, AlertCircle, RefreshCw, Square, Archive, X, Github, Minimize2 } from 'lucide-react'
+import {
+  Send,
+  ListPlus,
+  Loader2,
+  AlertCircle,
+  RefreshCw,
+  Square,
+  Archive,
+  X,
+  Github,
+  Minimize2
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { ProviderIcon } from '@/components/ui/provider-icon'
@@ -14,7 +25,11 @@ import { AttachmentPreview } from './AttachmentPreview'
 import { TicketAttachments } from './TicketAttachments'
 import { CodexFastToggle } from './CodexFastToggle'
 import type { Attachment } from './AttachmentPreview'
-import { buildMessageParts, buildDisplayContent, MAX_ATTACHMENTS } from '@/lib/file-attachment-utils'
+import {
+  buildMessageParts,
+  buildDisplayContent,
+  MAX_ATTACHMENTS
+} from '@/lib/file-attachment-utils'
 import { TicketPickerModal } from '@/components/kanban/TicketPickerModal'
 import type { TicketAttachmentData } from '@/components/kanban/TicketPickerModal'
 import { SlashCommandPopover } from './SlashCommandPopover'
@@ -59,10 +74,7 @@ import { snapshotTokenBaseline, computeTokenDelta } from '@/lib/token-baselines'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
-import {
-  buildSdkPlanImplementationPrompt,
-  looksLikeCodexProposedPlan
-} from '@/lib/proposedPlan'
+import { buildSdkPlanImplementationPrompt, looksLikeCodexProposedPlan } from '@/lib/proposedPlan'
 
 // Stable empty array to avoid creating new references in selectors
 const EMPTY_FILE_INDEX: FlatFile[] = []
@@ -71,7 +83,13 @@ import { QuestionPrompt } from './QuestionPrompt'
 import { PermissionPrompt } from './PermissionPrompt'
 import { CommandApprovalPrompt } from './CommandApprovalPrompt'
 import type { ToolStatus, ToolUseInfo } from './ToolCard'
-import { PLAN_MODE_PREFIX, ASK_MODE_PREFIX, SUPER_PLAN_MODE_PREFIX, stripPlanModePrefix, isPlanLike } from '@/lib/constants'
+import {
+  PLAN_MODE_PREFIX,
+  ASK_MODE_PREFIX,
+  SUPER_PLAN_MODE_PREFIX,
+  stripPlanModePrefix,
+  isPlanLike
+} from '@/lib/constants'
 
 /**
  * Resolve an OpenCode session ID to the corresponding Hive session ID
@@ -536,7 +554,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const [opencodeSessionId, setOpencodeSessionId] = useState<string | null>(null)
   const [isStreaming, setIsStreaming] = useState(false)
   const isStreamingRef = useRef(isStreaming)
-  useEffect(() => { isStreamingRef.current = isStreaming }, [isStreaming])
+  useEffect(() => {
+    isStreamingRef.current = isStreaming
+  }, [isStreaming])
   const [isCompacting, setIsCompacting] = useState(false)
   const [sessionRetry, setSessionRetry] = useState<SessionRetryState | null>(null)
   const [sessionErrorMessage, setSessionErrorMessage] = useState<string | null>(null)
@@ -1688,10 +1708,16 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
               sessionTitle || ''
             )
             if (sessionTitle && !isOpenCodeDefault) {
-              console.log('[TITLE_DEBUG] SessionView calling updateSessionName', { sessionId, sessionTitle })
+              console.log('[TITLE_DEBUG] SessionView calling updateSessionName', {
+                sessionId,
+                sessionTitle
+              })
               useSessionStore.getState().updateSessionName(sessionId, sessionTitle)
             } else {
-              console.log('[TITLE_DEBUG] SessionView SKIPPED updateSessionName', { sessionTitle, isOpenCodeDefault })
+              console.log('[TITLE_DEBUG] SessionView SKIPPED updateSessionName', {
+                sessionTitle,
+                isOpenCodeDefault
+              })
             }
             return
           }
@@ -1975,6 +2001,55 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
             // Route child/subagent events into their SubtaskCard
             if (event.childSessionId) {
+              if (sessionRecord?.agent_sdk === 'codex') {
+                const childPart = event.data?.part
+                if (childPart?.type === 'text') {
+                  const delta = event.data?.delta || childPart.text || ''
+                  if (delta) {
+                    applyCodexChildStreamingPart(event.childSessionId, {
+                      type: 'text',
+                      text: delta
+                    })
+                  }
+                } else if (childPart?.type === 'tool') {
+                  const state = childPart.state || {}
+                  const statusMap: Record<string, ToolStatus> = {
+                    pending: 'pending',
+                    running: 'running',
+                    completed: 'success',
+                    error: 'error'
+                  }
+                  applyCodexChildStreamingPart(event.childSessionId, {
+                    type: 'tool_use',
+                    toolUse: {
+                      id: childPart.callID || childPart.id || `tool-${Date.now()}`,
+                      name: childPart.tool || 'Unknown',
+                      input: state.input || {},
+                      status: statusMap[state.status] || 'running',
+                      startTime: state.time?.start || Date.now(),
+                      endTime: state.time?.end,
+                      output: state.status === 'completed' ? state.output : undefined,
+                      error: state.status === 'error' ? state.error : undefined
+                    }
+                  })
+                } else if (childPart?.type === 'subtask') {
+                  applyCodexChildStreamingPart(event.childSessionId, {
+                    type: 'subtask',
+                    subtask: {
+                      id: childPart.id || event.childSessionId,
+                      sessionID: childPart.sessionID || event.childSessionId,
+                      prompt: childPart.prompt || '',
+                      description: childPart.description || '',
+                      agent: childPart.agent || 'task',
+                      parts: [],
+                      status: childPart.status || 'running'
+                    }
+                  })
+                }
+                setIsStreaming(true)
+                return
+              }
+
               let subtaskIdx = childToSubtaskIndexRef.current.get(event.childSessionId)
 
               // Auto-create subtask entry on first child event (SDK doesn't
@@ -2122,6 +2197,19 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                     endTime: state.time?.end,
                     output: state.status === 'completed' ? state.output : undefined,
                     error: state.status === 'error' ? state.error : undefined
+                  }
+                })
+              } else if (part.type === 'subtask') {
+                applyCodexStreamingPart({
+                  type: 'subtask',
+                  subtask: {
+                    id: part.id || `subtask-${Date.now()}`,
+                    sessionID: part.sessionID || part.id || '',
+                    prompt: part.prompt || '',
+                    description: part.description || '',
+                    agent: part.agent || 'task',
+                    parts: [],
+                    status: part.status || 'running'
                   }
                 })
               }
@@ -2451,6 +2539,22 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           } else if (event.type === 'session.idle') {
             // Child session idle — update subtask status, don't finalize parent
             if (event.childSessionId) {
+              if (sessionRecord?.agent_sdk === 'codex') {
+                applyCodexChildStreamingPart(event.childSessionId, {
+                  type: 'subtask',
+                  subtask: {
+                    id: event.childSessionId,
+                    sessionID: event.childSessionId,
+                    prompt: '',
+                    description: '',
+                    agent: 'task',
+                    parts: [],
+                    status: 'completed'
+                  }
+                })
+                return
+              }
+
               const subtaskIdx = childToSubtaskIndexRef.current.get(event.childSessionId)
               if (subtaskIdx !== undefined) {
                 updateStreamingPartsRef((parts) => {
@@ -2526,7 +2630,10 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                 sessionId,
                 isBlocked: () => {
                   const currentStatus = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-                  return currentStatus?.status === 'command_approval' || currentStatus?.status === 'permission'
+                  return (
+                    currentStatus?.status === 'command_approval' ||
+                    currentStatus?.status === 'permission'
+                  )
                 },
                 dequeueFollowUp: () => useSessionStore.getState().consumeFollowUpMessage(sessionId),
                 requeueFollowUp: (message) =>
@@ -2580,9 +2687,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                     ...prev
                   ])
                   if (optimisticMessageId) {
-                    setMessages((prev) =>
-                      prev.filter((entry) => entry.id !== optimisticMessageId)
-                    )
+                    setMessages((prev) => prev.filter((entry) => entry.id !== optimisticMessageId))
                   }
                 },
                 onComplete: () => {
@@ -2605,7 +2710,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                   const word = COMPLETION_WORDS[Math.floor(Math.random() * COMPLETION_WORDS.length)]
                   const tokenDelta = computeTokenDelta(sessionId)
                   const statusStore = useWorktreeStatusStore.getState()
-                  statusStore.setSessionStatus(sessionId, 'completed', { word, durationMs, tokenDelta })
+                  statusStore.setSessionStatus(sessionId, 'completed', {
+                    word,
+                    durationMs,
+                    tokenDelta
+                  })
                 }
               })
             } else if (status.type === 'retry') {
@@ -2941,9 +3050,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
               .setSessionStatus(sessionId, isPlanLike(currentMode) ? 'planning' : 'working')
             // Apply mode prefix for OpenCode sessions (Claude Code uses native plan mode)
             const modePrefix =
-              currentMode === 'super-plan' ? SUPER_PLAN_MODE_PREFIX
-              : currentMode === 'plan' && !skipPlanModePrefix ? PLAN_MODE_PREFIX
-              : ''
+              currentMode === 'super-plan'
+                ? SUPER_PLAN_MODE_PREFIX
+                : currentMode === 'plan' && !skipPlanModePrefix
+                  ? PLAN_MODE_PREFIX
+                  : ''
             const promptMessage = modePrefix + pendingMsg
             // Store the full prompt so the stream handler can detect SDK echoes
             lastSentPromptRef.current = promptMessage
@@ -3439,7 +3550,15 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                           ...existingPart,
                           subtask: {
                             ...existingPart.subtask,
-                            parts: [...existingPart.subtask.parts]
+                            parts: existingPart.subtask.parts.map((subtaskPart) => {
+                              if (subtaskPart.type === 'tool_use' && subtaskPart.toolUse) {
+                                return {
+                                  ...subtaskPart,
+                                  toolUse: { ...subtaskPart.toolUse }
+                                }
+                              }
+                              return { ...subtaskPart }
+                            })
                           }
                         }
                       }
@@ -3493,8 +3612,165 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           } else {
             nextParts.push(part)
           }
+        } else if (part.type === 'subtask' && part.subtask) {
+          const existingSubtaskIndex = nextParts.findIndex(
+            (candidate) =>
+              candidate.type === 'subtask' &&
+              (candidate.subtask?.id === part.subtask?.id ||
+                candidate.subtask?.sessionID === part.subtask?.sessionID)
+          )
+          if (existingSubtaskIndex >= 0) {
+            const existingSubtask = nextParts[existingSubtaskIndex].subtask!
+            nextParts[existingSubtaskIndex] = {
+              type: 'subtask',
+              subtask: {
+                ...existingSubtask,
+                prompt: part.subtask.prompt || existingSubtask.prompt,
+                description: part.subtask.description || existingSubtask.description,
+                agent: part.subtask.agent || existingSubtask.agent,
+                status:
+                  part.subtask.status === 'completed' || part.subtask.status === 'error'
+                    ? part.subtask.status
+                    : existingSubtask.status,
+                parts: part.subtask.parts.length > 0 ? part.subtask.parts : existingSubtask.parts
+              }
+            }
+          } else {
+            nextParts.push(part)
+          }
         } else {
           nextParts.push(part)
+        }
+
+        const nextContent = nextParts
+          .filter((candidate) => candidate.type === 'text')
+          .map((candidate) => candidate.text ?? '')
+          .join('')
+
+        const nextMessage: OpenCodeMessage = {
+          ...existingMessage,
+          content: nextContent,
+          parts: nextParts
+        }
+
+        if (existingIndex >= 0) {
+          nextMessages[existingIndex] = nextMessage
+          return nextMessages
+        }
+
+        return [...nextMessages, nextMessage]
+      })
+    },
+    [setMessages]
+  )
+
+  const applyCodexChildStreamingPart = useCallback(
+    (childSessionId: string, childPart: StreamingPart) => {
+      setMessages((currentMessages) => {
+        const messageId =
+          codexStreamingMessageIdRef.current ?? `codex-streaming-${crypto.randomUUID()}`
+        codexStreamingMessageIdRef.current = messageId
+
+        const existingIndex = currentMessages.findIndex((message) => message.id === messageId)
+        const nextMessages = [...currentMessages]
+        const existingMessage =
+          existingIndex >= 0
+            ? {
+                ...nextMessages[existingIndex],
+                parts: (nextMessages[existingIndex].parts ?? []).map((existingPart) => {
+                  if (existingPart.type === 'tool_use' && existingPart.toolUse) {
+                    return { ...existingPart, toolUse: { ...existingPart.toolUse } }
+                  }
+                  if (existingPart.type === 'subtask' && existingPart.subtask) {
+                    return {
+                      ...existingPart,
+                      subtask: {
+                        ...existingPart.subtask,
+                        parts: existingPart.subtask.parts.map((subtaskPart) => {
+                          if (subtaskPart.type === 'tool_use' && subtaskPart.toolUse) {
+                            return { ...subtaskPart, toolUse: { ...subtaskPart.toolUse } }
+                          }
+                          return { ...subtaskPart }
+                        })
+                      }
+                    }
+                  }
+                  return { ...existingPart }
+                })
+              }
+            : {
+                id: messageId,
+                role: 'assistant' as const,
+                content: '',
+                timestamp: new Date().toISOString(),
+                parts: [] as StreamingPart[]
+              }
+
+        const nextParts = [...(existingMessage.parts ?? [])]
+        const existingSubtaskIndex = nextParts.findIndex(
+          (candidate) =>
+            candidate.type === 'subtask' &&
+            (candidate.subtask?.id === childSessionId ||
+              candidate.subtask?.sessionID === childSessionId)
+        )
+
+        const subtask =
+          existingSubtaskIndex >= 0
+            ? nextParts[existingSubtaskIndex].subtask!
+            : {
+                id: childSessionId,
+                sessionID: childSessionId,
+                prompt: '',
+                description: '',
+                agent: 'task',
+                parts: [] as StreamingPart[],
+                status: 'running' as const
+              }
+
+        const nextSubtaskParts = [...subtask.parts]
+
+        if (childPart.type === 'text') {
+          const lastPart = nextSubtaskParts[nextSubtaskParts.length - 1]
+          if (lastPart?.type === 'text') {
+            nextSubtaskParts[nextSubtaskParts.length - 1] = {
+              ...lastPart,
+              text: `${lastPart.text ?? ''}${childPart.text ?? ''}`
+            }
+          } else {
+            nextSubtaskParts.push({ type: 'text', text: childPart.text ?? '' })
+          }
+        } else if (childPart.type === 'tool_use' && childPart.toolUse) {
+          const existingToolIndex = nextSubtaskParts.findIndex(
+            (candidate) =>
+              candidate.type === 'tool_use' && candidate.toolUse?.id === childPart.toolUse?.id
+          )
+          if (existingToolIndex >= 0) {
+            nextSubtaskParts[existingToolIndex] = {
+              type: 'tool_use',
+              toolUse: {
+                ...nextSubtaskParts[existingToolIndex].toolUse!,
+                ...childPart.toolUse
+              }
+            }
+          } else {
+            nextSubtaskParts.push(childPart)
+          }
+        } else if (childPart.type === 'subtask' && childPart.subtask) {
+          subtask.prompt = childPart.subtask.prompt || subtask.prompt
+          subtask.description = childPart.subtask.description || subtask.description
+          subtask.agent = childPart.subtask.agent || subtask.agent
+          subtask.status = childPart.subtask.status
+        }
+
+        const nextSubtask: NonNullable<StreamingPart['subtask']> = {
+          ...subtask,
+          parts: nextSubtaskParts
+        }
+
+        if (existingSubtaskIndex >= 0) {
+          nextParts[existingSubtaskIndex] = { type: 'subtask', subtask: nextSubtask }
+        } else {
+          nextParts.push({ type: 'subtask', subtask: nextSubtask })
         }
 
         const nextContent = nextParts
@@ -3582,14 +3858,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         setForkingMessageId(null)
       }
     },
-    [
-      forkingMessageId,
-      opencodeSessionId,
-      sessionId,
-      sessionRecord,
-      worktreeId,
-      worktreePath
-    ]
+    [forkingMessageId, opencodeSessionId, sessionId, sessionRecord, worktreeId, worktreePath]
   )
 
   // Handle send message
@@ -3861,9 +4130,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         // instead of only appearing after a session reload from disk.
         const optimisticMode = currentModeForStatus
         const optimisticModePrefix =
-          optimisticMode === 'super-plan' ? SUPER_PLAN_MODE_PREFIX
-          : optimisticMode === 'plan' && !skipPlanModePrefix ? PLAN_MODE_PREFIX
-          : ''
+          optimisticMode === 'super-plan'
+            ? SUPER_PLAN_MODE_PREFIX
+            : optimisticMode === 'plan' && !skipPlanModePrefix
+              ? PLAN_MODE_PREFIX
+              : ''
         const optimisticPrComments = usePRReviewStore.getState().attachedComments
         let optimisticPrContext = ''
         if (optimisticPrComments.length > 0) {
@@ -3985,9 +4256,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
             } else {
               // Unknown command — send as regular prompt (SDK may handle it)
               const modePrefix =
-                currentModeForStatus === 'super-plan' ? SUPER_PLAN_MODE_PREFIX
-                : currentModeForStatus === 'plan' && !skipPlanModePrefix ? PLAN_MODE_PREFIX
-                : ''
+                currentModeForStatus === 'super-plan'
+                  ? SUPER_PLAN_MODE_PREFIX
+                  : currentModeForStatus === 'plan' && !skipPlanModePrefix
+                    ? PLAN_MODE_PREFIX
+                    : ''
               // Build PR review comment context
               const prAttachedComments = usePRReviewStore.getState().attachedComments
               let prContext = ''
@@ -4021,9 +4294,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           } else {
             // Regular prompt — existing code (with mode prefix, attachments, etc.)
             const modePrefix =
-              currentModeForStatus === 'super-plan' ? SUPER_PLAN_MODE_PREFIX
-              : currentModeForStatus === 'plan' && !skipPlanModePrefix ? PLAN_MODE_PREFIX
-              : ''
+              currentModeForStatus === 'super-plan'
+                ? SUPER_PLAN_MODE_PREFIX
+                : currentModeForStatus === 'plan' && !skipPlanModePrefix
+                  ? PLAN_MODE_PREFIX
+                  : ''
             // Build PR review comment context
             const prAttachedComments = usePRReviewStore.getState().attachedComments
             let prContext = ''
@@ -4337,7 +4612,15 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     notifyKanbanSessionSync(sessionId, { type: 'supercharge', newSessionId: result.session.id })
     sessionStore.setActiveSession(result.session.id)
     await setModePromise
-  }, [messages, worktreeId, sessionRecord?.project_id, connectionId, sessionId, worktreePath, opencodeSessionId])
+  }, [
+    messages,
+    worktreeId,
+    sessionRecord?.project_id,
+    connectionId,
+    sessionId,
+    worktreePath,
+    opencodeSessionId
+  ])
 
   const handlePlanReadySuperpowers = useCallback(async () => {
     // 1. Extract plan content
@@ -4494,7 +4777,15 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     // 4. Navigate to the new session (same worktree)
     sessionStore.setActiveSession(newSessionId)
     await setModePromise
-  }, [messages, worktreeId, sessionRecord?.project_id, pendingPlan, sessionId, worktreePath, opencodeSessionId])
+  }, [
+    messages,
+    worktreeId,
+    sessionRecord?.project_id,
+    pendingPlan,
+    sessionId,
+    worktreePath,
+    opencodeSessionId
+  ])
 
   const handlePlanReadySaveAsTicket = useCallback(async () => {
     const projectId = sessionRecord?.project_id
@@ -4681,33 +4972,30 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     setAttachments((prev) => prev.filter((a) => a.id !== id))
   }, [])
 
-  const handleTicketPickerSelect = useCallback(
-    (tickets: TicketAttachmentData[]) => {
-      setAttachments((prev) => {
-        const remaining = MAX_ATTACHMENTS - prev.length
-        if (remaining <= 0) {
-          toast.warning(`Maximum ${MAX_ATTACHMENTS} attachments reached`)
-          return prev
-        }
-        const toAdd = tickets.slice(0, remaining).map((t) => ({
-          kind: 'ticket' as const,
-          id: crypto.randomUUID(),
-          name: t.title,
-          ticketId: t.ticketId,
-          title: t.title,
-          description: t.description,
-          attachments: t.attachments
-        }))
-        if (tickets.length > remaining) {
-          toast.warning(
-            `Only ${remaining} of ${tickets.length} tickets attached (${MAX_ATTACHMENTS} max)`
-          )
-        }
-        return [...prev, ...toAdd]
-      })
-    },
-    []
-  )
+  const handleTicketPickerSelect = useCallback((tickets: TicketAttachmentData[]) => {
+    setAttachments((prev) => {
+      const remaining = MAX_ATTACHMENTS - prev.length
+      if (remaining <= 0) {
+        toast.warning(`Maximum ${MAX_ATTACHMENTS} attachments reached`)
+        return prev
+      }
+      const toAdd = tickets.slice(0, remaining).map((t) => ({
+        kind: 'ticket' as const,
+        id: crypto.randomUUID(),
+        name: t.title,
+        ticketId: t.ticketId,
+        title: t.title,
+        description: t.description,
+        attachments: t.attachments
+      }))
+      if (tickets.length > remaining) {
+        toast.warning(
+          `Only ${remaining} of ${tickets.length} tickets attached (${MAX_ATTACHMENTS} max)`
+        )
+      }
+      return [...prev, ...toAdd]
+    })
+  }, [])
 
   // Slash command handlers
   const handleInputChange = useCallback(
@@ -5195,7 +5483,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           onSuperpowers={handlePlanReadySuperpowers}
           onSuperpowersLocal={handlePlanReadySuperpowersLocal}
           isConnectionSession={!!connectionId}
-          onSaveAsTicket={sessionRecord?.project_id && !planSavedAsTicket ? handlePlanReadySaveAsTicket : undefined}
+          onSaveAsTicket={
+            sessionRecord?.project_id && !planSavedAsTicket
+              ? handlePlanReadySaveAsTicket
+              : undefined
+          }
         />
         {/* Scroll-to-bottom FAB */}
         <ScrollToBottomFab
@@ -5382,14 +5674,20 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                   )}
                 >
                   {elapsedTimerText ??
-                    (pendingPlan
-                      ? 'Enter to send feedback to revise the plan'
-                      : <span className="hidden @min-[42rem]:inline">{`${navigator.platform.includes('Mac') ? '⌃' : 'Ctrl+'}T to change variant, Shift+Enter for new line`}</span>)}
+                    (pendingPlan ? (
+                      'Enter to send feedback to revise the plan'
+                    ) : (
+                      <span className="hidden @min-[42rem]:inline">{`${navigator.platform.includes('Mac') ? '⌃' : 'Ctrl+'}T to change variant, Shift+Enter for new line`}</span>
+                    ))}
                 </span>
               </div>
               <div className="flex items-center gap-1.5">
                 {isStreaming && (
-                  <IndeterminateProgressBar mode={mode} isAsking={!!activeQuestion} isCompacting={isCompacting} />
+                  <IndeterminateProgressBar
+                    mode={mode}
+                    isAsking={!!activeQuestion}
+                    isCompacting={isCompacting}
+                  />
                 )}
                 {isStreaming && !inputValue.trim() ? (
                   <Button

--- a/src/renderer/src/lib/codex-timeline.ts
+++ b/src/renderer/src/lib/codex-timeline.ts
@@ -30,9 +30,9 @@ function parseToolPart(activity: SessionActivity): StreamingPart | null {
     payload && typeof payload.item === 'object' ? (payload.item as Record<string, unknown>) : null
   const toolName = normalizeCodexToolName(
     (typeof item?.toolName === 'string' && item.toolName) ||
-    (typeof item?.name === 'string' && item.name) ||
-    (typeof item?.type === 'string' && item.type) ||
-    'unknown'
+      (typeof item?.name === 'string' && item.name) ||
+      (typeof item?.type === 'string' && item.type) ||
+      'unknown'
   )
   const rawInput =
     item?.input && typeof item.input === 'object' && !Array.isArray(item.input)
@@ -91,6 +91,57 @@ function parsePlanPart(activity: SessionActivity): StreamingPart | null {
       input: { plan },
       status: 'pending',
       startTime: Date.parse(activity.created_at) || Date.now()
+    }
+  }
+}
+
+function parseTaskPart(activity: SessionActivity): StreamingPart | null {
+  if (
+    activity.kind !== 'task.started' &&
+    activity.kind !== 'task.updated' &&
+    activity.kind !== 'task.completed'
+  ) {
+    return null
+  }
+
+  const payload = parseJson<Record<string, unknown>>(activity.payload_json)
+  const task =
+    payload && typeof payload.task === 'object' && !Array.isArray(payload.task)
+      ? (payload.task as Record<string, unknown>)
+      : null
+
+  const taskId =
+    (typeof task?.id === 'string' && task.id) ||
+    (typeof payload?.taskId === 'string' && payload.taskId) ||
+    activity.item_id ||
+    activity.id
+
+  const sessionID =
+    (typeof task?.threadId === 'string' && task.threadId) ||
+    (typeof payload?.threadId === 'string' && payload.threadId) ||
+    taskId
+
+  const description =
+    (typeof task?.message === 'string' && task.message) ||
+    (typeof payload?.message === 'string' && payload.message) ||
+    activity.summary ||
+    ''
+
+  return {
+    type: 'subtask',
+    subtask: {
+      id: taskId,
+      sessionID,
+      prompt: '',
+      description,
+      agent: 'task',
+      parts: [],
+      status:
+        activity.kind === 'task.completed'
+          ? 'completed'
+          : activity.tone === 'error'
+            ? 'error'
+            : 'running'
     }
   }
 }
@@ -343,6 +394,44 @@ function upsertToolPart(
   return existingParts
 }
 
+function upsertSubtaskPart(
+  parts: StreamingPart[] | undefined,
+  nextPart: StreamingPart
+): StreamingPart[] {
+  const existingParts = parts ? [...parts] : []
+  const nextSubtask = nextPart.subtask
+  if (!nextSubtask) return existingParts
+
+  const partIndex = existingParts.findIndex(
+    (part) =>
+      part.type === 'subtask' &&
+      (part.subtask?.id === nextSubtask.id || part.subtask?.sessionID === nextSubtask.sessionID)
+  )
+
+  if (partIndex >= 0) {
+    const existing = existingParts[partIndex].subtask
+    existingParts[partIndex] = {
+      type: 'subtask',
+      subtask: {
+        id: existing?.id ?? nextSubtask.id,
+        sessionID: existing?.sessionID ?? nextSubtask.sessionID,
+        prompt: nextSubtask.prompt || existing?.prompt || '',
+        description: nextSubtask.description || existing?.description || '',
+        agent: nextSubtask.agent || existing?.agent || 'task',
+        parts: nextSubtask.parts.length > 0 ? nextSubtask.parts : (existing?.parts ?? []),
+        status:
+          nextSubtask.status === 'completed' || nextSubtask.status === 'error'
+            ? nextSubtask.status
+            : (existing?.status ?? nextSubtask.status)
+      }
+    }
+    return existingParts
+  }
+
+  existingParts.push(nextPart)
+  return existingParts
+}
+
 export function mergeCodexActivityMessages(
   baseMessages: OpenCodeMessage[],
   activityRows: SessionActivity[],
@@ -394,16 +483,24 @@ export function mergeCodexActivityMessages(
   for (const activity of sortedActivities) {
     const activityPart = activity.kind.startsWith('tool.')
       ? parseToolPart(activity)
-      : parsePlanPart(activity)
-    if (!activityPart?.toolUse) continue
+      : activity.kind === 'plan.ready'
+        ? parsePlanPart(activity)
+        : parseTaskPart(activity)
+    if (!activityPart) continue
 
-    const toolId = activityPart.toolUse.id
-    if (knownToolIds.has(toolId)) {
+    const toolId = activityPart.toolUse?.id
+    if (toolId && knownToolIds.has(toolId)) {
       continue
     }
 
     const turnId = activity.turn_id
-    const syntheticId = turnId ? `${turnId}:tool:${toolId}` : `tool:${toolId}`
+    const syntheticId = activityPart.toolUse
+      ? turnId
+        ? `${turnId}:tool:${toolId}`
+        : `tool:${toolId}`
+      : turnId
+        ? `${turnId}:task:${activityPart.subtask?.id ?? activity.id}`
+        : `task:${activityPart.subtask?.id ?? activity.id}`
     const targetCollection = turnId
       ? (anchoredSyntheticByTurnId.get(turnId) ?? [])
       : unanchoredSynthetic
@@ -422,7 +519,9 @@ export function mergeCodexActivityMessages(
         anchoredSyntheticByTurnId.set(turnId, targetCollection)
       }
     }
-    target.parts = upsertToolPart(target.parts, activityPart)
+    target.parts = activityPart.toolUse
+      ? upsertToolPart(target.parts, activityPart)
+      : upsertSubtaskPart(target.parts, activityPart)
   }
 
   const injectedTurns = new Set<string>()

--- a/test/phase-22/session-5/codex-child-session-routing.test.ts
+++ b/test/phase-22/session-5/codex-child-session-routing.test.ts
@@ -38,7 +38,10 @@ vi.mock('../../../src/main/services/codex-app-server-manager', () => {
   }
 })
 
-import { CodexImplementer, type CodexSessionState } from '../../../src/main/services/codex-implementer'
+import {
+  CodexImplementer,
+  type CodexSessionState
+} from '../../../src/main/services/codex-implementer'
 
 describe('Codex child session routing', () => {
   let impl: CodexImplementer
@@ -67,7 +70,15 @@ describe('Codex child session routing', () => {
       hiveSessionId,
       worktreePath,
       status: 'ready',
-      messages: []
+      messages: [],
+      currentTurnId: null,
+      currentAssistantMessageId: null,
+      revertMessageID: null,
+      revertDiff: null,
+      titleGenerated: false,
+      titleGenerationStarted: false,
+      persistDebounceTimer: null,
+      liveAssistantDraft: null
     }
     impl.getSessions().set(`${worktreePath}::${threadId}`, session)
     return session
@@ -178,6 +189,64 @@ describe('Codex child session routing', () => {
         expect(textPart.text).not.toContain('Response B')
       }
     })
+
+    it('routes child-thread text into a subtask instead of leaking it into the parent assistant text', async () => {
+      const session = seedSession('/project-a', 'thread-a', 'hive-a')
+
+      simulateEvents([
+        {
+          id: 'turn-start',
+          kind: 'notification',
+          provider: 'codex',
+          threadId: 'thread-a',
+          createdAt: new Date().toISOString(),
+          method: 'turn/started',
+          turnId: 'turn-1',
+          payload: { turn: { id: 'turn-1', status: 'running' } }
+        },
+        {
+          id: 'child-text',
+          kind: 'notification',
+          provider: 'codex',
+          threadId: 'thread-a',
+          childThreadId: 'child-1',
+          turnId: 'turn-1',
+          createdAt: new Date().toISOString(),
+          method: 'item/agentMessage/delta',
+          textDelta: 'Child analysis',
+          payload: { delta: 'Child analysis' }
+        },
+        {
+          id: 'turn-complete',
+          kind: 'notification',
+          provider: 'codex',
+          threadId: 'thread-a',
+          createdAt: new Date().toISOString(),
+          method: 'turn/completed',
+          turnId: 'turn-1',
+          payload: { turn: { id: 'turn-1', status: 'completed' } }
+        }
+      ])
+
+      await impl.prompt('/project-a', 'thread-a', 'Investigate')
+
+      const assistantMessage = session.messages.find(
+        (message: any) => message.role === 'assistant'
+      ) as any
+      expect(assistantMessage).toBeTruthy()
+      expect(assistantMessage.parts).toEqual([
+        {
+          type: 'subtask',
+          id: 'child-1',
+          sessionID: 'child-1',
+          prompt: '',
+          description: '',
+          agent: 'task',
+          parts: [{ type: 'text', text: 'Child analysis' }],
+          status: 'running'
+        }
+      ])
+    })
   })
 
   // ── Context injection compatibility ─────────────────────────
@@ -199,7 +268,8 @@ describe('Codex child session routing', () => {
       ])
 
       // IPC handler prepends context like this
-      const contextMessage = '[Worktree Context]\nThis is a React project\n\n[User Message]\nFix the bug'
+      const contextMessage =
+        '[Worktree Context]\nThis is a React project\n\n[User Message]\nFix the bug'
 
       await impl.prompt('/project', 'thread-ctx', contextMessage)
 
@@ -323,9 +393,7 @@ describe('Codex child session routing', () => {
         { role: 'user', parts: [{ type: 'text', text: 'Q-A' }] },
         { role: 'assistant', parts: [{ type: 'text', text: 'A-A' }] }
       ]
-      sessionB.messages = [
-        { role: 'user', parts: [{ type: 'text', text: 'Q-B' }] }
-      ]
+      sessionB.messages = [{ role: 'user', parts: [{ type: 'text', text: 'Q-B' }] }]
 
       const messagesA = await impl.getMessages('/project-a', 'thread-a')
       const messagesB = await impl.getMessages('/project-b', 'thread-b')

--- a/test/phase-22/session-5/codex-event-mapper.test.ts
+++ b/test/phase-22/session-5/codex-event-mapper.test.ts
@@ -640,11 +640,15 @@ describe('mapCodexEventToStreamEvents', () => {
       const result = mapCodexEventToStreamEvents(event, HIVE_SESSION)
 
       expect(result).toHaveLength(1)
-      expect(result[0].data).toEqual({
-        type: 'task',
-        taskId: 'task-1',
-        status: 'running',
-        message: 'Starting analysis'
+      expect(result[0].type).toBe('message.part.updated')
+      expect((result[0].data as any).part).toEqual({
+        type: 'subtask',
+        id: 'task-1',
+        sessionID: 'task-1',
+        prompt: '',
+        description: 'Starting analysis',
+        agent: 'task',
+        status: 'running'
       })
     })
 
@@ -652,14 +656,19 @@ describe('mapCodexEventToStreamEvents', () => {
       const event = makeEvent({
         method: 'task.progress',
         payload: {
-          task: { id: 'task-2', status: 'running', progress: 0.5 }
+          task: { id: 'task-2', status: 'running', message: 'Halfway there', progress: 0.5 }
         }
       })
 
       const result = mapCodexEventToStreamEvents(event, HIVE_SESSION)
 
       expect(result).toHaveLength(1)
-      expect((result[0].data as any).progress).toBe(0.5)
+      expect((result[0].data as any).part).toMatchObject({
+        type: 'subtask',
+        id: 'task-2',
+        description: 'Halfway there',
+        status: 'running'
+      })
     })
 
     it('maps task/completed (slash variant)', () => {
@@ -673,7 +682,11 @@ describe('mapCodexEventToStreamEvents', () => {
       const result = mapCodexEventToStreamEvents(event, HIVE_SESSION)
 
       expect(result).toHaveLength(1)
-      expect((result[0].data as any).status).toBe('completed')
+      expect((result[0].data as any).part).toMatchObject({
+        type: 'subtask',
+        id: 'task-3',
+        status: 'completed'
+      })
     })
   })
 

--- a/test/phase-22/session-8/codex-timeline.test.ts
+++ b/test/phase-22/session-8/codex-timeline.test.ts
@@ -142,6 +142,96 @@ describe('codex timeline derivation', () => {
     ).toBe(true)
   })
 
+  it('projects persisted task activities into a single subtask row with the latest status', () => {
+    const messages: SessionMessage[] = [
+      {
+        id: 'db-user-1',
+        session_id: 'session-1',
+        role: 'user',
+        content: 'Delegate the investigation',
+        opencode_message_id: 'turn-1:user',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([{ type: 'text', text: 'Delegate the investigation' }]),
+        opencode_timeline_json: null,
+        created_at: '2026-03-14T10:00:00.000Z'
+      },
+      {
+        id: 'db-assistant-1',
+        session_id: 'session-1',
+        role: 'assistant',
+        content: 'I delegated the investigation.',
+        opencode_message_id: 'turn-1:assistant',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([
+          { type: 'text', text: 'I delegated the investigation.' }
+        ]),
+        opencode_timeline_json: null,
+        created_at: '2026-03-14T10:00:05.000Z'
+      }
+    ]
+
+    const activities: SessionActivity[] = [
+      {
+        id: 'task-activity-1',
+        session_id: 'session-1',
+        agent_session_id: 'thread-1',
+        thread_id: 'thread-1',
+        turn_id: 'turn-1',
+        item_id: null,
+        request_id: null,
+        kind: 'task.started',
+        tone: 'info',
+        summary: 'Task started',
+        payload_json: JSON.stringify({
+          task: { id: 'child-1', status: 'running', message: 'Investigating the renderer' },
+          threadId: 'child-1'
+        }),
+        sequence: 10,
+        created_at: '2026-03-14T10:00:01.000Z'
+      },
+      {
+        id: 'task-activity-2',
+        session_id: 'session-1',
+        agent_session_id: 'thread-1',
+        thread_id: 'thread-1',
+        turn_id: 'turn-1',
+        item_id: null,
+        request_id: null,
+        kind: 'task.completed',
+        tone: 'info',
+        summary: 'Task completed',
+        payload_json: JSON.stringify({
+          task: {
+            id: 'child-1',
+            status: 'completed',
+            message: 'Finished investigating the renderer'
+          },
+          threadId: 'child-1'
+        }),
+        sequence: 11,
+        created_at: '2026-03-14T10:00:04.000Z'
+      }
+    ]
+
+    const timeline = deriveCodexTimelineMessages(messages, activities)
+    const taskRow = timeline.find((message) => message.id === 'turn-1:task:child-1')
+
+    expect(taskRow?.parts).toEqual([
+      {
+        type: 'subtask',
+        subtask: {
+          id: 'child-1',
+          sessionID: 'child-1',
+          prompt: '',
+          description: 'Finished investigating the renderer',
+          agent: 'task',
+          parts: [],
+          status: 'completed'
+        }
+      }
+    ])
+  })
+
   it('anchors later-turn tool activities to the matching assistant turn', () => {
     const messages: SessionMessage[] = [
       {


### PR DESCRIPTION
## Summary

- **Subtask support in stream events**: Added new `subtask` part type to represent nested agent work with status tracking (running/completed/error)
- **Child session delta routing**: Implemented `childSessionId` propagation through stream events to route subagent output to their corresponding subtask cards
- **Live and canonical subtask state**: Added dual-track state management for subtasks (`getOrCreateLiveAssistantSubtask`, `getOrCreateCanonicalAssistantSubtask`)
- **Subtask tooling**: Subtasks can contain nested text and tool parts with full input/output/error tracking
- **Task descriptor extraction**: New `extractSubtaskDescriptor()` normalizes subtask metadata (id, sessionID, prompt, description, agent, status)
- **Codex-specific child routing**: SessionView now detects `childSessionId` and applies parts directly to subtask state instead of generic child handling
- **Stream event formatting**: Tasks mapped from Codex task notifications now emit as `subtask` parts with status conversion and description formatting
- **Code formatting**: Improved formatting consistency across event mapper and implementer services

## Testing

- Unit tests added for subtask state management in `codex-implementer.test.ts` (implicit via part upsert logic)
- Timeline tests extended in `codex-timeline.test.ts` with 90 new lines covering subtask scenarios
- Child session routing tests updated in `codex-child-session-routing.test.ts` (80 lines modified)
- Existing event mapper tests updated to reflect new subtask part emission format
- **Not run**: Integration tests with live Codex streaming (requires running Codex server)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming→transcript plumbing across main-process mapper/implementer and renderer `SessionView`, so regressions could misroute deltas or corrupt persisted message parts. Changes are localized to Codex event handling but affect how tasks/child sessions render and persist.
> 
> **Overview**
> Adds first-class **subtask** support to Codex streaming so task/child-agent output is grouped under a dedicated subtask card instead of merging into the parent assistant text.
> 
> `codex-event-mapper` now maps task lifecycle notifications into `message.part.updated` events carrying a `subtask` part (with status/description) and propagates `childThreadId` as `childSessionId` on emitted stream events.
> 
> `codex-implementer` and the renderer update live and canonical assistant state to upsert/append nested subtask text and tool parts (including output-delta accumulation), and `codex-timeline` now projects persisted `task.*` activities into a single upserted subtask row. Tests are updated/added to validate task→subtask mapping, child-session routing, and timeline merging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e586528942cdf80b0599ce779164b79b3fd43da9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->