### PR TITLE
Preserve pinned board state when navigating from pinned-mode tickets

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -423,15 +423,16 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       // Cmd+click (Mac) / Ctrl+click (Win/Linux) — select attached worktree
       if ((e.metaKey || e.ctrlKey) && ticket.worktree_id && !isArchived) {
         e.preventDefault()
-        useWorktreeStore.getState().selectWorktree(ticket.worktree_id)
-        useProjectStore.getState().selectProject(ticket.project_id)
+        const selectionOptions = isPinnedMode ? { preservePinnedBoard: true } : undefined
+        useWorktreeStore.getState().selectWorktree(ticket.worktree_id, selectionOptions)
+        useProjectStore.getState().selectProject(ticket.project_id, selectionOptions)
         useWorktreeStatusStore.getState().clearWorktreeUnread(ticket.worktree_id)
         return
       }
 
       useKanbanStore.getState().setSelectedTicketId(ticket.id)
     },
-    [ticket.id, ticket.worktree_id, ticket.project_id, isArchived]
+    [ticket.id, ticket.worktree_id, ticket.project_id, isArchived, isPinnedMode]
   )
 
   // ── Middle-click — select attached worktree (same as sidebar) ─
@@ -443,11 +444,12 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       e.preventDefault()                     // suppress browser auto-scroll
 
       // Select worktree — same as sidebar's WorktreeItem.handleClick
-      useWorktreeStore.getState().selectWorktree(ticket.worktree_id)
-      useProjectStore.getState().selectProject(ticket.project_id)
+      const selectionOptions = isPinnedMode ? { preservePinnedBoard: true } : undefined
+      useWorktreeStore.getState().selectWorktree(ticket.worktree_id, selectionOptions)
+      useProjectStore.getState().selectProject(ticket.project_id, selectionOptions)
       useWorktreeStatusStore.getState().clearWorktreeUnread(ticket.worktree_id)
     },
