### PR TITLE
Add terminal position setting with bottom panel layout option

### DIFF
--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { Header } from './Header'
 import { LeftSidebar } from './LeftSidebar'
@@ -57,7 +57,7 @@ function GlobalProjectSettings(): React.JSX.Element | null {
 }
 
 function TerminalManagerPortal(): React.JSX.Element {
-  const { getTarget } = useTerminalPortal()
+  const { getTarget, revision } = useTerminalPortal()
   const terminalPosition = useSettingsStore((s) => s.terminalPosition)
 
   // Read layout state for visibility computation
@@ -92,14 +92,6 @@ function TerminalManagerPortal(): React.JSX.Element {
   const isVisible = terminalPosition === 'bottom'
     ? bottomTerminalExpanded
     : !rightSidebarCollapsed && effectiveBottomPanelTab === 'terminal' && collapsedPanel !== 'bottom'
-
-  // Force re-render when portal targets mount/unmount
-  const [, setTick] = useState(0)
-  useEffect(() => {
-    // Small delay to ensure portal targets are mounted
-    const timer = setTimeout(() => setTick((t) => t + 1), 50)
-    return () => clearTimeout(timer)
-  }, [terminalPosition])
 
   const target = getTarget(terminalPosition)
 

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Header } from './Header'
 import { LeftSidebar } from './LeftSidebar'
 import { MainPane } from './MainPane'
@@ -21,8 +22,13 @@ import { useAutoUpdate } from '@/hooks/useAutoUpdate'
 import { ErrorBoundary, ErrorFallback } from '@/components/error'
 import { CreatePRModal } from '@/components/pr/CreatePRModal'
 import { ProjectSettingsDialog } from '@/components/projects/ProjectSettingsDialog'
+import { TerminalPortalProvider, useTerminalPortal } from '@/contexts/TerminalPortalContext'
+import { TerminalManager } from '@/components/terminal/TerminalManager'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useLayoutStore } from '@/stores/useLayoutStore'
 import { useGitStore } from '@/stores/useGitStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useDropZone } from '@/hooks/useDropZone'
@@ -48,6 +54,69 @@ function GlobalProjectSettings(): React.JSX.Element | null {
       }}
     />
   )
+}
+
+function TerminalManagerPortal(): React.JSX.Element {
+  const { getTarget } = useTerminalPortal()
+  const terminalPosition = useSettingsStore((s) => s.terminalPosition)
+
+  // Read layout state for visibility computation
+  const rightSidebarCollapsed = useLayoutStore((s) => s.rightSidebarCollapsed)
+  const bottomPanelTab = useLayoutStore((s) => s.bottomPanelTab)
+  const collapsedPanel = useLayoutStore((s) => s.collapsedPanel)
+  const bottomTerminalExpanded = useLayoutStore((s) => s.bottomTerminalExpanded)
+
+  const selectedWorktreeId = useWorktreeStore((s) => s.selectedWorktreeId)
+  const selectedConnectionId = useConnectionStore((s) => s.selectedConnectionId)
+  const isConnectionMode = !!selectedConnectionId && !selectedWorktreeId
+  const effectiveBottomPanelTab = isConnectionMode ? 'terminal' : bottomPanelTab
+
+  const worktreesByProject = useWorktreeStore((s) => s.worktreesByProject)
+  const selectedConnection = useConnectionStore((s) =>
+    s.selectedConnectionId ? s.connections.find((c) => c.id === s.selectedConnectionId) : null
+  )
+
+  const selectedWorktreePath = useMemo(() => {
+    if (isConnectionMode && selectedConnection?.path) {
+      return selectedConnection.path
+    }
+    if (!selectedWorktreeId) return null
+    for (const [, worktrees] of worktreesByProject) {
+      const worktree = worktrees.find((w) => w.id === selectedWorktreeId)
+      if (worktree) return worktree.path
+    }
+    return null
+  }, [selectedWorktreeId, worktreesByProject, isConnectionMode, selectedConnection?.path])
+
+  // Compute visibility based on position
+  const isVisible = terminalPosition === 'bottom'
+    ? bottomTerminalExpanded
+    : !rightSidebarCollapsed && effectiveBottomPanelTab === 'terminal' && collapsedPanel !== 'bottom'
+
+  // Force re-render when portal targets mount/unmount
+  const [, setTick] = useState(0)
+  useEffect(() => {
+    // Small delay to ensure portal targets are mounted
+    const timer = setTimeout(() => setTick((t) => t + 1), 50)
+    return () => clearTimeout(timer)
+  }, [terminalPosition])
+
+  const target = getTarget(terminalPosition)
+
+  const terminalManager = (
+    <TerminalManager
+      selectedWorktreeId={selectedWorktreeId}
+      worktreePath={selectedWorktreePath}
+      isVisible={isVisible}
+    />
+  )
+
+  if (target) {
+    return createPortal(terminalManager, target)
+  }
+
+  // Fallback: keep mounted but hidden until portal target is available
+  return <div className="hidden">{terminalManager}</div>
 }
 
 interface AppLayoutProps {
@@ -180,56 +249,59 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
   }, [createPRWorktreeId, createPRWorktreePath])
 
   return (
-    <div className="h-screen flex flex-col bg-background text-foreground" data-testid="app-layout">
-      <ErrorBoundary componentName="Header" fallback={<div className="h-12 bg-muted" />}>
-        <Header />
-      </ErrorBoundary>
-      <div className="flex-1 flex min-h-0" data-testid="layout-content">
-        <ErrorBoundary
-          componentName="LeftSidebar"
-          fallback={
-            <div className="w-60 border-r bg-muted/50 flex items-center justify-center">
-              <ErrorFallback compact title="Sidebar Error" />
-            </div>
-          }
-        >
-          <LeftSidebar />
+    <TerminalPortalProvider>
+      <div className="h-screen flex flex-col bg-background text-foreground" data-testid="app-layout">
+        <ErrorBoundary componentName="Header" fallback={<div className="h-12 bg-muted" />}>
+          <Header />
         </ErrorBoundary>
-        <ErrorBoundary componentName="MainPane">
-          <MainPane>{children}</MainPane>
+        <div className="flex-1 flex min-h-0" data-testid="layout-content">
+          <ErrorBoundary
+            componentName="LeftSidebar"
+            fallback={
+              <div className="w-60 border-r bg-muted/50 flex items-center justify-center">
+                <ErrorFallback compact title="Sidebar Error" />
+              </div>
+            }
+          >
+            <LeftSidebar />
+          </ErrorBoundary>
+          <ErrorBoundary componentName="MainPane">
+            <MainPane>{children}</MainPane>
+          </ErrorBoundary>
+          <ErrorBoundary
+            componentName="RightSidebar"
+            fallback={<div className="border-l bg-muted/50" />}
+          >
+            <RightSidebar />
+          </ErrorBoundary>
+        </div>
+        <Toaster />
+        {isDragging && <DropOverlay variant={activeSessionId ? 'normal' : 'warning'} />}
+        <ErrorBoundary componentName="SessionHistory" fallback={null}>
+          <SessionHistory />
         </ErrorBoundary>
-        <ErrorBoundary
-          componentName="RightSidebar"
-          fallback={<div className="border-l bg-muted/50" />}
-        >
-          <RightSidebar />
+        <ErrorBoundary componentName="CommandPalette" fallback={null}>
+          <CommandPalette />
         </ErrorBoundary>
+        <ErrorBoundary componentName="SettingsModal" fallback={null}>
+          <SettingsModal />
+        </ErrorBoundary>
+        <ErrorBoundary componentName="FileSearchDialog" fallback={null}>
+          <FileSearchDialog />
+        </ErrorBoundary>
+        <GlobalProjectSettings />
+        {createPRWorktreeId && createPRWorktreePath && (
+          <ErrorBoundary componentName="CreatePRModal" fallback={null}>
+            <CreatePRModal
+              worktreeId={createPRWorktreeId}
+              worktreePath={createPRWorktreePath}
+            />
+          </ErrorBoundary>
+        )}
+        <AgentSetupGuard />
+        <HelpOverlay />
       </div>
-      <Toaster />
-      {isDragging && <DropOverlay variant={activeSessionId ? 'normal' : 'warning'} />}
-      <ErrorBoundary componentName="SessionHistory" fallback={null}>
-        <SessionHistory />
-      </ErrorBoundary>
-      <ErrorBoundary componentName="CommandPalette" fallback={null}>
-        <CommandPalette />
-      </ErrorBoundary>
-      <ErrorBoundary componentName="SettingsModal" fallback={null}>
-        <SettingsModal />
-      </ErrorBoundary>
-      <ErrorBoundary componentName="FileSearchDialog" fallback={null}>
-        <FileSearchDialog />
-      </ErrorBoundary>
-      <GlobalProjectSettings />
-      {createPRWorktreeId && createPRWorktreePath && (
-        <ErrorBoundary componentName="CreatePRModal" fallback={null}>
-          <CreatePRModal
-            worktreeId={createPRWorktreeId}
-            worktreePath={createPRWorktreePath}
-          />
-        </ErrorBoundary>
-      )}
-      <AgentSetupGuard />
-      <HelpOverlay />
-    </div>
+      <TerminalManagerPortal />
+    </TerminalPortalProvider>
   )
 }

