### PR TITLE
Propagate worktree cwd into PR and title generation

### DIFF
--- a/src/main/ipc/git-file-handlers.ts
+++ b/src/main/ipc/git-file-handlers.ts
@@ -1220,7 +1220,8 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
           commitSummary: rangeDiff.commitSummary,
           diffSummary: rangeDiff.diffSummary,
           diffPatch: rangeDiff.diffPatch,
-          provider: provider as import('../services/agent-sdk-types').AgentSdkId
+          provider: provider as import('../services/agent-sdk-types').AgentSdkId,
+          cwd: worktreePath
         })
 
         return { success: true, title: result.title, body: result.body }

--- a/src/main/services/codex-session-title.ts
+++ b/src/main/services/codex-session-title.ts
@@ -18,7 +18,7 @@ const log = createLogger({ component: 'CodexSessionTitle' })
 
 export async function generateCodexSessionTitle(
   message: string,
-  _worktreePath?: string
+  worktreePath?: string
 ): Promise<string | null> {
   const truncatedMessage =
     message.length > MAX_MESSAGE_LENGTH ? message.slice(0, MAX_MESSAGE_LENGTH) + '...' : message
@@ -50,7 +50,8 @@ export async function generateCodexSessionTitle(
         '-'
       ],
       prompt,
-      TITLE_TIMEOUT_MS
+      TITLE_TIMEOUT_MS,
+      worktreePath
     )
 
     const content = await readFile(outputFile, 'utf-8')

