### PR TITLE
codex-custom-bash-representation

### DIFF
--- a/src/main/services/codex-event-mapper.ts
+++ b/src/main/services/codex-event-mapper.ts
@@ -1,5 +1,8 @@
 import type { OpenCodeStreamEvent } from '@shared/types/opencode'
-import { normalizeCodexToolName, stripShellPrefix } from '@shared/codex-tool-normalizer'
+import {
+  normalizeCodexToolName,
+  normalizeCommandExecutionTool
+} from '@shared/codex-tool-normalizer'
 import type { CodexManagerEvent } from './codex-app-server-manager'
 import { asObject, asString, asNumber } from './codex-utils'
 import type {
@@ -71,41 +74,32 @@ function toReasoningPart(text: string): {
   }
 }
 
-function normalizeCommandValue(value: unknown): string | undefined {
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    return trimmed.length > 0 ? trimmed : undefined
-  }
-
-  if (!Array.isArray(value)) return undefined
-
-  const parts = value
-    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
-    .filter((entry) => entry.length > 0)
-
-  return parts.length > 0 ? parts.join(' ') : undefined
-}
-
 function normalizeToolInput(
   item: Record<string, unknown> | undefined,
   payload: Record<string, unknown> | undefined
 ): unknown {
   const rawInput = item?.input ?? payload?.input
   const inputRecord = asObject(rawInput)
-  const command =
-    normalizeCommandValue(item?.command) ??
-    normalizeCommandValue(inputRecord?.command) ??
-    normalizeCommandValue(payload?.command)
-  const cleanCommand = command ? stripShellPrefix(command) : undefined
   const changes = Array.isArray(item?.changes) ? item.changes : undefined
 
-  if (!cleanCommand && !changes) return rawInput
+  if (!changes) return rawInput
 
   return {
     ...(inputRecord ?? {}),
-    ...(cleanCommand ? { command: cleanCommand } : {}),
     ...(changes ? { changes } : {})
   }
+}
+
+function normalizeCommandExecutionPresentation(
+  item: Record<string, unknown> | undefined,
+  payload: Record<string, unknown> | undefined
+): { toolName: string; input: Record<string, unknown> } {
+  return normalizeCommandExecutionTool({
+    command: item?.command ?? payload?.command,
+    input: item?.input ?? payload?.input,
+    commandActions:
+      (Array.isArray(item?.commandActions) ? item.commandActions : payload?.commandActions) ?? null
+  })
 }
 
 function extractContentDelta(event: CodexManagerEvent): ContentDelta | null {
@@ -312,10 +306,11 @@ function isWellFormedThreadItem(item: { type: string; id: string; [k: string]: u
 
 function deriveInputFromThreadItem(item: ThreadItem): unknown {
   switch (item.type) {
-    case 'commandExecution': {
-      const command = stripShellPrefix(item.command)
-      return { command }
-    }
+    case 'commandExecution':
+      return normalizeCommandExecutionTool({
+        command: item.command,
+        commandActions: item.commandActions
+      }).input
     case 'fileChange':
       return { changes: item.changes }
     case 'mcpToolCall':
@@ -344,11 +339,19 @@ function extractItemInfo(event: CodexManagerEvent): ItemInfo {
     const item = candidate
     const itemRecord = item as Record<string, unknown>
     const itemType = item.type
-    const toolName = normalizeCodexToolName(item.type)
     const callId = item.id || event.itemId || ''
     const status = 'status' in itemRecord ? asString(itemRecord.status) : undefined
     const output = 'aggregatedOutput' in itemRecord ? itemRecord.aggregatedOutput : undefined
-    const input = deriveInputFromThreadItem(item)
+    const normalizedCommandTool =
+      item.type === 'commandExecution'
+        ? normalizeCommandExecutionTool({
+            command: item.command,
+            commandActions: item.commandActions
+          })
+        : null
+    const toolName =
+      normalizedCommandTool?.toolName ?? normalizeCodexToolName(item.type)
+    const input = normalizedCommandTool?.input ?? deriveInputFromThreadItem(item)
     return {
       ...(itemType ? { itemType } : {}),
       toolName,
@@ -363,21 +366,27 @@ function extractItemInfo(event: CodexManagerEvent): ItemInfo {
   const payload = asObject(event.payload)
   const item = asObject(payload?.item)
   const itemType = asString(item?.type) ?? asString(payload?.type)
+  const isCommandExecution = itemType?.toLowerCase() === 'commandexecution'
+  const normalizedCommandTool = isCommandExecution
+    ? normalizeCommandExecutionPresentation(item, payload)
+    : null
 
-  const toolName = normalizeCodexToolName(
-    asString(item?.toolName) ??
-      asString(item?.name) ??
-      asString(item?.type) ??
-      asString(payload?.toolName) ??
-      'unknown'
-  )
+  const toolName =
+    normalizedCommandTool?.toolName ??
+    normalizeCodexToolName(
+      asString(item?.toolName) ??
+        asString(item?.name) ??
+        asString(item?.type) ??
+        asString(payload?.toolName) ??
+        'unknown'
+    )
 
   const callId = asString(item?.id) ?? asString(event.itemId) ?? asString(payload?.itemId) ?? ''
 
   const status = asString(item?.status) ?? asString(payload?.status)
   const output =
     item?.output ?? item?.aggregatedOutput ?? payload?.output ?? payload?.aggregatedOutput
-  const input = normalizeToolInput(item, payload)
+  const input = normalizedCommandTool?.input ?? normalizeToolInput(item, payload)
 
   return {
     ...(itemType ? { itemType } : {}),
@@ -497,9 +506,14 @@ function mapCodexEventToStreamEventsInner(
       const callId =
         event.itemId ?? params?.itemId ?? asString(item?.id) ?? asString(payload?.itemId) ?? ''
       if (!callId) return []
-      const command = params?.command ? stripShellPrefix(params.command) : undefined
-      // Typed path: build input from top-level params; fallback to normalizeToolInput for legacy
-      const input = command ? { command } : normalizeToolInput(item, payload)
+      const normalizedCommandTool = normalizeCommandExecutionTool({
+        command: params?.command ?? item?.command ?? payload?.command,
+        input: item?.input ?? payload?.input,
+        commandActions:
+          params?.commandActions ??
+          (Array.isArray(item?.commandActions) ? item.commandActions : payload?.commandActions) ??
+          null
+      })
       return [
         {
           type: 'message.part.updated',
@@ -508,10 +522,10 @@ function mapCodexEventToStreamEventsInner(
             part: {
               type: 'tool',
               callID: callId,
-              tool: 'Bash',
+              tool: normalizedCommandTool.toolName,
               state: {
                 status: 'running',
-                ...(input !== undefined ? { input } : {})
+                input: normalizedCommandTool.input
               }
             }
           })

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -18,7 +18,10 @@ import { logCodexLifecycleEvent } from './codex-debug-logger'
 import { generateCodexSessionTitle } from './codex-session-title'
 import type { DatabaseService } from '../db/database'
 import { autoRenameWorktreeBranch } from './git-service'
-import { normalizeCodexToolName, stripShellPrefix } from '@shared/codex-tool-normalizer'
+import {
+  normalizeCodexToolName,
+  normalizeCommandExecutionTool
+} from '@shared/codex-tool-normalizer'
 import type { UserInput } from '@shared/codex-schemas/v2/UserInput'
 import type { TurnStartParams } from '@shared/codex-schemas/v2/TurnStartParams'
 import type { ThreadNameUpdatedNotification } from '@shared/codex-schemas/v2/ThreadNameUpdatedNotification'
@@ -149,27 +152,15 @@ export function normalizeCodexMessageTimestamps<T extends { created_at: string }
 
 // ── Snapshot tool-call helpers ────────────────────────────────────
 
-function extractSnapshotToolCommand(itemObj: Record<string, unknown>): string | undefined {
-  const inputObj =
-    typeof itemObj.input === 'object' && itemObj.input !== null
-      ? (itemObj.input as Record<string, unknown>)
-      : undefined
-
-  const candidates = [itemObj.command, inputObj?.command, itemObj.cmd, inputObj?.cmd]
-
-  for (const candidate of candidates) {
-    if (typeof candidate === 'string' && candidate.trim().length > 0) {
-      return stripShellPrefix(candidate.trim())
-    }
-    if (Array.isArray(candidate)) {
-      const joined = candidate
-        .filter((entry): entry is string => typeof entry === 'string')
-        .join(' ')
-        .trim()
-      if (joined.length > 0) return stripShellPrefix(joined)
-    }
-  }
-  return undefined
+function buildSnapshotCommandExecutionTool(itemObj: Record<string, unknown>): {
+  toolName: string
+  input: Record<string, unknown>
+} {
+  return normalizeCommandExecutionTool({
+    command: itemObj.command ?? itemObj.cmd,
+    input: itemObj.input,
+    commandActions: Array.isArray(itemObj.commandActions) ? itemObj.commandActions : null
+  })
 }
 
 function buildSnapshotToolInput(itemObj: Record<string, unknown>): Record<string, unknown> {
@@ -177,12 +168,10 @@ function buildSnapshotToolInput(itemObj: Record<string, unknown>): Record<string
     typeof itemObj.input === 'object' && itemObj.input !== null && !Array.isArray(itemObj.input)
       ? (itemObj.input as Record<string, unknown>)
       : {}
-  const command = extractSnapshotToolCommand(itemObj)
   const changes = Array.isArray(itemObj.changes) ? itemObj.changes : undefined
 
   return {
     ...inputObj,
-    ...(command ? { command } : {}),
     ...(changes ? { changes } : {})
   }
 }
@@ -3044,10 +3033,14 @@ export class CodexImplementer implements AgentSdkImplementer {
           }
 
           if (itemType === 'commandExecution' || itemType === 'fileChange') {
-            const toolName = normalizeCodexToolName(
-              asString(itemObj.toolName) ?? asString(itemObj.name) ?? itemType
-            )
-            const input = buildSnapshotToolInput(itemObj)
+            const normalizedCommandTool =
+              itemType === 'commandExecution' ? buildSnapshotCommandExecutionTool(itemObj) : null
+            const toolName =
+              normalizedCommandTool?.toolName ??
+              normalizeCodexToolName(
+                asString(itemObj.toolName) ?? asString(itemObj.name) ?? itemType
+              )
+            const input = normalizedCommandTool?.input ?? buildSnapshotToolInput(itemObj)
             const output = itemObj.output ?? itemObj.aggregatedOutput
             const status = asString(itemObj.status)
 

--- a/src/renderer/src/lib/codex-timeline.ts
+++ b/src/renderer/src/lib/codex-timeline.ts
@@ -3,7 +3,10 @@ import {
   type OpenCodeMessage,
   type StreamingPart
 } from '@/lib/opencode-transcript'
-import { normalizeCodexToolName } from '@shared/codex-tool-normalizer'
+import {
+  normalizeCodexToolName,
+  normalizeCommandExecutionTool
+} from '@shared/codex-tool-normalizer'
 
 function parseJson<T>(value: string | null): T | null {
   if (!value) return null
@@ -28,17 +31,30 @@ function parseToolPart(activity: SessionActivity): StreamingPart | null {
   const payload = parseJson<Record<string, unknown>>(activity.payload_json)
   const item =
     payload && typeof payload.item === 'object' ? (payload.item as Record<string, unknown>) : null
-  const toolName = normalizeCodexToolName(
-    (typeof item?.toolName === 'string' && item.toolName) ||
-      (typeof item?.name === 'string' && item.name) ||
-      (typeof item?.type === 'string' && item.type) ||
-      'unknown'
-  )
+  const itemType = typeof item?.type === 'string' ? item.type : ''
+  const normalizedCommandTool =
+    itemType === 'commandExecution'
+      ? normalizeCommandExecutionTool({
+          command: item?.command ?? item?.cmd,
+          input: item?.input,
+          commandActions: Array.isArray(item?.commandActions) ? item.commandActions : null
+        })
+      : null
+  const toolName =
+    normalizedCommandTool?.toolName ??
+    normalizeCodexToolName(
+      (typeof item?.toolName === 'string' && item.toolName) ||
+        (typeof item?.name === 'string' && item.name) ||
+        itemType ||
+        'unknown'
+    )
   const rawInput =
     item?.input && typeof item.input === 'object' && !Array.isArray(item.input)
       ? (item.input as Record<string, unknown>)
       : {}
-  const input = Array.isArray(item?.changes) ? { ...rawInput, changes: item.changes } : rawInput
+  const input =
+    normalizedCommandTool?.input ??
+    (Array.isArray(item?.changes) ? { ...rawInput, changes: item.changes } : rawInput)
   const output =
     item?.output ?? payload?.output ?? item?.aggregatedOutput ?? payload?.aggregatedOutput
 

--- a/src/shared/codex-tool-normalizer.ts
+++ b/src/shared/codex-tool-normalizer.ts
@@ -8,6 +8,8 @@
  * produces consistent names that the renderer's ToolCard can match.
  */
 
+import type { CommandAction } from './codex-schemas/v2/CommandAction'
+
 // ── Tool name normalization ──────────────────────────────────────
 
 const CODEX_TOOL_NAME_MAP: Record<string, string> = {
@@ -72,4 +74,165 @@ export function stripShellPrefix(command: string): string {
   }
 
   return command
+}
+
+// ── Command execution normalization ──────────────────────────────
+
+export interface NormalizedCommandExecutionTool {
+  toolName: string
+  input: Record<string, unknown>
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function normalizeCommandValue(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+
+  if (!Array.isArray(value)) return null
+
+  const parts = value
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter((entry) => entry.length > 0)
+
+  return parts.length > 0 ? parts.join(' ') : null
+}
+
+function stripMatchingQuotes(value: string): string {
+  const trimmed = value.trim()
+  if (trimmed.length < 2) return trimmed
+
+  const first = trimmed[0]
+  const last = trimmed[trimmed.length - 1]
+  if ((first === "'" || first === '"') && first === last) {
+    return trimmed.slice(1, -1)
+  }
+
+  return trimmed
+}
+
+function mapCommandActionToTool(action: CommandAction): NormalizedCommandExecutionTool | null {
+  switch (action.type) {
+    case 'read':
+      return {
+        toolName: 'Read',
+        input: { file_path: action.path }
+      }
+    case 'listFiles':
+      return {
+        toolName: 'Glob',
+        input: {
+          pattern: '*',
+          path: action.path ?? '.'
+        }
+      }
+    case 'search':
+      return {
+        toolName: 'Grep',
+        input: {
+          pattern: action.query ?? '',
+          path: action.path ?? '.'
+        }
+      }
+    default:
+      return null
+  }
+}
+
+function tryParseSedRead(command: string): NormalizedCommandExecutionTool | null {
+  const match = /^sed\s+-n\s+(?:(['"])(\d+),(\d+)p\1|(\d+),(\d+)p)\s+(.+)$/.exec(command)
+  if (!match) return null
+
+  const startLine = Number.parseInt(match[2] ?? match[4] ?? '', 10)
+  const endLine = Number.parseInt(match[3] ?? match[5] ?? '', 10)
+  const rawPath = stripMatchingQuotes(match[6] ?? '')
+  if (!Number.isFinite(startLine) || !Number.isFinite(endLine) || !rawPath) return null
+  if (startLine <= 0 || endLine < startLine) return null
+
+  const input: Record<string, unknown> = { file_path: rawPath }
+  if (endLine > startLine) {
+    input.offset = startLine
+    // ReadToolView currently renders the range as offset + limit.
+    input.limit = endLine - startLine
+  }
+
+  return {
+    toolName: 'Read',
+    input
+  }
+}
+
+function tryParseRgFiles(command: string): NormalizedCommandExecutionTool | null {
+  const match = /^rg\s+--files(?:\s+(.+))?$/.exec(command)
+  if (!match) return null
+
+  const path = stripMatchingQuotes(match[1] ?? '.')
+
+  return {
+    toolName: 'Glob',
+    input: {
+      pattern: '*',
+      path: path || '.'
+    }
+  }
+}
+
+function extractNormalizedCommand(
+  command: unknown,
+  inputRecord: Record<string, unknown>
+): string | null {
+  const rawCommand =
+    normalizeCommandValue(command) ??
+    normalizeCommandValue(inputRecord.command) ??
+    normalizeCommandValue(inputRecord.cmd) ??
+    normalizeCommandValue(inputRecord.argv)
+
+  return rawCommand ? stripShellPrefix(rawCommand) : null
+}
+
+export function normalizeCommandExecutionTool(options: {
+  command?: unknown
+  input?: unknown
+  commandActions?: CommandAction[] | null
+}): NormalizedCommandExecutionTool {
+  const inputRecord = asRecord(options.input) ?? {}
+  const command = extractNormalizedCommand(options.command, inputRecord)
+  const parsedTool = command ? tryParseSedRead(command) ?? tryParseRgFiles(command) : null
+  const actions = Array.isArray(options.commandActions)
+    ? options.commandActions
+        .map(mapCommandActionToTool)
+        .filter((tool): tool is NormalizedCommandExecutionTool => tool !== null)
+    : []
+
+  if (actions.length === 1 && options.commandActions?.length === 1) {
+    const enrichedInput =
+      parsedTool?.toolName === actions[0].toolName
+        ? { ...actions[0].input, ...parsedTool.input }
+        : actions[0].input
+    return {
+      toolName: actions[0].toolName,
+      input: { ...inputRecord, ...enrichedInput }
+    }
+  }
+
+  if (parsedTool) {
+    return {
+      toolName: parsedTool.toolName,
+      input: { ...inputRecord, ...parsedTool.input }
+    }
+  }
+
+  return {
+    toolName: 'Bash',
+    input: {
+      ...inputRecord,
+      ...(command ? { command } : {})
+    }
+  }
 }

--- a/test/codex-migration/session-5/codex-event-mapper-typed.test.ts
+++ b/test/codex-migration/session-5/codex-event-mapper-typed.test.ts
@@ -392,6 +392,90 @@ describe('typed event mapper migration', () => {
       expect(part.state.input).toEqual(expect.objectContaining({ command: 'ls -la' }))
     })
 
+    it('commandExecution item started maps sed reads to Read with line context', () => {
+      const event = makeEvent({
+        method: 'item/started',
+        payload: {
+          item: {
+            type: 'commandExecution',
+            id: 'cmd-read-1',
+            command: "/bin/zsh -lc 'sed -n \"1,80p\" main.py'",
+            cwd: '/home/user',
+            processId: null,
+            source: 'agent',
+            status: 'running',
+            commandActions: [
+              {
+                type: 'read',
+                command: 'sed -n "1,80p" main.py',
+                name: 'main.py',
+                path: 'main.py'
+              }
+            ],
+            aggregatedOutput: null,
+            exitCode: null,
+            durationMs: null
+          },
+          threadId: 'thread-1',
+          turnId: 'turn-1'
+        }
+      })
+
+      const result = mapCodexEventToStreamEvents(event, HIVE_SESSION)
+
+      expect(result).toHaveLength(1)
+      const part = (result[0].data as any).part
+      expect(part.tool).toBe('Read')
+      expect(part.state.input).toEqual(
+        expect.objectContaining({
+          file_path: 'main.py',
+          offset: 1,
+          limit: 79
+        })
+      )
+    })
+
+    it('commandExecution item started maps rg --files to Glob', () => {
+      const event = makeEvent({
+        method: 'item/started',
+        payload: {
+          item: {
+            type: 'commandExecution',
+            id: 'cmd-glob-1',
+            command: 'rg --files .',
+            cwd: '/home/user',
+            processId: null,
+            source: 'agent',
+            status: 'running',
+            commandActions: [
+              {
+                type: 'listFiles',
+                command: 'rg --files .',
+                path: '.'
+              }
+            ],
+            aggregatedOutput: null,
+            exitCode: null,
+            durationMs: null
+          },
+          threadId: 'thread-1',
+          turnId: 'turn-1'
+        }
+      })
+
+      const result = mapCodexEventToStreamEvents(event, HIVE_SESSION)
+
+      expect(result).toHaveLength(1)
+      const part = (result[0].data as any).part
+      expect(part.tool).toBe('Glob')
+      expect(part.state.input).toEqual(
+        expect.objectContaining({
+          pattern: '*',
+          path: '.'
+        })
+      )
+    })
+
     it('fileChange item started produces fileChange tool card', () => {
       const event = makeEvent({
         method: 'item/started',
@@ -606,6 +690,33 @@ describe('typed event mapper migration', () => {
       expect(part.callID).toBe('cmd-99')
       expect(part.state.status).toBe('running')
       expect(part.state.input).toEqual(expect.objectContaining({ command: 'npm test' }))
+    })
+
+    it('commandExecution approval maps rg --files fallback to Glob', () => {
+      const event = makeEvent({
+        kind: 'request',
+        method: 'item/commandExecution/requestApproval',
+        itemId: 'cmd-glob-approval',
+        payload: {
+          threadId: 'thread-1',
+          turnId: 'turn-1',
+          itemId: 'cmd-glob-approval',
+          command: "/bin/zsh -lc 'rg --files .'",
+          cwd: '/project'
+        }
+      })
+
+      const result = mapCodexEventToStreamEvents(event, HIVE_SESSION)
+
+      expect(result).toHaveLength(1)
+      const part = (result[0].data as any).part
+      expect(part.tool).toBe('Glob')
+      expect(part.state.input).toEqual(
+        expect.objectContaining({
+          pattern: '*',
+          path: '.'
+        })
+      )
     })
 
     it('fileChange approval with typed params', () => {

--- a/test/phase-22/session-8/codex-timeline.test.ts
+++ b/test/phase-22/session-8/codex-timeline.test.ts
@@ -73,6 +73,118 @@ describe('codex timeline derivation', () => {
     expect(timeline[2]?.parts?.some((part) => part.type === 'tool_use')).toBe(true)
   })
 
+  it('normalizes commandExecution activities into Read and Glob tool cards', () => {
+    const messages: SessionMessage[] = [
+      {
+        id: 'db-user-1',
+        session_id: 'session-1',
+        role: 'user',
+        content: 'Inspect the project files',
+        opencode_message_id: 'turn-1:user',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([{ type: 'text', text: 'Inspect the project files' }]),
+        opencode_timeline_json: null,
+        created_at: '2026-03-14T10:00:00.000Z'
+      },
+      {
+        id: 'db-assistant-1',
+        session_id: 'session-1',
+        role: 'assistant',
+        content: 'I checked the files.',
+        opencode_message_id: 'turn-1:assistant',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([{ type: 'text', text: 'I checked the files.' }]),
+        opencode_timeline_json: null,
+        created_at: '2026-03-14T10:00:05.000Z'
+      }
+    ]
+
+    const activities: SessionActivity[] = [
+      {
+        id: 'activity-read',
+        session_id: 'session-1',
+        agent_session_id: 'thread-1',
+        thread_id: 'thread-1',
+        turn_id: 'turn-1',
+        item_id: 'tool-read',
+        request_id: null,
+        kind: 'tool.completed',
+        tone: 'tool',
+        summary: 'Bash',
+        payload_json: JSON.stringify({
+          item: {
+            type: 'commandExecution',
+            command: 'sed -n "1,80p" main.py',
+            commandActions: [
+              {
+                type: 'read',
+                command: 'sed -n "1,80p" main.py',
+                name: 'main.py',
+                path: 'main.py'
+              }
+            ],
+            aggregatedOutput: "print('hello')\n"
+          }
+        }),
+        sequence: null,
+        created_at: '2026-03-14T10:00:02.000Z'
+      },
+      {
+        id: 'activity-glob',
+        session_id: 'session-1',
+        agent_session_id: 'thread-1',
+        thread_id: 'thread-1',
+        turn_id: 'turn-1',
+        item_id: 'tool-glob',
+        request_id: null,
+        kind: 'tool.completed',
+        tone: 'tool',
+        summary: 'Bash',
+        payload_json: JSON.stringify({
+          item: {
+            type: 'commandExecution',
+            command: 'rg --files .',
+            commandActions: [
+              {
+                type: 'listFiles',
+                command: 'rg --files .',
+                path: '.'
+              }
+            ],
+            aggregatedOutput: 'src/main.py\nsrc/lib/util.py\n'
+          }
+        }),
+        sequence: null,
+        created_at: '2026-03-14T10:00:03.000Z'
+      }
+    ]
+
+    const timeline = deriveCodexTimelineMessages(messages, activities)
+
+    expect(
+      timeline.some((message) =>
+        message.parts?.some(
+          (part) =>
+            part.type === 'tool_use' &&
+            part.toolUse?.id === 'tool-read' &&
+            part.toolUse.name === 'Read' &&
+            String(part.toolUse.input?.file_path) === 'main.py'
+        )
+      )
+    ).toBe(true)
+    expect(
+      timeline.some((message) =>
+        message.parts?.some(
+          (part) =>
+            part.type === 'tool_use' &&
+            part.toolUse?.id === 'tool-glob' &&
+            part.toolUse.name === 'Glob' &&
+            String(part.toolUse.input?.path) === '.'
+        )
+      )
+    ).toBe(true)
+  })
+
   it('projects persisted plan.ready activity into an ExitPlanMode tool card', () => {
     const messages: SessionMessage[] = [
       {

--- a/test/phase-6/session-8/rich-tool-rendering.test.tsx
+++ b/test/phase-6/session-8/rich-tool-rendering.test.tsx
@@ -107,6 +107,19 @@ describe('Session 8: Rich Tool Rendering', () => {
       expect(screen.getByText(/Lines 10/)).toBeTruthy()
     })
 
+    test('renders sed-derived line range context', () => {
+      render(
+        <ReadToolView
+          name="Read"
+          input={{ file_path: 'main.py', offset: 1, limit: 79 }}
+          output="print('hello')"
+          status="success"
+        />
+      )
+
+      expect(screen.getByText('Lines 1–80')).toBeTruthy()
+    })
+
     test('renders error state', () => {
       render(
         <ReadToolView
@@ -474,7 +487,8 @@ describe('Session 8: Rich Tool Rendering', () => {
     test('routes Grep tool to GrepToolView', () => {
       render(<ToolCard toolUse={makeToolUse('Grep', 'src/a.ts:1:match', { pattern: 'test' })} />)
 
-      fireEvent.click(screen.getByTestId('tool-card-header'))
+      const compactTool = screen.getByTestId('compact-file-tool')
+      fireEvent.click(compactTool.querySelector('button')!)
 
       expect(screen.getByTestId('grep-tool-view')).toBeTruthy()
     })
@@ -482,7 +496,8 @@ describe('Session 8: Rich Tool Rendering', () => {
     test('routes Glob tool to GrepToolView', () => {
       render(<ToolCard toolUse={makeToolUse('Glob', 'src/a.ts\nsrc/b.ts', { pattern: '*.ts' })} />)
 
-      fireEvent.click(screen.getByTestId('tool-card-header'))
+      const compactTool = screen.getByTestId('compact-file-tool')
+      fireEvent.click(compactTool.querySelector('button')!)
 
       expect(screen.getByTestId('grep-tool-view')).toBeTruthy()
     })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `commandExecution` events/activities/snapshots are mapped into tool names and inputs across streaming, persistence replay, and UI timeline rendering, which could affect tool card matching and display for existing sessions.
> 
> **Overview**
> **Command execution tool calls are now reclassified into higher-level tools** instead of always rendering as `Bash`. A new shared `normalizeCommandExecutionTool` derives `toolName` and structured `input` from `commandActions` and common command patterns (e.g. `sed -n` → `Read` with line range, `rg --files` → `Glob`, `search` → `Grep`), while still falling back to `Bash` with a cleaned `command`.
> 
> This normalization is applied consistently across Codex streaming (`codex-event-mapper` including approval requests), thread snapshot parsing (`codex-implementer`), and persisted activity timeline projection (`codex-timeline`), with updated/added tests to cover the new mappings and expected renderer interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efac676dd532d73457ca0da36c31b6cc301facd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->