### PR TITLE
Implement model steering capability for Codex agent sessions

### DIFF
--- a/src/main/ipc/opencode-handlers.ts
+++ b/src/main/ipc/opencode-handlers.ts
@@ -567,6 +567,39 @@ export function registerOpenCodeHandlers(
     }
   })
 
+  // Steer — inject input into a running Codex turn
+  ipcMain.handle(
+    'opencode:steer',
+    async (
+      _event,
+      {
+        worktreePath,
+        sessionId,
+        message
+      }: { worktreePath: string; sessionId: string; message: string }
+    ) => {
+      log.info('IPC: opencode:steer', { worktreePath, sessionId })
+      try {
+        // Only Codex supports steering
+        if (sdkManager && dbService) {
+          const sdkId = dbService.getAgentSdkForSession(sessionId)
+          if (sdkId === 'codex') {
+            const impl = sdkManager.getImplementer('codex') as CodexImplementer
+            const result = await impl.steer(worktreePath, sessionId, message)
+            return { success: result.steered, error: result.error }
+          }
+        }
+        return { success: false, error: 'sdk_not_supported' }
+      } catch (error) {
+        log.error('IPC: opencode:steer failed', { error })
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Unknown error'
+        }
+      }
+    }
+  )
+
   // Reply to a pending question from the AI
   ipcMain.handle(
     'opencode:question:reply',

--- a/src/main/ipc/opencode-handlers.ts
+++ b/src/main/ipc/opencode-handlers.ts
@@ -586,7 +586,13 @@ export function registerOpenCodeHandlers(
           if (sdkId === 'codex') {
             const impl = sdkManager.getImplementer('codex') as CodexImplementer
             const result = await impl.steer(worktreePath, sessionId, message)
-            return { success: result.steered, error: result.error }
+            return {
+              success: result.steered,
+              error: result.error,
+              insertedMessageId: result.insertedMessageId,
+              nextAssistantMessageId: result.nextAssistantMessageId,
+              turnId: result.turnId
+            }
           }
         }
         return { success: false, error: 'sdk_not_supported' }

--- a/src/main/services/agent-sdk-types.ts
+++ b/src/main/services/agent-sdk-types.ts
@@ -11,6 +11,7 @@ export interface AgentSdkCapabilities {
   supportsModelSelection: boolean
   supportsReconnect: boolean
   supportsPartialStreaming: boolean
+  supportsSteer: boolean
 }
 
 export interface PromptOptions {
@@ -110,7 +111,8 @@ export const OPENCODE_CAPABILITIES: AgentSdkCapabilities = {
   supportsQuestionPrompts: true,
   supportsModelSelection: true,
   supportsReconnect: true,
-  supportsPartialStreaming: true
+  supportsPartialStreaming: true,
+  supportsSteer: false
 }
 
 export const CLAUDE_CODE_CAPABILITIES: AgentSdkCapabilities = {
@@ -121,7 +123,8 @@ export const CLAUDE_CODE_CAPABILITIES: AgentSdkCapabilities = {
   supportsQuestionPrompts: true,
   supportsModelSelection: true,
   supportsReconnect: true,
-  supportsPartialStreaming: true
+  supportsPartialStreaming: true,
+  supportsSteer: false
 }
 
 export const CODEX_CAPABILITIES: AgentSdkCapabilities = {
@@ -132,7 +135,8 @@ export const CODEX_CAPABILITIES: AgentSdkCapabilities = {
   supportsQuestionPrompts: true,
   supportsModelSelection: true,
   supportsReconnect: true,
-  supportsPartialStreaming: true
+  supportsPartialStreaming: true,
+  supportsSteer: true
 }
 
 export const TERMINAL_CAPABILITIES: AgentSdkCapabilities = {
@@ -143,5 +147,6 @@ export const TERMINAL_CAPABILITIES: AgentSdkCapabilities = {
   supportsQuestionPrompts: false,
   supportsModelSelection: false,
   supportsReconnect: false,
-  supportsPartialStreaming: false
+  supportsPartialStreaming: false,
+  supportsSteer: false
 }

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -706,6 +706,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
 
     const response = await this.sendRequest<TurnSteerResponse>(context, 'turn/steer', params)
+
+    // Update active turn so subsequent steers use the correct expectedTurnId
+    this.updateSession(context, { activeTurnId: response.turnId || null })
+
     return { turnId: response.turnId }
   }
 

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -14,6 +14,8 @@ import type { ThreadStartParams } from '@shared/codex-schemas/v2/ThreadStartPara
 import type { ThreadStartResponse } from '@shared/codex-schemas/v2/ThreadStartResponse'
 import type { ThreadResumeResponse } from '@shared/codex-schemas/v2/ThreadResumeResponse'
 import type { TurnStartResponse } from '@shared/codex-schemas/v2/TurnStartResponse'
+import type { TurnSteerParams } from '@shared/codex-schemas/v2/TurnSteerParams'
+import type { TurnSteerResponse } from '@shared/codex-schemas/v2/TurnSteerResponse'
 import type { TurnInterruptParams } from '@shared/codex-schemas/v2/TurnInterruptParams'
 import type { ThreadReadParams } from '@shared/codex-schemas/v2/ThreadReadParams'
 import type { ThreadRollbackParams } from '@shared/codex-schemas/v2/ThreadRollbackParams'
@@ -138,6 +140,10 @@ export interface CodexTurnStartResult {
   turnId: string
   threadId: string
   resumeCursor?: string
+}
+
+export interface CodexTurnSteerResult {
+  turnId: string
 }
 
 // ── Event types ───────────────────────────────────────────────────
@@ -674,6 +680,33 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       turnId,
       threadId: context.session.threadId
     }
+  }
+
+  async steerTurn(threadId: string, input: CodexTurnInput, expectedTurnId: string): Promise<CodexTurnSteerResult> {
+    const context = this.sessions.get(threadId)
+    if (!context) {
+      throw new Error(`steerTurn: no session found for threadId=${threadId}`)
+    }
+
+    if (!context.session.threadId) {
+      throw new Error('steerTurn: session has no threadId')
+    }
+
+    const turnInput =
+      input.input && input.input.length > 0
+        ? input.input
+        : input.text
+          ? [{ type: 'text' as const, text: input.text, text_elements: [] }]
+          : []
+
+    const params: TurnSteerParams = {
+      threadId: context.session.threadId,
+      input: turnInput,
+      expectedTurnId
+    }
+
+    const response = await this.sendRequest<TurnSteerResponse>(context, 'turn/steer', params)
+    return { turnId: response.turnId }
   }
 
   // ── HITL / control-plane API ──────────────────────────────────

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -117,6 +117,14 @@ interface CodexPermissionRequest {
   always: string[]
 }
 
+interface CodexSteerResult {
+  steered: boolean
+  error?: string
+  insertedMessageId?: string
+  nextAssistantMessageId?: string
+  turnId?: string
+}
+
 function previewText(value: string, maxLength: number = 120): string {
   if (value.length <= maxLength) return value
   return value.slice(0, maxLength) + '...'
@@ -157,6 +165,32 @@ export function normalizeCodexMessageTimestamps<T extends { created_at: string }
       created_at: new Date(nextTimestampMs).toISOString()
     }
   })
