### PR TITLE
Prevent tab retap from resetting session state

### DIFF
--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -893,6 +893,13 @@ export function SessionTabs(): React.JSX.Element | null {
 
   // Handle clicking a session tab - deactivate file tab and clear unread status
   const handleSessionTabClick = (sessionId: string) => {
+    const isAlreadyPresentedSession =
+      activeSessionId === sessionId && activeFilePath === null && !inlineConnectionSessionId
+
+    if (isAlreadyPresentedSession) {
+      return
+    }
+
     setActiveFile(null)
     clearInlineConnectionSession()
     if (isConnectionMode) {
@@ -905,6 +912,13 @@ export function SessionTabs(): React.JSX.Element | null {
 
   // Handle clicking a sticky connection session tab (inline viewing in worktree mode)
   const handleConnectionSessionTabClick = (sessionId: string) => {
+    const isAlreadyPresentedConnectionSession =
+      inlineConnectionSessionId === sessionId && activeFilePath === null
+
+    if (isAlreadyPresentedConnectionSession) {
+      return
+    }
+
     setActiveFile(null)
     setInlineConnectionSession(sessionId)
     useWorktreeStatusStore.getState().clearSessionStatus(sessionId)

--- a/test/phase-19/session-8/tab-context-ui.test.tsx
+++ b/test/phase-19/session-8/tab-context-ui.test.tsx
@@ -222,6 +222,34 @@ describe('Session 8: Tab Context Menus UI', () => {
     })
   })
 
+  describe('Session tab click behavior', () => {
+    test('clicking the already presented session tab is a noop and preserves status', () => {
+      useWorktreeStatusStore.getState().setSessionStatus('s1', 'working')
+
+      render(<SessionTabs />)
+
+      fireEvent.click(screen.getByTestId('session-tab-s1'))
+
+      expect(useWorktreeStatusStore.getState().sessionStatuses.s1?.status).toBe('working')
+      expect(screen.getByTestId('tab-spinner-s1')).toBeInTheDocument()
+    })
+
+    test('clicking the active session tab while a file tab is foregrounded restores the session view', () => {
+      setupStores({ fileTabs: true })
+      useWorktreeStatusStore.getState().setSessionStatus('s1', 'working')
+      useFileViewerStore.setState({
+        activeFilePath: '/test/project/worktree/src/app.ts'
+      })
+
+      render(<SessionTabs />)
+
+      fireEvent.click(screen.getByTestId('session-tab-s1'))
+
+      expect(useFileViewerStore.getState().activeFilePath).toBeNull()
+      expect(useWorktreeStatusStore.getState().sessionStatuses.s1).toBeNull()
+    })
+  })
+
   describe('board assistant tab focus', () => {
     test('clicking the board assistant tab clears file focus and activates the assistant', () => {
       setupStores({ fileTabs: true })


### PR DESCRIPTION
## Summary

- Add early return in `handleSessionTabClick` when clicking an already-active session tab with no file tab open
- Add early return in `handleConnectionSessionTabClick` when clicking an already-active connection session tab with no file tab open
- Preserves session status (e.g., 'working') instead of clearing it on redundant clicks
- Allows retapping a session tab to restore it when a file tab is foregrounded

## Testing

- ✅ Clicking an already-presented session tab is a noop and preserves status
- ✅ Clicking the active session tab while a file tab is foregrounded restores the session view
- ✅ No regression in existing tab switching behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state tweak that only changes tab-click behavior by adding early-return guards; main risk is subtle regressions in edge cases around session/file focus transitions.
> 
> **Overview**
> Prevents redundant clicks on an already-presented session (or inline connection session) tab from resetting the view and clearing that session’s status.
> 
> Keeps the existing behavior when a file tab is foregrounded: clicking the active session tab still clears file focus to restore the session view, and status is cleared only on actual view transitions. Adds tests covering the noop retap case and the “restore session from file view” case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f42111d0be9e58f8b96673fe1a6437e31e5ab8bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->