--- a/src/renderer/src/components/layout/BottomPanel.tsx
+++ b/src/renderer/src/components/layout/BottomPanel.tsx
@@ -7,6 +7,7 @@ import { useLayoutStore } from '@/stores/useLayoutStore'
 import type { BottomPanelTab } from '@/stores/useLayoutStore'
 import { useScriptStore } from '@/stores/useScriptStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import type { TerminalPosition } from '@/stores/useSettingsStore'
 import { extractDevServerUrl } from '@/lib/format-utils'
 import { getOrCreateBuffer } from '@/lib/output-ring-buffer'
 import { SetupTab } from './SetupTab'
@@ -21,8 +22,10 @@ const tabs: { id: BottomPanelTab; label: string; keybind: string }[] = [
 ]
 
 interface BottomPanelProps {
-  /** TerminalManager rendered by RightSidebar — passed as a slot to keep it alive across sidebar collapse */
-  terminalSlot: React.ReactNode
+  /** Callback ref to register the terminal portal target container */
+  terminalContainerRef: (el: HTMLDivElement | null) => void
+  /** Current terminal position setting */
+  terminalPosition: TerminalPosition
   /** When true, only the terminal tab is shown (setup/run are worktree-specific) */
   isConnectionMode?: boolean
   /** When true, the panel content is hidden (but kept mounted to preserve PTY state) */
@@ -32,17 +35,25 @@ interface BottomPanelProps {
 }
 
 export function BottomPanel({
-  terminalSlot,
+  terminalContainerRef,
+  terminalPosition,
   isConnectionMode,
   isCollapsed,
   onToggleCollapse
 }: BottomPanelProps): React.JSX.Element {
   const activeTab = useLayoutStore((s) => s.bottomPanelTab)
   const effectiveTab = isConnectionMode ? 'terminal' : activeTab
-  useGhosttyPromotion(effectiveTab === 'terminal')
   const setActiveTab = useLayoutStore((s) => s.setBottomPanelTab)
   const selectedWorktreeId = useWorktreeStore((s) => s.selectedWorktreeId)
-  const visibleTabs = isConnectionMode ? tabs.filter((t) => t.id === 'terminal') : tabs
+  const visibleTabs = terminalPosition === 'bottom'
+    ? tabs.filter((t) => t.id !== 'terminal')
+    : isConnectionMode
+      ? tabs.filter((t) => t.id === 'terminal')
+      : tabs
+
+  // If terminal tab was active but is now hidden (moved to bottom panel), fall back
+  const resolvedTab = (terminalPosition === 'bottom' && effectiveTab === 'terminal') ? 'run' : effectiveTab
+  useGhosttyPromotion(resolvedTab === 'terminal')
 
   // Open in Chrome state
   const scriptState = useScriptStore((s) =>
@@ -92,12 +103,12 @@ export function BottomPanel({
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
             className={`text-xs px-3 py-1.5 transition-colors relative ${
-              effectiveTab === tab.id
+              resolvedTab === tab.id
                 ? 'text-foreground'
                 : 'text-muted-foreground hover:text-foreground'
             }`}
             data-testid={`bottom-panel-tab-${tab.id}`}
-            data-active={effectiveTab === tab.id}
+            data-active={resolvedTab === tab.id}
           >
             {vimModeEnabled ? (
               <>
@@ -107,7 +118,7 @@ export function BottomPanel({
             ) : (
               tab.label
             )}
-            {effectiveTab === tab.id && (
+            {resolvedTab === tab.id && (
               <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
             )}
           </button>
@@ -190,12 +201,13 @@ export function BottomPanel({
       </div>
       {/* Use CSS hidden (not conditional rendering) to keep TerminalManager mounted and preserve PTY state */}
       <div className={cn("flex-1 min-h-0 overflow-hidden", isCollapsed && "hidden")} data-testid="bottom-panel-content">
-        {effectiveTab === 'setup' && <SetupTab worktreeId={selectedWorktreeId} />}
-        {effectiveTab === 'run' && <RunTab worktreeId={selectedWorktreeId} />}
-        {/* Terminal slot is always rendered but hidden when not active, preserving PTY state */}
-        <div className={effectiveTab === 'terminal' ? 'h-full w-full' : 'hidden'}>
-          {terminalSlot}
-        </div>
+        {resolvedTab === 'setup' && <SetupTab worktreeId={selectedWorktreeId} />}
+        {resolvedTab === 'run' && <RunTab worktreeId={selectedWorktreeId} />}
+        {/* Terminal portal target — always mounted when in sidebar mode to preserve PTY state */}
+        <div
+          ref={terminalContainerRef}
+          className={resolvedTab === 'terminal' ? 'h-full w-full' : 'hidden'}
+        />
       </div>
     </div>
   )

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -17,6 +17,7 @@ import { useSettingsStore } from '@/stores/useSettingsStore'
 import { KanbanBoard } from '@/components/kanban/KanbanBoard'
 import { KanbanIcon } from '@/components/kanban/KanbanIcon'
 import { PRNotificationStack } from '@/components/pr/PRNotificationStack'
+import { MainPaneTerminalPanel } from './MainPaneTerminalPanel'
 
 const MonacoDiffView = lazy(() => import('@/components/diff/MonacoDiffView'))
 const WorktreeContextEditor = lazy(() =>
@@ -44,6 +45,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const isPinnedBoardActive = useKanbanStore((state) => state.isPinnedBoardActive)
   const pinnedStoreLoaded = usePinnedStore((state) => state.loaded)
   const boardMode = useSettingsStore((s) => s.boardMode)
+  const terminalPosition = useSettingsStore((s) => s.terminalPosition)
   const selectedProjectId = useProjectStore((state) => state.selectedProjectId)
   const selectedProjectPath = useProjectStore((state) =>
     state.projects.find((p) => p.id === state.selectedProjectId)?.path ?? ''
@@ -357,16 +359,19 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     >
       <PRNotificationStack />
       {(selectedWorktreeId || selectedConnectionId) && <SessionTabs />}
-      {renderContent()}
-      {/* Always-mounted terminal sessions — kept alive to preserve PTY state across tab switches */}
-      {mountedTerminalSessionIds.map((sessionId) => {
-        const isActive = visibleTerminalId === sessionId
-        return (
-          <div key={sessionId} className={isActive ? 'flex-1 flex flex-col min-h-0' : 'hidden'}>
-            <SessionTerminalView sessionId={sessionId} isVisible={isActive} />
-          </div>
-        )
-      })}
+      <div className="flex-1 flex flex-col min-h-0">
+        {renderContent()}
+        {/* Always-mounted terminal sessions — kept alive to preserve PTY state across tab switches */}
+        {mountedTerminalSessionIds.map((sessionId) => {
+          const isActive = visibleTerminalId === sessionId
+          return (
+            <div key={sessionId} className={isActive ? 'flex-1 flex flex-col min-h-0' : 'hidden'}>
+              <SessionTerminalView sessionId={sessionId} isVisible={isActive} />
+            </div>
+          )
+        })}
+      </div>
+      {terminalPosition === 'bottom' && <MainPaneTerminalPanel />}
     </main>
   )
 }

--- a/src/renderer/src/components/layout/MainPaneTerminalPanel.tsx
+++ b/src/renderer/src/components/layout/MainPaneTerminalPanel.tsx
@@ -12,6 +12,11 @@ export function MainPaneTerminalPanel(): React.JSX.Element {
   const setHeightFraction = useLayoutStore((s) => s.setBottomTerminalHeightFraction)
   const { registerTarget } = useTerminalPortal()
 
+  const bottomTargetRef = useCallback(
+    (el: HTMLDivElement | null) => registerTarget('bottom', el),
+    [registerTarget]
+  )
+
   const panelRef = useRef<HTMLDivElement>(null)
   const [parentHeight, setParentHeight] = useState(0)
 
@@ -34,9 +39,10 @@ export function MainPaneTerminalPanel(): React.JSX.Element {
     (delta: number) => {
       if (parentHeight <= 0) return
       const fractionDelta = delta / parentHeight
-      setHeightFraction(heightFraction + fractionDelta)
+      const current = useLayoutStore.getState().bottomTerminalHeightFraction
+      setHeightFraction(current + fractionDelta)
     },
-    [parentHeight, heightFraction, setHeightFraction]
+    [parentHeight, setHeightFraction]
   )
 
   const computedHeight = expanded ? Math.round(parentHeight * heightFraction) : 0
@@ -44,7 +50,7 @@ export function MainPaneTerminalPanel(): React.JSX.Element {
   return (
     <div ref={panelRef} className="flex flex-col flex-shrink-0 border-t border-border">
       {/* Resize handle - only when expanded */}
-      {expanded && <ResizeHandle direction="up" onResize={handleResize} />}
+      {expanded && <ResizeHandle direction="down" onResize={handleResize} />}
 
       {/* Toggle bar - always visible */}
       <button
@@ -68,7 +74,7 @@ export function MainPaneTerminalPanel(): React.JSX.Element {
 
       {/* Terminal content - portal target */}
       <div
-        ref={(el) => registerTarget('bottom', el)}
+        ref={bottomTargetRef}
         style={{
           height: computedHeight,
           transition: 'height 150ms ease-in-out'

--- a/src/renderer/src/components/layout/MainPaneTerminalPanel.tsx
+++ b/src/renderer/src/components/layout/MainPaneTerminalPanel.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ChevronUp, ChevronDown, Terminal } from 'lucide-react'
+import { ResizeHandle } from './ResizeHandle'
+import { useLayoutStore } from '@/stores/useLayoutStore'
+import { useTerminalPortal } from '@/contexts/TerminalPortalContext'
+import { cn } from '@/lib/utils'
+
+export function MainPaneTerminalPanel(): React.JSX.Element {
+  const expanded = useLayoutStore((s) => s.bottomTerminalExpanded)
+  const heightFraction = useLayoutStore((s) => s.bottomTerminalHeightFraction)
+  const toggle = useLayoutStore((s) => s.toggleBottomTerminal)
+  const setHeightFraction = useLayoutStore((s) => s.setBottomTerminalHeightFraction)
+  const { registerTarget } = useTerminalPortal()
+
+  const panelRef = useRef<HTMLDivElement>(null)
+  const [parentHeight, setParentHeight] = useState(0)
+
+  // Observe the parent (main pane) height for fraction-to-pixel conversion
+  useEffect(() => {
+    const parent = panelRef.current?.parentElement
+    if (!parent) return
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setParentHeight(entry.contentRect.height)
+      }
+    })
+
+    observer.observe(parent)
+    return () => observer.disconnect()
+  }, [])
+
+  const handleResize = useCallback(
+    (delta: number) => {
+      if (parentHeight <= 0) return
+      const fractionDelta = delta / parentHeight
+      setHeightFraction(heightFraction + fractionDelta)
+    },
+    [parentHeight, heightFraction, setHeightFraction]
+  )
+
+  const computedHeight = expanded ? Math.round(parentHeight * heightFraction) : 0
+
+  return (
+    <div ref={panelRef} className="flex flex-col flex-shrink-0 border-t border-border">
+      {/* Resize handle - only when expanded */}
+      {expanded && <ResizeHandle direction="up" onResize={handleResize} />}
+
+      {/* Toggle bar - always visible */}
+      <button
+        onClick={toggle}
+        className={cn(
+          'h-[30px] flex items-center gap-2 px-3 text-xs transition-colors',
+          'text-muted-foreground hover:text-foreground hover:bg-accent/50',
+          expanded && 'border-b border-border'
+        )}
+        data-testid="bottom-terminal-toggle"
+      >
+        <Terminal className="h-3.5 w-3.5" />
+        <span>Terminal</span>
+        <span className="flex-1" />
+        {expanded ? (
+          <ChevronDown className="h-3.5 w-3.5" />
+        ) : (
+          <ChevronUp className="h-3.5 w-3.5" />
+        )}
+      </button>
+
+      {/* Terminal content - portal target */}
+      <div
+        ref={(el) => registerTarget('bottom', el)}
+        style={{
+          height: computedHeight,
+          transition: 'height 150ms ease-in-out'
+        }}
+        className="overflow-hidden"
+        data-testid="bottom-terminal-content"
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/layout/RightSidebar.tsx
+++ b/src/renderer/src/components/layout/RightSidebar.tsx
@@ -30,6 +30,11 @@ export function RightSidebar(): React.JSX.Element {
   const { registerTarget } = useTerminalPortal()
   const terminalPosition = useSettingsStore((s) => s.terminalPosition)
 
+  const sidebarTargetRef = useCallback(
+    (el: HTMLDivElement | null) => registerTarget('sidebar', el),
+    [registerTarget]
+  )
+
   const entityKey = selectedWorktreeId || selectedConnectionId
   const splitFraction = entityKey
     ? (splitFractionByEntity[entityKey] ?? LAYOUT_CONSTRAINTS.splitFraction.default)
@@ -101,11 +106,13 @@ export function RightSidebar(): React.JSX.Element {
           className="flex flex-col min-h-0 overflow-hidden"
           style={{
             flex:
-              collapsedPanel === 'top'
-                ? '0 0 auto'
-                : collapsedPanel === 'bottom'
-                  ? '1 1 0%'
-                  : `${splitFraction} 1 0%`
+              (isConnectionMode && terminalPosition === 'bottom')
+                ? '1 1 0%'
+                : collapsedPanel === 'top'
+                  ? '0 0 auto'
+                  : collapsedPanel === 'bottom'
+                    ? '1 1 0%'
+                    : `${splitFraction} 1 0%`
           }}
           data-testid="right-sidebar-top"
         >
@@ -125,37 +132,41 @@ export function RightSidebar(): React.JSX.Element {
               onFileClick={handleFileClick}
               className="flex-1 min-h-0"
               isCollapsed={collapsedPanel === 'top'}
-              onToggleCollapse={toggleTopPanel}
+              onToggleCollapse={(isConnectionMode && terminalPosition === 'bottom') ? undefined : toggleTopPanel}
             />
           </ErrorBoundary>
         </div>
 
-        {/* Draggable divider between top and bottom panels */}
-        {collapsedPanel === 'none' && (
-          <ResizeHandle onResize={handleVerticalResize} direction="up" />
-        )}
+        {!(isConnectionMode && terminalPosition === 'bottom') && (
+          <>
+            {/* Draggable divider between top and bottom panels */}
+            {collapsedPanel === 'none' && (
+              <ResizeHandle onResize={handleVerticalResize} direction="up" />
+            )}
 
-        {/* Bottom half: Tab panel */}
-        <div
-          className="flex flex-col min-h-0 overflow-hidden"
-          style={{
-            flex:
-              collapsedPanel === 'bottom'
-                ? '0 0 auto'
-                : collapsedPanel === 'top'
-                  ? '1 1 0%'
-                  : `${1 - splitFraction} 1 0%`
-          }}
-          data-testid="right-sidebar-bottom"
-        >
-          <BottomPanel
-            terminalContainerRef={(el) => registerTarget('sidebar', el)}
-            terminalPosition={terminalPosition}
-            isConnectionMode={isConnectionMode}
-            isCollapsed={collapsedPanel === 'bottom'}
-            onToggleCollapse={toggleBottomPanel}
-          />
-        </div>
+            {/* Bottom half: Tab panel */}
+            <div
+              className="flex flex-col min-h-0 overflow-hidden"
+              style={{
+                flex:
+                  collapsedPanel === 'bottom'
+                    ? '0 0 auto'
+                    : collapsedPanel === 'top'
+                      ? '1 1 0%'
+                      : `${1 - splitFraction} 1 0%`
+              }}
+              data-testid="right-sidebar-bottom"
+            >
+              <BottomPanel
+                terminalContainerRef={sidebarTargetRef}
+                terminalPosition={terminalPosition}
+                isConnectionMode={isConnectionMode}
+                isCollapsed={collapsedPanel === 'bottom'}
+                onToggleCollapse={toggleBottomPanel}
+              />
+            </div>
+          </>
+        )}
       </aside>
     </div>
   )

--- a/src/renderer/src/components/layout/RightSidebar.tsx
+++ b/src/renderer/src/components/layout/RightSidebar.tsx
@@ -7,13 +7,13 @@ import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import { ResizeHandle } from './ResizeHandle'
 import { FileSidebar } from '@/components/file-tree'
 import { BottomPanel } from './BottomPanel'
-import { TerminalManager } from '@/components/terminal/TerminalManager'
+import { useTerminalPortal } from '@/contexts/TerminalPortalContext'
+import { useSettingsStore } from '@/stores/useSettingsStore'
 import { ErrorBoundary, ErrorFallback } from '@/components/error'
 
 export function RightSidebar(): React.JSX.Element {
   const { rightSidebarWidth, rightSidebarCollapsed, setRightSidebarWidth, toggleRightSidebar } =
     useLayoutStore()
-  const bottomPanelTab = useLayoutStore((s) => s.bottomPanelTab)
   const splitFractionByEntity = useLayoutStore((s) => s.splitFractionByEntity)
   const setSplitFraction = useLayoutStore((s) => s.setSplitFraction)
   const collapsedPanel = useLayoutStore((s) => s.collapsedPanel)
@@ -26,6 +26,9 @@ export function RightSidebar(): React.JSX.Element {
     s.selectedConnectionId ? s.connections.find((c) => c.id === s.selectedConnectionId) : null
   )
   const isConnectionMode = !!selectedConnectionId && !selectedWorktreeId
+
+  const { registerTarget } = useTerminalPortal()
+  const terminalPosition = useSettingsStore((s) => s.terminalPosition)
 
   const entityKey = selectedWorktreeId || selectedConnectionId
   const splitFraction = entityKey
@@ -77,26 +80,8 @@ export function RightSidebar(): React.JSX.Element {
     }
   }
 
-  // For connections, the effective tab is always 'terminal' since setup/run are worktree-specific
-  const effectiveBottomPanelTab = isConnectionMode ? 'terminal' : bottomPanelTab
-
-  // TerminalManager is always rendered (even when sidebar is collapsed) to preserve
-  // PTY state across sidebar collapse/expand and worktree switches.
-  const terminalManager = (
-    <TerminalManager
-      selectedWorktreeId={selectedWorktreeId}
-      worktreePath={selectedWorktreePath}
-      isVisible={!rightSidebarCollapsed && effectiveBottomPanelTab === 'terminal'}
-    />
-  )
-
   if (rightSidebarCollapsed) {
-    return (
-      <div data-testid="right-sidebar-collapsed">
-        {/* Keep TerminalManager alive when sidebar is collapsed so PTYs persist */}
-        <div className="hidden">{terminalManager}</div>
-      </div>
-    )
+    return <div data-testid="right-sidebar-collapsed" />
   }
 
   return (
@@ -164,7 +149,8 @@ export function RightSidebar(): React.JSX.Element {
           data-testid="right-sidebar-bottom"
         >
           <BottomPanel
-            terminalSlot={terminalManager}
+            terminalContainerRef={(el) => registerTarget('sidebar', el)}
+            terminalPosition={terminalPosition}
             isConnectionMode={isConnectionMode}
             isCollapsed={collapsedPanel === 'bottom'}
             onToggleCollapse={toggleBottomPanel}

--- a/src/renderer/src/components/settings/SettingsTerminal.tsx
+++ b/src/renderer/src/components/settings/SettingsTerminal.tsx
@@ -3,7 +3,8 @@ import { isMac as isMacPlatform, isWindows as isWindowsPlatform } from '@/lib/pl
 import {
   useSettingsStore,
   type TerminalOption,
-  type EmbeddedTerminalBackend
+  type EmbeddedTerminalBackend,
+  type TerminalPosition
 } from '@/stores/useSettingsStore'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
@@ -65,12 +66,30 @@ const BACKEND_OPTIONS: {
   }
 ]
 
+const POSITION_OPTIONS: {
+  id: TerminalPosition
+  label: string
+  description: string
+}[] = [
+  {
+    id: 'sidebar',
+    label: 'Sidebar',
+    description: 'Terminal appears as a tab alongside Setup and Run'
+  },
+  {
+    id: 'bottom',
+    label: 'Bottom panel',
+    description: 'Terminal gets a dedicated panel below the chat area'
+  }
+]
+
 export function SettingsTerminal(): React.JSX.Element {
   const {
     defaultTerminal,
     customTerminalCommand,
     embeddedTerminalBackend,
     ghosttyFontSize,
+    terminalPosition,
     updateSetting
   } = useSettingsStore()
   const [detectedTerminals, setDetectedTerminals] = useState<DetectedTerminal[]>([])
@@ -137,6 +156,42 @@ export function SettingsTerminal(): React.JSX.Element {
 
   return (
     <div className="space-y-8">
+      {/* Terminal Position */}
+      <div>
+        <h3 className="text-base font-medium mb-1">Terminal Position</h3>
+        <p className="text-sm text-muted-foreground mb-3">
+          Choose where the embedded terminal panel is displayed
+        </p>
+
+        <div className="space-y-1">
+          {POSITION_OPTIONS.map((opt) => {
+            const isSelected = terminalPosition === opt.id
+
+            return (
+              <button
+                key={opt.id}
+                onClick={() => updateSetting('terminalPosition', opt.id)}
+                className={cn(
+                  'w-full flex items-start justify-between px-3 py-2.5 rounded-md text-sm transition-colors text-left',
+                  isSelected
+                    ? 'bg-primary/10 border border-primary/30'
+                    : 'hover:bg-accent/50 border border-transparent'
+                )}
+                data-testid={`terminal-position-${opt.id}`}
+              >
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <span>{opt.label}</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-0.5">{opt.description}</p>
+                </div>
+                {isSelected && <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
       {/* Embedded Terminal Backend */}
       <div>
         <h3 className="text-base font-medium mb-1">Embedded Terminal</h3>

--- a/src/renderer/src/contexts/TerminalPortalContext.tsx
+++ b/src/renderer/src/contexts/TerminalPortalContext.tsx
@@ -1,10 +1,11 @@
-import { createContext, useContext, useRef, useCallback, type ReactNode } from 'react'
+import { createContext, useContext, useRef, useCallback, useState, type ReactNode } from 'react'
 
 type TerminalPositionTarget = 'sidebar' | 'bottom'
 
 interface TerminalPortalContextValue {
   registerTarget: (position: TerminalPositionTarget, el: HTMLDivElement | null) => void
   getTarget: (position: TerminalPositionTarget) => HTMLDivElement | null
+  revision: number
 }
 
 const TerminalPortalContext = createContext<TerminalPortalContextValue | null>(null)
@@ -12,12 +13,16 @@ const TerminalPortalContext = createContext<TerminalPortalContextValue | null>(n
 export function TerminalPortalProvider({ children }: { children: ReactNode }): React.JSX.Element {
   const sidebarRef = useRef<HTMLDivElement | null>(null)
   const bottomRef = useRef<HTMLDivElement | null>(null)
+  const [revision, setRevision] = useState(0)
 
   const registerTarget = useCallback((position: TerminalPositionTarget, el: HTMLDivElement | null) => {
     if (position === 'sidebar') {
       sidebarRef.current = el
     } else {
       bottomRef.current = el
+    }
+    if (el !== null) {
+      setRevision((r) => r + 1)
     }
   }, [])
 
@@ -26,7 +31,7 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }): R
   }, [])
 
   return (
-    <TerminalPortalContext.Provider value={{ registerTarget, getTarget }}>
+    <TerminalPortalContext.Provider value={{ registerTarget, getTarget, revision }}>
       {children}
     </TerminalPortalContext.Provider>
   )

--- a/src/renderer/src/contexts/TerminalPortalContext.tsx
+++ b/src/renderer/src/contexts/TerminalPortalContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useRef, useCallback, type ReactNode } from 'react'
+
+type TerminalPositionTarget = 'sidebar' | 'bottom'
+
+interface TerminalPortalContextValue {
+  registerTarget: (position: TerminalPositionTarget, el: HTMLDivElement | null) => void
+  getTarget: (position: TerminalPositionTarget) => HTMLDivElement | null
+}
+
+const TerminalPortalContext = createContext<TerminalPortalContextValue | null>(null)
+
+export function TerminalPortalProvider({ children }: { children: ReactNode }): React.JSX.Element {
+  const sidebarRef = useRef<HTMLDivElement | null>(null)
+  const bottomRef = useRef<HTMLDivElement | null>(null)
+
+  const registerTarget = useCallback((position: TerminalPositionTarget, el: HTMLDivElement | null) => {
+    if (position === 'sidebar') {
+      sidebarRef.current = el
+    } else {
+      bottomRef.current = el
+    }
+  }, [])
+
+  const getTarget = useCallback((position: TerminalPositionTarget): HTMLDivElement | null => {
+    return position === 'sidebar' ? sidebarRef.current : bottomRef.current
+  }, [])
+
+  return (
+    <TerminalPortalContext.Provider value={{ registerTarget, getTarget }}>
+      {children}
+    </TerminalPortalContext.Provider>
+  )
+}
+
+export function useTerminalPortal(): TerminalPortalContextValue {
+  const ctx = useContext(TerminalPortalContext)
+  if (!ctx) {
+    throw new Error('useTerminalPortal must be used within a TerminalPortalProvider')
+  }
+  return ctx
+}

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -526,6 +526,23 @@ function getShortcutHandlers(
         useLayoutStore.getState().toggleRightSidebar()
       }
     },
+    {
+      id: 'sidebar:toggle-bottom-terminal',
+      binding: getEffectiveBinding('sidebar:toggle-bottom-terminal'),
+      allowInInput: true,
+      handler: () => {
+        const terminalPosition = useSettingsStore.getState().terminalPosition
+        if (terminalPosition === 'bottom') {
+          useLayoutStore.getState().toggleBottomTerminal()
+        } else {
+          // In sidebar mode: open right sidebar + switch to terminal tab
+          const layout = useLayoutStore.getState()
+          if (layout.rightSidebarCollapsed) layout.setRightSidebarCollapsed(false)
+          layout.setBottomPanelTab('terminal')
+          if (layout.collapsedPanel === 'bottom') layout.toggleBottomPanel()
+        }
+      }
+    },
 
     // =====================
     // Focus shortcuts

--- a/src/renderer/src/hooks/useVimNavigation.ts
+++ b/src/renderer/src/hooks/useVimNavigation.ts
@@ -247,17 +247,32 @@ export function useVimNavigation(): void {
       }
 
       // --- Panel shortcuts: bottom panel tabs ---
-      if (event.key === 's' || event.key === 'u' || event.key === 't') {
+      if (event.key === 's' || event.key === 'u') {
         const layout = useLayoutStore.getState()
         if (layout.rightSidebarCollapsed) {
           layout.setRightSidebarCollapsed(false)
         }
-        const tabMap: Record<string, 'setup' | 'run' | 'terminal'> = {
+        const tabMap: Record<string, 'setup' | 'run'> = {
           s: 'setup',
-          u: 'run',
-          t: 'terminal'
+          u: 'run'
         }
         layout.setBottomPanelTab(tabMap[event.key])
+        event.preventDefault()
+        return
+      }
+
+      // Terminal shortcut: respects terminalPosition setting
+      if (event.key === 't') {
+        const terminalPosition = useSettingsStore.getState().terminalPosition
+        if (terminalPosition === 'bottom') {
+          useLayoutStore.getState().toggleBottomTerminal()
+        } else {
+          const layout = useLayoutStore.getState()
+          if (layout.rightSidebarCollapsed) {
+            layout.setRightSidebarCollapsed(false)
+          }
+          layout.setBottomPanelTab('terminal')
+        }
         event.preventDefault()
         return
       }

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -145,6 +145,13 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     category: 'sidebar',
     defaultBinding: { key: 'b', modifiers: ['meta', 'shift'] }
   },
+  {
+    id: 'sidebar:toggle-bottom-terminal',
+    label: 'Toggle Bottom Terminal',
+    description: 'Show or hide the bottom terminal panel',
+    category: 'sidebar',
+    defaultBinding: { key: '`', modifiers: ['ctrl'] }
+  },
 
   // Focus shortcuts
   {

--- a/src/renderer/src/stores/useLayoutStore.ts
+++ b/src/renderer/src/stores/useLayoutStore.ts
@@ -11,6 +11,9 @@ const RIGHT_SIDEBAR_DEFAULT = 280
 const SPLIT_FRACTION_DEFAULT = 0.5
 const SPLIT_FRACTION_MIN = 0.15
 const SPLIT_FRACTION_MAX = 0.85
+const BOTTOM_TERMINAL_HEIGHT_DEFAULT = 0.30
+const BOTTOM_TERMINAL_HEIGHT_MIN = 0.15
+const BOTTOM_TERMINAL_HEIGHT_MAX = 0.70
 
 // Module-level Set to track suppression keys — kept outside Zustand state
 // because Set cannot be serialized by the persist middleware.
@@ -25,6 +28,8 @@ interface LayoutState {
   ghosttyOverlaySuppressed: boolean
   collapsedPanel: CollapsedPanel
   splitFractionByEntity: Record<string, number>
+  bottomTerminalExpanded: boolean
+  bottomTerminalHeightFraction: number
   toggleTopPanel: () => void
   toggleBottomPanel: () => void
   setLeftSidebarWidth: (width: number) => void
@@ -38,6 +43,8 @@ interface LayoutState {
   pushGhosttySuppression: (key: string) => void
   popGhosttySuppression: (key: string) => void
   setSplitFraction: (entityKey: string, fraction: number) => void
+  toggleBottomTerminal: () => void
+  setBottomTerminalHeightFraction: (fraction: number) => void
 }
 
 export const useLayoutStore = create<LayoutState>()(
@@ -51,6 +58,8 @@ export const useLayoutStore = create<LayoutState>()(
       ghosttyOverlaySuppressed: false,
       collapsedPanel: 'none' as CollapsedPanel,
       splitFractionByEntity: {} as Record<string, number>,
+      bottomTerminalExpanded: false,
+      bottomTerminalHeightFraction: BOTTOM_TERMINAL_HEIGHT_DEFAULT,
 
       toggleTopPanel: () => {
         set((state) => ({
@@ -117,6 +126,17 @@ export const useLayoutStore = create<LayoutState>()(
         set((state) => ({
           splitFractionByEntity: { ...state.splitFractionByEntity, [entityKey]: clamped }
         }))
+      },
+
+      toggleBottomTerminal: () => {
+        set((state) => ({
+          bottomTerminalExpanded: !state.bottomTerminalExpanded
+        }))
+      },
+
+      setBottomTerminalHeightFraction: (fraction: number) => {
+        const clamped = Math.min(Math.max(fraction, BOTTOM_TERMINAL_HEIGHT_MIN), BOTTOM_TERMINAL_HEIGHT_MAX)
+        set({ bottomTerminalHeightFraction: clamped })
       }
     }),
     {
@@ -128,7 +148,9 @@ export const useLayoutStore = create<LayoutState>()(
         rightSidebarWidth: state.rightSidebarWidth,
         rightSidebarCollapsed: state.rightSidebarCollapsed,
         collapsedPanel: state.collapsedPanel,
-        splitFractionByEntity: state.splitFractionByEntity
+        splitFractionByEntity: state.splitFractionByEntity,
+        bottomTerminalExpanded: state.bottomTerminalExpanded,
+        bottomTerminalHeightFraction: state.bottomTerminalHeightFraction
       })
     }
   )
@@ -148,5 +170,10 @@ export const LAYOUT_CONSTRAINTS = {
     default: SPLIT_FRACTION_DEFAULT,
     min: SPLIT_FRACTION_MIN,
     max: SPLIT_FRACTION_MAX
+  },
+  bottomTerminal: {
+    default: BOTTOM_TERMINAL_HEIGHT_DEFAULT,
+    min: BOTTOM_TERMINAL_HEIGHT_MIN,
+    max: BOTTOM_TERMINAL_HEIGHT_MAX
   }
 }

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -20,6 +20,7 @@ export type TerminalOption =
   | 'cmd'
   | 'custom'
 export type EmbeddedTerminalBackend = 'xterm' | 'ghostty'
+export type TerminalPosition = 'sidebar' | 'bottom'
 export type MergeConflictMode = 'build' | 'plan' | 'always-ask'
 
 export interface SelectedModel {
@@ -63,6 +64,7 @@ export interface AppSettings {
   embeddedTerminalBackend: EmbeddedTerminalBackend
   ghosttyFontSize: number
   ghosttyPromotionDismissed: boolean
+  terminalPosition: TerminalPosition
 
   // Model
   selectedModel: SelectedModel | null
@@ -144,6 +146,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   embeddedTerminalBackend: 'xterm',
   ghosttyFontSize: 14,
   ghosttyPromotionDismissed: false,
+  terminalPosition: 'sidebar',
   selectedModel: null,
   selectedModelByProvider: {},
   defaultModels: null,
@@ -295,6 +298,7 @@ function extractSettings(state: SettingsState): AppSettings {
     embeddedTerminalBackend: state.embeddedTerminalBackend,
     ghosttyFontSize: state.ghosttyFontSize,
     ghosttyPromotionDismissed: state.ghosttyPromotionDismissed,
+    terminalPosition: state.terminalPosition,
     selectedModel: state.selectedModel,
     selectedModelByProvider: state.selectedModelByProvider,
     defaultModels: state.defaultModels,
@@ -551,6 +555,7 @@ export const useSettingsStore = create<SettingsState>()(
         embeddedTerminalBackend: state.embeddedTerminalBackend,
         ghosttyFontSize: state.ghosttyFontSize,
         ghosttyPromotionDismissed: state.ghosttyPromotionDismissed,
+        terminalPosition: state.terminalPosition,
         selectedModel: state.selectedModel,
         selectedModelByProvider: state.selectedModelByProvider,
         defaultModels: state.defaultModels,


### PR DESCRIPTION
## Summary

- Add `terminalPosition` setting ('sidebar' | 'bottom') to allow users to choose where the embedded terminal appears
- Implement `TerminalPortalContext` to dynamically route terminal rendering to the correct container
- Create `MainPaneTerminalPanel` component for dedicated bottom terminal panel with collapsible header and resize handle
- Refactor terminal rendering to use React portals, decoupling component mounting from display location
- Add `bottomTerminalExpanded` and `bottomTerminalHeightFraction` state to `useLayoutStore` for persistence
- Update keyboard shortcuts (Ctrl+` and Vim 't' key) to respect terminal position setting
- Remove terminal slot from `RightSidebar`; terminal now renders via portal to active position target
- Update `BottomPanel` to conditionally hide terminal tab when in bottom position mode

## Testing

- [ ] Verify terminal appears in sidebar (default setting) with Setup/Run tabs
- [ ] Switch to 'Bottom panel' setting and confirm terminal moves to new dedicated panel
- [ ] Test bottom terminal collapse/expand toggle button preserves height fraction
- [ ] Verify resize handle on bottom panel correctly adjusts terminal height
- [ ] Confirm Ctrl+` keyboard shortcut toggles bottom terminal when in bottom position
- [ ] Confirm Vim 't' key respects position setting (toggles bottom or switches to sidebar tab)
- [ ] Test PTY state persistence across sidebar collapse/expand
- [ ] Test terminal state persistence when switching between worktrees
- [ ] Verify connection mode forces terminal-only view regardless of position setting
- [ ] Check that height fraction is persisted and restored correctly on reload
- [ ] Test responsive layout when right sidebar is collapsed in bottom position mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/layout refactor that changes where and how the embedded terminal is mounted (React portals) and adds new persisted layout state; regressions could affect terminal visibility, resizing, and PTY persistence across navigation.
> 
> **Overview**
> Adds a new `terminalPosition` setting (`sidebar`/`bottom`) so the embedded terminal can either live as a right-sidebar tab or in a dedicated bottom panel under the main pane.
> 
> Refactors terminal rendering to go through a new `TerminalPortalContext` and an `AppLayout`-level `TerminalManagerPortal`, decoupling terminal mounting from `RightSidebar` and preserving PTY state while switching positions/collapsing panels. Introduces `MainPaneTerminalPanel` (collapsible + resizable) plus new persisted layout fields (`bottomTerminalExpanded`, `bottomTerminalHeightFraction`), updates `BottomPanel` tab behavior when the terminal is moved, and updates keyboard/Vim shortcuts (including new Ctrl+` binding) to toggle/show the terminal appropriately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed90c3d4968c97767f159cf6b00e59345fadea8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->