### PR TITLE
Fix terminal z-index conflicts with UI overlays via automatic suppression boundaries

### DIFF
--- a/src/renderer/src/components/layout/DropOverlay.tsx
+++ b/src/renderer/src/components/layout/DropOverlay.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle, Download } from 'lucide-react'
+import { useGhosttySuppression } from '@/hooks'
 
 interface DropOverlayProps {
   variant: 'normal' | 'warning'
@@ -6,6 +7,7 @@ interface DropOverlayProps {
 
 export function DropOverlay({ variant }: DropOverlayProps) {
   const isWarning = variant === 'warning'
+  useGhosttySuppression('drop-overlay', true)
 
   return (
     <div

--- a/src/renderer/src/components/sessions/SessionHistory.tsx
+++ b/src/renderer/src/components/sessions/SessionHistory.tsx
@@ -30,6 +30,7 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useGhosttySuppression } from '@/hooks'
 
 // Debounce hook for search input
 function useDebounce<T>(value: T, delay: number): T {
@@ -453,6 +454,8 @@ export function SessionHistory(): React.JSX.Element | null {
     if (!selectedSessionId) return null
     return searchResults.find((s) => s.id === selectedSessionId) || null
   }, [searchResults, selectedSessionId])
+
+  useGhosttySuppression('session-history', isOpen)
 
   if (!isOpen) return null
 

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -585,8 +585,6 @@ export function SessionTabs(): React.JSX.Element | null {
   const { projects } = useProjectStore()
   const selectedConnectionId = useConnectionStore((state) => state.selectedConnectionId)
   const connections = useConnectionStore((state) => state.connections)
-  const pushGhosttySuppression = useLayoutStore((state) => state.pushGhosttySuppression)
-  const popGhosttySuppression = useLayoutStore((state) => state.popGhosttySuppression)
   const isBoardViewActive = useKanbanStore((state) => state.isBoardViewActive)
   const pinnedSessionIds = useSessionStore((state) => state.pinnedSessionIds)
   const activePinnedSessionId = useSessionStore((state) => state.activePinnedSessionId)
@@ -784,13 +782,6 @@ export function SessionTabs(): React.JSX.Element | null {
     tabOrderByConnection,
     openFiles
   ])
-
-  // Safety: never leave Ghostty overlays suppressed if this component unmounts.
-  useEffect(() => {
-    return () => {
-      popGhosttySuppression('session-tabs-context')
-    }
-  }, [popGhosttySuppression])
 
   // Scroll functions
   const scrollLeft = () => {
@@ -1195,12 +1186,7 @@ export function SessionTabs(): React.JSX.Element | null {
         /* Session create button with right-click provider menu */
         <Tip tipId="provider-right-click" enabled={multipleProvidersAvailable}>
           <div className="shrink-0">
-            <ContextMenu
-              onOpenChange={(open) => {
-                if (open) pushGhosttySuppression('session-tabs-context')
-                else popGhosttySuppression('session-tabs-context')
-              }}
-            >
+            <ContextMenu>
               <ContextMenuTrigger asChild>
                 <button
                   onClick={handleCreateSession}

--- a/src/renderer/src/components/sessions/UserMessageAttachmentCards.tsx
+++ b/src/renderer/src/components/sessions/UserMessageAttachmentCards.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { KanbanSquare, FileText, MessageSquareText, X } from 'lucide-react'
 import { ProviderIcon } from '@/components/ui/provider-icon'
 import type { ParsedTicket, ParsedPrComment, ParsedFile, ParsedDataAttachment, ParsedDiffComment } from '@/lib/parse-user-message-attachments'
+import { useGhosttySuppression } from '@/hooks'
 
 interface UserMessageAttachmentCardsProps {
   tickets: ParsedTicket[]
@@ -19,6 +20,7 @@ export function UserMessageAttachmentCards({
   diffComments
 }: UserMessageAttachmentCardsProps): React.JSX.Element | null {
   const [expandedImage, setExpandedImage] = useState<{ dataUrl: string; name: string } | null>(null)
+  useGhosttySuppression('image-lightbox', expandedImage !== null)
 
   // Handle Escape key to close lightbox
   useEffect(() => {

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -16,7 +16,6 @@ import {
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { useSettingsStore } from '@/stores/useSettingsStore'
-import { useGhosttySuppression } from '@/hooks'
 import { SettingsAppearance } from './SettingsAppearance'
 import { SettingsGeneral } from './SettingsGeneral'
 import { SettingsModels } from './SettingsModels'
@@ -47,7 +46,6 @@ const SECTIONS = [
 export function SettingsModal(): React.JSX.Element {
   const { isOpen, activeSection, closeSettings, openSettings, setActiveSection } =
     useSettingsStore()
-  useGhosttySuppression('settings-modal', isOpen)
 
   // Listen for the custom event dispatched by keyboard shortcut handler
   useEffect(() => {

--- a/src/renderer/src/components/terminal/TerminalTabsHorizontal.tsx
+++ b/src/renderer/src/components/terminal/TerminalTabsHorizontal.tsx
@@ -35,8 +35,6 @@ export function TerminalTabsHorizontal({
   } = useTerminalTabActions(worktreeId)
 
   const setBottomPanelTab = useLayoutStore((s) => s.setBottomPanelTab)
-  const pushGhosttySuppression = useLayoutStore((s) => s.pushGhosttySuppression)
-  const popGhosttySuppression = useLayoutStore((s) => s.popGhosttySuppression)
 
   const [renamingTabId, setRenamingTabId] = useState<string | null>(null)
   const [editValue, setEditValue] = useState('')
@@ -97,17 +95,6 @@ export function TerminalTabsHorizontal({
     [setBottomPanelTab, handleSelectTab]
   )
 
-  const handleContextMenuOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        pushGhosttySuppression('terminal-tabs-context')
-      } else {
-        popGhosttySuppression('terminal-tabs-context')
-      }
-    },
-    [pushGhosttySuppression, popGhosttySuppression]
-  )
-
   const handlePlusClick = useCallback(() => {
     setBottomPanelTab('terminal')
     handleCreateTab()
@@ -116,7 +103,7 @@ export function TerminalTabsHorizontal({
   return (
     <>
       {tabs.map((tab) => (
-        <ContextMenu key={tab.id} onOpenChange={handleContextMenuOpenChange}>
+        <ContextMenu key={tab.id}>
           <ContextMenuTrigger asChild>
             <button
               onClick={() => handleTabClick(tab.id)}

--- a/src/renderer/src/components/ui/GhosttySuppressionBoundary.tsx
+++ b/src/renderer/src/components/ui/GhosttySuppressionBoundary.tsx
@@ -1,0 +1,18 @@
+import { useId, type ReactNode } from 'react'
+import { useGhosttySuppression } from '@/hooks'
+
+interface GhosttySuppressionBoundaryProps {
+  scope: string
+  active?: boolean
+  children: ReactNode
+}
+
+export function GhosttySuppressionBoundary({
+  scope,
+  active = true,
+  children
+}: GhosttySuppressionBoundaryProps): React.JSX.Element {
+  const id = useId()
+  useGhosttySuppression(`${scope}:${id}`, active)
+  return <>{children}</>
+}

--- a/src/renderer/src/components/ui/HelpOverlay.tsx
+++ b/src/renderer/src/components/ui/HelpOverlay.tsx
@@ -8,6 +8,7 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { DEFAULT_SHORTCUTS, formatBinding, shortcutCategoryOrder } from '@/lib/keyboard-shortcuts'
 import { cn } from '@/lib/utils'
+import { useGhosttySuppression } from '@/hooks'
 
 // ---------------------------------------------------------------------------
 // Mnemonic highlighting helper
@@ -173,6 +174,8 @@ export function HelpOverlay(): React.JSX.Element | null {
     }
     return groups
   }, [])
+
+  useGhosttySuppression('help-overlay', helpOverlayOpen)
 
   if (!vimModeEnabled || !helpOverlayOpen) return null
 

--- a/src/renderer/src/components/ui/alert-dialog.tsx
+++ b/src/renderer/src/components/ui/alert-dialog.tsx
@@ -3,6 +3,7 @@ import { AlertDialog as AlertDialogPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { GhosttySuppressionBoundary } from './GhosttySuppressionBoundary'
 
 function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
   return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
@@ -44,15 +45,17 @@ function AlertDialogContent({
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
-      <AlertDialogPrimitive.Content
-        data-slot="alert-dialog-content"
-        data-size={size}
-        className={cn(
-          'relative overflow-hidden bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg/5 duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-          className
-        )}
-        {...props}
-      />
+      <GhosttySuppressionBoundary scope="alert-dialog">
+        <AlertDialogPrimitive.Content
+          data-slot="alert-dialog-content"
+          data-size={size}
+          className={cn(
+            'relative overflow-hidden bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg/5 duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+            className
+          )}
+          {...props}
+        />
+      </GhosttySuppressionBoundary>
     </AlertDialogPortal>
   )
 }

--- a/src/renderer/src/components/ui/context-menu.tsx
+++ b/src/renderer/src/components/ui/context-menu.tsx
@@ -3,6 +3,7 @@ import * as ContextMenuPrimitive from '@radix-ui/react-context-menu'
 import { Check, ChevronRight, Circle } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
+import { GhosttySuppressionBoundary } from './GhosttySuppressionBoundary'
 
 const ContextMenu = ContextMenuPrimitive.Root
 
@@ -41,14 +42,16 @@ const ContextMenuSubContent = React.forwardRef<
   React.ComponentRef<typeof ContextMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-      className
-    )}
-    {...props}
-  />
+  <GhosttySuppressionBoundary scope="context-menu-sub">
+    <ContextMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+        className
+      )}
+      {...props}
+    />
+  </GhosttySuppressionBoundary>
 ))
 ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName
 
@@ -57,14 +60,16 @@ const ContextMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <ContextMenuPrimitive.Portal>
-    <ContextMenuPrimitive.Content
-      ref={ref}
-      className={cn(
-        'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-        className
-      )}
-      {...props}
-    />
+    <GhosttySuppressionBoundary scope="context-menu">
+      <ContextMenuPrimitive.Content
+        ref={ref}
+        className={cn(
+          'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+          className
+        )}
+        {...props}
+      />
+    </GhosttySuppressionBoundary>
   </ContextMenuPrimitive.Portal>
 ))
 ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName

--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { GhosttySuppressionBoundary } from './GhosttySuppressionBoundary'
 
 const Dialog = DialogPrimitive.Root
 
@@ -32,20 +33,22 @@ const DialogContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'relative overflow-hidden fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg/5 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
+    <GhosttySuppressionBoundary scope="dialog">
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'relative overflow-hidden fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg/5 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </GhosttySuppressionBoundary>
   </DialogPortal>
 ))
 DialogContent.displayName = DialogPrimitive.Content.displayName

--- a/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -3,6 +3,7 @@ import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import { Check, ChevronRight, Circle } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
+import { GhosttySuppressionBoundary } from './GhosttySuppressionBoundary'
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -41,14 +42,16 @@ const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-      className
-    )}
-    {...props}
-  />
+  <GhosttySuppressionBoundary scope="dropdown-menu-sub">
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+        className
+      )}
+      {...props}
+    />
+  </GhosttySuppressionBoundary>
 ))
 DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName
 
@@ -57,16 +60,18 @@ const DropdownMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(
-        'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className
-      )}
-      {...props}
-    />
+    <GhosttySuppressionBoundary scope="dropdown-menu">
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={cn(
+          'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </GhosttySuppressionBoundary>
   </DropdownMenuPrimitive.Portal>
 ))
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName

--- a/src/renderer/src/components/ui/popover.tsx
+++ b/src/renderer/src/components/ui/popover.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Popover as PopoverPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
+import { GhosttySuppressionBoundary } from './GhosttySuppressionBoundary'
 
 function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />
@@ -19,16 +20,18 @@ function PopoverContent({
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
   return (
     <PopoverPrimitive.Portal>
-      <PopoverPrimitive.Content
-        data-slot="popover-content"
-        align={align}
-        sideOffset={sideOffset}
-        className={cn(
-          'relative overflow-hidden z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-lg/5 outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-          className
-        )}
-        {...props}
-      />
+      <GhosttySuppressionBoundary scope="popover">
+        <PopoverPrimitive.Content
+          data-slot="popover-content"
+          align={align}
+          sideOffset={sideOffset}
+          className={cn(
+            'relative overflow-hidden z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-lg/5 outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+            className
+          )}
+          {...props}
+        />
+      </GhosttySuppressionBoundary>
     </PopoverPrimitive.Portal>
   )
 }

--- a/test/terminal/ghostty-overlay-primitives.test.tsx
+++ b/test/terminal/ghostty-overlay-primitives.test.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle
+} from '../../src/renderer/src/components/ui/dialog'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from '../../src/renderer/src/components/ui/popover'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '../../src/renderer/src/components/ui/dropdown-menu'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '../../src/renderer/src/components/ui/context-menu'
+import { useLayoutStore } from '../../src/renderer/src/stores/useLayoutStore'
+
+function NestedDialogPopoverHarness(): React.JSX.Element {
+  const [dialogOpen, setDialogOpen] = useState(true)
+  const [popoverOpen, setPopoverOpen] = useState(false)
+
+  return (
+    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <DialogContent>
+        <DialogTitle>Overlay test dialog</DialogTitle>
+        <DialogDescription>Verifies nested overlay suppression.</DialogDescription>
+        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+          <PopoverTrigger asChild>
+            <button>Toggle popover</button>
+          </PopoverTrigger>
+          <PopoverContent>
+            <button onClick={() => setPopoverOpen(false)}>Close popover</button>
+          </PopoverContent>
+        </Popover>
+        <button onClick={() => setDialogOpen(false)}>Dismiss dialog</button>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function MenuHarness(): React.JSX.Element {
+  return (
+    <div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button>Open dropdown</button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Dropdown action</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div data-testid="context-menu-target">Context target</div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem>Context action</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    </div>
+  )
+}
+
+describe('Ghostty overlay suppression primitives', () => {
+  beforeEach(() => {
+    useLayoutStore.setState({ ghosttyOverlaySuppressed: false })
+  })
+
+  test('keeps suppression active until the last nested overlay closes', async () => {
+    const user = userEvent.setup()
+    render(<NestedDialogPopoverHarness />)
+
+    await waitFor(() => {
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Toggle popover' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Close popover' })).toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Close popover' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Close popover' })).not.toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss dialog' }))
+
+    await waitFor(() => {
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(false)
+    })
+  })
+
+  test('suppresses Ghostty for dropdown menus and context menus while they are open', async () => {
+    const user = userEvent.setup()
+    render(<MenuHarness />)
+
+    await user.click(screen.getByRole('button', { name: 'Open dropdown' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Dropdown action')).toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+    })
+
+    await user.click(screen.getByText('Dropdown action'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Dropdown action')).not.toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(false)
+    })
+
+    fireEvent.contextMenu(screen.getByTestId('context-menu-target'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Context action')).toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+    })
+
+    await user.click(screen.getByText('Context action'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Context action')).not.toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(false)
+    })
+  })
+})

--- a/test/terminal/main-pane-terminal-persistence.test.tsx
+++ b/test/terminal/main-pane-terminal-persistence.test.tsx
@@ -1,11 +1,19 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest'
 import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MainPane } from '../../src/renderer/src/components/layout/MainPane'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle
+} from '../../src/renderer/src/components/ui/dialog'
 import { useSessionStore } from '../../src/renderer/src/stores/useSessionStore'
 import { useWorktreeStore } from '../../src/renderer/src/stores/useWorktreeStore'
 import { useConnectionStore } from '../../src/renderer/src/stores/useConnectionStore'
 import { useFileViewerStore } from '../../src/renderer/src/stores/useFileViewerStore'
 import { useLayoutStore } from '../../src/renderer/src/stores/useLayoutStore'
+import { useState } from 'react'
 
 const terminalMounts = new Map<string, number>()
 
@@ -69,6 +77,23 @@ function makeTerminalSession(id: string) {
     updated_at: '2026-01-01T00:00:00.000Z',
     completed_at: null
   }
+}
+
+function DialogHarness(): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open dialog</button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogTitle>Terminal overlay test</DialogTitle>
+          <DialogDescription>Ensures shared dialogs hide native terminals.</DialogDescription>
+          <button onClick={() => setOpen(false)}>Close dialog</button>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
 }
 
 describe('MainPane terminal persistence', () => {
@@ -144,6 +169,27 @@ describe('MainPane terminal persistence', () => {
 
     expect(screen.getByTestId('session-terminal-term-1')).toHaveAttribute('data-visible', 'false')
     expect(screen.getByTestId('session-terminal-term-2')).toHaveAttribute('data-visible', 'false')
+  })
+
+  test('hides terminal surfaces when a shared dialog opens and restores them after close', async () => {
+    const user = userEvent.setup()
+    render(
+      <>
+        <MainPane />
+        <DialogHarness />
+      </>
+    )
+
+    expect(screen.getByTestId('session-terminal-term-1')).toHaveAttribute('data-visible', 'true')
+
+    await user.click(screen.getByRole('button', { name: 'Open dialog' }))
+
+    expect(screen.getByTestId('session-terminal-term-1')).toHaveAttribute('data-visible', 'false')
+    expect(screen.getByTestId('session-terminal-term-2')).toHaveAttribute('data-visible', 'false')
+
+    await user.click(screen.getByRole('button', { name: 'Close dialog' }))
+
+    expect(screen.getByTestId('session-terminal-term-1')).toHaveAttribute('data-visible', 'true')
   })
 
   test('removes terminal from mounted list when session is closed via store signal', () => {


### PR DESCRIPTION
## Summary

- **New `GhosttySuppressionBoundary` component** wraps all overlay content (dialogs, menus, popovers) to automatically manage Ghostty terminal visibility
- **Replaced manual suppression state** managed by `pushGhosttySuppression`/`popGhosttySuppression` with declarative hook-based approach via `useGhosttySuppression`
- **Applied to UI components:** Dialogs, dropdown menus, context menus, popovers, alert dialogs all now properly suppress terminal overlays
- **Applied to feature overlays:** Session history, help overlay, image lightbox, drop overlay, and user message attachment cards use automatic suppression
- **Removed manual push/pop calls** from SessionTabs and TerminalTabsHorizontal context menu handlers
- **Removed suppression from SettingsModal** (now handled by Dialog component wrapper)
- **Added comprehensive test coverage** for nested overlay scenarios and terminal persistence during overlay interactions

## Testing

- ✅ Nested overlay suppression: Dialog with nested popover maintains suppression until all overlays close
- ✅ Dropdown menu suppression: Ghostty suppressed while menu open, released on selection
- ✅ Context menu suppression: Ghostty suppressed on right-click menu, released on action or dismiss
- ✅ Terminal visibility restoration: Terminal surfaces restore `data-visible="true"` after overlay closes
- ✅ Multiple terminal sessions: All active terminal sessions hidden when any overlay opens
- ✅ Boundary activation: Automatic activation/deactivation based on overlay state via `active` prop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core UI overlay primitives and the global terminal-visibility suppression mechanism, so regressions could hide terminals incorrectly or fail to suppress them across the app; changes are mitigated by new interaction tests (nested overlays and restoration).
> 
> **Overview**
> Fixes Ghostty terminal z-index/overlay conflicts by making overlay-driven terminal suppression *automatic and composable*.
> 
> Adds `GhosttySuppressionBoundary` (built on `useGhosttySuppression`) and wraps shared Radix overlay primitives (`Dialog`, `AlertDialog`, `Popover`, `DropdownMenu`, `ContextMenu`, including sub-menus) so opening/closing these overlays declaratively toggles `ghosttyOverlaySuppressed` with correct nesting semantics. Feature overlays (e.g. `SessionHistory`, `HelpOverlay`, image lightbox, `DropOverlay`) also opt into suppression, and ad-hoc `pushGhosttySuppression`/`popGhosttySuppression` wiring is removed from `SessionTabs` and `TerminalTabsHorizontal`.
> 
> Adds tests covering nested overlays, menus, and MainPane terminal visibility restoration when dialogs open/close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f471a264bd4bdc16839830de08f220500f9fcad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->