### PR TITLE
Keep branch selected after PR creation

### DIFF
--- a/src/renderer/src/components/pr/CreatePRModal.tsx
+++ b/src/renderer/src/components/pr/CreatePRModal.tsx
@@ -140,7 +140,7 @@ export function CreatePRModal({
     setIsStaging(false)
 
     // Pre-fill base branch from store
-    setBaseBranch(prTargetBranch ?? 'main')
+    setBaseBranch(prTargetBranch?.replace(/^origin\//, '') ?? 'main')
 
     // Fetch remote branches
     setLoadingBranches(true)
@@ -276,6 +276,15 @@ export function CreatePRModal({
     const prBody = body.trim()
     const branchName = branchInfo?.name ?? 'Pull Request'
     const provider = resolvePRContentProvider(defaultAgentSdk, availableAgentSdks)
+
+    // Persist the selected target branch so the Header dropdowns keep showing it
+    // after the push changes branchInfo.tracking
+    const normalizedTarget = targetBase.startsWith('origin/') ? targetBase : `origin/${targetBase}`
+    useGitStore.getState().setPrTargetBranch(worktreeId, normalizedTarget)
+    // Also pin the review dropdown so it doesn't shift to the pushed branch
+    if (!useGitStore.getState().reviewTargetBranch.get(worktreeId)) {
+      useGitStore.getState().setReviewTargetBranch(worktreeId, normalizedTarget)
+    }
 
     // Close modal — PR creation continues in background via notification
     setOpen(false)


### PR DESCRIPTION
## Summary

- Fix base branch initialization to properly strip `origin/` prefix from remote branch references
- Persist the selected PR target branch in the store after PR creation to maintain state in header dropdowns
- Pin the review target branch to prevent it from automatically shifting to the newly pushed branch
- Ensures consistent branch selection across the UI after completing PR workflow

## Testing

- Verify that base branch dropdown shows correct branch name without `origin/` prefix when opening PR modal
- Create a PR and confirm the target branch remains selected in header dropdowns after creation
- Verify review target branch doesn't shift to the newly pushed branch after PR creation
- Test with both remote-prefixed and local branch names

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change that normalizes branch names and persists dropdown selections; main risk is incorrect `origin/` normalization causing surprising branch targets in the PR flow.
> 
> **Overview**
> Fixes base-branch initialization in `CreatePRModal` to strip an `origin/` prefix when pre-filling the selected target branch.
> 
> When creating a PR, the modal now persists the chosen target branch (normalized to `origin/<branch>`) into the git store and, if unset, pins `reviewTargetBranch` as well so Header dropdown selections don’t shift after a push updates tracking info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a4b3ef882505b2823b41b94fc23e95c1e80d2a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->