### PR TITLE
feat(kanban): expose Run/Stop + Cmd+R across all ticket modal modes

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -12,8 +12,6 @@ import {
   ArrowRight,
   AlertCircle,
   Bolt,
-  Play,
-  Square,
   FileSearch,
   GitPullRequest,
   GitMerge,
@@ -55,7 +53,8 @@ import { snapshotTokenBaseline } from '@/lib/token-baselines'
 import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
 import { buildSdkPlanImplementationPrompt } from '@/lib/proposedPlan'
 import { toast } from '@/lib/toast'
-import { useScriptStore, fireRunScript, killRunScript } from '@/stores/useScriptStore'
+import { useTicketRunScript, useTicketRunScriptHotkey, type TicketRunScriptState } from '@/hooks/useTicketRunScript'
+import { TicketRunButton } from './TicketRunButton'
 import { useQuestionStore, type QuestionRequest } from '@/stores/useQuestionStore'
 import { QuestionPrompt } from '@/components/sessions/QuestionPrompt'
 import { FollowupInput } from './FollowupInput'
@@ -343,6 +342,12 @@ function KanbanTicketModalContent({
   const moveTicket = useKanbanStore((s) => s.moveTicket)
   const [editDraftDirty, setEditDraftDirty] = useState(false)
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
+
+  // ── Run script state (shared across all modal modes) ─────────────
+  // Hoisted here so the Cmd+R hotkey registers exactly once, and so each
+  // mode receives the same state object via props.
+  const runScriptState = useTicketRunScript(ticket)
+  useTicketRunScriptHotkey(runScriptState)
 
   // ── Session lookup ────────────────────────────────────────────────
   const sessionStatus = useSessionStore(
@@ -634,6 +639,7 @@ function KanbanTicketModalContent({
           onDirtyChange={setEditDraftDirty}
           updateTicket={updateTicket}
           deleteTicket={deleteTicket}
+          runScriptState={runScriptState}
         />
       )
       break
@@ -648,6 +654,7 @@ function KanbanTicketModalContent({
           dualPane={wantsDualPane}
           worktreePath={worktreePath}
           opcSessionId={opcSessionId}
+          runScriptState={runScriptState}
         />
       )
       break
@@ -659,11 +666,19 @@ function KanbanTicketModalContent({
           moveTicket={moveTicket}
           updateTicket={updateTicket}
           dualPane={wantsDualPane}
+          runScriptState={runScriptState}
         />
       )
       break
     case 'error':
-      modeContent = <ErrorModeContent ticket={ticket} onClose={forceClose} dualPane={wantsDualPane} />
+      modeContent = (
+        <ErrorModeContent
+          ticket={ticket}
+          onClose={forceClose}
+          dualPane={wantsDualPane}
+          runScriptState={runScriptState}
+        />
+      )
       break
     case 'question':
       modeContent = (
@@ -672,6 +687,7 @@ function KanbanTicketModalContent({
           onClose={forceClose}
           activeQuestion={activeQuestion!}
           dualPane={wantsDualPane}
+          runScriptState={runScriptState}
         />
       )
       break
@@ -697,12 +713,19 @@ function KanbanTicketModalContent({
               opencodeSessionId={opcSessionId!}
               title={ticket.title}
               headerAction={(
-                <JumpToSessionButton
-                  ticket={ticket}
-                  onClose={forceClose}
-                  label="Go to session"
-                  testId="go-to-session-btn"
-                />
+                <div className="flex items-center gap-2">
+                  <TicketRunButton
+                    state={runScriptState}
+                    testId="full-width-run-btn"
+                    className="h-7 px-2 text-xs"
+                  />
+                  <JumpToSessionButton
+                    ticket={ticket}
+                    onClose={forceClose}
+                    label="Go to session"
+                    testId="go-to-session-btn"
+                  />
+                </div>
               )}
               fullWidth
             />
@@ -788,7 +811,8 @@ function EditModeContent({
   onRequestClose,
   onDirtyChange,
   updateTicket,
-  deleteTicket
+  deleteTicket,
+  runScriptState
 }: {
   ticket: KanbanTicket
   onClose: () => void
@@ -796,6 +820,7 @@ function EditModeContent({
   onDirtyChange: (isDirty: boolean) => void
   updateTicket: (ticketId: string, projectId: string, data: KanbanTicketUpdate) => Promise<void>
   deleteTicket: (ticketId: string, projectId: string) => Promise<void>
+  runScriptState: TicketRunScriptState
 }) {
   const [title, setTitle] = useState(ticket.title)
   const [description, setDescription] = useState(ticket.description ?? '')
@@ -1160,6 +1185,7 @@ function EditModeContent({
               Archive
             </Button>
           )}
+          <TicketRunButton state={runScriptState} testId="edit-run-btn" />
           <Button
             type="button"
             variant="outline"
@@ -1194,7 +1220,8 @@ function PlanReviewModeContent({
   updateTicket,
   dualPane = false,
   worktreePath,
-  opcSessionId
+  opcSessionId,
+  runScriptState
 }: {
   ticket: KanbanTicket
   onClose: () => void
@@ -1208,6 +1235,7 @@ function PlanReviewModeContent({
   dualPane?: boolean
   worktreePath: string | null
   opcSessionId: string | null
+  runScriptState: TicketRunScriptState
 }) {
   const [isActioning, setIsActioning] = useState(false)
   const [followUpText, setFollowUpText] = useState('')
@@ -1713,6 +1741,14 @@ function PlanReviewModeContent({
         </div>
       )}
 
+      {/* Run/Stop footer — always visible when the ticket has a worktree and
+          the project has a run_script, regardless of whether the plan has arrived. */}
+      {runScriptState.hasRunScript && (
+        <DialogFooter className="flex-shrink-0 gap-1.5 flex-wrap">
+          <TicketRunButton state={runScriptState} testId="plan-review-run-btn" />
+        </DialogFooter>
+      )}
+
       {/* Action buttons only visible when ExitPlanMode is awaiting approval
           (matches SessionView's showPlanReadyImplementFab gating on !!pendingPlan) */}
       {!!pendingPlan && (
@@ -1774,13 +1810,15 @@ function ReviewModeContent({
   onClose,
   moveTicket,
   updateTicket,
-  dualPane = false
+  dualPane = false,
+  runScriptState
 }: {
   ticket: KanbanTicket
   onClose: () => void
   moveTicket: (ticketId: string, projectId: string, column: 'todo' | 'in_progress' | 'review' | 'done', sortOrder: number) => Promise<void>
   updateTicket: (ticketId: string, projectId: string, data: KanbanTicketUpdate) => Promise<void>
   dualPane?: boolean
+  runScriptState: TicketRunScriptState
 }) {
   const worktree = useMemo(
     () => (ticket.worktree_id ? findWorktreeById(ticket.worktree_id) : null),
@@ -1855,12 +1893,10 @@ function ReviewModeContent({
   // Display ticket description as context, with notice to view session for full conversation
   const reviewDescription = ticket.description ?? null
 
-  // ── Run-script state ───────────────────────────────────────────────
-  const project = useMemo(
-    () => useProjectStore.getState().projects.find((p) => p.id === ticket.project_id) ?? null,
-    [ticket.project_id]
-  )
-
+  // ── Resolve worktree for diff summary (base_branch lookup) ────────
+  // NOTE: Run-script state lives on `runScriptState` (hoisted at the parent).
+  // This effect is kept here because the diff summary below still needs the
+  // resolved worktree to read `base_branch`.
   useEffect(() => {
     let cancelled = false
 
@@ -1916,8 +1952,6 @@ function ReviewModeContent({
     }
   }, [ticket.project_id, ticket.worktree_id, resolvedWorktree])
 
-  const hasRunScript = !!project?.run_script && !!resolvedWorktree
-
   useEffect(() => {
     let cancelled = false
 
@@ -1966,10 +2000,6 @@ function ReviewModeContent({
       cleanup()
     }
   }, [dualPane, resolvedWorktree?.path, resolvedBaseBranch])
-
-  const runRunning = useScriptStore((s) =>
-    ticket.worktree_id ? (s.scriptStates[ticket.worktree_id]?.runRunning ?? false) : false
-  )
 
   const toggleMode = useCallback(() => {
     setFollowUpMode((prev) => prev === 'build' ? 'plan' : 'build')
@@ -2096,44 +2126,6 @@ function ReviewModeContent({
     }
   }, [ticket, moveTicket])
 
-  // ── Run / Stop handlers ────────────────────────────────────────────
-  const handleRunScript = useCallback(() => {
-    if (!ticket.worktree_id || !resolvedWorktree || !project?.run_script || runRunning) return
-    const commands = project.run_script
-      .split('\n')
-      .map((l) => l.trim())
-      .filter((l) => l && !l.startsWith('#'))
-    fireRunScript(ticket.worktree_id, commands, resolvedWorktree.path)
-    toast.success('Run script started')
-  }, [ticket.worktree_id, resolvedWorktree, project, runRunning])
-
-  const handleStopScript = useCallback(async () => {
-    if (!ticket.worktree_id) return
-    await killRunScript(ticket.worktree_id)
-    toast.success('Run script stopped')
-  }, [ticket.worktree_id])
-
-  // Cmd+R / Ctrl+R toggles run/stop while the review modal is open
-  useEffect(() => {
-    if (!hasRunScript) return
-    const handler = (e: KeyboardEvent): void => {
-      if (e.key === 'r' && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
-        const modal = document.querySelector('[data-testid="kanban-ticket-modal"]')
-        if (modal?.contains(document.activeElement)) {
-          e.preventDefault()
-          e.stopImmediatePropagation()
-          if (runRunning) {
-            handleStopScript()
-          } else {
-            handleRunScript()
-          }
-        }
-      }
-    }
-    window.addEventListener('keydown', handler, true) // capture phase
-    return () => window.removeEventListener('keydown', handler, true)
-  }, [hasRunScript, runRunning, handleRunScript, handleStopScript])
-
   return (
     <div ref={dropZoneRef} className="relative contents">
       <DialogHeader>
@@ -2217,23 +2209,7 @@ function ReviewModeContent({
         >
           Cancel
         </Button>
-        {hasRunScript && (
-          <Button
-            type="button"
-            variant="outline"
-            data-testid="review-run-btn"
-            onClick={runRunning ? handleStopScript : handleRunScript}
-            className={cn(
-              'gap-1.5',
-              runRunning
-                ? 'border-red-500/30 text-red-500 hover:bg-red-500/10'
-                : 'border-green-500/30 text-green-500 hover:bg-green-500/10'
-            )}
-          >
-            {runRunning ? <><Square className="h-3.5 w-3.5" /> Stop</> : <><Play className="h-3.5 w-3.5" /> Run</>}
-              <kbd className="ml-1 text-[10px] opacity-60 font-sans">⌘R</kbd>
-          </Button>
-        )}
+        <TicketRunButton state={runScriptState} testId="review-run-btn" />
         {ticket.worktree_id && (
           <Button
             type="button"
@@ -2332,11 +2308,13 @@ function ReviewModeContent({
 function ErrorModeContent({
   ticket,
   onClose,
-  dualPane = false
+  dualPane = false,
+  runScriptState
 }: {
   ticket: KanbanTicket
   onClose: () => void
   dualPane?: boolean
+  runScriptState: TicketRunScriptState
 }) {
   const [followUpText, setFollowUpText] = useState('')
   const [followUpMode, setFollowUpMode] = useState<FollowUpMode>('build')
@@ -2517,6 +2495,7 @@ function ErrorModeContent({
       )}
 
       <DialogFooter>
+        <TicketRunButton state={runScriptState} testId="error-run-btn" />
         <Button
           type="button"
           variant="outline"
@@ -2553,12 +2532,14 @@ function QuestionModeContent({
   ticket,
   onClose,
   activeQuestion,
-  dualPane = false
+  dualPane = false,
+  runScriptState
 }: {
   ticket: KanbanTicket
   onClose: () => void
   activeQuestion: QuestionRequest
   dualPane?: boolean
+  runScriptState: TicketRunScriptState
 }) {
   const handleReply = useCallback(async (requestId: string, answers: string[][]) => {
     try {
@@ -2613,7 +2594,14 @@ function QuestionModeContent({
           <DialogTitle className="flex items-center gap-2">
             Question from Agent
           </DialogTitle>
-          <JumpToSessionButton ticket={ticket} onClose={onClose} />
+          <div className="flex items-center gap-2">
+            <TicketRunButton
+              state={runScriptState}
+              testId="question-run-btn"
+              className="h-7 px-2 text-xs"
+            />
+            <JumpToSessionButton ticket={ticket} onClose={onClose} />
+          </div>
         </div>
         <DialogDescription>{dualPane ? 'An agent question needs your attention.' : ticket.title}</DialogDescription>
       </DialogHeader>

--- a/src/renderer/src/components/kanban/TicketRunButton.tsx
+++ b/src/renderer/src/components/kanban/TicketRunButton.tsx
@@ -1,0 +1,47 @@
+import { Play, Square } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { TicketRunScriptState } from '@/hooks/useTicketRunScript'
+
+interface TicketRunButtonProps {
+  state: TicketRunScriptState
+  testId: string
+  className?: string
+}
+
+/**
+ * Presentational Run/Stop button for the kanban ticket modal.
+ * Renders null when the ticket has no attached worktree or the project has
+ * no `run_script` configured.
+ */
+export function TicketRunButton({ state, testId, className }: TicketRunButtonProps): React.JSX.Element | null {
+  const { hasRunScript, runRunning, handleRunScript, handleStopScript } = state
+  if (!hasRunScript) return null
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      data-testid={testId}
+      onClick={runRunning ? handleStopScript : handleRunScript}
+      className={cn(
+        'gap-1.5',
+        runRunning
+          ? 'border-red-500/30 text-red-500 hover:bg-red-500/10'
+          : 'border-green-500/30 text-green-500 hover:bg-green-500/10',
+        className
+      )}
+    >
+      {runRunning ? (
+        <>
+          <Square className="h-3.5 w-3.5" /> Stop
+        </>
+      ) : (
+        <>
+          <Play className="h-3.5 w-3.5" /> Run
+        </>
+      )}
+      <kbd className="ml-1 text-[10px] opacity-60 font-sans">⌘R</kbd>
+    </Button>
+  )
+}

--- a/src/renderer/src/hooks/useTicketRunScript.ts
+++ b/src/renderer/src/hooks/useTicketRunScript.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useScriptStore, fireRunScript, killRunScript } from '@/stores/useScriptStore'
+import { toast } from '@/lib/toast'
+import type { KanbanTicket, Worktree } from '../../../main/db/types'
+
+/**
+ * Combined state + actions for running the project's `run_script` against
+ * a ticket's attached worktree.  Consumed by the presentational
+ * `TicketRunButton` and the modal-scoped Cmd+R hotkey.
+ */
+export interface TicketRunScriptState {
+  /** True when the ticket has a worktree and the project has a run_script configured. */
+  hasRunScript: boolean
+  /** True while the run script is actively executing for this ticket's worktree. */
+  runRunning: boolean
+  /** Start the project's run script in the ticket's worktree.  No-op when no run script. */
+  handleRunScript: () => void
+  /** Kill the running script in this ticket's worktree.  No-op when worktree_id is null. */
+  handleStopScript: () => Promise<void>
+}
+
+/**
+ * Resolve the ticket's worktree from the in-memory store with a DB fallback,
+ * subscribe reactively to the project's `run_script`, and expose
+ * start/stop handlers + a reactive `runRunning` flag from `useScriptStore`.
+ */
+export function useTicketRunScript(ticket: KanbanTicket): TicketRunScriptState {
+  // Reactive project selector — ensures `hasRunScript` updates if run_script
+  // changes in Project Settings while the modal is open.
+  const runScript = useProjectStore(
+    (s) => s.projects.find((p) => p.id === ticket.project_id)?.run_script ?? null
+  )
+
+  // In-memory worktree lookup (reactive to worktreesByProject changes).
+  const inMemoryWorktree = useWorktreeStore((s) => {
+    if (!ticket.worktree_id) return null
+    for (const worktrees of s.worktreesByProject.values()) {
+      const wt = worktrees.find((w) => w.id === ticket.worktree_id)
+      if (wt) return wt
+    }
+    return null
+  })
+
+  // DB fallback: when the worktree isn't in memory (project not loaded),
+  // hydrate from the DB so the button still works on pinned-board cross-project views.
+  const [dbWorktree, setDbWorktree] = useState<Worktree | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!ticket.worktree_id) {
+      setDbWorktree(null)
+      return
+    }
+    if (inMemoryWorktree) {
+      setDbWorktree(null)
+      return
+    }
+
+    window.db.worktree
+      .get(ticket.worktree_id)
+      .then((wt) => {
+        if (!cancelled) setDbWorktree(wt ?? null)
+      })
+      .catch(() => {
+        if (!cancelled) setDbWorktree(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [ticket.worktree_id, inMemoryWorktree])
+
+  const resolvedWorktree = inMemoryWorktree ?? dbWorktree
+
+  const hasRunScript = !!runScript && !!resolvedWorktree
+
+  const runRunning = useScriptStore((s) =>
+    ticket.worktree_id ? (s.scriptStates[ticket.worktree_id]?.runRunning ?? false) : false
+  )
+
+  const handleRunScript = useCallback(() => {
+    if (!ticket.worktree_id || !resolvedWorktree || !runScript || runRunning) return
+    const commands = runScript
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#'))
+    fireRunScript(ticket.worktree_id, commands, resolvedWorktree.path)
+    toast.success('Run script started')
+  }, [ticket.worktree_id, resolvedWorktree, runScript, runRunning])
+
+  const handleStopScript = useCallback(async () => {
+    if (!ticket.worktree_id) return
+    await killRunScript(ticket.worktree_id)
+    toast.success('Run script stopped')
+  }, [ticket.worktree_id])
+
+  return useMemo(
+    () => ({ hasRunScript, runRunning, handleRunScript, handleStopScript }),
+    [hasRunScript, runRunning, handleRunScript, handleStopScript]
+  )
+}
+
+/**
+ * Register a window-capture Cmd+R / Ctrl+R handler that toggles run/stop
+ * whenever the kanban ticket modal has focus.  Runs in the capture phase
+ * and calls `stopImmediatePropagation()` so the global Cmd+R handler
+ * (which targets the sidebar's selected worktree) doesn't also fire.
+ */
+export function useTicketRunScriptHotkey(state: TicketRunScriptState): void {
+  const { hasRunScript, runRunning, handleRunScript, handleStopScript } = state
+
+  useEffect(() => {
+    if (!hasRunScript) return
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'r' && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+        const modal = document.querySelector('[data-testid="kanban-ticket-modal"]')
+        if (modal?.contains(document.activeElement)) {
+          e.preventDefault()
+          e.stopImmediatePropagation()
+          if (runRunning) {
+            void handleStopScript()
+          } else {
+            handleRunScript()
+          }
+        }
+      }
+    }
+    window.addEventListener('keydown', handler, true)
+    return () => window.removeEventListener('keydown', handler, true)
+  }, [hasRunScript, runRunning, handleRunScript, handleStopScript])
+}


### PR DESCRIPTION
## Summary

- **Extracted run script logic** into a reusable `useTicketRunScript` hook that manages state, DB fallback for worktrees, and handlers
- **Created `TicketRunButton` component** for consistent Run/Stop presentation across all modal modes (edit, plan-review, review, error, question)
- **Unified Cmd+R hotkey handling** into `useTicketRunScriptHotkey` to prevent duplicate registrations and ensure single source of truth
- **Hoisted run script state** to `KanbanTicketModalContent` so all child modes share the same state object
- **Added run button to all modal modes** that have a worktree and project with `run_script` configured
- **Session view mode** now includes Run button in header alongside "Go to session"
- **Plan-review and error modes** now show Run button in footer when applicable

## Testing

- Verify Run/Stop button appears in all modal modes when ticket has worktree + project has run_script
- Verify Run/Stop button does not appear when worktree is missing or run_script is not configured
- Test Cmd+R hotkey toggles run/stop in each modal mode
- Verify hotkey does not trigger when focus is outside the modal
- Test run script execution starts successfully and displays "Run script started" toast
- Test stop script execution and displays "Run script stopped" toast
- Verify button state (green Run vs red Stop) matches actual script execution state
- Test DB fallback worktree lookup works on cross-project pinned board views
- Verify run state updates reactively when run_script is changed in Project Settings
- Not run: End-to-end cross-modal workflow testing with actual script execution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global keyboard handling and script-execution wiring, so regressions could affect hotkey behavior or running scripts in the wrong context. UI changes are straightforward but rely on correct worktree resolution (including DB fallback).
> 
> **Overview**
> Adds a shared, modal-scoped Run/Stop capability for kanban tickets by extracting script execution + Cmd/Ctrl+R hotkey handling into a new `useTicketRunScript`/`useTicketRunScriptHotkey` hook (including DB fallback worktree resolution).
> 
> Replaces inline run-script logic in `KanbanTicketModal` with a reusable `TicketRunButton` and threads the shared state into *all* modal modes (edit/plan review/review/error/question) plus the full-width session header so users can run or stop the project `run_script` consistently wherever they are in the ticket modal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 071687d020014d3d444aa344ad39b4191741f0b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->