### PR TITLE
Implement superpowers codex supercharge with proper error handling and async state management

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1506,14 +1506,46 @@ function PlanReviewModeContent({
     }
   }, [ticket, isActioning, planContent, onClose])
 
+  // Synchronously re-link the ticket to the new session and (if needed) move it to in_progress
+  // so the kanban board reflects the supercharge before the modal closes. Per-session timing /
+  // status bookkeeping is intentionally deferred to eagerSuperchargeStart so it only runs once
+  // the OpenCode connection actually succeeds — otherwise a failed connect leaves the ticket
+  // permanently marked 'working' with no work running.
+  const prepareTicketSuperchargeSession = useCallback((newSessionId: string): void => {
+    useKanbanStore
+      .getState()
+      .updateTicket(ticket.id, ticket.project_id, {
+        current_session_id: newSessionId,
+        plan_ready: false,
+        mode: 'build'
+      })
+      .catch((err) => {
+        console.error('[KanbanTicketModal] failed to relink supercharge session:', err)
+        toast.error('Failed to attach the new session to the ticket')
+      })
+
+    if (ticket.column === 'todo' || ticket.column === 'review') {
+      useKanbanStore
+        .getState()
+        .moveTicket(ticket.id, ticket.project_id, 'in_progress', ticket.sort_order)
+        .catch((err) => {
+          console.error('[KanbanTicketModal] failed to move supercharged ticket to in_progress:', err)
+          toast.error('Failed to move the ticket to in progress')
+        })
+    }
+  }, [ticket.id, ticket.project_id, ticket.column, ticket.sort_order])
+
   // ── Shared: eagerly connect, send /using-superpowers, queue follow-up for global listener ──
   const eagerSuperchargeStart = useCallback(async (
     worktreePath: string,
     newSessionId: string
   ) => {
-    // Connect to OpenCode
+    // Connect to OpenCode. Surface failure so the caller can alert the user — staying silent
+    // here would leave optimistic UI state with no work running and no error feedback.
     const connectResult = await window.opencodeOps.connect(worktreePath, newSessionId)
-    if (!connectResult.success || !connectResult.sessionId) return
+    if (!connectResult.success || !connectResult.sessionId) {
+      throw new Error('Failed to connect to supercharge session')
+    }
 
     // Persist the opencode session ID to Zustand + DB
     useSessionStore.getState().setOpenCodeSessionId(newSessionId, connectResult.sessionId)
@@ -1521,17 +1553,18 @@ function PlanReviewModeContent({
       opencode_session_id: connectResult.sessionId
     })
 
-    // Queue the follow-up for the global idle listener to dispatch after /using-superpowers completes
-    useSessionStore.getState().setPendingFollowUpMessages(newSessionId, [
-      'use the subagent development skill to implement the following plan:\n' + planContent
-    ])
-
-    // Set status tracking
+    // Status / timing tracking — only after connect succeeds, so a failed connect does not
+    // leave the session permanently marked 'working' on the worktree status store.
     messageSendTimes.set(newSessionId, Date.now())
     userExplicitSendTimes.set(newSessionId, Date.now())
     snapshotTokenBaseline(newSessionId)
     lastSendMode.set(newSessionId, 'build')
     useWorktreeStatusStore.getState().setSessionStatus(newSessionId, 'working')
+
+    // Queue the follow-up for the global idle listener to dispatch after /using-superpowers completes
+    useSessionStore.getState().setPendingFollowUpMessages(newSessionId, [
+      'use the subagent development skill to implement the following plan:\n' + planContent
+    ])
 
     // Send /using-superpowers — global listener handles follow-up on idle
     const model = resolveSessionModel(newSessionId)
@@ -1592,25 +1625,30 @@ function PlanReviewModeContent({
       }
 
       const newSessionId = sessionResult.session.id
-      await sessionStore.setSessionMode(newSessionId, 'build')
+      const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
+      // Hoist into a const so TS narrowing survives across the background IIFE closure.
+      const newWorktreePath = dupResult.worktree.path
 
-      // Notify kanban store: supercharge re-attaches ticket to new session
-      notifyKanbanSessionSync(sessionId, {
-        type: 'supercharge',
-        newSessionId
-      })
-
-      toast.success('Supercharge session started')
+      prepareTicketSuperchargeSession(newSessionId)
       onClose()
 
-      // Eagerly connect + send /using-superpowers in background; follow-up dispatched by global listener
-      await eagerSuperchargeStart(dupResult.worktree.path, newSessionId)
+      // Finish session configuration and startup in the background so the modal can close
+      // immediately. The success toast is deferred until the background work succeeds —
+      // otherwise we'd announce success and then have to follow it with a failure toast.
+      void (async () => {
+        await setModePromise
+        await eagerSuperchargeStart(newWorktreePath, newSessionId)
+        toast.success('Supercharge session started')
+      })().catch((error) => {
+        console.error('[KanbanTicketModal] supercharge background start failed:', error)
+        toast.error('Failed to supercharge')
+      })
     } catch {
       toast.error('Failed to supercharge')
     } finally {
       setIsActioning(false)
     }
-  }, [ticket, isActioning, planContent, onClose, eagerSuperchargeStart, worktreePath, opcSessionId])
+  }, [ticket, isActioning, onClose, eagerSuperchargeStart, prepareTicketSuperchargeSession, worktreePath, opcSessionId])
 
   // ── Supercharge Local handler (same worktree, no duplication) ───
   const handleSuperchargeLocal = useCallback(async () => {
@@ -1644,25 +1682,28 @@ function PlanReviewModeContent({
       }
 
       const newSessionId = sessionResult.session.id
-      await sessionStore.setSessionMode(newSessionId, 'build')
+      const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
 
-      // Re-attach ticket to the new session, clear plan_ready
-      notifyKanbanSessionSync(sessionId, {
-        type: 'supercharge',
-        newSessionId
-      })
-
-      toast.success('Local supercharge session started')
+      prepareTicketSuperchargeSession(newSessionId)
       onClose()
 
-      // Eagerly connect + send /using-superpowers in background; follow-up dispatched by global listener
-      await eagerSuperchargeStart(localWorktreePath, newSessionId)
+      // Finish session configuration and startup in the background so the modal can close
+      // immediately. The success toast is deferred until the background work succeeds —
+      // otherwise we'd announce success and then have to follow it with a failure toast.
+      void (async () => {
+        await setModePromise
+        await eagerSuperchargeStart(localWorktreePath, newSessionId)
+        toast.success('Local supercharge session started')
+      })().catch((error) => {
+        console.error('[KanbanTicketModal] local supercharge background start failed:', error)
+        toast.error('Failed to supercharge locally')
+      })
     } catch {
       toast.error('Failed to supercharge locally')
     } finally {
       setIsActioning(false)
     }
-  }, [ticket, isActioning, planContent, onClose, eagerSuperchargeStart, worktreePath, opcSessionId])
+  }, [ticket, isActioning, onClose, eagerSuperchargeStart, prepareTicketSuperchargeSession, worktreePath, opcSessionId])
 
   return (
     <div ref={dropZoneRef} className="relative contents">

--- a/test/kanban/plan-review-followup-dispatch.test.tsx
+++ b/test/kanban/plan-review-followup-dispatch.test.tsx
@@ -49,6 +49,7 @@ const mockOpencodeOps = {
   connect: vi.fn().mockResolvedValue({ success: true, sessionId: 'opc-session-1' }),
   prompt: vi.fn().mockResolvedValue({ success: true }),
   reconnect: vi.fn().mockResolvedValue({ success: true }),
+  getMessages: vi.fn().mockResolvedValue({ success: true, messages: [] }),
   planApprove: vi.fn().mockResolvedValue({ success: true }),
   abort: vi.fn().mockResolvedValue({ success: true })
 }
@@ -56,6 +57,10 @@ const mockOpencodeOps = {
 const mockWorktreeOps = {
   create: vi.fn().mockResolvedValue({ success: true }),
   duplicate: vi.fn().mockResolvedValue({ success: true })
+}
+
+const mockGitOps = {
+  listBranchesWithStatus: vi.fn().mockResolvedValue({ success: true, branches: [] })
 }
 
 Object.defineProperty(window, 'kanban', {
@@ -83,6 +88,12 @@ Object.defineProperty(window, 'worktreeOps', {
   writable: true,
   configurable: true,
   value: mockWorktreeOps
+})
+
+Object.defineProperty(window, 'gitOps', {
+  writable: true,
+  configurable: true,
+  value: mockGitOps
 })
 
 // ── Mock toast ──────────────────────────────────────────────────────
@@ -426,5 +437,278 @@ describe('Plan review followup dispatch', () => {
     expect(mockOpencodeOps.prompt).not.toHaveBeenCalled()
 
     errorSpy.mockRestore()
+  })
+
+  test('codex supercharge from ticket view stays on the board and starts background work', async () => {
+    const codexPlanTicket = makeTicket({
+      id: 'ticket-codex',
+      column: 'review',
+      plan_ready: true,
+      current_session_id: 'session-codex-old',
+      worktree_id: 'wt-1',
+      mode: 'plan',
+      description: '## Plan\n\nStep 1: Implement auth flow'
+    })
+
+    mockDbSession.create.mockResolvedValueOnce(
+      makeSession({
+        id: 'session-codex-new',
+        agent_sdk: 'codex',
+        mode: 'build',
+        opencode_session_id: null
+      })
+    )
+
+    act(() => {
+      useKanbanStore.setState({
+        tickets: new Map([['proj-1', [codexPlanTicket]]]),
+        isBoardViewActive: true,
+        selectedTicketId: 'ticket-codex'
+      })
+      useSessionStore.setState({
+        activeSessionId: null,
+        activeWorktreeId: null,
+        sessionsByWorktree: new Map([
+          [
+            'wt-1',
+            [makeSession({ id: 'session-codex-old', agent_sdk: 'codex', opencode_session_id: 'opc-session-1' })]
+          ]
+        ]),
+        pendingPlans: new Map([
+          [
+            'session-codex-old',
+            {
+              requestId: 'req-codex',
+              planContent: '## Detailed Plan\n\nStep 1: Implement auth flow',
+              toolUseID: 'tool-codex'
+            }
+          ]
+        ]),
+        pendingMessages: new Map(),
+        pendingFollowUpMessages: new Map()
+      })
+      useWorktreeStatusStore.setState({
+        sessionStatuses: {}
+      })
+      useWorktreeStore.setState({
+        selectedWorktreeId: null,
+        worktreesByProject: new Map([['proj-1', [makeWorktree()]]])
+      })
+    })
+
+    render(<KanbanTicketModal />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('plan-review-supercharge-local-btn'))
+    })
+
+    await waitFor(() => {
+      expect(mockOpencodeOps.connect).toHaveBeenCalledWith('/test/feature-auth', 'session-codex-new')
+    })
+
+    await waitFor(() => {
+      expect(mockOpencodeOps.prompt).toHaveBeenCalled()
+    })
+
+    const promptCall = mockOpencodeOps.prompt.mock.calls.at(-1)
+    expect(promptCall?.[0]).toBe('/test/feature-auth')
+    expect(promptCall?.[1]).toBe('opc-session-1')
+    expect(promptCall?.[2]).toEqual([{ type: 'text', text: '/using-superpowers' }])
+
+    const updatedTicket = useKanbanStore.getState().tickets.get('proj-1')?.find((t) => t.id === 'ticket-codex')
+    expect(updatedTicket?.current_session_id).toBe('session-codex-new')
+    expect(updatedTicket?.plan_ready).toBe(false)
+    expect(updatedTicket?.mode).toBe('build')
+    expect(updatedTicket?.column).toBe('in_progress')
+
+    expect(useKanbanStore.getState().isBoardViewActive).toBe(true)
+    expect(useKanbanStore.getState().selectedTicketId).toBeNull()
+    expect(useWorktreeStore.getState().selectedWorktreeId).toBeNull()
+    expect(useSessionStore.getState().activeSessionId).toBeNull()
+
+    expect(useWorktreeStatusStore.getState().sessionStatuses['session-codex-new']?.status).toBe('working')
+    expect(
+      useSessionStore.getState().pendingFollowUpMessages.get('session-codex-new')
+    ).toEqual([
+      'use the subagent development skill to implement the following plan:\n## Detailed Plan\n\nStep 1: Implement auth flow'
+    ])
+  })
+
+  test('supercharge does not leave session stuck "working" when background connect fails', async () => {
+    const codexPlanTicket = makeTicket({
+      id: 'ticket-codex',
+      column: 'review',
+      plan_ready: true,
+      current_session_id: 'session-codex-old',
+      worktree_id: 'wt-1',
+      mode: 'plan',
+      description: '## Plan\n\nStep 1: Implement auth flow'
+    })
+
+    mockDbSession.create.mockResolvedValueOnce(
+      makeSession({
+        id: 'session-codex-new',
+        agent_sdk: 'codex',
+        mode: 'build',
+        opencode_session_id: null
+      })
+    )
+
+    // Background connect fails — modal has already closed.
+    mockOpencodeOps.connect.mockResolvedValueOnce({ success: false })
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    act(() => {
+      useKanbanStore.setState({
+        tickets: new Map([['proj-1', [codexPlanTicket]]]),
+        isBoardViewActive: true,
+        selectedTicketId: 'ticket-codex'
+      })
+      useSessionStore.setState({
+        activeSessionId: null,
+        activeWorktreeId: null,
+        sessionsByWorktree: new Map([
+          [
+            'wt-1',
+            [makeSession({ id: 'session-codex-old', agent_sdk: 'codex', opencode_session_id: 'opc-session-1' })]
+          ]
+        ]),
+        pendingPlans: new Map([
+          [
+            'session-codex-old',
+            {
+              requestId: 'req-codex',
+              planContent: '## Detailed Plan\n\nStep 1: Implement auth flow',
+              toolUseID: 'tool-codex'
+            }
+          ]
+        ]),
+        pendingMessages: new Map(),
+        pendingFollowUpMessages: new Map()
+      })
+      useWorktreeStatusStore.setState({ sessionStatuses: {} })
+      useWorktreeStore.setState({
+        selectedWorktreeId: null,
+        worktreesByProject: new Map([['proj-1', [makeWorktree()]]])
+      })
+    })
+
+    render(<KanbanTicketModal />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('plan-review-supercharge-local-btn'))
+    })
+
+    // Wait for the background IIFE to reach connect (which we've forced to fail).
+    await waitFor(() => {
+      expect(mockOpencodeOps.connect).toHaveBeenCalledWith('/test/feature-auth', 'session-codex-new')
+    })
+
+    // Let the failing background chain settle.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    // prompt must not have fired — we never got a valid opencode session id.
+    expect(mockOpencodeOps.prompt).not.toHaveBeenCalled()
+
+    // Regression guard: connect failure must not leave the new session stuck in 'working'.
+    expect(
+      useWorktreeStatusStore.getState().sessionStatuses['session-codex-new']?.status
+    ).not.toBe('working')
+
+    // User is told the supercharge failed, not falsely told it started.
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('upercharge'))
+
+    errorSpy.mockRestore()
+  })
+
+  test('supercharge shows success toast only after background work succeeds', async () => {
+    const codexPlanTicket = makeTicket({
+      id: 'ticket-codex',
+      column: 'review',
+      plan_ready: true,
+      current_session_id: 'session-codex-old',
+      worktree_id: 'wt-1',
+      mode: 'plan',
+      description: '## Plan\n\nStep 1: Implement auth flow'
+    })
+
+    mockDbSession.create.mockResolvedValueOnce(
+      makeSession({
+        id: 'session-codex-new',
+        agent_sdk: 'codex',
+        mode: 'build',
+        opencode_session_id: null
+      })
+    )
+
+    // Hold prompt pending so success can't be claimed until we release it.
+    let resolvePrompt!: () => void
+    mockOpencodeOps.prompt.mockReturnValue(
+      new Promise<{ success: boolean }>((resolve) => {
+        resolvePrompt = () => resolve({ success: true })
+      })
+    )
+
+    act(() => {
+      useKanbanStore.setState({
+        tickets: new Map([['proj-1', [codexPlanTicket]]]),
+        isBoardViewActive: true,
+        selectedTicketId: 'ticket-codex'
+      })
+      useSessionStore.setState({
+        activeSessionId: null,
+        activeWorktreeId: null,
+        sessionsByWorktree: new Map([
+          [
+            'wt-1',
+            [makeSession({ id: 'session-codex-old', agent_sdk: 'codex', opencode_session_id: 'opc-session-1' })]
+          ]
+        ]),
+        pendingPlans: new Map([
+          [
+            'session-codex-old',
+            {
+              requestId: 'req-codex',
+              planContent: '## Detailed Plan\n\nStep 1: Implement auth flow',
+              toolUseID: 'tool-codex'
+            }
+          ]
+        ]),
+        pendingMessages: new Map(),
+        pendingFollowUpMessages: new Map()
+      })
+      useWorktreeStatusStore.setState({ sessionStatuses: {} })
+      useWorktreeStore.setState({
+        selectedWorktreeId: null,
+        worktreesByProject: new Map([['proj-1', [makeWorktree()]]])
+      })
+    })
+
+    render(<KanbanTicketModal />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('plan-review-supercharge-local-btn'))
+    })
+
+    // Wait for the background work to reach prompt (still pending).
+    await waitFor(() => {
+      expect(mockOpencodeOps.prompt).toHaveBeenCalled()
+    })
+
+    // Success cannot be claimed while background prompt is still in flight.
+    expect(toast.success).not.toHaveBeenCalledWith(expect.stringContaining('upercharge'))
+
+    // Release the background prompt — now success should be reported.
+    await act(async () => {
+      resolvePrompt()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('upercharge'))
+    })
   })
 })


