### PR TITLE
Add update_plan support to Codex session flow

### DIFF
--- a/src/main/services/codex-activity-mapper.ts
+++ b/src/main/services/codex-activity-mapper.ts
@@ -5,6 +5,7 @@ import { asObject, asString } from './codex-utils'
 import type { ItemStartedNotification } from '@shared/codex-schemas/v2/ItemStartedNotification'
 import type { ItemCompletedNotification } from '@shared/codex-schemas/v2/ItemCompletedNotification'
 import type { ThreadNameUpdatedNotification } from '@shared/codex-schemas/v2/ThreadNameUpdatedNotification'
+import type { TurnPlanUpdatedNotification } from '@shared/codex-schemas/v2/TurnPlanUpdatedNotification'
 
 
 function stringifyPayload(payload: unknown): string | null {
@@ -197,6 +198,20 @@ export function mapCodexManagerEventToActivity(
         'info',
         params?.threadName ?? asString(payload?.threadName) ?? 'Thread title updated'
       )
+    }
+
+    case 'turn/plan/updated': {
+      const params = event.payload as TurnPlanUpdatedNotification | undefined
+      const plan = params?.plan ?? payload?.plan
+      const steps = Array.isArray(plan) ? plan : []
+      const completedCount = steps.filter((step) => {
+        const stepObj = asObject(step)
+        return asString(stepObj?.status) === 'completed'
+      }).length
+      const summary =
+        steps.length > 0 ? `Plan updated (${completedCount}/${steps.length} completed)` : 'Plan updated'
+
+      return buildActivity(sessionId, agentSessionId, event, 'session.info', 'info', summary)
     }
 
     default:

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -197,6 +197,8 @@ You are operating in **default** (autonomous execution) mode. This mode is set b
 
 **IMPORTANT:** The \`request_user_input\` tool is **UNAVAILABLE** in this session mode.
 
+The \`update_plan\` tool is available in this mode for checklist/progress tracking. Use it for non-trivial multi-step work to keep an up-to-date list of steps and statuses. Do not use it for simple one-step tasks, and do not repeat the full plan contents after calling it.
+
 - Do NOT attempt to call \`request_user_input\`
 - Make reasonable assumptions and proceed autonomously
 - If something is ambiguous, pick the most sensible interpretation and execute
@@ -244,6 +246,11 @@ When you have sufficient clarity, produce your implementation plan:
 - Use it to ask ONE focused question at a time
 - Do NOT ask multiple questions in a single call
 - Only ask what you genuinely need to know to finalize the plan
+
+## \`update_plan\`
+
+- \`update_plan\` is a checklist/progress tool and is NOT available in Plan mode
+- Do not attempt to call \`update_plan\` while you are in Plan mode
 
 ## Finalization Rules
 

--- a/src/main/services/codex-event-mapper.ts
+++ b/src/main/services/codex-event-mapper.ts
@@ -5,6 +5,7 @@ import { asObject, asString, asNumber } from './codex-utils'
 import type {
   ThreadNameUpdatedNotification,
   TurnCompletedNotification,
+  TurnPlanUpdatedNotification,
   ThreadItem,
   CommandExecutionRequestApprovalParams,
   FileChangeRequestApprovalParams,
@@ -234,6 +235,61 @@ interface ItemInfo {
   input?: unknown
 }
 
+interface ChecklistTodoItem {
+  id: string
+  content: string
+  status: 'pending' | 'in_progress' | 'completed'
+  priority: 'medium'
+}
+
+function buildUpdatePlanCallId(event: CodexManagerEvent): string {
+  if (event.turnId) return `update-plan:${event.threadId}:${event.turnId}`
+  return `update-plan:${event.threadId}:${event.id}`
+}
+
+function toChecklistTodoStatus(status: unknown): ChecklistTodoItem['status'] {
+  switch (status) {
+    case 'completed':
+      return 'completed'
+    case 'inProgress':
+    case 'in_progress':
+      return 'in_progress'
+    default:
+      return 'pending'
+  }
+}
+
+function buildChecklistToolInput(
+  event: CodexManagerEvent,
+  payload: TurnPlanUpdatedNotification | Record<string, unknown> | undefined
+): { explanation?: string; todos: ChecklistTodoItem[] } | null {
+  const explanation = asString(payload && 'explanation' in payload ? payload.explanation : undefined)
+  const rawPlan = payload && 'plan' in payload ? payload.plan : undefined
+  if (!Array.isArray(rawPlan)) return null
+
+  const todos = rawPlan.flatMap((entry, index) => {
+    const planEntry = asObject(entry)
+    const step = asString(planEntry?.step)?.trim()
+    if (!step) return []
+
+    return [
+      {
+        id: `${buildUpdatePlanCallId(event)}:${index}`,
+        content: step,
+        status: toChecklistTodoStatus(planEntry?.status),
+        priority: 'medium' as const
+      }
+    ]
+  })
+
+  if (todos.length === 0) return null
+
+  return {
+    ...(explanation ? { explanation } : {}),
+    todos
+  }
+}
+
 function isWellFormedThreadItem(item: { type: string; id: string; [k: string]: unknown }): boolean {
   switch (item.type) {
     case 'commandExecution':
@@ -286,11 +342,12 @@ function extractItemInfo(event: CodexManagerEvent): ItemInfo {
     isWellFormedThreadItem(candidate as { type: string; id: string; [k: string]: unknown })
   ) {
     const item = candidate
+    const itemRecord = item as Record<string, unknown>
     const itemType = item.type
     const toolName = normalizeCodexToolName(item.type)
     const callId = item.id || event.itemId || ''
-    const status = 'status' in item ? String((item as any).status) : undefined
-    const output = 'aggregatedOutput' in item ? (item as any).aggregatedOutput : undefined
+    const status = 'status' in itemRecord ? asString(itemRecord.status) : undefined
+    const output = 'aggregatedOutput' in itemRecord ? itemRecord.aggregatedOutput : undefined
     const input = deriveInputFromThreadItem(item)
     return {
       ...(itemType ? { itemType } : {}),
@@ -559,6 +616,32 @@ function mapCodexEventToStreamEventsInner(
         sessionId: hiveSessionId,
         data: annotateData({ status: { type: 'busy' } }),
         statusPayload: { type: 'busy' }
+      }
+    ]
+  }
+
+  // ── Turn plan updated (Codex update_plan) ────────────────────
+  if (method === 'turn/plan/updated') {
+    const typed = event.payload as TurnPlanUpdatedNotification | undefined
+    const payload = asObject(event.payload)
+    const input = buildChecklistToolInput(event, typed ?? payload ?? undefined)
+    if (!input) return []
+
+    return [
+      {
+        type: 'message.part.updated',
+        sessionId: hiveSessionId,
+        data: annotateData({
+          part: {
+            type: 'tool',
+            callID: buildUpdatePlanCallId(event),
+            tool: 'update_plan',
+            state: {
+              status: 'completed',
+              input
+            }
+          }
+        })
       }
     ]
   }

--- a/src/renderer/src/components/sessions/ToolCard.tsx
+++ b/src/renderer/src/components/sessions/ToolCard.tsx
@@ -53,10 +53,10 @@ export interface ToolUseInfo {
   endTime?: number
 }
 
-/** Check if a tool name refers to the TodoWrite tool */
+/** Check if a tool name refers to a checklist-style tool */
 function isTodoWriteTool(name: string): boolean {
   const lower = name.toLowerCase()
-  return lower.includes('todowrite') || lower.includes('todo_write')
+  return lower.includes('todowrite') || lower.includes('todo_write') || lower === 'update_plan'
 }
 
 /** Figma brand color for consistent icon styling */
@@ -311,6 +311,7 @@ const TOOL_RENDERERS: Record<string, React.FC<ToolViewProps>> = {
   mcp_todowrite: TodoWriteToolView,
   TodoWrite: TodoWriteToolView,
   todowrite: TodoWriteToolView,
+  update_plan: TodoWriteToolView,
   Skill: SkillToolView,
   mcp_skill: SkillToolView,
   ExitPlanMode: ExitPlanModeToolView,
@@ -329,7 +330,7 @@ function getToolRenderer(name: string): React.FC<ToolViewProps> {
   if (TOOL_RENDERERS[name]) return TOOL_RENDERERS[name]
   // Try case-insensitive match via known patterns
   const lower = name.toLowerCase()
-  if (lower.includes('todowrite') || lower.includes('todo_write')) return TodoWriteToolView
+  if (isTodoWriteTool(lower)) return TodoWriteToolView
   if (lower.includes('read') || lower === 'cat' || lower === 'view') return ReadToolView
   if (lower.includes('write') || lower === 'create') return WriteToolView
   if (isFileChangeTool(lower)) return FileChangeToolView

--- a/test/codex-migration/session-7/codex-plan-update-activity.test.ts
+++ b/test/codex-migration/session-7/codex-plan-update-activity.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { mapCodexManagerEventToActivity } from '../../../src/main/services/codex-activity-mapper'
+import type { CodexManagerEvent } from '../../../src/main/services/codex-app-server-manager'
+
+function makeEvent(overrides: Partial<CodexManagerEvent>): CodexManagerEvent {
+  return {
+    id: 'evt-plan-activity-1',
+    kind: 'notification',
+    provider: 'codex',
+    threadId: 'thread-1',
+    createdAt: new Date().toISOString(),
+    method: '',
+    ...overrides
+  }
+}
+
+describe('codex-activity-mapper plan updates', () => {
+  it('persists turn/plan/updated as a session info activity with progress summary', () => {
+    const result = mapCodexManagerEventToActivity('session-1', 'agent-1', makeEvent({
+      method: 'turn/plan/updated',
+      turnId: 'turn-1',
+      payload: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        explanation: 'Tracking progress',
+        plan: [
+          { step: 'Inspect adapter', status: 'completed' },
+          { step: 'Map plan updates', status: 'inProgress' },
+          { step: 'Verify logging', status: 'pending' }
+        ]
+      }
+    }))
+
+    expect(result).not.toBeNull()
+    expect(result!.kind).toBe('session.info')
+    expect(result!.tone).toBe('info')
+    expect(result!.turn_id).toBe('turn-1')
+    expect(result!.summary).toBe('Plan updated (1/3 completed)')
+    expect(result!.payload_json).toContain('"plan"')
+  })
+})

--- a/test/phase-22/session-5/codex-app-server-manager.test.ts
+++ b/test/phase-22/session-5/codex-app-server-manager.test.ts
@@ -143,6 +143,9 @@ describe('CodexAppServerManager — collaborationMode in sendTurn', () => {
     expect(params.collaborationMode.settings.developer_instructions).toContain(
       'Stop after producing the plan block'
     )
+    expect(params.collaborationMode.settings.developer_instructions).toContain(
+      '`update_plan` is a checklist/progress tool and is NOT available in Plan mode'
+    )
   })
 
   it('includes collaborationMode with mode: default and default developer instructions when interactionMode is default', async () => {
@@ -172,6 +175,10 @@ describe('CodexAppServerManager — collaborationMode in sendTurn', () => {
     expect(params.collaborationMode.mode).toBe('default')
     expect(params.collaborationMode.settings).toBeDefined()
     expect(params.collaborationMode.settings.developer_instructions).toContain('default')
+    expect(params.collaborationMode.settings.developer_instructions).toContain('update_plan')
+    expect(params.collaborationMode.settings.developer_instructions).toContain(
+      'The `update_plan` tool is available in this mode'
+    )
   })
 
   it('does not include collaborationMode when interactionMode is not provided', async () => {

--- a/test/phase-22/session-5/codex-plan-update-mapper.test.ts
+++ b/test/phase-22/session-5/codex-plan-update-mapper.test.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it } from 'vitest'
+import { mapCodexEventToStreamEvents } from '../../../src/main/services/codex-event-mapper'
+import type { CodexManagerEvent } from '../../../src/main/services/codex-app-server-manager'
+
+const HIVE_SESSION = 'hive-session-123'
+
+function makeEvent(overrides: Partial<CodexManagerEvent>): CodexManagerEvent {
+  return {
+    id: 'evt-plan-1',
+    kind: 'notification',
+    provider: 'codex',
+    threadId: 'thread-1',
+    createdAt: new Date().toISOString(),
+    method: '',
+    ...overrides
+  }
+}
+
+describe('Codex plan update stream mapping', () => {
+  it('maps turn/plan/updated into an update_plan checklist tool event', () => {
+    const event = makeEvent({
+      method: 'turn/plan/updated',
+      turnId: 'turn-1',
+      payload: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        explanation: 'Tracking progress',
+        plan: [
+          { step: 'Inspect adapter', status: 'completed' },
+          { step: 'Map plan updates', status: 'inProgress' },
+          { step: 'Verify logging', status: 'pending' }
+        ]
+      }
+    })
+
+    const result = mapCodexEventToStreamEvents(event, HIVE_SESSION)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.type).toBe('message.part.updated')
+    expect(result[0]?.sessionId).toBe(HIVE_SESSION)
+
+    const data = result[0]?.data as any
+    expect(data._codexEventId).toBe('evt-plan-1')
+    expect(data.part.type).toBe('tool')
+    expect(data.part.callID).toBe('update-plan:thread-1:turn-1')
+    expect(data.part.tool).toBe('update_plan')
+    expect(data.part.state.status).toBe('completed')
+    expect(data.part.state.input).toEqual({
+      explanation: 'Tracking progress',
+      todos: [
+        {
+          id: 'update-plan:thread-1:turn-1:0',
+          content: 'Inspect adapter',
+          status: 'completed',
+          priority: 'medium'
+        },
+        {
+          id: 'update-plan:thread-1:turn-1:1',
+          content: 'Map plan updates',
+          status: 'in_progress',
+          priority: 'medium'
+        },
+        {
+          id: 'update-plan:thread-1:turn-1:2',
+          content: 'Verify logging',
+          status: 'pending',
+          priority: 'medium'
+        }
+      ]
+    })
+  })
+})

--- a/test/phase-22/session-5/codex-update-plan-logging.test.ts
+++ b/test/phase-22/session-5/codex-update-plan-logging.test.ts
@@ -1,0 +1,146 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const debugLoggerMocks = vi.hoisted(() => ({
+  logCodexMessage: vi.fn(),
+  logCodexLifecycleEvent: vi.fn(),
+  resetSession: vi.fn()
+}))
+
+vi.mock('../../../src/main/services/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    spawn: vi.fn(),
+    spawnSync: vi.fn()
+  }
+})
+
+vi.mock('../../../src/main/services/codex-debug-logger', () => ({
+  logCodexMessage: debugLoggerMocks.logCodexMessage,
+  logCodexLifecycleEvent: debugLoggerMocks.logCodexLifecycleEvent,
+  resetSession: debugLoggerMocks.resetSession,
+  configure: vi.fn()
+}))
+
+import {
+  CodexAppServerManager,
+  type CodexProviderSession,
+  type CodexSessionContext
+} from '../../../src/main/services/codex-app-server-manager'
+
+function createTestContext(overrides?: Partial<CodexProviderSession>): {
+  context: CodexSessionContext
+  stdin: { write: ReturnType<typeof vi.fn>; writable: boolean }
+} {
+  const stdin = { write: vi.fn(), writable: true }
+
+  const child = {
+    stdin,
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    pid: 12345,
+    killed: false,
+    kill: vi.fn(),
+    on: vi.fn()
+  } as any
+
+  const output = {
+    on: vi.fn(),
+    close: vi.fn(),
+    removeAllListeners: vi.fn()
+  } as any
+
+  const session: CodexProviderSession = {
+    provider: 'codex',
+    status: 'ready',
+    threadId: 'thread-123',
+    cwd: '/test/project',
+    model: 'gpt-5.4',
+    activeTurnId: null,
+    resumeCursor: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides
+  }
+
+  const context: CodexSessionContext = {
+    session,
+    child,
+    output,
+    pending: new Map(),
+    pendingApprovals: new Map(),
+    pendingUserInputs: new Map(),
+    collabReceiverTurns: new Map(),
+    nextRequestId: 1,
+    stopping: false
+  }
+
+  return { context, stdin }
+}
+
+describe('Codex update_plan logging boundaries', () => {
+  let manager: CodexAppServerManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    manager = new CodexAppServerManager()
+  })
+
+  afterEach(() => {
+    manager.stopAll()
+    manager.removeAllListeners()
+  })
+
+  it('logs outgoing turn/start requests that expose update_plan guidance', async () => {
+    const { context, stdin } = createTestContext()
+    ;((manager as any).sessions as Map<string, CodexSessionContext>).set('thread-123', context)
+
+    const turnPromise = manager.sendTurn('thread-123', {
+      text: 'do the thing',
+      model: 'gpt-5.4',
+      interactionMode: 'default'
+    })
+
+    const messages = stdin.write.mock.calls.map((call: any[]) =>
+      JSON.parse((call[0] as string).trim())
+    )
+    const turnStartMsg = messages.find((message: any) => message.method === 'turn/start')
+    expect(turnStartMsg).toBeDefined()
+    expect(debugLoggerMocks.logCodexMessage).toHaveBeenCalledWith('outgoing', turnStartMsg)
+
+    manager.handleStdoutLine(
+      context,
+      JSON.stringify({ id: turnStartMsg.id, result: { turn: { id: 'turn-123' } } })
+    )
+
+    await turnPromise
+  })
+
+  it('logs incoming turn/plan/updated notifications to codex.jsonl', () => {
+    const { context } = createTestContext()
+
+    const notification = {
+      method: 'turn/plan/updated',
+      params: {
+        threadId: 'thread-123',
+        turnId: 'turn-123',
+        explanation: 'Tracking progress',
+        plan: [{ step: 'Map plan updates', status: 'inProgress' }]
+      }
+    }
+
+    manager.handleStdoutLine(context, JSON.stringify(notification))
+
+    expect(debugLoggerMocks.logCodexMessage).toHaveBeenCalledWith('incoming', notification)
+  })
+})

--- a/test/phase-22/session-5/codex-update-plan-rendering.test.tsx
+++ b/test/phase-22/session-5/codex-update-plan-rendering.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ToolCard, type ToolUseInfo } from '../../../src/renderer/src/components/sessions/ToolCard'
+
+function makeToolUse(): ToolUseInfo {
+  return {
+    id: 'update-plan:thread-1:turn-1',
+    name: 'update_plan',
+    input: {
+      todos: [
+        {
+          id: 'todo-1',
+          content: 'Inspect adapter',
+          status: 'completed',
+          priority: 'medium'
+        },
+        {
+          id: 'todo-2',
+          content: 'Map plan updates',
+          status: 'in_progress',
+          priority: 'medium'
+        }
+      ]
+    },
+    status: 'success',
+    startTime: 1000,
+    endTime: 2000
+  }
+}
+
+describe('update_plan tool rendering', () => {
+  it('reuses the TodoWrite checklist renderer for update_plan', () => {
+    render(<ToolCard toolUse={makeToolUse()} />)
+
+    expect(screen.getByTestId('todowrite-tool-view')).toBeTruthy()
+    expect(screen.getByText('Tasks')).toBeTruthy()
+    expect(screen.getByText('1/2 completed')).toBeTruthy()
+    expect(screen.getByText('Inspect adapter')).toBeTruthy()
+    expect(screen.getByText('Map plan updates')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- Map `turn/plan/updated` events into session activity entries with a progress summary.
- Translate plan updates into `update_plan` checklist tool events for stream rendering.
- Treat `update_plan` as a checklist-style tool in the renderer so it reuses the existing TodoWrite UI.
- Update Codex session instructions to describe when `update_plan` is available.
- Add coverage for activity mapping, stream mapping, logging, and rendering.

## Testing
- Not run
- Added unit tests for `turn/plan/updated` activity mapping.
- Added stream-mapping tests for `update_plan` checklist payloads.
- Added logging tests to verify incoming/outgoing plan-update events are recorded.
- Added renderer test to confirm `update_plan` uses the checklist tool view.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new `turn/plan/updated` handling in both backend event/activity mapping and renderer tool selection, which could affect session timelines and tool-card rendering if the payload shape varies.
> 
> **Overview**
> Adds end-to-end support for Codex plan updates: `turn/plan/updated` is now persisted as a `session.info` activity with a computed progress summary, and is also mapped into a synthetic `update_plan` checklist tool part for the stream.
> 
> Updates collaboration-mode developer instructions to document when `update_plan` can be used, and teaches the renderer to treat `update_plan` as a checklist tool by reusing the existing `TodoWrite` UI. Includes new unit tests covering activity mapping, stream mapping, logging, and rendering for plan updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cff0f816f3ab8f743c4f2f7d4d6443c81cd9b8e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->