### PR TITLE
Skip notification for queued messages

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -404,6 +404,15 @@ function registerSystemHandlers(openCodeLaunchSpec: OpenCodeLaunchSpec | null): 
     return process.platform
   })
 
+  // Mirror renderer-side follow-up message queue state into the main process so
+  // notification-service can suppress session-complete notifications while more
+  // queued messages are about to be auto-sent.
+  ipcMain.handle(
+    'notification:setSessionQueuedState',
+    (_event, sessionId: string, hasQueued: boolean) => {
+      notificationService.setSessionQueuedState(sessionId, hasQueued)
+    }
+  )
 }
 
 // Register response logging IPC handlers (only when --log is active)

--- a/src/main/services/notification-service.ts
+++ b/src/main/services/notification-service.ts
@@ -14,6 +14,7 @@ interface SessionNotificationData {
 class NotificationService {
   private mainWindow: BrowserWindow | null = null
   private unreadCount = 0
+  private sessionsWithQueuedMessages = new Set<string>()
 
   setMainWindow(window: BrowserWindow): void {
     this.mainWindow = window
@@ -25,6 +26,15 @@ class NotificationService {
   }
 
   showSessionComplete(data: SessionNotificationData): void {
+    if (this.sessionsWithQueuedMessages.has(data.sessionId)) {
+      log.info('Skipping session complete notification: session has queued follow-up messages', {
+        sessionId: data.sessionId,
+        projectName: data.projectName,
+        sessionName: data.sessionName
+      })
+      return
+    }
+
     if (!Notification.isSupported()) {
       log.warn('Notifications not supported on this platform')
       return
@@ -61,6 +71,17 @@ class NotificationService {
       app.dock?.setBadge(String(this.unreadCount))
     } else {
       app.setBadgeCount(this.unreadCount)
+    }
+  }
+
+  // Track which sessions currently have queued follow-up messages so that
+  // `showSessionComplete` can suppress notifications while the session is
+  // about to continue with the next queued message.
+  setSessionQueuedState(sessionId: string, hasQueued: boolean): void {
+    if (hasQueued) {
+      this.sessionsWithQueuedMessages.add(sessionId)
+    } else {
+      this.sessionsWithQueuedMessages.delete(sessionId)
     }
   }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -599,6 +599,7 @@ declare global {
       onMenuAction: (channel: string, callback: () => void) => () => void
       isPackaged: () => Promise<boolean>
       getPlatform: () => Promise<string>
+      setSessionQueuedState: (sessionId: string, hasQueued: boolean) => Promise<void>
     }
     loggingOps: {
       createResponseLog: (sessionId: string) => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -548,7 +548,13 @@ const systemOps = {
   isPackaged: (): Promise<boolean> => ipcRenderer.invoke('system:isPackaged'),
 
   // Get the current platform (darwin, win32, linux)
-  getPlatform: (): Promise<string> => ipcRenderer.invoke('system:getPlatform')
+  getPlatform: (): Promise<string> => ipcRenderer.invoke('system:getPlatform'),
+
+  // Push the renderer's follow-up-message queue state into the main process so
+  // `notificationService.showSessionComplete` can suppress notifications while
+  // more queued messages are about to be auto-sent.
+  setSessionQueuedState: (sessionId: string, hasQueued: boolean): Promise<void> =>
+    ipcRenderer.invoke('notification:setSessionQueuedState', sessionId, hasQueued)
 }
 
 // Response logging operations API (only functional when --log is active)

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -6,6 +6,23 @@ import { notifyKanbanSessionSync, notifyKanbanNewSession } from './store-coordin
 import { useSettingsStore } from './useSettingsStore'
 import { getUnavailableAgentSdkMessage } from '@/lib/agent-sdk-availability'
 
+/**
+ * Push the follow-up-message queue state for a session into the main process
+ * via IPC. Main uses this to suppress session-complete notifications while
+ * more queued messages are about to be auto-sent.
+ *
+ * Fire-and-forget: swallows errors because the IPC surface may be absent in
+ * test harnesses and a failure here must not block queue mutations.
+ */
+const pushQueuedState = (sessionId: string, hasQueued: boolean): void => {
+  // Optional chaining short-circuits to `undefined` if `window.systemOps` or the
+  // method are missing (test harness), and `?.catch` short-circuits in turn — so
+  // this single expression covers both the "IPC surface absent" and "IPC rejects"
+  // cases. An IPC failure just falls back to the default (show notification),
+  // which is the safer behavior.
+  window.systemOps?.setSessionQueuedState?.(sessionId, hasQueued)?.catch?.(() => {})
+}
+
 export const BOARD_TAB_ID = '__board__'
 export const BOARD_ASSISTANT_SESSION_NAME_PREFIX = '[Board Assistant]'
 
@@ -600,6 +617,11 @@ export const useSessionStore = create<SessionState>()(
             const newConnectionSessionsMap = new Map(state.sessionsByConnection)
             const newConnectionTabOrderMap = new Map(state.tabOrderByConnection)
             const newOrphanedSessions = new Map(state.orphanedSessions)
+            // Clone up-front so both the orphan early-return and the main path
+            // drop any queued follow-up messages for the closed session — keeping
+            // the renderer map consistent with the main-process `Set` cleared below.
+            const newPendingFollowUps = new Map(state.pendingFollowUpMessages)
+            newPendingFollowUps.delete(sessionId)
             let newActiveSessionId = state.activeSessionId
 
             // Check if this is an orphaned session
@@ -610,7 +632,8 @@ export const useSessionStore = create<SessionState>()(
               }
               return {
                 orphanedSessions: newOrphanedSessions,
-                activeSessionId: newActiveSessionId
+                activeSessionId: newActiveSessionId,
+                pendingFollowUpMessages: newPendingFollowUps
               }
             }
 
@@ -711,11 +734,13 @@ export const useSessionStore = create<SessionState>()(
               activeSessionByConnection: newActiveByConnection,
               closedTerminalSessionIds: newClosedTerminals,
               pinnedSessionIds: newPinnedIds,
+              pendingFollowUpMessages: newPendingFollowUps,
               activePinnedSessionId:
                 state.activePinnedSessionId === sessionId ? null : state.activePinnedSessionId
             }
           })
 
+          pushQueuedState(sessionId, false)
           return { success: true }
         } catch (error) {
           return {
@@ -1478,6 +1503,7 @@ export const useSessionStore = create<SessionState>()(
           newMap.set(sessionId, [...messages])
           return { pendingFollowUpMessages: newMap }
         })
+        pushQueuedState(sessionId, messages.length > 0)
       },
 
       // Dequeue (pop first) a follow-up message for a session
@@ -1496,6 +1522,7 @@ export const useSessionStore = create<SessionState>()(
           }
           return { pendingFollowUpMessages: newMap }
         })