-    [ticket.worktree_id, ticket.project_id, isArchived]
+    [ticket.worktree_id, ticket.project_id, isArchived, isPinnedMode]
   )
 
   const handleMouseEnter = useCallback(() => {

--- a/src/renderer/src/stores/useProjectStore.ts
+++ b/src/renderer/src/stores/useProjectStore.ts
@@ -22,6 +22,10 @@ interface Project {
   last_accessed_at: string
 }
 
+interface ProjectSelectionOptions {
+  preservePinnedBoard?: boolean
+}
+
 interface ProjectState {
   // Data
   projects: Project[]
@@ -54,7 +58,7 @@ interface ProjectState {
       auto_assign_port?: boolean
     }
   ) => Promise<boolean>
-  selectProject: (id: string | null) => void
+  selectProject: (id: string | null, options?: ProjectSelectionOptions) => void
   toggleProjectExpanded: (id: string) => void
   setEditingProject: (id: string | null) => void
   touchProject: (id: string) => Promise<void>
@@ -275,12 +279,12 @@ export const useProjectStore = create<ProjectState>()(
       },
 
       // Select a project
-      selectProject: (id: string | null) => {
+      selectProject: (id: string | null, options?: ProjectSelectionOptions) => {
         set({ selectedProjectId: id })
         if (id) {
           // Close pinned board when navigating to a specific project
           const kanbanState = useKanbanStore.getState()
-          if (kanbanState.isPinnedBoardActive) {
+          if (!options?.preservePinnedBoard && kanbanState.isPinnedBoardActive) {
             kanbanState.togglePinnedBoard()
           }
           // Touch project to update last_accessed_at

--- a/src/renderer/src/stores/useWorktreeStore.ts
+++ b/src/renderer/src/stores/useWorktreeStore.ts
@@ -85,6 +85,10 @@ interface Worktree {
   github_pr_url: string | null
 }
 
+interface WorktreeSelectionOptions {
+  preservePinnedBoard?: boolean
+}
+
 interface WorktreeState {
   // Data - keyed by project ID
   worktreesByProject: Map<string, Worktree[]>
@@ -116,7 +120,7 @@ interface WorktreeState {
     branchName: string,
     projectPath: string
   ) => Promise<{ success: boolean; error?: string }>
-  selectWorktree: (id: string | null) => void
+  selectWorktree: (id: string | null, options?: WorktreeSelectionOptions) => void
   selectWorktreeOnly: (id: string | null) => void
   touchWorktree: (id: string) => Promise<void>
   syncWorktrees: (projectId: string, projectPath: string) => Promise<void>
@@ -630,12 +634,12 @@ export const useWorktreeStore = create<WorktreeState>((set, get) => ({
   },
 
   // Select a worktree (with connection deconfliction)
-  selectWorktree: (id: string | null) => {
+  selectWorktree: (id: string | null, options?: WorktreeSelectionOptions) => {
     const previousWorktreeId = get().selectedWorktreeId
     set({ selectedWorktreeId: id })
     applyWorktreeSelectionEffects(previousWorktreeId, id, {
       clearConnectionSelection: Boolean(id),
-      closePinnedBoard: Boolean(id),
+      closePinnedBoard: Boolean(id) && !options?.preservePinnedBoard,
       refreshLanguage: Boolean(id)
     })
   },

--- a/test/kanban/pinned-board-ticket-navigation.test.tsx
+++ b/test/kanban/pinned-board-ticket-navigation.test.tsx
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { fireEvent, render, screen } from '../utils/render'
+import { KanbanTicketCard } from '@/components/kanban/KanbanTicketCard'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useGitStore } from '@/stores/useGitStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { usePinnedStore } from '@/stores/usePinnedStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useQuestionStore } from '@/stores/useQuestionStore'
+import { useScriptStore } from '@/stores/useScriptStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket } from '../../src/main/db/types'
+
+vi.mock('@/components/kanban/WorktreePickerModal', () => ({
+  WorktreePickerModal: () => null
+}))
+
+vi.mock('@/components/kanban/AttachPRPopover', () => ({
+  AttachPRPopover: () => null
+}))
+
+vi.mock('@/components/kanban/UpdateStatusModal', () => ({
+  UpdateStatusModal: () => null
+}))
+
+vi.mock('@/components/worktrees/PulseAnimation', () => ({
+  PulseAnimation: () => null
+}))
+
+vi.mock('@/components/sessions/IndeterminateProgressBar', () => ({
+  IndeterminateProgressBar: () => null
+}))
+
+vi.mock('@/hooks/useSessionTimer', () => ({
+  useSessionTimer: () => null
+}))
+
+vi.mock('@/hooks/useSessionTokenDelta', () => ({
+  useSessionTokenDelta: () => null
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const mockDb = {
+  project: {
+    touch: vi.fn().mockResolvedValue(undefined)
+  },
+  worktree: {
+    touch: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'proj-1',
+    title: 'Keep pinned board active',
+    description: null,
+    attachments: [],
+    column: 'todo',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: 'wt-1',
+    mode: null,
+    plan_ready: false,
+    created_at: '2026-04-16T00:00:00.000Z',
+    updated_at: '2026-04-16T00:00:00.000Z',
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    ...overrides
+  }
+}
+
+function seedStores(): void {
+  useKanbanStore.setState({
+    tickets: new Map([['proj-1', [makeTicket()]]]),
+    dependencyMap: new Map(),
+    selectedTicketId: null,
+    isPinnedBoardActive: true
+  })
+
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'proj-1',
+        name: 'Project One',
+        path: '/tmp/proj-1',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-04-16T00:00:00.000Z',
+        last_accessed_at: '2026-04-16T00:00:00.000Z'
+      }
+    ],
+    selectedProjectId: null
+  })
+
+  useWorktreeStore.setState({
+    selectedWorktreeId: null,
+    worktreesByProject: new Map([
+      [
+        'proj-1',
+        [
+          {
+            id: 'wt-1',
+            project_id: 'proj-1',
+            name: 'feature-auth',
+            branch_name: 'feature-auth',
+            path: '/tmp/proj-1/feature-auth',
+            status: 'active',
+            is_default: false,
+            branch_renamed: 0,
+            last_message_at: null,
+            session_titles: '[]',
+            last_model_provider_id: null,
+            last_model_id: null,
+            last_model_variant: null,
+            created_at: '2026-04-16T00:00:00.000Z',
+            last_accessed_at: '2026-04-16T00:00:00.000Z',
+            github_pr_number: null,
+            github_pr_url: null
+          }
+        ]
+      ]
+    ]),
+    worktreeOrderByProject: new Map()
+  })
+
+  useSessionStore.setState({
+    sessionsByWorktree: new Map([
+      [
+        'wt-1',
+        [
+          {
+            id: 'session-1',
+            worktree_id: 'wt-1',
+            project_id: 'proj-1',
+            connection_id: null,
+            name: 'Session 1',
+            status: 'active',
+            opencode_session_id: null,
+            agent_sdk: 'opencode',
+            mode: 'build',
+            session_type: 'default',
+            model_provider_id: null,
+            model_id: null,
+            model_variant: null,
+            created_at: '2026-04-16T00:00:00.000Z',
+            updated_at: '2026-04-16T00:00:00.000Z',
+            completed_at: null,
+            pinned_to_board: false
+          }
+        ]
+      ]
+    ]),
+    sessionsByConnection: new Map()
+  })
+
+  useWorktreeStatusStore.setState({
+    sessionStatuses: {
+      'session-1': {
+        status: 'unread',
+        timestamp: Date.now()
+      }
+    },
+    reviewSessionByWorktree: {},
+    completedReviewSessionByWorktree: {}
+  })
+
+  useConnectionStore.setState({
+    selectedConnectionId: null,
+    connections: []
+  })
+
+  usePinnedStore.setState({
+    loaded: true,
+    pinnedProjectIds: new Set(['proj-1']),
+    pinnedWorktreeIds: new Set(),
+    pinnedConnectionIds: new Set()
+  })
+
+  useGitStore.setState({
+    remoteInfo: new Map(),
+    creatingPRByWorktreeId: new Map()
+  })
+
+  useScriptStore.setState({
+    scriptStates: {}
+  })
+
+  useQuestionStore.setState({
+    pendingBySession: new Map()
+  })
+}
+
+describe('pinned board ticket navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    Object.defineProperty(window, 'db', {
+      writable: true,
+      configurable: true,
+      value: mockDb
+    })
+
+    seedStores()
+  })
+
+  test('cmd-click on a pinned-board ticket keeps the pinned board active', () => {
+    render(<KanbanTicketCard ticket={makeTicket()} isPinnedMode />)
+
+    fireEvent.click(screen.getByTestId('kanban-ticket-ticket-1'), { metaKey: true })
+
+    expect(useKanbanStore.getState().isPinnedBoardActive).toBe(true)
+    expect(useWorktreeStore.getState().selectedWorktreeId).toBe('wt-1')
+    expect(useProjectStore.getState().selectedProjectId).toBe('proj-1')
+    expect(useWorktreeStatusStore.getState().sessionStatuses['session-1']).toBeNull()
+  })
+
+  test('middle-click on a pinned-board ticket keeps the pinned board active', () => {
+    render(<KanbanTicketCard ticket={makeTicket()} isPinnedMode />)
+
+    fireEvent.mouseDown(screen.getByTestId('kanban-ticket-ticket-1'), { button: 1 })
+
+    expect(useKanbanStore.getState().isPinnedBoardActive).toBe(true)
+    expect(useWorktreeStore.getState().selectedWorktreeId).toBe('wt-1')
+    expect(useProjectStore.getState().selectedProjectId).toBe('proj-1')
+    expect(useWorktreeStatusStore.getState().sessionStatuses['session-1']).toBeNull()
+  })
+
+  test('cmd-click outside pinned mode still closes the pinned board', () => {
+    render(<KanbanTicketCard ticket={makeTicket()} />)
+
+    fireEvent.click(screen.getByTestId('kanban-ticket-ticket-1'), { metaKey: true })
+
+    expect(useKanbanStore.getState().isPinnedBoardActive).toBe(false)
+    expect(useWorktreeStore.getState().selectedWorktreeId).toBe('wt-1')
+    expect(useProjectStore.getState().selectedProjectId).toBe('proj-1')
+    expect(useWorktreeStatusStore.getState().sessionStatuses['session-1']).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- **Problem**: Clicking on a ticket in pinned board mode was closing the pinned board when selecting the attached worktree, disrupting the user's workflow
- **Solution**: Added `preservePinnedBoard` option to `selectWorktree()` and `selectProject()` methods to maintain pinned board state during ticket navigation
- **Changes**: Modified ticket click handlers to pass selection options when in pinned mode
- **Coverage**: Added comprehensive test suite (262 lines) validating behavior for cmd-click, middle-click, and normal mode scenarios

## Testing

- Verified cmd-click on pinned-board ticket keeps pinned board active and selects worktree
- Verified middle-click on pinned-board ticket keeps pinned board active and selects worktree  
- Verified cmd-click outside pinned mode still closes pinned board as expected
- Confirmed dependency array includes `isPinnedMode` flag to prevent stale closure references
- Confirmed selection options properly prevent `closePinnedBoard` effect in store logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to UI navigation state with optional parameters and targeted test coverage; main risk is unintended pinned-board persistence in edge navigation paths.
> 
> **Overview**
> Keeps the **pinned Kanban board** open when navigating to a ticket’s attached worktree/project from pinned-board mode (cmd/ctrl-click or middle-click).
> 
> This introduces an optional `preservePinnedBoard` flag on `useWorktreeStore.selectWorktree` and `useProjectStore.selectProject`, and wires `KanbanTicketCard` to pass it when `isPinnedMode` is true; a new Vitest suite asserts pinned vs non-pinned navigation behavior and unread clearing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043756e437d8f155dd932977f5e604516c9b103a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->