### PR TITLE
Fix modal button clipping in progress column

### DIFF
--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -698,7 +698,7 @@ export function WorktreePickerModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         data-testid="worktree-picker-modal"
-        className="sm:max-w-[520px]"
+        className="sm:max-w-[520px] overflow-visible"
         onKeyDown={handleKeyDown}
       >
         <DialogHeader className="space-y-2.5 pb-1">


### PR DESCRIPTION
## Summary

- Adds `overflow-visible` class to WorktreePickerModal DialogContent
- Resolves button clipping issue when modal is displayed in the progress column
- Minimal change affecting only CSS class configuration

## Testing

- Verify modal displays without button clipping in progress column
- Confirm modal appearance and functionality unchanged in other columns
- Check that modal content remains properly contained and accessible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single Tailwind class change affecting modal overflow behavior; could slightly alter layering/scrolling but no logic or data-path changes.
> 
> **Overview**
> Fixes button/content clipping in the Kanban `WorktreePickerModal` by changing the `DialogContent` container to `overflow-visible` (keeping the existing max width). This allows elements that extend past the modal bounds to remain visible, particularly in the progress column layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caffca8e78fd0309cbfa487a8c0ae6f28efc171e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->