### PR TITLE
feat: Make board assistant a persistent tab instead of drawer

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -116,7 +116,8 @@ export class DatabaseService {
   private mapSessionRow(row: Record<string, unknown>): Session {
     return {
       ...row,
-      pinned_to_board: !!(row.pinned_to_board as number)
+      pinned_to_board: !!(row.pinned_to_board as number),
+      session_type: (row.session_type as string) ?? 'default'
     } as Session
   }
 
@@ -389,6 +390,7 @@ export class DatabaseService {
     this.safeAddColumn('kanban_tickets', 'github_pr_number', 'INTEGER DEFAULT NULL')
     this.safeAddColumn('kanban_tickets', 'github_pr_url', 'TEXT DEFAULT NULL')
     this.safeAddColumn('kanban_tickets', 'mark', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('sessions', 'session_type', "TEXT NOT NULL DEFAULT 'default'")
 
     db.exec(`
       CREATE INDEX IF NOT EXISTS idx_sessions_connection ON sessions(connection_id);
@@ -1004,6 +1006,7 @@ export class DatabaseService {
       opencode_session_id: data.opencode_session_id ?? null,
       agent_sdk: data.agent_sdk ?? 'opencode',
       mode: data.mode ?? 'build',
+      session_type: data.session_type ?? 'default',
       model_provider_id: data.model_provider_id ?? null,
       model_id: data.model_id ?? null,
       model_variant: data.model_variant ?? null,
@@ -1014,8 +1017,8 @@ export class DatabaseService {
     }
 
     db.prepare(
-      `INSERT INTO sessions (id, worktree_id, project_id, connection_id, name, status, opencode_session_id, agent_sdk, mode, model_provider_id, model_id, model_variant, created_at, updated_at, completed_at, pinned_to_board)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO sessions (id, worktree_id, project_id, connection_id, name, status, opencode_session_id, agent_sdk, mode, session_type, model_provider_id, model_id, model_variant, created_at, updated_at, completed_at, pinned_to_board)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       session.id,
       session.worktree_id,
@@ -1026,6 +1029,7 @@ export class DatabaseService {
       session.opencode_session_id,
       session.agent_sdk,
       session.mode,
+      session.session_type,
       session.model_provider_id,
       session.model_id,
       session.model_variant,
@@ -1092,6 +1096,16 @@ export class DatabaseService {
     return rows.map((row) => this.mapSessionRow(row))
   }
 
+  getActiveBoardAssistantByProject(projectId: string): Session | null {
+    const db = this.getDb()
+    const row = db
+      .prepare(
+        "SELECT * FROM sessions WHERE project_id = ? AND session_type = 'board-assistant' AND status = 'active' ORDER BY updated_at DESC LIMIT 1"
+      )
+      .get(projectId) as Record<string, unknown> | undefined
+    return row ? this.mapSessionRow(row) : null
+  }
+
   countActiveSessions(): number {
     const db = this.getDb()
     const row = db.prepare("SELECT COUNT(*) as count FROM sessions WHERE status = 'active'").get() as { count: number } | undefined
@@ -1125,6 +1139,10 @@ export class DatabaseService {
     if (data.mode !== undefined) {
       updates.push('mode = ?')
       values.push(data.mode)
+    }
+    if (data.session_type !== undefined) {
+      updates.push('session_type = ?')
+      values.push(data.session_type)
     }
     if (data.model_provider_id !== undefined) {
       updates.push('model_provider_id = ?')

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 22
+export const CURRENT_SCHEMA_VERSION = 23
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -442,6 +442,12 @@ export const MIGRATIONS: Migration[] = [
 CREATE INDEX idx_ticket_deps_dependent ON ticket_dependencies(dependent_id);
 CREATE INDEX idx_ticket_deps_blocker ON ticket_dependencies(blocker_id);
 ALTER TABLE kanban_tickets ADD COLUMN pending_launch_config TEXT DEFAULT NULL;`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 23,
+    name: 'add_session_type',
+    up: `ALTER TABLE sessions ADD COLUMN session_type TEXT NOT NULL DEFAULT 'default'`,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -89,6 +89,7 @@ export interface WorktreeUpdate {
 }
 
 export type SessionMode = 'build' | 'plan' | 'super-plan'
+export type SessionType = 'default' | 'board-assistant'
 
 export interface Session {
   id: string
@@ -100,6 +101,7 @@ export interface Session {
   opencode_session_id: string | null
   agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
   mode: SessionMode
+  session_type: SessionType
   model_provider_id: string | null
   model_id: string | null
   model_variant: string | null
@@ -117,6 +119,7 @@ export interface SessionCreate {
   opencode_session_id?: string | null
   agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
   mode?: SessionMode
+  session_type?: SessionType
   model_provider_id?: string | null
   model_id?: string | null
   model_variant?: string | null
@@ -129,6 +132,7 @@ export interface SessionUpdate {
   opencode_session_id?: string | null
   agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
   mode?: SessionMode
+  session_type?: SessionType
   model_provider_id?: string | null
   model_id?: string | null
   model_variant?: string | null

--- a/src/main/ipc/database-handlers.ts
+++ b/src/main/ipc/database-handlers.ts
@@ -291,6 +291,10 @@ export function registerDatabaseHandlers(): void {
     return getDatabase().searchSessions(options)
   })
 
+  ipcMain.handle('db:session:getActiveBoardAssistant', (_event, projectId: string) => {
+    return getDatabase().getActiveBoardAssistantByProject(projectId)
+  })
+
   ipcMain.handle('db:session:getDraft', (_event, sessionId: string) => {
     return getDatabase().getSessionDraft(sessionId)
   })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -365,6 +365,7 @@ declare global {
           name?: string | null
           opencode_session_id?: string | null
           agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+          session_type?: 'default' | 'board-assistant'
           model_provider_id?: string | null
           model_id?: string | null
           model_variant?: string | null
@@ -396,6 +397,7 @@ declare global {
         getActiveByConnection: (connectionId: string) => Promise<Session[]>
         setPinnedToBoard: (sessionId: string, pinned: boolean) => Promise<Session | null>
         getPinnedSessions: (worktreeId: string) => Promise<Session[]>
+        getActiveBoardAssistant: (projectId: string) => Promise<Session | null>
       }
       sessionMessage: {
         list: (sessionId: string) => Promise<SessionMessage[]>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -98,6 +98,7 @@ const db = {
       opencode_session_id?: string | null
       agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
       mode?: 'build' | 'plan'
+      session_type?: 'default' | 'board-assistant'
       model_provider_id?: string | null
       model_id?: string | null
       model_variant?: string | null
@@ -142,7 +143,9 @@ const db = {
     setPinnedToBoard: (sessionId: string, pinned: boolean) =>
       ipcRenderer.invoke('db:session:setPinnedToBoard', sessionId, pinned),
     getPinnedSessions: (worktreeId: string) =>
-      ipcRenderer.invoke('db:session:getPinnedSessions', worktreeId)
+      ipcRenderer.invoke('db:session:getPinnedSessions', worktreeId),
+    getActiveBoardAssistant: (projectId: string) =>
+      ipcRenderer.invoke('db:session:getActiveBoardAssistant', projectId)
   },
 
   sessionMessage: {

--- a/src/renderer/src/components/kanban/BoardAssistantView.tsx
+++ b/src/renderer/src/components/kanban/BoardAssistantView.tsx
@@ -265,6 +265,9 @@ async function ensureRuntimeSession(scope: BoardChatScope, targetProjectId: stri
   const connectResult = await window.opencodeOps.connect(runtimePath, session.id)
   if (!connectResult.success || !connectResult.sessionId) {
     await window.db.session.delete(session.id).catch(() => {})
+    // Re-sync store so the stale entry is removed and the tab disappears
+    const { useSessionStore } = await import('@/stores/useSessionStore')
+    void useSessionStore.getState().loadBoardAssistantSession(targetProjectId)
     return null
   }
 
@@ -291,6 +294,10 @@ async function cleanupBoardChatRuntime(): Promise<void> {
   const opencodeSessionId = state.opencodeSessionId
   const runtimePath = state.runtimePath
 
+  // If the store has already been reset (e.g. closeBoardAssistantSession
+  // already cleaned up), there is nothing left to do.
+  if (!sessionId && !opencodeSessionId && !runtimePath) return
+
   if (sessionId) {
     useQuestionStore.getState().clearSession(sessionId)
     usePermissionStore.getState().clearSession(sessionId)
@@ -306,14 +313,6 @@ async function cleanupBoardChatRuntime(): Promise<void> {
 
     try {
       await window.opencodeOps.disconnect(runtimePath, opencodeSessionId)
-    } catch {
-      // Best effort cleanup.
-    }
-  }
-
-  if (sessionId) {
-    try {
-      await window.db.session.delete(sessionId)
     } catch {
       // Best effort cleanup.
     }

--- a/src/renderer/src/components/kanban/BoardAssistantView.tsx
+++ b/src/renderer/src/components/kanban/BoardAssistantView.tsx
@@ -3,11 +3,9 @@ import {
   Bot,
   CheckSquare,
   Loader2,
-  Minimize2,
   Send,
   Sparkles,
-  Trash2,
-  X
+  Trash2
 } from 'lucide-react'
 import { ModelSelector } from '@/components/sessions/ModelSelector'
 import { AssistantCanvas } from '@/components/sessions/AssistantCanvas'
@@ -23,7 +21,6 @@ import { Textarea } from '@/components/ui/textarea'
 import { useSessionStream } from '@/hooks/useSessionStream'
 import { parseBoardAssistantDraftSet } from '@/lib/board-assistant-drafts'
 import { toast } from '@/lib/toast'
-import { cn } from '@/lib/utils'
 import { useBoardChatStore, type BoardChatMessage, type BoardChatScope, type TicketDraft, stripBoardAssistantScaffolding, stripBoardDraftBlocks, resolveBoardChatAgentSdk, resolveBoardChatDefaultModel } from '@/stores/useBoardChatStore'
 import { useCommandApprovalStore } from '@/stores/useCommandApprovalStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -33,16 +30,13 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useQuestionStore, type QuestionAnswer } from '@/stores/useQuestionStore'
 import { useSettingsStore, type SelectedModel } from '@/stores/useSettingsStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
-import { BOARD_ASSISTANT_SESSION_NAME_PREFIX } from '@/stores/useSessionStore'
+// Session store no longer needed for name prefix — session_type column is used instead
 import type { StreamingPart } from '@/components/sessions/SessionView'
 import type { QuestionRequest } from '@/stores/useQuestionStore'
 import type { CommandApprovalRequest } from '@/stores/useCommandApprovalStore'
 
-interface BoardChatDrawerProps {
-  projectId?: string
-  projectPath?: string
-  connectionId?: string
-  isPinnedMode?: boolean
+interface BoardAssistantViewProps {
+  projectId: string
 }
 
 const BOARD_ASSISTANT_RULES = [
@@ -230,21 +224,43 @@ async function ensureRuntimeSession(scope: BoardChatScope, targetProjectId: stri
     return null
   }
 
-  const session = await window.db.session.create({
-    worktree_id: worktreeId,
-    connection_id: connectionId,
-    project_id: targetProjectId,
-    name: `${BOARD_ASSISTANT_SESSION_NAME_PREFIX} Board Assistant`,
-    agent_sdk: agentSdk,
-    mode: 'build',
-    ...(selectedModel
-      ? {
-          model_provider_id: selectedModel.providerID,
-          model_id: selectedModel.modelID,
-          model_variant: selectedModel.variant ?? null
-        }
-      : {})
-  })
+  // Reuse the session already created by the session store (from createBoardAssistantSession)
+  // rather than creating a duplicate. Only create if none exists.
+  const { useSessionStore } = await import('@/stores/useSessionStore')
+  const existingStoreSession = useSessionStore.getState().boardAssistantByProject.get(targetProjectId)
+
+  let session: { id: string }
+  if (existingStoreSession) {
+    session = existingStoreSession
+    // Update the existing session with the model/SDK settings
+    await window.db.session.update(session.id, {
+      agent_sdk: agentSdk,
+      ...(selectedModel
+        ? {
+            model_provider_id: selectedModel.providerID,
+            model_id: selectedModel.modelID,
+            model_variant: selectedModel.variant ?? null
+          }
+        : {})
+    })
+  } else {
+    session = await window.db.session.create({
+      worktree_id: worktreeId,
+      connection_id: connectionId,
+      project_id: targetProjectId,
+      name: 'Board Assistant',
+      session_type: 'board-assistant',
+      agent_sdk: agentSdk,
+      mode: 'build',
+      ...(selectedModel
+        ? {
+            model_provider_id: selectedModel.providerID,
+            model_id: selectedModel.modelID,
+            model_variant: selectedModel.variant ?? null
+          }
+        : {})
+    })
+  }
 
   const connectResult = await window.opencodeOps.connect(runtimePath, session.id)
   if (!connectResult.success || !connectResult.sessionId) {
@@ -316,9 +332,7 @@ function BoardChatHeader({
   onSelectModel,
   onResetModel,
   onSelectTargetProject,
-  onClear,
-  onMinimize,
-  onClose
+  onClear
 }: {
   scope: BoardChatScope
   selectedTargetProjectId: string | null
@@ -332,8 +346,6 @@ function BoardChatHeader({
   onResetModel: () => void
   onSelectTargetProject: (projectId: string) => void
   onClear: () => void
-  onMinimize: () => void
-  onClose: () => void
 }): React.JSX.Element {
   const selectedTargetProject =
     scope.kind === 'connection'
@@ -427,18 +439,6 @@ function BoardChatHeader({
       <div className="flex items-center gap-1">
         <Button type="button" variant="ghost" size="icon" onClick={onClear} aria-label="Clear chat">
           <Trash2 className="h-4 w-4" />
-        </Button>
-        <Button type="button" variant="ghost" size="icon" onClick={onMinimize} aria-label="Minimize assistant">
-          <Minimize2 className="h-4 w-4" />
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          onClick={onClose}
-          aria-label="Minimize assistant"
-        >
-          <X className="h-4 w-4" />
         </Button>
       </div>
     </div>
@@ -736,54 +736,28 @@ function BoardChatComposer({
   )
 }
 
-export function BoardChatDrawer({
-  projectId,
-  projectPath,
-  connectionId,
-  isPinnedMode = false
-}: BoardChatDrawerProps): React.JSX.Element | null {
+export function BoardAssistantView({ projectId }: BoardAssistantViewProps): React.JSX.Element | null {
   const projects = useProjectStore((state) => state.projects)
-  const connections = useConnectionStore((state) => state.connections)
-  const scope = useMemo<BoardChatScope | null>(() => {
-    if (isPinnedMode) return { kind: 'pinned' }
-
-    if (connectionId) {
-      const connection = connections.find((candidate) => candidate.id === connectionId)
-      if (!connection) return null
-
-      const seen = new Set<string>()
-      const availableProjects = connection.members.reduce<Array<{ id: string; name: string }>>((acc, member) => {
-        if (seen.has(member.project_id)) return acc
-        seen.add(member.project_id)
-        acc.push({ id: member.project_id, name: member.project_name })
-        return acc
-      }, [])
-
-      return {
-        kind: 'connection',
-        connectionId: connection.id,
-        connectionName: connection.custom_name || connection.name,
-        connectionPath: connection.path,
-        availableProjects
-      }
+  const project = projects.find((p) => p.id === projectId)
+  const worktree = useWorktreeStore((state) => {
+    // find default worktree for project to get path
+    for (const worktrees of state.worktreesByProject.values()) {
+      const found = worktrees.find((w) => w.project_id === projectId && w.status === 'active')
+      if (found) return found
     }
-
-    if (projectId) {
-      const project = projects.find((candidate) => candidate.id === projectId)
-      if (!project) return null
-      return {
-        kind: 'project',
-        projectId: project.id,
-        projectName: project.name,
-        projectPath: projectPath ?? project.path
-      }
-    }
-
     return null
-  }, [connectionId, connections, isPinnedMode, projectId, projectPath, projects])
+  })
 
-  const isOpen = useBoardChatStore((state) => state.isOpen)
-  const isMinimized = useBoardChatStore((state) => state.isMinimized)
+  const scope = useMemo<BoardChatScope | null>(() => {
+    if (!project) return null
+    return {
+      kind: 'project' as const,
+      projectId: project.id,
+      projectName: project.name,
+      projectPath: worktree?.path ?? project.path
+    }
+  }, [project, worktree])
+
   const storedScope = useBoardChatStore((state) => state.scope)
   const messages = useBoardChatStore((state) => state.messages)
   const drafts = useBoardChatStore((state) => state.drafts)
@@ -812,8 +786,6 @@ export function BoardChatDrawer({
   const setError = useBoardChatStore((state) => state.setError)
   const updateOpencodeSessionId = useBoardChatStore((state) => state.updateOpencodeSessionId)
   const setComposerValue = useBoardChatStore((state) => state.setComposerValue)
-  const minimizeDrawer = useBoardChatStore((state) => state.minimizeDrawer)
-  const restoreDrawer = useBoardChatStore((state) => state.restoreDrawer)
   const resetState = useBoardChatStore((state) => state.resetState)
 
   const latestScopeKey = buildScopeKey(scope)
@@ -848,12 +820,11 @@ export function BoardChatDrawer({
       if (scopeSyncKeyRef.current === latestScopeKey) return
       scopeSyncKeyRef.current = latestScopeKey
 
-      const preserveOpen = useBoardChatStore.getState().isOpen
       await cleanupBoardChatRuntime()
       if (cancelled) return
 
       resetState({
-        preserveOpen,
+        preserveOpen: true,
         scope,
         selectedTargetProjectId:
           scope?.kind === 'project'
@@ -863,7 +834,7 @@ export function BoardChatDrawer({
               : null
       })
 
-      if (preserveOpen && scope && scope.kind !== 'pinned') {
+      if (scope && scope.kind !== 'pinned') {
         addLocalSystemMessage(
           scope.kind === 'project'
             ? `Assistant scope set to ${scope.projectName}.`
@@ -1253,117 +1224,81 @@ export function BoardChatDrawer({
 
   if (!scope) return null
 
-  if (!isOpen) return null
-
-  if (isMinimized) {
-    return (
-      <div className="pointer-events-auto absolute bottom-4 right-4 z-30 w-[min(28rem,calc(100%-1.5rem))]">
-        <button
-          type="button"
-          onClick={restoreDrawer}
-          className="flex h-14 w-full items-center justify-between rounded-t-2xl rounded-b-xl border border-border/70 bg-muted/30 px-4 shadow-sm transition-colors hover:bg-muted/50"
-        >
-          <div className="flex items-center gap-3">
-            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/12 text-primary">
-              <Bot className="h-4 w-4" />
-            </div>
-            <div className="text-left">
-              <p className="text-sm font-semibold text-foreground">Board Assistant</p>
-              <p className="text-xs text-muted-foreground">{getStatusLabel(status)}</p>
-            </div>
-          </div>
-          <span className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground">
-            <Minimize2 className="h-4 w-4 rotate-180" />
-          </span>
-        </button>
-      </div>
-    )
-  }
-
   return (
-    <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex justify-end p-3">
-      <div
-        className={cn(
-          'pointer-events-auto flex max-h-[min(72vh,42rem)] w-full flex-col overflow-hidden rounded-t-[28px] rounded-b-2xl border border-border/70 bg-card shadow-xl',
-          'sm:w-[28rem] lg:w-[32rem]'
-        )}
-      >
-        <BoardChatHeader
-          scope={scope}
-          selectedTargetProjectId={selectedTargetProjectId}
-          status={status}
-          selectedModel={effectiveSelectedModel}
-          agentSdk={effectiveAgentSdk}
-          availableAgentSdks={agentSdkOptions}
-          modelResetVisible={Boolean(selectedModelOverride)}
-          onSelectAgentSdk={(agentSdk) => {
-            void handleSelectAgentSdk(agentSdk)
-          }}
-          onSelectModel={(model) => {
-            void handleSelectModel(model)
-          }}
-          onResetModel={() => {
-            void handleResetModel()
-          }}
-          onSelectTargetProject={handleSelectTargetProject}
-          onClear={() => {
-            void handleClear()
-          }}
-          onMinimize={minimizeDrawer}
-          onClose={minimizeDrawer}
-        />
+    <div className="flex h-full flex-col overflow-hidden bg-card">
+      <BoardChatHeader
+        scope={scope}
+        selectedTargetProjectId={selectedTargetProjectId}
+        status={status}
+        selectedModel={effectiveSelectedModel}
+        agentSdk={effectiveAgentSdk}
+        availableAgentSdks={agentSdkOptions}
+        modelResetVisible={Boolean(selectedModelOverride)}
+        onSelectAgentSdk={(agentSdk) => {
+          void handleSelectAgentSdk(agentSdk)
+        }}
+        onSelectModel={(model) => {
+          void handleSelectModel(model)
+        }}
+        onResetModel={() => {
+          void handleResetModel()
+        }}
+        onSelectTargetProject={handleSelectTargetProject}
+        onClear={() => {
+          void handleClear()
+        }}
+      />
 
-        {error && (
-          <div className="border-b border-destructive/20 bg-destructive/10 px-4 py-2 text-sm text-destructive">
-            {error}
-          </div>
-        )}
+      {error && (
+        <div className="border-b border-destructive/20 bg-destructive/10 px-4 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
 
-        <BoardChatMessageList
-          messages={messages}
-          drafts={drafts}
-          draftSourceMessageId={draftSourceMessageId}
-          streamingMessage={streamingMessage}
-          activeQuestion={activeQuestion}
-          activePermission={activePermission}
-          activeApproval={activeApproval}
-          sessionId={sessionId}
-          onToggleDraft={toggleDraftSelection}
-          onCreateAll={() => {
-            void handleCreateDrafts(false)
-          }}
-          onCreateSelected={() => {
-            void handleCreateDrafts(true)
-          }}
-          onRevise={handleRevise}
-          onCancelDrafts={handleCancelDrafts}
-          hasInvalidDrafts={hasInvalidDrafts}
-          onQuestionReply={(requestId, answers) => {
-            void handleQuestionReply(requestId, answers)
-          }}
-          onQuestionReject={(requestId) => {
-            void handleQuestionReject(requestId)
-          }}
-          onPermissionReply={(requestId, reply, message) => {
-            void handlePermissionReply(requestId, reply, message)
-          }}
-          onCommandApprovalReply={(requestId, approved, remember, pattern, patterns) => {
-            void handleCommandApprovalReply(requestId, approved, remember, pattern, patterns)
-          }}
-        />
+      <BoardChatMessageList
+        messages={messages}
+        drafts={drafts}
+        draftSourceMessageId={draftSourceMessageId}
+        streamingMessage={streamingMessage}
+        activeQuestion={activeQuestion}
+        activePermission={activePermission}
+        activeApproval={activeApproval}
+        sessionId={sessionId}
+        onToggleDraft={toggleDraftSelection}
+        onCreateAll={() => {
+          void handleCreateDrafts(false)
+        }}
+        onCreateSelected={() => {
+          void handleCreateDrafts(true)
+        }}
+        onRevise={handleRevise}
+        onCancelDrafts={handleCancelDrafts}
+        hasInvalidDrafts={hasInvalidDrafts}
+        onQuestionReply={(requestId, answers) => {
+          void handleQuestionReply(requestId, answers)
+        }}
+        onQuestionReject={(requestId) => {
+          void handleQuestionReject(requestId)
+        }}
+        onPermissionReply={(requestId, reply, message) => {
+          void handlePermissionReply(requestId, reply, message)
+        }}
+        onCommandApprovalReply={(requestId, approved, remember, pattern, patterns) => {
+          void handleCommandApprovalReply(requestId, approved, remember, pattern, patterns)
+        }}
+      />
 
-        <BoardChatComposer
-          value={composerValue}
-          disabled={!canInteract || (scope.kind === 'connection' && !selectedTargetProjectId)}
-          sending={status === 'starting' || status === 'thinking'}
-          canSend={canSend}
-          textareaRef={composerFocusRef}
-          onChange={setComposerValue}
-          onSend={() => {
-            void handleSend()
-          }}
-        />
-      </div>
+      <BoardChatComposer
+        value={composerValue}
+        disabled={!canInteract || (scope.kind === 'connection' && !selectedTargetProjectId)}
+        sending={status === 'starting' || status === 'thinking'}
+        canSend={canSend}
+        textareaRef={composerFocusRef}
+        onChange={setComposerValue}
+        onSend={() => {
+          void handleSend()
+        }}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/kanban/BoardAssistantView.tsx
+++ b/src/renderer/src/components/kanban/BoardAssistantView.tsx
@@ -28,9 +28,10 @@ import { useKanbanStore } from '@/stores/useKanbanStore'
 import { usePermissionStore } from '@/stores/usePermissionStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useQuestionStore, type QuestionAnswer } from '@/stores/useQuestionStore'
+import { useSessionStore, BOARD_TAB_ID } from '@/stores/useSessionStore'
 import { useSettingsStore, type SelectedModel } from '@/stores/useSettingsStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
-// Session store no longer needed for name prefix — session_type column is used instead
+import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import type { StreamingPart } from '@/components/sessions/SessionView'
 import type { QuestionRequest } from '@/stores/useQuestionStore'
 import type { CommandApprovalRequest } from '@/stores/useCommandApprovalStore'
@@ -230,6 +231,7 @@ async function ensureRuntimeSession(scope: BoardChatScope, targetProjectId: stri
   const existingStoreSession = useSessionStore.getState().boardAssistantByProject.get(targetProjectId)
 
   let session: { id: string }
+  const isReused = Boolean(existingStoreSession)
   if (existingStoreSession) {
     session = existingStoreSession
     // Update the existing session with the model/SDK settings
@@ -264,10 +266,14 @@ async function ensureRuntimeSession(scope: BoardChatScope, targetProjectId: stri
 
   const connectResult = await window.opencodeOps.connect(runtimePath, session.id)
   if (!connectResult.success || !connectResult.sessionId) {
-    await window.db.session.delete(session.id).catch(() => {})
+    // Only delete the session if we just created it. Reused sessions
+    // should be kept so the user doesn't lose the record and messages.
+    if (!isReused) {
+      await window.db.session.delete(session.id).catch(() => {})
+    }
     // Re-sync store so the stale entry is removed and the tab disappears
     const { useSessionStore } = await import('@/stores/useSessionStore')
-    void useSessionStore.getState().loadBoardAssistantSession(targetProjectId)
+    await useSessionStore.getState().loadBoardAssistantSession(targetProjectId)
     return null
   }
 
@@ -295,8 +301,12 @@ async function cleanupBoardChatRuntime(): Promise<void> {
   const runtimePath = state.runtimePath
 
   // If the store has already been reset (e.g. closeBoardAssistantSession
-  // already cleaned up), there is nothing left to do.
-  if (!sessionId && !opencodeSessionId && !runtimePath) return
+  // already cleaned up), skip runtime teardown but still reset the store
+  // in case partial state remains.
+  if (!sessionId && !opencodeSessionId && !runtimePath) {
+    useBoardChatStore.getState().resetState()
+    return
+  }
 
   if (sessionId) {
     useQuestionStore.getState().clearSession(sessionId)
@@ -317,6 +327,10 @@ async function cleanupBoardChatRuntime(): Promise<void> {
       // Best effort cleanup.
     }
   }
+
+  // Always reset the chat store after full cleanup so callers don't
+  // need to remember to call resetState() separately.
+  useBoardChatStore.getState().resetState()
 }
 
 function BoardChatHeader({
@@ -777,7 +791,7 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
   const setDrafts = useBoardChatStore((state) => state.setDrafts)
   const clearDrafts = useBoardChatStore((state) => state.clearDrafts)
   const markDraftsCreated = useBoardChatStore((state) => state.markDraftsCreated)
-  const toggleDraftSelection = useBoardChatStore((state) => state.toggleDraftSelection)
+  const toggleDraftSelected = useBoardChatStore((state) => state.toggleDraftSelected)
   const setStatus = useBoardChatStore((state) => state.setStatus)
   const setSelectedTargetProjectId = useBoardChatStore((state) => state.setSelectedTargetProjectId)
   const setSelectedAgentSdkOverride = useBoardChatStore((state) => state.setSelectedAgentSdkOverride)
@@ -786,9 +800,8 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
   const updateOpencodeSessionId = useBoardChatStore((state) => state.updateOpencodeSessionId)
   const setComposerValue = useBoardChatStore((state) => state.setComposerValue)
   const resetState = useBoardChatStore((state) => state.resetState)
+  const activateScope = useBoardChatStore((state) => state.activateScope)
 
-  const latestScopeKey = buildScopeKey(scope)
-  const scopeSyncKeyRef = useRef<string>('')
   const composerFocusRef = useRef<HTMLTextAreaElement | null>(null)
   const availableAgentSdks = useSettingsStore((state) => state.availableAgentSdks)
   const defaultBoardAgentSdk = useSettingsStore((state) => resolveBoardChatAgentSdk(state.defaultAgentSdk))
@@ -816,13 +829,13 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
     let cancelled = false
 
     const syncScope = async (): Promise<void> => {
-      if (scopeSyncKeyRef.current === latestScopeKey) return
-      scopeSyncKeyRef.current = latestScopeKey
+      const scopeKey = buildScopeKey(scope)
+      const existingSnapshot =
+        scope?.kind === 'project'
+          ? useBoardChatStore.getState().getProjectSnapshot(scope.projectId)
+          : null
 
-      await cleanupBoardChatRuntime()
-      if (cancelled) return
-
-      resetState({
+      activateScope(scope, {
         preserveOpen: true,
         scope,
         selectedTargetProjectId:
@@ -833,7 +846,22 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
               : null
       })
 
-      if (scope && scope.kind !== 'pinned') {
+      if (cancelled) return
+
+      const state = useBoardChatStore.getState()
+      if (state.sessionId && state.opencodeSessionId && state.runtimePath && scopeKey !== 'none') {
+        try {
+          await window.opencodeOps.reconnect(
+            state.runtimePath,
+            state.opencodeSessionId,
+            state.sessionId
+          )
+        } catch {
+          // useSessionStream will handle reconnection failures
+        }
+      }
+
+      if (!existingSnapshot && scope && scope.kind !== 'pinned') {
         addLocalSystemMessage(
           scope.kind === 'project'
             ? `Assistant scope set to ${scope.projectName}.`
@@ -847,15 +875,15 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
     return () => {
       cancelled = true
     }
-  }, [addLocalSystemMessage, latestScopeKey, resetState, scope])
+  }, [activateScope, addLocalSystemMessage, scope])
 
-  useEffect(() => {
-    return () => {
-      void cleanupBoardChatRuntime()
-      useBoardChatStore.getState().resetState()
-      scopeSyncKeyRef.current = ''
-    }
-  }, [])
+  // NOTE: We intentionally do NOT clean up the runtime on unmount.
+  // The board assistant is a persistent tab — the runtime and chat state
+  // must survive across tab switches, just like normal sessions.
+  // Runtime cleanup happens only when:
+  // - The user explicitly closes the board assistant tab (closeBoardAssistantSession)
+  // - The scope changes to a different project (scope sync above)
+  // - The user clicks "Clear" (handleClear)
 
   const { messages: transcriptMessages, streamingParts, streamingContent, isStreaming } = useSessionStream({
     sessionId: sessionId ?? '',
@@ -867,6 +895,11 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
 
   useEffect(() => {
     if (!sessionId || !opencodeSessionId || !runtimePath) return
+    // useSessionStream starts with an empty array before getMessages() loads.
+    // Syncing that empty array would wipe all existing transcript messages from
+    // the store (mergeTranscriptMessages only keeps 'local'-kind messages when
+    // the transcript array is empty). Skip the sync until real data arrives.
+    if (transcriptMessages.length === 0 && useBoardChatStore.getState().messages.length > 0) return
     setTranscriptMessages(transcriptMessages)
   }, [opencodeSessionId, runtimePath, sessionId, setTranscriptMessages, transcriptMessages])
 
@@ -985,6 +1018,24 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
     status !== 'starting' &&
     status !== 'thinking'
 
+  const navigateToBoard = useCallback(() => {
+    useFileViewerStore.getState().clearActiveViews()
+
+    const sessionStore = useSessionStore.getState()
+    sessionStore.setActivePinnedSession(null)
+
+    if (useSettingsStore.getState().boardMode === 'sticky-tab') {
+      sessionStore.setActiveSession(BOARD_TAB_ID)
+      return
+    }
+
+    sessionStore.clearBoardAssistantFocus()
+    const kanbanStore = useKanbanStore.getState()
+    if (!kanbanStore.isBoardViewActive) {
+      kanbanStore.toggleBoardView()
+    }
+  }, [])
+
   const handleDiscardConversation = useCallback(
     async (options?: {
       preserveOpen?: boolean
@@ -1089,6 +1140,7 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
       addLocalSystemMessage(
         `Created ${result.tickets.length} ticket${result.tickets.length === 1 ? '' : 's'} and ${result.dependencies.length} dependenc${result.dependencies.length === 1 ? 'y' : 'ies'} in ${draftsToCreate[0].projectName}.`
       )
+      navigateToBoard()
       toast.success(
         `Created ${result.tickets.length} ticket${result.tickets.length === 1 ? '' : 's'}.`
       )
@@ -1096,7 +1148,7 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
       const message = error instanceof Error ? error.message : 'Failed to create one or more tickets.'
       toast.error(message)
     }
-  }, [addLocalSystemMessage, drafts, markDraftsCreated])
+  }, [addLocalSystemMessage, drafts, markDraftsCreated, navigateToBoard])
 
   const handleClear = useCallback(async () => {
     await handleDiscardConversation({ preserveOpen: true })
@@ -1263,7 +1315,7 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
         activePermission={activePermission}
         activeApproval={activeApproval}
         sessionId={sessionId}
-        onToggleDraft={toggleDraftSelection}
+        onToggleDraft={toggleDraftSelected}
         onCreateAll={() => {
           void handleCreateDrafts(false)
         }}

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -4,9 +4,9 @@ import { Pin } from 'lucide-react'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { usePinnedStore } from '@/stores/usePinnedStore'
 import { useBoardChatStore } from '@/stores/useBoardChatStore'
+import { useSessionStore } from '@/stores/useSessionStore'
 import { KanbanColumn } from '@/components/kanban/KanbanColumn'
 import { KanbanTicketModal } from '@/components/kanban/KanbanTicketModal'
-import { BoardChatDrawer } from '@/components/kanban/BoardChatDrawer'
 import { BoardChatLauncher } from '@/components/kanban/BoardChatLauncher'
 import { MergeOnDoneDialog } from './MergeOnDoneDialog'
 import { toast } from '@/lib/toast'
@@ -32,9 +32,10 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
   const getConnectionProjectIds = useKanbanStore((state) => state.getConnectionProjectIds)
   const getPinnedProjectIdsArray = useKanbanStore((state) => state.getPinnedProjectIdsArray)
   const pinnedProjectIds = usePinnedStore((state) => state.pinnedProjectIds)
-  const isBoardChatOpen = useBoardChatStore((state) => state.isOpen)
   const boardChatStatus = useBoardChatStore((state) => state.status)
-  const openBoardChat = useBoardChatStore((state) => state.openDrawer)
+  const boardAssistantByProject = useSessionStore((state) => state.boardAssistantByProject)
+  const createBoardAssistantSession = useSessionStore((s) => s.createBoardAssistantSession)
+  const focusBoardAssistantSession = useSessionStore((s) => s.focusBoardAssistantSession)
 
   // Dependency mode subscriptions
   const dependencyMode = useKanbanStore((state) => state.dependencyMode)
@@ -344,26 +345,26 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
           </motion.div>
         )}
         <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 flex justify-end p-4">
-          <div className="pointer-events-auto flex flex-col items-end gap-3">
-            {!isBoardChatOpen && (
-              <BoardChatLauncher
-                disabled={Boolean(isPinnedMode)}
-                disabledReason={
-                  isPinnedMode
-                    ? 'Board Assistant is not available on pinned multi-project boards yet.'
-                    : undefined
-                }
-                onClick={openBoardChat}
-                status={boardChatStatus}
-              />
-            )}
-            <BoardChatDrawer
-              projectId={projectId}
-              projectPath={projectPath}
-              connectionId={connectionId}
-              isPinnedMode={isPinnedMode}
-            />
-          </div>
+          <BoardChatLauncher
+            disabled={Boolean(isPinnedMode) || !projectId}
+            disabledReason={
+              isPinnedMode
+                ? 'Board Assistant is not available on pinned multi-project boards yet.'
+                : !projectId
+                  ? 'No project selected.'
+                  : undefined
+            }
+            onClick={() => {
+              if (!projectId) return
+              const existing = boardAssistantByProject.get(projectId)
+              if (existing) {
+                focusBoardAssistantSession(projectId)
+              } else {
+                void createBoardAssistantSession(projectId)
+              }
+            }}
+            status={boardChatStatus}
+          />
         </div>
       </div>
     </LayoutGroup>

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -32,7 +32,12 @@ export function KanbanBoard({ projectId, projectPath, connectionId, isPinnedMode
   const getConnectionProjectIds = useKanbanStore((state) => state.getConnectionProjectIds)
   const getPinnedProjectIdsArray = useKanbanStore((state) => state.getPinnedProjectIdsArray)
   const pinnedProjectIds = usePinnedStore((state) => state.pinnedProjectIds)
-  const boardChatStatus = useBoardChatStore((state) => state.status)
+  const boardChatStatus = useBoardChatStore((state) => {
+    if (!projectId) return 'idle'
+    const key = `project:${projectId}`
+    if (state.activeScopeKey === key) return state.status
+    return state.snapshots[key]?.status ?? 'idle'
+  })
   const boardAssistantByProject = useSessionStore((state) => state.boardAssistantByProject)
   const createBoardAssistantSession = useSessionStore((s) => s.createBoardAssistantSession)
   const focusBoardAssistantSession = useSessionStore((s) => s.focusBoardAssistantSession)

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -16,6 +16,7 @@ import { usePinnedStore } from '@/stores/usePinnedStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { KanbanBoard } from '@/components/kanban/KanbanBoard'
 import { KanbanIcon } from '@/components/kanban/KanbanIcon'
+import { BoardAssistantView } from '@/components/kanban/BoardAssistantView'
 import { PRNotificationStack } from '@/components/pr/PRNotificationStack'
 
 const MonacoDiffView = lazy(() => import('@/components/diff/MonacoDiffView'))
@@ -40,6 +41,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const closedTerminalSessionIds = useSessionStore((state) => state.closedTerminalSessionIds)
   const ghosttyOverlaySuppressed = useLayoutStore((state) => state.ghosttyOverlaySuppressed)
   const activePinnedSessionId = useSessionStore((state) => state.activePinnedSessionId)
+  const activeBoardAssistantProjectId = useSessionStore((state) => state.activeBoardAssistantProjectId)
   const isBoardViewActive = useKanbanStore((state) => state.isBoardViewActive)
   const isPinnedBoardActive = useKanbanStore((state) => state.isPinnedBoardActive)
   const pinnedStoreLoaded = usePinnedStore((state) => state.loaded)
@@ -171,6 +173,11 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const renderContent = () => {
     if (children) {
       return children
+    }
+
+    // Board assistant tab is active — render BoardAssistantView in main pane
+    if (activeBoardAssistantProjectId && !activeFilePath && !activeDiff && !contextEditorWorktreeId) {
+      return <BoardAssistantView key={activeBoardAssistantProjectId} projectId={activeBoardAssistantProjectId} />
     }
 
     // Sticky-tab board mode: render board when BOARD_TAB_ID is the active session

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -592,6 +592,13 @@ export function SessionTabs(): React.JSX.Element | null {
   const activePinnedSessionId = useSessionStore((state) => state.activePinnedSessionId)
   const boardMode = useSettingsStore((s) => s.boardMode)
 
+  // Board assistant state
+  const boardAssistantByProject = useSessionStore((state) => state.boardAssistantByProject)
+  const activeBoardAssistantProjectId = useSessionStore((state) => state.activeBoardAssistantProjectId)
+  const createBoardAssistantSession = useSessionStore((s) => s.createBoardAssistantSession)
+  const closeBoardAssistantSession = useSessionStore((s) => s.closeBoardAssistantSession)
+  const focusBoardAssistantSession = useSessionStore((s) => s.focusBoardAssistantSession)
+
   // Determine whether we are in connection mode or worktree mode
   const isConnectionMode = !!selectedConnectionId && !selectedWorktreeId
 
@@ -849,6 +856,30 @@ export function SessionTabs(): React.JSX.Element | null {
       if (sdk !== defaultAgentSdk) {
         useTipStore.getState().setNonDefaultProviderChosen(true)
       }
+    }
+  }
+
+  // Handle creating or focusing the board assistant tab
+  const handleCreateBoardAssistant = async () => {
+    if (!project) return
+    const existing = boardAssistantByProject.get(project.id)
+    if (existing) {
+      focusBoardAssistantSession(project.id)
+    } else {
+      const result = await createBoardAssistantSession(project.id)
+      if (!result.success) {
+        toast.error(result.error || 'Failed to create board assistant')
+      }
+    }
+  }
+
+  // Handle closing the board assistant tab
+  const handleCloseBoardAssistant = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (!project) return
+    const result = await closeBoardAssistantSession(project.id)
+    if (!result.success) {
+      toast.error(result.error || 'Failed to close board assistant')
     }
   }
 
@@ -1116,6 +1147,37 @@ export function SessionTabs(): React.JSX.Element | null {
           />
         )
       })}
+
+      {/* Board assistant tab */}
+      {project && boardAssistantByProject.has(project.id) && (
+        <button
+          className={cn(
+            'group relative flex items-center gap-1.5 px-3 py-1.5 text-xs whitespace-nowrap border-r border-border min-w-0 max-w-[200px] transition-colors',
+            activeBoardAssistantProjectId === project.id && !isFileTabActive
+              ? 'bg-background text-foreground'
+              : 'bg-muted/50 text-muted-foreground hover:bg-muted'
+          )}
+          onClick={() => focusBoardAssistantSession(project.id)}
+          title="Board Assistant"
+          data-testid="board-assistant-tab"
+        >
+          <KanbanIcon className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+          <span className="truncate">Board Assistant</span>
+          {/* Active bottom accent */}
+          {activeBoardAssistantProjectId === project.id && !isFileTabActive && (
+            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+          )}
+          {/* Close button */}
+          <span
+            className="ml-1 shrink-0 rounded-sm p-0.5 opacity-0 group-hover:opacity-100 hover:bg-accent transition-opacity"
+            onClick={handleCloseBoardAssistant}
+            role="button"
+            tabIndex={-1}
+          >
+            <X className="h-3 w-3" />
+          </span>
+        </button>
+      )}
     </>
   )
 
@@ -1167,6 +1229,11 @@ export function SessionTabs(): React.JSX.Element | null {
                 <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('terminal')}>
                   <TerminalSquare className="h-4 w-4 mr-2 text-emerald-500" />
                   New Terminal
+                </ContextMenuItem>
+                <ContextMenuSeparator />
+                <ContextMenuItem onSelect={handleCreateBoardAssistant}>
+                  <KanbanIcon className="h-4 w-4 mr-2 text-blue-500" />
+                  New Board Assistant
                 </ContextMenuItem>
               </ContextMenuContent>
             </ContextMenu>

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -1152,17 +1152,21 @@ export function SessionTabs(): React.JSX.Element | null {
       {project && boardAssistantByProject.has(project.id) && (
         <button
           className={cn(
-            'group relative flex items-center gap-1.5 px-3 py-1.5 text-xs whitespace-nowrap border-r border-border min-w-0 max-w-[200px] transition-colors',
+            'group relative flex items-center gap-1.5 px-3 py-1.5 text-sm cursor-pointer select-none whitespace-nowrap border-r border-border min-w-[100px] max-w-[200px] transition-colors',
             activeBoardAssistantProjectId === project.id && !isFileTabActive
               ? 'bg-background text-foreground'
-              : 'bg-muted/50 text-muted-foreground hover:bg-muted'
+              : 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground'
           )}
-          onClick={() => focusBoardAssistantSession(project.id)}
+          onClick={() => {
+            setActiveFile(null)
+            clearInlineConnectionSession()
+            focusBoardAssistantSession(project.id)
+          }}
           title="Board Assistant"
           data-testid="board-assistant-tab"
         >
           <KanbanIcon className="h-3.5 w-3.5 shrink-0 text-blue-500" />
-          <span className="truncate">Board Assistant</span>
+          <span className="truncate flex-1">Board Assistant</span>
           {/* Active bottom accent */}
           {activeBoardAssistantProjectId === project.id && !isFileTabActive && (
             <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -530,6 +530,14 @@ export function useOpenCodeGlobalListener(): void {
                 }
               }
             }
+            if (!idleSession) {
+              for (const session of sessionState.boardAssistantByProject.values()) {
+                if (session.id === sessionId) {
+                  idleSession = session
+                  break
+                }
+              }
+            }
             if (idleSession) {
               const provider = resolveUsageProvider(idleSession)
               useUsageStore.getState().fetchUsageForProvider(provider)

--- a/src/renderer/src/stores/useBoardChatStore.ts
+++ b/src/renderer/src/stores/useBoardChatStore.ts
@@ -58,9 +58,7 @@ interface ResetBoardChatOptions {
   selectedModelOverride?: SelectedModel | null
 }
 
-interface BoardChatState {
-  isOpen: boolean
-  isMinimized: boolean
+export interface BoardChatSnapshot {
   scope: BoardChatScope | null
   messages: BoardChatMessage[]
   drafts: TicketDraft[]
@@ -75,11 +73,22 @@ interface BoardChatState {
   selectedAgentSdkOverride: 'opencode' | 'claude-code' | 'codex' | null
   selectedModelOverride: SelectedModel | null
   composerValue: string
+}
+
+interface BoardChatState extends BoardChatSnapshot {
+  isOpen: boolean
+  isMinimized: boolean
+  activeScopeKey: string
+  snapshots: Record<string, BoardChatSnapshot>
   open: () => void
   minimize: () => void
   restore: () => void
   close: () => Promise<void>
   clear: () => Promise<void>
+  activateScope: (scope: BoardChatScope | null, options?: ResetBoardChatOptions) => void
+  getProjectSnapshot: (projectId: string) => BoardChatSnapshot | null
+  getSessionSnapshot: (sessionId: string) => { key: string; snapshot: BoardChatSnapshot } | null
+  clearProjectSnapshot: (projectId: string) => void
   syncScope: (scope: BoardChatScope | null) => Promise<void>
   resetForBoardExit: () => Promise<void>
   syncTranscript: (messages: OpenCodeMessage[], isStreaming: boolean) => void
@@ -207,13 +216,108 @@ function buildDefaultTargetProjectId(scope: BoardChatScope | null): string | nul
   return null
 }
 
-function createInitialState(options?: ResetBoardChatOptions): Omit<
+function createInitialSnapshot(options?: ResetBoardChatOptions): BoardChatSnapshot {
+  const scope = options?.scope ?? null
+  return {
+    scope,
+    messages: [],
+    drafts: [],
+    createdDraftIds: [],
+    draftSourceMessageId: null,
+    status: 'idle',
+    selectedTargetProjectId:
+      options?.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope),
+    error: null,
+    sessionId: null,
+    opencodeSessionId: null,
+    runtimePath: null,
+    selectedAgentSdkOverride: options?.selectedAgentSdkOverride ?? null,
+    selectedModelOverride: options?.selectedModelOverride ?? null,
+    composerValue: ''
+  }
+}
+
+function getScopeKey(scope: BoardChatScope | null): string {
+  if (!scope) return 'none'
+  if (scope.kind === 'project') return `project:${scope.projectId}`
+  if (scope.kind === 'connection') return `connection:${scope.connectionId}`
+  return 'pinned'
+}
+
+function getSnapshotFromState(state: BoardChatState): BoardChatSnapshot {
+  return {
+    scope: state.scope,
+    messages: state.messages,
+    drafts: state.drafts,
+    createdDraftIds: state.createdDraftIds,
+    draftSourceMessageId: state.draftSourceMessageId,
+    status: state.status,
+    selectedTargetProjectId: state.selectedTargetProjectId,
+    error: state.error,
+    sessionId: state.sessionId,
+    opencodeSessionId: state.opencodeSessionId,
+    runtimePath: state.runtimePath,
+    selectedAgentSdkOverride: state.selectedAgentSdkOverride,
+    selectedModelOverride: state.selectedModelOverride,
+    composerValue: state.composerValue
+  }
+}
+
+function replaceActiveSnapshot(
+  state: BoardChatState,
+  snapshot: BoardChatSnapshot,
+  activeScopeKey = getScopeKey(snapshot.scope),
+  options?: { dropExistingSnapshot?: boolean }
+): Partial<BoardChatState> {
+  const nextSnapshots = { ...state.snapshots }
+  if (activeScopeKey !== 'none') {
+    if (options?.dropExistingSnapshot) {
+      delete nextSnapshots[activeScopeKey]
+    } else {
+      nextSnapshots[activeScopeKey] = snapshot
+    }
+  }
+
+  return {
+    ...snapshot,
+    activeScopeKey,
+    snapshots: nextSnapshots
+  }
+}
+
+function patchActiveSnapshot(
+  state: BoardChatState,
+  patch: Partial<BoardChatSnapshot>
+): Partial<BoardChatState> {
+  const activeScopeKey = state.activeScopeKey || getScopeKey(state.scope)
+  const nextSnapshot = {
+    ...getSnapshotFromState(state),
+    ...patch
+  }
+
+  const nextSnapshots = { ...state.snapshots }
+  if (activeScopeKey !== 'none') {
+    nextSnapshots[activeScopeKey] = nextSnapshot
+  }
+
+  return {
+    ...patch,
+    activeScopeKey,
+    snapshots: nextSnapshots
+  }
+}
+
+function createBaseState(): Omit<
   BoardChatState,
   | 'open'
   | 'minimize'
   | 'restore'
   | 'close'
   | 'clear'
+  | 'activateScope'
+  | 'getProjectSnapshot'
+  | 'getSessionSnapshot'
+  | 'clearProjectSnapshot'
   | 'syncScope'
   | 'resetForBoardExit'
   | 'syncTranscript'
@@ -238,33 +342,13 @@ function createInitialState(options?: ResetBoardChatOptions): Omit<
   | 'setComposerValue'
   | 'resetState'
 > {
-  const scope = options?.scope ?? null
   return {
-    isOpen: options?.preserveOpen ?? false,
+    isOpen: false,
     isMinimized: false,
-    scope,
-    messages: [],
-    drafts: [],
-    createdDraftIds: [],
-    draftSourceMessageId: null,
-    status: 'idle',
-    selectedTargetProjectId:
-      options?.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope),
-    error: null,
-    sessionId: null,
-    opencodeSessionId: null,
-    runtimePath: null,
-    selectedAgentSdkOverride: options?.selectedAgentSdkOverride ?? null,
-    selectedModelOverride: options?.selectedModelOverride ?? null,
-    composerValue: ''
+    activeScopeKey: 'none',
+    snapshots: {},
+    ...createInitialSnapshot()
   }
-}
-
-function getScopeKey(scope: BoardChatScope | null): string {
-  if (!scope) return 'none'
-  if (scope.kind === 'project') return `project:${scope.projectId}`
-  if (scope.kind === 'connection') return `connection:${scope.connectionId}`
-  return 'pinned'
 }
 
 function applyCreatedDraftState(drafts: TicketDraft[], createdDraftIds: string[]): TicketDraft[] {
@@ -479,11 +563,13 @@ async function ensureRuntime(): Promise<{
 
   await window.db.session.update(session.id, { opencode_session_id: connectResult.sessionId })
 
-  useBoardChatStore.setState({
-    sessionId: session.id,
-    opencodeSessionId: connectResult.sessionId,
-    runtimePath
-  })
+  useBoardChatStore.setState((state) =>
+    patchActiveSnapshot(state, {
+      sessionId: session.id,
+      opencodeSessionId: connectResult.sessionId,
+      runtimePath
+    })
+  )
 
   return {
     sessionId: session.id,
@@ -497,7 +583,7 @@ async function resetAndCleanup(state: Pick<BoardChatState, 'sessionId' | 'openco
 }
 
 export const useBoardChatStore = create<BoardChatState>((set, get) => ({
-  ...createInitialState(),
+  ...createBaseState(),
 
   open: () => set({ isOpen: true, isMinimized: false }),
   minimize: () => set({ isOpen: true, isMinimized: true }),
@@ -505,59 +591,142 @@ export const useBoardChatStore = create<BoardChatState>((set, get) => ({
 
   close: async () => {
     const state = get()
-    set({
-      ...createInitialState({
-        scope: state.scope,
-        selectedTargetProjectId:
-          state.scope?.kind === 'project' ? state.scope.projectId : state.selectedTargetProjectId,
-        selectedAgentSdkOverride: state.selectedAgentSdkOverride,
-        selectedModelOverride: state.selectedModelOverride
-      }),
-      isOpen: false
+    const resetSnapshot = createInitialSnapshot({
+      scope: state.scope,
+      selectedTargetProjectId:
+        state.scope?.kind === 'project' ? state.scope.projectId : state.selectedTargetProjectId,
+      selectedAgentSdkOverride: state.selectedAgentSdkOverride,
+      selectedModelOverride: state.selectedModelOverride
     })
+    set((current) => ({
+      isOpen: false,
+      ...replaceActiveSnapshot(current, resetSnapshot, current.activeScopeKey, {
+        dropExistingSnapshot: true
+      })
+    }))
     await resetAndCleanup(state)
   },
 
   clear: async () => {
     const state = get()
-    set({
-      ...createInitialState({
-        preserveOpen: state.isOpen,
-        scope: state.scope,
-        selectedTargetProjectId:
-          state.scope?.kind === 'project' ? state.scope.projectId : state.selectedTargetProjectId,
-        selectedAgentSdkOverride: state.selectedAgentSdkOverride,
-        selectedModelOverride: state.selectedModelOverride
-      })
-    })
+    set((current) =>
+      replaceActiveSnapshot(
+        current,
+        createInitialSnapshot({
+          scope: state.scope,
+          selectedTargetProjectId:
+            state.scope?.kind === 'project' ? state.scope.projectId : state.selectedTargetProjectId,
+          selectedAgentSdkOverride: state.selectedAgentSdkOverride,
+          selectedModelOverride: state.selectedModelOverride
+        }),
+        current.activeScopeKey
+      )
+    )
     await resetAndCleanup(state)
+  },
+
+  activateScope: (scope, options) => {
+    set((state) => {
+      const scopeKey = getScopeKey(scope)
+      const existing = scopeKey !== 'none' ? state.snapshots[scopeKey] : null
+
+      if (existing) {
+        const hydrated = {
+          ...existing,
+          scope,
+          selectedTargetProjectId:
+            scope?.kind === 'project'
+              ? scope.projectId
+              : existing.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope)
+        }
+        return replaceActiveSnapshot(state, hydrated, scopeKey)
+      }
+
+      return replaceActiveSnapshot(
+        state,
+        createInitialSnapshot({
+          ...options,
+          scope,
+          selectedTargetProjectId:
+            options?.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope)
+        }),
+        scopeKey
+      )
+    })
+  },
+
+  getProjectSnapshot: (projectId) => {
+    const key = `project:${projectId}`
+    const state = get()
+    if (state.activeScopeKey === key) {
+      return getSnapshotFromState(state)
+    }
+    return state.snapshots[key] ?? null
+  },
+
+  getSessionSnapshot: (sessionId) => {
+    const state = get()
+    if (!sessionId) return null
+
+    if (state.sessionId === sessionId) {
+      return {
+        key: state.activeScopeKey,
+        snapshot: getSnapshotFromState(state)
+      }
+    }
+
+    for (const [key, snapshot] of Object.entries(state.snapshots)) {
+      if (snapshot.sessionId === sessionId) {
+        return { key, snapshot }
+      }
+    }
+
+    return null
+  },
+
+  clearProjectSnapshot: (projectId) => {
+    set((state) => {
+      const key = `project:${projectId}`
+      const nextSnapshots = { ...state.snapshots }
+      delete nextSnapshots[key]
+
+      if (state.activeScopeKey === key) {
+        return {
+          ...createBaseState(),
+          isOpen: state.isOpen,
+          isMinimized: state.isMinimized,
+          snapshots: nextSnapshots
+        }
+      }
+
+      return { snapshots: nextSnapshots }
+    })
   },
 
   syncScope: async (scope) => {
     const current = get()
     if (getScopeKey(current.scope) === getScopeKey(scope)) {
-      set({
-        scope,
-        selectedTargetProjectId:
-          scope?.kind === 'project'
-            ? scope.projectId
-            : current.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope)
-      })
+      set((state) =>
+        patchActiveSnapshot(state, {
+          scope,
+          selectedTargetProjectId:
+            scope?.kind === 'project'
+              ? scope.projectId
+              : current.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope)
+        })
+      )
       return
     }
 
-    set({
-      ...createInitialState({
-        scope,
-        selectedTargetProjectId: buildDefaultTargetProjectId(scope)
-      })
+    get().activateScope(scope, {
+      scope,
+      selectedTargetProjectId: buildDefaultTargetProjectId(scope)
     })
-    await resetAndCleanup(current)
   },
 
   resetForBoardExit: async () => {
     const state = get()
-    set({ ...createInitialState() })
+    set({ ...createBaseState() })
     await resetAndCleanup(state)
   },
 
@@ -570,23 +739,25 @@ export const useBoardChatStore = create<BoardChatState>((set, get) => ({
       ? parseDraftsFromMessage(latestDraftMessage, get().scope, get().selectedTargetProjectId)
       : null
 
-    set((state) => ({
-      messages: mergedMessages,
-      drafts:
-        parsedDrafts && latestDraftMessage
-          ? applyCreatedDraftState(parsedDrafts, state.createdDraftIds)
-          : latestDraftMessage
-            ? []
-            : state.drafts,
-      draftSourceMessageId: latestDraftMessage?.id ?? state.draftSourceMessageId,
-      status: isStreaming
-        ? 'thinking'
-        : parsedDrafts && parsedDrafts.length > 0
-          ? 'awaiting_confirmation'
-          : state.status === 'error'
-            ? 'error'
-            : 'idle'
-    }))
+    set((state) =>
+      patchActiveSnapshot(state, {
+        messages: mergedMessages,
+        drafts:
+          parsedDrafts && latestDraftMessage
+            ? applyCreatedDraftState(parsedDrafts, state.createdDraftIds)
+            : latestDraftMessage
+              ? []
+              : state.drafts,
+        draftSourceMessageId: latestDraftMessage?.id ?? state.draftSourceMessageId,
+        status: isStreaming
+          ? 'thinking'
+          : parsedDrafts && parsedDrafts.length > 0
+            ? 'awaiting_confirmation'
+            : state.status === 'error'
+              ? 'error'
+              : 'idle'
+      })
+    )
   },
 
   sendMessage: async (message) => {
@@ -595,24 +766,31 @@ export const useBoardChatStore = create<BoardChatState>((set, get) => ({
 
     const scope = get().scope
     if (!scope || scope.kind === 'pinned') {
-      set({ status: 'error', error: 'Board Assistant is unavailable for this board.' })
+      set((state) =>
+        patchActiveSnapshot(state, {
+          status: 'error',
+          error: 'Board Assistant is unavailable for this board.'
+        })
+      )
       return
     }
 
-    set({
+    set((state) => ({
       isOpen: true,
       isMinimized: false,
-      status: 'starting',
-      error: null,
-      composerValue: ''
-    })
+      ...patchActiveSnapshot(state, {
+        status: 'starting',
+        error: null,
+        composerValue: ''
+      })
+    }))
     get().addLocalUserMessage(trimmed)
 
     try {
       const runtime = await ensureRuntime()
       const boardContext = await buildBoardContext(scope, get().selectedTargetProjectId)
       const prompt = buildAssistantPrompt(scope, get().selectedTargetProjectId, boardContext, trimmed)
-      set({ status: 'thinking' })
+      set((state) => patchActiveSnapshot(state, { status: 'thinking' }))
 
       const result = await window.opencodeOps.prompt(
         runtime.runtimePath,
@@ -626,10 +804,12 @@ export const useBoardChatStore = create<BoardChatState>((set, get) => ({
         throw new Error(result.error || 'Failed to send board assistant prompt.')
       }
     } catch (error) {
-      set({
-        status: 'error',
-        error: error instanceof Error ? error.message : 'Failed to send board assistant prompt.'
-      })
+      set((state) =>
+        patchActiveSnapshot(state, {
+          status: 'error',
+          error: error instanceof Error ? error.message : 'Failed to send board assistant prompt.'
+        })
+      )
       get().addLocalSystemMessage('Board Assistant failed to send that message.')
     }
   },
@@ -641,7 +821,7 @@ export const useBoardChatStore = create<BoardChatState>((set, get) => ({
       return
     }
 
-    set({ status: 'starting', error: null })
+    set((state) => patchActiveSnapshot(state, { status: 'starting', error: null }))
 
     try {
       const invalidDrafts = selectedDrafts.filter((draft) => draft.validationIssues.length > 0)
@@ -670,49 +850,62 @@ export const useBoardChatStore = create<BoardChatState>((set, get) => ({
       get().addLocalSystemMessage(
         `Created ${result.tickets.length} ticket${result.tickets.length === 1 ? '' : 's'} with ${result.dependencies.length} dependenc${result.dependencies.length === 1 ? 'y' : 'ies'}.`
       )
-      set({ status: 'idle' })
+      set((state) => patchActiveSnapshot(state, { status: 'idle' }))
     } catch (error) {
-      set({
-        status: 'error',
-        error: error instanceof Error ? error.message : 'Failed to create selected tickets.'
-      })
+      set((state) =>
+        patchActiveSnapshot(state, {
+          status: 'error',
+          error: error instanceof Error ? error.message : 'Failed to create selected tickets.'
+        })
+      )
     }
   },
 
   toggleDraftSelected: (draftId) =>
-    set((state) => ({
-      drafts: state.drafts.map((draft) =>
-        draft.id === draftId ? { ...draft, selected: !draft.selected } : draft
-      )
-    })),
+    set((state) =>
+      patchActiveSnapshot(state, {
+        drafts: state.drafts.map((draft) =>
+          draft.id === draftId ? { ...draft, selected: !draft.selected } : draft
+        )
+      })
+    ),
 
   markDraftsCreated: (draftIds) =>
-    set((state) => ({
-      createdDraftIds: [...new Set([...state.createdDraftIds, ...draftIds])],
-      drafts: state.drafts.map((draft) =>
-        draftIds.includes(draft.id) ? { ...draft, createdAt: draft.createdAt ?? new Date().toISOString() } : draft
-      )
-    })),
+    set((state) =>
+      patchActiveSnapshot(state, {
+        createdDraftIds: [...new Set([...state.createdDraftIds, ...draftIds])],
+        drafts: state.drafts.map((draft) =>
+          draftIds.includes(draft.id)
+            ? { ...draft, createdAt: draft.createdAt ?? new Date().toISOString() }
+            : draft
+        )
+      })
+    ),
 
   setSelectedTargetProjectId: async (projectId) => {
     const state = get()
     if (state.selectedTargetProjectId === projectId) return
 
-    set({
-      ...createInitialState({
-        preserveOpen: state.isOpen,
-        scope: state.scope,
-        selectedTargetProjectId: projectId,
-        selectedAgentSdkOverride: state.selectedAgentSdkOverride,
-        selectedModelOverride: state.selectedModelOverride
-      })
-    })
+    set((current) =>
+      replaceActiveSnapshot(
+        current,
+        createInitialSnapshot({
+          scope: state.scope,
+          selectedTargetProjectId: projectId,
+          selectedAgentSdkOverride: state.selectedAgentSdkOverride,
+          selectedModelOverride: state.selectedModelOverride
+        }),
+        current.activeScopeKey
+      )
+    )
     await resetAndCleanup(state)
   },
 
-  setSelectedAgentSdkOverride: (selectedAgentSdkOverride) => set({ selectedAgentSdkOverride }),
+  setSelectedAgentSdkOverride: (selectedAgentSdkOverride) =>
+    set((state) => patchActiveSnapshot(state, { selectedAgentSdkOverride })),
 
-  setSelectedModelOverride: (selectedModelOverride) => set({ selectedModelOverride }),
+  setSelectedModelOverride: (selectedModelOverride) =>
+    set((state) => patchActiveSnapshot(state, { selectedModelOverride })),
 
   openDrawer: () => get().open(),
   minimizeDrawer: () => get().minimize(),
@@ -721,40 +914,60 @@ export const useBoardChatStore = create<BoardChatState>((set, get) => ({
   setTranscriptMessages: (messages) => get().syncTranscript(messages, false),
 
   addLocalUserMessage: (content) =>
-    set((state) => ({
-      messages: [...state.messages, makeLocalMessage('user', content)]
-    })),
+    set((state) =>
+      patchActiveSnapshot(state, {
+        messages: [...state.messages, makeLocalMessage('user', content)]
+      })
+    ),
 
   addLocalSystemMessage: (content) =>
-    set((state) => ({
-      messages: [...state.messages, makeLocalMessage('system', content)]
-    })),
+    set((state) =>
+      patchActiveSnapshot(state, {
+        messages: [...state.messages, makeLocalMessage('system', content)]
+      })
+    ),
 
   setDrafts: (drafts, sourceMessageId) =>
-    set((state) => ({
-      drafts: applyCreatedDraftState(drafts, state.createdDraftIds),
-      draftSourceMessageId: sourceMessageId,
-      status: drafts.length > 0 ? 'awaiting_confirmation' : 'idle'
-    })),
+    set((state) =>
+      patchActiveSnapshot(state, {
+        drafts: applyCreatedDraftState(drafts, state.createdDraftIds),
+        draftSourceMessageId: sourceMessageId,
+        status: drafts.length > 0 ? 'awaiting_confirmation' : 'idle'
+      })
+    ),
 
   clearDrafts: () =>
-    set((state) => ({
-      drafts: [],
-      draftSourceMessageId: null,
-      status: state.status === 'awaiting_confirmation' ? 'idle' : state.status
-    })),
+    set((state) =>
+      patchActiveSnapshot(state, {
+        drafts: [],
+        draftSourceMessageId: null,
+        status: state.status === 'awaiting_confirmation' ? 'idle' : state.status
+      })
+    ),
 
   setAllDraftsSelected: (selected) =>
-    set((state) => ({
-      drafts: state.drafts.map((draft) => (draft.createdAt ? draft : { ...draft, selected }))
-    })),
+    set((state) =>
+      patchActiveSnapshot(state, {
+        drafts: state.drafts.map((draft) => (draft.createdAt ? draft : { ...draft, selected }))
+      })
+    ),
 
-  setStatus: (status) => set({ status }),
-  setError: (error) => set({ error }),
+  setStatus: (status) => set((state) => patchActiveSnapshot(state, { status })),
+  setError: (error) => set((state) => patchActiveSnapshot(state, { error })),
   setRuntimeSession: ({ sessionId, opencodeSessionId, runtimePath }) =>
-    set({ sessionId, opencodeSessionId, runtimePath }),
-  updateOpencodeSessionId: (opencodeSessionId) => set({ opencodeSessionId }),
-  clearRuntimeSession: () => set({ sessionId: null, opencodeSessionId: null, runtimePath: null }),
-  setComposerValue: (composerValue) => set({ composerValue }),
-  resetState: (options) => set(() => ({ ...createInitialState(options) }))
+    set((state) => patchActiveSnapshot(state, { sessionId, opencodeSessionId, runtimePath })),
+  updateOpencodeSessionId: (opencodeSessionId) =>
+    set((state) => patchActiveSnapshot(state, { opencodeSessionId })),
+  clearRuntimeSession: () =>
+    set((state) => patchActiveSnapshot(state, { sessionId: null, opencodeSessionId: null, runtimePath: null })),
+  setComposerValue: (composerValue) =>
+    set((state) => patchActiveSnapshot(state, { composerValue })),
+  resetState: (options) =>
+    set((state) =>
+      replaceActiveSnapshot(
+        state,
+        createInitialSnapshot(options ? { ...options, scope: options.scope ?? state.scope } : { scope: state.scope }),
+        state.activeScopeKey
+      )
+    )
 }))

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -1598,6 +1598,37 @@ export const useSessionStore = create<SessionState>()(
           const session = get().boardAssistantByProject.get(projectId)
           if (!session) return { success: false, error: 'No board assistant session found' }
 
+          // Clean up the runtime BEFORE updating store state.
+          // We must do this here rather than relying on component unmount,
+          // because the BoardAssistantView may not be mounted (e.g. user
+          // switched to a file tab and then closed the board assistant tab).
+          const { useBoardChatStore } = await import('./useBoardChatStore')
+          const chatState = useBoardChatStore.getState()
+          if (chatState.sessionId === session.id) {
+            const { useQuestionStore } = await import('./useQuestionStore')
+            const { usePermissionStore } = await import('./usePermissionStore')
+            const { useCommandApprovalStore } = await import('./useCommandApprovalStore')
+
+            useQuestionStore.getState().clearSession(session.id)
+            usePermissionStore.getState().clearSession(session.id)
+            useCommandApprovalStore.getState().clearSession(session.id)
+
+            if (chatState.runtimePath && chatState.opencodeSessionId) {
+              try {
+                await window.opencodeOps.abort(chatState.runtimePath, chatState.opencodeSessionId)
+              } catch {
+                // Best-effort cleanup
+              }
+              try {
+                await window.opencodeOps.disconnect(chatState.runtimePath, chatState.opencodeSessionId)
+              } catch {
+                // Best-effort cleanup
+              }
+            }
+
+            useBoardChatStore.getState().resetState()
+          }
+
           await window.db.session.update(session.id, {
             status: 'completed',
             completed_at: new Date().toISOString()
@@ -1607,13 +1638,26 @@ export const useSessionStore = create<SessionState>()(
             const map = new Map(state.boardAssistantByProject)
             map.delete(projectId)
 
-            // If this was the active board assistant, clear focus
+            // If this was the active board assistant, clear focus and
+            // restore the previously active session for this worktree
             const clearFocus = state.activeBoardAssistantProjectId === projectId
 
-            return {
-              boardAssistantByProject: map,
-              ...(clearFocus ? { activeBoardAssistantProjectId: null } : {})
+            if (clearFocus) {
+              const worktreeId = state.activeWorktreeId
+              const connectionId = state.activeConnectionId
+              const restoredSessionId =
+                (worktreeId ? state.activeSessionByWorktree[worktreeId] : null) ??
+                (connectionId ? state.activeSessionByConnection[connectionId] : null) ??
+                null
+
+              return {
+                boardAssistantByProject: map,
+                activeBoardAssistantProjectId: null,
+                activeSessionId: restoredSessionId
+              }
             }
+
+            return { boardAssistantByProject: map }
           })
 
           return { success: true }

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -13,7 +13,8 @@ export function isBoardAssistantSessionName(name: string | null | undefined): bo
   return typeof name === 'string' && name.startsWith(BOARD_ASSISTANT_SESSION_NAME_PREFIX)
 }
 
-function isVisibleSession(session: { name: string | null }): boolean {
+function isVisibleSession(session: { name: string | null; session_type?: string }): boolean {
+  if (session.session_type === 'board-assistant') return false
   return !isBoardAssistantSessionName(session.name)
 }
 
@@ -45,6 +46,7 @@ interface Session {
   opencode_session_id: string | null
   agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
   mode: SessionMode
+  session_type: 'default' | 'board-assistant'
   model_provider_id: string | null
   model_id: string | null
   model_variant: string | null
@@ -98,6 +100,10 @@ interface SessionState {
   // Pinned session state — sessions pinned to the kanban board
   pinnedSessionIds: Set<string>
   activePinnedSessionId: string | null
+
+  // Board assistant state — project-scoped, one per project
+  boardAssistantByProject: Map<string, Session>
+  activeBoardAssistantProjectId: string | null
 
   // Actions
   acknowledgeClosedTerminals: (ids: Set<string>) => void
@@ -165,6 +171,15 @@ interface SessionState {
   clearInlineConnectionSession: () => void
   loadConnectionSessionsBackground: (connectionId: string) => Promise<void>
 
+  // Board assistant actions
+  loadBoardAssistantSession: (projectId: string) => Promise<void>
+  createBoardAssistantSession: (
+    projectId: string
+  ) => Promise<{ success: boolean; session?: Session; error?: string }>
+  closeBoardAssistantSession: (projectId: string) => Promise<{ success: boolean; error?: string }>
+  focusBoardAssistantSession: (projectId: string) => void
+  clearBoardAssistantFocus: () => void
+
   // Connection session actions
   loadConnectionSessions: (connectionId: string) => Promise<void>
   createConnectionSession: (
@@ -231,6 +246,10 @@ export const useSessionStore = create<SessionState>()(
       pinnedSessionIds: new Set<string>(),
       activePinnedSessionId: null,
 
+      // Board assistant state
+      boardAssistantByProject: new Map(),
+      activeBoardAssistantProjectId: null,
+
       acknowledgeClosedTerminals: (ids: Set<string>) => {
         set((state) => {
           const remaining = new Set(state.closedTerminalSessionIds)
@@ -241,6 +260,8 @@ export const useSessionStore = create<SessionState>()(
 
       // Load sessions for a worktree from database (only active sessions for tabs)
       loadSessions: async (worktreeId: string, _projectId: string) => {
+        // Also load board assistant session for this project (fire-and-forget)
+        void get().loadBoardAssistantSession(_projectId)
         // Only show loading indicator when no sessions are cached yet.
         // When sessions already exist (e.g., after createSession populated them),
         // skip the indicator to avoid unmounting active SessionViews mid-init.
@@ -864,6 +885,7 @@ export const useSessionStore = create<SessionState>()(
         if (sessionId && worktreeId) {
           set((state) => ({
             activeSessionId: sessionId,
+            activeBoardAssistantProjectId: null,
             activeSessionByWorktree: {
               ...state.activeSessionByWorktree,
               [worktreeId]: sessionId
@@ -872,13 +894,14 @@ export const useSessionStore = create<SessionState>()(
         } else if (sessionId && connectionId) {
           set((state) => ({
             activeSessionId: sessionId,
+            activeBoardAssistantProjectId: null,
             activeSessionByConnection: {
               ...state.activeSessionByConnection,
               [connectionId]: sessionId
             }
           }))
         } else {
-          set({ activeSessionId: sessionId })
+          set({ activeSessionId: sessionId, activeBoardAssistantProjectId: null })
         }
       },
 
@@ -1510,6 +1533,113 @@ export const useSessionStore = create<SessionState>()(
 
       getPendingPlan: (sessionId: string): PendingPlan | null => {
         return get().pendingPlans.get(sessionId) ?? null
+      },
+
+      // ─── Board assistant actions ──────────────────────────────────────
+
+      loadBoardAssistantSession: async (projectId: string) => {
+        try {
+          const session = await window.db.session.getActiveBoardAssistant(projectId)
+          set((state) => {
+            const map = new Map(state.boardAssistantByProject)
+            if (session) {
+              map.set(projectId, session)
+            } else {
+              map.delete(projectId)
+            }
+            return { boardAssistantByProject: map }
+          })
+        } catch {
+          // Non-fatal: board assistant tab won't show until next load
+        }
+      },
+
+      createBoardAssistantSession: async (projectId: string) => {
+        try {
+          // If one already exists, just focus it
+          const existing = get().boardAssistantByProject.get(projectId)
+          if (existing) {
+            get().focusBoardAssistantSession(projectId)
+            return { success: true, session: existing }
+          }
+
+          const session = await window.db.session.create({
+            worktree_id: null,
+            project_id: projectId,
+            name: 'Board Assistant',
+            session_type: 'board-assistant',
+            agent_sdk: useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
+          })
+
+          set((state) => {
+            const map = new Map(state.boardAssistantByProject)
+            map.set(projectId, session)
+            return {
+              boardAssistantByProject: map,
+              activeBoardAssistantProjectId: projectId,
+              // Clear other active states so the board assistant view shows
+              activeSessionId: null,
+              activePinnedSessionId: null,
+              inlineConnectionSessionId: null
+            }
+          })
+
+          return { success: true, session }
+        } catch (error) {
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to create board assistant'
+          }
+        }
+      },
+
+      closeBoardAssistantSession: async (projectId: string) => {
+        try {
+          const session = get().boardAssistantByProject.get(projectId)
+          if (!session) return { success: false, error: 'No board assistant session found' }
+
+          await window.db.session.update(session.id, {
+            status: 'completed',
+            completed_at: new Date().toISOString()
+          })
+
+          set((state) => {
+            const map = new Map(state.boardAssistantByProject)
+            map.delete(projectId)
+
+            // If this was the active board assistant, clear focus
+            const clearFocus = state.activeBoardAssistantProjectId === projectId
+
+            return {
+              boardAssistantByProject: map,
+              ...(clearFocus ? { activeBoardAssistantProjectId: null } : {})
+            }
+          })
+
+          return { success: true }
+        } catch (error) {
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to close board assistant'
+          }
+        }
+      },
+
+      focusBoardAssistantSession: (projectId: string) => {
+        const session = get().boardAssistantByProject.get(projectId)
+        if (!session) return
+
+        set({
+          activeBoardAssistantProjectId: projectId,
+          // Clear other active states so the board assistant view shows
+          activeSessionId: null,
+          activePinnedSessionId: null,
+          inlineConnectionSessionId: null
+        })
+      },
+
+      clearBoardAssistantFocus: () => {
+        set({ activeBoardAssistantProjectId: null })
       },
 
       // ─── Inline connection session actions ─────────────────────────────

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -914,7 +914,8 @@ export const useSessionStore = create<SessionState>()(
         set({
           activeWorktreeId: worktreeId,
           activeConnectionId: null,
-          inlineConnectionSessionId: null
+          inlineConnectionSessionId: null,
+          activeBoardAssistantProjectId: null
         })
 
         if (worktreeId) {
@@ -1065,6 +1066,9 @@ export const useSessionStore = create<SessionState>()(
           const found = sessions.find((s) => s.id === sessionId)
           if (found) return found
         }
+        for (const session of get().boardAssistantByProject.values()) {
+          if (session.id === sessionId) return session
+        }
         return null
       },
 
@@ -1075,9 +1079,18 @@ export const useSessionStore = create<SessionState>()(
       hydrateSession: (session: Session) => {
         // Already in store? Skip.
         if (get().getSessionById(session.id)) return
-        if (isBoardAssistantSessionName(session.name)) return
 
         set((state) => {
+          if (session.session_type === 'board-assistant') {
+            const newMap = new Map(state.boardAssistantByProject)
+            newMap.set(session.project_id, session)
+
+            const newModeMap = new Map(state.modeBySession)
+            newModeMap.set(session.id, session.mode || 'build')
+
+            return { boardAssistantByProject: newMap, modeBySession: newModeMap }
+          }
+
           if (session.worktree_id) {
             const newMap = new Map(state.sessionsByWorktree)
             const existing = newMap.get(session.worktree_id) || []
@@ -1300,6 +1313,14 @@ export const useSessionStore = create<SessionState>()(
             }
           }
         }
+        if (agentSdk === 'opencode') {
+          for (const session of get().boardAssistantByProject.values()) {
+            if (session.id === sessionId && session.agent_sdk) {
+              agentSdk = session.agent_sdk
+              break
+            }
+          }
+        }
 
         // Push to agent backend (SDK-aware) — skip for terminal sessions
         try {
@@ -1397,6 +1418,17 @@ export const useSessionStore = create<SessionState>()(
               newConnectionSessionsMap.set(connectionId, updatedSessions)
               return { sessionsByConnection: newConnectionSessionsMap }
             }
+          }
+
+          const newBoardAssistantMap = new Map(state.boardAssistantByProject)
+          for (const [projectId, session] of newBoardAssistantMap.entries()) {
+            if (session.id !== sessionId) continue
+            updatedAny = true
+            newBoardAssistantMap.set(projectId, {
+              ...session,
+              opencode_session_id: opencodeSessionId
+            })
+            return { boardAssistantByProject: newBoardAssistantMap }
           }
 
           return {}
@@ -1542,12 +1574,14 @@ export const useSessionStore = create<SessionState>()(
           const session = await window.db.session.getActiveBoardAssistant(projectId)
           set((state) => {
             const map = new Map(state.boardAssistantByProject)
+            const newModeMap = new Map(state.modeBySession)
             if (session) {
               map.set(projectId, session)
+              newModeMap.set(session.id, session.mode || 'build')
             } else {
               map.delete(projectId)
             }
-            return { boardAssistantByProject: map }
+            return { boardAssistantByProject: map, modeBySession: newModeMap }
           })
         } catch {
           // Non-fatal: board assistant tab won't show until next load
@@ -1573,9 +1607,12 @@ export const useSessionStore = create<SessionState>()(
 
           set((state) => {
             const map = new Map(state.boardAssistantByProject)
+            const newModeMap = new Map(state.modeBySession)
             map.set(projectId, session)
+            newModeMap.set(session.id, session.mode || 'build')
             return {
               boardAssistantByProject: map,
+              modeBySession: newModeMap,
               activeBoardAssistantProjectId: projectId,
               // Clear other active states so the board assistant view shows
               activeSessionId: null,
@@ -1596,15 +1633,29 @@ export const useSessionStore = create<SessionState>()(
       closeBoardAssistantSession: async (projectId: string) => {
         try {
           const session = get().boardAssistantByProject.get(projectId)
-          if (!session) return { success: false, error: 'No board assistant session found' }
+          if (!session) {
+            // Clear stale focus/map state so the UI doesn't get stuck
+            set((state) => {
+              const map = new Map(state.boardAssistantByProject)
+              map.delete(projectId)
+              return {
+                boardAssistantByProject: map,
+                activeBoardAssistantProjectId:
+                  state.activeBoardAssistantProjectId === projectId
+                    ? null
+                    : state.activeBoardAssistantProjectId
+              }
+            })
+            return { success: true }
+          }
 
           // Clean up the runtime BEFORE updating store state.
           // We must do this here rather than relying on component unmount,
           // because the BoardAssistantView may not be mounted (e.g. user
           // switched to a file tab and then closed the board assistant tab).
           const { useBoardChatStore } = await import('./useBoardChatStore')
-          const chatState = useBoardChatStore.getState()
-          if (chatState.sessionId === session.id) {
+          const chatSession = useBoardChatStore.getState().getSessionSnapshot(session.id)
+          if (chatSession) {
             const { useQuestionStore } = await import('./useQuestionStore')
             const { usePermissionStore } = await import('./usePermissionStore')
             const { useCommandApprovalStore } = await import('./useCommandApprovalStore')
@@ -1613,21 +1664,27 @@ export const useSessionStore = create<SessionState>()(
             usePermissionStore.getState().clearSession(session.id)
             useCommandApprovalStore.getState().clearSession(session.id)
 
-            if (chatState.runtimePath && chatState.opencodeSessionId) {
+            if (chatSession.snapshot.runtimePath && chatSession.snapshot.opencodeSessionId) {
               try {
-                await window.opencodeOps.abort(chatState.runtimePath, chatState.opencodeSessionId)
+                await window.opencodeOps.abort(
+                  chatSession.snapshot.runtimePath,
+                  chatSession.snapshot.opencodeSessionId
+                )
               } catch {
                 // Best-effort cleanup
               }
               try {
-                await window.opencodeOps.disconnect(chatState.runtimePath, chatState.opencodeSessionId)
+                await window.opencodeOps.disconnect(
+                  chatSession.snapshot.runtimePath,
+                  chatSession.snapshot.opencodeSessionId
+                )
               } catch {
                 // Best-effort cleanup
               }
             }
 
-            useBoardChatStore.getState().resetState()
           }
+          useBoardChatStore.getState().clearProjectSnapshot(projectId)
 
           await window.db.session.update(session.id, {
             status: 'completed',

--- a/src/shared/types/session.ts
+++ b/src/shared/types/session.ts
@@ -1,3 +1,5 @@
+export type SessionType = 'default' | 'board-assistant'
+
 export interface Session {
   id: string
   worktree_id: string | null
@@ -8,6 +10,7 @@ export interface Session {
   opencode_session_id: string | null
   agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
   mode: 'build' | 'plan'
+  session_type: SessionType
   model_provider_id: string | null
   model_id: string | null
   model_variant: string | null

--- a/test/kanban/board-assistant-create-navigation.test.tsx
+++ b/test/kanban/board-assistant-create-navigation.test.tsx
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { BoardAssistantView } from '../../src/renderer/src/components/kanban/BoardAssistantView'
+import { useBoardChatStore, type TicketDraft } from '../../src/renderer/src/stores/useBoardChatStore'
+import { useProjectStore } from '../../src/renderer/src/stores/useProjectStore'
+import { useWorktreeStore } from '../../src/renderer/src/stores/useWorktreeStore'
+import { useKanbanStore } from '../../src/renderer/src/stores/useKanbanStore'
+import { useSettingsStore } from '../../src/renderer/src/stores/useSettingsStore'
+import { useSessionStore, BOARD_TAB_ID } from '../../src/renderer/src/stores/useSessionStore'
+
+vi.mock('../../src/renderer/src/hooks/useSessionStream', () => ({
+  useSessionStream: () => ({
+    messages: [],
+    streamingParts: [],
+    streamingContent: '',
+    isStreaming: false,
+    isLoading: false
+  })
+}))
+
+vi.mock('../../src/renderer/src/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const projectId = 'proj-1'
+const assistantMessageId = 'assistant-msg-1'
+
+const boardDraft: TicketDraft = {
+  id: `${assistantMessageId}:draft-1:${projectId}`,
+  draftKey: 'draft-1',
+  title: 'Create persistence ticket',
+  description: 'Persist the board assistant state',
+  dependsOn: [],
+  resolvedDependsOnTitles: [],
+  warnings: [],
+  validationIssues: [],
+  projectId,
+  projectName: 'Project One',
+  selected: true,
+  createdAt: null
+}
+
+function seedStores(boardMode: 'sticky-tab' | 'toggle') {
+  useBoardChatStore.setState(useBoardChatStore.getInitialState())
+
+  useProjectStore.setState({
+    selectedProjectId: projectId,
+    projects: [
+      {
+        id: projectId,
+        name: 'Project One',
+        path: '/tmp/proj-1',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        sort_order: 0,
+        created_at: '2026-04-15T00:00:00.000Z',
+        last_accessed_at: '2026-04-15T00:00:00.000Z'
+      }
+    ]
+  })
+
+  useWorktreeStore.setState({
+    selectedWorktreeId: 'wt-1',
+    worktreesByProject: new Map([
+      [
+        projectId,
+        [
+          {
+            id: 'wt-1',
+            project_id: projectId,
+            name: 'main',
+            branch_name: 'main',
+            path: '/tmp/proj-1',
+            status: 'active',
+            is_default: true,
+            branch_renamed: 0,
+            last_message_at: null,
+            session_titles: '[]',
+            last_model_provider_id: null,
+            last_model_id: null,
+            last_model_variant: null,
+            created_at: '2026-04-15T00:00:00.000Z',
+            last_accessed_at: '2026-04-15T00:00:00.000Z',
+            github_pr_number: null,
+            github_pr_url: null
+          }
+        ]
+      ]
+    ])
+  })
+
+  useKanbanStore.setState({
+    tickets: new Map([[projectId, []]]),
+    isBoardViewActive: false,
+    isPinnedBoardActive: false,
+    loadTickets: vi.fn().mockResolvedValue(undefined),
+    loadDependencies: vi.fn().mockResolvedValue(undefined)
+  })
+
+  useSettingsStore.setState({
+    boardMode,
+    defaultAgentSdk: 'opencode'
+  })
+
+  useSessionStore.setState({
+    activeSessionId: null,
+    activeBoardAssistantProjectId: projectId,
+    activePinnedSessionId: null,
+    inlineConnectionSessionId: null
+  })
+
+  Object.defineProperty(window, 'kanban', {
+    writable: true,
+    configurable: true,
+    value: {
+      ticket: {
+        createBatch: vi.fn().mockResolvedValue({
+          tickets: [{ id: 'ticket-1' }],
+          dependencies: []
+        })
+      }
+    }
+  })
+
+  const store = useBoardChatStore.getState()
+  const scope = {
+    kind: 'project' as const,
+    projectId,
+    projectName: 'Project One',
+    projectPath: '/tmp/proj-1'
+  }
+  store.activateScope(scope, { scope })
+  useBoardChatStore.setState({
+    scope,
+    messages: [
+      {
+        id: assistantMessageId,
+        role: 'assistant',
+        content: [
+          'Ready.',
+          '```board-ticket-drafts',
+          JSON.stringify({
+            drafts: [
+              {
+                draftKey: 'draft-1',
+                title: boardDraft.title,
+                description: boardDraft.description,
+                projectId,
+                dependsOn: [],
+                warnings: []
+              }
+            ]
+          }),
+          '```'
+        ].join('\n'),
+        timestamp: '2026-04-15T00:00:00.000Z',
+        kind: 'transcript'
+      }
+    ],
+    drafts: [boardDraft],
+    draftSourceMessageId: assistantMessageId,
+    status: 'awaiting_confirmation'
+  })
+}
+
+describe('board assistant create navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('switches to the sticky board tab after creating tickets', async () => {
+    seedStores('sticky-tab')
+
+    render(<BoardAssistantView projectId={projectId} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Create all' }))
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().activeSessionId).toBe(BOARD_TAB_ID)
+    })
+    expect(useSessionStore.getState().activeBoardAssistantProjectId).toBeNull()
+  })
+
+  test('switches back to the toggle board view after creating tickets', async () => {
+    seedStores('toggle')
+
+    render(<BoardAssistantView projectId={projectId} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Create all' }))
+
+    await waitFor(() => {
+      expect(useKanbanStore.getState().isBoardViewActive).toBe(true)
+    })
+    expect(useSessionStore.getState().activeBoardAssistantProjectId).toBeNull()
+  })
+})

