### PR TITLE
feat(pinned): show sibling status summary on pinned main-branch row

### DIFF
--- a/src/renderer/src/components/layout/PinnedList.tsx
+++ b/src/renderer/src/components/layout/PinnedList.tsx
@@ -3,6 +3,7 @@ import { revealLabel } from '@/lib/platform'
 import {
   AlertCircle,
   Archive,
+  CheckCircle2,
   Code,
   Copy,
   ExternalLink,
@@ -69,6 +70,7 @@ import { LanguageIcon } from '@/components/projects/LanguageIcon'
 import { ArchiveConfirmDialog } from '@/components/worktrees/ArchiveConfirmDialog'
 import { AddAttachmentDialog } from '@/components/worktrees/AddAttachmentDialog'
 import { ManageConnectionWorktreesDialog } from '@/components/connections/ManageConnectionWorktreesDialog'
+import { useSiblingAggregate, type SiblingBucket } from '@/hooks/useSiblingAggregate'
 
 type PinnedItem = { kind: 'worktree'; id: string } | { kind: 'connection'; id: string }
 
@@ -680,6 +682,9 @@ function PinnedWorktreeItem({ worktreeId }: { worktreeId: string }): React.JSX.E
               <span className={cn('text-[11px]', statusClass)} data-testid="pinned-status-text">
                 {displayStatus}
               </span>
+              {worktree.is_default && (
+                <SiblingCountChips projectId={project.id} excludeId={worktree.id} />
+              )}
               <span className="flex-1" />
               {lastMessageTime && (
                 <span
@@ -760,6 +765,75 @@ function PinnedWorktreeItem({ worktreeId }: { worktreeId: string }): React.JSX.E
         onAttachmentAdded={handleAttachmentAdded}
       />
     </ContextMenu>
+  )
+}
+
+// ── Sibling count chips (pinned main row only) ─────────────────
+
+function SiblingCountChips({
+  projectId,
+  excludeId
+}: {
+  projectId: string
+  excludeId: string
+}): React.JSX.Element | null {
+  const { working, ready, waiting } = useSiblingAggregate(projectId, excludeId)
+
+  if (working.count === 0 && ready.count === 0 && waiting.count === 0) return null
+
+  return (
+    <>
+      {working.count > 0 && (
+        <SiblingChip
+          bucket={working}
+          icon={<Loader2 className="h-2.5 w-2.5 text-primary animate-spin" />}
+          testId="pinned-sibling-working"
+        />
+      )}
+      {ready.count > 0 && (
+        <SiblingChip
+          bucket={ready}
+          icon={<CheckCircle2 className="h-2.5 w-2.5 text-green-400" />}
+          testId="pinned-sibling-ready"
+        />
+      )}
+      {waiting.count > 0 && (
+        <SiblingChip
+          bucket={waiting}
+          icon={<AlertCircle className="h-2.5 w-2.5 text-amber-500" />}
+          testId="pinned-sibling-waiting"
+        />
+      )}
+    </>
+  )
+}
+
+function SiblingChip({
+  bucket,
+  icon,
+  testId
+}: {
+  bucket: SiblingBucket
+  icon: React.ReactNode
+  testId: string
+}): React.JSX.Element {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="ml-1.5 inline-flex items-center gap-0.5 text-[11px] tabular-nums text-muted-foreground shrink-0"
+          data-testid={testId}
+        >
+          {icon}
+          {bucket.count}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {bucket.names.map((n) => (
+          <div key={n}>{n}</div>
+        ))}
+      </TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/src/renderer/src/hooks/useSiblingAggregate.ts
+++ b/src/renderer/src/hooks/useSiblingAggregate.ts
@@ -1,0 +1,111 @@
+import { useMemo } from 'react'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useGitStore } from '@/stores/useGitStore'
+
+export interface SiblingBucket {
+  count: number
+  names: string[]
+}
+
+export interface SiblingAggregate {
+  working: SiblingBucket
+  ready: SiblingBucket
+  waiting: SiblingBucket
+}
+
+const EMPTY_BUCKET: SiblingBucket = { count: 0, names: [] }
+const EMPTY_AGGREGATE: SiblingAggregate = {
+  working: EMPTY_BUCKET,
+  ready: EMPTY_BUCKET,
+  waiting: EMPTY_BUCKET
+}
+
+/**
+ * Aggregates status counts across all non-default, non-archiving siblings of a project,
+ * grouped into three buckets used by the pinned main-branch row dashboard:
+ *
+ *   - working: working | planning
+ *   - ready:   completed
+ *   - waiting: answering | permission | command_approval | plan_ready
+ *
+ * Siblings with status `unread` or `null` (idle) are not counted.
+ *
+ * Reactivity: subscribes to every store slice whose change could affect the result
+ * (sessionStatuses, sessionsByWorktree, connections, branchInfoByWorktree, worktrees,
+ * archivingWorktreeIds). The per-sibling `getWorktreeStatus(...)` call is a one-shot
+ * read against `.getState()`, which is safe because all of its inputs are subscribed
+ * to above, so the enclosing useMemo re-runs whenever any of them changes.
+ */
+export function useSiblingAggregate(
+  projectId: string,
+  excludeWorktreeId: string
+): SiblingAggregate {
+  const worktrees = useWorktreeStore((s) => s.worktreesByProject.get(projectId))
+  const archivingWorktreeIds = useWorktreeStore((s) => s.archivingWorktreeIds)
+  const sessionStatuses = useWorktreeStatusStore((s) => s.sessionStatuses)
+  const sessionsByWorktree = useSessionStore((s) => s.sessionsByWorktree)
+  const connections = useConnectionStore((s) => s.connections)
+  const branchInfoByWorktree = useGitStore((s) => s.branchInfoByWorktree)
+
+  return useMemo<SiblingAggregate>(() => {
+    if (!worktrees || worktrees.length === 0) return EMPTY_AGGREGATE
+
+    const working: string[] = []
+    const ready: string[] = []
+    const waiting: string[] = []
+
+    for (const w of worktrees) {
+      if (w.id === excludeWorktreeId) continue
+      if (w.is_default) continue
+      if (archivingWorktreeIds.has(w.id)) continue
+
+      const status = useWorktreeStatusStore.getState().getWorktreeStatus(w.id)
+      if (!status) continue
+
+      const displayName = branchInfoByWorktree.get(w.path)?.name ?? w.name
+
+      switch (status) {
+        case 'working':
+        case 'planning':
+          working.push(displayName)
+          break
+        case 'completed':
+          ready.push(displayName)
+          break
+        case 'answering':
+        case 'permission':
+        case 'command_approval':
+        case 'plan_ready':
+          waiting.push(displayName)
+          break
+        // unread + idle (null) are intentionally skipped
+        default:
+          break
+      }
+    }
+
+    return {
+      working: { count: working.length, names: working },
+      ready: { count: ready.length, names: ready },
+      waiting: { count: waiting.length, names: waiting }
+    }
+    // `sessionStatuses`, `sessionsByWorktree`, and `connections` are not referenced
+    // directly inside this useMemo, but `getWorktreeStatus()` reads them via
+    // `.getState()`. We list them here so that a change in any of them triggers
+    // a recomputation of the aggregate. `projectId` drives the outer selector
+    // for `worktrees` but is also listed for clarity and stability of intent.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    projectId,
+    excludeWorktreeId,
+    worktrees,
+    archivingWorktreeIds,
+    sessionStatuses,
+    sessionsByWorktree,
+    connections,
+    branchInfoByWorktree
+  ])
+}


### PR DESCRIPTION
## Summary

- Adds `useSiblingAggregate` hook to aggregate status counts across non-default sibling worktrees
- Groups siblings into three status buckets: `working`, `ready`, and `waiting`
- Displays sibling count chips on the pinned main-branch (default) worktree row
- Each chip shows icon, count, and tooltip with sibling names on hover
- Only shows chips when there are non-idle siblings with actionable statuses

## Testing

- Verify sibling count chips appear only on the default/main-branch pinned item
- Check that chips show correct counts for each status bucket (working/ready/waiting)
- Confirm chips display correct icons (spinner for working, checkmark for ready, alert for waiting)
- Verify tooltip displays all sibling names in the bucket on hover
- Test that chips disappear when all siblings are archived or in idle state
- Verify chips update reactively when sibling statuses change
- Check that excluded worktree and archiving worktrees are not counted
- Confirm branch display names are used from git info when available

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds derived status aggregation for sibling worktrees; main concerns are correctness/performance of the new memoized aggregation when store slices update frequently.
> 
> **Overview**
> Shows *sibling worktree status summaries* on the pinned **default/main** worktree row via small count “chips” (working/ready/waiting) with icons and tooltips listing the sibling names.
> 
> Introduces a new `useSiblingAggregate` hook that scans a project’s non-default, non-archiving worktrees (excluding the current one), buckets them by `getWorktreeStatus()` into working/ready/waiting, and uses git branch info when available for display names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c28f3345d45043a26c282fd4532ca90f9e893c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->