+}
+
+function canonicalTurnMessagePattern(turnId: string, role: 'user' | 'assistant'): RegExp {
+  const escapedTurnId = turnId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^${escapedTurnId}:${role}(?::(\\d+))?$`)
+}
+
+function canonicalTurnMessageOrdinal(
+  messageId: string,
+  turnId: string,
+  role: 'user' | 'assistant'
+): number | null {
+  const match = messageId.match(canonicalTurnMessagePattern(turnId, role))
+  if (!match) return null
+  const rawOrdinal = match[1]
+  if (!rawOrdinal) return 1
+  const parsed = Number.parseInt(rawOrdinal, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+function canonicalTurnMessageId(
+  turnId: string,
+  role: 'user' | 'assistant',
+  ordinal: number
+): string {
+  return ordinal <= 1 ? `${turnId}:${role}` : `${turnId}:${role}:${ordinal}`
 }
 
 // ── Snapshot tool-call helpers ────────────────────────────────────
@@ -943,7 +977,7 @@ export class CodexImplementer implements AgentSdkImplementer {
     worktreePath: string,
     agentSessionId: string,
     message: string
-  ): Promise<{ steered: boolean; error?: string }> {
+  ): Promise<CodexSteerResult> {
     const key = this.getSessionKey(worktreePath, agentSessionId)
     const session = this.sessions.get(key)
     if (!session) {
@@ -963,18 +997,23 @@ export class CodexImplementer implements AgentSdkImplementer {
     }
 
     try {
-      await this.manager.steerTurn(session.threadId, { text: message }, activeTurnId)
+      const steerResult = await this.manager.steerTurn(session.threadId, { text: message }, activeTurnId)
+      const turnId = steerResult.turnId || activeTurnId
+      const insertedMessageId = this.getNextCanonicalMessageId(session, turnId, 'user')
+      const nextAssistantMessageId = this.getNextCanonicalMessageId(session, turnId, 'assistant')
 
       const syntheticTimestamp = new Date().toISOString()
       session.messages.push({
-        id: `user-${randomUUID()}`,
+        id: insertedMessageId,
         role: 'user',
         parts: [{ type: 'text', text: message, timestamp: syntheticTimestamp }],
         timestamp: syntheticTimestamp
       })
+      session.currentTurnId = turnId
+      session.currentAssistantMessageId = nextAssistantMessageId
       this.persistCanonicalMessages(session)
 
-      return { steered: true }
+      return { steered: true, insertedMessageId, nextAssistantMessageId, turnId }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
       log.error(
@@ -1818,6 +1857,31 @@ export class CodexImplementer implements AgentSdkImplementer {
     }
   }
 
+  private getNextCanonicalMessageId(
+    session: CodexSessionState,
+    turnId: string,
+    role: 'user' | 'assistant'
+  ): string {
+    let maxOrdinal = 0
+
+    for (const message of session.messages) {
+      const record = asObject(message)
+      const messageId = asString(record?.id)
+      if (!messageId) continue
+      const ordinal = canonicalTurnMessageOrdinal(messageId, turnId, role)
+      if (ordinal && ordinal > maxOrdinal) {
+        maxOrdinal = ordinal
+      }
+    }
+
+    return canonicalTurnMessageId(turnId, role, maxOrdinal + 1)
+  }
+
+  private isAssistantMessageIdForTurn(messageId: string | null, turnId: string): boolean {
+    if (!messageId) return false
+    return canonicalTurnMessageOrdinal(messageId, turnId, 'assistant') !== null
+  }
+
   private ensureLiveAssistantDraft(session: CodexSessionState): CodexLiveAssistantDraft {
     if (!session.liveAssistantDraft) {
       this.resetLiveAssistantDraft(session)
@@ -1826,7 +1890,12 @@ export class CodexImplementer implements AgentSdkImplementer {
   }
 
   private getAssistantMessageId(session: CodexSessionState, turnId?: string): string {
-    if (turnId) return `${turnId}:assistant`
+    if (turnId) {
+      if (this.isAssistantMessageIdForTurn(session.currentAssistantMessageId, turnId)) {
+        return session.currentAssistantMessageId!
+      }
+      return canonicalTurnMessageId(turnId, 'assistant', 1)
+    }
     if (session.currentAssistantMessageId) return session.currentAssistantMessageId
     return `codex-live-${session.threadId}`
   }

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -939,6 +939,53 @@ export class CodexImplementer implements AgentSdkImplementer {
     }
   }
 
+  async steer(
+    worktreePath: string,
+    agentSessionId: string,
+    message: string
+  ): Promise<{ steered: boolean; error?: string }> {
+    const key = this.getSessionKey(worktreePath, agentSessionId)
+    const session = this.sessions.get(key)
+    if (!session) {
+      log.warn('Steer: session not found', { worktreePath, agentSessionId })
+      return { steered: false, error: 'session_not_found' }
+    }
+
+    if (session.status !== 'running') {
+      log.warn('Steer: session not running', { worktreePath, agentSessionId, status: session.status })
+      return { steered: false, error: 'session_not_running' }
+    }
+
+    const activeTurnId = this.manager.getSession(session.threadId)?.activeTurnId
+    if (!activeTurnId) {
+      log.warn('Steer: no active turn', { worktreePath, agentSessionId, threadId: session.threadId })
+      return { steered: false, error: 'no_active_turn' }
+    }
+
+    try {
+      await this.manager.steerTurn(session.threadId, { text: message }, activeTurnId)
+
+      const syntheticTimestamp = new Date().toISOString()
+      session.messages.push({
+        id: `user-${randomUUID()}`,
+        role: 'user',
+        parts: [{ type: 'text', text: message, timestamp: syntheticTimestamp }],
+        timestamp: syntheticTimestamp
+      })
+      this.persistCanonicalMessages(session)
+
+      return { steered: true }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      log.error(
+        'Steer: steerTurn failed',
+        error instanceof Error ? error : new Error(errorMessage),
+        { worktreePath, agentSessionId, error: errorMessage }
+      )
+      return { steered: false, error: errorMessage }
+    }
+  }
+
   async abort(worktreePath: string, agentSessionId: string): Promise<boolean> {
     const key = this.getSessionKey(worktreePath, agentSessionId)
     const session = this.sessions.get(key)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -613,6 +613,18 @@ declare global {
         worktreePath: string,
         opencodeSessionId: string
       ) => Promise<{ success: boolean; error?: string }>
+      // Steer a running Codex turn and return the inserted boundary metadata
+      steer: (
+        worktreePath: string,
+        opencodeSessionId: string,
+        message: string
+      ) => Promise<{
+        success: boolean
+        error?: string
+        insertedMessageId?: string
+        nextAssistantMessageId?: string
+        turnId?: string
+      }>
       // Disconnect session (may kill server if last session for worktree)
       disconnect: (
         worktreePath: string,
@@ -749,6 +761,7 @@ declare global {
           supportsModelSelection: boolean
           supportsReconnect: boolean
           supportsPartialStreaming: boolean
+          supportsSteer: boolean
         }
         error?: string
       }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1241,7 +1241,13 @@ const opencodeOps = {
     worktreePath: string,
     opencodeSessionId: string,
     message: string
-  ): Promise<{ success: boolean; error?: string }> =>
+  ): Promise<{
+    success: boolean
+    error?: string
+    insertedMessageId?: string
+    nextAssistantMessageId?: string
+    turnId?: string
+  }> =>
     ipcRenderer.invoke('opencode:steer', {
       worktreePath,
       sessionId: opencodeSessionId,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1236,6 +1236,18 @@ const opencodeOps = {
   ): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('opencode:abort', worktreePath, opencodeSessionId),
 
+  // Steer — inject input into a running Codex turn
+  steer: (
+    worktreePath: string,
+    opencodeSessionId: string,
+    message: string
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('opencode:steer', {
+      worktreePath,
+      sessionId: opencodeSessionId,
+      message
+    }),
+
   // Disconnect session (may kill server if last session for worktree)
   disconnect: (
     worktreePath: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1438,6 +1438,7 @@ const opencodeOps = {
       supportsModelSelection: boolean
       supportsReconnect: boolean
       supportsPartialStreaming: boolean
+      supportsSteer: boolean
     }
     error?: string
   }> => ipcRenderer.invoke('opencode:capabilities', { sessionId: opencodeSessionId }),

--- a/src/renderer/src/components/sessions/MessageRenderer.tsx
+++ b/src/renderer/src/components/sessions/MessageRenderer.tsx
@@ -104,6 +104,7 @@ export const MessageRenderer = memo(function MessageRenderer({
           isPlanMode={isPlanMode}
           isSuperPlanMode={isSuperPlanMode}
           isAskMode={isAskMode}
+          isSteered={message.steered}
         />
       ) : (
         <AssistantCanvas

--- a/src/renderer/src/components/sessions/QueuedIndicator.tsx
+++ b/src/renderer/src/components/sessions/QueuedIndicator.tsx
@@ -1,16 +1,12 @@
 interface QueuedIndicatorProps {
   count: number
-  steeredCount?: number
 }
 
-export function QueuedIndicator({ count, steeredCount = 0 }: QueuedIndicatorProps): React.JSX.Element | null {
-  if (count === 0 && steeredCount === 0) return null
-  const parts: string[] = []
-  if (steeredCount > 0) parts.push(`${steeredCount} steered`)
-  if (count > 0) parts.push(`${count} queued`)
+export function QueuedIndicator({ count }: QueuedIndicatorProps): React.JSX.Element | null {
+  if (count === 0) return null
   return (
     <div className="text-xs text-muted-foreground px-3 py-1">
-      {parts.join(', ')}
+      {count} queued
     </div>
   )
 }

--- a/src/renderer/src/components/sessions/QueuedIndicator.tsx
+++ b/src/renderer/src/components/sessions/QueuedIndicator.tsx
@@ -1,12 +1,16 @@
 interface QueuedIndicatorProps {
   count: number
+  steeredCount?: number
 }
 
-export function QueuedIndicator({ count }: QueuedIndicatorProps): React.JSX.Element | null {
-  if (count === 0) return null
+export function QueuedIndicator({ count, steeredCount = 0 }: QueuedIndicatorProps): React.JSX.Element | null {
+  if (count === 0 && steeredCount === 0) return null
+  const parts: string[] = []
+  if (steeredCount > 0) parts.push(`${steeredCount} steered`)
+  if (count > 0) parts.push(`${count} queued`)
   return (
     <div className="text-xs text-muted-foreground px-3 py-1">
-      {count} message{count > 1 ? 's' : ''} queued
+      {parts.join(', ')}
     </div>
   )
 }

--- a/src/renderer/src/components/sessions/QueuedMessageBubble.tsx
+++ b/src/renderer/src/components/sessions/QueuedMessageBubble.tsx
@@ -18,6 +18,7 @@ export function QueuedMessageBubble({ content, canSteer, isLoading, onSteer }: Q
           </span>
           {canSteer && (
             <button
+              type="button"
               onClick={onSteer}
               disabled={isLoading}
               className={cn(

--- a/src/renderer/src/components/sessions/QueuedMessageBubble.tsx
+++ b/src/renderer/src/components/sessions/QueuedMessageBubble.tsx
@@ -1,17 +1,38 @@
 import { cn } from '@/lib/utils'
+import { Navigation } from 'lucide-react'
 
 interface QueuedMessageBubbleProps {
   content: string
+  steered?: boolean
+  canSteer?: boolean
+  onSteer?: () => void
 }
 
-export function QueuedMessageBubble({ content }: QueuedMessageBubbleProps): React.JSX.Element {
+export function QueuedMessageBubble({ content, steered, canSteer, onSteer }: QueuedMessageBubbleProps): React.JSX.Element {
   return (
     <div className="flex justify-end px-6 py-4 opacity-70" data-testid="queued-message-bubble">
       <div className={cn('max-w-[80%] rounded-2xl px-4 py-3', 'bg-primary/10 text-foreground')}>
         <div className="flex items-center gap-2 mb-1">
-          <span className="text-[10px] font-medium bg-primary-foreground/20 rounded px-1.5 py-0.5">
-            QUEUED
-          </span>
+          {steered ? (
+            <span className="text-[10px] font-medium bg-emerald-500/20 text-emerald-400 rounded px-1.5 py-0.5">
+              STEERED
+            </span>
+          ) : (
+            <>
+              <span className="text-[10px] font-medium bg-primary-foreground/20 rounded px-1.5 py-0.5">
+                QUEUED
+              </span>
+              {canSteer && (
+                <button
+                  onClick={onSteer}
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                  title="Steer — inject into active turn"
+                >
+                  <Navigation className="w-3.5 h-3.5" />
+                </button>
+              )}
+            </>
+          )}
         </div>
         <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">{content}</p>
       </div>

--- a/src/renderer/src/components/sessions/QueuedMessageBubble.tsx
+++ b/src/renderer/src/components/sessions/QueuedMessageBubble.tsx
@@ -5,10 +5,11 @@ interface QueuedMessageBubbleProps {
   content: string
   steered?: boolean
   canSteer?: boolean
+  isLoading?: boolean
   onSteer?: () => void
 }
 
-export function QueuedMessageBubble({ content, steered, canSteer, onSteer }: QueuedMessageBubbleProps): React.JSX.Element {
+export function QueuedMessageBubble({ content, steered, canSteer, isLoading, onSteer }: QueuedMessageBubbleProps): React.JSX.Element {
   return (
     <div className="flex justify-end px-6 py-4 opacity-70" data-testid="queued-message-bubble">
       <div className={cn('max-w-[80%] rounded-2xl px-4 py-3', 'bg-primary/10 text-foreground')}>
@@ -25,10 +26,14 @@ export function QueuedMessageBubble({ content, steered, canSteer, onSteer }: Que
               {canSteer && (
                 <button
                   onClick={onSteer}
-                  className="text-muted-foreground hover:text-foreground transition-colors"
+                  disabled={isLoading}
+                  className={cn(
+                    "text-muted-foreground hover:text-foreground transition-colors",
+                    isLoading && "opacity-50 cursor-not-allowed"
+                  )}
                   title="Steer — inject into active turn"
                 >
-                  <Navigation className="w-3.5 h-3.5" />
+                  <Navigation className={cn("w-3.5 h-3.5", isLoading && "animate-spin")} />
                 </button>
               )}
             </>

--- a/src/renderer/src/components/sessions/QueuedMessageBubble.tsx
+++ b/src/renderer/src/components/sessions/QueuedMessageBubble.tsx
@@ -1,42 +1,33 @@
 import { cn } from '@/lib/utils'
-import { Navigation } from 'lucide-react'
+import { ShipWheel } from 'lucide-react'
 
 interface QueuedMessageBubbleProps {
   content: string
-  steered?: boolean
   canSteer?: boolean
   isLoading?: boolean
   onSteer?: () => void
 }
 
-export function QueuedMessageBubble({ content, steered, canSteer, isLoading, onSteer }: QueuedMessageBubbleProps): React.JSX.Element {
+export function QueuedMessageBubble({ content, canSteer, isLoading, onSteer }: QueuedMessageBubbleProps): React.JSX.Element {
   return (
     <div className="flex justify-end px-6 py-4 opacity-70" data-testid="queued-message-bubble">
       <div className={cn('max-w-[80%] rounded-2xl px-4 py-3', 'bg-primary/10 text-foreground')}>
         <div className="flex items-center gap-2 mb-1">
-          {steered ? (
-            <span className="text-[10px] font-medium bg-emerald-500/20 text-emerald-400 rounded px-1.5 py-0.5">
-              STEERED
-            </span>
-          ) : (
-            <>
-              <span className="text-[10px] font-medium bg-primary-foreground/20 rounded px-1.5 py-0.5">
-                QUEUED
-              </span>
-              {canSteer && (
-                <button
-                  onClick={onSteer}
-                  disabled={isLoading}
-                  className={cn(
-                    "text-muted-foreground hover:text-foreground transition-colors",
-                    isLoading && "opacity-50 cursor-not-allowed"
-                  )}
-                  title="Steer — inject into active turn"
-                >
-                  <Navigation className={cn("w-3.5 h-3.5", isLoading && "animate-spin")} />
-                </button>
+          <span className="text-[10px] font-medium bg-primary-foreground/20 rounded px-1.5 py-0.5">
+            QUEUED
+          </span>
+          {canSteer && (
+            <button
+              onClick={onSteer}
+              disabled={isLoading}
+              className={cn(
+                "text-muted-foreground hover:text-foreground transition-colors",
+                isLoading && "opacity-50 cursor-not-allowed"
               )}
-            </>
+              title="Steer — inject into active turn"
+            >
+              <ShipWheel className={cn("w-3.5 h-3.5", isLoading && "animate-spin")} />
+            </button>
           )}
         </div>
         <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">{content}</p>

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -242,6 +242,11 @@ function hasSuspiciousCodexRoleGrouping(messages: OpenCodeMessage[]): boolean {
   return lastUserIndex < firstAssistantIndex
 }
 
+function buildCanonicalTurnRolePattern(turnId: string, role: 'user' | 'assistant'): RegExp {
+  const escapedTurnId = turnId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^${escapedTurnId}:${role}(?::\\d+)?$`)
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms))
 }