--- a/test/kanban/board-assistant-persistence.test.ts
+++ b/test/kanban/board-assistant-persistence.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { useBoardChatStore, type TicketDraft } from '../../src/renderer/src/stores/useBoardChatStore'
+import { useSessionStore } from '../../src/renderer/src/stores/useSessionStore'
+
+const projectScope = {
+  kind: 'project' as const,
+  projectId: 'proj-1',
+  projectName: 'Project One',
+  projectPath: '/tmp/proj-1'
+}
+
+const otherProjectScope = {
+  kind: 'project' as const,
+  projectId: 'proj-2',
+  projectName: 'Project Two',
+  projectPath: '/tmp/proj-2'
+}
+
+const boardDraft: TicketDraft = {
+  id: 'draft-1',
+  draftKey: 'draft-1',
+  title: 'Create ticket',
+  description: 'Persist the board assistant state',
+  dependsOn: [],
+  resolvedDependsOnTitles: [],
+  warnings: [],
+  validationIssues: [],
+  projectId: 'proj-1',
+  projectName: 'Project One',
+  selected: true,
+  createdAt: null
+}
+
+describe('board assistant persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useBoardChatStore.setState(useBoardChatStore.getInitialState())
+    useSessionStore.setState({
+      boardAssistantByProject: new Map(),
+      activeBoardAssistantProjectId: null,
+      modeBySession: new Map()
+    })
+
+    Object.defineProperty(window, 'db', {
+      writable: true,
+      configurable: true,
+      value: {
+        session: {
+          update: vi.fn().mockResolvedValue({ success: true })
+        }
+      }
+    })
+
+    Object.defineProperty(window, 'opencodeOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        abort: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined)
+      }
+    })
+  })
+
+  test('restores the existing project snapshot after switching away and back', () => {
+    const boardChat = useBoardChatStore.getState()
+
+    boardChat.activateScope(projectScope, { scope: projectScope })
+    boardChat.addLocalUserMessage('Break this into tickets')
+    boardChat.setDrafts([boardDraft], 'assistant-msg-1')
+    boardChat.setRuntimeSession({
+      sessionId: 'board-session-1',
+      opencodeSessionId: 'opc-1',
+      runtimePath: '/tmp/proj-1'
+    })
+    boardChat.setStatus('awaiting_confirmation')
+
+    boardChat.activateScope(otherProjectScope, { scope: otherProjectScope })
+    boardChat.addLocalUserMessage('Different board')
+
+    boardChat.activateScope(projectScope, { scope: projectScope })
+
+    const restored = useBoardChatStore.getState()
+    expect(restored.sessionId).toBe('board-session-1')
+    expect(restored.opencodeSessionId).toBe('opc-1')
+    expect(restored.status).toBe('awaiting_confirmation')
+    expect(restored.drafts).toHaveLength(1)
+    expect(restored.messages.some((message) => message.content === 'Break this into tickets')).toBe(true)
+    expect(restored.messages.some((message) => message.content === 'Different board')).toBe(false)
+  })
+
+  test('finds inactive project snapshots by session id', () => {
+    const boardChat = useBoardChatStore.getState()
+
+    boardChat.activateScope(projectScope, { scope: projectScope })
+    boardChat.setRuntimeSession({
+      sessionId: 'board-session-1',
+      opencodeSessionId: 'opc-1',
+      runtimePath: '/tmp/proj-1'
+    })
+
+    boardChat.activateScope(otherProjectScope, { scope: otherProjectScope })
+
+    const inactive = useBoardChatStore.getState().getSessionSnapshot('board-session-1')
+    expect(inactive).not.toBeNull()
+    expect(inactive?.key).toBe('project:proj-1')
+    expect(inactive?.snapshot.runtimePath).toBe('/tmp/proj-1')
+  })
+
+  test('closing an unfocused board assistant clears the correct project snapshot', async () => {
+    const boardChat = useBoardChatStore.getState()
+
+    boardChat.activateScope(projectScope, { scope: projectScope })
+    boardChat.setRuntimeSession({
+      sessionId: 'board-session-1',
+      opencodeSessionId: 'opc-1',
+      runtimePath: '/tmp/proj-1'
+    })
+
+    boardChat.activateScope(otherProjectScope, { scope: otherProjectScope })
+    boardChat.setRuntimeSession({
+      sessionId: 'board-session-2',
+      opencodeSessionId: 'opc-2',
+      runtimePath: '/tmp/proj-2'
+    })
+
+    useSessionStore.setState({
+      boardAssistantByProject: new Map([
+        [
+          'proj-1',
+          {
+            id: 'board-session-1',
+            worktree_id: null,
+            project_id: 'proj-1',
+            connection_id: null,
+            name: 'Board Assistant',
+            status: 'active',
+            opencode_session_id: 'opc-1',
+            agent_sdk: 'opencode',
+            mode: 'build',
+            session_type: 'board-assistant',
+            model_provider_id: null,
+            model_id: null,
+            model_variant: null,
+            created_at: '2026-04-15T00:00:00.000Z',
+            updated_at: '2026-04-15T00:00:00.000Z',
+            completed_at: null
+          }
+        ]
+      ]),
+      modeBySession: new Map([['board-session-1', 'build']])
+    })
+
+    const result = await useSessionStore.getState().closeBoardAssistantSession('proj-1')
+
+    expect(result.success).toBe(true)
+    expect(useBoardChatStore.getState().getProjectSnapshot('proj-1')).toBeNull()
+    expect(useBoardChatStore.getState().getProjectSnapshot('proj-2')).not.toBeNull()
+    expect(window.opencodeOps.abort).toHaveBeenCalledWith('/tmp/proj-1', 'opc-1')
+    expect(window.opencodeOps.disconnect).toHaveBeenCalledWith('/tmp/proj-1', 'opc-1')
+    expect(useSessionStore.getState().boardAssistantByProject.has('proj-1')).toBe(false)
+  })
+
+  test('setOpenCodeSessionId updates board assistant sessions in the session store', () => {
+    useSessionStore.setState({
+      boardAssistantByProject: new Map([
+        [
+          'proj-1',
+          {
+            id: 'board-session-1',
+            worktree_id: null,
+            project_id: 'proj-1',
+            connection_id: null,
+            name: 'Board Assistant',
+            status: 'active',
+            opencode_session_id: 'pending::1',
+            agent_sdk: 'opencode',
+            mode: 'build',
+            session_type: 'board-assistant',
+            model_provider_id: null,
+            model_id: null,
+            model_variant: null,
+            created_at: '2026-04-15T00:00:00.000Z',
+            updated_at: '2026-04-15T00:00:00.000Z',
+            completed_at: null
+          }
+        ]
+      ])
+    })
+
+    useSessionStore.getState().setOpenCodeSessionId('board-session-1', 'materialized-1')
+
+    expect(useSessionStore.getState().boardAssistantByProject.get('proj-1')?.opencode_session_id).toBe(
+      'materialized-1'
+    )
+  })
+})