--- a/src/main/services/pr-content-generator.ts
+++ b/src/main/services/pr-content-generator.ts
@@ -34,6 +34,7 @@ export interface GeneratePRContentOptions {
   diffSummary: string
   diffPatch: string
   provider: AgentSdkId
+  cwd: string
 }
 
 export interface PRContent {
@@ -51,7 +52,7 @@ export interface PRContent {
  * Returns null if generation fails or the response cannot be parsed.
  */
 export async function generatePRContent(options: GeneratePRContentOptions): Promise<PRContent> {
-  const { baseBranch, headBranch, commitSummary, diffSummary, diffPatch, provider } = options
+  const { baseBranch, headBranch, commitSummary, diffSummary, diffPatch, provider, cwd } = options
 
   const truncatedCommitSummary = truncate(commitSummary, MAX_COMMIT_SUMMARY_LENGTH)
   const truncatedDiffSummary = truncate(diffSummary, MAX_DIFF_SUMMARY_LENGTH)
@@ -69,14 +70,16 @@ ${truncatedDiffSummary}
 Diff patch:
 ${truncatedDiffPatch}`
 
-  log.info('Generating PR content', { baseBranch, headBranch, provider })
+  log.info('Generating PR content', { baseBranch, headBranch, provider, cwd })
 
   const response = await generateText(
     prompt,
     SYSTEM_PROMPT,
     provider,
-    undefined,
-    PR_CONTENT_JSON_SCHEMA
+    {
+      cwd,
+      outputSchema: PR_CONTENT_JSON_SCHEMA
+    }
   )
   if (!response) {
     throw new Error('AI provider returned an empty response')

--- a/src/main/services/text-generation-router.ts
+++ b/src/main/services/text-generation-router.ts
@@ -16,6 +16,12 @@ const TIMEOUT_MS = 30_000
 const MAX_RETRIES = 1
 const MAX_OUTPUT_SIZE = 1024 * 1024 // 1 MB
 
+export interface GenerateTextOptions {
+  modelOverride?: string
+  outputSchema?: string
+  cwd?: string
+}
+
 let cachedSdks: AgentSdkDetection | null = null
 let cacheTimestamp = 0
 const SDK_CACHE_TTL_MS = 60_000
@@ -51,9 +57,9 @@ export async function generateText(
   prompt: string,
   systemPrompt: string,
   provider: AgentSdkId,
-  modelOverride?: string,
-  outputSchema?: string
+  options: GenerateTextOptions = {}
 ): Promise<string | null> {
+  const { modelOverride, outputSchema, cwd } = options
   const resolvedProvider = resolveProvider(provider)
   if (!resolvedProvider) {
     throw new Error(
@@ -73,14 +79,16 @@ export async function generateText(
         prompt,
         systemPrompt,
         modelOverride,
-        outputSchema
+        outputSchema,
+        cwd
       )
       if (result !== null) {
         log.info('Text generation succeeded', {
           requestedProvider: provider,
           resolvedProvider,
           attempt,
-          usedStructuredOutput: Boolean(outputSchema)
+          usedStructuredOutput: Boolean(outputSchema),
+          cwd
         })
         return result
       }
@@ -88,7 +96,8 @@ export async function generateText(
       log.warn('Text generation returned empty result', {
         requestedProvider: provider,
         resolvedProvider,
-        attempt
+        attempt,
+        cwd
       })
     } catch (err: unknown) {
       lastError = err instanceof Error ? err : new Error(String(err))
@@ -96,14 +105,16 @@ export async function generateText(
         requestedProvider: provider,
         resolvedProvider,
         attempt,
-        error: lastError.message
+        error: lastError.message,
+        cwd
       })
     }
   }
 
   log.warn('Text generation: all attempts exhausted', {
     requestedProvider: provider,
-    resolvedProvider
+    resolvedProvider,
+    cwd
   })
   throw lastError ?? new Error('Text generation failed: all attempts returned empty results')
 }
@@ -140,15 +151,16 @@ function generateWithProvider(
   prompt: string,
   systemPrompt: string,
   modelOverride?: string,
-  outputSchema?: string
+  outputSchema?: string,
+  cwd?: string
 ): Promise<string | null> {
   switch (provider) {
     case 'claude-code':
-      return generateWithClaude(prompt, systemPrompt, modelOverride)
+      return generateWithClaude(prompt, systemPrompt, modelOverride, cwd)
     case 'codex':
-      return generateWithCodex(prompt, systemPrompt, modelOverride, outputSchema)
+      return generateWithCodex(prompt, systemPrompt, modelOverride, outputSchema, cwd)
     case 'opencode':
-      return generateWithOpenCode(prompt, systemPrompt, modelOverride)
+      return generateWithOpenCode(prompt, systemPrompt, modelOverride, cwd)
     case 'terminal':
       return Promise.resolve(null)
   }
@@ -157,7 +169,12 @@ function generateWithProvider(
 /**
  * Generate text using the Claude Agent SDK (haiku model).
  */
-async function generateWithClaude(prompt: string, systemPrompt: string, modelOverride?: string): Promise<string | null> {
+async function generateWithClaude(
+  prompt: string,
+  systemPrompt: string,
+  modelOverride?: string,
+  cwd?: string
+): Promise<string | null> {
   const sdk = await loadClaudeSDK()
 
   const abortController = new AbortController()
@@ -168,7 +185,7 @@ async function generateWithClaude(prompt: string, systemPrompt: string, modelOve
     const query = sdk.query({
       prompt,
       options: {
-        cwd: homedir(),
+        cwd: cwd ?? homedir(),
         model: modelOverride ?? 'haiku',
         maxTurns: 2,
         abortController,
@@ -245,7 +262,8 @@ async function generateWithCodex(
   prompt: string,
   systemPrompt: string,
   modelOverride?: string,
-  outputSchema?: string
+  outputSchema?: string,
+  cwd?: string
 ): Promise<string | null> {
   const outputFile = join(tmpdir(), `hive-codex-${randomUUID()}.txt`)
   const schemaFile = outputSchema
@@ -275,7 +293,8 @@ async function generateWithCodex(
     await spawnWithStdin(
       'codex',
       args,
-      fullPrompt
+      fullPrompt,
+      cwd
     )
     const output = await readFile(outputFile, 'utf-8')
     return output.trim() || null
@@ -303,7 +322,8 @@ async function generateWithCodex(
 async function generateWithOpenCode(
   prompt: string,
   systemPrompt: string,
-  modelOverride?: string
+  modelOverride?: string,
+  cwd?: string
 ): Promise<string | null> {
   const model = modelOverride ?? 'claude-haiku'
   const fullPrompt = `${systemPrompt}\n\n${prompt}`
@@ -311,7 +331,8 @@ async function generateWithOpenCode(
   const stdout = await spawnWithStdin(
     'opencode',
     ['run', '--format', 'json', '--model', model],
-    fullPrompt
+    fullPrompt,
+    cwd
   )
 
   // Parse newline-delimited JSON events, collecting text from "text" type events
@@ -337,11 +358,12 @@ async function generateWithOpenCode(
  * Spawn a CLI process, pipe input to stdin, and collect stdout.
  * Rejects on non-zero exit, timeout, or spawn error.
  */
-function spawnWithStdin(command: string, args: string[], input: string): Promise<string> {
+function spawnWithStdin(command: string, args: string[], input: string, cwd?: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const proc = spawn(command, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: process.env
+      env: process.env,
+      cwd
     })
 
     let stdout = ''

--- a/src/main/services/title-generation-shared.ts
+++ b/src/main/services/title-generation-shared.ts
@@ -128,13 +128,15 @@ export function spawnCLI(
   command: string,
   args: string[],
   input: string,
-  timeoutMs: number = TITLE_TIMEOUT_MS
+  timeoutMs: number = TITLE_TIMEOUT_MS,
+  cwd?: string
 ): Promise<string> {
-  log.info('spawnCLI: starting', { command, argCount: args.length, inputLength: input.length, timeoutMs })
+  log.info('spawnCLI: starting', { command, argCount: args.length, inputLength: input.length, timeoutMs, cwd })
   return new Promise((resolve, reject) => {
     const proc = spawn(command, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: process.env
+      env: process.env,
+      cwd
     })
 
     let stdout = ''

--- a/test/main/pr-content-generator.test.ts
+++ b/test/main/pr-content-generator.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGenerateText } = vi.hoisted(() => ({
+  mockGenerateText: vi.fn()
+}))
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('../../src/main/services/text-generation-router', () => ({
+  generateText: mockGenerateText
+}))
+
+describe('pr-content-generator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGenerateText.mockResolvedValue(
+      '{"title":"Refine PR flow","body":"## Summary\\n- Added cwd propagation\\n## Testing\\n- Not run"}'
+    )
+  })
+
+  it('passes cwd through to generateText', async () => {
+    const { generatePRContent, PR_CONTENT_JSON_SCHEMA } = await import(
+      '../../src/main/services/pr-content-generator'
+    )
+
+    await generatePRContent({
+      baseBranch: 'main',
+      headBranch: 'feature/pr-content',
+      commitSummary: 'abc123 Add cwd propagation',
+      diffSummary: ' 1 file changed, 3 insertions(+)',
+      diffPatch: 'diff --git a/file b/file',
+      provider: 'codex',
+      cwd: '/tmp/worktree'
+    })
+
+    expect(mockGenerateText).toHaveBeenCalledOnce()
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      'codex',
+      {
+        cwd: '/tmp/worktree',
+        outputSchema: PR_CONTENT_JSON_SCHEMA
+      }
+    )
+  })
+})

--- a/test/main/text-generation-router-pr-content.test.ts
+++ b/test/main/text-generation-router-pr-content.test.ts
@@ -68,19 +68,23 @@ describe('text-generation-router codex structured output', () => {
       'Prompt',
       'System',
       'codex',
-      undefined,
-      '{"type":"object","properties":{"title":{"type":"string"},"body":{"type":"string"}}}'
+      {
+        cwd: '/tmp/worktree',
+        outputSchema:
+          '{"type":"object","properties":{"title":{"type":"string"},"body":{"type":"string"}}}'
+      }
     )
 
     expect(result).toContain('"title":"Refine PR flow"')
     expect(mockSpawn).toHaveBeenCalledOnce()
 
-    const [, args] = mockSpawn.mock.calls[0] as [string, string[]]
+    const [, args, options] = mockSpawn.mock.calls[0] as [string, string[], { cwd?: string }]
     expect(args).toContain('exec')
     expect(args).toContain('--output-schema')
     expect(args).toContain('--output-last-message')
     expect(args).toContain('--config')
     expect(args).toContain('model_reasoning_effort="low"')
+    expect(options.cwd).toBe('/tmp/worktree')
     expect(mockWriteFile).toHaveBeenCalledTimes(2)
     expect(mockUnlink).toHaveBeenCalledTimes(2)
   })

--- a/test/phase-22/session-7/codex-session-title.test.ts
+++ b/test/phase-22/session-7/codex-session-title.test.ts
@@ -68,10 +68,10 @@ describe('generateCodexSessionTitle', () => {
       '../../../src/main/services/codex-session-title'
     )
 
-    await generateCodexSessionTitle('Some message')
+    await generateCodexSessionTitle('Some message', '/tmp/worktree')
 
     expect(mockSpawnCLI).toHaveBeenCalledOnce()
-    const [command, args] = mockSpawnCLI.mock.calls[0]
+    const [command, args, , timeoutMs, cwd] = mockSpawnCLI.mock.calls[0]
     expect(command).toBe('codex')
     expect(args).toContain('exec')
     expect(args).toContain('--ephemeral')
@@ -83,6 +83,8 @@ describe('generateCodexSessionTitle', () => {
     expect(args).toContain('model_reasoning_effort="low"')
     expect(args).toContain('--output-schema')
     expect(args).toContain('--output-last-message')
+    expect(timeoutMs).toBeDefined()
+    expect(cwd).toBe('/tmp/worktree')
   })
 
   it('writes schema JSON to temp file', async () => {


### PR DESCRIPTION
## Summary
- Threaded the worktree `cwd` through PR content generation and Codex session title generation.
- Updated the text generation router and CLI spawn helpers to accept an optional working directory and pass it to spawned processes.
- Added tests covering `cwd` propagation for PR content and Codex title flows.

## Testing
- `Not run`
- Added/updated unit tests in `test/main/pr-content-generator.test.ts`, `test/main/text-generation-router-pr-content.test.ts`, and `test/phase-22/session-7/codex-session-title.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how AI CLIs/SDK are invoked by adding an optional `cwd`, which could affect execution context and provider behavior across `claude-code`, `codex`, and `opencode` paths.
> 
> **Overview**
> **Propagates the worktree working directory into AI generation flows.** PR content generation (`git:generatePRContent` -> `generatePRContent`) now passes `cwd` through to `generateText`, and Codex session title generation threads an optional `worktreePath` into `spawnCLI`.
> 
> **Updates the text generation router to accept a single options object.** `generateText` now takes `{ modelOverride, outputSchema, cwd }`, passes `cwd` into provider implementations, and ensures spawned processes (`codex`, `opencode`) and the Claude SDK query use that working directory when provided.
> 
> Adds/updates unit tests to assert `cwd` propagation for PR content generation, Codex structured output invocation, and Codex session title spawning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46dfda43bf88f834df3099d000bab9f464c81658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->