### PR TITLE
Fix terminal startup bug by deferring surface creation until portal is ready

### DIFF
--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -94,12 +94,14 @@ function TerminalManagerPortal(): React.JSX.Element {
     : !rightSidebarCollapsed && effectiveBottomPanelTab === 'terminal' && collapsedPanel !== 'bottom'
 
   const target = getTarget(terminalPosition)
+  const portalReady = target !== null
 
   const terminalManager = (
     <TerminalManager
       selectedWorktreeId={selectedWorktreeId}
       worktreePath={selectedWorktreePath}
       isVisible={isVisible}
+      portalReady={portalReady}
     />
   )
 

--- a/src/renderer/src/components/layout/DropOverlay.tsx
+++ b/src/renderer/src/components/layout/DropOverlay.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle, Download } from 'lucide-react'
+import { useGhosttySuppression } from '@/hooks'
 
 interface DropOverlayProps {
   variant: 'normal' | 'warning'
@@ -6,6 +7,7 @@ interface DropOverlayProps {
 
 export function DropOverlay({ variant }: DropOverlayProps) {
   const isWarning = variant === 'warning'
+  useGhosttySuppression('drop-overlay', true)
 
   return (
     <div

--- a/src/renderer/src/components/sessions/SessionHistory.tsx
+++ b/src/renderer/src/components/sessions/SessionHistory.tsx
@@ -30,6 +30,7 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useGhosttySuppression } from '@/hooks'
 
 // Debounce hook for search input
 function useDebounce<T>(value: T, delay: number): T {
@@ -453,6 +454,8 @@ export function SessionHistory(): React.JSX.Element | null {
     if (!selectedSessionId) return null
     return searchResults.find((s) => s.id === selectedSessionId) || null
   }, [searchResults, selectedSessionId])
+
+  useGhosttySuppression('session-history', isOpen)
 
   if (!isOpen) return null
 

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -585,8 +585,6 @@ export function SessionTabs(): React.JSX.Element | null {
   const { projects } = useProjectStore()
   const selectedConnectionId = useConnectionStore((state) => state.selectedConnectionId)
   const connections = useConnectionStore((state) => state.connections)
-  const pushGhosttySuppression = useLayoutStore((state) => state.pushGhosttySuppression)
-  const popGhosttySuppression = useLayoutStore((state) => state.popGhosttySuppression)
   const isBoardViewActive = useKanbanStore((state) => state.isBoardViewActive)
   const pinnedSessionIds = useSessionStore((state) => state.pinnedSessionIds)
   const activePinnedSessionId = useSessionStore((state) => state.activePinnedSessionId)
@@ -784,13 +782,6 @@ export function SessionTabs(): React.JSX.Element | null {
     tabOrderByConnection,
     openFiles
   ])
-
-  // Safety: never leave Ghostty overlays suppressed if this component unmounts.
-  useEffect(() => {
-    return () => {
-      popGhosttySuppression('session-tabs-context')
-    }
-  }, [popGhosttySuppression])
 
   // Scroll functions
   const scrollLeft = () => {
@@ -1195,12 +1186,7 @@ export function SessionTabs(): React.JSX.Element | null {
         /* Session create button with right-click provider menu */
         <Tip tipId="provider-right-click" enabled={multipleProvidersAvailable}>
           <div className="shrink-0">
-            <ContextMenu
-              onOpenChange={(open) => {
-                if (open) pushGhosttySuppression('session-tabs-context')
-                else popGhosttySuppression('session-tabs-context')
-              }}
-            >
+            <ContextMenu>
               <ContextMenuTrigger asChild>
                 <button
                   onClick={handleCreateSession}

--- a/src/renderer/src/components/sessions/UserMessageAttachmentCards.tsx
+++ b/src/renderer/src/components/sessions/UserMessageAttachmentCards.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { KanbanSquare, FileText, MessageSquareText, X } from 'lucide-react'
 import { ProviderIcon } from '@/components/ui/provider-icon'
 import type { ParsedTicket, ParsedPrComment, ParsedFile, ParsedDataAttachment, ParsedDiffComment } from '@/lib/parse-user-message-attachments'
+import { useGhosttySuppression } from '@/hooks'
 
 interface UserMessageAttachmentCardsProps {
   tickets: ParsedTicket[]
@@ -19,6 +20,7 @@ export function UserMessageAttachmentCards({
   diffComments
 }: UserMessageAttachmentCardsProps): React.JSX.Element | null {
   const [expandedImage, setExpandedImage] = useState<{ dataUrl: string; name: string } | null>(null)
+  useGhosttySuppression('image-lightbox', expandedImage !== null)
 
   // Handle Escape key to close lightbox
   useEffect(() => {

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -16,7 +16,6 @@ import {
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { useSettingsStore } from '@/stores/useSettingsStore'
-import { useGhosttySuppression } from '@/hooks'
 import { SettingsAppearance } from './SettingsAppearance'
 import { SettingsGeneral } from './SettingsGeneral'
 import { SettingsModels } from './SettingsModels'
@@ -47,7 +46,6 @@ const SECTIONS = [
 export function SettingsModal(): React.JSX.Element {
   const { isOpen, activeSection, closeSettings, openSettings, setActiveSection } =
     useSettingsStore()
-  useGhosttySuppression('settings-modal', isOpen)
 
   // Listen for the custom event dispatched by keyboard shortcut handler
   useEffect(() => {

--- a/src/renderer/src/components/terminal/TerminalManager.tsx
+++ b/src/renderer/src/components/terminal/TerminalManager.tsx
@@ -14,6 +14,8 @@ interface TerminalManagerProps {
   worktreePath: string | null
   /** Whether the terminal tab is currently visible */
   isVisible: boolean
+  /** Whether a real portal target exists for terminal rendering */
+  portalReady: boolean
 }
 
 /**
@@ -26,7 +28,8 @@ interface TerminalManagerProps {
 export function TerminalManager({
   selectedWorktreeId,
   worktreePath,
-  isVisible
+  isVisible,
+  portalReady
 }: TerminalManagerProps): React.JSX.Element {
   // Map worktreeId -> path for resolving CWD of non-selected worktrees' tabs
   const worktreePathsRef = useRef<Map<string, string>>(new Map())
@@ -73,14 +76,14 @@ export function TerminalManager({
   // panel is visible to avoid unnecessary PTY creation.
   // Read tabs via getState() to avoid re-triggering on every tab state change.
   useEffect(() => {
-    const shouldCreate = terminalPosition === 'sidebar' || isVisible
+    const shouldCreate = portalReady && (terminalPosition === 'sidebar' || isVisible)
     if (selectedWorktreeId && worktreePath && shouldCreate) {
       const tabs = useTerminalTabStore.getState().getTabs(selectedWorktreeId)
       if (tabs.length === 0) {
         createTab(selectedWorktreeId)
       }
     }
-  }, [selectedWorktreeId, worktreePath, isVisible, terminalPosition, createTab])
+  }, [selectedWorktreeId, worktreePath, isVisible, terminalPosition, portalReady, createTab])
 
   // When backend setting changes, tear down all active terminals so they get re-created
   // with the new backend on next visibility.

--- a/src/renderer/src/components/terminal/TerminalTabsHorizontal.tsx
+++ b/src/renderer/src/components/terminal/TerminalTabsHorizontal.tsx
@@ -35,8 +35,6 @@ export function TerminalTabsHorizontal({
   } = useTerminalTabActions(worktreeId)
 
   const setBottomPanelTab = useLayoutStore((s) => s.setBottomPanelTab)
-  const pushGhosttySuppression = useLayoutStore((s) => s.pushGhosttySuppression)
-  const popGhosttySuppression = useLayoutStore((s) => s.popGhosttySuppression)
 
   const [renamingTabId, setRenamingTabId] = useState<string | null>(null)
   const [editValue, setEditValue] = useState('')
@@ -97,17 +95,6 @@ export function TerminalTabsHorizontal({
     [setBottomPanelTab, handleSelectTab]
   )
 
-  const handleContextMenuOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        pushGhosttySuppression('terminal-tabs-context')
-      } else {
-        popGhosttySuppression('terminal-tabs-context')
-      }
-    },
-    [pushGhosttySuppression, popGhosttySuppression]
-  )
-
   const handlePlusClick = useCallback(() => {
     setBottomPanelTab('terminal')
     handleCreateTab()
@@ -116,7 +103,7 @@ export function TerminalTabsHorizontal({
   return (
     <>
       {tabs.map((tab) => (
-        <ContextMenu key={tab.id} onOpenChange={handleContextMenuOpenChange}>
+        <ContextMenu key={tab.id}>
           <ContextMenuTrigger asChild>
             <button
               onClick={() => handleTabClick(tab.id)}

--- a/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
@@ -22,11 +22,28 @@ export class GhosttyBackend implements TerminalBackend {
   private mounted = false
   private syncFrameTimer: ReturnType<typeof requestAnimationFrame> | null = null
   private lastVisibleRect: { x: number; y: number; w: number; h: number } | null = null
+  private opts: TerminalOpts | null = null
+  private callbacks: TerminalBackendCallbacks | null = null
+  private visible = true
+  private runtimeReady = false
+  private runtimeInitPromise: Promise<boolean> | null = null
+  private createSurfacePromise: Promise<void> | null = null
+  private surfaceCreated = false
+  private failed = false
 
   mount(container: HTMLDivElement, opts: TerminalOpts, callbacks: TerminalBackendCallbacks): void {
     this.terminalId = opts.terminalId
     this.container = container
+    this.opts = opts
+    this.callbacks = callbacks
     this.mounted = true
+    this.visible = true
+    this.runtimeReady = false
+    this.runtimeInitPromise = null
+    this.createSurfacePromise = null
+    this.surfaceCreated = false
+    this.failed = false
+    this.lastVisibleRect = null
 
     // The container acts as a transparent "hole" — the native NSView renders behind it.
     // We need pointer-events: none so mouse events pass through to the native view.
@@ -35,14 +52,7 @@ export class GhosttyBackend implements TerminalBackend {
     container.style.position = 'relative'
 
     callbacks.onStatusChange('creating')
-
-    this.initAndCreateSurface(opts).then((success) => {
-      if (success) {
-        callbacks.onStatusChange('running')
-      } else {
-        callbacks.onStatusChange('exited')
-      }
-    })
+    void this.ensureSurface()
 
     // Track container position/size and update the native NSView frame.
     // Debounced via requestAnimationFrame to avoid rapid-fire IPC during resizing.
@@ -59,43 +69,146 @@ export class GhosttyBackend implements TerminalBackend {
   }
 
   /**
-   * Initialize the Ghostty runtime (if needed) and create a surface.
+   * Initialize the Ghostty runtime once.
    */
-  private async initAndCreateSurface(opts: TerminalOpts): Promise<boolean> {
-    try {
-      // Ensure Ghostty runtime is initialized
-      const initResult = await window.terminalOps.ghosttyInit()
-      if (!initResult.success) {
-        console.error('Failed to initialize Ghostty:', initResult.error)
-        return false
-      }
+  private async ensureRuntimeReady(): Promise<boolean> {
+    if (this.runtimeReady) return true
+    if (this.runtimeInitPromise) return this.runtimeInitPromise
 
-      // Get container rect for initial surface placement
+    this.runtimeInitPromise = (async () => {
+      try {
+        const initResult = await window.terminalOps.ghosttyInit()
+        if (!initResult.success) {
+          console.error('Failed to initialize Ghostty:', initResult.error)
+          return false
+        }
+        this.runtimeReady = true
+        return true
+      } catch (err) {
+        console.error('Error initializing Ghostty:', err)
+        return false
+      } finally {
+        this.runtimeInitPromise = null
+      }
+    })()
+
+    return this.runtimeInitPromise
+  }
+
+  /**
+   * Create the native Ghostty surface once the container has a measurable rect.
+   * Hidden or zero-sized containers are treated as "not ready yet", not terminal failure.
+   */
+  private async ensureSurface(): Promise<void> {
+    if (
+      !this.mounted ||
+      this.failed ||
+      this.surfaceCreated ||
+      this.createSurfacePromise ||
+      !this.opts
+    ) {
+      return
+    }
+
+    const initialRect = this.getContainerRect()
+    if (!initialRect) return
+
+    this.createSurfacePromise = (async () => {
+      const runtimeReady = await this.ensureRuntimeReady()
+      if (!runtimeReady) {
+        this.fail()
+        return
+      }
+      if (!this.mounted || this.failed || this.surfaceCreated || !this.opts) return
+
       const rect = this.getContainerRect()
-      if (!rect) return false
+      if (!rect) return
       this.lastVisibleRect = rect
 
-      // Create the native surface
-      const result = await window.terminalOps.ghosttyCreateSurface(this.terminalId, rect, {
-        cwd: opts.cwd,
-        shell: opts.shell,
-        scaleFactor: window.devicePixelRatio || 2.0,
-        fontSize: useSettingsStore.getState().ghosttyFontSize || GhosttyBackend.FALLBACK_FONT_SIZE
-      })
+      try {
+        const result = await window.terminalOps.ghosttyCreateSurface(this.terminalId, rect, {
+          cwd: this.opts.cwd,
+          shell: this.opts.shell,
+          scaleFactor: window.devicePixelRatio || 2.0,
+          fontSize: useSettingsStore.getState().ghosttyFontSize || GhosttyBackend.FALLBACK_FONT_SIZE
+        })
 
-      if (!result.success) {
-        console.error('Failed to create Ghostty surface:', result.error)
-        return false
+        if (!result.success) {
+          console.error('Failed to create Ghostty surface:', result.error)
+          this.fail()
+          return
+        }
+
+        if (!this.mounted || this.failed) {
+          // Disposed or failed between the create call and its resolution.
+          // The native surface exists but we never stored it as surfaceCreated,
+          // so dispose() skipped cleanup — destroy it here to avoid leaking.
+          window.terminalOps.ghosttyDestroySurface(this.terminalId).catch(() => {
+            // Best-effort cleanup
+          })
+          return
+        }
+
+        this.surfaceCreated = true
+        this.callbacks?.onStatusChange('running')
+
+        if (this.visible) {
+          this.syncFrame()
+          await window.terminalOps.ghosttySetFocus(this.terminalId, true)
+        } else {
+          this.hideSurface()
+        }
+      } catch (err) {
+        console.error('Error creating Ghostty surface:', err)
+        this.fail()
+      } finally {
+        this.createSurfacePromise = null
       }
+    })()
 
-      // Set initial focus
-      await window.terminalOps.ghosttySetFocus(this.terminalId, true)
+    await this.createSurfacePromise
+  }
 
-      return true
-    } catch (err) {
-      console.error('Error creating Ghostty surface:', err)
-      return false
+  private fail(): void {
+    if (!this.mounted || this.failed) return
+    this.failed = true
+    this.callbacks?.onStatusChange('exited')
+  }
+
+  private hideSurface(): void {
+    if (!this.surfaceCreated) return
+
+    window.terminalOps.ghosttySetFocus(this.terminalId, false).catch(() => {
+      // Ignore focus errors
+    })
+    const hiddenRect = this.lastVisibleRect
+      ? {
+          x: GhosttyBackend.HIDDEN_RECT.x,
+          y: GhosttyBackend.HIDDEN_RECT.y,
+          w: this.lastVisibleRect.w,
+          h: this.lastVisibleRect.h
+        }
+      : GhosttyBackend.HIDDEN_RECT
+
+    window.terminalOps.ghosttySetFrame(this.terminalId, hiddenRect).catch(() => {
+      // Ignore frame sync errors during teardown
+    })
+  }
+
+  private showSurface(): void {
+    if (!this.surfaceCreated) {
+      void this.ensureSurface()
+      return
     }
+
+    this.syncFrame()
+    // Restore macOS first responder so focusedSurfaceId() returns this surface
+    // and the menu paste handler routes Cmd+V correctly. Without this, focus
+    // restoration depends on a fragile setTimeout in TerminalView that can be
+    // cancelled by rapid effectiveVisible changes (e.g. overlay suppression race).
+    window.terminalOps.ghosttySetFocus(this.terminalId, true).catch(() => {
+      // Ignore focus errors
+    })
   }
 
   /**
@@ -154,7 +267,14 @@ export class GhosttyBackend implements TerminalBackend {
    * internally, so we only need the single setFrame call here.
    */
   private syncFrame(): void {
-    if (!this.mounted) return
+    if (!this.mounted || this.failed) return
+
+    if (!this.surfaceCreated) {
+      if (this.visible) {
+        void this.ensureSurface()
+      }
+      return
+    }
 
     const rect = this.getContainerRect()
     if (!rect) return
@@ -178,6 +298,10 @@ export class GhosttyBackend implements TerminalBackend {
 
   focus(): void {
     if (!this.mounted) return
+    if (!this.surfaceCreated) {
+      void this.ensureSurface()
+      return
+    }
     window.terminalOps.ghosttySetFocus(this.terminalId, true).catch(() => {
       // Ignore focus errors
     })
@@ -185,34 +309,14 @@ export class GhosttyBackend implements TerminalBackend {
 
   setVisible(visible: boolean): void {
     if (!this.mounted) return
+    this.visible = visible
 
     if (!visible) {
-      window.terminalOps.ghosttySetFocus(this.terminalId, false).catch(() => {
-        // Ignore focus errors
-      })
-      const hiddenRect = this.lastVisibleRect
-        ? {
-            x: GhosttyBackend.HIDDEN_RECT.x,
-            y: GhosttyBackend.HIDDEN_RECT.y,
-            w: this.lastVisibleRect.w,
-            h: this.lastVisibleRect.h
-          }
-        : GhosttyBackend.HIDDEN_RECT
-
-      window.terminalOps.ghosttySetFrame(this.terminalId, hiddenRect).catch(() => {
-        // Ignore frame sync errors during teardown
-      })
+      this.hideSurface()
       return
     }
 
-    this.syncFrame()
-    // Restore macOS first responder so focusedSurfaceId() returns this surface
-    // and the menu paste handler routes Cmd+V correctly. Without this, focus
-    // restoration depends on a fragile setTimeout in TerminalView that can be
-    // cancelled by rapid effectiveVisible changes (e.g. overlay suppression race).
-    window.terminalOps.ghosttySetFocus(this.terminalId, true).catch(() => {
-      // Ignore focus errors
-    })
+    this.showSurface()
   }
 
   clear(): void {
@@ -241,9 +345,19 @@ export class GhosttyBackend implements TerminalBackend {
       this.container = null
     }
 
-    window.terminalOps.ghosttyDestroySurface(this.terminalId).catch(() => {
-      // Best-effort cleanup
-    })
+    if (this.surfaceCreated) {
+      window.terminalOps.ghosttyDestroySurface(this.terminalId).catch(() => {
+        // Best-effort cleanup
+      })
+    }
+
+    this.opts = null
+    this.callbacks = null
+    this.runtimeReady = false
+    this.runtimeInitPromise = null
+    this.createSurfacePromise = null
+    this.surfaceCreated = false
+    this.failed = false
   }
 }
 

--- a/src/renderer/src/components/ui/GhosttySuppressionBoundary.tsx
+++ b/src/renderer/src/components/ui/GhosttySuppressionBoundary.tsx
@@ -1,0 +1,18 @@
+import { useId, type ReactNode } from 'react'
+import { useGhosttySuppression } from '@/hooks'
+
+interface GhosttySuppressionBoundaryProps {
+  scope: string
+  active?: boolean
+  children: ReactNode
+}
+
+export function GhosttySuppressionBoundary({
+  scope,
+  active = true,
+  children
+}: GhosttySuppressionBoundaryProps): React.JSX.Element {
+  const id = useId()
+  useGhosttySuppression(`${scope}:${id}`, active)
+  return <>{children}</>
+}

--- a/src/renderer/src/components/ui/HelpOverlay.tsx
+++ b/src/renderer/src/components/ui/HelpOverlay.tsx
@@ -8,6 +8,7 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { DEFAULT_SHORTCUTS, formatBinding, shortcutCategoryOrder } from '@/lib/keyboard-shortcuts'
 import { cn } from '@/lib/utils'
+import { useGhosttySuppression } from '@/hooks'
 
 // ---------------------------------------------------------------------------
 // Mnemonic highlighting helper
@@ -173,6 +174,8 @@ export function HelpOverlay(): React.JSX.Element | null {
     }
     return groups
   }, [])
+
+  useGhosttySuppression('help-overlay', helpOverlayOpen)
 
   if (!vimModeEnabled || !helpOverlayOpen) return null
 

--- a/src/renderer/src/components/ui/alert-dialog.tsx
+++ b/src/renderer/src/components/ui/alert-dialog.tsx
@@ -3,6 +3,7 @@ import { AlertDialog as AlertDialogPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { GhosttySuppressionBoundary } from './GhosttySuppressionBoundary'
 
 function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
   return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
@@ -44,15 +45,17 @@ function AlertDialogContent({
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
-      <AlertDialogPrimitive.Content
-        data-slot="alert-dialog-content"
-        data-size={size}
-        className={cn(
-          'relative overflow-hidden bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg/5 duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-          className
-        )}
-        {...props}
-      />
+      <GhosttySuppressionBoundary scope="alert-dialog">
+        <AlertDialogPrimitive.Content
+          data-slot="alert-dialog-content"
+          data-size={size}
+          className={cn(
+            'relative overflow-hidden bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg/5 duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+            className
+          )}
+          {...props}
+        />
+      </GhosttySuppressionBoundary>
     </AlertDialogPortal>
   )
 }

--- a/src/renderer/src/components/ui/context-menu.tsx
+++ b/src/renderer/src/components/ui/context-menu.tsx
@@ -3,6 +3,7 @@ import * as ContextMenuPrimitive from '@radix-ui/react-context-menu'
 import { Check, ChevronRight, Circle } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
+import { GhosttySuppressionBoundary } from './GhosttySuppressionBoundary'
 
 const ContextMenu = ContextMenuPrimitive.Root
 
@@ -41,14 +42,16 @@ const ContextMenuSubContent = React.forwardRef<
   React.ComponentRef<typeof ContextMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-      className
-    )}
-    {...props}
-  />
+  <GhosttySuppressionBoundary scope="context-menu-sub">
+    <ContextMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+        className
+      )}
+      {...props}
+    />
+  </GhosttySuppressionBoundary>
 ))
 ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName
 
@@ -57,14 +60,16 @@ const ContextMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <ContextMenuPrimitive.Portal>
-    <ContextMenuPrimitive.Content
-      ref={ref}
-      className={cn(
-        'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-        className
-      )}
-      {...props}
-    />
+    <GhosttySuppressionBoundary scope="context-menu">
+      <ContextMenuPrimitive.Content
+        ref={ref}
+        className={cn(
+          'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+          className
+        )}
+        {...props}
+      />
+    </GhosttySuppressionBoundary>
   </ContextMenuPrimitive.Portal>
 ))
 ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName

--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { GhosttySuppressionBoundary } from './GhosttySuppressionBoundary'
 
 const Dialog = DialogPrimitive.Root
 
@@ -32,20 +33,22 @@ const DialogContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'relative overflow-hidden fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg/5 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
+    <GhosttySuppressionBoundary scope="dialog">
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'relative overflow-hidden fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg/5 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </GhosttySuppressionBoundary>
   </DialogPortal>
 ))
 DialogContent.displayName = DialogPrimitive.Content.displayName

--- a/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -3,6 +3,7 @@ import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import { Check, ChevronRight, Circle } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
+import { GhosttySuppressionBoundary } from './GhosttySuppressionBoundary'
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -41,14 +42,16 @@ const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-      className
-    )}
-    {...props}
-  />
+  <GhosttySuppressionBoundary scope="dropdown-menu-sub">
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+        className
+      )}
+      {...props}
+    />
+  </GhosttySuppressionBoundary>
 ))
 DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName
 
@@ -57,16 +60,18 @@ const DropdownMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(
-        'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className
-      )}
-      {...props}
-    />
+    <GhosttySuppressionBoundary scope="dropdown-menu">
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={cn(
+          'relative overflow-hidden z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </GhosttySuppressionBoundary>
   </DropdownMenuPrimitive.Portal>
 ))
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName

--- a/src/renderer/src/components/ui/popover.tsx
+++ b/src/renderer/src/components/ui/popover.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Popover as PopoverPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
+import { GhosttySuppressionBoundary } from './GhosttySuppressionBoundary'
 
 function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />
@@ -19,16 +20,18 @@ function PopoverContent({
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
   return (
     <PopoverPrimitive.Portal>
-      <PopoverPrimitive.Content
-        data-slot="popover-content"
-        align={align}
-        sideOffset={sideOffset}
-        className={cn(
-          'relative overflow-hidden z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-lg/5 outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
-          className
-        )}
-        {...props}
-      />
+      <GhosttySuppressionBoundary scope="popover">
+        <PopoverPrimitive.Content
+          data-slot="popover-content"
+          align={align}
+          sideOffset={sideOffset}
+          className={cn(
+            'relative overflow-hidden z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-lg/5 outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+            className
+          )}
+          {...props}
+        />
+      </GhosttySuppressionBoundary>
     </PopoverPrimitive.Portal>
   )
 }

--- a/test/terminal/ghostty-backend-visibility.test.ts
+++ b/test/terminal/ghostty-backend-visibility.test.ts
@@ -10,11 +10,29 @@ const mockTerminalOps = {
   ghosttyDestroySurface: vi.fn().mockResolvedValue(undefined)
 }
 
+const observers: MockResizeObserver[] = []
+
 class MockResizeObserver {
   observe = vi.fn()
   disconnect = vi.fn()
+  private callback: ResizeObserverCallback
 
-  constructor(_callback: ResizeObserverCallback) {}
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    observers.push(this)
+  }
+
+  trigger(target: Element): void {
+    this.callback(
+      [
+        {
+          target,
+          contentRect: target.getBoundingClientRect()
+        } as ResizeObserverEntry
+      ],
+      this as unknown as ResizeObserver
+    )
+  }
 }
 
 function flushPromises(): Promise<void> {
@@ -24,6 +42,7 @@ function flushPromises(): Promise<void> {
 describe('GhosttyBackend visibility', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    observers.length = 0
 
     Object.defineProperty(window, 'terminalOps', {
       value: mockTerminalOps,
@@ -32,6 +51,11 @@ describe('GhosttyBackend visibility', () => {
     })
 
     vi.stubGlobal('ResizeObserver', MockResizeObserver)
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      ((callback: FrameRequestCallback) => setTimeout(() => callback(0), 0)) as typeof requestAnimationFrame
+    )
+    vi.stubGlobal('cancelAnimationFrame', ((id: number) => clearTimeout(id)) as typeof cancelAnimationFrame)
   })
 
   test('hides and restores native surface when visibility changes', async () => {
@@ -52,7 +76,7 @@ describe('GhosttyBackend visibility', () => {
     backend.mount(
       container,
       {
-        worktreeId: 'wt-1',
+        terminalId: 'wt-1',
         cwd: '/tmp/wt-1'
       },
       {
@@ -87,5 +111,112 @@ describe('GhosttyBackend visibility', () => {
     expect(mockTerminalOps.ghosttySetFocus).toHaveBeenCalledWith('wt-1', true)
 
     backend.dispose()
+  })
+
+  test('waits for a measurable container instead of failing on initial zero-size mount', async () => {
+    const backend = new GhosttyBackend()
+    const onStatusChange = vi.fn()
+    const container = document.createElement('div')
+    let rect = {
+      left: 100,
+      top: 80,
+      width: 0,
+      height: 0,
+      right: 100,
+      bottom: 80,
+      x: 100,
+      y: 80,
+      toJSON: () => ({})
+    }
+    container.getBoundingClientRect = vi.fn(() => rect)
+
+    backend.mount(
+      container,
+      {
+        terminalId: 'wt-1',
+        cwd: '/tmp/wt-1'
+      },
+      {
+        onStatusChange
+      }
+    )
+
+    await flushPromises()
+
+    expect(mockTerminalOps.ghosttyInit).not.toHaveBeenCalled()
+    expect(mockTerminalOps.ghosttyCreateSurface).not.toHaveBeenCalled()
+    expect(onStatusChange).toHaveBeenNthCalledWith(1, 'creating')
+    expect(onStatusChange).not.toHaveBeenCalledWith('exited')
+
+    rect = {
+      ...rect,
+      width: 640,
+      height: 360,
+      right: 740,
+      bottom: 440
+    }
+    observers[0].trigger(container)
+
+    await flushPromises()
+    await flushPromises()
+
+    expect(mockTerminalOps.ghosttyInit).toHaveBeenCalledTimes(1)
+    expect(mockTerminalOps.ghosttyCreateSurface).toHaveBeenCalledTimes(1)
+    expect(onStatusChange).toHaveBeenNthCalledWith(2, 'running')
+    expect(onStatusChange).not.toHaveBeenCalledWith('exited')
+
+    backend.dispose()
+  })
+
+  test('destroys native surface when dispose races with in-flight createSurface', async () => {
+    const backend = new GhosttyBackend()
+    const container = document.createElement('div')
+    container.getBoundingClientRect = vi.fn(() => ({
+      left: 0,
+      top: 0,
+      width: 640,
+      height: 360,
+      right: 640,
+      bottom: 360,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    }))
+
+    // Make ghosttyCreateSurface hang so dispose happens before it resolves.
+    let resolveCreate!: (value: { success: true; surfaceId: number }) => void
+    mockTerminalOps.ghosttyCreateSurface.mockImplementationOnce(
+      () =>
+        new Promise<{ success: true; surfaceId: number }>((resolve) => {
+          resolveCreate = resolve
+        })
+    )
+
+    backend.mount(
+      container,
+      {
+        terminalId: 'wt-1',
+        cwd: '/tmp/wt-1'
+      },
+      {
+        onStatusChange: vi.fn()
+      }
+    )
+
+    // Let the runtime init finish and createSurface kick off, but not resolve.
+    await flushPromises()
+    expect(mockTerminalOps.ghosttyCreateSurface).toHaveBeenCalledTimes(1)
+    expect(mockTerminalOps.ghosttyDestroySurface).not.toHaveBeenCalled()
+
+    // Unmount while createSurface is still in flight.
+    backend.dispose()
+
+    // Now the native side finishes creating the surface AFTER dispose.
+    resolveCreate({ success: true, surfaceId: 1 })
+    await flushPromises()
+    await flushPromises()
+
+    // The orphaned native surface must be destroyed to avoid leaking NSViews.
+    expect(mockTerminalOps.ghosttyDestroySurface).toHaveBeenCalledWith('wt-1')
   })
 })

--- a/test/terminal/ghostty-overlay-primitives.test.tsx
+++ b/test/terminal/ghostty-overlay-primitives.test.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle
+} from '../../src/renderer/src/components/ui/dialog'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from '../../src/renderer/src/components/ui/popover'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '../../src/renderer/src/components/ui/dropdown-menu'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '../../src/renderer/src/components/ui/context-menu'
+import { useLayoutStore } from '../../src/renderer/src/stores/useLayoutStore'
+
+function NestedDialogPopoverHarness(): React.JSX.Element {
+  const [dialogOpen, setDialogOpen] = useState(true)
+  const [popoverOpen, setPopoverOpen] = useState(false)
+
+  return (
+    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <DialogContent>
+        <DialogTitle>Overlay test dialog</DialogTitle>
+        <DialogDescription>Verifies nested overlay suppression.</DialogDescription>
+        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+          <PopoverTrigger asChild>
+            <button>Toggle popover</button>
+          </PopoverTrigger>
+          <PopoverContent>
+            <button onClick={() => setPopoverOpen(false)}>Close popover</button>
+          </PopoverContent>
+        </Popover>
+        <button onClick={() => setDialogOpen(false)}>Dismiss dialog</button>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function MenuHarness(): React.JSX.Element {
+  return (
+    <div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button>Open dropdown</button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Dropdown action</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div data-testid="context-menu-target">Context target</div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem>Context action</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    </div>
+  )
+}
+
+describe('Ghostty overlay suppression primitives', () => {
+  beforeEach(() => {
+    useLayoutStore.setState({ ghosttyOverlaySuppressed: false })
+  })
+
+  test('keeps suppression active until the last nested overlay closes', async () => {
+    const user = userEvent.setup()
+    render(<NestedDialogPopoverHarness />)
+
+    await waitFor(() => {
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Toggle popover' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Close popover' })).toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Close popover' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Close popover' })).not.toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss dialog' }))
+
+    await waitFor(() => {
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(false)
+    })
+  })
+
+  test('suppresses Ghostty for dropdown menus and context menus while they are open', async () => {
+    const user = userEvent.setup()
+    render(<MenuHarness />)
+
+    await user.click(screen.getByRole('button', { name: 'Open dropdown' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Dropdown action')).toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+    })
+
+    await user.click(screen.getByText('Dropdown action'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Dropdown action')).not.toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(false)
+    })
+
+    fireEvent.contextMenu(screen.getByTestId('context-menu-target'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Context action')).toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+    })
+
+    await user.click(screen.getByText('Context action'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Context action')).not.toBeInTheDocument()
+      expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(false)
+    })
+  })
+})

--- a/test/terminal/main-pane-terminal-persistence.test.tsx
+++ b/test/terminal/main-pane-terminal-persistence.test.tsx
@@ -1,11 +1,19 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest'
 import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MainPane } from '../../src/renderer/src/components/layout/MainPane'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle
+} from '../../src/renderer/src/components/ui/dialog'
 import { useSessionStore } from '../../src/renderer/src/stores/useSessionStore'
 import { useWorktreeStore } from '../../src/renderer/src/stores/useWorktreeStore'
 import { useConnectionStore } from '../../src/renderer/src/stores/useConnectionStore'
 import { useFileViewerStore } from '../../src/renderer/src/stores/useFileViewerStore'
 import { useLayoutStore } from '../../src/renderer/src/stores/useLayoutStore'
+import { useState } from 'react'
 
 const terminalMounts = new Map<string, number>()
 
@@ -69,6 +77,23 @@ function makeTerminalSession(id: string) {
     updated_at: '2026-01-01T00:00:00.000Z',
     completed_at: null
   }
+}
+
+function DialogHarness(): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open dialog</button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogTitle>Terminal overlay test</DialogTitle>
+          <DialogDescription>Ensures shared dialogs hide native terminals.</DialogDescription>
+          <button onClick={() => setOpen(false)}>Close dialog</button>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
 }
 
 describe('MainPane terminal persistence', () => {
@@ -144,6 +169,27 @@ describe('MainPane terminal persistence', () => {
 
     expect(screen.getByTestId('session-terminal-term-1')).toHaveAttribute('data-visible', 'false')
     expect(screen.getByTestId('session-terminal-term-2')).toHaveAttribute('data-visible', 'false')
+  })
+
+  test('hides terminal surfaces when a shared dialog opens and restores them after close', async () => {
+    const user = userEvent.setup()
+    render(
+      <>
+        <MainPane />
+        <DialogHarness />
+      </>
+    )
+
+    expect(screen.getByTestId('session-terminal-term-1')).toHaveAttribute('data-visible', 'true')
+
+    await user.click(screen.getByRole('button', { name: 'Open dialog' }))
+
+    expect(screen.getByTestId('session-terminal-term-1')).toHaveAttribute('data-visible', 'false')
+    expect(screen.getByTestId('session-terminal-term-2')).toHaveAttribute('data-visible', 'false')
+
+    await user.click(screen.getByRole('button', { name: 'Close dialog' }))
+
+    expect(screen.getByTestId('session-terminal-term-1')).toHaveAttribute('data-visible', 'true')
   })
 
   test('removes terminal from mounted list when session is closed via store signal', () => {

--- a/test/terminal/session-terminal-view-persistence.test.tsx
+++ b/test/terminal/session-terminal-view-persistence.test.tsx
@@ -10,19 +10,19 @@ vi.mock('@/components/terminal/TerminalView', async () => {
   const React = await import('react')
 
   function TerminalView({
-    worktreeId,
+    terminalId,
     cwd
   }: {
-    worktreeId: string
+    terminalId: string
     cwd: string
   }): React.JSX.Element {
     React.useEffect(() => {
-      terminalViewMounts.set(worktreeId, (terminalViewMounts.get(worktreeId) || 0) + 1)
-    }, [worktreeId])
+      terminalViewMounts.set(terminalId, (terminalViewMounts.get(terminalId) || 0) + 1)
+    }, [terminalId])
 
     return (
-      <div data-testid={`terminal-view-${worktreeId}`} data-cwd={cwd}>
-        terminal-view:{worktreeId}
+      <div data-testid={`terminal-view-${terminalId}`} data-cwd={cwd}>
+        terminal-view:{terminalId}
       </div>
     )
   }

--- a/test/terminal/terminal-manager-portal-readiness.test.tsx
+++ b/test/terminal/terminal-manager-portal-readiness.test.tsx
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, render, waitFor } from '@testing-library/react'
+import { TerminalManager } from '../../src/renderer/src/components/terminal/TerminalManager'
+import { useSettingsStore } from '../../src/renderer/src/stores/useSettingsStore'
+import { useTerminalTabStore } from '../../src/renderer/src/stores/useTerminalTabStore'
+import { useWorktreeStore } from '../../src/renderer/src/stores/useWorktreeStore'
+
+vi.mock('@/components/terminal/TerminalView', () => ({
+  TerminalView: ({ terminalId }: { terminalId: string }) => (
+    <div data-testid={`terminal-view-${terminalId}`}>{terminalId}</div>
+  )
+}))
+
+vi.mock('@/components/terminal/TerminalTabSidebar', () => ({
+  TerminalTabSidebar: () => <div data-testid="terminal-tab-sidebar" />
+}))
+
+describe('TerminalManager portal readiness', () => {
+  beforeEach(() => {
+    act(() => {
+      useTerminalTabStore.getState().removeAllTabs()
+
+      useSettingsStore.setState({
+        embeddedTerminalBackend: 'ghostty',
+        terminalPosition: 'sidebar'
+      })
+
+      useWorktreeStore.setState({
+        selectedWorktreeId: 'wt-1',
+        worktreesByProject: new Map([
+          [
+            'proj-1',
+            [
+              {
+                id: 'wt-1',
+                project_id: 'proj-1',
+                name: 'main',
+                branch_name: 'main',
+                path: '/tmp/project',
+                status: 'active',
+                is_default: true,
+                branch_renamed: 0,
+                last_message_at: null,
+                session_titles: '[]',
+                last_model_provider_id: null,
+                last_model_id: null,
+                last_model_variant: null,
+                created_at: '2026-01-01T00:00:00.000Z',
+                last_accessed_at: '2026-01-01T00:00:00.000Z',
+                github_pr_number: null,
+                github_pr_url: null
+              }
+            ]
+          ]
+        ])
+      })
+    })
+  })
+
+  test('does not auto-create a sidebar terminal until a real portal target exists', async () => {
+    const { rerender } = render(
+      <TerminalManager
+        selectedWorktreeId="wt-1"
+        worktreePath="/tmp/project"
+        isVisible={false}
+        portalReady={false}
+      />
+    )
+
+    await waitFor(() => {
+      expect(useTerminalTabStore.getState().getTabs('wt-1')).toHaveLength(0)
+    })
+
+    rerender(
+      <TerminalManager
+        selectedWorktreeId="wt-1"
+        worktreePath="/tmp/project"
+        isVisible={false}
+        portalReady
+      />
+    )
+
+    await waitFor(() => {
+      expect(useTerminalTabStore.getState().getTabs('wt-1')).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **Problem**: Terminal surfaces were being created before the React portal target was ready, causing startup failures and potential race conditions
- **Solution**: Introduced `portalReady` flag to defer terminal initialization until the DOM target exists
- **Key Changes**:
  - Added `portalReady` prop to `TerminalManager` to gate terminal creation
  - Refactored `GhosttyBackend.initAndCreateSurface()` into separate `ensureRuntimeReady()` and `ensureSurface()` methods for better lifecycle management
  - Implemented deferred surface creation that waits for a measurable container rect instead of failing on zero-size mounts
  - Fixed visibility state management with `showSurface()` and `hideSurface()` helpers
  - Added safety check to destroy orphaned native surfaces if dispose races with in-flight createSurface calls
  - Enhanced test coverage with portal readiness and race condition scenarios

## Testing

- Added test: `terminal-manager-portal-readiness.test.tsx` verifies sidebar terminals don't auto-create until `portalReady` is true
- Enhanced `ghostty-backend-visibility.test.ts` with:
  - ResizeObserver mock with `trigger()` method to simulate container size changes
  - Test for deferred surface creation when container starts at zero-size
  - Test for orphaned surface cleanup when dispose races with createSurface
  - RAF/cancelAnimationFrame stubs for sync frame testing
- Updated `session-terminal-view-persistence.test.tsx` to use `terminalId` consistently (was `worktreeId`)
- All tests pass with proper async flushing and mock verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal initialization and native Ghostty surface lifecycle, where timing/race regressions could prevent terminals from appearing or leak native resources. Changes are well-scoped and covered by new tests for portal readiness, zero-size mounts, and dispose/create races.
> 
> **Overview**
> Fixes terminal startup/visibility issues by gating terminal tab auto-creation on a new `portalReady` signal (wired from `AppLayout` into `TerminalManager`) so terminals don’t initialize before a real portal target exists.
> 
> Refactors `GhosttyBackend` surface lifecycle to initialize runtime/surface lazily, wait for a measurable container rect instead of treating zero-size mounts as failure, and clean up orphaned native surfaces when `dispose()` races with an in-flight `ghosttyCreateSurface`.
> 
> Updates worktree/project selection APIs to accept `preservePinnedBoard` options and uses them from `KanbanTicketCard` so cmd/middle-clicking tickets in pinned-board mode can navigate without closing the pinned board; adds focused tests for the pinned-board navigation behavior and the new Ghostty/portal readiness edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 837b388cdbb66b1e032e9dc3f68b01b25ae809d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->