### PR TITLE
Upgrade Claude Agent SDK to version 0.2.112 (Opus 4.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "install:mac": "bash scripts/install.sh"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.107",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.112",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-cpp": "^6.0.3",
     "@codemirror/lang-css": "^6.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.107
-        version: 0.2.107(zod@3.25.76)
+        specifier: ^0.2.112
+        version: 0.2.112(zod@3.25.76)
       '@codemirror/commands':
         specifier: ^6.10.3
         version: 6.10.3
@@ -302,8 +302,8 @@ packages:
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
     hasBin: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.107':
-    resolution: {integrity: sha512-zH5CCjvFn4A+RN0LLaqKJYEcGEg2O/Bm+tDpkBGcEKaRZOqwXkKJ2d9JmboALGSxsCAN5K0+uQxPgzk9LhiQzg==}
+  '@anthropic-ai/claude-agent-sdk@0.2.112':
+    resolution: {integrity: sha512-vMFoiDKlOive8p3tphpV1gQaaytOipwGJ+uw9mvvaLQUODSC2+fCdRDAY25i2Tsv+lOtxzXBKctmaDuWqZY7ig==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -6361,7 +6361,7 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
 
-  '@anthropic-ai/claude-agent-sdk@0.2.107(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.2.112(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.81.0(zod@3.25.76)
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -25,7 +25,7 @@ const CLAUDE_OPUS_EFFORT_VARIANTS = { low: {}, medium: {}, high: {}, max: {} }
 const CLAUDE_MODELS = [
   {
     id: 'opus',
-    name: 'Opus 4.6',
+    name: 'Opus 4.7',
     limit: { context: 1000000, output: 32000 },
     variants: CLAUDE_OPUS_EFFORT_VARIANTS,
     defaultVariant: 'high'

--- a/test/phase-21/session-6/claude-model-catalog.test.ts
+++ b/test/phase-21/session-6/claude-model-catalog.test.ts
@@ -63,7 +63,7 @@ describe('ClaudeCodeImplementer model catalog', () => {
     const info = await impl.getModelInfo('any', 'opus')
     expect(info).toEqual({
       id: 'opus',
-      name: 'Opus 4.6',
+      name: 'Opus 4.7',
       limit: { context: 1000000, output: 32000 }
     })
   })


### PR DESCRIPTION
## Summary

- Upgrade `@anthropic-ai/claude-agent-sdk` from v0.2.107 to v0.2.112
- Update Claude Opus model reference from 4.6 to 4.7
- Update package lock file with new dependency resolution
- Update test expectations to reflect new model version

## Testing

- Verify the model catalog test passes with updated Opus 4.7 version name
- Confirm the `getModelInfo('any', 'opus')` returns the correct model details with updated name
- Check that the agent SDK upgrade doesn't break existing functionality
- Run integration tests to ensure compatibility with the new SDK version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump and metadata rename; main risk is subtle runtime behavior changes from the upgraded `@anthropic-ai/claude-agent-sdk`.
> 
> **Overview**
> Upgrades `@anthropic-ai/claude-agent-sdk` from `0.2.107` to `0.2.112` (including lockfile updates).
> 
> Updates the Claude model catalog to label Opus as **`Opus 4.7`** (from 4.6) and adjusts the model-catalog test expectations accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8bb34a9179fdf450057f6142e2c989466e2df6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->