### PR TITLE
Use SDK-specific super-plan prefix wording

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -53,7 +53,7 @@ import { useGitStore } from '@/stores/useGitStore'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
-import { PLAN_MODE_PREFIX, SUPER_PLAN_MODE_PREFIX, isPlanLike } from '@/lib/constants'
+import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
 import { buildSdkPlanImplementationPrompt } from '@/lib/proposedPlan'
 import { toast } from '@/lib/toast'
 import { useScriptStore, fireRunScript, killRunScript } from '@/stores/useScriptStore'
@@ -229,7 +229,7 @@ async function sendFollowupToSession(opts: {
   // Claude Code & Codex handle plan mode via the SDK — don't prepend the text prefix
   const skipPrefix = session.agent_sdk === 'claude-code' || session.agent_sdk === 'codex'
   const modePrefix =
-    opts.followUpMode === 'super-plan' ? SUPER_PLAN_MODE_PREFIX
+    opts.followUpMode === 'super-plan' ? getSuperPlanModePrefix(session.agent_sdk)
     : opts.followUpMode === 'plan' && !skipPrefix ? PLAN_MODE_PREFIX
     : ''
   const fullPrompt = modePrefix + opts.prompt

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -25,7 +25,7 @@ import { ModelSelector } from '@/components/sessions/ModelSelector'
 import { CodexFastToggle } from '@/components/sessions/CodexFastToggle'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
-import { PLAN_MODE_PREFIX, SUPER_PLAN_MODE_PREFIX, isPlanLike } from '@/lib/constants'
+import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
 import { toast } from '@/lib/toast'
 import type { KanbanTicket } from '../../../../main/db/types'
 import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
@@ -425,7 +425,7 @@ export function WorktreePickerModal({
         // Send prompt
         if (promptText.trim()) {
           const skipPrefix = sessionAgentSdk === 'claude-code' || sessionAgentSdk === 'codex'
-          const modePrefix = mode === 'super-plan' ? SUPER_PLAN_MODE_PREFIX
+          const modePrefix = mode === 'super-plan' ? getSuperPlanModePrefix(sessionAgentSdk)
             : mode === 'plan' && !skipPrefix ? PLAN_MODE_PREFIX
             : ''
           const fullPrompt = modePrefix + promptText.trim()
@@ -640,7 +640,7 @@ export function WorktreePickerModal({
       if (promptText.trim()) {
         const skipPrefix = sessionAgentSdk === 'claude-code' || sessionAgentSdk === 'codex'
         const modePrefix =
-          mode === 'super-plan' ? SUPER_PLAN_MODE_PREFIX
+          mode === 'super-plan' ? getSuperPlanModePrefix(sessionAgentSdk)
           : mode === 'plan' && !skipPrefix ? PLAN_MODE_PREFIX
           : ''
         const fullPrompt = modePrefix + promptText.trim()

--- a/src/renderer/src/components/sessions/MessageRenderer.tsx
+++ b/src/renderer/src/components/sessions/MessageRenderer.tsx
@@ -3,7 +3,11 @@ import { UserBubble } from './UserBubble'
 import { AssistantCanvas } from './AssistantCanvas'
 import { CopyMessageButton } from './CopyMessageButton'
 import { ForkMessageButton } from './ForkMessageButton'
-import { PLAN_MODE_PREFIX, ASK_MODE_PREFIX, SUPER_PLAN_MODE_PREFIX } from '@/lib/constants'
+import {
+  PLAN_MODE_PREFIX,
+  ASK_MODE_PREFIX,
+  stripSuperPlanModePrefix
+} from '@/lib/constants'
 import type { OpenCodeMessage } from './SessionView'
 
 interface MessageRendererProps {
@@ -68,9 +72,10 @@ export const MessageRenderer = memo(function MessageRenderer({
     const { prefix, remaining } = skipAttachments(message.content)
 
     // Check for mode prefixes in order (longest first to avoid false positives)
-    if (remaining.startsWith(SUPER_PLAN_MODE_PREFIX)) {
+    const strippedSuperPlan = stripSuperPlanModePrefix(remaining)
+    if (strippedSuperPlan !== null) {
       isSuperPlanMode = true
-      displayContent = prefix + remaining.slice(SUPER_PLAN_MODE_PREFIX.length)
+      displayContent = prefix + strippedSuperPlan
     } else if (remaining.startsWith(PLAN_MODE_PREFIX)) {
       isPlanMode = true
       displayContent = prefix + remaining.slice(PLAN_MODE_PREFIX.length)

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -90,7 +90,7 @@ import type { ToolStatus, ToolUseInfo } from './ToolCard'
 import {
   PLAN_MODE_PREFIX,
   ASK_MODE_PREFIX,
-  SUPER_PLAN_MODE_PREFIX,
+  getSuperPlanModePrefix,
   stripPlanModePrefix,
   isPlanLike
 } from '@/lib/constants'
@@ -3104,7 +3104,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
             // Apply mode prefix for OpenCode sessions (Claude Code uses native plan mode)
             const modePrefix =
               currentMode === 'super-plan'
-                ? SUPER_PLAN_MODE_PREFIX
+                ? getSuperPlanModePrefix(sessionAgentSdk)
                 : currentMode === 'plan' && !skipPlanModePrefix
                   ? PLAN_MODE_PREFIX
                   : ''
@@ -4184,7 +4184,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         const optimisticMode = currentModeForStatus
         const optimisticModePrefix =
           optimisticMode === 'super-plan'
-            ? SUPER_PLAN_MODE_PREFIX
+            ? getSuperPlanModePrefix(sessionAgentSdk)
             : optimisticMode === 'plan' && !skipPlanModePrefix
               ? PLAN_MODE_PREFIX
               : ''
@@ -4310,7 +4310,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
               // Unknown command — send as regular prompt (SDK may handle it)
               const modePrefix =
                 currentModeForStatus === 'super-plan'
-                  ? SUPER_PLAN_MODE_PREFIX
+                  ? getSuperPlanModePrefix(sessionAgentSdk)
                   : currentModeForStatus === 'plan' && !skipPlanModePrefix
                     ? PLAN_MODE_PREFIX
                     : ''
@@ -4348,7 +4348,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
             // Regular prompt — existing code (with mode prefix, attachments, etc.)
             const modePrefix =
               currentModeForStatus === 'super-plan'
-                ? SUPER_PLAN_MODE_PREFIX
+                ? getSuperPlanModePrefix(sessionAgentSdk)
                 : currentModeForStatus === 'plan' && !skipPlanModePrefix
                   ? PLAN_MODE_PREFIX
                   : ''

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -8,7 +8,7 @@ import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
-import { PLAN_MODE_PREFIX, SUPER_PLAN_MODE_PREFIX, isPlanLike } from '@/lib/constants'
+import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
 import { toast } from '@/lib/toast'
 import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
 
@@ -111,7 +111,7 @@ export async function autoLaunchTicket(ticket: KanbanTicket): Promise<void> {
     if (config.prompt.trim()) {
       const skipPrefix = sessionAgentSdk === 'claude-code' || sessionAgentSdk === 'codex'
       const modePrefix =
-        config.mode === 'super-plan' ? SUPER_PLAN_MODE_PREFIX
+        config.mode === 'super-plan' ? getSuperPlanModePrefix(sessionAgentSdk)
         : config.mode === 'plan' && !skipPrefix ? PLAN_MODE_PREFIX
         : ''
       const fullPrompt = modePrefix + config.prompt.trim()

--- a/src/renderer/src/lib/constants.ts
+++ b/src/renderer/src/lib/constants.ts
@@ -4,12 +4,32 @@ export const PLAN_MODE_PREFIX =
 export const SUPER_PLAN_MODE_PREFIX =
   'Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.\n\nIf a question can be answered by exploring the codebase, explore the codebase instead.\nAll questions should be asked using the AskUserQuestion tool if possible\n\n'
 
+export const CODEX_SUPER_PLAN_MODE_PREFIX =
+  'Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.\n\nIf a question can be answered by exploring the codebase, explore the codebase instead.\nAll questions should be asked using the request_user_input tool if possible\n\n'
+
 export const ASK_MODE_PREFIX =
   '[Mode: Ask] You are in question-answering mode. The user wants information only. Do NOT make any code changes, do NOT use file editing tools, do NOT modify any files. Simply answer the question directly and concisely.\n\n'
 
+const SUPER_PLAN_MODE_PREFIXES = [CODEX_SUPER_PLAN_MODE_PREFIX, SUPER_PLAN_MODE_PREFIX]
+
+export function getSuperPlanModePrefix(agentSdk: string | null | undefined): string {
+  return agentSdk === 'codex' ? CODEX_SUPER_PLAN_MODE_PREFIX : SUPER_PLAN_MODE_PREFIX
+}
+
+export function stripSuperPlanModePrefix(value: string): string | null {
+  for (const prefix of SUPER_PLAN_MODE_PREFIXES) {
+    if (value.startsWith(prefix)) {
+      return value.slice(prefix.length)
+    }
+  }
+
+  return null
+}
+
 export function stripModePrefix(value: string): string {
-  if (value.startsWith(SUPER_PLAN_MODE_PREFIX)) {
-    return value.slice(SUPER_PLAN_MODE_PREFIX.length)
+  const superPlanStripped = stripSuperPlanModePrefix(value)
+  if (superPlanStripped !== null) {
+    return superPlanStripped
   }
   if (value.startsWith(PLAN_MODE_PREFIX)) {
     return value.slice(PLAN_MODE_PREFIX.length)

--- a/test/kanban/session-9/worktree-picker-modal.test.tsx
+++ b/test/kanban/session-9/worktree-picker-modal.test.tsx
@@ -161,6 +161,15 @@ Object.defineProperty(window, 'gitOps', {
   value: mockGitOps
 })
 
+Object.defineProperty(window, 'usageOps', {
+  writable: true,
+  configurable: true,
+  value: {
+    fetch: vi.fn().mockResolvedValue({ success: true, data: null }),
+    fetchOpenai: vi.fn().mockResolvedValue({ success: true, data: null })
+  }
+})
+
 Object.defineProperty(window, 'opencodeOps', {
   writable: true,
   configurable: true,
@@ -173,6 +182,7 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { getSuperPlanModePrefix } from '@/lib/constants'
 
 // ── Import component under test ─────────────────────────────────────
 import { WorktreePickerModal, _resetLastSourceBranch } from '@/components/kanban/WorktreePickerModal'
@@ -782,6 +792,69 @@ describe('Session 9: Worktree Picker Modal', () => {
       undefined,
       { codexFastMode: true }
     )
+  })
+
+  test('super-plan prompts use request_user_input wording for Codex sessions', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    fireEvent.click(screen.getByTestId('wt-picker-mode-toggle'))
+    fireEvent.click(screen.getByTestId('wt-picker-super-toggle'))
+    fireEvent.click(screen.getByTestId('worktree-item-wt-1'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('wt-picker-send-btn'))
+    })
+
+    await waitFor(() => {
+      expect(mockOpencodeOps.prompt).toHaveBeenCalled()
+    })
+
+    const promptParts = mockOpencodeOps.prompt.mock.calls.at(-1)?.[2] as Array<{
+      type: string
+      text: string
+    }>
+    expect(promptParts[0]?.text).toContain(getSuperPlanModePrefix('codex'))
+    expect(promptParts[0]?.text).toContain('request_user_input')
+    expect(promptParts[0]?.text).not.toContain('AskUserQuestion')
+  })
+
+  test('super-plan prompts keep AskUserQuestion wording for non-Codex sessions', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('wt-picker-mode-toggle'))
+    fireEvent.click(screen.getByTestId('wt-picker-super-toggle'))
+    fireEvent.click(screen.getByTestId('worktree-item-wt-1'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('wt-picker-send-btn'))
+    })
+
+    await waitFor(() => {
+      expect(mockOpencodeOps.prompt).toHaveBeenCalled()
+    })
+
+    const promptParts = mockOpencodeOps.prompt.mock.calls.at(-1)?.[2] as Array<{
+      type: string
+      text: string
+    }>
+    expect(promptParts[0]?.text).toContain(getSuperPlanModePrefix('opencode'))
+    expect(promptParts[0]?.text).toContain('AskUserQuestion')
+    expect(promptParts[0]?.text).not.toContain('request_user_input')
   })
 
   // ── Source branch picker tests ──────────────────────────────────

--- a/test/phase-17/session-3/plan-mode-badge.test.tsx
+++ b/test/phase-17/session-3/plan-mode-badge.test.tsx
@@ -1,6 +1,13 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { PLAN_MODE_PREFIX, stripPlanModePrefix } from '@/lib/constants'
+import {
+  PLAN_MODE_PREFIX,
+  SUPER_PLAN_MODE_PREFIX,
+  CODEX_SUPER_PLAN_MODE_PREFIX,
+  getSuperPlanModePrefix,
+  stripModePrefix,
+  stripPlanModePrefix
+} from '@/lib/constants'
 import { UserBubble } from '@/components/sessions/UserBubble'
 import { MessageRenderer } from '@/components/sessions/MessageRenderer'
 
@@ -35,6 +42,23 @@ describe('Session 3: Plan Mode Badge', () => {
 
     test('ends with double newline', () => {
       expect(PLAN_MODE_PREFIX.endsWith('\n\n')).toBe(true)
+    })
+  })
+
+  describe('super-plan prompt helpers', () => {
+    test('returns Codex-specific super-plan wording for codex sessions', () => {
+      expect(getSuperPlanModePrefix('codex')).toBe(CODEX_SUPER_PLAN_MODE_PREFIX)
+      expect(getSuperPlanModePrefix('codex')).toContain('request_user_input')
+    })
+
+    test('keeps AskUserQuestion wording for non-codex sessions', () => {
+      expect(getSuperPlanModePrefix('opencode')).toBe(SUPER_PLAN_MODE_PREFIX)
+      expect(getSuperPlanModePrefix('claude-code')).toContain('AskUserQuestion')
+    })
+
+    test('stripModePrefix removes both legacy and codex super-plan prefixes', () => {
+      expect(stripModePrefix(SUPER_PLAN_MODE_PREFIX + 'Plan text')).toBe('Plan text')
+      expect(stripModePrefix(CODEX_SUPER_PLAN_MODE_PREFIX + 'Plan text')).toBe('Plan text')
     })
   })
 
@@ -151,6 +175,23 @@ describe('Session 3: Plan Mode Badge', () => {
       )
       expect(screen.queryByTestId('plan-mode-badge')).not.toBeInTheDocument()
       expect(screen.getByText('Normal message')).toBeInTheDocument()
+    })
+
+    test('user message with Codex super-plan prefix shows SUPER badge and stripped content', () => {
+      render(
+        <MessageRenderer
+          message={{
+            id: 'msg-super-codex',
+            role: 'user',
+            content: CODEX_SUPER_PLAN_MODE_PREFIX + 'Clarify the API boundary',
+            timestamp: '2025-01-01T00:00:00.000Z',
+            parts: []
+          }}
+        />
+      )
+      expect(screen.getByTestId('super-plan-mode-badge')).toBeInTheDocument()
+      expect(screen.getByText('Clarify the API boundary')).toBeInTheDocument()
+      expect(screen.queryByText(/request_user_input/)).not.toBeInTheDocument()
     })
 
     test('only the prefix is stripped, user content preserved', () => {


### PR DESCRIPTION
## Summary
- Added SDK-aware super-plan prompt prefixes so Codex sessions use `request_user_input` wording while other agents keep `AskUserQuestion`.
- Centralized super-plan prefix selection and stripping in `src/renderer/src/lib/constants.ts` to support both legacy and Codex variants.
- Updated Kanban, worktree, session, and auto-launch prompt paths to use the new helper.
- Expanded tests to cover Codex-specific prompt text and badge stripping behavior.

## Testing
- `Not run`
- Added/updated unit coverage for `getSuperPlanModePrefix`, `stripModePrefix`, and `MessageRenderer` super-plan detection.
- Added integration-style coverage for worktree picker prompt generation in Codex and non-Codex sessions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes prompt text injected into multiple session creation/sending paths and modifies how the UI detects/strips super-plan prefixes, which can affect agent behavior and message rendering.
> 
> **Overview**
> Adds an SDK-aware super-plan prefix: Codex sessions now use a `request_user_input` variant while other SDKs keep the existing `AskUserQuestion` wording via `getSuperPlanModePrefix()`.
> 
> Updates all prompt-send entry points (Kanban followups, WorktreePickerModal, SessionView, auto-launch) to use the helper, and updates message rendering to detect/strip either super-plan prefix (`stripSuperPlanModePrefix`/`stripModePrefix`) so SUPER badges and displayed user text remain correct. Tests are expanded to cover Codex vs non-Codex prompt generation and prefix stripping/badge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a999a257a4c8ffe0ae138c81e80dbe65e799d774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->