### PR TITLE
Default review prompt to standard

### DIFF
--- a/src/renderer/src/constants/reviewPrompts.ts
+++ b/src/renderer/src/constants/reviewPrompts.ts
@@ -6,7 +6,7 @@ export const REVIEW_PROMPT_LABELS: Record<ReviewPromptType, string> = {
   standard: 'Standard',
 }
 
-export const DEFAULT_REVIEW_PROMPT_TYPE: ReviewPromptType = 'superpowers'
+export const DEFAULT_REVIEW_PROMPT_TYPE: ReviewPromptType = 'standard'
 
 export const REVIEW_PROMPTS: Record<ReviewPromptType, string> = {
   superpowers: `## Superpowers Code Review

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -185,7 +185,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   perfDiagnosticsEnabled: false,
   codexJsonlLoggingEnabled: false,
   codexJsonlResetPerSession: true,
-  reviewPromptType: 'superpowers',
+  reviewPromptType: 'standard',
   _boardModeMigratedToStickyTab: false
 }
 

--- a/test/phase-7/session-4/code-review.test.ts
+++ b/test/phase-7/session-4/code-review.test.ts
@@ -185,12 +185,35 @@ describe('Session 4: Code Review', () => {
       expect(REVIEW_PROMPTS).toHaveProperty('standard')
     })
 
-    test('default review prompt type is superpowers', async () => {
+    test('default review prompt type is standard', async () => {
       const { DEFAULT_REVIEW_PROMPT_TYPE } = await import(
         '../../../src/renderer/src/constants/reviewPrompts'
       )
 
-      expect(DEFAULT_REVIEW_PROMPT_TYPE).toBe('superpowers')
+      expect(DEFAULT_REVIEW_PROMPT_TYPE).toBe('standard')
+    })
+
+    test('settings reset restores standard review prompt type', async () => {
+      const { useSettingsStore } = await import('../../../src/renderer/src/stores/useSettingsStore')
+
+      useSettingsStore.getState().updateSetting('reviewPromptType', 'superpowers')
+      expect(useSettingsStore.getState().reviewPromptType).toBe('superpowers')
+
+      useSettingsStore.getState().resetToDefaults()
+
+      expect(useSettingsStore.getState().reviewPromptType).toBe('standard')
+    })
+
+    test('loading persisted superpowers review prompt preserves existing user preference', async () => {
+      const { useSettingsStore } = await import('../../../src/renderer/src/stores/useSettingsStore')
+
+      mockDb.setting.get.mockResolvedValueOnce(JSON.stringify({
+        reviewPromptType: 'superpowers'
+      }))
+
+      await useSettingsStore.getState().loadFromDatabase()
+
+      expect(useSettingsStore.getState().reviewPromptType).toBe('superpowers')
     })
 
     test('each prompt type produces a non-empty string', async () => {


### PR DESCRIPTION
## Summary
- Change the default review prompt type from `superpowers` to `standard`.
- Update the settings store default so resets now restore `standard` review prompts.
- Add coverage for the new default and for preserving an existing persisted `superpowers` preference on load.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the default `reviewPromptType` used for new/ reset settings and updates tests; persisted user preferences should remain unaffected.
> 
> **Overview**
> Defaults for code review prompting are switched from `superpowers` to `standard` by updating `DEFAULT_REVIEW_PROMPT_TYPE` and the settings store’s `DEFAULT_SETTINGS.reviewPromptType`.
> 
> Tests are updated/expanded to assert the new default, that `resetToDefaults()` restores `standard`, and that loading persisted settings still preserves an existing `superpowers` preference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1722451d1cb2ffe9341ed529dc38b6c36bdb2fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->