### PR TITLE
Confirm discard on ticket create and edit cancel

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -20,8 +20,6 @@ import {
   Archive,
   Loader2,
   Github,
-  FileUp,
-  File as FileIcon,
   Upload,
   Lock,
   Plus
@@ -72,6 +70,7 @@ import { ProviderIcon, getProviderLabel } from '@/components/ui/provider-icon'
 import { useLifecycleActions } from '@/hooks/useLifecycleActions'
 import { usePinAndActivateSession } from '@/hooks/usePinAndActivateSession'
 import { TicketAttachmentEditor } from './TicketAttachmentEditor'
+import { TicketDiscardChangesDialog } from './TicketDiscardChangesDialog'
 import { useImagePaste } from '@/hooks/useImagePaste'
 import type { KanbanTicket, KanbanTicketUpdate, Worktree } from '../../../../main/db/types'
 
@@ -90,6 +89,24 @@ const MODE_DIALOG_CLASS: Record<ModalMode, string> = {
 
 // TicketAttachment is now imported from TicketAttachmentEditor
 type TicketAttachment = import('./TicketAttachmentEditor').TicketAttachment
+
+function normalizeDraftText(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeTicketAttachments(attachments: unknown[]): string {
+  return JSON.stringify(
+    attachments.map((attachment) => {
+      const candidate = attachment as { type?: string; url?: string; label?: string }
+      return {
+        type: candidate.type ?? '',
+        url: candidate.url ?? '',
+        label: candidate.label ?? ''
+      }
+    })
+  )
+}
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -307,34 +324,24 @@ export function KanbanTicketModal() {
     return null
   }, [selectedTicketId, tickets])
 
-  const open = ticket !== null
-  const handleOpenChange = useCallback(
-    (isOpen: boolean) => {
-      if (!isOpen) setSelectedTicketId(null)
-    },
-    [setSelectedTicketId]
-  )
-
   if (!ticket) return null
 
-  return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <KanbanTicketModalContent ticket={ticket} onClose={() => setSelectedTicketId(null)} />
-    </Dialog>
-  )
+  return <KanbanTicketModalContent ticket={ticket} onForceClose={() => setSelectedTicketId(null)} />
 }
 
 // ── Inner content (only rendered when ticket is non-null) ───────────
 function KanbanTicketModalContent({
   ticket,
-  onClose
+  onForceClose
 }: {
   ticket: KanbanTicket
-  onClose: () => void
+  onForceClose: () => void
 }) {
   const updateTicket = useKanbanStore((s) => s.updateTicket)
   const deleteTicket = useKanbanStore((s) => s.deleteTicket)
   const moveTicket = useKanbanStore((s) => s.moveTicket)
+  const [editDraftDirty, setEditDraftDirty] = useState(false)
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
 
   // ── Session lookup ────────────────────────────────────────────────
   const sessionStatus = useSessionStore(
@@ -495,6 +502,30 @@ function KanbanTicketModalContent({
   // the agent regardless of other ticket state (error, plan_ready, etc.)
   const modalMode = activeQuestion ? 'question' : baseModalMode
 
+  useEffect(() => {
+    setEditDraftDirty(false)
+    setShowDiscardConfirm(false)
+  }, [ticket.id, modalMode])
+
+  const forceClose = useCallback(() => {
+    setShowDiscardConfirm(false)
+    onForceClose()
+  }, [onForceClose])
+
+  const requestClose = useCallback(() => {
+    if (modalMode === 'edit' && editDraftDirty) {
+      setShowDiscardConfirm(true)
+      return
+    }
+    forceClose()
+  }, [editDraftDirty, forceClose, modalMode])
+
+  const handleDialogOpenChange = useCallback((isOpen: boolean) => {
+    if (!isOpen) {
+      requestClose()
+    }
+  }, [requestClose])
+
   // ── Session stream resolution ────────────────────────────────────
   let worktreePath: string | null = null
   if (effectiveSession?.worktree_id) {
@@ -597,7 +628,9 @@ function KanbanTicketModalContent({
       modeContent = (
         <EditModeContent
           ticket={ticket}
-          onClose={onClose}
+          onClose={forceClose}
+          onRequestClose={requestClose}
+          onDirtyChange={setEditDraftDirty}
           updateTicket={updateTicket}
           deleteTicket={deleteTicket}
         />
@@ -607,7 +640,7 @@ function KanbanTicketModalContent({
       modeContent = (
         <PlanReviewModeContent
           ticket={ticket}
-          onClose={onClose}
+          onClose={forceClose}
           pendingPlan={pendingPlan}
           sessionRecord={effectiveSession}
           updateTicket={updateTicket}
@@ -621,7 +654,7 @@ function KanbanTicketModalContent({
       modeContent = (
         <ReviewModeContent
           ticket={ticket}
-          onClose={onClose}
+          onClose={forceClose}
           moveTicket={moveTicket}
           updateTicket={updateTicket}
           dualPane={wantsDualPane}
@@ -629,13 +662,13 @@ function KanbanTicketModalContent({
       )
       break
     case 'error':
-      modeContent = <ErrorModeContent ticket={ticket} onClose={onClose} dualPane={wantsDualPane} />
+      modeContent = <ErrorModeContent ticket={ticket} onClose={forceClose} dualPane={wantsDualPane} />
       break
     case 'question':
       modeContent = (
         <QuestionModeContent
           ticket={ticket}
-          onClose={onClose}
+          onClose={forceClose}
           activeQuestion={activeQuestion!}
           dualPane={wantsDualPane}
         />
@@ -644,8 +677,10 @@ function KanbanTicketModalContent({
   }
 
   // ── Full-width session layout (only in-progress edit mode — left pane has no actionable content) ──
+  let dialogBody: React.ReactNode
+
   if (wantsDualPane && modalMode === 'edit' && ticket.column === 'in_progress') {
-    return (
+    dialogBody = (
       <DialogContent
         data-testid="kanban-ticket-modal"
         className="w-[96vw] max-w-[1920px] h-[90vh] p-0 gap-0 overflow-hidden"
@@ -663,7 +698,7 @@ function KanbanTicketModalContent({
               headerAction={(
                 <JumpToSessionButton
                   ticket={ticket}
-                  onClose={onClose}
+                  onClose={forceClose}
                   label="Go to session"
                   testId="go-to-session-btn"
                 />
@@ -678,11 +713,9 @@ function KanbanTicketModalContent({
         </div>
       </DialogContent>
     )
-  }
-
-  // ── Dual-pane layout (ticket + session stream) ──────────────────
-  if (wantsDualPane) {
-    return (
+  } else if (wantsDualPane) {
+    // ── Dual-pane layout (ticket + session stream) ──────────────────
+    dialogBody = (
       <DialogContent
         data-testid="kanban-ticket-modal"
         className="w-[96vw] max-w-[1920px] h-[90vh] p-0 gap-0 overflow-hidden"
@@ -720,16 +753,27 @@ function KanbanTicketModalContent({
         </div>
       </DialogContent>
     )
+  } else {
+    // ── Standard layout (no session) ────────────────────────────────
+    dialogBody = (
+      <DialogContent
+        data-testid="kanban-ticket-modal"
+        className={MODE_DIALOG_CLASS[modalMode]}
+      >
+        {modeContent}
+      </DialogContent>
+    )
   }
 
-  // ── Standard layout (no session) ────────────────────────────────
   return (
-    <DialogContent
-      data-testid="kanban-ticket-modal"
-      className={MODE_DIALOG_CLASS[modalMode]}
-    >
-      {modeContent}
-    </DialogContent>
+    <Dialog open onOpenChange={handleDialogOpenChange}>
+      {dialogBody}
+      <TicketDiscardChangesDialog
+        open={showDiscardConfirm}
+        onKeepEditing={() => setShowDiscardConfirm(false)}
+        onDiscard={forceClose}
+      />
+    </Dialog>
   )
 }
 
@@ -740,11 +784,15 @@ function KanbanTicketModalContent({
 function EditModeContent({
   ticket,
   onClose,
+  onRequestClose,
+  onDirtyChange,
   updateTicket,
   deleteTicket
 }: {
   ticket: KanbanTicket
   onClose: () => void
+  onRequestClose: () => void
+  onDirtyChange: (isDirty: boolean) => void
   updateTicket: (ticketId: string, projectId: string, data: KanbanTicketUpdate) => Promise<void>
   deleteTicket: (ticketId: string, projectId: string) => Promise<void>
 }) {
@@ -763,6 +811,13 @@ function EditModeContent({
   const lifecycle = useLifecycleActions(ticket.worktree_id)
   const { pinAndActivate: pinAndActivateSession, lifecycleLoading } = usePinAndActivateSession(onClose)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const isDirty = normalizeDraftText(title) !== normalizeDraftText(ticket.title)
+    || normalizeDraftText(description) !== normalizeDraftText(ticket.description)
+    || normalizeTicketAttachments(attachments) !== normalizeTicketAttachments(ticket.attachments)
+
+  useEffect(() => {
+    onDirtyChange(isDirty)
+  }, [isDirty, onDirtyChange])
 
   // ── Dependency selectors ──────────────────────────────────────────
   // useShallow prevents infinite re-render loops by doing shallow equality
@@ -1106,7 +1161,7 @@ function EditModeContent({
             type="button"
             variant="outline"
             data-testid="ticket-edit-cancel-btn"
-            onClick={onClose}
+            onClick={onRequestClose}
           >
             Cancel
           </Button>

--- a/src/renderer/src/components/kanban/TicketCreateModal.tsx
+++ b/src/renderer/src/components/kanban/TicketCreateModal.tsx
@@ -19,6 +19,7 @@ import { usePinnedStore } from '@/stores/usePinnedStore'
 import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 import { TicketAttachmentEditor, MAX_ATTACHMENTS } from './TicketAttachmentEditor'
+import { TicketDiscardChangesDialog } from './TicketDiscardChangesDialog'
 import type { TicketAttachment } from './TicketAttachmentEditor'
 import { useImagePaste } from '@/hooks/useImagePaste'
 
@@ -38,6 +39,7 @@ export function TicketCreateModal({ open, onOpenChange, projectId, connectionId,
   const [attachments, setAttachments] = useState<TicketAttachment[]>([])
   const [isCreating, setIsCreating] = useState(false)
   const [selectedProjectId, setSelectedProjectId] = useState('')
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
 
   const titleInputRef = useRef<HTMLInputElement>(null)
   const createdSuccessfully = useRef(false)
@@ -74,6 +76,11 @@ export function TicketCreateModal({ open, onOpenChange, projectId, connectionId,
 
   const isMultiProjectMode = isConnectionMode || !!isPinnedMode
   const availableProjects = isConnectionMode ? connectionProjects : pinnedProjects
+  const initialSelectedProjectId = availableProjects[0]?.id ?? ''
+  const isDirty = title.trim().length > 0
+    || description.trim().length > 0
+    || attachments.length > 0
+    || (isMultiProjectMode && selectedProjectId !== '' && selectedProjectId !== initialSelectedProjectId)
 
   // Allow natural Tab navigation between form fields — block SessionView's
   // global capture-phase Tab handler which would toggle Build/Plan mode instead.
@@ -97,6 +104,7 @@ export function TicketCreateModal({ open, onOpenChange, projectId, connectionId,
     if (open) {
       createdSuccessfully.current = false
     } else {
+      setShowDiscardConfirm(false)
       // Modal just closed — if creation didn't succeed, delete any saved images
       if (!createdSuccessfully.current) {
         for (const att of attachments) {
@@ -147,6 +155,7 @@ export function TicketCreateModal({ open, onOpenChange, projectId, connectionId,
         column: 'todo'
       })
       createdSuccessfully.current = true
+      setShowDiscardConfirm(false)
       toast.success('Ticket created')
       onOpenChange(false)
     } catch {
@@ -156,9 +165,30 @@ export function TicketCreateModal({ open, onOpenChange, projectId, connectionId,
     }
   }, [title, description, attachments, isCreating, createTicket, projectId, selectedProjectId, isMultiProjectMode, onOpenChange])
 
-  const handleCancel = useCallback(() => {
+  const closeImmediately = useCallback(() => {
+    setShowDiscardConfirm(false)
     onOpenChange(false)
   }, [onOpenChange])
+
+  const requestClose = useCallback(() => {
+    if (isDirty) {
+      setShowDiscardConfirm(true)
+      return
+    }
+    closeImmediately()
+  }, [closeImmediately, isDirty])
+
+  const handleCancel = useCallback(() => {
+    requestClose()
+  }, [requestClose])
+
+  const handleDialogOpenChange = useCallback((nextOpen: boolean) => {
+    if (!nextOpen) {
+      requestClose()
+      return
+    }
+    onOpenChange(true)
+  }, [onOpenChange, requestClose])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -172,7 +202,7 @@ export function TicketCreateModal({ open, onOpenChange, projectId, connectionId,
   const isTitleEmpty = !title.trim()
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <DialogContent
         data-testid="ticket-create-modal"
         className={cn("sm:max-w-lg", isDragOver && "ring-2 ring-primary ring-offset-2")}
@@ -301,6 +331,11 @@ export function TicketCreateModal({ open, onOpenChange, projectId, connectionId,
           </Button>
         </DialogFooter>
       </DialogContent>
+      <TicketDiscardChangesDialog
+        open={showDiscardConfirm}
+        onKeepEditing={() => setShowDiscardConfirm(false)}
+        onDiscard={closeImmediately}
+      />
     </Dialog>
   )
 }

--- a/src/renderer/src/components/kanban/TicketDiscardChangesDialog.tsx
+++ b/src/renderer/src/components/kanban/TicketDiscardChangesDialog.tsx
@@ -1,0 +1,50 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+
+interface TicketDiscardChangesDialogProps {
+  open: boolean
+  onKeepEditing: () => void
+  onDiscard: () => void
+}
+
+export function TicketDiscardChangesDialog({
+  open,
+  onKeepEditing,
+  onDiscard
+}: TicketDiscardChangesDialogProps): React.JSX.Element {
+  return (
+    <AlertDialog open={open} onOpenChange={(isOpen) => !isOpen && onKeepEditing()}>
+      <AlertDialogContent data-testid="ticket-discard-confirm-dialog">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Discard changes?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to close this window? Your changes will be discarded.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            data-testid="ticket-discard-keep-editing-btn"
+            onClick={onKeepEditing}
+          >
+            Keep editing
+          </AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            data-testid="ticket-discard-confirm-btn"
+            onClick={onDiscard}
+          >
+            Discard changes
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/test/kanban/session-11/ticket-modal-modes.test.tsx
+++ b/test/kanban/session-11/ticket-modal-modes.test.tsx
@@ -386,6 +386,103 @@ describe('Session 11: Kanban Ticket Modal Modes', () => {
       })
     })
 
+    test('pristine cancel closes edit modal immediately', () => {
+      act(() => {
+        useKanbanStore.setState({ selectedTicketId: 'ticket-1' })
+      })
+
+      render(<KanbanTicketModal />)
+
+      fireEvent.click(screen.getByTestId('ticket-edit-cancel-btn'))
+
+      expect(useKanbanStore.getState().selectedTicketId).toBeNull()
+      expect(screen.queryByTestId('ticket-discard-confirm-dialog')).not.toBeInTheDocument()
+    })
+
+    test('dirty cancel shows discard confirmation instead of closing edit modal', () => {
+      act(() => {
+        useKanbanStore.setState({ selectedTicketId: 'ticket-1' })
+      })
+
+      render(<KanbanTicketModal />)
+
+      fireEvent.change(screen.getByTestId('ticket-edit-title-input'), {
+        target: { value: 'Changed title' }
+      })
+      fireEvent.click(screen.getByTestId('ticket-edit-cancel-btn'))
+
+      expect(useKanbanStore.getState().selectedTicketId).toBe('ticket-1')
+      expect(screen.getByTestId('ticket-discard-confirm-dialog')).toBeInTheDocument()
+    })
+
+    test('keep editing preserves edit draft after discard prompt', () => {
+      act(() => {
+        useKanbanStore.setState({ selectedTicketId: 'ticket-1' })
+      })
+
+      render(<KanbanTicketModal />)
+
+      const descriptionInput = screen.getByTestId('ticket-edit-description-input') as HTMLTextAreaElement
+      fireEvent.change(descriptionInput, {
+        target: { value: 'Changed description' }
+      })
+      fireEvent.click(screen.getByTestId('ticket-edit-cancel-btn'))
+      fireEvent.click(screen.getByTestId('ticket-discard-keep-editing-btn'))
+
+      expect(useKanbanStore.getState().selectedTicketId).toBe('ticket-1')
+      expect(descriptionInput).toHaveValue('Changed description')
+      expect(screen.queryByTestId('ticket-discard-confirm-dialog')).not.toBeInTheDocument()
+    })
+
+    test('discard confirmation closes edit modal without saving', () => {
+      act(() => {
+        useKanbanStore.setState({ selectedTicketId: 'ticket-1' })
+      })
+
+      render(<KanbanTicketModal />)
+
+      fireEvent.change(screen.getByTestId('ticket-edit-title-input'), {
+        target: { value: 'Changed title' }
+      })
+      fireEvent.click(screen.getByTestId('ticket-edit-cancel-btn'))
+      fireEvent.click(screen.getByTestId('ticket-discard-confirm-btn'))
+
+      expect(useKanbanStore.getState().selectedTicketId).toBeNull()
+      expect(mockKanban.ticket.update).not.toHaveBeenCalled()
+    })
+
+    test('top-right close button uses the same discard confirmation in edit modal', () => {
+      act(() => {
+        useKanbanStore.setState({ selectedTicketId: 'ticket-1' })
+      })
+
+      render(<KanbanTicketModal />)
+
+      fireEvent.change(screen.getByTestId('ticket-edit-title-input'), {
+        target: { value: 'Changed title' }
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^close$/i }))
+
+      expect(useKanbanStore.getState().selectedTicketId).toBe('ticket-1')
+      expect(screen.getByTestId('ticket-discard-confirm-dialog')).toBeInTheDocument()
+    })
+
+    test('reverting edit draft back to original allows immediate close', () => {
+      act(() => {
+        useKanbanStore.setState({ selectedTicketId: 'ticket-1' })
+      })
+
+      render(<KanbanTicketModal />)
+
+      const titleInput = screen.getByTestId('ticket-edit-title-input')
+      fireEvent.change(titleInput, { target: { value: 'Changed title' } })
+      fireEvent.change(titleInput, { target: { value: 'Implement auth flow' } })
+      fireEvent.click(screen.getByTestId('ticket-edit-cancel-btn'))
+
+      expect(useKanbanStore.getState().selectedTicketId).toBeNull()
+      expect(screen.queryByTestId('ticket-discard-confirm-dialog')).not.toBeInTheDocument()
+    })
+
     test('delete removes ticket after confirmation', async () => {
       act(() => {
         useKanbanStore.setState({ selectedTicketId: 'ticket-1' })

--- a/test/kanban/session-7/ticket-creation-modal.test.tsx
+++ b/test/kanban/session-7/ticket-creation-modal.test.tsx
@@ -201,7 +201,7 @@ describe('Session 7: Ticket Creation Modal', () => {
     })
   })
 
-  test('Cancel button closes modal without creating', () => {
+  test('pristine Cancel button closes modal without creating', () => {
     const onOpenChange = vi.fn()
     render(
       <TicketCreateModal open={true} onOpenChange={onOpenChange} projectId="proj-1" />
@@ -212,6 +212,69 @@ describe('Session 7: Ticket Creation Modal', () => {
 
     expect(onOpenChange).toHaveBeenCalledWith(false)
     expect(mockKanban.ticket.create).not.toHaveBeenCalled()
+  })
+
+  test('dirty Cancel button shows discard confirmation before closing', () => {
+    const onOpenChange = vi.fn()
+    render(
+      <TicketCreateModal open={true} onOpenChange={onOpenChange} projectId="proj-1" />
+    )
+
+    fireEvent.change(screen.getByTestId('ticket-title-input'), {
+      target: { value: 'Unsaved ticket' }
+    })
+
+    fireEvent.click(screen.getByTestId('ticket-cancel-btn'))
+
+    expect(screen.getByTestId('ticket-discard-confirm-dialog')).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  test('discard confirmation keep editing preserves create draft', () => {
+    const onOpenChange = vi.fn()
+    render(
+      <TicketCreateModal open={true} onOpenChange={onOpenChange} projectId="proj-1" />
+    )
+
+    const titleInput = screen.getByTestId('ticket-title-input') as HTMLInputElement
+    fireEvent.change(titleInput, { target: { value: 'Unsaved ticket' } })
+    fireEvent.click(screen.getByTestId('ticket-cancel-btn'))
+    fireEvent.click(screen.getByTestId('ticket-discard-keep-editing-btn'))
+
+    expect(screen.queryByTestId('ticket-discard-confirm-dialog')).not.toBeInTheDocument()
+    expect(titleInput).toHaveValue('Unsaved ticket')
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  test('discard confirmation closes create modal after confirm', () => {
+    const onOpenChange = vi.fn()
+    render(
+      <TicketCreateModal open={true} onOpenChange={onOpenChange} projectId="proj-1" />
+    )
+
+    fireEvent.change(screen.getByTestId('ticket-description-input'), {
+      target: { value: 'Unsaved description' }
+    })
+    fireEvent.click(screen.getByTestId('ticket-cancel-btn'))
+    fireEvent.click(screen.getByTestId('ticket-discard-confirm-btn'))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  test('top-right close button uses the same discard confirmation in create modal', () => {
+    const onOpenChange = vi.fn()
+    render(
+      <TicketCreateModal open={true} onOpenChange={onOpenChange} projectId="proj-1" />
+    )
+
+    fireEvent.change(screen.getByTestId('ticket-title-input'), {
+      target: { value: 'Unsaved ticket' }
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }))
+
+    expect(screen.getByTestId('ticket-discard-confirm-dialog')).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalled()
   })
 
   test('description field accepts markdown text', () => {


### PR DESCRIPTION
## Summary
- Added a shared discard-confirmation dialog for ticket create and edit flows.
- Made ticket edit cancel and modal close respect draft dirtiness, including title, description, and attachments.
- Updated create modal close handling so dirty drafts prompt before closing, while pristine forms close immediately.
- Expanded modal tests to cover pristine close, dirty discard, keep-editing, and top-right close behavior.

## Testing
- Added/updated Vitest coverage in `test/kanban/session-11/ticket-modal-modes.test.tsx` for edit modal discard flows.
- Added/updated Vitest coverage in `test/kanban/session-7/ticket-creation-modal.test.tsx` for create modal discard flows.
- Not run locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that only alters modal close behavior to prevent accidental loss of unsaved ticket drafts. Main risk is minor regressions in modal open/close flow or dirty-state detection (title/description/attachments).
> 
> **Overview**
> Adds a shared `TicketDiscardChangesDialog` and wires it into both ticket creation and ticket editing so closing/canceling prompts when there are **unsaved changes**.
> 
> `KanbanTicketModal` now tracks edit-draft dirtiness (including attachments) and routes *Cancel* and the dialog close button through a single close handler that either shows the confirmation or force-closes the modal. `TicketCreateModal` similarly blocks closing a dirty draft (including multi-project selection changes) until the user confirms discard.
> 
> Expands Vitest coverage to assert pristine closes immediately, dirty drafts trigger the discard dialog, *Keep editing* preserves inputs, and top-right close uses the same behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03db76ee602e7714432c327e7316853516b5a728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->