--- a/test/phase-19/session-8/tab-context-ui.test.tsx
+++ b/test/phase-19/session-8/tab-context-ui.test.tsx
@@ -222,6 +222,53 @@ describe('Session 8: Tab Context Menus UI', () => {
     })
   })
 
+  describe('board assistant tab focus', () => {
+    test('clicking the board assistant tab clears file focus and activates the assistant', () => {
+      setupStores({ fileTabs: true })
+
+      useSessionStore.setState({
+        boardAssistantByProject: new Map([
+          [
+            projectId,
+            {
+              id: 'board-assistant-1',
+              worktree_id: null,
+              project_id: projectId,
+              connection_id: null,
+              name: 'Board Assistant',
+              status: 'active',
+              opencode_session_id: 'opc-1',
+              agent_sdk: 'opencode',
+              mode: 'build',
+              session_type: 'board-assistant',
+              model_provider_id: null,
+              model_id: null,
+              model_variant: null,
+              created_at: '2024-01-01',
+              updated_at: '2024-01-01',
+              completed_at: null
+            }
+          ]
+        ]),
+        activeBoardAssistantProjectId: null
+      })
+
+      useFileViewerStore.setState({
+        activeFilePath: '/test/project/worktree/src/app.ts'
+      })
+
+      render(<SessionTabs />)
+      const boardAssistantTab = screen.getByTestId('board-assistant-tab')
+      expect(boardAssistantTab.className).toContain('text-sm')
+      expect(boardAssistantTab.className).not.toContain('text-xs')
+
+      fireEvent.click(boardAssistantTab)
+
+      expect(useFileViewerStore.getState().activeFilePath).toBeNull()
+      expect(useSessionStore.getState().activeBoardAssistantProjectId).toBe(projectId)
+    })
+  })
+
   describe('File tab context menu', () => {
     test('right-click shows close actions and copy path items', async () => {
       setupStores({ fileTabs: true })


### PR DESCRIPTION
## Summary

- Converts board assistant from a floating drawer to a dedicated persistent tab in the session tab bar
- Adds `session_type` database field to distinguish board-assistant sessions from regular sessions
- Implements tab lifecycle management with create, focus, and close operations for each project
- Preserves chat state and runtime across tab switches—cleanup only occurs on explicit tab close
- Refactors `BoardChatDrawer` component to `BoardAssistantView` for full-pane rendering
- Removes minimize/restore UI since the tab bar provides native minimization via tab switching
- Renames internal method `toggleDraftSelection` to `toggleDraftSelected` for clarity
- Adds `getActiveBoardAssistantByProject` database query to retrieve active board assistant sessions
- Persists all snapshots (messages, drafts, scope) per project for seamless context preservation
- Updates IPC handlers and preload types to expose new board assistant session methods

## Testing

- Verified tab creation when launching board assistant from a project
- Confirmed persistence of chat state and drafts when switching between tabs
- Validated cleanup of session runtime and store state when explicitly closing the tab
- Checked that scope changes within board assistant properly reset conversation state
- Ensured reconnection logic handles temporary connection loss gracefully
- Confirmed board assistant is unavailable on pinned multi-project boards (as expected)
- Validated that only one active board assistant session exists per project
- Tested navigation to board after creating tickets from drafts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a DB schema migration (`sessions.session_type`) plus broad state/UI refactors that change session lifecycle and cleanup behavior; regressions could affect session/tab switching or leave runtimes running if close paths fail.
> 
> **Overview**
> **Board Assistant is now a persistent tab**: the drawer/minimize UI is removed and the assistant renders as `BoardAssistantView` in the main pane, with a dedicated tab in `SessionTabs` and launch behavior updated from `KanbanBoard`.
> 
> **Adds first-class board-assistant sessions** via a new `sessions.session_type` column (schema v23), plumbed through DB create/update/mapping, IPC/preload typings, and a new query `getActiveBoardAssistantByProject` to restore active assistants.
> 
> **Refactors assistant state management for persistence**: `useBoardChatStore` now keeps per-scope snapshots (messages/drafts/runtime/status) and `useSessionStore` manages create/focus/close flows, including explicit runtime teardown and navigation back to the board after ticket creation, plus tests covering persistence and tab navigation/close behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fd82a70eb2d85bcf5ab80ca1b212bec5767103a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->