### PR TITLE
feat(kanban): add personal note field to tickets with LLM-leak guards

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -155,7 +155,8 @@ export class DatabaseService {
       github_pr_url: (row.github_pr_url as string) ?? null,
       mark: (row.mark as TicketMark) ?? null,
       total_tokens: (row.total_tokens as number) ?? 0,
-      pending_launch_config: (row.pending_launch_config as string) ?? null
+      pending_launch_config: (row.pending_launch_config as string) ?? null,
+      note: (row.note as string) ?? null
     }
   }
 
@@ -2047,6 +2048,10 @@ export class DatabaseService {
     if (data.pending_launch_config !== undefined) {
       updates.push('pending_launch_config = ?')
       values.push(data.pending_launch_config)
+    }
+    if (data.note !== undefined) {
+      updates.push('note = ?')
+      values.push(data.note)
     }
 
     if (updates.length === 1) return existing // Only updated_at, nothing meaningful changed

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -391,6 +391,7 @@ export class DatabaseService {
     this.safeAddColumn('kanban_tickets', 'github_pr_number', 'INTEGER DEFAULT NULL')
     this.safeAddColumn('kanban_tickets', 'github_pr_url', 'TEXT DEFAULT NULL')
     this.safeAddColumn('kanban_tickets', 'mark', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('kanban_tickets', 'note', 'TEXT DEFAULT NULL')
     this.safeAddColumn('sessions', 'session_type', "TEXT NOT NULL DEFAULT 'default'")
 
     db.exec(`

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 23
+export const CURRENT_SCHEMA_VERSION = 24
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -448,6 +448,12 @@ ALTER TABLE kanban_tickets ADD COLUMN pending_launch_config TEXT DEFAULT NULL;`,
     version: 23,
     name: 'add_session_type',
     up: `ALTER TABLE sessions ADD COLUMN session_type TEXT NOT NULL DEFAULT 'default'`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 24,
+    name: 'add_ticket_note',
+    up: `ALTER TABLE kanban_tickets ADD COLUMN note TEXT DEFAULT NULL`,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -367,6 +367,8 @@ export interface KanbanTicket {
   mark: TicketMark | null
   total_tokens: number
   pending_launch_config: string | null
+  /** Personal annotation. MUST NOT be included in any LLM prompt. */
+  note: string | null
 }
 
 export interface KanbanTicketCreate {
@@ -403,6 +405,7 @@ export interface KanbanTicketUpdate {
   github_pr_url?: string | null
   mark?: TicketMark | null
   pending_launch_config?: string | null
+  note?: string | null
 }
 
 export interface BoardAssistantDraft {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1953,6 +1953,7 @@ const kanban = {
         mode?: 'build' | 'plan' | null
         plan_ready?: boolean
         mark?: string | null
+        note?: string | null
       }
     ) => ipcRenderer.invoke('kanban:ticket:update', id, data),
     delete: (id: string) => ipcRenderer.invoke('kanban:ticket:delete', id),

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -1,7 +1,9 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles, Lock, Link2, Plus } from 'lucide-react'
+import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles, Lock, Link2, Plus, StickyNote } from 'lucide-react'
 import { UpdateStatusModal } from './UpdateStatusModal'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { NoteEditorModal } from './NoteEditorModal'
 import { cn } from '@/lib/utils'
 import { ProviderIcon, getProviderLabel } from '@/components/ui/provider-icon'
 import { toast } from '@/lib/toast'
@@ -98,6 +100,8 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
   const [showPreAssignPicker, setShowPreAssignPicker] = useState(false)
   const [showStatusUpdate, setShowStatusUpdate] = useState(false)
   const [showPRPicker, setShowPRPicker] = useState(false)
+  const [showNoteEditor, setShowNoteEditor] = useState(false)
+  const hasNote = !!ticket.note && ticket.note.trim().length > 0
   const isExternalTicket = !!ticket.external_provider
   const dragCloneRef = useRef<HTMLElement | null>(null)
 
@@ -576,6 +580,14 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     }
   }, [ticket.id, ticket.project_id])
 
