### PR TITLE
review-focus-tab-if-not-on-board

### DIFF
--- a/src/renderer/src/hooks/usePinAndActivateSession.ts
+++ b/src/renderer/src/hooks/usePinAndActivateSession.ts
@@ -1,5 +1,28 @@
 import { useCallback, useState } from 'react'
-import { useSessionStore } from '@/stores/useSessionStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useFileViewerStore } from '@/stores/useFileViewerStore'
+import { BOARD_TAB_ID, useSessionStore } from '@/stores/useSessionStore'
+
+function isBoardVisible(): boolean {
+  const sessionState = useSessionStore.getState()
+  const boardMode = useSettingsStore.getState().boardMode
+  const hasActiveOverlay = useFileViewerStore.getState().hasActiveOverlay()
+
+  if (boardMode === 'sticky-tab') {
+    return (
+      sessionState.activeSessionId === BOARD_TAB_ID &&
+      !sessionState.inlineConnectionSessionId &&
+      !hasActiveOverlay
+    )
+  }
+
+  return (
+    useKanbanStore.getState().isBoardViewActive &&
+    !sessionState.activePinnedSessionId &&
+    !hasActiveOverlay
+  )
+}
 
 /** Creates a session, pins it to the board, activates it, and optionally runs a callback (e.g. close modal). */
 export function usePinAndActivateSession(onClose?: () => void) {
@@ -13,6 +36,9 @@ export function usePinAndActivateSession(onClose?: () => void) {
         if (sessionId) {
           const sessionStore = useSessionStore.getState()
           await sessionStore.pinSessionToBoard(sessionId)
+          if (!isBoardVisible()) {
+            sessionStore.setActiveSession(sessionId)
+          }
           onClose?.()
         }
       } catch {

--- a/test/phase-7/session-4/code-review.test.ts
+++ b/test/phase-7/session-4/code-review.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
 import { cleanup } from '@testing-library/react'
 
 // ---------------------------------------------------------------------------
@@ -68,6 +69,7 @@ const mockDb = {
     getByProject: vi.fn(),
     getActiveByWorktree: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
+    setPinnedToBoard: vi.fn().mockResolvedValue(undefined),
     delete: vi.fn(),
     search: vi.fn()
   },
@@ -194,7 +196,7 @@ describe('Session 4: Code Review', () => {
     test('each prompt type produces a non-empty string', async () => {
       const { REVIEW_PROMPTS } = await import('../../../src/renderer/src/constants/reviewPrompts')
 
-      for (const [type, content] of Object.entries(REVIEW_PROMPTS)) {
+      for (const [, content] of Object.entries(REVIEW_PROMPTS)) {
         expect(content).toBeTruthy()
         expect(typeof content).toBe('string')
         expect(content.length).toBeGreaterThan(100)
@@ -291,6 +293,155 @@ describe('Session 4: Code Review', () => {
       const targetBranch = 'origin/main'
       const sessionName = `Code Review — ${branchName} vs ${targetBranch}`
       expect(sessionName).toBe('Code Review — unknown vs origin/main')
+    })
+
+    test('focuses the new review tab when not currently on the board', async () => {
+      const [{ usePinAndActivateSession }, { useSessionStore }, { useKanbanStore }, { useSettingsStore }, { useFileViewerStore }] = await Promise.all([
+        import('../../../src/renderer/src/hooks/usePinAndActivateSession'),
+        import('../../../src/renderer/src/stores/useSessionStore'),
+        import('../../../src/renderer/src/stores/useKanbanStore'),
+        import('../../../src/renderer/src/stores/useSettingsStore'),
+        import('../../../src/renderer/src/stores/useFileViewerStore')
+      ])
+
+      act(() => {
+        useSettingsStore.setState({ boardMode: 'toggle' })
+        useKanbanStore.setState({ isBoardViewActive: false })
+        useFileViewerStore.setState({
+          openFiles: new Map(),
+          activeFilePath: null,
+          activeDiff: null,
+          contextEditorWorktreeId: null
+        })
+        useSessionStore.setState({
+          activeSessionId: 'session-0',
+          activeWorktreeId: 'wt-1',
+          activePinnedSessionId: null,
+          inlineConnectionSessionId: null,
+          pinnedSessionIds: new Set()
+        })
+      })
+
+      const { result } = renderHook(() => usePinAndActivateSession())
+
+      await act(async () => {
+        await result.current.pinAndActivate(async () => 'review-session-1')
+      })
+
+      expect(mockDb.session.setPinnedToBoard).toHaveBeenCalledWith('review-session-1', true)
+      expect(useSessionStore.getState().pinnedSessionIds.has('review-session-1')).toBe(true)
+      expect(useSessionStore.getState().activeSessionId).toBe('review-session-1')
+    })
+
+    test('keeps focus on toggle board when the board is visible', async () => {
+      const [{ usePinAndActivateSession }, { useSessionStore }, { useKanbanStore }, { useSettingsStore }, { useFileViewerStore }] = await Promise.all([
+        import('../../../src/renderer/src/hooks/usePinAndActivateSession'),
+        import('../../../src/renderer/src/stores/useSessionStore'),
+        import('../../../src/renderer/src/stores/useKanbanStore'),
+        import('../../../src/renderer/src/stores/useSettingsStore'),
+        import('../../../src/renderer/src/stores/useFileViewerStore')
+      ])
+
+      act(() => {
+        useSettingsStore.setState({ boardMode: 'toggle' })
+        useKanbanStore.setState({ isBoardViewActive: true })
+        useFileViewerStore.setState({
+          openFiles: new Map(),
+          activeFilePath: null,
+          activeDiff: null,
+          contextEditorWorktreeId: null
+        })
+        useSessionStore.setState({
+          activeSessionId: 'session-0',
+          activeWorktreeId: 'wt-1',
+          activePinnedSessionId: null,
+          inlineConnectionSessionId: null,
+          pinnedSessionIds: new Set()
+        })
+      })
+
+      const { result } = renderHook(() => usePinAndActivateSession())
+
+      await act(async () => {
+        await result.current.pinAndActivate(async () => 'review-session-2')
+      })
+
+      expect(useSessionStore.getState().pinnedSessionIds.has('review-session-2')).toBe(true)
+      expect(useSessionStore.getState().activeSessionId).toBe('session-0')
+    })
+
+    test('keeps focus on sticky board when the board tab is visible', async () => {
+      const [{ usePinAndActivateSession }, { useSessionStore, BOARD_TAB_ID }, { useKanbanStore }, { useSettingsStore }, { useFileViewerStore }] = await Promise.all([
+        import('../../../src/renderer/src/hooks/usePinAndActivateSession'),
+        import('../../../src/renderer/src/stores/useSessionStore'),
+        import('../../../src/renderer/src/stores/useKanbanStore'),
+        import('../../../src/renderer/src/stores/useSettingsStore'),
+        import('../../../src/renderer/src/stores/useFileViewerStore')
+      ])
+
+      act(() => {
+        useSettingsStore.setState({ boardMode: 'sticky-tab' })
+        useKanbanStore.setState({ isBoardViewActive: false })
+        useFileViewerStore.setState({
+          openFiles: new Map(),
+          activeFilePath: null,
+          activeDiff: null,
+          contextEditorWorktreeId: null
+        })
+        useSessionStore.setState({
+          activeSessionId: BOARD_TAB_ID,
+          activeWorktreeId: 'wt-1',
+          activePinnedSessionId: null,
+          inlineConnectionSessionId: null,
+          pinnedSessionIds: new Set()
+        })
+      })
+
+      const { result } = renderHook(() => usePinAndActivateSession())
+
+      await act(async () => {
+        await result.current.pinAndActivate(async () => 'review-session-3')
+      })
+
+      expect(useSessionStore.getState().pinnedSessionIds.has('review-session-3')).toBe(true)
+      expect(useSessionStore.getState().activeSessionId).toBe(BOARD_TAB_ID)
+    })
+
+    test('focuses the new review tab when board mode is active but an overlay is covering it', async () => {
+      const [{ usePinAndActivateSession }, { useSessionStore }, { useKanbanStore }, { useSettingsStore }, { useFileViewerStore }] = await Promise.all([
+        import('../../../src/renderer/src/hooks/usePinAndActivateSession'),
+        import('../../../src/renderer/src/stores/useSessionStore'),
+        import('../../../src/renderer/src/stores/useKanbanStore'),
+        import('../../../src/renderer/src/stores/useSettingsStore'),
+        import('../../../src/renderer/src/stores/useFileViewerStore')
+      ])
+
+      act(() => {
+        useSettingsStore.setState({ boardMode: 'toggle' })
+        useKanbanStore.setState({ isBoardViewActive: true })
+        useFileViewerStore.setState({
+          openFiles: new Map(),
+          activeFilePath: '/tmp/file.ts',
+          activeDiff: null,
+          contextEditorWorktreeId: null
+        })
+        useSessionStore.setState({
+          activeSessionId: 'session-0',
+          activeWorktreeId: 'wt-1',
+          activePinnedSessionId: null,
+          inlineConnectionSessionId: null,
+          pinnedSessionIds: new Set()
+        })
+      })
+
+      const { result } = renderHook(() => usePinAndActivateSession())
+
+      await act(async () => {
+        await result.current.pinAndActivate(async () => 'review-session-4')
+      })
+
+      expect(useSessionStore.getState().pinnedSessionIds.has('review-session-4')).toBe(true)
+      expect(useSessionStore.getState().activeSessionId).toBe('review-session-4')
     })
   })
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI behavior change: it only alters when a newly created/pinned session becomes the active tab, based on board visibility/overlay state, with added tests to lock in the intended focus behavior.
> 
> **Overview**
> Updates `usePinAndActivateSession` so creating and pinning a new session **only switches the active tab when the board isn’t currently visible** (accounting for `boardMode` and whether a file overlay is covering the board). 
> 
> Expands `code-review.test.ts` with new hook-based tests and required mocks to verify focus stays on the board when appropriate, and moves focus to the new review tab otherwise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58e8b7831fc57b875a6959ef0cca04b6448f231e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->