### PR TITLE
Fix: Close pinned board when switching connections

### DIFF
--- a/src/renderer/src/stores/useConnectionStore.ts
+++ b/src/renderer/src/stores/useConnectionStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { toast } from '@/lib/toast'
 import { registerConnectionClear, clearWorktreeSelection } from './store-coordination'
+import { useKanbanStore } from './useKanbanStore'
 
 // Connection types matching the database schema
 interface ConnectionMemberEnriched {
@@ -324,6 +325,11 @@ export const useConnectionStore = create<ConnectionState>()(
         if (id) {
           // Deconflict: clear worktree selection synchronously (same tick)
           clearWorktreeSelection()
+          // Close pinned board when entering connection mode (matches worktree behavior)
+          const kanbanState = useKanbanStore.getState()
+          if (kanbanState.isPinnedBoardActive) {
+            kanbanState.togglePinnedBoard()
+          }
         }
       }
     }),


### PR DESCRIPTION
## Summary

- Prevents tab switching from being blocked in pinned board mode when entering connection mode
- Adds logic to automatically close the pinned board when a connection is activated, matching existing worktree behavior
- Imports `useKanbanStore` to access and toggle pinned board state
- Deconflicts UI state by clearing both worktree selection and pinned board status synchronously

## Testing

- Verify that switching between connections closes any active pinned board
- Confirm that tab navigation works normally after entering connection mode
- Ensure worktree behavior and pinned board behavior are now consistent
- Manual test: Open pinned board, switch to a different connection, verify board closes automatically
- Not run: Automated tests (if applicable, should verify state synchronization)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI state coordination change limited to `selectConnection`, with minimal chance of regressions beyond pinned-board toggling behavior.
> 
> **Overview**
> Selecting a connection now *synchronously deconflicts UI state* by closing the Kanban pinned board (via `useKanbanStore.togglePinnedBoard`) when `isPinnedBoardActive` is set, alongside the existing worktree selection clear.
> 
> This prevents pinned-board mode from interfering with navigation when entering connection mode and aligns behavior with the worktree selection flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b490a6f69c08930ea9e9597d522405bbd6c6dcea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->