+  const handleSaveNote = useCallback(async (note: string | null) => {
+    try {
+      await useKanbanStore.getState().updateTicket(ticket.id, ticket.project_id, { note })
+    } catch (err) {
+      toast.error(`Failed to save note: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }, [ticket.id, ticket.project_id])
+
   return (
     <>
       <Popover open={showPRPicker} onOpenChange={setShowPRPicker}>
@@ -637,7 +649,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isBeingReviewed || completedReviewSessionId || isArchived || isBlocked || isRunProcessAlive || ticket.github_pr_number || isCreatingPR) && (
+            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isBeingReviewed || completedReviewSessionId || isArchived || isBlocked || isRunProcessAlive || ticket.github_pr_number || isCreatingPR) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
@@ -662,6 +674,22 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                     <Paperclip className="h-3 w-3" />
                     {ticket.attachments.length}
                   </span>
+                )}
+                {/* Note badge */}
+                {hasNote && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        data-testid="kanban-ticket-note"
+                        className="inline-flex items-center gap-1 rounded-full bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground cursor-help"
+                      >
+                        <StickyNote className="h-3 w-3" />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs whitespace-pre-wrap break-words">
+                      {ticket.note}
+                    </TooltipContent>
+                  </Tooltip>
                 )}
 
                 {/* Project tag (connection mode) or worktree name badge */}
@@ -878,6 +906,17 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </ContextMenuItem>
           )}
 
+          <ContextMenuItem onClick={() => setShowNoteEditor(true)} className="gap-2">
+            <StickyNote className="h-3.5 w-3.5" />
+            {hasNote ? 'Edit note' : 'Add note'}
+          </ContextMenuItem>
+          {hasNote && (
+            <ContextMenuItem onClick={() => handleSaveNote(null)} className="gap-2">
+              <X className="h-3.5 w-3.5" />
+              Remove note
+            </ContextMenuItem>
+          )}
+
           <ContextMenuSeparator />
           <ContextMenuSub>
             <ContextMenuSubTrigger data-testid="ctx-mark-submenu" className="gap-2">
@@ -1033,6 +1072,14 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
           ticketTitle={ticket.title}
         />
       )}
+
+      <NoteEditorModal
+        open={showNoteEditor}
+        onOpenChange={setShowNoteEditor}
+        ticketTitle={ticket.title}
+        initialNote={ticket.note}
+        onSave={handleSaveNote}
+      />
     </>
   )
 })

--- a/src/renderer/src/components/kanban/NoteEditorModal.tsx
+++ b/src/renderer/src/components/kanban/NoteEditorModal.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { StickyNote } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+
+const MAX_NOTE_LENGTH = 500
+
+interface NoteEditorModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  ticketTitle: string
+  initialNote: string | null
+  onSave: (note: string | null) => Promise<void> | void
+}
+
+export function NoteEditorModal({
+  open,
+  onOpenChange,
+  ticketTitle,
+  initialNote,
+  onSave
+}: NoteEditorModalProps) {
+  const [value, setValue] = useState('')
+  const [saving, setSaving] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setValue(initialNote ?? '')
+  }, [open, initialNote])
+
+  const handleSave = useCallback(async () => {
+    if (saving) return
+    const trimmed = value.trim()
+    const next = trimmed.length === 0 ? null : trimmed
+    setSaving(true)
+    try {
+      await onSave(next)
+      onOpenChange(false)
+    } finally {
+      setSaving(false)
+    }
+  }, [value, saving, onSave, onOpenChange])
+
+  const handleClear = useCallback(async () => {
+    if (saving) return
+    setSaving(true)
+    try {
+      await onSave(null)
+      onOpenChange(false)
+    } finally {
+      setSaving(false)
+    }
+  }, [saving, onSave, onOpenChange])
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault()
+      void handleSave()
+    }
+  }
+
+  const hasExistingNote = !!initialNote && initialNote.trim().length > 0
+  const remaining = MAX_NOTE_LENGTH - value.length
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-sm">
+            <StickyNote className="h-4 w-4" />
+            Note
+          </DialogTitle>
+          <p className="text-xs text-muted-foreground truncate mt-1">{ticketTitle}</p>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-2 py-2">
+          <Textarea
+            ref={textareaRef}
+            autoFocus
+            value={value}
+            onChange={(e) => setValue(e.target.value.slice(0, MAX_NOTE_LENGTH))}
+            onKeyDown={handleKeyDown}
+            placeholder="Write a personal note for this ticket..."
+            className="min-h-[140px] resize-none"
+            disabled={saving}
+          />
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>Not sent to the LLM.</span>
+            <span>{remaining} characters remaining</span>
+          </div>
+        </div>
+
+        <DialogFooter className="sm:justify-between">
+          <div>
+            {hasExistingNote && (
+              <Button variant="ghost" size="sm" onClick={handleClear} disabled={saving}>
+                Clear note
+              </Button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving...' : 'Save note'}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/kanban/NoteEditorModal.tsx
+++ b/src/renderer/src/components/kanban/NoteEditorModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { StickyNote } from 'lucide-react'
 import {
   Dialog,
@@ -29,7 +29,6 @@ export function NoteEditorModal({
 }: NoteEditorModalProps) {
   const [value, setValue] = useState('')
   const [saving, setSaving] = useState(false)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
     if (!open) return
@@ -83,7 +82,6 @@ export function NoteEditorModal({
 
         <div className="flex flex-col gap-2 py-2">
           <Textarea
-            ref={textareaRef}
             autoFocus
             value={value}
             onChange={(e) => setValue(e.target.value.slice(0, MAX_NOTE_LENGTH))}

--- a/test/kanban/llm-note-leak-guard.test.ts
+++ b/test/kanban/llm-note-leak-guard.test.ts
@@ -1,3 +1,18 @@
+/**
+ * Guard test: the kanban ticket `note` field must NEVER be included in any
+ * LLM prompt. The `note` is a personal annotation for the user only.
+ *
+ * Approach: static analysis on the known prompt-building source files. The
+ * relevant prompt-construction helpers in these files are internal/non-exported,
+ * so behavioral testing isn't practical today. Instead we assert two regression
+ * classes are absent from each file:
+ *   1. Direct access to `ticket.note`.
+ *   2. Object spread of a ticket-like variable (`...ticket` / `...t`), which
+ *      would silently include `note` if added to the projection.
+ *
+ * MAINTENANCE: when introducing a new code path that builds an LLM prompt from
+ * `KanbanTicket`, add its source path to `LLM_PROMPT_FILES` below.
+ */
 import { describe, test, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -32,6 +47,6 @@ describe('Kanban ticket note never leaks into LLM prompts', () => {
     const content = readFileSync(typesPath, 'utf8')
     // Confirms the type-level marker is intact (defensive: anyone editing the type
     // will see the warning above the field).
-    expect(content).toMatch(/MUST NOT be included in any LLM prompt[\s\S]*\n\s*note: string \| null/)
+    expect(content).toMatch(/MUST NOT be included in any LLM prompt[\s\S]{0,200}\n\s*note\??\s*:/)
   })
 })

--- a/test/kanban/llm-note-leak-guard.test.ts
+++ b/test/kanban/llm-note-leak-guard.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const REPO_ROOT = join(__dirname, '..', '..')
+
+const LLM_PROMPT_FILES = [
+  'src/renderer/src/components/kanban/BoardAssistantView.tsx',
+  'src/renderer/src/stores/useBoardChatStore.ts',
+  'src/renderer/src/components/kanban/WorktreePickerModal.tsx'
+] as const
+
+describe('Kanban ticket note never leaks into LLM prompts', () => {
+  test.each(LLM_PROMPT_FILES)('%s does not read ticket.note', (relPath) => {
+    const content = readFileSync(join(REPO_ROOT, relPath), 'utf8')
+    expect(content, `${relPath} must not access .note on a ticket`).not.toMatch(/\bticket\.note\b/)
+  })
+
+  test.each(LLM_PROMPT_FILES)(
+    '%s does not spread a ticket-like object into prompt context',
+    (relPath) => {
+      const content = readFileSync(join(REPO_ROOT, relPath), 'utf8')
+      expect(
+        content,
+        `${relPath} must not spread "...ticket" or "...t" (would include note)`
+      ).not.toMatch(/\.\.\.\s*(ticket|t)\b/)
+    }
+  )
+
+  test('KanbanTicket.note has the LLM-exclusion JSDoc marker', () => {
+    const typesPath = join(REPO_ROOT, 'src', 'main', 'db', 'types.ts')
+    const content = readFileSync(typesPath, 'utf8')
+    // Confirms the type-level marker is intact (defensive: anyone editing the type
+    // will see the warning above the field).
+    expect(content).toMatch(/MUST NOT be included in any LLM prompt[\s\S]*\n\s*note: string \| null/)
+  })
+})

--- a/test/kanban/session-1/ticket-note.test.ts
+++ b/test/kanban/session-1/ticket-note.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect, beforeEach, afterEach, beforeAll } from 'vitest'
+import { CURRENT_SCHEMA_VERSION } from '../../../src/main/db/schema'
+import {
+  createTestDatabase,
+  canRunDatabaseTests,
+  getDatabaseLoadError
+} from '../../utils/db-test-utils'
+
+const canRun = canRunDatabaseTests()
+const loadError = getDatabaseLoadError()
+
+const describeIf = canRun ? describe : describe.skip
+
+describeIf('Session 1: Kanban Ticket Note', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let db: any
+  let cleanup: () => void
+
+  beforeAll(() => {
+    if (!canRun) {
+      console.warn(
+        'Skipping database tests: better-sqlite3 not available.',
+        'Error:',
+        loadError?.message
+      )
+    }
+  })
+
+  beforeEach(() => {
+    const testSetup = createTestDatabase()
+    db = testSetup.db
+    cleanup = testSetup.cleanup
+  })
+
+  afterEach(() => {
+    if (cleanup) {
+      cleanup()
+    }
+  })
+
+  test('schema version is at least 24 and note column exists with correct type', () => {
+    expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(24)
+    expect(db.getSchemaVersion()).toBeGreaterThanOrEqual(24)
+
+    const rawDb = db['db']
+    const columns = rawDb.pragma('table_info(kanban_tickets)') as {
+      name: string
+      type: string
+      notnull: number
+      pk: number
+    }[]
+    const noteCol = columns.find((c) => c.name === 'note')
+
+    expect(noteCol, 'note column should exist').toBeTruthy()
+    expect(noteCol!.type).toBe('TEXT')
+    expect(noteCol!.notnull).toBe(0)
+  })
+
+  test('newly created ticket has note === null by default', () => {
+    const project = db.createProject({ name: 'Note Default Test', path: '/note-default' })
+    const ticket = db.createKanbanTicket({ project_id: project.id, title: 'No note yet' })
+
+    expect(ticket.note).toBeNull()
+
+    // Round-trip via getKanbanTicket as well
+    const fetched = db.getKanbanTicket(ticket.id)
+    expect(fetched).toBeTruthy()
+    expect(fetched.note).toBeNull()
+  })
+
+  test('updateKanbanTicket persists a note value', () => {
+    const project = db.createProject({ name: 'Note Persist Test', path: '/note-persist' })
+    const ticket = db.createKanbanTicket({ project_id: project.id, title: 'Persist note' })
+
+    const updated = db.updateKanbanTicket(ticket.id, { note: 'hello' })
+    expect(updated).toBeTruthy()
+    expect(updated.note).toBe('hello')
+
+    const fetched = db.getKanbanTicket(ticket.id)
+    expect(fetched.note).toBe('hello')
+  })
+
+  test('updateKanbanTicket clears note when set to null', () => {
+    const project = db.createProject({ name: 'Note Clear Test', path: '/note-clear' })
+    const ticket = db.createKanbanTicket({ project_id: project.id, title: 'Clear note' })
+
+    db.updateKanbanTicket(ticket.id, { note: 'will be cleared' })
+    const beforeClear = db.getKanbanTicket(ticket.id)
+    expect(beforeClear.note).toBe('will be cleared')
+
+    const cleared = db.updateKanbanTicket(ticket.id, { note: null })
+    expect(cleared).toBeTruthy()
+    expect(cleared.note).toBeNull()
+
+    const fetched = db.getKanbanTicket(ticket.id)
+    expect(fetched.note).toBeNull()
+  })
+
+  test('updateKanbanTicket without note key does not clobber existing note', () => {
+    const project = db.createProject({ name: 'Note Preserve Test', path: '/note-preserve' })
+    const ticket = db.createKanbanTicket({ project_id: project.id, title: 'Preserve note' })
+
+    db.updateKanbanTicket(ticket.id, { note: 'keep me' })
+    const beforeUpdate = db.getKanbanTicket(ticket.id)
+    expect(beforeUpdate.note).toBe('keep me')
+
+    // Update something else without touching note
+    const updated = db.updateKanbanTicket(ticket.id, { title: 'new title' })
+    expect(updated).toBeTruthy()
+    expect(updated.title).toBe('new title')
+    expect(updated.note).toBe('keep me')
+
+    const fetched = db.getKanbanTicket(ticket.id)
+    expect(fetched.title).toBe('new title')
+    expect(fetched.note).toBe('keep me')
+  })
+})
+
+// Show information when tests are skipped
+if (!canRun) {
+  describe('Session 1: Kanban Ticket Note (skipped)', () => {
+    test('better-sqlite3 not available for Node.js testing', () => {
+      console.log(
+        'Database tests skipped: better-sqlite3 was compiled for Electron.',
+        'To run these tests, either:',
+        '1. Run tests in Electron environment',
+        '2. Rebuild better-sqlite3 for Node.js: npm rebuild better-sqlite3'
+      )
+      expect(true).toBe(true)
+    })
+  })
+}


### PR DESCRIPTION
## Summary

- **Database**: Add `note` column (v23→v24 schema migration) to `kanban_tickets` table for personal annotations
- **Backend**: Wire note field into ticket model and database update logic with proper null handling
- **UI**: Implement `NoteEditorModal` component with:
  - 500-character limit with remaining count
  - Keyboard shortcut: Cmd/Ctrl+Enter to save
  - Clear and Cancel buttons
  - Warning: "Not sent to the LLM" disclaimer
- **Ticket Card**: Display note badge with sticky note icon + tooltip when note exists; add context menu to edit/remove
- **Safety**: Add LLM-leak guard tests that:
  - Scan prompt-building files for direct `ticket.note` access
  - Reject object spreads (`...ticket`) that could silently include note
  - Enforce JSDoc marker on the type definition
- **Type Safety**: Add JSDoc to `KanbanTicket.note` explicitly stating "MUST NOT be included in any LLM prompt"

## Testing

- [x] `ticket-note.test.ts`: Schema version ≥24, column type is TEXT, nullable
- [x] `ticket-note.test.ts`: Default note is null on new tickets
- [x] `ticket-note.test.ts`: Update persists and clears note correctly
- [x] `ticket-note.test.ts`: Update without note key preserves existing note
- [x] `llm-note-leak-guard.test.ts`: Static analysis on 3 LLM prompt files (BoardAssistantView, useBoardChatStore, WorktreePickerModal)
- [x] `llm-note-leak-guard.test.ts`: JSDoc marker present on type definition
- [x] Manual: Note badge appears/disappears when note is added/removed
- [x] Manual: Modal opens from context menu ("Add note" / "Edit note")
- [x] Manual: Cmd/Ctrl+Enter saves, character limit enforced, clear works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted `note` field to `kanban_tickets` (schema v24) and wires it through update paths and UI, which can affect migrations/backwards compatibility and ticket update behavior. Includes guard tests to prevent accidental inclusion of notes in LLM prompt-building code paths.
> 
> **Overview**
> Adds a new nullable `note` field on Kanban tickets, persisted in SQLite via a v24 migration and surfaced through the ticket model and `updateKanbanTicket` update logic (including IPC typing in `preload`).
> 
> Updates the Kanban UI to let users add/edit/remove a personal note from the ticket context menu, show a sticky-note badge with tooltip when present, and introduces a `NoteEditorModal` with length limit and save shortcut.
> 
> Adds tests covering DB round-trips/defaults for `note` and a static “LLM leak guard” that asserts prompt-building files don’t access `ticket.note` or spread ticket objects into prompt context, plus a type-level JSDoc warning marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcafb8003b737c4c181cdea48b5218c9958f220a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->