### PR TITLE
Reselect fallback worktree after archive

### DIFF
--- a/src/renderer/src/constants/reviewPrompts.ts
+++ b/src/renderer/src/constants/reviewPrompts.ts
@@ -6,7 +6,7 @@ export const REVIEW_PROMPT_LABELS: Record<ReviewPromptType, string> = {
   standard: 'Standard',
 }
 
-export const DEFAULT_REVIEW_PROMPT_TYPE: ReviewPromptType = 'superpowers'
+export const DEFAULT_REVIEW_PROMPT_TYPE: ReviewPromptType = 'standard'
 
 export const REVIEW_PROMPTS: Record<ReviewPromptType, string> = {
   superpowers: `## Superpowers Code Review

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -185,7 +185,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   perfDiagnosticsEnabled: false,
   codexJsonlLoggingEnabled: false,
   codexJsonlResetPerSession: true,
-  reviewPromptType: 'superpowers',
+  reviewPromptType: 'standard',
   _boardModeMigratedToStickyTab: false
 }
 

--- a/src/renderer/src/stores/useWorktreeStore.ts
+++ b/src/renderer/src/stores/useWorktreeStore.ts
@@ -161,6 +161,102 @@ function loadPersistedOrder(): Map<string, string[]> {
   return new Map()
 }
 
+function getOrderedProjectWorktrees(
+  worktreesByProject: Map<string, Worktree[]>,
+  worktreeOrderByProject: Map<string, string[]>,
+  projectId: string
+): Worktree[] {
+  const worktrees = worktreesByProject.get(projectId) || []
+
+  // Separate default worktree (always last) from non-default
+  const defaultWorktree = worktrees.find((w) => w.is_default)
+  const nonDefault = worktrees.filter((w) => !w.is_default)
+
+  const customOrder = worktreeOrderByProject.get(projectId)
+  if (!customOrder || customOrder.length === 0) {
+    return defaultWorktree ? [...nonDefault, defaultWorktree] : nonDefault
+  }
+
+  // Sort non-default worktrees by custom order; unordered ones go at end
+  const ordered: Worktree[] = []
+  for (const id of customOrder) {
+    const wt = nonDefault.find((w) => w.id === id)
+    if (wt) ordered.push(wt)
+  }
+
+  // Append any worktrees not in the custom order (newly created)
+  for (const wt of nonDefault) {
+    if (!customOrder.includes(wt.id)) ordered.push(wt)
+  }
+
+  return defaultWorktree ? [...ordered, defaultWorktree] : ordered
+}
+
+function resolveArchiveFallbackWorktreeId(
+  worktreesByProject: Map<string, Worktree[]>,
+  worktreeOrderByProject: Map<string, string[]>,
+  projectId: string,
+  archivedWorktreeId: string
+): string | null {
+  const remaining = getOrderedProjectWorktrees(
+    worktreesByProject,
+    worktreeOrderByProject,
+    projectId
+  ).filter((w) => w.id !== archivedWorktreeId)
+
+  return remaining[0]?.id ?? null
+}
+
+function applyWorktreeSelectionEffects(
+  previousWorktreeId: string | null,
+  nextWorktreeId: string | null,
+  options: {
+    clearConnectionSelection?: boolean
+    preserveProjectId?: string | null
+    refreshLanguage?: boolean
+    closePinnedBoard?: boolean
+  } = {}
+): void {
+  if (nextWorktreeId !== previousWorktreeId) {
+    useFileViewerStore.getState().closeAllFiles()
+  }
+
+  if (options.clearConnectionSelection) {
+    clearConnectionSelection()
+  }
+
+  if (options.closePinnedBoard) {
+    const kanbanState = useKanbanStore.getState()
+    if (kanbanState.isPinnedBoardActive) {
+      kanbanState.togglePinnedBoard()
+    }
+  }
+
+  if (options.preserveProjectId) {
+    useProjectStore.setState((state) =>
+      state.selectedProjectId === options.preserveProjectId
+        ? state
+        : { selectedProjectId: options.preserveProjectId }
+    )
+  }
+
+  if (!nextWorktreeId) return
+
+  void useWorktreeStore.getState().touchWorktree(nextWorktreeId)
+
+  if (options.refreshLanguage) {
+    const worktrees = Array.from(useWorktreeStore.getState().worktreesByProject.values()).flat()
+    const worktree = worktrees.find((w) => w.id === nextWorktreeId)
+    if (worktree) {
+      const ps = useProjectStore.getState()
+      const project = ps.projects.find((p) => p.id === worktree.project_id)
+      if (project && !project.language && !project.custom_icon) {
+        void ps.refreshLanguage(project.id, worktree.path)
+      }
+    }
+  }
+}
+
 export const useWorktreeStore = create<WorktreeState>((set, get) => ({
   // Initial state
   worktreesByProject: new Map(),
@@ -392,8 +488,12 @@ export const useWorktreeStore = create<WorktreeState>((set, get) => ({
       const { usePinnedStore } = await import('./usePinnedStore')
       usePinnedStore.getState().removeWorktree(worktreeId)
 
-      // Remove from state
+      // Remove from state and resolve post-archive fallback selection
       const wasSelected = get().selectedWorktreeId === worktreeId
+      const projectId = worktree?.project_id ?? null
+      const previousSelectedWorktreeId = get().selectedWorktreeId
+      let nextSelectedWorktreeId = previousSelectedWorktreeId
+
       set((state) => {
         const newMap = new Map(state.worktreesByProject)
         for (const [projectId, worktrees] of newMap.entries()) {
@@ -402,16 +502,29 @@ export const useWorktreeStore = create<WorktreeState>((set, get) => ({
             newMap.set(projectId, filtered)
           }
         }
+
+        if (wasSelected && projectId) {
+          nextSelectedWorktreeId = resolveArchiveFallbackWorktreeId(
+            newMap,
+            state.worktreeOrderByProject,
+            projectId,
+            worktreeId
+          )
+        } else if (state.selectedWorktreeId === worktreeId) {
+          nextSelectedWorktreeId = null
+        }
+
         return {
           worktreesByProject: newMap,
-          selectedWorktreeId:
-            state.selectedWorktreeId === worktreeId ? null : state.selectedWorktreeId
+          selectedWorktreeId: nextSelectedWorktreeId
         }
       })
 
-      // Close file tabs if the archived worktree was the active one
       if (wasSelected) {
-        useFileViewerStore.getState().closeAllFiles()
+        applyWorktreeSelectionEffects(previousSelectedWorktreeId, nextSelectedWorktreeId, {
+          clearConnectionSelection: true,
+          preserveProjectId: projectId
+        })
       }
 
       return { success: true }
@@ -518,44 +631,21 @@ export const useWorktreeStore = create<WorktreeState>((set, get) => ({
 
   // Select a worktree (with connection deconfliction)
   selectWorktree: (id: string | null) => {
-    if (id !== get().selectedWorktreeId) {
-      useFileViewerStore.getState().closeAllFiles()
-    }
+    const previousWorktreeId = get().selectedWorktreeId
     set({ selectedWorktreeId: id })
-    if (id) {
-      // Touch worktree to update last_accessed_at
-      get().touchWorktree(id)
-      // Deconflict: clear any selected connection synchronously (same tick)
-      clearConnectionSelection()
-      // Close pinned board when navigating to a specific worktree
-      const kanbanState = useKanbanStore.getState()
-      if (kanbanState.isPinnedBoardActive) {
-        kanbanState.togglePinnedBoard()
-      }
-
-      // Auto-detect language from worktree folder when project has none (fire-and-forget)
-      const worktrees = Array.from(get().worktreesByProject.values()).flat()
-      const worktree = worktrees.find((w) => w.id === id)
-      if (worktree) {
-        const ps = useProjectStore.getState()
-        const project = ps.projects.find((p) => p.id === worktree.project_id)
-        if (project && !project.language && !project.custom_icon) {
-          ps.refreshLanguage(project.id, worktree.path)
-        }
-      }
-    }
+    applyWorktreeSelectionEffects(previousWorktreeId, id, {
+      clearConnectionSelection: Boolean(id),
+      closePinnedBoard: Boolean(id),
+      refreshLanguage: Boolean(id)
+    })
   },
 
   // Select a worktree without triggering connection deconfliction
   // Used by connection store to avoid circular deconfliction
   selectWorktreeOnly: (id: string | null) => {
-    if (id !== get().selectedWorktreeId) {
-      useFileViewerStore.getState().closeAllFiles()
-    }
+    const previousWorktreeId = get().selectedWorktreeId
     set({ selectedWorktreeId: id })
-    if (id) {
-      get().touchWorktree(id)
-    }
+    applyWorktreeSelectionEffects(previousWorktreeId, id)
   },
 
   // Touch worktree (update last_accessed_at)
@@ -593,29 +683,11 @@ export const useWorktreeStore = create<WorktreeState>((set, get) => ({
 
   // Get worktrees for a specific project (applies custom order if available)
   getWorktreesForProject: (projectId: string) => {
-    const worktrees = get().worktreesByProject.get(projectId) || []
-
-    // Separate default worktree (always last) from non-default
-    const defaultWorktree = worktrees.find((w) => w.is_default)
-    const nonDefault = worktrees.filter((w) => !w.is_default)
-
-    const customOrder = get().worktreeOrderByProject.get(projectId)
-    if (!customOrder || customOrder.length === 0) {
-      return defaultWorktree ? [...nonDefault, defaultWorktree] : nonDefault
-    }
-
-    // Sort non-default worktrees by custom order; unordered ones go at end
-    const ordered: typeof nonDefault = []
-    for (const id of customOrder) {
-      const wt = nonDefault.find((w) => w.id === id)
-      if (wt) ordered.push(wt)
-    }
-    // Append any worktrees not in the custom order (newly created)
-    for (const wt of nonDefault) {
-      if (!customOrder.includes(wt.id)) ordered.push(wt)
-    }
-
-    return defaultWorktree ? [...ordered, defaultWorktree] : ordered
+    return getOrderedProjectWorktrees(
+      get().worktreesByProject,
+      get().worktreeOrderByProject,
+      projectId
+    )
   },
 
   // Get the default worktree for a project

--- a/test/phase-7/session-4/code-review.test.ts
+++ b/test/phase-7/session-4/code-review.test.ts
@@ -185,12 +185,35 @@ describe('Session 4: Code Review', () => {
       expect(REVIEW_PROMPTS).toHaveProperty('standard')
     })
 
-    test('default review prompt type is superpowers', async () => {
+    test('default review prompt type is standard', async () => {
       const { DEFAULT_REVIEW_PROMPT_TYPE } = await import(
         '../../../src/renderer/src/constants/reviewPrompts'
       )
 
-      expect(DEFAULT_REVIEW_PROMPT_TYPE).toBe('superpowers')
+      expect(DEFAULT_REVIEW_PROMPT_TYPE).toBe('standard')
+    })
+
+    test('settings reset restores standard review prompt type', async () => {
+      const { useSettingsStore } = await import('../../../src/renderer/src/stores/useSettingsStore')
+
+      useSettingsStore.getState().updateSetting('reviewPromptType', 'superpowers')
+      expect(useSettingsStore.getState().reviewPromptType).toBe('superpowers')
+
+      useSettingsStore.getState().resetToDefaults()
+
+      expect(useSettingsStore.getState().reviewPromptType).toBe('standard')
+    })
+
+    test('loading persisted superpowers review prompt preserves existing user preference', async () => {
+      const { useSettingsStore } = await import('../../../src/renderer/src/stores/useSettingsStore')
+
+      mockDb.setting.get.mockResolvedValueOnce(JSON.stringify({
+        reviewPromptType: 'superpowers'
+      }))
+
+      await useSettingsStore.getState().loadFromDatabase()
+
+      expect(useSettingsStore.getState().reviewPromptType).toBe('superpowers')
     })
 
     test('each prompt type produces a non-empty string', async () => {

--- a/test/session-5/worktrees.test.tsx
+++ b/test/session-5/worktrees.test.tsx
@@ -11,6 +11,7 @@ interface MockWorktree {
   branch_name: string
   path: string
   status: 'active' | 'archived'
+  is_default?: boolean
   created_at: string
   last_accessed_at: string
 }
@@ -43,7 +44,8 @@ const mockProjectOps = {
   copyToClipboard: vi.fn(),
   readFromClipboard: vi.fn(),
   openPath: vi.fn(),
-  isGitRepository: vi.fn()
+  isGitRepository: vi.fn(),
+  loadLanguageIcons: vi.fn().mockResolvedValue([])
 }
 
 const mockWorktreeOps = {
@@ -57,6 +59,17 @@ const mockWorktreeOps = {
   branchExists: vi.fn()
 }
 
+const mockConnectionOps = {
+  removeWorktreeFromAll: vi.fn().mockResolvedValue({ success: true }),
+  getAll: vi.fn().mockResolvedValue({ success: true, connections: [] })
+}
+
+const mockKanban = {
+  ticket: {
+    detachWorktree: vi.fn().mockResolvedValue(0)
+  }
+}
+
 // Setup window mocks
 beforeEach(() => {
   // @ts-expect-error - Mock window.db
@@ -65,6 +78,10 @@ beforeEach(() => {
   window.projectOps = mockProjectOps
   // @ts-expect-error - Mock window.worktreeOps
   window.worktreeOps = mockWorktreeOps
+  // @ts-expect-error - Mock window.connectionOps
+  window.connectionOps = mockConnectionOps
+  // @ts-expect-error - Mock window.kanban
+  window.kanban = mockKanban
 
   // Reset all mocks
   vi.clearAllMocks()
@@ -113,6 +130,19 @@ describe('Session 5: Git Worktree Operations', () => {
     branch_name: 'tokyo',
     path: '/Users/test/.hive-worktrees/test-project/tokyo',
     status: 'active',
+    is_default: false,
+    created_at: new Date().toISOString(),
+    last_accessed_at: new Date().toISOString()
+  }
+
+  const defaultWorktree: MockWorktree = {
+    id: 'worktree-default',
+    project_id: 'project-1',
+    name: '(no-worktree)',
+    branch_name: '',
+    path: '/path/to/test-project',
+    status: 'active',
+    is_default: true,
     created_at: new Date().toISOString(),
     last_accessed_at: new Date().toISOString()
   }
@@ -445,10 +475,9 @@ describe('Session 5: Git Worktree Operations', () => {
     )
   })
 
-  test('Worktree store: archiveWorktree success', async () => {
-    // Setup initial state with a worktree
+  test('Worktree store: archiveWorktree selects default worktree when no other worktrees remain', async () => {
     useWorktreeStore.setState({
-      worktreesByProject: new Map([['project-1', [mockWorktree]]]),
+      worktreesByProject: new Map([['project-1', [mockWorktree, defaultWorktree]]]),
       selectedWorktreeId: mockWorktree.id
     })
 
@@ -464,8 +493,125 @@ describe('Session 5: Git Worktree Operations', () => {
       )
 
     expect(result.success).toBe(true)
-    expect(useWorktreeStore.getState().worktreesByProject.get('project-1')).toHaveLength(0)
-    expect(useWorktreeStore.getState().selectedWorktreeId).toBeNull()
+    expect(useWorktreeStore.getState().worktreesByProject.get('project-1')).toHaveLength(1)
+    expect(useWorktreeStore.getState().worktreesByProject.get('project-1')?.[0]?.id).toBe(
+      defaultWorktree.id
+    )
+    expect(useWorktreeStore.getState().selectedWorktreeId).toBe(defaultWorktree.id)
+  })
+
+  test('Worktree store: archiveWorktree selects top remaining non-default worktree', async () => {
+    const secondWorktree: MockWorktree = {
+      id: 'worktree-2',
+      project_id: 'project-1',
+      name: 'paris',
+      branch_name: 'paris',
+      path: '/Users/test/.hive-worktrees/test-project/paris',
+      status: 'active',
+      is_default: false,
+      created_at: new Date().toISOString(),
+      last_accessed_at: new Date().toISOString()
+    }
+
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([['project-1', [mockWorktree, secondWorktree, defaultWorktree]]]),
+      selectedWorktreeId: mockWorktree.id
+    })
+
+    mockWorktreeOps.delete.mockResolvedValue({ success: true })
+
+    const result = await useWorktreeStore
+      .getState()
+      .archiveWorktree(
+        'worktree-1',
+        '/Users/test/.hive-worktrees/test-project/tokyo',
+        'tokyo',
+        '/path/to/test-project'
+      )
+
+    expect(result.success).toBe(true)
+    expect(useWorktreeStore.getState().selectedWorktreeId).toBe(secondWorktree.id)
+  })
+
+  test('Worktree store: archiveWorktree respects custom ordering when selecting fallback', async () => {
+    const secondWorktree: MockWorktree = {
+      id: 'worktree-2',
+      project_id: 'project-1',
+      name: 'paris',
+      branch_name: 'paris',
+      path: '/Users/test/.hive-worktrees/test-project/paris',
+      status: 'active',
+      is_default: false,
+      created_at: new Date().toISOString(),
+      last_accessed_at: new Date().toISOString()
+    }
+
+    const thirdWorktree: MockWorktree = {
+      id: 'worktree-3',
+      project_id: 'project-1',
+      name: 'oslo',
+      branch_name: 'oslo',
+      path: '/Users/test/.hive-worktrees/test-project/oslo',
+      status: 'active',
+      is_default: false,
+      created_at: new Date().toISOString(),
+      last_accessed_at: new Date().toISOString()
+    }
+
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        ['project-1', [mockWorktree, secondWorktree, thirdWorktree, defaultWorktree]]
+      ]),
+      worktreeOrderByProject: new Map([['project-1', ['worktree-3', 'worktree-2', 'worktree-1']]]),
+      selectedWorktreeId: mockWorktree.id
+    })
+
+    mockWorktreeOps.delete.mockResolvedValue({ success: true })
+
+    const result = await useWorktreeStore
+      .getState()
+      .archiveWorktree(
+        'worktree-1',
+        '/Users/test/.hive-worktrees/test-project/tokyo',
+        'tokyo',
+        '/path/to/test-project'
+      )
+
+    expect(result.success).toBe(true)
+    expect(useWorktreeStore.getState().selectedWorktreeId).toBe(thirdWorktree.id)
+  })
+
+  test('Worktree store: archiveWorktree keeps current selection when another worktree is archived', async () => {
+    const secondWorktree: MockWorktree = {
+      id: 'worktree-2',
+      project_id: 'project-1',
+      name: 'paris',
+      branch_name: 'paris',
+      path: '/Users/test/.hive-worktrees/test-project/paris',
+      status: 'active',
+      is_default: false,
+      created_at: new Date().toISOString(),
+      last_accessed_at: new Date().toISOString()
+    }
+
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([['project-1', [mockWorktree, secondWorktree, defaultWorktree]]]),
+      selectedWorktreeId: secondWorktree.id
+    })
+
+    mockWorktreeOps.delete.mockResolvedValue({ success: true })
+
+    const result = await useWorktreeStore
+      .getState()
+      .archiveWorktree(
+        'worktree-1',
+        '/Users/test/.hive-worktrees/test-project/tokyo',
+        'tokyo',
+        '/path/to/test-project'
+      )
+
+    expect(result.success).toBe(true)
+    expect(useWorktreeStore.getState().selectedWorktreeId).toBe(secondWorktree.id)
   })
 
   test('Worktree store: unbranchWorktree success', async () => {

--- a/test/worktree-connection/session-10/archive-cascade-integration.test.ts
+++ b/test/worktree-connection/session-10/archive-cascade-integration.test.ts
@@ -577,6 +577,19 @@ describe('Session 10: Archive Cascade & Integration', () => {
       expect(connections[0].members).toHaveLength(1)
     })
 
+    test('archiving the selected worktree reselects the project default worktree', async () => {
+      useWorktreeStore.setState({ selectedWorktreeId: 'wt-1' })
+
+      await act(async () => {
+        const result = await useWorktreeStore
+          .getState()
+          .archiveWorktree('wt-1', '/repos/frontend/city-one', 'feat/auth', '/repos/frontend')
+        expect(result?.success).toBe(true)
+      })
+
+      expect(useWorktreeStore.getState().selectedWorktreeId).toBe('wt-default')
+    })
+
     test('archiving both members deletes the connection entirely', async () => {
       useConnectionStore.setState({ connections: [makeConnection()] })
 


### PR DESCRIPTION
## Summary
- Add shared worktree selection effect handling so archive and direct selection follow the same cleanup path.
- When archiving the active worktree, reselect the best remaining worktree in project order instead of clearing selection.
- Keep the default worktree last in project ordering and use it as the fallback when no non-default worktrees remain.
- Expand worktree archive coverage with cases for default fallback, ordered fallback, and non-selected archive behavior.

## Testing
- Added unit tests in `test/session-5/worktrees.test.tsx` for archive fallback selection and ordering.
- Added integration coverage in `test/worktree-connection/session-10/archive-cascade-integration.test.ts` for reselection of the project default worktree.
- Not run locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `archiveWorktree` selection and side-effect behavior (closing files, clearing connections, pinned board handling), which can affect navigation state across projects/worktrees. Logic is covered by expanded unit/integration tests for fallback selection and ordering.
> 
> **Overview**
> When archiving the currently selected worktree, the app now **automatically selects a fallback worktree** (respecting per-project custom order and keeping the default worktree last) instead of clearing selection.
> 
> Worktree selection side effects (close file tabs, clear connection selection, close pinned board, touch worktree, and optional language refresh) are centralized in `applyWorktreeSelectionEffects` and reused by both `selectWorktree` and the archive flow. Separately, the default review prompt type is changed from `superpowers` to `standard`, with tests ensuring resets use the new default while persisted user preferences are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f9d5be985da84ca963e610db4b8cc2872d8e32a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->