### PR DESCRIPTION
## Summary

- **Refactors supercharge flow** to handle kanban ticket state updates synchronously before modal close
- **Defers connection and session work** to background IIFE to allow immediate modal dismissal
- **Prevents zombie sessions** by only marking sessions 'working' after OpenCode connection succeeds
- **Improves error resilience** by surfacing connection failures instead of silently failing
- **Separates concerns**: `prepareTicketSuperchargeSession()` updates UI immediately, `eagerSuperchargeStart()` handles async backend work
- **Defers success toast** until background work completes, preventing false success announcements
- **Moves ticket relinking** out of `notifyKanbanSessionSync()` into deterministic callback
- **Auto-moves tickets** from 'todo'/'review' to 'in_progress' during supercharge
- **Adds 3 new tests** to verify correct state transitions, error handling, and async sequencing

## Testing

- [x] Kanban board remains visible (isBoardViewActive = true) after supercharge initiation
- [x] Modal closes immediately while background work proceeds
- [x] Ticket relinking happens before modal close via `prepareTicketSuperchargeSession()`
- [x] Ticket status changes: `plan_ready → false`, `mode → 'build'`, moves to `in_progress`
- [x] Background failure (connect) prevents session from being marked 'working'
- [x] Connection failure surfaces error toast instead of false success
- [x] Success toast only appears after entire background chain completes (connect + prompt)
- [x] Follow-up messages queued only after successful connection
- [x] OpenCode prompt sent with correct `/using-superpowers` message
- [x] Session status set to 'working' only after connection succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches asynchronous session startup and kanban ticket state transitions, where ordering/race conditions could cause incorrect UI state or status tracking. Scope is localized and backed by new regression tests for the main failure modes.
> 
> **Overview**
> Refactors the plan-review **Supercharge** flow in `KanbanTicketModal` to synchronously re-link the ticket to the new session (and auto-move `todo`/`review` tickets to `in_progress`) before closing the modal, so the board updates immediately.
> 
> Moves OpenCode connection, status/timing bookkeeping, `/using-superpowers` prompt, and follow-up queuing into a background async chain; connection failures now throw and are surfaced to the user, and sessions are only marked `working` after a successful connect to avoid “zombie” working states. Success toasts are deferred until the background startup completes.
> 
> Extends `plan-review-followup-dispatch` tests with new coverage for supercharge UI/state transitions, connect-failure handling, and success-toast sequencing, and updates mocks to include missing window APIs (`opencodeOps.getMessages`, `gitOps.listBranchesWithStatus`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642cb5b8f57b3c13c1c044f4d85f3a4a4aaef961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->