+        pushQueuedState(sessionId, rest.length > 0)
         return first
       },
 
@@ -1507,6 +1534,7 @@ export const useSessionStore = create<SessionState>()(
           newMap.set(sessionId, [message, ...existing])
           return { pendingFollowUpMessages: newMap }
         })
+        pushQueuedState(sessionId, true)
       },
 
       // Consume (pop first) a follow-up message for a session
@@ -1521,6 +1549,7 @@ export const useSessionStore = create<SessionState>()(
           newMap.set(sessionId, [...existing, message])
           return { pendingFollowUpMessages: newMap }
         })
+        pushQueuedState(sessionId, true)
       },
 
       // Close all sessions except the kept one

--- a/test/phase-23/session-1/notification-queued-suppression.test.ts
+++ b/test/phase-23/session-1/notification-queued-suppression.test.ts
@@ -1,0 +1,249 @@
+import { vi, describe, test, expect, beforeEach } from 'vitest'
+
+// -----------------------------------------------------------------------------
+// Suite 1 setup: mock electron + logger BEFORE importing notificationService.
+// Pattern copied from test/phase-14/session-6/dock-badge.test.ts.
+// -----------------------------------------------------------------------------
+
+const mockSetBadge = vi.fn()
+const mockNotificationShow = vi.fn()
+const mockNotificationOn = vi.fn()
+let notificationsSupported = true
+
+vi.mock('electron', () => ({
+  Notification: class MockNotification {
+    static isSupported(): boolean {
+      return notificationsSupported
+    }
+    constructor(_opts: Record<string, unknown>) {}
+    on = mockNotificationOn
+    show = mockNotificationShow
+  },
+  BrowserWindow: vi.fn(),
+  app: {
+    getPath: () => '/tmp/test-home',
+    dock: {
+      setBadge: (...args: string[]) => mockSetBadge(...args)
+    }
+  }
+}))
+
+vi.mock('../../../src/main/services/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+// Import AFTER mocks so notificationService resolves the mocked electron module.
+import { notificationService } from '../../../src/main/services/notification-service'
+import type { BrowserWindow } from 'electron'
+import { useSessionStore } from '../../../src/renderer/src/stores/useSessionStore'
+
+const mockSessionData = {
+  projectName: 'Test Project',
+  sessionName: 'Test Session',
+  projectId: 'proj-1',
+  worktreeId: 'wt-1',
+  sessionId: 'sess-1'
+}
+
+function createMockWindow(): { window: BrowserWindow; triggerFocus: () => void } {
+  let focusHandler: (() => void) | undefined
+  const mockWindow = {
+    on: vi.fn((event: string, handler: () => void) => {
+      if (event === 'focus') focusHandler = handler
+    })
+  } as unknown as BrowserWindow
+  return {
+    window: mockWindow,
+    triggerFocus: () => focusHandler?.()
+  }
+}
+
+// Clear accumulated unread count + any previous queued-state for the IDs this
+// suite uses. The notificationService is a module singleton, so state from a
+// prior test in the same file leaks unless we explicitly clear it. Cross-file
+// isolation relies on vitest's default `isolate: true`, which gives each test
+// file a fresh module graph.
+function resetNotificationServiceState(): void {
+  const { window, triggerFocus } = createMockWindow()
+  notificationService.setMainWindow(window)
+  triggerFocus() // Clear unread count via the focus handler we just registered
+  notificationService.setSessionQueuedState('s1', false)
+  notificationService.setSessionQueuedState('s2', false)
+  vi.clearAllMocks()
+}
+
+describe('Phase 23 · Session 1: NotificationService queued-state suppression', () => {
+  beforeEach(() => {
+    notificationsSupported = true
+    resetNotificationServiceState()
+  })
+
+  test('showSessionComplete suppresses notification + badge when session has queued messages', () => {
+    notificationService.setSessionQueuedState('s1', true)
+
+    notificationService.showSessionComplete({ ...mockSessionData, sessionId: 's1' })
+
+    expect(mockNotificationShow).not.toHaveBeenCalled()
+    expect(mockSetBadge).not.toHaveBeenCalled()
+  })
+
+  test('showSessionComplete fires notification after setSessionQueuedState("s1", false)', () => {
+    notificationService.setSessionQueuedState('s1', true)
+    notificationService.setSessionQueuedState('s1', false)
+
+    notificationService.showSessionComplete({ ...mockSessionData, sessionId: 's1' })
+
+    expect(mockNotificationShow).toHaveBeenCalledTimes(1)
+    expect(mockSetBadge).toHaveBeenCalledWith('1')
+  })
+
+  test('suppression is per-session — setting "s1" does not affect "s2"', () => {
+    notificationService.setSessionQueuedState('s1', true)
+
+    notificationService.showSessionComplete({ ...mockSessionData, sessionId: 's2' })
+
+    expect(mockNotificationShow).toHaveBeenCalledTimes(1)
+    expect(mockSetBadge).toHaveBeenCalledWith('1')
+  })
+
+  test('redundant setSessionQueuedState("s1", true) calls are idempotent', () => {
+    notificationService.setSessionQueuedState('s1', true)
+    notificationService.setSessionQueuedState('s1', true)
+
+    // Still suppressed after two "true" pushes.
+    notificationService.showSessionComplete({ ...mockSessionData, sessionId: 's1' })
+    expect(mockNotificationShow).not.toHaveBeenCalled()
+    expect(mockSetBadge).not.toHaveBeenCalled()
+
+    // A single "false" is enough to restore firing — the internal Set
+    // removes the ID once, regardless of how many times `true` was pushed.
+    notificationService.setSessionQueuedState('s1', false)
+    notificationService.showSessionComplete({ ...mockSessionData, sessionId: 's1' })
+
+    expect(mockNotificationShow).toHaveBeenCalledTimes(1)
+    expect(mockSetBadge).toHaveBeenCalledWith('1')
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Suite 2: Zustand store mutators push queued-state into the main-process IPC.
+// -----------------------------------------------------------------------------
+
+describe('Phase 23 · Session 1: Zustand queue → IPC push', () => {
+  let mockSetSessionQueuedState: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockSetSessionQueuedState = vi.fn().mockResolvedValue(undefined)
+
+    // test/setup.ts already defines window.systemOps with writable:true,
+    // configurable:true. We only need to overwrite the one method we assert on,
+    // leaving every other mock (onNotificationNavigate etc.) intact.
+    ;(window as unknown as {
+      systemOps: { setSessionQueuedState: typeof mockSetSessionQueuedState }
+    }).systemOps.setSessionQueuedState = mockSetSessionQueuedState
+
+    // Reset only the slices this suite touches. Other slices (connection,
+    // orphaned, board-assistant, etc.) keep their initial Map/Set values from
+    // the module's create() call, so we don't need to clobber them.
+    useSessionStore.setState({
+      pendingFollowUpMessages: new Map(),
+      sessionsByWorktree: new Map(),
+      tabOrderByWorktree: new Map(),
+      activeSessionId: null,
+      activeSessionByWorktree: {}
+    })
+  })
+
+  test('enqueueFollowUpMessage("s1", "msg1") pushes ("s1", true)', () => {
+    useSessionStore.getState().enqueueFollowUpMessage('s1', 'msg1')
+
+    expect(mockSetSessionQueuedState).toHaveBeenCalledWith('s1', true)
+    expect(mockSetSessionQueuedState).toHaveBeenCalledTimes(1)
+  })
+
+  test('after two enqueues, dequeueFollowUpMessage("s1") pushes ("s1", true) (queue still non-empty)', () => {
+    useSessionStore.getState().enqueueFollowUpMessage('s1', 'msg1')
+    useSessionStore.getState().enqueueFollowUpMessage('s1', 'msg2')
+
+    mockSetSessionQueuedState.mockClear()
+
+    const popped = useSessionStore.getState().dequeueFollowUpMessage('s1')
+
+    expect(popped).toBe('msg1')
+    expect(mockSetSessionQueuedState).toHaveBeenCalledWith('s1', true)
+    expect(mockSetSessionQueuedState).toHaveBeenCalledTimes(1)
+  })
+
+  test('last dequeueFollowUpMessage that empties the queue pushes ("s1", false)', () => {
+    useSessionStore.getState().enqueueFollowUpMessage('s1', 'only-msg')
+
+    mockSetSessionQueuedState.mockClear()
+
+    const popped = useSessionStore.getState().dequeueFollowUpMessage('s1')
+
+    expect(popped).toBe('only-msg')
+    expect(mockSetSessionQueuedState).toHaveBeenCalledWith('s1', false)
+    expect(mockSetSessionQueuedState).toHaveBeenCalledTimes(1)
+  })
+
+  test('requeueFollowUpMessageFront("s1", "msg") pushes ("s1", true)', () => {
+    useSessionStore.getState().requeueFollowUpMessageFront('s1', 'msg')
+
+    expect(mockSetSessionQueuedState).toHaveBeenCalledWith('s1', true)
+    expect(mockSetSessionQueuedState).toHaveBeenCalledTimes(1)
+  })
+
+  test('setPendingFollowUpMessages pushes true for non-empty and false for empty', () => {
+    useSessionStore.getState().setPendingFollowUpMessages('s1', ['a', 'b'])
+    expect(mockSetSessionQueuedState).toHaveBeenLastCalledWith('s1', true)
+
+    useSessionStore.getState().setPendingFollowUpMessages('s1', [])
+    expect(mockSetSessionQueuedState).toHaveBeenLastCalledWith('s1', false)
+
+    expect(mockSetSessionQueuedState).toHaveBeenCalledTimes(2)
+  })
+
+  test('closeSession("s1") pushes ("s1", false) and clears the map entry', async () => {
+    // closeSession hits window.db.session.update regardless of whether it finds
+    // the session in any map, so we need that method to resolve. The rest of
+    // closeSession's DB surface is not exercised for a non-terminal session
+    // with no opencode_session_id.
+    Object.defineProperty(window, 'db', {
+      writable: true,
+      configurable: true,
+      value: {
+        session: {
+          update: vi.fn().mockResolvedValue({ id: 's1', status: 'completed' })
+        }
+      }
+    })
+
+    // Seed a queued message so we can assert the entry is removed afterwards.
+    useSessionStore.getState().enqueueFollowUpMessage('s1', 'pending-msg')
+    mockSetSessionQueuedState.mockClear()
+
+    await useSessionStore.getState().closeSession('s1')
+
+    expect(mockSetSessionQueuedState).toHaveBeenCalledWith('s1', false)
+    expect(useSessionStore.getState().pendingFollowUpMessages.has('s1')).toBe(false)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Suite 3: Smoke test — preload IPC surface exposes the expected method shape.
+// test/setup.ts provides window.systemOps.setSessionQueuedState globally.
+// -----------------------------------------------------------------------------
+
+describe('Phase 23 · Session 1: Preload IPC contract', () => {
+  test('window.systemOps.setSessionQueuedState exists and is callable', async () => {
+    expect(typeof window.systemOps.setSessionQueuedState).toBe('function')
+
+    const result = window.systemOps.setSessionQueuedState('s1', true)
+    expect(result).toBeInstanceOf(Promise)
+    await expect(result).resolves.toBeUndefined()
+  })
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -122,7 +122,8 @@ if (typeof window !== 'undefined') {
         onWindowFocused: vi.fn().mockReturnValue(() => {}),
         updateMenuState: vi.fn().mockResolvedValue(undefined),
         isPackaged: vi.fn().mockResolvedValue(false),
-        getPlatform: vi.fn().mockResolvedValue('darwin')
+        getPlatform: vi.fn().mockResolvedValue('darwin'),
+        setSessionQueuedState: vi.fn().mockResolvedValue(undefined)
       }
     })
   }


### PR DESCRIPTION
## Summary

- Add `NotificationService.setSessionQueuedState()` to track sessions with pending follow-up messages
- Suppress session-complete notifications and badge updates when a session has queued messages awaiting auto-send
- Introduce `window.systemOps.setSessionQueuedState()` IPC method to push renderer queue state to main process
- Update `useSessionStore` queue mutators (`enqueue`, `dequeue`, `requeue`, `setPending`) to push state changes via IPC
- Clear queued state in `closeSession()` to maintain consistency between renderer and main process
- Implement fire-and-forget error handling for IPC calls to tolerate test harnesses lacking the surface

## Testing

- Unit tests for `NotificationService` verify suppression per-session and idempotency of state transitions
- Unit tests for Zustand mutators verify each queue operation pushes the correct state (true/false) based on remaining queue length
- Integration test verifies `closeSession()` clears both the queue entry and notifies main process
- Smoke test confirms `window.systemOps.setSessionQueuedState` exists and returns a Promise
- Manual verification: queue a follow-up message, verify no notification fires; dequeue it, verify notification fires on session complete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Electron main/renderer IPC and notification/badge behavior; mistakes could cause missed or extra notifications, but the change is scoped and covered by new unit tests.
> 
> **Overview**
> Prevents noisy “session complete” notifications when a session is about to continue: `NotificationService` now tracks sessions with queued follow-up messages and skips both the native notification and badge increment for those sessions.
> 
> Adds a new IPC contract (`window.systemOps.setSessionQueuedState` → `notification:setSessionQueuedState`) so the renderer can mirror follow-up queue state into the main process, and updates `useSessionStore` queue mutators (and `closeSession`) to push state changes and clear queued entries. Includes new Vitest coverage for per-session suppression/idempotency and for verifying the store mutators/IPC contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e8693736d9725ddb2d9920e6b8962c5640a4761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->