### PR TITLE
feat: add Follow-up Ticket Trigger setting to control blocker satisfaction

### DIFF
--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -29,6 +29,7 @@ import { useKanbanStore, getKanbanDragData, setKanbanDragData, suppressLayoutAni
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { isBlockerSatisfied } from '@/lib/blocker-utils'
 import type { KanbanTicket, KanbanTicketColumn as ColumnType } from '../../../../main/db/types'
 
 // ── Layout animation spring ─────────────────────────────────────────
@@ -249,11 +250,12 @@ export function KanbanColumn({ column, tickets, archivedTickets, projectId, conn
           if (draggedTicket) {
             // Check if ticket has unresolved blockers
             const blockerIds = store.dependencyMap.get(ticketId)
+            const triggerColumn = useSettingsStore.getState().followUpTriggerColumn
             let isBlocked = false
             if (blockerIds?.size) {
               for (const [, projTickets] of store.tickets) {
                 for (const t of projTickets) {
-                  if (blockerIds.has(t.id) && t.column !== 'done') {
+                  if (blockerIds.has(t.id) && !isBlockerSatisfied(t.column, triggerColumn)) {
                     isBlocked = true
                     break
                   }

--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -255,7 +255,7 @@ export function KanbanColumn({ column, tickets, archivedTickets, projectId, conn
             if (blockerIds?.size) {
               for (const [, projTickets] of store.tickets) {
                 for (const t of projTickets) {
-                  if (blockerIds.has(t.id) && !isBlockerSatisfied(t.column, triggerColumn)) {
+                  if (blockerIds.has(t.id) && !isBlockerSatisfied(t.column, t.mode, triggerColumn)) {
                     isBlocked = true
                     break
                   }

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -36,6 +36,8 @@ import { PulseAnimation } from '@/components/worktrees/PulseAnimation'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { setKanbanDragData, useKanbanStore } from '@/stores/useKanbanStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { isBlockerSatisfied } from '@/lib/blocker-utils'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useScriptStore } from '@/stores/useScriptStore'
@@ -116,6 +118,8 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     })
   )
 
+  const followUpTriggerColumn = useSettingsStore(s => s.followUpTriggerColumn)
+
   const unresolvedBlockerCount = useKanbanStore(
     useCallback((state) => {
       const blockers = state.dependencyMap.get(ticket.id)
@@ -123,11 +127,11 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       let count = 0
       for (const [, projectTickets] of state.tickets) {
         for (const t of projectTickets) {
-          if (blockers.has(t.id) && t.column !== 'done') count++
+          if (blockers.has(t.id) && !isBlockerSatisfied(t.column, followUpTriggerColumn)) count++
         }
       }
       return count
-    }, [ticket.id])
+    }, [ticket.id, followUpTriggerColumn])
   )
 
   const isSimpleMode = useKanbanStore(

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -127,7 +127,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       let count = 0
       for (const [, projectTickets] of state.tickets) {
         for (const t of projectTickets) {
-          if (blockers.has(t.id) && !isBlockerSatisfied(t.column, followUpTriggerColumn)) count++
+          if (blockers.has(t.id) && !isBlockerSatisfied(t.column, t.mode, followUpTriggerColumn)) count++
         }
       }
       return count

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -341,7 +341,6 @@ function KanbanTicketModalContent({
   const updateTicket = useKanbanStore((s) => s.updateTicket)
   const deleteTicket = useKanbanStore((s) => s.deleteTicket)
   const moveTicket = useKanbanStore((s) => s.moveTicket)
-  const followUpTriggerColumn = useSettingsStore(s => s.followUpTriggerColumn)
   const [editDraftDirty, setEditDraftDirty] = useState(false)
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
 
@@ -820,6 +819,8 @@ function EditModeContent({
   useEffect(() => {
     onDirtyChange(isDirty)
   }, [isDirty, onDirtyChange])
+
+  const followUpTriggerColumn = useSettingsStore(s => s.followUpTriggerColumn)
 
   // ── Dependency selectors ──────────────────────────────────────────
   // useShallow prevents infinite re-render loops by doing shallow equality

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -47,6 +47,7 @@ import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useCommandApprovalStore } from '@/stores/useCommandApprovalStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
+import { isBlockerSatisfied } from '@/lib/blocker-utils'
 import { useGitStore } from '@/stores/useGitStore'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
@@ -340,6 +341,7 @@ function KanbanTicketModalContent({
   const updateTicket = useKanbanStore((s) => s.updateTicket)
   const deleteTicket = useKanbanStore((s) => s.deleteTicket)
   const moveTicket = useKanbanStore((s) => s.moveTicket)
+  const followUpTriggerColumn = useSettingsStore(s => s.followUpTriggerColumn)
   const [editDraftDirty, setEditDraftDirty] = useState(false)
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
 
@@ -1018,7 +1020,7 @@ function EditModeContent({
                 {blockerTickets.map(blocker => (
                   <div key={blocker.id} className="flex items-center justify-between gap-2 px-2 py-1 rounded-md bg-muted/30">
                     <div className="flex items-center gap-2 min-w-0">
-                      {blocker.column === 'done' ? (
+                      {isBlockerSatisfied(blocker.column, followUpTriggerColumn) ? (
                         <span className="text-green-500 text-xs">&#10003;</span>
                       ) : (
                         <Lock className="h-3 w-3 text-amber-500" />

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1021,7 +1021,7 @@ function EditModeContent({
                 {blockerTickets.map(blocker => (
                   <div key={blocker.id} className="flex items-center justify-between gap-2 px-2 py-1 rounded-md bg-muted/30">
                     <div className="flex items-center gap-2 min-w-0">
-                      {isBlockerSatisfied(blocker.column, followUpTriggerColumn) ? (
+                      {isBlockerSatisfied(blocker.column, blocker.mode, followUpTriggerColumn) ? (
                         <span className="text-green-500 text-xs">&#10003;</span>
                       ) : (
                         <Lock className="h-3 w-3 text-amber-500" />

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -17,6 +17,7 @@ export function SettingsGeneral(): React.JSX.Element {
     autoStartSession,
     autoPullBeforeWorktree,
     boardMode,
+    followUpTriggerColumn,
     vimModeEnabled,
     mergeConflictMode,
     tipsEnabled,
@@ -143,6 +144,40 @@ export function SettingsGeneral(): React.JSX.Element {
             data-testid="board-mode-sticky-tab"
           >
             Sticky Tab
+          </button>
+        </div>
+      </div>
+
+      {/* Follow-up ticket trigger */}
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Follow-up Ticket Trigger</label>
+        <p className="text-xs text-muted-foreground">
+          When should blocked tickets auto-launch? When all blockers reach this column.
+        </p>
+        <div className="flex gap-2">
+          <button
+            onClick={() => updateSetting('followUpTriggerColumn', 'review')}
+            className={cn(
+              'px-3 py-1.5 rounded-md text-sm border transition-colors',
+              followUpTriggerColumn === 'review'
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+            )}
+            data-testid="follow-up-trigger-review"
+          >
+            Review
+          </button>
+          <button
+            onClick={() => updateSetting('followUpTriggerColumn', 'done')}
+            className={cn(
+              'px-3 py-1.5 rounded-md text-sm border transition-colors',
+              followUpTriggerColumn === 'done'
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+            )}
+            data-testid="follow-up-trigger-done"
+          >
+            Done
           </button>
         </div>
       </div>

--- a/src/renderer/src/lib/blocker-utils.ts
+++ b/src/renderer/src/lib/blocker-utils.ts
@@ -1,0 +1,12 @@
+import type { KanbanTicketColumn } from '../../../main/db/types'
+import type { FollowUpTriggerColumn } from '@/stores/useSettingsStore'
+
+export function isBlockerSatisfied(
+  blockerColumn: KanbanTicketColumn,
+  triggerColumn: FollowUpTriggerColumn
+): boolean {
+  if (triggerColumn === 'review') {
+    return blockerColumn === 'review' || blockerColumn === 'done'
+  }
+  return blockerColumn === 'done'
+}

--- a/src/renderer/src/lib/blocker-utils.ts
+++ b/src/renderer/src/lib/blocker-utils.ts
@@ -3,10 +3,13 @@ import type { FollowUpTriggerColumn } from '@/stores/useSettingsStore'
 
 export function isBlockerSatisfied(
   blockerColumn: KanbanTicketColumn,
+  blockerMode: 'build' | 'plan' | 'super-plan' | null,
   triggerColumn: FollowUpTriggerColumn
 ): boolean {
   if (triggerColumn === 'review') {
-    return blockerColumn === 'review' || blockerColumn === 'done'
+    if (blockerColumn === 'done') return true
+    if (blockerColumn === 'review' && blockerMode === 'build') return true
+    return false
   }
   return blockerColumn === 'done'
 }

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -506,17 +506,17 @@ export const useKanbanStore = create<KanbanState>()(
             // Find tickets that list this ticket as a blocker
             for (const [depId, blockers] of dependencyMap) {
               if (!blockers.has(ticketId)) continue
-              // Check if ALL blockers of this dependent are now done
-              let allDone = true
+              // Check if ALL blockers of this dependent are now satisfied
+              let allSatisfied = true
               for (const bid of blockers) {
                 // Find the blocker ticket across all projects
                 for (const [, projTickets] of allTickets) {
                   const bt = projTickets.find(t => t.id === bid)
-                  if (bt && !isBlockerSatisfied(bt.column, triggerColumn)) { allDone = false; break }
+                  if (bt && !isBlockerSatisfied(bt.column, triggerColumn)) { allSatisfied = false; break }
                 }
-                if (!allDone) break
+                if (!allSatisfied) break
               }
-              if (allDone) {
+              if (allSatisfied) {
                 // Find the dependent ticket and auto-launch if it has pending config
                 for (const [, projTickets] of allTickets) {
                   const depTicket = projTickets.find(t => t.id === depId)

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -501,7 +501,7 @@ export const useKanbanStore = create<KanbanState>()(
           const { useSettingsStore } = await import('./useSettingsStore')
           const { isBlockerSatisfied } = await import('../lib/blocker-utils')
           const triggerColumn = useSettingsStore.getState().followUpTriggerColumn
-          if (column === 'done' || (triggerColumn === 'review' && column === 'review')) {
+          if (column === 'done' || (triggerColumn === 'review' && column === 'review' && movedTicket?.mode === 'build')) {
             const { dependencyMap, tickets: allTickets } = get()
             // Find tickets that list this ticket as a blocker
             for (const [depId, blockers] of dependencyMap) {
@@ -512,7 +512,7 @@ export const useKanbanStore = create<KanbanState>()(
                 // Find the blocker ticket across all projects
                 for (const [, projTickets] of allTickets) {
                   const bt = projTickets.find(t => t.id === bid)
-                  if (bt && !isBlockerSatisfied(bt.column, triggerColumn)) { allSatisfied = false; break }
+                  if (bt && !isBlockerSatisfied(bt.column, bt.mode, triggerColumn)) { allSatisfied = false; break }
                 }
                 if (!allSatisfied) break
               }

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -497,8 +497,11 @@ export const useKanbanStore = create<KanbanState>()(
         try {
           await window.kanban.ticket.move(ticketId, column, sortOrder)
 
-          // When a ticket moves to done, check if any dependents can be auto-launched
-          if (column === 'done') {
+          // When a ticket moves to done (or review, if that's the trigger), check if any dependents can be auto-launched
+          const { useSettingsStore } = await import('./useSettingsStore')
+          const { isBlockerSatisfied } = await import('../lib/blocker-utils')
+          const triggerColumn = useSettingsStore.getState().followUpTriggerColumn
+          if (column === 'done' || (triggerColumn === 'review' && column === 'review')) {
             const { dependencyMap, tickets: allTickets } = get()
             // Find tickets that list this ticket as a blocker
             for (const [depId, blockers] of dependencyMap) {
@@ -509,7 +512,7 @@ export const useKanbanStore = create<KanbanState>()(
                 // Find the blocker ticket across all projects
                 for (const [, projTickets] of allTickets) {
                   const bt = projTickets.find(t => t.id === bid)
-                  if (bt && bt.column !== 'done') { allDone = false; break }
+                  if (bt && !isBlockerSatisfied(bt.column, triggerColumn)) { allDone = false; break }
                 }
                 if (!allDone) break
               }

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -22,6 +22,7 @@ export type TerminalOption =
 export type EmbeddedTerminalBackend = 'xterm' | 'ghostty'
 export type TerminalPosition = 'sidebar' | 'bottom'
 export type MergeConflictMode = 'build' | 'plan' | 'always-ask'
+export type FollowUpTriggerColumn = 'review' | 'done'
 
 export interface SelectedModel {
   providerID: string
@@ -53,6 +54,7 @@ export interface AppSettings {
   vimModeEnabled: boolean
   mergeConflictMode: MergeConflictMode
   boardMode: 'toggle' | 'sticky-tab'
+  followUpTriggerColumn: FollowUpTriggerColumn
 
   // Editor
   defaultEditor: EditorOption
@@ -139,6 +141,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   vimModeEnabled: false,
   mergeConflictMode: 'always-ask',
   boardMode: 'sticky-tab',
+  followUpTriggerColumn: 'done',
   defaultEditor: 'vscode',
   customEditorCommand: '',
   defaultTerminal: 'terminal',
@@ -291,6 +294,7 @@ function extractSettings(state: SettingsState): AppSettings {
     vimModeEnabled: state.vimModeEnabled,
     mergeConflictMode: state.mergeConflictMode,
     boardMode: state.boardMode,
+    followUpTriggerColumn: state.followUpTriggerColumn,
     defaultEditor: state.defaultEditor,
     customEditorCommand: state.customEditorCommand,
     defaultTerminal: state.defaultTerminal,
@@ -548,6 +552,7 @@ export const useSettingsStore = create<SettingsState>()(
         vimModeEnabled: state.vimModeEnabled,
         mergeConflictMode: state.mergeConflictMode,
         boardMode: state.boardMode,
+        followUpTriggerColumn: state.followUpTriggerColumn,
         defaultEditor: state.defaultEditor,
         customEditorCommand: state.customEditorCommand,
         defaultTerminal: state.defaultTerminal,


### PR DESCRIPTION
## Summary

- Add `FollowUpTriggerColumn` setting with 'review' and 'done' options to control when blocked tickets auto-launch
- Implement `isBlockerSatisfied()` helper function to check if a blocker ticket meets the trigger condition
- Update blocker checks across 4 call sites (KanbanColumn, KanbanTicketCard, KanbanTicketModal, useKanbanStore) to use the new helper
- For 'review' trigger: blockers in 'done' column or 'review' column with 'build' mode satisfy the condition
- For 'done' trigger: only blockers in 'done' column satisfy the condition (default behavior)
- Add Settings UI with toggle buttons to switch between trigger modes
- Refactor variable name from `allDone` to `allSatisfied` for clarity

## Testing

- Verify 'review' trigger mode allows blockers in review (build-mode tickets) to satisfy dependencies
- Verify 'done' trigger mode requires blockers to reach done column
- Confirm Follow-up Ticket Trigger setting UI displays and persists correctly in Settings → General
- Test that unresolvedBlockerCount updates correctly when changing trigger modes
- Verify blocked tickets auto-launch when all blockers satisfy the current trigger condition
- Confirm blocker status indicators (✓ or 🔒) in ticket modal reflect the active trigger setting
- Not run: E2E tests for cross-project dependency workflows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Kanban dependency satisfaction and auto-launch conditions, so misclassification could cause tickets to auto-launch too early/late. Scope is contained to renderer settings + blocker checks but affects multiple user-visible workflows.
> 
> **Overview**
> Adds a new persisted setting, `followUpTriggerColumn` (default `done`), plus a Settings → General toggle to control when blocker dependencies are considered satisfied.
> 
> Centralizes blocker-completion logic in `isBlockerSatisfied()` and updates Kanban UI/state to use it for: blocked/unblocked detection when dragging into In Progress, unresolved blocker counts/badges, dependency status indicators in the ticket modal, and dependent-ticket auto-launch gating when a blocker moves to `review`/`done` based on the configured trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ecfcaedf5016e021465f40a2cc1990a5da1d07d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->