### PR TITLE
Fix OpenCode process termination and pass launch spec to SDK detection

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,10 +43,14 @@ import { CodexImplementer } from './services/codex-implementer'
 import { AgentSdkManager } from './services/agent-sdk-manager'
 import { resolveClaudeBinaryPath } from './services/claude-binary-resolver'
 import { resolveCodexBinaryPath } from './services/codex-binary-resolver'
-import { resolveOpenCodeLaunchSpec } from './services/opencode-binary-resolver'
+import {
+  resolveOpenCodeLaunchSpec,
+  type OpenCodeLaunchSpec
+} from './services/opencode-binary-resolver'
 import {
   setClaudeBinaryPath as setRouterClaudeBinaryPath,
-  setCodexBinaryPath as setRouterCodexBinaryPath
+  setCodexBinaryPath as setRouterCodexBinaryPath,
+  setOpenCodeLaunchSpec as setRouterOpenCodeLaunchSpec
 } from './services/text-generation-router'
 import type { AgentSdkImplementer } from './services/agent-sdk-types'
 import { telemetryService } from './services/telemetry-service'
@@ -272,7 +276,7 @@ function createWindow(): void {
 }
 
 // Register system IPC handlers
-function registerSystemHandlers(): void {
+function registerSystemHandlers(openCodeLaunchSpec: OpenCodeLaunchSpec | null): void {
   // Get log directory path
   ipcMain.handle('system:getLogDir', () => {
     return getLogDir()
@@ -379,7 +383,7 @@ function registerSystemHandlers(): void {
 
   // Detect which agent SDKs are installed on the system (first-launch setup)
   ipcMain.handle('system:detectAgentSdks', () => {
-    return detectAgentSdks()
+    return detectAgentSdks(openCodeLaunchSpec)
   })
 
   // Quit the app (needed for macOS where window.close() doesn't quit)
@@ -450,7 +454,7 @@ app.whenReady().then(async () => {
   registerDatabaseHandlers()
   registerProjectHandlers()
   registerWorktreeHandlers()
-  registerSystemHandlers()
+  registerSystemHandlers(openCodeLaunchSpec)
   registerSettingsHandlers()
   registerFileHandlers()
   registerAttachmentHandlers()
@@ -523,6 +527,7 @@ app.whenReady().then(async () => {
     claudeImpl.setClaudeBinaryPath(claudeBinaryPath)
     setRouterClaudeBinaryPath(claudeBinaryPath)
     openCodeService.setOpenCodeLaunchSpec(openCodeLaunchSpec)
+    setRouterOpenCodeLaunchSpec(openCodeLaunchSpec)
     const openCodePlaceholder = {
       id: 'opencode' as const,
       capabilities: {

--- a/src/main/ipc/opencode-handlers.ts
+++ b/src/main/ipc/opencode-handlers.ts
@@ -7,6 +7,7 @@ import type { AgentSdkManager } from '../services/agent-sdk-manager'
 import type { PromptOptions } from '../services/agent-sdk-types'
 import { ClaudeCodeImplementer } from '../services/claude-code-implementer'
 import { CodexImplementer } from '../services/codex-implementer'
+import { toError } from '../services/error-utils'
 
 const log = createLogger({ component: 'OpenCodeHandlers' })
 
@@ -16,10 +17,6 @@ const log = createLogger({ component: 'OpenCodeHandlers' })
 // SDK ID after the first prompt — using the session ID would cause re-injection
 // when the ID changes.
 const injectedWorktrees = new Set<string>()
-
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error))
-}
 
 export function registerOpenCodeHandlers(
   mainWindow: BrowserWindow,

--- a/src/main/services/error-utils.ts
+++ b/src/main/services/error-utils.ts
@@ -1,0 +1,6 @@
+/**
+ * Normalize an unknown thrown value into a proper Error instance.
+ */
+export function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/src/main/services/opencode-service.ts
+++ b/src/main/services/opencode-service.ts
@@ -7,6 +7,7 @@ import { autoRenameWorktreeBranch } from './git-service'
 import { getUserEnvironmentVariables } from './env-vars'
 import { maybeExtractJsonTitle } from '@shared/title-utils'
 import type { OpenCodeLaunchSpec } from './opencode-binary-resolver'
+import { toError } from './error-utils'
 
 const log = createLogger({ component: 'OpenCodeService' })
 
@@ -78,10 +79,6 @@ function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined
 }
 
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error))
-}
-
 function messageInfo(message: unknown): { id?: string; role?: string; parts: unknown[] } {
   const record = asRecord(message)
   const info = asRecord(record?.info)
@@ -141,6 +138,31 @@ function spawnOpenCodeServer(
     shell: launchSpec.shell
   })
 
+  // Hoisted to function scope so close() can use it. On Windows with shell:true,
+  // proc is cmd.exe — proc.kill() only kills the shell wrapper. terminateProcess
+  // uses taskkill /t to kill the entire process tree including the opencode child.
+  const terminateProcess = (force: boolean = false): void => {
+    if (process.platform === 'win32' && proc.pid !== undefined) {
+      const taskkillArgs = ['/pid', String(proc.pid), '/t']
+      if (force) taskkillArgs.push('/f')
+      const taskkill = spawn('taskkill', taskkillArgs, { stdio: 'ignore' })
+      taskkill.on('error', () => {
+        try {
+          proc.kill(force ? 'SIGKILL' : 'SIGTERM')
+        } catch {
+          // Process already exited
+        }
+      })
+      return
+    }
+
+    try {
+      proc.kill(force ? 'SIGKILL' : 'SIGTERM')
+    } catch {
+      // Process already exited
+    }
+  }
+
   const url = new Promise<string>((resolve, reject) => {
     let settled = false
 
@@ -156,28 +178,6 @@ function spawnOpenCodeServer(
       settled = true
       clearTimeout(id)
       reject(error)
-    }
-
-    const terminateProcess = (force: boolean = false): void => {
-      if (process.platform === 'win32' && proc.pid !== undefined) {
-        const taskkillArgs = ['/pid', String(proc.pid), '/t']
-        if (force) taskkillArgs.push('/f')
-        const taskkill = spawn('taskkill', taskkillArgs, { stdio: 'ignore' })
-        taskkill.on('error', () => {
-          try {
-            proc.kill(force ? 'SIGKILL' : 'SIGTERM')
-          } catch {
-            // Process already exited
-          }
-        })
-        return
-      }
-
-      try {
-        proc.kill(force ? 'SIGKILL' : 'SIGTERM')
-      } catch {
-        // Process already exited
-      }
     }
 
     const id = setTimeout(() => {
@@ -230,7 +230,7 @@ function spawnOpenCodeServer(
   return url.then((resolvedUrl) => ({
     url: resolvedUrl,
     close() {
-      proc.kill()
+      terminateProcess()
     }
   }))
 }

--- a/src/main/services/system-info.ts
+++ b/src/main/services/system-info.ts
@@ -2,7 +2,7 @@ import { app } from 'electron'
 import { execFileSync } from 'child_process'
 import { existsSync } from 'fs'
 import { getLogDir } from './logger'
-import { resolveOpenCodeLaunchSpec } from './opencode-binary-resolver'
+import type { OpenCodeLaunchSpec } from './opencode-binary-resolver'
 
 export interface AgentSdkDetection {
   opencode: boolean
@@ -16,7 +16,7 @@ export interface AppPaths {
   logs: string
 }
 
-export function detectAgentSdks(): AgentSdkDetection {
+export function detectAgentSdks(openCodeLaunchSpec: OpenCodeLaunchSpec | null): AgentSdkDetection {
   const whichCmd = process.platform === 'win32' ? 'where' : 'which'
   const check = (binary: string): boolean => {
     try {
@@ -32,7 +32,7 @@ export function detectAgentSdks(): AgentSdkDetection {
     }
   }
   return {
-    opencode: resolveOpenCodeLaunchSpec() !== null,
+    opencode: openCodeLaunchSpec !== null,
     claude: check('claude'),
     codex: check('codex')
   }

--- a/src/main/services/text-generation-router.ts
+++ b/src/main/services/text-generation-router.ts
@@ -9,6 +9,7 @@ import { resolveCodexBinaryPath } from './codex-binary-resolver'
 import { getCodexCliEnv } from './codex-cli-env'
 import { detectAgentSdks } from './system-info'
 import type { AgentSdkDetection } from './system-info'
+import type { OpenCodeLaunchSpec } from './opencode-binary-resolver'
 import { createLogger } from './logger'
 import type { AgentSdkId } from './agent-sdk-types'
 
@@ -30,6 +31,7 @@ const SDK_CACHE_TTL_MS = 60_000
 
 let claudeBinaryPath: string | null = null
 let codexBinaryPath: string | null = null
+let openCodeLaunchSpec: OpenCodeLaunchSpec | null = null
 
 export function setClaudeBinaryPath(path: string | null): void {
   claudeBinaryPath = path
@@ -39,10 +41,14 @@ export function setCodexBinaryPath(path: string | null): void {
   codexBinaryPath = path
 }
 
+export function setOpenCodeLaunchSpec(spec: OpenCodeLaunchSpec | null): void {
+  openCodeLaunchSpec = spec
+}
+
 function getCachedSdkDetection(): AgentSdkDetection {
   const now = Date.now()
   if (!cachedSdks || now - cacheTimestamp > SDK_CACHE_TTL_MS) {
-    cachedSdks = detectAgentSdks()
+    cachedSdks = detectAgentSdks(openCodeLaunchSpec)
     cacheTimestamp = now
   }
   return cachedSdks

--- a/test/phase-22/session-2/system-info-opencode-detection.test.ts
+++ b/test/phase-22/session-2/system-info-opencode-detection.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockExecFileSync, mockExistsSync, mockResolveOpenCodeLaunchSpec } = vi.hoisted(() => ({
+const { mockExecFileSync, mockExistsSync } = vi.hoisted(() => ({
   mockExecFileSync: vi.fn(),
-  mockExistsSync: vi.fn(),
-  mockResolveOpenCodeLaunchSpec: vi.fn()
+  mockExistsSync: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -11,10 +10,6 @@ vi.mock('electron', () => ({
     getPath: vi.fn().mockReturnValue('/tmp'),
     getVersion: vi.fn().mockReturnValue('1.0.0')
   }
-}))
-
-vi.mock('../../../src/main/services/opencode-binary-resolver', () => ({
-  resolveOpenCodeLaunchSpec: (...args: unknown[]) => mockResolveOpenCodeLaunchSpec(...args)
 }))
 
 vi.mock('child_process', () => ({
@@ -35,10 +30,6 @@ describe('system-info: detectAgentSdks opencode launchability', () => {
   })
 
   it('marks opencode available only when the launch spec resolves', async () => {
-    mockResolveOpenCodeLaunchSpec.mockReturnValue({
-      command: '/usr/local/bin/opencode',
-      shell: false
-    })
     mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
       const binary = args[0]
       if (binary === 'claude') return '/usr/local/bin/claude\n'
@@ -48,22 +39,23 @@ describe('system-info: detectAgentSdks opencode launchability', () => {
 
     const { detectAgentSdks } = await import('../../../src/main/services/system-info')
 
-    expect(detectAgentSdks()).toEqual({
+    expect(
+      detectAgentSdks({ command: '/usr/local/bin/opencode', shell: false })
+    ).toEqual({
       opencode: true,
       claude: true,
       codex: true
     })
   })
 
-  it('returns opencode false when the resolver cannot produce a launch spec', async () => {
-    mockResolveOpenCodeLaunchSpec.mockReturnValue(null)
+  it('returns opencode false when the launch spec is null', async () => {
     mockExecFileSync.mockImplementation(() => {
       throw new Error('not found')
     })
 
     const { detectAgentSdks } = await import('../../../src/main/services/system-info')
 
-    expect(detectAgentSdks()).toEqual({
+    expect(detectAgentSdks(null)).toEqual({
       opencode: false,
       claude: false,
       codex: false


### PR DESCRIPTION
## Summary

- **Extract `toError` utility function** to `error-utils.ts` for reusability across multiple modules (opencode-handlers and opencode-service)
- **Hoist `terminateProcess` function** in opencode-service to function scope so it can be properly called on process close, fixing resource cleanup
- **Improve Windows process termination** by using `taskkill /t` to kill entire process tree instead of just the shell wrapper when `shell: true`
- **Pass `openCodeLaunchSpec` to `detectAgentSdks()`** instead of having it resolve internally, allowing the detection logic to use the pre-resolved spec
- **Add `setOpenCodeLaunchSpec` setter** to text-generation-router for caching the launch spec alongside other SDK paths
- **Update system-info to accept OpenCodeLaunchSpec parameter** rather than calling resolver directly, reducing coupling and improving testability
- **Fix test mocking** by removing mock of opencode-binary-resolver and passing spec directly to detectAgentSdks

## Testing

- Unit tests updated: system-info-opencode-detection.test.ts now passes launch spec directly to detectAgentSdks
- Verify OpenCode server closes cleanly on Windows by checking process tree termination
- Verify OpenCode server closes cleanly on Linux/macOS with SIGTERM/SIGKILL signals
- Confirm SDK detection cache includes opencode launch spec state
- Verify no regressions in detectAgentSdks() detection of claude and codex binaries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OpenCode server spawning/termination and SDK availability routing, which can affect session lifecycle and provider fallback behavior across platforms (notably Windows). Changes are localized but could regress process cleanup or detection if the launch spec is not wired correctly.
> 
> **Overview**
> Fixes OpenCode server cleanup by making `spawnOpenCodeServer().close()` terminate the correct process, including using `taskkill` on Windows to kill the full process tree when launched with `shell: true`.
> 
> Plumbs a pre-resolved `OpenCodeLaunchSpec` through startup and routing: `detectAgentSdks` now takes the spec instead of resolving it internally, the system IPC handler passes it through, and `text-generation-router` stores it via a new `setOpenCodeLaunchSpec` so provider-availability caching reflects OpenCode launchability. Error normalization is deduplicated by extracting `toError` into `error-utils`, and the corresponding unit test is updated to pass the spec directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbf01fb60ea94218bdd7914f3784bfde1922424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->