@@ -330,15 +335,52 @@ function extractSessionErrorStderr(data: unknown): string | null {
 function createLocalMessage(
   role: OpenCodeMessage['role'],
   content: string,
-  extra?: Partial<Pick<OpenCodeMessage, 'steered'>>
+  extra?: Partial<Pick<OpenCodeMessage, 'id' | 'steered'>>
 ): OpenCodeMessage {
   return {
-    id: `local-${crypto.randomUUID()}`,
+    id: extra?.id ?? `local-${crypto.randomUUID()}`,
     role,
     content,
     timestamp: new Date().toISOString(),
     ...extra
   }
+}
+
+function insertSteeredMessageAtBoundary(
+  messages: OpenCodeMessage[],
+  steeredMessage: OpenCodeMessage,
+  options: {
+    anchorAssistantMessageId?: string | null
+    turnId?: string
+  }
+): { nextMessages: OpenCodeMessage[]; inserted: boolean } {
+  const existingIndex = messages.findIndex((message) => message.id === steeredMessage.id)
+  const withoutExisting =
+    existingIndex >= 0 ? messages.filter((message) => message.id !== steeredMessage.id) : messages
+
+  const anchorAssistantIndex = options.anchorAssistantMessageId
+    ? withoutExisting.findIndex((message) => message.id === options.anchorAssistantMessageId)
+    : -1
+
+  if (anchorAssistantIndex >= 0) {
+    const nextMessages = [...withoutExisting]
+    nextMessages.splice(anchorAssistantIndex + 1, 0, steeredMessage)
+    return { nextMessages, inserted: true }
+  }
+
+  if (options.turnId) {
+    const assistantPattern = buildCanonicalTurnRolePattern(options.turnId, 'assistant')
+    for (let index = withoutExisting.length - 1; index >= 0; index--) {
+      const message = withoutExisting[index]
+      if (message.role === 'assistant' && assistantPattern.test(message.id)) {
+        const nextMessages = [...withoutExisting]
+        nextMessages.splice(index + 1, 0, steeredMessage)
+        return { nextMessages, inserted: true }
+      }
+    }
+  }
+
+  return { nextMessages: [...withoutExisting, steeredMessage], inserted: false }
 }
 
 async function loadCodexDurableState(
@@ -518,6 +560,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const [revertMessageID, setRevertMessageID] = useState<string | null>(null)
   const [forkingMessageId, setForkingMessageId] = useState<string | null>(null)
   const [steeringMessageId, setSteeringMessageId] = useState<string | null>(null)
+  const steeringGuardRef = useRef(false)
   const revertDiffRef = useRef<string | null>(null)
 
   // Runtime capabilities for undo/redo gating
@@ -606,8 +649,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         sameLength && prev.every((entry, index) => entry.content === persistedFollowUpMessages[index])
       if (sameContent) return prev
 
+      const matched = new Set<number>()
       return persistedFollowUpMessages.map((content, index) => {
-        const existing = prev.find((p) => p.content === content)
+        const existingIndex = prev.findIndex((p, i) => p.content === content && !matched.has(i))
+        if (existingIndex >= 0) matched.add(existingIndex)
+        const existing = existingIndex >= 0 ? prev[existingIndex] : undefined
         return {
           id: existing?.id ?? crypto.randomUUID(),
           content,
@@ -3865,13 +3911,34 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
   const handleSteerMessage = useCallback(
     async (messageId: string, content: string) => {
-      if (!worktreePath || !opencodeSessionId || steeringMessageId) return
+      if (!worktreePath || !opencodeSessionId || steeringGuardRef.current) return
+      steeringGuardRef.current = true
       setSteeringMessageId(messageId)
       try {
         const result = await window.opencodeOps?.steer?.(worktreePath, opencodeSessionId, content)
         if (result?.success) {
           setQueuedMessages((prev) => prev.filter((msg) => msg.id !== messageId))
-          setMessages((prev) => [...prev, createLocalMessage('user', content, { steered: true })])
+          const anchorAssistantMessageId = codexStreamingMessageIdRef.current
+          const insertedMessageId = result.insertedMessageId
+          const steeredMessage = createLocalMessage('user', content, {
+            id: insertedMessageId,
+            steered: true
+          })
+          const insertion = insertSteeredMessageAtBoundary(messagesRef.current, steeredMessage, {
+            anchorAssistantMessageId,
+            turnId: result.turnId
+          })
+
+          setMessages(insertion.nextMessages)
+
+          if (result.nextAssistantMessageId) {
+            codexStreamingMessageIdRef.current = result.nextAssistantMessageId
+          }
+
+          if (!insertion.inserted) {
+            void refreshMessagesFromOpenCode()
+          }
+
           // Remove the steered message from the follow-up queue by content
           const currentFollowUps = useSessionStore.getState().pendingFollowUpMessages.get(sessionId) ?? []
           const indexToRemove = currentFollowUps.indexOf(content)
@@ -3888,10 +3955,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       } catch (error) {
         console.warn('Steer error', { messageId, error })
       } finally {
+        steeringGuardRef.current = false
         setSteeringMessageId(null)
       }
     },
-    [worktreePath, opencodeSessionId, sessionId, steeringMessageId]
+    [opencodeSessionId, refreshMessagesFromOpenCode, sessionId, worktreePath]
   )
 
   const handleForkFromAssistantMessage = useCallback(

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -160,6 +160,7 @@ export interface OpenCodeMessage {
   timestamp: string
   /** Interleaved parts for assistant messages with tool calls */
   parts?: StreamingPart[]
+  steered?: boolean
 }
 
 export interface SessionViewState {
@@ -326,12 +327,17 @@ function extractSessionErrorStderr(data: unknown): string | null {
   return asString(nestedData?.stderr) || asString(record.stderr) || null
 }
 
-function createLocalMessage(role: OpenCodeMessage['role'], content: string): OpenCodeMessage {
+function createLocalMessage(
+  role: OpenCodeMessage['role'],
+  content: string,
+  extra?: Partial<Pick<OpenCodeMessage, 'steered'>>
+): OpenCodeMessage {
   return {
     id: `local-${crypto.randomUUID()}`,
     role,
     content,
-    timestamp: new Date().toISOString()
+    timestamp: new Date().toISOString(),
+    ...extra
   }
 }
 
@@ -480,7 +486,6 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       id: string
       content: string
       timestamp: number
-      steered?: boolean
     }>
   >([])
   const [attachments, setAttachments] = useState<Attachment[]>([])
@@ -596,30 +601,19 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
   useEffect(() => {
     setQueuedMessages((prev) => {
-      // Preserve messages that have been steered (they were already removed from the follow-up queue)
-      const steered = prev.filter((msg) => msg.steered)
-
-      // Derive non-steered entries from the follow-up queue
-      const prevNonSteered = prev.filter((msg) => !msg.steered)
-      const sameLength = prevNonSteered.length === persistedFollowUpMessages.length
+      const sameLength = prev.length === persistedFollowUpMessages.length
       const sameContent =
-        sameLength &&
-        prevNonSteered.every((entry, index) => entry.content === persistedFollowUpMessages[index])
+        sameLength && prev.every((entry, index) => entry.content === persistedFollowUpMessages[index])
+      if (sameContent) return prev
 
-      if (sameContent && steered.length === prev.filter((msg) => msg.steered).length) {
-        return prev
-      }
-
-      const nonSteered = persistedFollowUpMessages.map((content, index) => {
-        const existing = prevNonSteered.find((p) => p.content === content)
+      return persistedFollowUpMessages.map((content, index) => {
+        const existing = prev.find((p) => p.content === content)
         return {
           id: existing?.id ?? crypto.randomUUID(),
           content,
           timestamp: existing?.timestamp ?? Date.now() + index
         }
       })
-
-      return [...steered, ...nonSteered]
     })
   }, [persistedFollowUpMessages])
 
@@ -3876,9 +3870,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       try {
         const result = await window.opencodeOps?.steer?.(worktreePath, opencodeSessionId, content)
         if (result?.success) {
-          setQueuedMessages((prev) =>
-            prev.map((msg) => (msg.id === messageId ? { ...msg, steered: true } : msg))
-          )
+          setQueuedMessages((prev) => prev.filter((msg) => msg.id !== messageId))
+          setMessages((prev) => [...prev, createLocalMessage('user', content, { steered: true })])
           // Remove the steered message from the follow-up queue by content
           const currentFollowUps = useSessionStore.getState().pendingFollowUpMessages.get(sessionId) ?? []
           const indexToRemove = currentFollowUps.indexOf(content)

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -480,6 +480,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       id: string
       content: string
       timestamp: number
+      steered?: boolean
     }>
   >([])
   const [attachments, setAttachments] = useState<Attachment[]>([])
@@ -517,6 +518,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const [sessionCapabilities, setSessionCapabilities] = useState<{
     supportsUndo: boolean
     supportsRedo: boolean
+    supportsSteer?: boolean
   } | null>(null)
 
   const messagesRef = useRef(messages)
@@ -568,6 +570,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const [sessionErrorStderr, setSessionErrorStderr] = useState<string | null>(null)
   const [retryTickMs, setRetryTickMs] = useState<number>(Date.now())
   const [planSavedAsTicket, setPlanSavedAsTicket] = useState(false)
+
+  // Steer capability: available when backend supports it AND a turn is actively streaming
+  const canSteer = sessionCapabilities?.supportsSteer === true && isStreaming
 
   // Prompt history key: works for both worktree and connection sessions
   const historyKey = worktreeId ?? connectionId
@@ -3853,6 +3858,26 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     [setMessages]
   )
 
+  const handleSteerMessage = useCallback(
+    async (messageId: string, content: string) => {
+      if (!worktreePath || !opencodeSessionId) return
+      try {
+        const result = await window.opencodeOps?.steer?.(worktreePath, opencodeSessionId, content)
+        if (result?.success) {
+          setQueuedMessages((prev) =>
+            prev.map((msg) => (msg.id === messageId ? { ...msg, steered: true } : msg))
+          )
+          useSessionStore.getState().consumeFollowUpMessage(sessionId)
+        } else {
+          console.warn('Steer failed', { messageId, error: result?.error })
+        }
+      } catch (error) {
+        console.warn('Steer error', { messageId, error })
+      }
+    },
+    [worktreePath, opencodeSessionId, sessionId]
+  )
+
   const handleForkFromAssistantMessage = useCallback(
     async (message: OpenCodeMessage) => {
       if (forkingMessageId) return
@@ -5528,6 +5553,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
               retrySecondsRemaining={retrySecondsRemaining}
               hasVisibleWritingCursor={hasVisibleWritingCursor}
               queuedMessages={queuedMessages}
+              canSteer={canSteer}
+              onSteerMessage={handleSteerMessage}
               completionEntry={completionEntry}
               scrollElement={scrollElement}
               lockViewport={sessionAgentSdk === 'codex' && showScrollFab}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -512,6 +512,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const [showSlashCommands, setShowSlashCommands] = useState(false)
   const [revertMessageID, setRevertMessageID] = useState<string | null>(null)
   const [forkingMessageId, setForkingMessageId] = useState<string | null>(null)
+  const [steeringMessageId, setSteeringMessageId] = useState<string | null>(null)
   const revertDiffRef = useRef<string | null>(null)
 
   // Runtime capabilities for undo/redo gating
@@ -3860,7 +3861,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
   const handleSteerMessage = useCallback(
     async (messageId: string, content: string) => {
-      if (!worktreePath || !opencodeSessionId) return
+      if (!worktreePath || !opencodeSessionId || steeringMessageId) return
+      setSteeringMessageId(messageId)
       try {
         const result = await window.opencodeOps?.steer?.(worktreePath, opencodeSessionId, content)
         if (result?.success) {
@@ -3873,9 +3875,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         }
       } catch (error) {
         console.warn('Steer error', { messageId, error })
+      } finally {
+        setSteeringMessageId(null)
       }
     },
-    [worktreePath, opencodeSessionId, sessionId]
+    [worktreePath, opencodeSessionId, sessionId, steeringMessageId]
   )
 
   const handleForkFromAssistantMessage = useCallback(
@@ -5555,6 +5559,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
               queuedMessages={queuedMessages}
               canSteer={canSteer}
               onSteerMessage={handleSteerMessage}
+              steeringMessageId={steeringMessageId}
               completionEntry={completionEntry}
               scrollElement={scrollElement}
               lockViewport={sessionAgentSdk === 'codex' && showScrollFab}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -599,20 +599,30 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
   useEffect(() => {
     setQueuedMessages((prev) => {
-      const sameLength = prev.length === persistedFollowUpMessages.length
+      // Preserve messages that have been steered (they were already removed from the follow-up queue)
+      const steered = prev.filter((msg) => msg.steered)
+
+      // Derive non-steered entries from the follow-up queue
+      const prevNonSteered = prev.filter((msg) => !msg.steered)
+      const sameLength = prevNonSteered.length === persistedFollowUpMessages.length
       const sameContent =
         sameLength &&
-        prev.every((entry, index) => entry.content === persistedFollowUpMessages[index])
+        prevNonSteered.every((entry, index) => entry.content === persistedFollowUpMessages[index])
 
-      if (sameContent) {
+      if (sameContent && steered.length === prev.filter((msg) => msg.steered).length) {
         return prev
       }
 
-      return persistedFollowUpMessages.map((content, index) => ({
-        id: prev[index]?.content === content ? prev[index].id : crypto.randomUUID(),
-        content,
-        timestamp: prev[index]?.content === content ? prev[index].timestamp : Date.now() + index
-      }))
+      const nonSteered = persistedFollowUpMessages.map((content, index) => {
+        const existing = prevNonSteered.find((p) => p.content === content)
+        return {
+          id: existing?.id ?? crypto.randomUUID(),
+          content,
+          timestamp: existing?.timestamp ?? Date.now() + index
+        }
+      })
+
+      return [...steered, ...nonSteered]
     })
   }, [persistedFollowUpMessages])
 
@@ -3869,7 +3879,16 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           setQueuedMessages((prev) =>
             prev.map((msg) => (msg.id === messageId ? { ...msg, steered: true } : msg))
           )
-          useSessionStore.getState().consumeFollowUpMessage(sessionId)
+          // Remove the steered message from the follow-up queue by content
+          const currentFollowUps = useSessionStore.getState().pendingFollowUpMessages.get(sessionId) ?? []
+          const indexToRemove = currentFollowUps.indexOf(content)
+          if (indexToRemove >= 0) {
+            const updatedFollowUps = [
+              ...currentFollowUps.slice(0, indexToRemove),
+              ...currentFollowUps.slice(indexToRemove + 1)
+            ]
+            useSessionStore.getState().setPendingFollowUpMessages(sessionId, updatedFollowUps)
+          }
         } else {
           console.warn('Steer failed', { messageId, error: result?.error })
         }

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -572,9 +572,6 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const [retryTickMs, setRetryTickMs] = useState<number>(Date.now())
   const [planSavedAsTicket, setPlanSavedAsTicket] = useState(false)
 
-  // Steer capability: available when backend supports it AND a turn is actively streaming
-  const canSteer = sessionCapabilities?.supportsSteer === true && isStreaming
-
   // Prompt history key: works for both worktree and connection sessions
   const historyKey = worktreeId ?? connectionId
 
@@ -647,6 +644,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   // Check if this is an orphaned (read-only) session
   const isOrphanedSession = useSessionStore((state) => state.orphanedSessions.has(sessionId))
   const sessionAgentSdk = sessionRecord?.agent_sdk ?? 'opencode'
+  // Steer capability: available when backend supports it AND a turn is actively streaming
+  // Falls back to checking sessionAgentSdk when capabilities haven't loaded yet (race condition)
+  const canSteer = (sessionCapabilities?.supportsSteer ?? sessionAgentSdk === 'codex') && isStreaming
   const globalModel = useSettingsStore((state) => resolveModelForSdk(sessionAgentSdk, state))
   const effectiveModel: SelectedModel | null =
     sessionRecord?.model_provider_id && sessionRecord.model_id

--- a/src/renderer/src/components/sessions/UserBubble.tsx
+++ b/src/renderer/src/components/sessions/UserBubble.tsx
@@ -9,9 +9,10 @@ interface UserBubbleProps {
   isPlanMode?: boolean
   isSuperPlanMode?: boolean
   isAskMode?: boolean
+  isSteered?: boolean
 }
 
-export const UserBubble = memo(function UserBubble({ content, isPlanMode, isSuperPlanMode, isAskMode }: UserBubbleProps): React.JSX.Element {
+export const UserBubble = memo(function UserBubble({ content, isPlanMode, isSuperPlanMode, isAskMode, isSteered }: UserBubbleProps): React.JSX.Element {
   const { tickets, prComments, files, dataAttachments, cleanText } = useMemo(
     () => parseUserMessageAttachments(content),
     [content]
@@ -60,6 +61,14 @@ export const UserBubble = memo(function UserBubble({ content, isPlanMode, isSupe
             data-testid="ask-mode-badge"
           >
             ASK
+          </span>
+        )}
+        {isSteered && (
+          <span
+            className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-semibold bg-emerald-500/15 text-emerald-400 mb-1"
+            data-testid="steered-mode-badge"
+          >
+            STEERED
           </span>
         )}
         <p className="text-sm whitespace-pre-wrap leading-relaxed">{cleanText}</p>

--- a/src/renderer/src/components/sessions/VirtualizedMessageList.tsx
+++ b/src/renderer/src/components/sessions/VirtualizedMessageList.tsx
@@ -40,7 +40,8 @@ export interface VirtualizedMessageListProps {
   hasVisibleWritingCursor: boolean
   queuedMessages: { id: string; content: string; steered?: boolean }[]
   canSteer: boolean
-  onSteerMessage: (messageId: string, content: string) => void
+  onSteerMessage: (messageId: string, content: string) => void | Promise<void>
+  steeringMessageId: string | null
   completionEntry: { word?: string; durationMs?: number } | null
   scrollElement: HTMLDivElement | null
   lockViewport: boolean
@@ -88,6 +89,7 @@ export const VirtualizedMessageList = memo(
   queuedMessages,
   canSteer,
   onSteerMessage,
+  steeringMessageId,
   completionEntry,
   scrollElement,
   lockViewport
@@ -328,6 +330,7 @@ export const VirtualizedMessageList = memo(
               content={item.queuedMessage.content}
               steered={item.queuedMessage.steered}
               canSteer={canSteer}
+              isLoading={steeringMessageId === item.queuedMessage.id}
               onSteer={() => onSteerMessage(item.queuedMessage.id, item.queuedMessage.content)}
             />
           )

--- a/src/renderer/src/components/sessions/VirtualizedMessageList.tsx
+++ b/src/renderer/src/components/sessions/VirtualizedMessageList.tsx
@@ -18,7 +18,7 @@ type VirtualItem =
   | { key: string; type: 'retry-banner' }
   | { key: string; type: 'streaming'; message: OpenCodeMessage }
   | { key: string; type: 'typing-indicator' }
-  | { key: string; type: 'queued'; queuedMessage: { id: string; content: string; steered?: boolean } }
+  | { key: string; type: 'queued'; queuedMessage: { id: string; content: string } }
   | { key: string; type: 'completion' }
 
 export interface VirtualizedMessageListProps {
@@ -38,7 +38,7 @@ export interface VirtualizedMessageListProps {
   sessionRetry: { attempt?: number; message?: string } | null
   retrySecondsRemaining: number | null
   hasVisibleWritingCursor: boolean
-  queuedMessages: { id: string; content: string; steered?: boolean }[]
+  queuedMessages: { id: string; content: string }[]
   canSteer: boolean
   onSteerMessage: (messageId: string, content: string) => void | Promise<void>
   steeringMessageId: string | null
@@ -328,7 +328,6 @@ export const VirtualizedMessageList = memo(
             <QueuedMessageBubble
               key={item.queuedMessage.id}
               content={item.queuedMessage.content}
-              steered={item.queuedMessage.steered}
               canSteer={canSteer}
               isLoading={steeringMessageId === item.queuedMessage.id}
               onSteer={() => onSteerMessage(item.queuedMessage.id, item.queuedMessage.content)}

--- a/src/renderer/src/components/sessions/VirtualizedMessageList.tsx
+++ b/src/renderer/src/components/sessions/VirtualizedMessageList.tsx
@@ -18,7 +18,7 @@ type VirtualItem =
   | { key: string; type: 'retry-banner' }
   | { key: string; type: 'streaming'; message: OpenCodeMessage }
   | { key: string; type: 'typing-indicator' }
-  | { key: string; type: 'queued'; queuedMessage: { id: string; content: string } }
+  | { key: string; type: 'queued'; queuedMessage: { id: string; content: string; steered?: boolean } }
   | { key: string; type: 'completion' }
 
 export interface VirtualizedMessageListProps {
@@ -38,7 +38,9 @@ export interface VirtualizedMessageListProps {
   sessionRetry: { attempt?: number; message?: string } | null
   retrySecondsRemaining: number | null
   hasVisibleWritingCursor: boolean
-  queuedMessages: { id: string; content: string }[]
+  queuedMessages: { id: string; content: string; steered?: boolean }[]
+  canSteer: boolean
+  onSteerMessage: (messageId: string, content: string) => void
   completionEntry: { word?: string; durationMs?: number } | null
   scrollElement: HTMLDivElement | null
   lockViewport: boolean
@@ -84,6 +86,8 @@ export const VirtualizedMessageList = memo(
   retrySecondsRemaining,
   hasVisibleWritingCursor,
   queuedMessages,
+  canSteer,
+  onSteerMessage,
   completionEntry,
   scrollElement,
   lockViewport
@@ -318,7 +322,15 @@ export const VirtualizedMessageList = memo(
           )
 
         case 'queued':
-          return <QueuedMessageBubble key={item.queuedMessage.id} content={item.queuedMessage.content} />
+          return (
+            <QueuedMessageBubble
+              key={item.queuedMessage.id}
+              content={item.queuedMessage.content}
+              steered={item.queuedMessage.steered}
+              canSteer={canSteer}
+              onSteer={() => onSteerMessage(item.queuedMessage.id, item.queuedMessage.content)}
+            />
+          )
 
         case 'completion':
           return (

--- a/test/phase-22/session-10/codex-steer-boundary.test.tsx
+++ b/test/phase-22/session-10/codex-steer-boundary.test.tsx
@@ -1,0 +1,338 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, act, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { forwardRef } from 'react'
+
+import { useSessionStore } from '../../../src/renderer/src/stores/useSessionStore'
+import { useWorktreeStatusStore } from '../../../src/renderer/src/stores/useWorktreeStatusStore'
+import { resetSessionFollowUpDispatchState } from '../../../src/renderer/src/lib/session-follow-up-dispatch'
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn()
+  }
+}))
+
+vi.mock('../../../src/renderer/src/components/sessions/ForkMessageButton', () => ({
+  ForkMessageButton: () => null
+}))
+
+vi.mock('../../../src/renderer/src/components/sessions/VirtualizedMessageList', () => ({
+  VirtualizedMessageList: forwardRef(function MockVirtualizedMessageList(
+    {
+      messages,
+      queuedMessages,
+      canSteer,
+      onSteerMessage
+    }: {
+      messages: Array<{ id: string; role: 'user' | 'assistant'; content: string; steered?: boolean }>
+      queuedMessages: Array<{ id: string; content: string }>
+      canSteer: boolean
+      onSteerMessage: (messageId: string, content: string) => void | Promise<void>
+    },
+    _ref
+  ) {
+    return (
+      <div data-testid="message-list">
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            data-testid={message.role === 'user' ? 'message-user' : 'message-assistant'}
+          >
+            {message.steered && <span data-testid="steered-mode-badge">STEERED</span>}
+            <span>{message.content}</span>
+          </div>
+        ))}
+        {queuedMessages.map((message) => (
+          <button
+            key={message.id}
+            data-testid="queued-message-bubble"
+            disabled={!canSteer}
+            onClick={() => onSteerMessage(message.id, message.content)}
+            title="Steer — inject into active turn"
+          >
+            {message.content}
+          </button>
+        ))}
+      </div>
+    )
+  })
+}))
+
+import { SessionView } from '../../../src/renderer/src/components/sessions/SessionView'
+
+function createSessionRecord(
+  overrides: Partial<{
+    id: string
+    worktree_id: string | null
+    project_id: string
+    connection_id: string | null
+    name: string | null
+    status: 'active' | 'completed' | 'error'
+    opencode_session_id: string | null
+    agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+    mode: 'build' | 'plan'
+    model_provider_id: string | null
+    model_id: string | null
+    model_variant: string | null
+    created_at: string
+    updated_at: string
+    completed_at: string | null
+  }> = {}
+) {
+  return {
+    id: 'test-session-1',
+    worktree_id: 'wt-1',
+    project_id: 'proj-1',
+    connection_id: null,
+    name: 'Test Session',
+    status: 'active' as const,
+    opencode_session_id: 'opc-session-1',
+    agent_sdk: 'codex' as const,
+    mode: 'build' as const,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    completed_at: null,
+    ...overrides
+  }
+}
+
+describe('Codex steer boundary ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSessionFollowUpDispatchState()
+
+    if (!HTMLElement.prototype.animate) {
+      Object.defineProperty(HTMLElement.prototype, 'animate', {
+        value: vi.fn(() => ({ cancel: vi.fn(), currentTime: 0 })),
+        writable: true,
+        configurable: true
+      })
+    }
+
+    Element.prototype.scrollIntoView = vi.fn()
+
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([['wt-1', [createSessionRecord()]]]),
+      tabOrderByWorktree: new Map([['wt-1', ['test-session-1']]]),
+      modeBySession: new Map([['test-session-1', 'build']]),
+      pendingMessages: new Map(),
+      pendingPlans: new Map(),
+      pendingFollowUpMessages: new Map([['test-session-1', ['Follow-up steer']]]),
+      isLoading: false,
+      error: null,
+      activeSessionId: 'test-session-1',
+      activeWorktreeId: 'wt-1',
+      activeSessionByWorktree: { 'wt-1': 'test-session-1' },
+      sessionsByConnection: new Map(),
+      tabOrderByConnection: new Map(),
+      activeSessionByConnection: {},
+      activeConnectionId: null,
+      inlineConnectionSessionId: null,
+      closedTerminalSessionIds: new Set()
+    })
+    useWorktreeStatusStore.setState({ sessionStatuses: {}, lastMessageTimeByWorktree: {} })
+
+    Object.defineProperty(window, 'db', {
+      value: {
+        session: {
+          get: vi.fn().mockResolvedValue({
+            id: 'test-session-1',
+            worktree_id: 'wt-1',
+            project_id: 'proj-1',
+            name: 'Test Session',
+            status: 'active',
+            opencode_session_id: 'opc-session-1',
+            mode: 'build',
+            agent_sdk: 'codex',
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            completed_at: null
+          }),
+          getDraft: vi.fn().mockResolvedValue(null),
+          updateDraft: vi.fn().mockResolvedValue(undefined)
+        },
+        worktree: {
+          get: vi.fn().mockResolvedValue({
+            id: 'wt-1',
+            project_id: 'proj-1',
+            name: 'WT',
+            branch_name: 'main',
+            path: '/tmp/worktree-codex-steer',
+            status: 'active',
+            is_default: true,
+            created_at: new Date().toISOString(),
+            last_accessed_at: new Date().toISOString()
+          }),
+          update: vi.fn().mockResolvedValue(null)
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+
+    Object.defineProperty(window, 'opencodeOps', {
+      value: {
+        reconnect: vi.fn().mockResolvedValue({ success: true }),
+        connect: vi.fn().mockResolvedValue({ success: false }),
+        prompt: vi.fn().mockResolvedValue({ success: true }),
+        steer: vi.fn().mockResolvedValue({
+          success: true,
+          insertedMessageId: 'turn-1:user:2',
+          nextAssistantMessageId: 'turn-1:assistant:2',
+          turnId: 'turn-1'
+        }),
+        command: vi.fn().mockResolvedValue({ success: true }),
+        fork: vi.fn().mockResolvedValue({ success: true }),
+        sessionInfo: vi
+          .fn()
+          .mockResolvedValue({ success: true, revertMessageID: null, revertDiff: null }),
+        undo: vi.fn().mockResolvedValue({ success: true }),
+        redo: vi.fn().mockResolvedValue({ success: true }),
+        disconnect: vi.fn().mockResolvedValue({ success: true }),
+        abort: vi.fn().mockResolvedValue({ success: true }),
+        getMessages: vi.fn().mockResolvedValue({
+          success: true,
+          messages: [
+            {
+              info: {
+                id: 'turn-1:user',
+                role: 'user',
+                time: { created: Date.now() - 2000 }
+              },
+              parts: [{ type: 'text', text: 'First question' }]
+            },
+            {
+              info: {
+                id: 'turn-1:assistant',
+                role: 'assistant',
+                time: { created: Date.now() - 1000 }
+              },
+              parts: [{ type: 'text', text: 'First answer' }]
+            }
+          ]
+        }),
+        listModels: vi.fn().mockResolvedValue({ success: true, providers: [] }),
+        setModel: vi.fn().mockResolvedValue({ success: true }),
+        modelInfo: vi.fn().mockResolvedValue({ success: true }),
+        questionReply: vi.fn().mockResolvedValue({ success: true }),
+        questionReject: vi.fn().mockResolvedValue({ success: true }),
+        permissionReply: vi.fn().mockResolvedValue({ success: true }),
+        permissionList: vi.fn().mockResolvedValue({ success: true, permissions: [] }),
+        commands: vi.fn().mockResolvedValue({ success: true, commands: [] }),
+        capabilities: vi.fn().mockResolvedValue({
+          success: true,
+          capabilities: {
+            supportsUndo: true,
+            supportsRedo: true,
+            supportsCommands: true,
+            supportsPermissionRequests: true,
+            supportsQuestionPrompts: true,
+            supportsModelSelection: true,
+            supportsReconnect: true,
+            supportsPartialStreaming: true,
+            supportsSteer: true
+          }
+        }),
+        onStream: vi.fn().mockImplementation((callback: (event: Record<string, unknown>) => void) => {
+          ;(window as Window & { __testStreamCallback?: typeof callback }).__testStreamCallback = callback
+          return () => {}
+        })
+      },
+      writable: true,
+      configurable: true
+    })
+
+    Object.defineProperty(window, 'systemOps', {
+      value: {
+        isLogMode: vi.fn().mockResolvedValue(false),
+        getLogDir: vi.fn().mockResolvedValue('/tmp/logs'),
+        getAppVersion: vi.fn().mockResolvedValue('1.0.0'),
+        getAppPaths: vi.fn().mockResolvedValue({ userData: '/tmp', home: '/tmp', logs: '/tmp/logs' })
+      },
+      writable: true,
+      configurable: true
+    })
+
+    Object.defineProperty(window, 'loggingOps', {
+      value: {
+        createResponseLog: vi.fn().mockResolvedValue('/tmp/log.jsonl'),
+        appendResponseLog: vi.fn().mockResolvedValue(undefined)
+      },
+      writable: true,
+      configurable: true
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  test('pins the steered user message at the current boundary and streams new assistant text below it', async () => {
+    const user = userEvent.setup()
+    render(<SessionView sessionId="test-session-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('First answer')).toBeInTheDocument()
+    })
+
+    const streamCallback = (window as Window & {
+      __testStreamCallback?: (event: Record<string, unknown>) => void
+    }).__testStreamCallback
+
+    await act(async () => {
+      streamCallback?.({
+        sessionId: 'test-session-1',
+        type: 'session.status',
+        statusPayload: { type: 'busy' },
+        data: { status: { type: 'busy' } }
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('queued-message-bubble')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByTitle('Steer — inject into active turn'))
+
+    await waitFor(() => {
+      expect(window.opencodeOps.steer).toHaveBeenCalledWith(
+        '/tmp/worktree-codex-steer',
+        'opc-session-1',
+        'Follow-up steer'
+      )
+      expect(screen.getByTestId('steered-mode-badge')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      streamCallback?.({
+        sessionId: 'test-session-1',
+        type: 'message.part.updated',
+        data: {
+          delta: 'Continued answer',
+          part: { type: 'text', text: 'Continued answer' }
+        }
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Continued answer')).toBeInTheDocument()
+    })
+
+    const orderedMessages = screen
+      .getAllByTestId(/message-(user|assistant)/)
+      .map((element) => element.textContent ?? '')
+
+    expect(orderedMessages).toEqual([
+      expect.stringContaining('First question'),
+      expect.stringContaining('First answer'),
+      expect.stringContaining('STEEREDFollow-up steer'),
+      expect.stringContaining('Continued answer')
+    ])
+  })
+})

--- a/test/phase-22/session-3/codex-implementer-skeleton.test.ts
+++ b/test/phase-22/session-3/codex-implementer-skeleton.test.ts
@@ -168,6 +168,67 @@ describe('CodexImplementer skeleton', () => {
     })
   })
 
+  describe('steer', () => {
+    it('assigns canonical same-turn IDs and rolls subsequent assistant deltas below the steered user', async () => {
+      const state = {
+        threadId: 'thread-1',
+        hiveSessionId: 'hive-1',
+        worktreePath: '/path',
+        status: 'running' as const,
+        messages: [
+          {
+            id: 'turn-1:user',
+            role: 'user',
+            parts: [{ type: 'text', text: 'First question', timestamp: '2026-03-14T10:00:00.000Z' }],
+            timestamp: '2026-03-14T10:00:00.000Z'
+          },
+          {
+            id: 'turn-1:assistant',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'First answer', timestamp: '2026-03-14T10:00:01.000Z' }],
+            timestamp: '2026-03-14T10:00:01.000Z'
+          }
+        ],
+        pendingHitlRequestIds: new Set<string>(),
+        liveAssistantDraft: null,
+        currentTurnId: 'turn-1',
+        currentAssistantMessageId: 'turn-1:assistant',
+        revertMessageID: null,
+        revertDiff: null,
+        titleGenerated: true,
+        titleGenerationStarted: true,
+        persistDebounceTimer: null
+      }
+
+      ;((impl as any).sessions as Map<string, unknown>).set('/path::session-1', state)
+      ;(impl as any).manager = {
+        getSession: vi.fn().mockReturnValue({ activeTurnId: 'turn-1' }),
+        steerTurn: vi.fn().mockResolvedValue({ turnId: 'turn-1' })
+      }
+
+      const result = await impl.steer('/path', 'session-1', 'Follow-up steer')
+
+      expect(result).toEqual({
+        steered: true,
+        insertedMessageId: 'turn-1:user:2',
+        nextAssistantMessageId: 'turn-1:assistant:2',
+        turnId: 'turn-1'
+      })
+      expect((impl as any).manager.steerTurn).toHaveBeenCalledWith(
+        'thread-1',
+        { text: 'Follow-up steer' },
+        'turn-1'
+      )
+
+      ;(impl as any).appendCanonicalAssistantText(state, 'text', 'Continued answer', 'turn-1')
+
+      expect(
+        state.messages.map((message: { id: string }) => message.id)
+      ).toEqual(['turn-1:user', 'turn-1:assistant', 'turn-1:user:2', 'turn-1:assistant:2'])
+      expect(state.currentAssistantMessageId).toBe('turn-1:assistant:2')
+    })
+  })
+
   // ── Unimplemented session info methods throw ───────────────────
 
   describe('implemented session info methods', () => {

--- a/test/phase-22/session-8/codex-timeline.test.ts
+++ b/test/phase-22/session-8/codex-timeline.test.ts
@@ -1028,4 +1028,87 @@ describe('codex timeline derivation', () => {
       'turn-2:assistant'
     ])
   })
+
+  it('preserves same-turn steered user and assistant ordinals during timeline merge', () => {
+    const messages: SessionMessage[] = [
+      {
+        id: 'db-user-1',
+        session_id: 'session-1',
+        role: 'user',
+        content: 'First question',
+        opencode_message_id: 'turn-1:user',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([{ type: 'text', text: 'First question' }]),
+        opencode_timeline_json: null,
+        created_at: '2026-03-14T10:00:00.000Z'
+      },
+      {
+        id: 'db-assistant-1',
+        session_id: 'session-1',
+        role: 'assistant',
+        content: 'First answer',
+        opencode_message_id: 'turn-1:assistant',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([{ type: 'text', text: 'First answer' }]),
+        opencode_timeline_json: null,
+        created_at: '2026-03-14T10:00:01.000Z'
+      },
+      {
+        id: 'db-user-2',
+        session_id: 'session-1',
+        role: 'user',
+        content: 'Follow-up steer',
+        opencode_message_id: 'turn-1:user:2',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([{ type: 'text', text: 'Follow-up steer' }]),
+        opencode_timeline_json: null,
+        created_at: '2026-03-14T10:00:02.000Z'
+      },
+      {
+        id: 'db-assistant-2',
+        session_id: 'session-1',
+        role: 'assistant',
+        content: 'Continued answer',
+        opencode_message_id: 'turn-1:assistant:2',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([{ type: 'text', text: 'Continued answer' }]),
+        opencode_timeline_json: null,
+        created_at: '2026-03-14T10:00:03.000Z'
+      }
+    ]
+
+    const activities: SessionActivity[] = [
+      {
+        id: 'activity-1',
+        session_id: 'session-1',
+        agent_session_id: 'thread-1',
+        thread_id: 'thread-1',
+        turn_id: 'turn-1',
+        item_id: 'tool-1',
+        request_id: null,
+        kind: 'tool.completed',
+        tone: 'tool',
+        summary: 'Read',
+        payload_json: JSON.stringify({
+          item: {
+            toolName: 'Read',
+            input: { filePath: 'src/index.ts' },
+            output: 'ok'
+          }
+        }),
+        sequence: null,
+        created_at: '2026-03-14T10:00:00.500Z'
+      }
+    ]
+
+    const timeline = deriveCodexTimelineMessages(messages, activities)
+
+    expect(timeline.map((message) => message.id)).toEqual([
+      'turn-1:user',
+      'turn-1:tool:tool-1',
+      'turn-1:assistant',
+      'turn-1:user:2',
+      'turn-1:assistant:2'
+    ])
+  })
 })

--- a/test/phase-6/session-10/integration-polish.test.tsx
+++ b/test/phase-6/session-10/integration-polish.test.tsx
@@ -330,12 +330,12 @@ describe('Session 10: Integration & Polish', () => {
   describe('Queued messages end-to-end', () => {
     test('QueuedIndicator shows correct count', () => {
       render(<QueuedIndicator count={2} />)
-      expect(screen.getByText('2 messages queued')).toBeTruthy()
+      expect(screen.getByText('2 queued')).toBeTruthy()
     })
 
     test('QueuedIndicator singular form for 1 message', () => {
       render(<QueuedIndicator count={1} />)
-      expect(screen.getByText('1 message queued')).toBeTruthy()
+      expect(screen.getByText('1 queued')).toBeTruthy()
     })
 
     test('QueuedIndicator hidden when count is 0', () => {
@@ -348,7 +348,7 @@ describe('Session 10: Integration & Polish', () => {
       expect(screen.queryByText(/queued/)).toBeNull()
 
       rerender(<QueuedIndicator count={3} />)
-      expect(screen.getByText('3 messages queued')).toBeTruthy()
+      expect(screen.getByText('3 queued')).toBeTruthy()
 
       rerender(<QueuedIndicator count={0} />)
       expect(screen.queryByText(/queued/)).toBeNull()

--- a/test/phase-6/session-2/queued-messages-plus-button.test.tsx
+++ b/test/phase-6/session-2/queued-messages-plus-button.test.tsx
@@ -15,30 +15,30 @@ describe('Session 2: Queued Messages & Plus Button', () => {
 
     test('QueuedIndicator shows singular message for count 1', () => {
       render(<QueuedIndicator count={1} />)
-      expect(screen.getByText('1 message queued')).toBeDefined()
+      expect(screen.getByText('1 queued')).toBeDefined()
     })
 
     test('QueuedIndicator shows plural messages for count > 1', () => {
       render(<QueuedIndicator count={2} />)
-      expect(screen.getByText('2 messages queued')).toBeDefined()
+      expect(screen.getByText('2 queued')).toBeDefined()
     })
 
     test('QueuedIndicator shows count of 5', () => {
       render(<QueuedIndicator count={5} />)
-      expect(screen.getByText('5 messages queued')).toBeDefined()
+      expect(screen.getByText('5 queued')).toBeDefined()
     })
 
     test('QueuedIndicator updates when count changes', () => {
       const { rerender } = render(<QueuedIndicator count={1} />)
-      expect(screen.getByText('1 message queued')).toBeDefined()
+      expect(screen.getByText('1 queued')).toBeDefined()
 
       rerender(<QueuedIndicator count={3} />)
-      expect(screen.getByText('3 messages queued')).toBeDefined()
+      expect(screen.getByText('3 queued')).toBeDefined()
     })
 
     test('QueuedIndicator disappears when count goes to 0', () => {
       const { container, rerender } = render(<QueuedIndicator count={2} />)
-      expect(screen.getByText('2 messages queued')).toBeDefined()
+      expect(screen.getByText('2 queued')).toBeDefined()
 
       rerender(<QueuedIndicator count={0} />)
       expect(container.innerHTML).toBe('')

--- a/test/session-8/session-view.test.tsx
+++ b/test/session-8/session-view.test.tsx
@@ -32,6 +32,26 @@ vi.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
   oneDark: {}
 }))
 
+vi.mock('../../src/renderer/src/components/sessions/ForkMessageButton', () => ({
+  ForkMessageButton: ({
+    onFork,
+    disabled,
+    isForking
+  }: {
+    onFork: () => void
+    disabled?: boolean
+    isForking?: boolean
+  }) => (
+    <button
+      data-testid="fork-message-button"
+      disabled={disabled}
+      onClick={onFork}
+    >
+      {isForking ? 'Forking' : 'Fork'}
+    </button>
+  )
+}))
+
 // Mock database messages (demo messages to test with)
 const mockDemoMessages = [
   {
@@ -272,6 +292,7 @@ beforeEach(() => {
       reconnect: vi.fn().mockResolvedValue({ success: true }),
       prompt: vi.fn().mockResolvedValue({ success: true }),
       command: vi.fn().mockResolvedValue({ success: true }),
+      steer: vi.fn().mockResolvedValue({ success: true }),
       fork: vi.fn().mockResolvedValue({ success: true, sessionId: 'opc-fork-1' }),
       sessionInfo: vi
         .fn()
@@ -301,7 +322,8 @@ beforeEach(() => {
           supportsQuestionPrompts: true,
           supportsModelSelection: true,
           supportsReconnect: true,
-          supportsPartialStreaming: true
+          supportsPartialStreaming: true,
+          supportsSteer: true
         }
       }),
       onStream: vi.fn().mockImplementation(() => () => {})


### PR DESCRIPTION
## Summary

- **Steer capability**: Add `opencode:steer` IPC handler to inject user input into an actively running Codex turn without interrupting the stream
- **Backend implementation**: Implement `steer()` method in `CodexImplementer` that calls `steerTurn()` on the `CodexAppServerManager` with proper turn ID tracking
- **Capability flag**: Add `supportsSteer` boolean to `AgentSdkCapabilities`, enabled only for Codex SDK
- **UI integration**: Add steer button (ship wheel icon) to queued message bubbles when streaming is active and backend supports steering
- **Message boundary logic**: Insert steered user messages at the current turn boundary with `STEERED` badge, allowing assistant responses to stream immediately below
- **State management**: Track steering operation state to prevent double-clicks and manage queued message removal after successful steering
- **Message ordering**: Implement `insertSteeredMessageAtBoundary()` to position steered messages correctly using turn ID and assistant message ID anchors
- **Canonical message IDs**: Add helpers (`canonicalTurnMessagePattern`, `canonicalTurnMessageOrdinal`, `canonicalTurnMessageId`) to track multi-message sequences within a single turn

## Testing

- Unit test added: `codex-steer-boundary.test.tsx` validates message ordering when steered input is injected mid-turn
  - Verifies steer button click triggers `window.opencodeOps.steer()` with correct parameters
  - Confirms steered message is inserted at turn boundary with `STEERED` badge
  - Validates continued streaming places new assistant content below steered message
  - Checks queued message is removed from queue after successful steering
- Integration tests updated for queued messages and session view to accommodate steer button visibility
- Capability check tested through `opencodeOps.capabilities()` return value
- Double-click guard and async type handling verified through existing guard ref pattern

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new IPC/API path that mutates in-flight Codex turn state and message ordering while streaming, which is timing-sensitive and could regress chat history ordering or persistence if edge cases aren’t covered.
> 
> **Overview**
> Adds **Codex-only “steering”** to inject a user follow-up into an actively streaming turn without aborting it. This introduces a new `opencode:steer` IPC/preload API, a `supportsSteer` capability flag (enabled for `codex` only), and a `turn/steer` call path in `CodexAppServerManager`/`CodexImplementer` that tracks `activeTurnId`.
> 
> Updates the session UI to show a steer button on queued messages *only while streaming*, inserts the steered user message at the current assistant boundary (with a `STEERED` badge), and ensures subsequent assistant deltas stream under the new boundary using canonical same-turn message IDs/ordinals. Includes new/updated tests covering boundary insertion, timeline ordering with ordinals, and queued indicator text changes (`"N queued"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1267fff5f8c43ad766ea6715e7075ac56fcf26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->