### PR TITLE
Fix progress bar regression by correcting width calculation

### DIFF
--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -452,7 +452,7 @@ body::after {
 /* Safety-net defaults: bar is visible even if JS animation fails to start */
 .progress-bounce-bar {
   left: 0;
-  width: 25%;
+  right: 75%;
 }
 
 /* PR review comment HTML body styling (GitHub bodyHTML) */


### PR DESCRIPTION
## Summary

- Changes progress bar CSS from `width: 25%` to `right: 75%` for more reliable positioning
- Fixes regression in progress-bounce-bar element styling
- Uses right-based positioning instead of width-based to ensure consistent bar visibility
- Single-line CSS change in globals.css

## Testing

- Visual verification: Progress bar renders correctly at 25% width from the left
- Cross-browser: Confirm `right` property works consistently across Chrome, Firefox, Safari
- Animation state: Verify bar appears properly when JS animation fails to start
- Regression: Test against previous width-based implementation to ensure improvement
- Responsive: Check bar positioning on different viewport sizes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only tweak that changes fallback sizing/positioning for the indeterminate progress bar; potential impact is limited to visual rendering of the bar in edge cases where JS animation doesn't start.
> 
> **Overview**
> Fixes a regression in the indeterminate progress indicator by updating the `.progress-bounce-bar` safety-net CSS to use `right: 75%` (with `left: 0`) instead of `width: 25%`, aligning the fallback styling with the left/right-based animation approach to keep the bar reliably visible if JS-driven animation fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2e5b745bc14016434b77d0f9b4a1e0af4a50b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->