### PR TITLE
Add terminal tabs UI with multi-tab support and tab management

### DIFF
--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -6,7 +6,7 @@ import { createLogger } from '../services/logger'
 
 const log = createLogger({ component: 'TerminalHandlers' })
 
-// Track listener cleanup functions per worktreeId to prevent duplicate registrations
+// Track listener cleanup functions per terminalId to prevent duplicate registrations
 const listenerCleanups = new Map<string, { removeData: () => void; removeExit: () => void }>()
 
 // Per-worktree data buffers for batching PTY output before IPC send.
@@ -29,65 +29,65 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
   // Create a PTY for a worktree
   ipcMain.handle(
     'terminal:create',
-    async (_event, worktreeId: string, cwd: string, shell?: string) => {
-      log.info('IPC: terminal:create', { worktreeId, cwd, shell })
+    async (_event, terminalId: string, cwd: string, shell?: string) => {
+      log.info('IPC: terminal:create', { terminalId, cwd, shell })
       try {
         // Check if PTY already exists before creating — if it does, skip listener registration
-        const alreadyExists = ptyService.has(worktreeId)
-        const { cols, rows } = ptyService.create(worktreeId, { cwd, shell: shell || undefined })
+        const alreadyExists = ptyService.has(terminalId)
+        const { cols, rows } = ptyService.create(terminalId, { cwd, shell: shell || undefined })
 
         if (alreadyExists) {
-          log.info('PTY already exists, skipping listener registration', { worktreeId })
+          log.info('PTY already exists, skipping listener registration', { terminalId })
           return { success: true, cols, rows }
         }
 
-        // Clean up any stale listeners for this worktreeId (shouldn't happen, but defensive)
-        const existing = listenerCleanups.get(worktreeId)
+        // Clean up any stale listeners for this terminalId (shouldn't happen, but defensive)
+        const existing = listenerCleanups.get(terminalId)
         if (existing) {
           existing.removeData()
           existing.removeExit()
-          listenerCleanups.delete(worktreeId)
+          listenerCleanups.delete(terminalId)
         }
 
         // Wire PTY output to renderer (batched via setImmediate)
-        const removeData = ptyService.onData(worktreeId, (data) => {
+        const removeData = ptyService.onData(terminalId, (data) => {
           if (mainWindow.isDestroyed()) return
 
           // Accumulate into buffer
-          const existing = dataBuffers.get(worktreeId)
-          dataBuffers.set(worktreeId, existing ? existing + data : data)
+          const existing = dataBuffers.get(terminalId)
+          dataBuffers.set(terminalId, existing ? existing + data : data)
 
           // Schedule a flush if one isn't already pending
-          if (!flushScheduled.has(worktreeId)) {
-            flushScheduled.add(worktreeId)
+          if (!flushScheduled.has(terminalId)) {
+            flushScheduled.add(terminalId)
             setImmediate(() => {
-              flushScheduled.delete(worktreeId)
-              const buffered = dataBuffers.get(worktreeId)
-              dataBuffers.delete(worktreeId)
+              flushScheduled.delete(terminalId)
+              const buffered = dataBuffers.get(terminalId)
+              dataBuffers.delete(terminalId)
               if (buffered && !mainWindow.isDestroyed()) {
-                mainWindow.webContents.send(`terminal:data:${worktreeId}`, buffered)
+                mainWindow.webContents.send(`terminal:data:${terminalId}`, buffered)
               }
             })
           }
         })
 
         // Wire PTY exit to renderer
-        const removeExit = ptyService.onExit(worktreeId, (code) => {
+        const removeExit = ptyService.onExit(terminalId, (code) => {
           if (!mainWindow.isDestroyed()) {
-            mainWindow.webContents.send(`terminal:exit:${worktreeId}`, code)
+            mainWindow.webContents.send(`terminal:exit:${terminalId}`, code)
           }
           // Clean up listener tracking on exit
-          listenerCleanups.delete(worktreeId)
+          listenerCleanups.delete(terminalId)
         })
 
-        listenerCleanups.set(worktreeId, { removeData, removeExit })
+        listenerCleanups.set(terminalId, { removeData, removeExit })
 
         return { success: true, cols, rows }
       } catch (error) {
         log.error(
           'IPC: terminal:create failed',
           error instanceof Error ? error : new Error(String(error)),
-          { worktreeId }
+          { terminalId }
         )
         return {
           success: false,
@@ -98,29 +98,29 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
   )
 
   // Write data to a PTY (fire-and-forget — no response needed for keystrokes)
-  ipcMain.on('terminal:write', (_event, worktreeId: string, data: string) => {
-    ptyService.write(worktreeId, data)
+  ipcMain.on('terminal:write', (_event, terminalId: string, data: string) => {
+    ptyService.write(terminalId, data)
   })
 
   // Resize a PTY
-  ipcMain.handle('terminal:resize', (_event, worktreeId: string, cols: number, rows: number) => {
-    ptyService.resize(worktreeId, cols, rows)
+  ipcMain.handle('terminal:resize', (_event, terminalId: string, cols: number, rows: number) => {
+    ptyService.resize(terminalId, cols, rows)
   })
 
   // Destroy a PTY
-  ipcMain.handle('terminal:destroy', (_event, worktreeId: string) => {
-    log.info('IPC: terminal:destroy', { worktreeId })
+  ipcMain.handle('terminal:destroy', (_event, terminalId: string) => {
+    log.info('IPC: terminal:destroy', { terminalId })
     // Clean up listener tracking
-    const cleanup = listenerCleanups.get(worktreeId)
+    const cleanup = listenerCleanups.get(terminalId)
     if (cleanup) {
       cleanup.removeData()
       cleanup.removeExit()
-      listenerCleanups.delete(worktreeId)
+      listenerCleanups.delete(terminalId)
     }
     // Discard any pending buffered data
-    dataBuffers.delete(worktreeId)
-    flushScheduled.delete(worktreeId)
-    ptyService.destroy(worktreeId)
+    dataBuffers.delete(terminalId)
+    flushScheduled.delete(terminalId)
+    ptyService.destroy(terminalId)
   })
 
   // Get Ghostty config for terminal theming
@@ -163,28 +163,28 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
     'terminal:ghostty:createSurface',
     (
       _event,
-      worktreeId: string,
+      terminalId: string,
       rect: { x: number; y: number; w: number; h: number },
       opts?: { cwd?: string; shell?: string; scaleFactor?: number; fontSize?: number }
     ) => {
-      log.info('IPC: terminal:ghostty:createSurface', { worktreeId, rect })
-      return ghosttyService.createSurface(worktreeId, rect, opts || {})
+      log.info('IPC: terminal:ghostty:createSurface', { terminalId, rect })
+      return ghosttyService.createSurface(terminalId, rect, opts || {})
     }
   )
 
   // Update the native view frame (position + size)
   ipcMain.handle(
     'terminal:ghostty:setFrame',
-    (_event, worktreeId: string, rect: { x: number; y: number; w: number; h: number }) => {
-      ghosttyService.setFrame(worktreeId, rect)
+    (_event, terminalId: string, rect: { x: number; y: number; w: number; h: number }) => {
+      ghosttyService.setFrame(terminalId, rect)
     }
   )
 
   // Update surface size in pixels
   ipcMain.handle(
     'terminal:ghostty:setSize',
-    (_event, worktreeId: string, width: number, height: number) => {
-      ghosttyService.setSize(worktreeId, width, height)
+    (_event, terminalId: string, width: number, height: number) => {
+      ghosttyService.setSize(terminalId, width, height)
     }
   )
 
@@ -193,7 +193,7 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
     'terminal:ghostty:keyEvent',
     (
       _event,
-      worktreeId: string,
+      terminalId: string,
       keyEvent: {
         action: number
         keycode: number
@@ -204,42 +204,42 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
         composing?: boolean
       }
     ) => {
-      return ghosttyService.keyEvent(worktreeId, keyEvent)
+      return ghosttyService.keyEvent(terminalId, keyEvent)
     }
   )
 
   // Forward a mouse button event
   ipcMain.handle(
     'terminal:ghostty:mouseButton',
-    (_event, worktreeId: string, state: number, button: number, mods: number) => {
-      ghosttyService.mouseButton(worktreeId, state, button, mods)
+    (_event, terminalId: string, state: number, button: number, mods: number) => {
+      ghosttyService.mouseButton(terminalId, state, button, mods)
     }
   )
 
   // Forward a mouse position event
   ipcMain.handle(
     'terminal:ghostty:mousePos',
-    (_event, worktreeId: string, x: number, y: number, mods: number) => {
-      ghosttyService.mousePos(worktreeId, x, y, mods)
+    (_event, terminalId: string, x: number, y: number, mods: number) => {
+      ghosttyService.mousePos(terminalId, x, y, mods)
     }
   )
 
   // Forward a mouse scroll event
   ipcMain.handle(
     'terminal:ghostty:mouseScroll',
-    (_event, worktreeId: string, dx: number, dy: number, mods: number) => {
-      ghosttyService.mouseScroll(worktreeId, dx, dy, mods)
+    (_event, terminalId: string, dx: number, dy: number, mods: number) => {
+      ghosttyService.mouseScroll(terminalId, dx, dy, mods)
     }
   )
 
   // Set focus state for a surface
-  ipcMain.handle('terminal:ghostty:setFocus', (_event, worktreeId: string, focused: boolean) => {
-    ghosttyService.setFocus(worktreeId, focused)
+  ipcMain.handle('terminal:ghostty:setFocus', (_event, terminalId: string, focused: boolean) => {
+    ghosttyService.setFocus(terminalId, focused)
   })
 
   // Paste text into a Ghostty surface (programmatic paste, bypasses macOS focus)
-  ipcMain.handle('terminal:ghostty:pasteText', (_event, worktreeId: string, text: string) => {
-    ghosttyService.pasteText(worktreeId, text)
+  ipcMain.handle('terminal:ghostty:pasteText', (_event, terminalId: string, text: string) => {
+    ghosttyService.pasteText(terminalId, text)
   })
 
   // Diagnostic: inspect Ghostty view hierarchy and first responder state
@@ -248,9 +248,9 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
   })
 
   // Destroy a Ghostty surface for a worktree
-  ipcMain.handle('terminal:ghostty:destroySurface', (_event, worktreeId: string) => {
-    log.info('IPC: terminal:ghostty:destroySurface', { worktreeId })
-    ghosttyService.destroySurface(worktreeId)
+  ipcMain.handle('terminal:ghostty:destroySurface', (_event, terminalId: string) => {
+    log.info('IPC: terminal:ghostty:destroySurface', { terminalId })
+    ghosttyService.destroySurface(terminalId)
   })
 
   // Shut down the Ghostty runtime entirely

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -893,15 +893,15 @@ declare global {
     }
     terminalOps: {
       create: (
-        worktreeId: string,
+        terminalId: string,
         cwd: string,
         shell?: string
       ) => Promise<{ success: boolean; cols?: number; rows?: number; error?: string }>
-      write: (worktreeId: string, data: string) => void
-      resize: (worktreeId: string, cols: number, rows: number) => Promise<void>
-      destroy: (worktreeId: string) => Promise<void>
-      onData: (worktreeId: string, callback: (data: string) => void) => () => void
-      onExit: (worktreeId: string, callback: (code: number) => void) => () => void
+      write: (terminalId: string, data: string) => void
+      resize: (terminalId: string, cols: number, rows: number) => Promise<void>
+      destroy: (terminalId: string) => Promise<void>
+      onData: (terminalId: string, callback: (data: string) => void) => () => void
+      onExit: (terminalId: string, callback: (code: number) => void) => () => void
       getConfig: () => Promise<GhosttyTerminalConfig>
 
       // Native Ghostty backend methods
@@ -912,17 +912,17 @@ declare global {
         platform: string
       }>
       ghosttyCreateSurface: (
-        worktreeId: string,
+        terminalId: string,
         rect: { x: number; y: number; w: number; h: number },
         opts?: { cwd?: string; shell?: string; scaleFactor?: number; fontSize?: number }
       ) => Promise<{ success: boolean; surfaceId?: number; error?: string }>
       ghosttySetFrame: (
-        worktreeId: string,
+        terminalId: string,
         rect: { x: number; y: number; w: number; h: number }
       ) => Promise<void>
-      ghosttySetSize: (worktreeId: string, width: number, height: number) => Promise<void>
+      ghosttySetSize: (terminalId: string, width: number, height: number) => Promise<void>
       ghosttyKeyEvent: (
-        worktreeId: string,
+        terminalId: string,
         event: {
           action: number
           keycode: number
@@ -934,21 +934,21 @@ declare global {
         }
       ) => Promise<boolean>
       ghosttyMouseButton: (
-        worktreeId: string,
+        terminalId: string,
         state: number,
         button: number,
         mods: number
       ) => Promise<void>
-      ghosttyMousePos: (worktreeId: string, x: number, y: number, mods: number) => Promise<void>
+      ghosttyMousePos: (terminalId: string, x: number, y: number, mods: number) => Promise<void>
       ghosttyMouseScroll: (
-        worktreeId: string,
+        terminalId: string,
         dx: number,
         dy: number,
         mods: number
       ) => Promise<void>
-      ghosttySetFocus: (worktreeId: string, focused: boolean) => Promise<void>
-      ghosttyPasteText: (worktreeId: string, text: string) => Promise<void>
-      ghosttyDestroySurface: (worktreeId: string) => Promise<void>
+      ghosttySetFocus: (terminalId: string, focused: boolean) => Promise<void>
+      ghosttyPasteText: (terminalId: string, text: string) => Promise<void>
+      ghosttyDestroySurface: (terminalId: string) => Promise<void>
       ghosttyShutdown: () => Promise<void>
     }
     gitOps: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1612,23 +1612,23 @@ const settingsOps = {
 // Terminal operations API (PTY management)
 const terminalOps = {
   create: (
-    worktreeId: string,
+    terminalId: string,
     cwd: string,
     shell?: string
   ): Promise<{ success: boolean; cols?: number; rows?: number; error?: string }> =>
-    ipcRenderer.invoke('terminal:create', worktreeId, cwd, shell),
+    ipcRenderer.invoke('terminal:create', terminalId, cwd, shell),
 
-  write: (worktreeId: string, data: string): void =>
-    ipcRenderer.send('terminal:write', worktreeId, data),
+  write: (terminalId: string, data: string): void =>
+    ipcRenderer.send('terminal:write', terminalId, data),
 
-  resize: (worktreeId: string, cols: number, rows: number): Promise<void> =>
-    ipcRenderer.invoke('terminal:resize', worktreeId, cols, rows),
+  resize: (terminalId: string, cols: number, rows: number): Promise<void> =>
+    ipcRenderer.invoke('terminal:resize', terminalId, cols, rows),
 
-  destroy: (worktreeId: string): Promise<void> =>
-    ipcRenderer.invoke('terminal:destroy', worktreeId),
+  destroy: (terminalId: string): Promise<void> =>
+    ipcRenderer.invoke('terminal:destroy', terminalId),
 
-  onData: (worktreeId: string, callback: (data: string) => void): (() => void) => {
-    const channel = `terminal:data:${worktreeId}`
+  onData: (terminalId: string, callback: (data: string) => void): (() => void) => {
+    const channel = `terminal:data:${terminalId}`
     const handler = (_event: Electron.IpcRendererEvent, data: string): void => {
       callback(data)
     }
@@ -1638,8 +1638,8 @@ const terminalOps = {
     }
   },
 
-  onExit: (worktreeId: string, callback: (code: number) => void): (() => void) => {
-    const channel = `terminal:exit:${worktreeId}`
+  onExit: (terminalId: string, callback: (code: number) => void): (() => void) => {
+    const channel = `terminal:exit:${terminalId}`
     const handler = (_event: Electron.IpcRendererEvent, code: number): void => {
       callback(code)
     }
@@ -1675,22 +1675,22 @@ const terminalOps = {
   }> => ipcRenderer.invoke('terminal:ghostty:isAvailable'),
 
   ghosttyCreateSurface: (
-    worktreeId: string,
+    terminalId: string,
     rect: { x: number; y: number; w: number; h: number },
     opts?: { cwd?: string; shell?: string; scaleFactor?: number; fontSize?: number }
   ): Promise<{ success: boolean; surfaceId?: number; error?: string }> =>
-    ipcRenderer.invoke('terminal:ghostty:createSurface', worktreeId, rect, opts),
+    ipcRenderer.invoke('terminal:ghostty:createSurface', terminalId, rect, opts),
 
   ghosttySetFrame: (
-    worktreeId: string,
+    terminalId: string,
     rect: { x: number; y: number; w: number; h: number }
-  ): Promise<void> => ipcRenderer.invoke('terminal:ghostty:setFrame', worktreeId, rect),
+  ): Promise<void> => ipcRenderer.invoke('terminal:ghostty:setFrame', terminalId, rect),
 
-  ghosttySetSize: (worktreeId: string, width: number, height: number): Promise<void> =>
-    ipcRenderer.invoke('terminal:ghostty:setSize', worktreeId, width, height),
+  ghosttySetSize: (terminalId: string, width: number, height: number): Promise<void> =>
+    ipcRenderer.invoke('terminal:ghostty:setSize', terminalId, width, height),
 
   ghosttyKeyEvent: (
-    worktreeId: string,
+    terminalId: string,
     event: {
       action: number
       keycode: number
@@ -1700,27 +1700,27 @@ const terminalOps = {
       unshiftedCodepoint?: number
       composing?: boolean
     }
-  ): Promise<boolean> => ipcRenderer.invoke('terminal:ghostty:keyEvent', worktreeId, event),
+  ): Promise<boolean> => ipcRenderer.invoke('terminal:ghostty:keyEvent', terminalId, event),
 
   ghosttyMouseButton: (
-    worktreeId: string,
+    terminalId: string,
     state: number,
     button: number,
     mods: number
   ): Promise<void> =>
-    ipcRenderer.invoke('terminal:ghostty:mouseButton', worktreeId, state, button, mods),
+    ipcRenderer.invoke('terminal:ghostty:mouseButton', terminalId, state, button, mods),
 
-  ghosttyMousePos: (worktreeId: string, x: number, y: number, mods: number): Promise<void> =>
-    ipcRenderer.invoke('terminal:ghostty:mousePos', worktreeId, x, y, mods),
+  ghosttyMousePos: (terminalId: string, x: number, y: number, mods: number): Promise<void> =>
+    ipcRenderer.invoke('terminal:ghostty:mousePos', terminalId, x, y, mods),
 
-  ghosttyMouseScroll: (worktreeId: string, dx: number, dy: number, mods: number): Promise<void> =>
-    ipcRenderer.invoke('terminal:ghostty:mouseScroll', worktreeId, dx, dy, mods),
+  ghosttyMouseScroll: (terminalId: string, dx: number, dy: number, mods: number): Promise<void> =>
+    ipcRenderer.invoke('terminal:ghostty:mouseScroll', terminalId, dx, dy, mods),
 
-  ghosttySetFocus: (worktreeId: string, focused: boolean): Promise<void> =>
-    ipcRenderer.invoke('terminal:ghostty:setFocus', worktreeId, focused),
+  ghosttySetFocus: (terminalId: string, focused: boolean): Promise<void> =>
+    ipcRenderer.invoke('terminal:ghostty:setFocus', terminalId, focused),
 
-  ghosttyPasteText: (worktreeId: string, text: string): Promise<void> =>
-    ipcRenderer.invoke('terminal:ghostty:pasteText', worktreeId, text),
+  ghosttyPasteText: (terminalId: string, text: string): Promise<void> =>
+    ipcRenderer.invoke('terminal:ghostty:pasteText', terminalId, text),
 
   ghosttyFocusDiagnostics: (): Promise<
     Array<{
@@ -1733,8 +1733,8 @@ const terminalOps = {
     }>
   > => ipcRenderer.invoke('terminal:ghostty:focusDiagnostics'),
 
-  ghosttyDestroySurface: (worktreeId: string): Promise<void> =>
-    ipcRenderer.invoke('terminal:ghostty:destroySurface', worktreeId),
+  ghosttyDestroySurface: (terminalId: string): Promise<void> =>
+    ipcRenderer.invoke('terminal:ghostty:destroySurface', terminalId),
 
   ghosttyShutdown: (): Promise<void> => ipcRenderer.invoke('terminal:ghostty:shutdown')
 }

--- a/src/renderer/src/components/sessions/SessionTerminalView.tsx
+++ b/src/renderer/src/components/sessions/SessionTerminalView.tsx
@@ -80,7 +80,7 @@ export function SessionTerminalView({
 
   return (
     <div className="flex-1 flex flex-col min-h-0" data-testid="session-terminal-view">
-      <TerminalView worktreeId={sessionId} cwd={cwd} isVisible={isVisible} />
+      <TerminalView terminalId={sessionId} cwd={cwd} isVisible={isVisible} />
     </div>
   )
 }

--- a/src/renderer/src/components/terminal/TerminalCloseConfirmDialog.tsx
+++ b/src/renderer/src/components/terminal/TerminalCloseConfirmDialog.tsx
@@ -13,6 +13,7 @@ interface TerminalCloseConfirmDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   terminalName: string
+  description?: string
   onConfirm: () => void
 }
 
@@ -20,6 +21,7 @@ export function TerminalCloseConfirmDialog({
   open,
   onOpenChange,
   terminalName,
+  description,
   onConfirm
 }: TerminalCloseConfirmDialogProps): React.JSX.Element {
   return (
@@ -28,7 +30,7 @@ export function TerminalCloseConfirmDialog({
         <AlertDialogHeader>
           <AlertDialogTitle>Close Terminal?</AlertDialogTitle>
           <AlertDialogDescription>
-            Terminal &ldquo;{terminalName}&rdquo; has a running process. Close anyway?
+            {description ?? <>Terminal &ldquo;{terminalName}&rdquo; has a running process. Close anyway?</>}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/src/renderer/src/components/terminal/TerminalCloseConfirmDialog.tsx
+++ b/src/renderer/src/components/terminal/TerminalCloseConfirmDialog.tsx
@@ -1,0 +1,43 @@
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction
+} from '@/components/ui/alert-dialog'
+
+interface TerminalCloseConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  terminalName: string
+  onConfirm: () => void
+}
+
+export function TerminalCloseConfirmDialog({
+  open,
+  onOpenChange,
+  terminalName,
+  onConfirm
+}: TerminalCloseConfirmDialogProps): React.JSX.Element {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Close Terminal?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Terminal &ldquo;{terminalName}&rdquo; has a running process. Close anyway?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onConfirm}>
+            Close Terminal
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/src/components/terminal/TerminalManager.tsx
+++ b/src/renderer/src/components/terminal/TerminalManager.tsx
@@ -67,12 +67,14 @@ export function TerminalManager({
   }
 
   // Auto-create "Terminal 1" when a worktree is selected and has no tabs
-  if (selectedWorktreeId && worktreePath && isVisible) {
-    const tabs = tabsByWorktree.get(selectedWorktreeId)
-    if (!tabs || tabs.length === 0) {
-      createTab(selectedWorktreeId)
+  useEffect(() => {
+    if (selectedWorktreeId && worktreePath && isVisible) {
+      const tabs = tabsByWorktree.get(selectedWorktreeId)
+      if (!tabs || tabs.length === 0) {
+        createTab(selectedWorktreeId)
+      }
     }
-  }
+  }, [selectedWorktreeId, worktreePath, isVisible, tabsByWorktree, createTab])
 
   // When backend setting changes, tear down all active terminals so they get re-created
   // with the new backend on next visibility

--- a/src/renderer/src/components/terminal/TerminalManager.tsx
+++ b/src/renderer/src/components/terminal/TerminalManager.tsx
@@ -66,23 +66,26 @@ export function TerminalManager({
     worktreePathsRef.current.set(selectedWorktreeId, worktreePath)
   }
 
-  // Auto-create "Terminal 1" when a worktree is selected and has no tabs
+  // Auto-create "Terminal 1" when a worktree is selected and has no tabs.
+  // Read tabs via getState() to avoid re-triggering on every tab state change.
   useEffect(() => {
     if (selectedWorktreeId && worktreePath && isVisible) {
-      const tabs = tabsByWorktree.get(selectedWorktreeId)
-      if (!tabs || tabs.length === 0) {
+      const tabs = useTerminalTabStore.getState().getTabs(selectedWorktreeId)
+      if (tabs.length === 0) {
         createTab(selectedWorktreeId)
       }
     }
-  }, [selectedWorktreeId, worktreePath, isVisible, tabsByWorktree, createTab])
+  }, [selectedWorktreeId, worktreePath, isVisible, createTab])
 
   // When backend setting changes, tear down all active terminals so they get re-created
-  // with the new backend on next visibility
+  // with the new backend on next visibility.
+  // Read tabs via getState() — this effect responds to backend changes, not tab changes.
   useEffect(() => {
     if (prevBackendRef.current !== embeddedTerminalBackend) {
       prevBackendRef.current = embeddedTerminalBackend
       // Destroy all PTYs across all worktrees by tab ID
-      for (const [, tabs] of tabsByWorktree) {
+      const currentTabs = useTerminalTabStore.getState().tabsByWorktree
+      for (const [, tabs] of currentTabs) {
         for (const tab of tabs) {
           destroyTerminal(tab.id)
         }
@@ -90,9 +93,11 @@ export function TerminalManager({
       removeAllTabs()
       terminalRefsMap.current.clear()
     }
-  }, [embeddedTerminalBackend, destroyTerminal, tabsByWorktree, removeAllTabs])
+  }, [embeddedTerminalBackend, destroyTerminal, removeAllTabs])
 
-  // Clean up terminals for worktrees that no longer exist
+  // Clean up terminals for worktrees that no longer exist.
+  // Only responds to worktreesByProject changes (actual worktree addition/removal),
+  // NOT to tab state changes. Reads tabs via getState() to avoid feedback loop with auto-create.
   useEffect(() => {
     const existingWorktreeIds = new Set<string>()
     for (const [, worktrees] of worktreesByProject) {
@@ -101,7 +106,8 @@ export function TerminalManager({
       }
     }
 
-    for (const [worktreeId, tabs] of tabsByWorktree) {
+    const currentTabs = useTerminalTabStore.getState().tabsByWorktree
+    for (const [worktreeId, tabs] of currentTabs) {
       if (!existingWorktreeIds.has(worktreeId)) {
         // Worktree was deleted/archived — destroy all its tab PTYs
         for (const tab of tabs) {
@@ -112,7 +118,7 @@ export function TerminalManager({
         worktreePathsRef.current.delete(worktreeId)
       }
     }
-  }, [worktreesByProject, destroyTerminal, tabsByWorktree, removeWorktree])
+  }, [worktreesByProject, destroyTerminal, removeWorktree])
 
   // Collect ALL tabs across ALL worktrees for rendering
   const allTabs = Array.from(tabsByWorktree.values()).flat()

--- a/src/renderer/src/components/terminal/TerminalManager.tsx
+++ b/src/renderer/src/components/terminal/TerminalManager.tsx
@@ -1,8 +1,11 @@
 import { useRef, useCallback, useEffect } from 'react'
 import { TerminalView, type TerminalViewHandle } from './TerminalView'
+import { TerminalTabSidebar } from './TerminalTabSidebar'
 import { useTerminalStore } from '@/stores/useTerminalStore'
+import { useTerminalTabStore } from '@/stores/useTerminalTabStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useShallow } from 'zustand/react/shallow'
 
 interface TerminalManagerProps {
   /** The currently selected worktree ID (null if none selected) */
@@ -14,20 +17,19 @@ interface TerminalManagerProps {
 }
 
 /**
- * TerminalManager ensures one TerminalView per worktree is kept alive across
- * tab switches and worktree changes. It renders all active terminals but only
- * shows the one matching the selected worktree.
+ * TerminalManager renders one TerminalView per tab across all worktrees,
+ * with a TerminalTabSidebar for the currently selected worktree.
  *
- * When the user switches from Terminal to Setup and back, the terminal DOM
- * and PTY process stay alive — no state is lost.
+ * All tabs are kept mounted (CSS hidden) to preserve PTY state.
+ * The tab store owns terminal identity — no activeWorktreesRef needed.
  */
 export function TerminalManager({
   selectedWorktreeId,
   worktreePath,
   isVisible
 }: TerminalManagerProps): React.JSX.Element {
-  // Track which worktrees have had terminals opened
-  const activeWorktreesRef = useRef<Map<string, string>>(new Map()) // worktreeId -> cwd
+  // Map worktreeId -> path for resolving CWD of non-selected worktrees' tabs
+  const worktreePathsRef = useRef<Map<string, string>>(new Map())
   const terminalRefsMap = useRef<Map<string, React.RefObject<TerminalViewHandle | null>>>(new Map())
 
   const destroyTerminal = useTerminalStore((s) => s.destroyTerminal)
@@ -35,23 +37,40 @@ export function TerminalManager({
   const embeddedTerminalBackend = useSettingsStore((s) => s.embeddedTerminalBackend)
   const prevBackendRef = useRef(embeddedTerminalBackend)
 
-  // Get or create a ref for a worktree's terminal
+  const { tabsByWorktree, activeTabByWorktree, createTab, removeWorktree, removeAllTabs } =
+    useTerminalTabStore(
+      useShallow((s) => ({
+        tabsByWorktree: s.tabsByWorktree,
+        activeTabByWorktree: s.activeTabByWorktree,
+        createTab: s.createTab,
+        removeWorktree: s.removeWorktree,
+        removeAllTabs: s.removeAllTabs
+      }))
+    )
+
+  // Get or create a ref for a tab's terminal
   const getTerminalRef = useCallback(
-    (worktreeId: string): React.RefObject<TerminalViewHandle | null> => {
-      let ref = terminalRefsMap.current.get(worktreeId)
+    (tabId: string): React.RefObject<TerminalViewHandle | null> => {
+      let ref = terminalRefsMap.current.get(tabId)
       if (!ref) {
         ref = { current: null }
-        terminalRefsMap.current.set(worktreeId, ref)
+        terminalRefsMap.current.set(tabId, ref)
       }
       return ref
     },
     []
   )
 
-  // Add the selected worktree to active terminals if it has a valid path
+  // Update worktree paths map when the selected worktree changes
+  if (selectedWorktreeId && worktreePath) {
+    worktreePathsRef.current.set(selectedWorktreeId, worktreePath)
+  }
+
+  // Auto-create "Terminal 1" when a worktree is selected and has no tabs
   if (selectedWorktreeId && worktreePath && isVisible) {
-    if (!activeWorktreesRef.current.has(selectedWorktreeId)) {
-      activeWorktreesRef.current.set(selectedWorktreeId, worktreePath)
+    const tabs = tabsByWorktree.get(selectedWorktreeId)
+    if (!tabs || tabs.length === 0) {
+      createTab(selectedWorktreeId)
     }
   }
 
@@ -60,14 +79,16 @@ export function TerminalManager({
   useEffect(() => {
     if (prevBackendRef.current !== embeddedTerminalBackend) {
       prevBackendRef.current = embeddedTerminalBackend
-      // Destroy all active terminals — TerminalView will re-create with new backend
-      for (const [worktreeId] of activeWorktreesRef.current) {
-        destroyTerminal(worktreeId)
+      // Destroy all PTYs across all worktrees by tab ID
+      for (const [, tabs] of tabsByWorktree) {
+        for (const tab of tabs) {
+          destroyTerminal(tab.id)
+        }
       }
-      activeWorktreesRef.current.clear()
+      removeAllTabs()
       terminalRefsMap.current.clear()
     }
-  }, [embeddedTerminalBackend, destroyTerminal])
+  }, [embeddedTerminalBackend, destroyTerminal, tabsByWorktree, removeAllTabs])
 
   // Clean up terminals for worktrees that no longer exist
   useEffect(() => {
@@ -78,20 +99,28 @@ export function TerminalManager({
       }
     }
 
-    for (const [worktreeId] of activeWorktreesRef.current) {
+    for (const [worktreeId, tabs] of tabsByWorktree) {
       if (!existingWorktreeIds.has(worktreeId)) {
-        // Worktree was deleted/archived — clean up its terminal
-        destroyTerminal(worktreeId)
-        activeWorktreesRef.current.delete(worktreeId)
-        terminalRefsMap.current.delete(worktreeId)
+        // Worktree was deleted/archived — destroy all its tab PTYs
+        for (const tab of tabs) {
+          destroyTerminal(tab.id)
+          terminalRefsMap.current.delete(tab.id)
+        }
+        removeWorktree(worktreeId)
+        worktreePathsRef.current.delete(worktreeId)
       }
     }
-  }, [worktreesByProject, destroyTerminal])
+  }, [worktreesByProject, destroyTerminal, tabsByWorktree, removeWorktree])
 
-  // Build the list of active terminals
-  const activeTerminals = Array.from(activeWorktreesRef.current.entries())
+  // Collect ALL tabs across ALL worktrees for rendering
+  const allTabs = Array.from(tabsByWorktree.values()).flat()
 
-  if (activeTerminals.length === 0 && !selectedWorktreeId) {
+  // Determine which tab is currently active for the selected worktree
+  const activeTabId = selectedWorktreeId
+    ? activeTabByWorktree.get(selectedWorktreeId)
+    : undefined
+
+  if (allTabs.length === 0 && !selectedWorktreeId) {
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
         Select a worktree to open a terminal
@@ -100,29 +129,37 @@ export function TerminalManager({
   }
 
   return (
-    <>
-      {activeTerminals.map(([worktreeId, cwd]) => {
-        const isActive = worktreeId === selectedWorktreeId && isVisible
-        const termRef = getTerminalRef(worktreeId)
+    <div className="flex h-full w-full">
+      <div className="flex-1 min-w-0 relative">
+        {allTabs.map((tab) => {
+          const isTabVisible =
+            tab.worktreeId === selectedWorktreeId && tab.id === activeTabId
+          const termRef = getTerminalRef(tab.id)
+          const cwd = worktreePathsRef.current.get(tab.worktreeId) ?? ''
 
-        return (
-          <div
-            key={worktreeId}
-            className={isActive ? 'h-full w-full' : 'hidden'}
-            data-testid={`terminal-instance-${worktreeId}`}
-          >
-            <TerminalView ref={termRef} worktreeId={worktreeId} cwd={cwd} isVisible={isActive} />
-          </div>
-        )
-      })}
-      {/* Show placeholder if selected worktree doesn't have a terminal yet */}
-      {selectedWorktreeId &&
-        !activeWorktreesRef.current.has(selectedWorktreeId) &&
-        !worktreePath && (
+          return (
+            <div
+              key={tab.id}
+              className={isTabVisible ? 'h-full w-full' : 'hidden'}
+              data-testid={`terminal-instance-${tab.id}`}
+            >
+              <TerminalView
+                ref={termRef}
+                terminalId={tab.id}
+                cwd={cwd}
+                isVisible={isTabVisible && isVisible}
+              />
+            </div>
+          )
+        })}
+        {/* Show placeholder if no tabs are visible */}
+        {allTabs.length === 0 && selectedWorktreeId && (
           <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
             Select a worktree to open a terminal
           </div>
         )}
-    </>
+      </div>
+      {selectedWorktreeId && <TerminalTabSidebar worktreeId={selectedWorktreeId} />}
+    </div>
   )
 }

--- a/src/renderer/src/components/terminal/TerminalTabEntry.tsx
+++ b/src/renderer/src/components/terminal/TerminalTabEntry.tsx
@@ -1,0 +1,139 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { TerminalTab } from '@/stores/useTerminalTabStore'
+import {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator
+} from '@/components/ui/context-menu'
+
+interface TerminalTabEntryProps {
+  tab: TerminalTab
+  isActive: boolean
+  onSelect: () => void
+  onClose: () => void
+  onRename: (name: string) => void
+  onCloseOthers: () => void
+}
+
+export function TerminalTabEntry({
+  tab,
+  isActive,
+  onSelect,
+  onClose,
+  onRename,
+  onCloseOthers
+}: TerminalTabEntryProps): React.JSX.Element {
+  const [isEditing, setIsEditing] = useState(false)
+  const [editValue, setEditValue] = useState(tab.name)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (isEditing) {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus()
+        inputRef.current?.select()
+      })
+    }
+  }, [isEditing])
+
+  const startRename = useCallback(() => {
+    setEditValue(tab.name)
+    setIsEditing(true)
+  }, [tab.name])
+
+  const commitRename = useCallback(() => {
+    const trimmed = editValue.trim()
+    if (trimmed && trimmed !== tab.name) {
+      onRename(trimmed)
+    }
+    setIsEditing(false)
+  }, [editValue, tab.name, onRename])
+
+  const cancelRename = useCallback(() => {
+    setEditValue(tab.name)
+    setIsEditing(false)
+  }, [tab.name])
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    e.stopPropagation()
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      commitRename()
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      cancelRename()
+    }
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          className={cn(
+            'group flex items-center gap-1.5 px-2 py-1 mx-0.5 rounded-sm cursor-pointer text-xs select-none',
+            isActive ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent/50'
+          )}
+          onClick={onSelect}
+        >
+          {/* Status dot */}
+          <span
+            className={cn('h-1.5 w-1.5 rounded-full shrink-0', {
+              'bg-yellow-500 animate-pulse': tab.status === 'creating',
+              'bg-green-500': tab.status === 'running',
+              'bg-red-500': tab.status === 'exited' && tab.exitCode !== 0,
+              'bg-muted-foreground': tab.status === 'exited' && tab.exitCode === 0
+            })}
+          />
+
+          {/* Name or inline edit */}
+          {isEditing ? (
+            <input
+              ref={inputRef}
+              type="text"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onBlur={commitRename}
+              className="flex-1 min-w-0 h-4 px-0.5 text-xs bg-background border border-border rounded focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          ) : (
+            <span
+              className="flex-1 min-w-0 truncate"
+              onDoubleClick={(e) => {
+                e.stopPropagation()
+                startRename()
+              }}
+            >
+              {tab.name}
+            </span>
+          )}
+
+          {/* Hover-reveal close button */}
+          {!isEditing && (
+            <button
+              className="shrink-0 opacity-0 group-hover:opacity-100 p-0.5 text-muted-foreground hover:text-foreground rounded transition-opacity"
+              onClick={(e) => {
+                e.stopPropagation()
+                onClose()
+              }}
+              title="Close"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={startRename}>Rename</ContextMenuItem>
+        <ContextMenuItem onSelect={onClose}>Close</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={onCloseOthers}>Close Others</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/src/renderer/src/components/terminal/TerminalTabSidebar.tsx
+++ b/src/renderer/src/components/terminal/TerminalTabSidebar.tsx
@@ -1,10 +1,23 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Plus } from 'lucide-react'
 import { useTerminalTabStore } from '@/stores/useTerminalTabStore'
+import type { TerminalTab } from '@/stores/useTerminalTabStore'
 import { useTerminalStore } from '@/stores/useTerminalStore'
 import { useShallow } from 'zustand/react/shallow'
 import { TerminalTabEntry } from './TerminalTabEntry'
 import { TerminalCloseConfirmDialog } from './TerminalCloseConfirmDialog'
+
+/**
+ * Stable empty array to avoid infinite re-render loops in useShallow selectors.
+ *
+ * `useShallow` uses `Object.is` to compare each property of the selector result.
+ * An inline `?? []` creates a new array reference on every selector invocation,
+ * which `Object.is([]_prev, []_next)` considers different. During React's commit
+ * phase, `useSyncExternalStore` re-runs the selector for tearing detection — if
+ * the result is always "different" (due to unstable `[]`), it forces a synchronous
+ * re-render, which triggers another tearing check, creating an infinite loop.
+ */
+const EMPTY_TABS: TerminalTab[] = []
 
 interface TerminalTabSidebarProps {
   worktreeId: string
@@ -13,7 +26,7 @@ interface TerminalTabSidebarProps {
 export function TerminalTabSidebar({ worktreeId }: TerminalTabSidebarProps): React.JSX.Element {
   const { tabs, activeTabId } = useTerminalTabStore(
     useShallow((s) => ({
-      tabs: s.tabsByWorktree.get(worktreeId) ?? [],
+      tabs: s.tabsByWorktree.get(worktreeId) ?? EMPTY_TABS,
       activeTabId: s.activeTabByWorktree.get(worktreeId)
     }))
   )

--- a/src/renderer/src/components/terminal/TerminalTabSidebar.tsx
+++ b/src/renderer/src/components/terminal/TerminalTabSidebar.tsx
@@ -1,8 +1,10 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Plus } from 'lucide-react'
 import { useTerminalTabStore } from '@/stores/useTerminalTabStore'
+import { useTerminalStore } from '@/stores/useTerminalStore'
 import { useShallow } from 'zustand/react/shallow'
 import { TerminalTabEntry } from './TerminalTabEntry'
+import { TerminalCloseConfirmDialog } from './TerminalCloseConfirmDialog'
 
 interface TerminalTabSidebarProps {
   worktreeId: string
@@ -26,9 +28,56 @@ export function TerminalTabSidebar({ worktreeId }: TerminalTabSidebarProps): Rea
     }))
   )
 
+  const destroyTerminal = useTerminalStore((s) => s.destroyTerminal)
+
+  const [closeConfirmTab, setCloseConfirmTab] = useState<{ id: string; name: string } | null>(null)
+
   const handleCreateTab = useCallback(() => {
     createTab(worktreeId)
   }, [createTab, worktreeId])
+
+  const handleCloseTab = useCallback(
+    (tabId: string) => {
+      const tab = tabs.find((t) => t.id === tabId)
+      if (!tab) return
+
+      if (tab.status === 'running') {
+        setCloseConfirmTab({ id: tab.id, name: tab.name })
+      } else {
+        closeTab(worktreeId, tabId)
+        destroyTerminal(tabId)
+      }
+    },
+    [tabs, worktreeId, closeTab, destroyTerminal]
+  )
+
+  const confirmCloseTab = useCallback(() => {
+    if (!closeConfirmTab) return
+    closeTab(worktreeId, closeConfirmTab.id)
+    destroyTerminal(closeConfirmTab.id)
+    setCloseConfirmTab(null)
+  }, [closeConfirmTab, worktreeId, closeTab, destroyTerminal])
+
+  const handleCloseOtherTabs = useCallback(
+    (keepTabId: string) => {
+      const tabsToClose = tabs.filter((t) => t.id !== keepTabId)
+      for (const tab of tabsToClose) {
+        destroyTerminal(tab.id)
+      }
+      closeOtherTabs(worktreeId, keepTabId)
+    },
+    [tabs, worktreeId, destroyTerminal, closeOtherTabs]
+  )
+
+  // Listen for close-terminal-tab events dispatched by Cmd+W keyboard shortcut
+  useEffect(() => {
+    const handler = (e: CustomEvent): void => {
+      const { tabId, tabName } = e.detail
+      setCloseConfirmTab({ id: tabId, name: tabName })
+    }
+    window.addEventListener('hive:close-terminal-tab', handler as EventListener)
+    return () => window.removeEventListener('hive:close-terminal-tab', handler as EventListener)
+  }, [])
 
   return (
     <div className="w-[140px] border-l border-border flex flex-col h-full bg-background/50">
@@ -51,12 +100,20 @@ export function TerminalTabSidebar({ worktreeId }: TerminalTabSidebarProps): Rea
             tab={tab}
             isActive={tab.id === activeTabId}
             onSelect={() => setActiveTab(worktreeId, tab.id)}
-            onClose={() => closeTab(worktreeId, tab.id)}
+            onClose={() => handleCloseTab(tab.id)}
             onRename={(name) => renameTab(worktreeId, tab.id, name)}
-            onCloseOthers={() => closeOtherTabs(worktreeId, tab.id)}
+            onCloseOthers={() => handleCloseOtherTabs(tab.id)}
           />
         ))}
       </div>
+      <TerminalCloseConfirmDialog
+        open={closeConfirmTab !== null}
+        onOpenChange={(open) => {
+          if (!open) setCloseConfirmTab(null)
+        }}
+        terminalName={closeConfirmTab?.name ?? ''}
+        onConfirm={confirmCloseTab}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/terminal/TerminalTabSidebar.tsx
+++ b/src/renderer/src/components/terminal/TerminalTabSidebar.tsx
@@ -30,7 +30,11 @@ export function TerminalTabSidebar({ worktreeId }: TerminalTabSidebarProps): Rea
 
   const destroyTerminal = useTerminalStore((s) => s.destroyTerminal)
 
-  const [closeConfirmTab, setCloseConfirmTab] = useState<{ id: string; name: string } | null>(null)
+  const [closeConfirmTab, setCloseConfirmTab] = useState<{
+    id: string
+    name: string
+    mode: 'single' | 'close-others'
+  } | null>(null)
 
   const handleCreateTab = useCallback(() => {
     createTab(worktreeId)
@@ -42,7 +46,7 @@ export function TerminalTabSidebar({ worktreeId }: TerminalTabSidebarProps): Rea
       if (!tab) return
 
       if (tab.status === 'running') {
-        setCloseConfirmTab({ id: tab.id, name: tab.name })
+        setCloseConfirmTab({ id: tab.id, name: tab.name, mode: 'single' })
       } else {
         closeTab(worktreeId, tabId)
         destroyTerminal(tabId)
@@ -53,18 +57,38 @@ export function TerminalTabSidebar({ worktreeId }: TerminalTabSidebarProps): Rea
 
   const confirmCloseTab = useCallback(() => {
     if (!closeConfirmTab) return
-    closeTab(worktreeId, closeConfirmTab.id)
-    destroyTerminal(closeConfirmTab.id)
+
+    if (closeConfirmTab.mode === 'close-others') {
+      const tabsToClose = tabs.filter((t) => t.id !== closeConfirmTab.id)
+      for (const tab of tabsToClose) {
+        destroyTerminal(tab.id)
+      }
+      closeOtherTabs(worktreeId, closeConfirmTab.id)
+    } else {
+      closeTab(worktreeId, closeConfirmTab.id)
+      destroyTerminal(closeConfirmTab.id)
+    }
+
     setCloseConfirmTab(null)
-  }, [closeConfirmTab, worktreeId, closeTab, destroyTerminal])
+  }, [closeConfirmTab, tabs, worktreeId, closeTab, closeOtherTabs, destroyTerminal])
 
   const handleCloseOtherTabs = useCallback(
     (keepTabId: string) => {
       const tabsToClose = tabs.filter((t) => t.id !== keepTabId)
-      for (const tab of tabsToClose) {
-        destroyTerminal(tab.id)
+      const runningCount = tabsToClose.filter((t) => t.status === 'running').length
+
+      if (runningCount > 0) {
+        setCloseConfirmTab({
+          id: keepTabId,
+          name: `${runningCount} running terminal${runningCount > 1 ? 's' : ''}`,
+          mode: 'close-others'
+        })
+      } else {
+        for (const tab of tabsToClose) {
+          destroyTerminal(tab.id)
+        }
+        closeOtherTabs(worktreeId, keepTabId)
       }
-      closeOtherTabs(worktreeId, keepTabId)
     },
     [tabs, worktreeId, destroyTerminal, closeOtherTabs]
   )
@@ -73,7 +97,7 @@ export function TerminalTabSidebar({ worktreeId }: TerminalTabSidebarProps): Rea
   useEffect(() => {
     const handler = (e: CustomEvent): void => {
       const { tabId, tabName } = e.detail
-      setCloseConfirmTab({ id: tabId, name: tabName })
+      setCloseConfirmTab({ id: tabId, name: tabName, mode: 'single' })
     }
     window.addEventListener('hive:close-terminal-tab', handler as EventListener)
     return () => window.removeEventListener('hive:close-terminal-tab', handler as EventListener)
@@ -112,6 +136,11 @@ export function TerminalTabSidebar({ worktreeId }: TerminalTabSidebarProps): Rea
           if (!open) setCloseConfirmTab(null)
         }}
         terminalName={closeConfirmTab?.name ?? ''}
+        description={
+          closeConfirmTab?.mode === 'close-others'
+            ? `${closeConfirmTab.name} ${closeConfirmTab.name.startsWith('1 ') ? 'has' : 'have'} a running process. Close anyway?`
+            : undefined
+        }
         onConfirm={confirmCloseTab}
       />
     </div>

--- a/src/renderer/src/components/terminal/TerminalTabSidebar.tsx
+++ b/src/renderer/src/components/terminal/TerminalTabSidebar.tsx
@@ -1,0 +1,62 @@
+import { useCallback } from 'react'
+import { Plus } from 'lucide-react'
+import { useTerminalTabStore } from '@/stores/useTerminalTabStore'
+import { useShallow } from 'zustand/react/shallow'
+import { TerminalTabEntry } from './TerminalTabEntry'
+
+interface TerminalTabSidebarProps {
+  worktreeId: string
+}
+
+export function TerminalTabSidebar({ worktreeId }: TerminalTabSidebarProps): React.JSX.Element {
+  const { tabs, activeTabId } = useTerminalTabStore(
+    useShallow((s) => ({
+      tabs: s.tabsByWorktree.get(worktreeId) ?? [],
+      activeTabId: s.activeTabByWorktree.get(worktreeId)
+    }))
+  )
+
+  const { createTab, setActiveTab, closeTab, renameTab, closeOtherTabs } = useTerminalTabStore(
+    useShallow((s) => ({
+      createTab: s.createTab,
+      setActiveTab: s.setActiveTab,
+      closeTab: s.closeTab,
+      renameTab: s.renameTab,
+      closeOtherTabs: s.closeOtherTabs
+    }))
+  )
+
+  const handleCreateTab = useCallback(() => {
+    createTab(worktreeId)
+  }, [createTab, worktreeId])
+
+  return (
+    <div className="w-[140px] border-l border-border flex flex-col h-full bg-background/50">
+      {/* Header */}
+      <div className="flex items-center justify-between px-2 py-1 border-b border-border shrink-0">
+        <span className="text-xs text-muted-foreground font-medium select-none">Terminals</span>
+        <button
+          onClick={handleCreateTab}
+          className="p-0.5 text-muted-foreground hover:text-foreground rounded transition-colors"
+          title="New Terminal"
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      {/* Scrollable tab list */}
+      <div className="flex-1 overflow-y-auto py-0.5">
+        {tabs.map((tab) => (
+          <TerminalTabEntry
+            key={tab.id}
+            tab={tab}
+            isActive={tab.id === activeTabId}
+            onSelect={() => setActiveTab(worktreeId, tab.id)}
+            onClose={() => closeTab(worktreeId, tab.id)}
+            onRename={(name) => renameTab(worktreeId, tab.id, name)}
+            onCloseOthers={() => closeOtherTabs(worktreeId, tab.id)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback, useImperativeHandle, forwardRef, useState } from 'react'
 import { useTerminalStore } from '@/stores/useTerminalStore'
+import { useTerminalTabStore } from '@/stores/useTerminalTabStore'
 import { useSettingsStore, type EmbeddedTerminalBackend } from '@/stores/useSettingsStore'
 import { useLayoutStore } from '@/stores/useLayoutStore'
 import { useThemeStore } from '@/stores/useThemeStore'
@@ -11,7 +12,7 @@ import '@xterm/xterm/css/xterm.css'
 import '@/styles/xterm.css'
 
 interface TerminalViewProps {
-  worktreeId: string
+  terminalId: string
   cwd: string
   isVisible?: boolean
 }
@@ -34,7 +35,7 @@ function createBackend(type: TerminalBackendType): ITerminalBackend {
 }
 
 export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(function TerminalView(
-  { worktreeId, cwd, isVisible = true },
+  { terminalId, cwd, isVisible = true },
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -131,16 +132,16 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
 
     const cleanup = window.systemOps.onEditPaste((text) => {
       if (activeBackendTypeRef.current === 'ghostty') {
-        window.terminalOps.ghosttyPasteText(worktreeId, text)
+        window.terminalOps.ghosttyPasteText(terminalId, text)
       } else if (activeBackendTypeRef.current === 'xterm') {
-        window.terminalOps.write(worktreeId, text)
+        window.terminalOps.write(terminalId, text)
       }
     })
 
     return cleanup
     // embeddedTerminalBackend in deps ensures re-evaluation when the user switches backends,
     // since activeBackendTypeRef is a ref and doesn't trigger re-renders on its own.
-  }, [effectiveVisible, worktreeId, embeddedTerminalBackend])
+  }, [effectiveVisible, terminalId, embeddedTerminalBackend])
 
   // Search helpers (only for xterm backend)
   const handleSearch = useCallback((query: string) => {
@@ -180,8 +181,8 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       const container = containerRef.current
       if (!container) return
 
-      // Prevent re-initializing for the same worktree+backend combo
-      if (initializedRef.current === worktreeId && activeBackendTypeRef.current === backendType) {
+      // Prevent re-initializing for the same terminal+backend combo
+      if (initializedRef.current === terminalId && activeBackendTypeRef.current === backendType) {
         return
       }
 
@@ -192,11 +193,11 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       }
 
       // If switching backends on an existing terminal, destroy the old PTY
-      if (initializedRef.current === worktreeId && activeBackendTypeRef.current !== backendType) {
-        await destroyTerminal(worktreeId)
+      if (initializedRef.current === terminalId && activeBackendTypeRef.current !== backendType) {
+        await destroyTerminal(terminalId)
       }
 
-      initializedRef.current = worktreeId
+      initializedRef.current = terminalId
       activeBackendTypeRef.current = backendType
 
       container.innerHTML = ''
@@ -219,7 +220,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       backend.mount(
         container,
         {
-          worktreeId,
+          terminalId,
           cwd,
           fontFamily: config.fontFamily,
           fontSize: config.fontSize,
@@ -231,13 +232,14 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
           onStatusChange: (status, code) => {
             setTerminalStatus(status)
             if (code !== undefined) setExitCode(code)
+            useTerminalTabStore.getState().setTabStatus(terminalId, status, code)
           }
         }
       )
 
       backendRef.current = backend
     },
-    [worktreeId, cwd, destroyTerminal]
+    [terminalId, cwd, destroyTerminal]
   )
 
   // Handle restart — destroy old PTY and re-create terminal
@@ -260,9 +262,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       // Use default shell
     }
 
-    await restartTerminal(worktreeId, cwd, shell)
+    await restartTerminal(terminalId, cwd, shell)
     setupTerminal(embeddedTerminalBackend || 'xterm')
-  }, [worktreeId, cwd, restartTerminal, setupTerminal, embeddedTerminalBackend])
+  }, [terminalId, cwd, restartTerminal, setupTerminal, embeddedTerminalBackend])
 
   // Initialize terminal on mount, and re-create when backend setting changes
   useEffect(() => {
@@ -298,12 +300,12 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       setTerminalStatus('creating')
       setExitCode(undefined)
 
-      await destroyTerminal(worktreeId)
-      await restartTerminal(worktreeId, cwd)
+      await destroyTerminal(terminalId)
+      await restartTerminal(terminalId, cwd)
       setupTerminal('ghostty')
     }
     restart()
-  }, [ghosttyFontSize, worktreeId, cwd, destroyTerminal, restartTerminal, setupTerminal])
+  }, [ghosttyFontSize, terminalId, cwd, destroyTerminal, restartTerminal, setupTerminal])
 
   // Focus terminal on click
   const handleClick = useCallback(() => {

--- a/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
@@ -15,7 +15,7 @@ export class GhosttyBackend implements TerminalBackend {
   /** Fallback font size when the setting is unavailable (points). */
   private static readonly FALLBACK_FONT_SIZE = 14
 
-  private worktreeId: string = ''
+  private terminalId: string = ''
   private container: HTMLDivElement | null = null
   private resizeObserver: ResizeObserver | null = null
   private windowResizeHandler: (() => void) | null = null
@@ -24,7 +24,7 @@ export class GhosttyBackend implements TerminalBackend {
   private lastVisibleRect: { x: number; y: number; w: number; h: number } | null = null
 
   mount(container: HTMLDivElement, opts: TerminalOpts, callbacks: TerminalBackendCallbacks): void {
-    this.worktreeId = opts.worktreeId
+    this.terminalId = opts.terminalId
     this.container = container
     this.mounted = true
 
@@ -76,7 +76,7 @@ export class GhosttyBackend implements TerminalBackend {
       this.lastVisibleRect = rect
 
       // Create the native surface
-      const result = await window.terminalOps.ghosttyCreateSurface(this.worktreeId, rect, {
+      const result = await window.terminalOps.ghosttyCreateSurface(this.terminalId, rect, {
         cwd: opts.cwd,
         shell: opts.shell,
         scaleFactor: window.devicePixelRatio || 2.0,
@@ -89,7 +89,7 @@ export class GhosttyBackend implements TerminalBackend {
       }
 
       // Set initial focus
-      await window.terminalOps.ghosttySetFocus(this.worktreeId, true)
+      await window.terminalOps.ghosttySetFocus(this.terminalId, true)
 
       return true
     } catch (err) {
@@ -161,7 +161,7 @@ export class GhosttyBackend implements TerminalBackend {
 
     this.lastVisibleRect = rect
 
-    window.terminalOps.ghosttySetFrame(this.worktreeId, rect).catch(() => {
+    window.terminalOps.ghosttySetFrame(this.terminalId, rect).catch(() => {
       // Ignore frame sync errors during teardown
     })
   }
@@ -178,7 +178,7 @@ export class GhosttyBackend implements TerminalBackend {
 
   focus(): void {
     if (!this.mounted) return
-    window.terminalOps.ghosttySetFocus(this.worktreeId, true).catch(() => {
+    window.terminalOps.ghosttySetFocus(this.terminalId, true).catch(() => {
       // Ignore focus errors
     })
   }
@@ -187,7 +187,7 @@ export class GhosttyBackend implements TerminalBackend {
     if (!this.mounted) return
 
     if (!visible) {
-      window.terminalOps.ghosttySetFocus(this.worktreeId, false).catch(() => {
+      window.terminalOps.ghosttySetFocus(this.terminalId, false).catch(() => {
         // Ignore focus errors
       })
       const hiddenRect = this.lastVisibleRect
@@ -199,7 +199,7 @@ export class GhosttyBackend implements TerminalBackend {
           }
         : GhosttyBackend.HIDDEN_RECT
 
-      window.terminalOps.ghosttySetFrame(this.worktreeId, hiddenRect).catch(() => {
+      window.terminalOps.ghosttySetFrame(this.terminalId, hiddenRect).catch(() => {
         // Ignore frame sync errors during teardown
       })
       return
@@ -210,7 +210,7 @@ export class GhosttyBackend implements TerminalBackend {
     // and the menu paste handler routes Cmd+V correctly. Without this, focus
     // restoration depends on a fragile setTimeout in TerminalView that can be
     // cancelled by rapid effectiveVisible changes (e.g. overlay suppression race).
-    window.terminalOps.ghosttySetFocus(this.worktreeId, true).catch(() => {
+    window.terminalOps.ghosttySetFocus(this.terminalId, true).catch(() => {
       // Ignore focus errors
     })
   }
@@ -241,7 +241,7 @@ export class GhosttyBackend implements TerminalBackend {
       this.container = null
     }
 
-    window.terminalOps.ghosttyDestroySurface(this.worktreeId).catch(() => {
+    window.terminalOps.ghosttyDestroySurface(this.terminalId).catch(() => {
       // Best-effort cleanup
     })
   }

--- a/src/renderer/src/components/terminal/backends/XtermBackend.ts
+++ b/src/renderer/src/components/terminal/backends/XtermBackend.ts
@@ -131,7 +131,7 @@ export class XtermBackend implements TerminalBackend {
   private removeDataListener: (() => void) | null = null
   private removeExitListener: (() => void) | null = null
   private inputDisposable: { dispose: () => void } | null = null
-  private worktreeId: string = ''
+  private terminalId: string = ''
   private ghosttyConfig: GhosttyTerminalConfig = {}
 
   /** Callback for the host to wire Cmd+F search toggling */
@@ -140,7 +140,7 @@ export class XtermBackend implements TerminalBackend {
   onClearRequest?: () => void
 
   mount(container: HTMLDivElement, opts: TerminalOpts, callbacks: TerminalBackendCallbacks): void {
-    this.worktreeId = opts.worktreeId
+    this.terminalId = opts.terminalId
     container.innerHTML = ''
 
     // Store config for theme rebuilding
@@ -203,7 +203,7 @@ export class XtermBackend implements TerminalBackend {
           .readText()
           .catch(() => window.projectOps.readFromClipboard())
           .then((text) => {
-            if (text) window.terminalOps.write(this.worktreeId, text)
+            if (text) window.terminalOps.write(this.terminalId, text)
           })
           .catch((err) => console.error('Terminal paste failed:', err))
         return false
@@ -248,23 +248,23 @@ export class XtermBackend implements TerminalBackend {
 
     // Wire user input -> PTY
     this.inputDisposable = terminal.onData((data) => {
-      window.terminalOps.write(this.worktreeId, data)
+      window.terminalOps.write(this.terminalId, data)
     })
 
     // Wire PTY output -> terminal display
-    this.removeDataListener = window.terminalOps.onData(this.worktreeId, (data) => {
+    this.removeDataListener = window.terminalOps.onData(this.terminalId, (data) => {
       terminal.write(data)
     })
 
     // Wire PTY exit -> status change
-    this.removeExitListener = window.terminalOps.onExit(this.worktreeId, (code) => {
+    this.removeExitListener = window.terminalOps.onExit(this.terminalId, (code) => {
       terminal.write(`\r\n\x1b[90m[Process exited with code ${code}]\x1b[0m\r\n`)
       callbacks.onStatusChange('exited', code)
     })
 
     // Create the PTY
     callbacks.onStatusChange('creating')
-    window.terminalOps.create(this.worktreeId, opts.cwd, opts.shell).then((result) => {
+    window.terminalOps.create(this.terminalId, opts.cwd, opts.shell).then((result) => {
       if (result.success) {
         callbacks.onStatusChange('running')
 
@@ -280,7 +280,7 @@ export class XtermBackend implements TerminalBackend {
             this.fitAddon.fit()
             const dims = this.fitAddon.proposeDimensions()
             if (dims) {
-              window.terminalOps.resize(this.worktreeId, dims.cols, dims.rows)
+              window.terminalOps.resize(this.terminalId, dims.cols, dims.rows)
             }
           }
         } catch {
@@ -299,7 +299,7 @@ export class XtermBackend implements TerminalBackend {
           this.fitAddon.fit()
           const dims = this.fitAddon.proposeDimensions()
           if (dims) {
-            window.terminalOps.resize(this.worktreeId, dims.cols, dims.rows)
+            window.terminalOps.resize(this.terminalId, dims.cols, dims.rows)
           }
         }
       } catch {
@@ -314,7 +314,7 @@ export class XtermBackend implements TerminalBackend {
   }
 
   resize(cols: number, rows: number): void {
-    window.terminalOps.resize(this.worktreeId, cols, rows)
+    window.terminalOps.resize(this.terminalId, cols, rows)
   }
 
   focus(): void {
@@ -337,7 +337,7 @@ export class XtermBackend implements TerminalBackend {
       this.fitAddon?.fit()
       const dims = this.fitAddon?.proposeDimensions()
       if (dims) {
-        window.terminalOps.resize(this.worktreeId, dims.cols, dims.rows)
+        window.terminalOps.resize(this.terminalId, dims.cols, dims.rows)
       }
     } catch {
       // Ignore fit errors

--- a/src/renderer/src/components/terminal/backends/XtermBackend.ts
+++ b/src/renderer/src/components/terminal/backends/XtermBackend.ts
@@ -113,6 +113,9 @@ function isAppShortcut(e: KeyboardEvent): boolean {
   if (e.metaKey && e.shiftKey && e.key === 'P') return true
   if (e.metaKey && (e.key === '[' || e.key === ']')) return true
 
+  // Ctrl+Tab / Ctrl+Shift+Tab — terminal tab cycling handled by the app
+  if (e.ctrlKey && e.key === 'Tab') return true
+
   return false
 }
 

--- a/src/renderer/src/components/terminal/backends/types.ts
+++ b/src/renderer/src/components/terminal/backends/types.ts
@@ -6,7 +6,7 @@
 export type TerminalBackendType = 'xterm' | 'ghostty'
 
 export interface TerminalOpts {
-  worktreeId: string
+  terminalId: string
   cwd: string
   fontFamily?: string
   fontSize?: number

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -15,8 +15,24 @@ import { useShortcutStore } from '@/stores/useShortcutStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useScriptStore, fireRunScript, killRunScript } from '@/stores/useScriptStore'
 import { useFileViewerStore } from '@/stores/useFileViewerStore'
+import { useTerminalTabStore } from '@/stores/useTerminalTabStore'
+import { useTerminalStore } from '@/stores/useTerminalStore'
 import { eventMatchesBinding, type KeyBinding } from '@/lib/keyboard-shortcuts'
 import { toast } from '@/lib/toast'
+
+/**
+ * Check if the terminal panel is currently focused.
+ * Returns true if the active element is inside a terminal view (.xterm) or
+ * the terminal tab sidebar.
+ */
+function isTerminalFocused(): boolean {
+  const active = document.activeElement
+  if (!active) return false
+  return (
+    active.closest?.('.xterm') !== null ||
+    active.closest?.('[data-testid="terminal-view"]') !== null
+  )
+}
 
 /**
  * Runs or stops the project run script for the currently selected worktree.
@@ -181,12 +197,15 @@ export function useKeyboardShortcuts(): void {
       // Don't intercept bare-key shortcuts (no modifiers) when the xterm terminal
       // is focused — the terminal needs unmodified keystrokes for shell features
       // like Tab completion. Modified shortcuts (Cmd+T, Cmd+W, etc.) still work.
-      const isTerminalFocused = target.closest?.('.xterm') !== null
+      // Also skip bare Tab (no ctrl) since the terminal uses it for completion,
+      // but allow Ctrl+Tab through for terminal tab cycling.
+      const isXtermFocused = target.closest?.('.xterm') !== null
 
       for (const { binding, handler, allowInInput } of shortcuts) {
         if (!binding) continue
         if (isInputFocused && !allowInInput) continue
-        if (isTerminalFocused && (binding.modifiers.length === 0 || binding.key?.toLowerCase() === 'tab')) continue
+        if (isXtermFocused && binding.modifiers.length === 0) continue
+        if (isXtermFocused && binding.key?.toLowerCase() === 'tab' && !binding.modifiers.includes('ctrl')) continue
 
         if (eventMatchesBinding(event, binding)) {
           event.preventDefault()
@@ -210,6 +229,13 @@ export function useKeyboardShortcuts(): void {
     if (!window.systemOps?.onNewSessionShortcut) return
 
     const cleanup = window.systemOps.onNewSessionShortcut(() => {
+      if (isTerminalFocused()) {
+        const worktreeId = useWorktreeStore.getState().selectedWorktreeId
+        if (worktreeId) {
+          useTerminalTabStore.getState().createTab(worktreeId)
+        }
+        return
+      }
       createNewSession()
     })
 
@@ -240,6 +266,27 @@ export function useKeyboardShortcuts(): void {
     const cleanup = window.systemOps.onCloseSessionShortcut(() => {
       // Priority 0: Close any open modal/dialog
       if (tryCloseOpenModal()) return
+
+      // Priority 0.5: Close active terminal tab when terminal is focused
+      if (isTerminalFocused()) {
+        const worktreeId = useWorktreeStore.getState().selectedWorktreeId
+        if (worktreeId) {
+          const activeTab = useTerminalTabStore.getState().getActiveTab(worktreeId)
+          if (activeTab) {
+            if (activeTab.status === 'running') {
+              window.dispatchEvent(
+                new CustomEvent('hive:close-terminal-tab', {
+                  detail: { worktreeId, tabId: activeTab.id, tabName: activeTab.name }
+                })
+              )
+            } else {
+              useTerminalTabStore.getState().closeTab(worktreeId, activeTab.id)
+              useTerminalStore.getState().destroyTerminal(activeTab.id)
+            }
+          }
+        }
+        return
+      }
 
       const { activeFilePath, activeDiff } = useFileViewerStore.getState()
 
@@ -304,6 +351,13 @@ function getShortcutHandlers(
       binding: getEffectiveBinding('session:new'),
       allowInInput: true,
       handler: () => {
+        if (isTerminalFocused()) {
+          const worktreeId = useWorktreeStore.getState().selectedWorktreeId
+          if (worktreeId) {
+            useTerminalTabStore.getState().createTab(worktreeId)
+          }
+          return
+        }
         createNewSession()
       }
     },
@@ -314,6 +368,31 @@ function getShortcutHandlers(
       handler: () => {
         // Priority 0: Close any open modal/dialog
         if (tryCloseOpenModal()) return
+
+        // Priority 0.5: Close active terminal tab when terminal is focused
+        if (isTerminalFocused()) {
+          const worktreeId = useWorktreeStore.getState().selectedWorktreeId
+          if (worktreeId) {
+            const activeTab = useTerminalTabStore.getState().getActiveTab(worktreeId)
+            if (activeTab) {
+              if (activeTab.status === 'running') {
+                // Dispatch a custom event that TerminalTabSidebar can listen for
+                // to show the close confirmation dialog
+                window.dispatchEvent(
+                  new CustomEvent('hive:close-terminal-tab', {
+                    detail: { worktreeId, tabId: activeTab.id, tabName: activeTab.name }
+                  })
+                )
+              } else {
+                // Non-running tab: close directly
+                useTerminalTabStore.getState().closeTab(worktreeId, activeTab.id)
+                // Destroy the PTY
+                useTerminalStore.getState().destroyTerminal(activeTab.id)
+              }
+            }
+          }
+          return
+        }
 
         const { activeFilePath, activeDiff } = useFileViewerStore.getState()
 
@@ -581,6 +660,32 @@ function getShortcutHandlers(
           } else {
             mainPane.focus()
           }
+        }
+      }
+    },
+
+    // =====================
+    // Terminal tab cycling
+    // =====================
+    {
+      id: 'terminal:next-tab',
+      binding: { key: 'Tab', modifiers: ['ctrl'] },
+      allowInInput: true,
+      handler: () => {
+        const worktreeId = useWorktreeStore.getState().selectedWorktreeId
+        if (worktreeId) {
+          useTerminalTabStore.getState().cycleTab(worktreeId, 'next')
+        }
+      }
+    },
+    {
+      id: 'terminal:prev-tab',
+      binding: { key: 'Tab', modifiers: ['ctrl', 'shift'] },
+      allowInInput: true,
+      handler: () => {
+        const worktreeId = useWorktreeStore.getState().selectedWorktreeId
+        if (worktreeId) {
+          useTerminalTabStore.getState().cycleTab(worktreeId, 'prev')
         }
       }
     },

--- a/src/renderer/src/stores/useTerminalTabStore.ts
+++ b/src/renderer/src/stores/useTerminalTabStore.ts
@@ -88,8 +88,11 @@ export const useTerminalTabStore = create<TerminalTabState>((set, get) => ({
     const remaining = tabs.filter((t) => t.id !== tabId)
 
     if (remaining.length === 0) {
-      // Last tab closed: auto-create a fresh "Terminal 1" with counter reset
-      const freshTabId = `${worktreeId}::tab-1`
+      // Last tab closed: auto-create a fresh tab named "Terminal 1"
+      // Use next counter value for ID to avoid collision with in-flight PTY destroy
+      const currentCounter = state.tabCounterByWorktree.get(worktreeId) ?? 0
+      const nextCounter = currentCounter + 1
+      const freshTabId = `${worktreeId}::tab-${nextCounter}`
       const freshTab: TerminalTab = {
         id: freshTabId,
         worktreeId,
@@ -105,7 +108,7 @@ export const useTerminalTabStore = create<TerminalTabState>((set, get) => ({
 
         tabsByWorktree.set(worktreeId, [freshTab])
         activeTabByWorktree.set(worktreeId, freshTabId)
-        tabCounterByWorktree.set(worktreeId, 1)
+        tabCounterByWorktree.set(worktreeId, nextCounter)
 
         return { tabsByWorktree, activeTabByWorktree, tabCounterByWorktree }
       })

--- a/src/renderer/src/stores/useTerminalTabStore.ts
+++ b/src/renderer/src/stores/useTerminalTabStore.ts
@@ -1,0 +1,250 @@
+import { create } from 'zustand'
+import { toast } from '@/lib/toast'
+import { TerminalStatus } from './useTerminalStore'
+
+export interface TerminalTab {
+  id: string // Format: `${worktreeId}::tab-${counter}`
+  worktreeId: string
+  name: string // "Terminal 1", "Terminal 2", etc.
+  status: TerminalStatus // 'creating' | 'running' | 'exited'
+  exitCode?: number
+  createdAt: number
+}
+
+const TAB_SOFT_LIMIT = 10
+
+interface TerminalTabState {
+  tabsByWorktree: Map<string, TerminalTab[]>
+  activeTabByWorktree: Map<string, string> // worktreeId -> tabId
+  tabCounterByWorktree: Map<string, number>
+
+  // Actions
+  createTab(worktreeId: string): string
+  closeTab(worktreeId: string, tabId: string): void
+  closeOtherTabs(worktreeId: string, keepTabId: string): void
+  setActiveTab(worktreeId: string, tabId: string): void
+  renameTab(worktreeId: string, tabId: string, name: string): void
+  setTabStatus(tabId: string, status: TerminalStatus, exitCode?: number): void
+  cycleTab(worktreeId: string, direction: 'next' | 'prev'): void
+
+  // Queries
+  getActiveTab(worktreeId: string): TerminalTab | undefined
+  getTabs(worktreeId: string): TerminalTab[]
+  getTabCount(worktreeId: string): number
+
+  // Cleanup
+  removeWorktree(worktreeId: string): void
+  removeAllTabs(): void
+}
+
+export const useTerminalTabStore = create<TerminalTabState>((set, get) => ({
+  tabsByWorktree: new Map(),
+  activeTabByWorktree: new Map(),
+  tabCounterByWorktree: new Map(),
+
+  createTab: (worktreeId: string): string => {
+    const state = get()
+    const currentCount = state.tabCounterByWorktree.get(worktreeId) ?? 0
+    const counter = currentCount + 1
+    const tabId = `${worktreeId}::tab-${counter}`
+
+    const existingTabs = state.tabsByWorktree.get(worktreeId) ?? []
+    if (existingTabs.length >= TAB_SOFT_LIMIT) {
+      toast.warning(
+        'You have many terminal tabs open. Consider closing unused ones.'
+      )
+    }
+
+    const newTab: TerminalTab = {
+      id: tabId,
+      worktreeId,
+      name: `Terminal ${counter}`,
+      status: 'creating',
+      createdAt: Date.now()
+    }
+
+    set((state) => {
+      const tabsByWorktree = new Map(state.tabsByWorktree)
+      const activeTabByWorktree = new Map(state.activeTabByWorktree)
+      const tabCounterByWorktree = new Map(state.tabCounterByWorktree)
+
+      const tabs = [...(tabsByWorktree.get(worktreeId) ?? []), newTab]
+      tabsByWorktree.set(worktreeId, tabs)
+      activeTabByWorktree.set(worktreeId, tabId)
+      tabCounterByWorktree.set(worktreeId, counter)
+
+      return { tabsByWorktree, activeTabByWorktree, tabCounterByWorktree }
+    })
+
+    return tabId
+  },
+
+  closeTab: (worktreeId: string, tabId: string): void => {
+    const state = get()
+    const tabs = state.tabsByWorktree.get(worktreeId) ?? []
+    const tabIndex = tabs.findIndex((t) => t.id === tabId)
+    if (tabIndex === -1) return
+
+    const remaining = tabs.filter((t) => t.id !== tabId)
+
+    if (remaining.length === 0) {
+      // Last tab closed: auto-create a fresh "Terminal 1" with counter reset
+      const freshTabId = `${worktreeId}::tab-1`
+      const freshTab: TerminalTab = {
+        id: freshTabId,
+        worktreeId,
+        name: 'Terminal 1',
+        status: 'creating',
+        createdAt: Date.now()
+      }
+
+      set((state) => {
+        const tabsByWorktree = new Map(state.tabsByWorktree)
+        const activeTabByWorktree = new Map(state.activeTabByWorktree)
+        const tabCounterByWorktree = new Map(state.tabCounterByWorktree)
+
+        tabsByWorktree.set(worktreeId, [freshTab])
+        activeTabByWorktree.set(worktreeId, freshTabId)
+        tabCounterByWorktree.set(worktreeId, 1)
+
+        return { tabsByWorktree, activeTabByWorktree, tabCounterByWorktree }
+      })
+      return
+    }
+
+    // Determine new active tab if the closed one was active
+    const wasActive = state.activeTabByWorktree.get(worktreeId) === tabId
+
+    set((state) => {
+      const tabsByWorktree = new Map(state.tabsByWorktree)
+      const activeTabByWorktree = new Map(state.activeTabByWorktree)
+
+      tabsByWorktree.set(worktreeId, remaining)
+
+      if (wasActive) {
+        // Activate next tab in list, or previous if closed tab was last
+        const newIndex = tabIndex < remaining.length ? tabIndex : remaining.length - 1
+        activeTabByWorktree.set(worktreeId, remaining[newIndex].id)
+      }
+
+      return { tabsByWorktree, activeTabByWorktree }
+    })
+  },
+
+  closeOtherTabs: (worktreeId: string, keepTabId: string): void => {
+    const state = get()
+    const tabs = state.tabsByWorktree.get(worktreeId) ?? []
+    const keepTab = tabs.find((t) => t.id === keepTabId)
+    if (!keepTab) return
+
+    set((state) => {
+      const tabsByWorktree = new Map(state.tabsByWorktree)
+      const activeTabByWorktree = new Map(state.activeTabByWorktree)
+
+      tabsByWorktree.set(worktreeId, [keepTab])
+      activeTabByWorktree.set(worktreeId, keepTabId)
+
+      return { tabsByWorktree, activeTabByWorktree }
+    })
+  },
+
+  setActiveTab: (worktreeId: string, tabId: string): void => {
+    set((state) => {
+      const activeTabByWorktree = new Map(state.activeTabByWorktree)
+      activeTabByWorktree.set(worktreeId, tabId)
+      return { activeTabByWorktree }
+    })
+  },
+
+  renameTab: (worktreeId: string, tabId: string, name: string): void => {
+    set((state) => {
+      const tabsByWorktree = new Map(state.tabsByWorktree)
+      const tabs = tabsByWorktree.get(worktreeId)
+      if (!tabs) return state
+
+      const updatedTabs = tabs.map((t) =>
+        t.id === tabId ? { ...t, name } : t
+      )
+      tabsByWorktree.set(worktreeId, updatedTabs)
+
+      return { tabsByWorktree }
+    })
+  },
+
+  setTabStatus: (tabId: string, status: TerminalStatus, exitCode?: number): void => {
+    set((state) => {
+      const tabsByWorktree = new Map(state.tabsByWorktree)
+
+      for (const [worktreeId, tabs] of tabsByWorktree) {
+        const tabIndex = tabs.findIndex((t) => t.id === tabId)
+        if (tabIndex !== -1) {
+          const updatedTabs = tabs.map((t) =>
+            t.id === tabId ? { ...t, status, exitCode } : t
+          )
+          tabsByWorktree.set(worktreeId, updatedTabs)
+          return { tabsByWorktree }
+        }
+      }
+
+      return state
+    })
+  },
+
+  cycleTab: (worktreeId: string, direction: 'next' | 'prev'): void => {
+    const state = get()
+    const tabs = state.tabsByWorktree.get(worktreeId) ?? []
+    if (tabs.length <= 1) return
+
+    const activeTabId = state.activeTabByWorktree.get(worktreeId)
+    const currentIndex = tabs.findIndex((t) => t.id === activeTabId)
+    if (currentIndex === -1) return
+
+    const offset = direction === 'next' ? 1 : -1
+    const newIndex = (currentIndex + offset + tabs.length) % tabs.length
+
+    set((state) => {
+      const activeTabByWorktree = new Map(state.activeTabByWorktree)
+      activeTabByWorktree.set(worktreeId, tabs[newIndex].id)
+      return { activeTabByWorktree }
+    })
+  },
+
+  getActiveTab: (worktreeId: string): TerminalTab | undefined => {
+    const state = get()
+    const activeTabId = state.activeTabByWorktree.get(worktreeId)
+    if (!activeTabId) return undefined
+
+    const tabs = state.tabsByWorktree.get(worktreeId) ?? []
+    return tabs.find((t) => t.id === activeTabId)
+  },
+
+  getTabs: (worktreeId: string): TerminalTab[] => {
+    return get().tabsByWorktree.get(worktreeId) ?? []
+  },
+
+  getTabCount: (worktreeId: string): number => {
+    return (get().tabsByWorktree.get(worktreeId) ?? []).length
+  },
+
+  removeWorktree: (worktreeId: string): void => {
+    set((state) => {
+      const tabsByWorktree = new Map(state.tabsByWorktree)
+      const activeTabByWorktree = new Map(state.activeTabByWorktree)
+      const tabCounterByWorktree = new Map(state.tabCounterByWorktree)
+
+      tabsByWorktree.delete(worktreeId)
+      activeTabByWorktree.delete(worktreeId)
+      tabCounterByWorktree.delete(worktreeId)
+
+      return { tabsByWorktree, activeTabByWorktree, tabCounterByWorktree }
+    })
+  },
+
+  removeAllTabs: (): void => {
+    set({
+      tabsByWorktree: new Map(),
+      activeTabByWorktree: new Map(),
+      tabCounterByWorktree: new Map()
+    })
+  }
+}))

--- a/src/renderer/src/stores/useTerminalTabStore.ts
+++ b/src/renderer/src/stores/useTerminalTabStore.ts
@@ -43,30 +43,27 @@ export const useTerminalTabStore = create<TerminalTabState>((set, get) => ({
   tabCounterByWorktree: new Map(),
 
   createTab: (worktreeId: string): string => {
-    const state = get()
-    const currentCount = state.tabCounterByWorktree.get(worktreeId) ?? 0
-    const counter = currentCount + 1
-    const tabId = `${worktreeId}::tab-${counter}`
-
-    const existingTabs = state.tabsByWorktree.get(worktreeId) ?? []
-    if (existingTabs.length >= TAB_SOFT_LIMIT) {
-      toast.warning(
-        'You have many terminal tabs open. Consider closing unused ones.'
-      )
-    }
-
-    const newTab: TerminalTab = {
-      id: tabId,
-      worktreeId,
-      name: `Terminal ${counter}`,
-      status: 'creating',
-      createdAt: Date.now()
-    }
+    // Compute counter, tabId, and newTab INSIDE set() to avoid TOCTOU races.
+    // Two rapid calls (e.g. double-click, or auto-create racing with user click)
+    // would otherwise read the same counter from get() and produce duplicate IDs.
+    let tabId = ''
 
     set((state) => {
       const tabsByWorktree = new Map(state.tabsByWorktree)
       const activeTabByWorktree = new Map(state.activeTabByWorktree)
       const tabCounterByWorktree = new Map(state.tabCounterByWorktree)
+
+      const currentCount = tabCounterByWorktree.get(worktreeId) ?? 0
+      const counter = currentCount + 1
+      tabId = `${worktreeId}::tab-${counter}`
+
+      const newTab: TerminalTab = {
+        id: tabId,
+        worktreeId,
+        name: `Terminal ${counter}`,
+        status: 'creating',
+        createdAt: Date.now()
+      }
 
       const tabs = [...(tabsByWorktree.get(worktreeId) ?? []), newTab]
       tabsByWorktree.set(worktreeId, tabs)
@@ -75,6 +72,14 @@ export const useTerminalTabStore = create<TerminalTabState>((set, get) => ({
 
       return { tabsByWorktree, activeTabByWorktree, tabCounterByWorktree }
     })
+
+    // Toast after set() so the tab count reflects the just-created tab
+    const tabCount = get().tabsByWorktree.get(worktreeId)?.length ?? 0
+    if (tabCount >= TAB_SOFT_LIMIT) {
+      toast.warning(
+        'You have many terminal tabs open. Consider closing unused ones.'
+      )
+    }
 
     return tabId
   },


### PR DESCRIPTION
## Summary

- **Added terminal tab state management** via `useTerminalTabStore` with per-worktree tab tracking, active tab selection, and tab lifecycle (create, close, rename)
- **Created terminal tab UI components**:
  - `TerminalTabSidebar`: displays tabs for the selected worktree with add button
  - `TerminalTabEntry`: individual tab with status indicator, inline rename, and context menu (rename, close, close others)
  - `TerminalCloseConfirmDialog`: confirmation dialog for closing running terminals
- **Updated TerminalManager** to render all tabs across all worktrees while keeping them mounted (CSS hidden) to preserve PTY state
- **Fixed infinite re-render loop** by using stable empty array in `useShallow` selector to prevent unstable references
- **Added keyboard shortcuts** for terminal tab management:
  - `Cmd+T`: create new tab
  - `Cmd+W` or `Ctrl+W`: close current tab
  - `Ctrl+Tab`: switch to next tab
  - `Ctrl+Shift+Tab`: switch to previous tab
- **Updated terminal IPC layer** to use `terminalId` (tab ID) instead of `worktreeId` throughout handlers and preload API
- **Renamed terminal API parameters** from `worktreeId` to `terminalId` for clarity and consistency

## Testing

- Verify new terminal opens with `Cmd+T` and appears in sidebar
- Confirm `Cmd+W` closes the active tab and shows confirmation dialog if process is running
- Test tab switching with `Ctrl+Tab` / `Ctrl+Shift+Tab` maintains isolation between tabs
- Verify double-clicking tab name allows inline rename (Enter to save, Escape to cancel)
- Confirm right-click context menu shows rename, close, and close others options
- Test "close others" confirmation only appears if there are running processes
- Verify tab status indicator (yellow pulsing for creating, green for running, red for exited with error)
- Test that closing all tabs for a worktree shows placeholder
- Confirm switching between worktrees preserves their respective active tabs
- Verify backend changes teardown and recreate all tabs with new backend

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces new terminal tab state/UI and reroutes PTY/Ghostty IPC identifiers from `worktreeId` to `terminalId`, which could break terminal lifecycle or message routing if any call sites were missed.
> 
> **Overview**
> Adds **multi-tab terminal support per worktree** via a new `useTerminalTabStore` and a right-side `TerminalTabSidebar` UI (create, select, rename, close, close-others) while keeping all tabs mounted to preserve PTY state.
> 
> Refactors terminal identity across the stack from `worktreeId` to `terminalId` (tab ID) for PTY and Ghostty IPC/preload APIs, updates `TerminalManager`/`TerminalView`/backends accordingly, and wires tab status updates (creating/running/exited + exit code) into the tab store.
> 
> Enhances keyboard handling for terminals: `Cmd/Ctrl+T` creates a terminal tab when terminal is focused, `Cmd/Ctrl+W` closes the active terminal tab (with confirmation for running processes), and `Ctrl+Tab`/`Ctrl+Shift+Tab` cycles tabs; xterm now allows app-level `Ctrl+Tab` to pass through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3d3bf42f93adc7b74307c7eec52b9bd6e231215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->