### PR TITLE
feat(sessions): add TaskListWidget with dynamic positioning and settings integration

### DIFF
--- a/src/renderer/src/components/kanban/SessionStreamPanel.tsx
+++ b/src/renderer/src/components/kanban/SessionStreamPanel.tsx
@@ -1,7 +1,10 @@
-import { useRef, useState, useCallback, useEffect } from 'react'
+import { useRef, useState, useCallback, useEffect, useMemo } from 'react'
 import { useSessionStream } from '@/hooks/useSessionStream'
 import { MessageRenderer } from '@/components/sessions/MessageRenderer'
 import { ScrollToBottomFab } from '@/components/sessions/ScrollToBottomFab'
+import { TaskListWidget } from '@/components/sessions/TaskListWidget'
+import { useLatestTodoList } from '@/components/sessions/useLatestTodoList'
+import { BASELINE_TOP_PX } from '@/components/sessions/usePRStackTopOffset'
 import type { OpenCodeMessage } from '@/components/sessions/SessionView'
 
 export interface SessionStreamPanelProps {
@@ -156,6 +159,20 @@ export function SessionStreamPanel({
 
   const hasStreamingContent = streamingParts.length > 0 || streamingContent.length > 0
 
+  const streamingMessage = useMemo<OpenCodeMessage | null>(() => {
+    if (!hasStreamingContent) return null
+    return {
+      id: 'streaming',
+      role: 'assistant',
+      content: streamingContent,
+      timestamp: new Date().toISOString(),
+      parts: streamingParts
+    }
+  }, [hasStreamingContent, streamingContent, streamingParts])
+
+  const { todos: latestTodos, isIncomplete: latestTodosIncomplete } =
+    useLatestTodoList(messages, streamingMessage)
+
   return (
     <div className={`flex flex-col h-full bg-background flex-1 min-w-0${fullWidth ? '' : ' border-l border-border/60'}`}>
       {/* Header */}
@@ -200,17 +217,9 @@ export function SessionStreamPanel({
             ))}
 
             {/* Streaming message rendered separately */}
-            {hasStreamingContent && (
+            {streamingMessage && (
               <MessageRenderer
-                message={
-                  {
-                    id: 'streaming',
-                    role: 'assistant',
-                    content: streamingContent,
-                    timestamp: new Date().toISOString(),
-                    parts: streamingParts
-                  } as OpenCodeMessage
-                }
+                message={streamingMessage}
                 isStreaming={isStreaming}
                 cwd={worktreePath}
               />
@@ -218,6 +227,10 @@ export function SessionStreamPanel({
 
             <div ref={messagesEndRef} />
           </div>
+        )}
+
+        {latestTodos && latestTodosIncomplete && (
+          <TaskListWidget todos={latestTodos} topOffsetPx={BASELINE_TOP_PX} />
         )}
 
         <ScrollToBottomFab

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -42,6 +42,8 @@ import { FileMentionPopover } from './FileMentionPopover'
 import { ScrollToBottomFab } from './ScrollToBottomFab'
 import { PlanReadyImplementFab } from './PlanReadyImplementFab'
 import { IndeterminateProgressBar } from './IndeterminateProgressBar'
+import { TaskListWidget } from './TaskListWidget'
+import { useLatestTodoList } from './useLatestTodoList'
 import { useFileMentions } from '@/hooks/useFileMentions'
 import { useSessionTimer } from '@/hooks/useSessionTimer'
 import { useBashRuns } from '@/hooks/useBashRuns'
@@ -70,6 +72,7 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { usePRReviewStore } from '@/stores/usePRReviewStore'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
 import { useFileTreeStore } from '@/stores/useFileTreeStore'
 import { mapOpencodeMessagesToSessionViewMessages } from '@/lib/opencode-transcript'
 import { appendStreamedAssistantFallback } from '@/lib/transcript-refresh'
@@ -5478,6 +5481,11 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     }
   }, [hasStreamingContent, sessionRecord?.agent_sdk, streamingContent, streamingParts])
 
+  const { todos: latestTodos, isIncomplete: latestTodosIncomplete } =
+    useLatestTodoList(visibleMessages, streamingMessage)
+  const prNotificationCount = usePRNotificationStore((s) => s.notifications.length)
+  const taskListTopOffsetClass = prNotificationCount > 0 ? 'top-20' : 'top-4'
+
   const handleRedoRevert = useCallback(() => {
     setInputValue('/redo')
     inputValueRef.current = '/redo'
@@ -5686,6 +5694,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
             />
           )}
         </div>
+        {latestTodos && latestTodosIncomplete && (
+          <TaskListWidget todos={latestTodos} topOffsetClass={taskListTopOffsetClass} />
+        )}
         <PlanReadyImplementFab
           onImplement={handlePlanReadyImplement}
           onHandoff={handlePlanReadyHandoff}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -44,6 +44,7 @@ import { PlanReadyImplementFab } from './PlanReadyImplementFab'
 import { IndeterminateProgressBar } from './IndeterminateProgressBar'
 import { TaskListWidget } from './TaskListWidget'
 import { useLatestTodoList } from './useLatestTodoList'
+import { usePRStackTopOffset } from './usePRStackTopOffset'
 import { useFileMentions } from '@/hooks/useFileMentions'
 import { useSessionTimer } from '@/hooks/useSessionTimer'
 import { useBashRuns } from '@/hooks/useBashRuns'
@@ -72,7 +73,6 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { usePRReviewStore } from '@/stores/usePRReviewStore'
-import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
 import { useFileTreeStore } from '@/stores/useFileTreeStore'
 import { mapOpencodeMessagesToSessionViewMessages } from '@/lib/opencode-transcript'
 import { appendStreamedAssistantFallback } from '@/lib/transcript-refresh'
@@ -5483,8 +5483,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
   const { todos: latestTodos, isIncomplete: latestTodosIncomplete } =
     useLatestTodoList(visibleMessages, streamingMessage)
-  const prNotificationCount = usePRNotificationStore((s) => s.notifications.length)
-  const taskListTopOffsetClass = prNotificationCount > 0 ? 'top-20' : 'top-4'
+  const taskListTopOffsetPx = usePRStackTopOffset()
 
   const handleRedoRevert = useCallback(() => {
     setInputValue('/redo')
@@ -5695,7 +5694,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           )}
         </div>
         {latestTodos && latestTodosIncomplete && (
-          <TaskListWidget todos={latestTodos} topOffsetClass={taskListTopOffsetClass} />
+          <TaskListWidget todos={latestTodos} topOffsetPx={taskListTopOffsetPx} />
         )}
         <PlanReadyImplementFab
           onImplement={handlePlanReadyImplement}

--- a/src/renderer/src/components/sessions/TaskListWidget.tsx
+++ b/src/renderer/src/components/sessions/TaskListWidget.tsx
@@ -1,0 +1,82 @@
+import { ChevronDown, ChevronUp, ListTodo } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { PriorityBadge, StatusIcon, type TodoItem } from './tools/todoIcons'
+
+export interface TaskListWidgetProps {
+  todos: TodoItem[]
+  topOffsetClass: string
+}
+
+export function TaskListWidget({
+  todos,
+  topOffsetClass
+}: TaskListWidgetProps): React.JSX.Element {
+  const collapsed = useSettingsStore((s) => s.taskListCollapsed)
+  const updateSetting = useSettingsStore((s) => s.updateSetting)
+
+  const completed = todos.filter((t) => t.status === 'completed').length
+  const total = todos.length
+
+  return (
+    <div
+      data-testid="task-list-widget"
+      className={`absolute right-4 ${topOffsetClass} z-20 w-72 rounded-lg border border-border bg-background/95 backdrop-blur shadow-md transition-all duration-150`}
+    >
+      {collapsed ? (
+        <button
+          type="button"
+          data-testid="task-list-widget-toggle"
+          onClick={() => updateSetting('taskListCollapsed', false)}
+          className="px-3 py-2 flex items-center gap-2 cursor-pointer w-full text-left"
+          aria-label="Expand task list"
+        >
+          <ListTodo className="h-4 w-4 shrink-0" />
+          <span className="text-sm font-medium">
+            {completed}/{total}
+          </span>
+          <ChevronDown className="h-4 w-4 shrink-0 ml-auto" />
+        </button>
+      ) : (
+        <>
+          <button
+            type="button"
+            data-testid="task-list-widget-toggle"
+            onClick={() => updateSetting('taskListCollapsed', true)}
+            className="px-3 py-2 flex items-center gap-2 cursor-pointer border-b border-border w-full text-left"
+            aria-label="Collapse task list"
+          >
+            <span className="text-sm font-medium">Tasks</span>
+            <span className="ml-auto text-sm text-muted-foreground">
+              {completed}/{total}
+            </span>
+            <ChevronUp className="h-4 w-4 shrink-0" />
+          </button>
+          <div className="max-h-[60vh] overflow-y-auto p-2 space-y-0.5">
+            {todos.map((todo) => (
+              <div
+                key={todo.id}
+                className={cn(
+                  'flex items-center gap-2 py-0.5 px-1 rounded-sm text-xs',
+                  todo.status === 'in_progress' && 'bg-blue-500/5'
+                )}
+              >
+                <StatusIcon status={todo.status} />
+                <span
+                  className={cn(
+                    'flex-1 min-w-0 truncate',
+                    (todo.status === 'completed' || todo.status === 'cancelled') &&
+                      'line-through text-muted-foreground/50'
+                  )}
+                >
+                  {todo.content}
+                </span>
+                <PriorityBadge priority={todo.priority} />
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/sessions/TaskListWidget.tsx
+++ b/src/renderer/src/components/sessions/TaskListWidget.tsx
@@ -5,12 +5,17 @@ import { PriorityBadge, StatusIcon, type TodoItem } from './tools/todoIcons'
 
 export interface TaskListWidgetProps {
   todos: TodoItem[]
-  topOffsetClass: string
+  /**
+   * Distance from the top edge of the widget's positioning parent, in pixels.
+   * Driven by a measurement of the PR notification stack so the widget always
+   * clears its bottom edge (see usePRStackTopOffset).
+   */
+  topOffsetPx: number
 }
 
 export function TaskListWidget({
   todos,
-  topOffsetClass
+  topOffsetPx
 }: TaskListWidgetProps): React.JSX.Element {
   const collapsed = useSettingsStore((s) => s.taskListCollapsed)
   const updateSetting = useSettingsStore((s) => s.updateSetting)
@@ -21,7 +26,8 @@ export function TaskListWidget({
   return (
     <div
       data-testid="task-list-widget"
-      className={`absolute right-4 ${topOffsetClass} z-20 w-72 rounded-lg border border-border bg-background/95 backdrop-blur shadow-md transition-all duration-150`}
+      style={{ top: `${topOffsetPx}px` }}
+      className="absolute right-4 z-20 w-72 rounded-lg border border-border bg-background/95 backdrop-blur shadow-md transition-all duration-150"
     >
       {collapsed ? (
         <button

--- a/src/renderer/src/components/sessions/ToolCard.tsx
+++ b/src/renderer/src/components/sessions/ToolCard.tsx
@@ -56,7 +56,7 @@ export interface ToolUseInfo {
 }
 
 /** Check if a tool name refers to a checklist-style tool */
-function isTodoWriteTool(name: string): boolean {
+export function isTodoWriteTool(name: string): boolean {
   const lower = name.toLowerCase()
   return lower.includes('todowrite') || lower.includes('todo_write') || lower === 'update_plan'
 }

--- a/src/renderer/src/components/sessions/tools/TodoWriteToolView.tsx
+++ b/src/renderer/src/components/sessions/tools/TodoWriteToolView.tsx
@@ -1,52 +1,10 @@
 import { useMemo } from 'react'
-import {
-  ChevronDown,
-  ChevronUp,
-  ChevronsUp,
-  Circle,
-  CircleCheck,
-  CircleDot,
-  CircleX
-} from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { ToolViewProps } from './types'
-
-interface TodoItem {
-  id: string
-  content: string
-  status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
-  priority: 'high' | 'medium' | 'low'
-}
+import { PriorityBadge, StatusIcon, type TodoItem } from './todoIcons'
 
 interface TodoInput {
   todos: TodoItem[]
-}
-
-function StatusIcon({ status }: { status: TodoItem['status'] }) {
-  switch (status) {
-    case 'completed':
-      return <CircleCheck className="h-3.5 w-3.5 text-green-500 shrink-0" />
-    case 'in_progress':
-      return <CircleDot className="h-3.5 w-3.5 text-blue-500 shrink-0 animate-pulse" />
-    case 'cancelled':
-      return <CircleX className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />
-    case 'pending':
-    default:
-      return <Circle className="h-3.5 w-3.5 text-muted-foreground/40 shrink-0" />
-  }
-}
-
-function PriorityBadge({ priority }: { priority: TodoItem['priority'] }) {
-  switch (priority) {
-    case 'high':
-      return <ChevronsUp className="h-3.5 w-3.5 text-red-500 shrink-0" />
-    case 'medium':
-      return <ChevronUp className="h-3.5 w-3.5 text-amber-500 shrink-0" />
-    case 'low':
-      return <ChevronDown className="h-3.5 w-3.5 text-blue-500 shrink-0" />
-    default:
-      return null
-  }
 }
 
 export function TodoWriteToolView({ input, error }: ToolViewProps) {

--- a/src/renderer/src/components/sessions/tools/todoIcons.tsx
+++ b/src/renderer/src/components/sessions/tools/todoIcons.tsx
@@ -1,0 +1,43 @@
+import {
+  ChevronDown,
+  ChevronUp,
+  ChevronsUp,
+  Circle,
+  CircleCheck,
+  CircleDot,
+  CircleX
+} from 'lucide-react'
+
+export interface TodoItem {
+  id: string
+  content: string
+  status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
+  priority: 'high' | 'medium' | 'low'
+}
+
+export function StatusIcon({ status }: { status: TodoItem['status'] }) {
+  switch (status) {
+    case 'completed':
+      return <CircleCheck className="h-3.5 w-3.5 text-green-500 shrink-0" />
+    case 'in_progress':
+      return <CircleDot className="h-3.5 w-3.5 text-blue-500 shrink-0 animate-pulse" />
+    case 'cancelled':
+      return <CircleX className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />
+    case 'pending':
+    default:
+      return <Circle className="h-3.5 w-3.5 text-muted-foreground/40 shrink-0" />
+  }
+}
+
+export function PriorityBadge({ priority }: { priority: TodoItem['priority'] }) {
+  switch (priority) {
+    case 'high':
+      return <ChevronsUp className="h-3.5 w-3.5 text-red-500 shrink-0" />
+    case 'medium':
+      return <ChevronUp className="h-3.5 w-3.5 text-amber-500 shrink-0" />
+    case 'low':
+      return <ChevronDown className="h-3.5 w-3.5 text-blue-500 shrink-0" />
+    default:
+      return null
+  }
+}

--- a/src/renderer/src/components/sessions/useLatestTodoList.ts
+++ b/src/renderer/src/components/sessions/useLatestTodoList.ts
@@ -1,0 +1,64 @@
+import { useMemo } from 'react'
+import { isTodoWriteTool } from './ToolCard'
+import type { OpenCodeMessage } from './SessionView'
+import type { TodoItem } from './tools/todoIcons'
+
+export type { TodoItem }
+
+/**
+ * Scan a list of messages (and an optional streaming message) for the latest
+ * `TodoWrite`-style tool_use and return its parsed todos list.
+ *
+ * Logic:
+ *  1. If `streamingMessage` is provided and contains a TodoWrite tool_use whose
+ *     `input.todos` is an array, that list wins.
+ *  2. Otherwise, walk `messages` from the end to the start and return the todos
+ *     from the first TodoWrite tool_use whose `input.todos` is an array.
+ *  3. If nothing is found, `todos` is `null`.
+ *
+ * `isIncomplete` is `true` when any returned todo has a status other than
+ * `completed` or `cancelled` (i.e. `pending` or `in_progress`).
+ */
+export function useLatestTodoList(
+  messages: OpenCodeMessage[],
+  streamingMessage?: OpenCodeMessage | null
+): { todos: TodoItem[] | null; isIncomplete: boolean } {
+  return useMemo(() => {
+    const scan = (msg: OpenCodeMessage | null | undefined): TodoItem[] | null => {
+      const parts = msg?.parts
+      if (!parts || parts.length === 0) return null
+      for (let i = parts.length - 1; i >= 0; i--) {
+        const part = parts[i]
+        if (part?.type !== 'tool_use') continue
+        if (!isTodoWriteTool(part.toolUse?.name ?? '')) continue
+        const input = part.toolUse?.input
+        if (!input || !Array.isArray(input.todos)) continue
+        return input.todos as TodoItem[]
+      }
+      return null
+    }
+
+    let found: TodoItem[] | null = null
+    if (streamingMessage) {
+      found = scan(streamingMessage)
+    }
+    if (!found) {
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const hit = scan(messages[i])
+        if (hit) {
+          found = hit
+          break
+        }
+      }
+    }
+
+    if (!found) {
+      return { todos: null, isIncomplete: false }
+    }
+
+    const isIncomplete = found.some(
+      (t) => t.status !== 'completed' && t.status !== 'cancelled'
+    )
+    return { todos: found, isIncomplete }
+  }, [messages, streamingMessage])
+}

--- a/src/renderer/src/components/sessions/usePRStackTopOffset.ts
+++ b/src/renderer/src/components/sessions/usePRStackTopOffset.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
+
+/**
+ * The PR notification stack is rendered at `top-4 right-4` inside `MainPane`.
+ * Its stacked cards can grow well past 80px (single card with description ≈
+ * 60–100px; two cards + 8px gap easily exceeds 150px), so a fixed `top-20`
+ * (=80px) offset for the TaskListWidget visibly overlaps the stack whenever a
+ * notification has any description or when more than one is queued.
+ *
+ * This hook measures the stack's actual rendered height via
+ * `data-testid="pr-notification-stack"` and returns an offset (in px) that
+ * clears it with an 8px gap. Without any notifications (stack unmounted) it
+ * returns the baseline 16px — the same position as `top-4`.
+ *
+ * It re-measures in response to:
+ *   - `notifications.length` changes (card added or removed)
+ *   - `ResizeObserver` callbacks (a single card's own height changed, e.g.
+ *     a status transition that added or removed an action row)
+ *
+ * If `ResizeObserver` is unavailable (older runtime, some test environments)
+ * the hook still performs the initial measurement and gracefully skips
+ * observation.
+ */
+
+/** Matches the stack's own `top-4` (=16px) position inside MainPane. */
+export const BASELINE_TOP_PX = 16
+/** Vertical gap between the stack's bottom edge and the widget. */
+const STACK_TO_WIDGET_GAP_PX = 8
+/** Selector for the stack element. Kept in sync with PRNotificationStack. */
+const PR_STACK_SELECTOR = '[data-testid="pr-notification-stack"]'
+
+export function usePRStackTopOffset(): number {
+  const notificationCount = usePRNotificationStore((s) => s.notifications.length)
+  const [stackHeightPx, setStackHeightPx] = useState(0)
+
+  useEffect(() => {
+    if (notificationCount === 0) {
+      setStackHeightPx(0)
+      return
+    }
+
+    const stack = document.querySelector(PR_STACK_SELECTOR)
+    if (!(stack instanceof HTMLElement)) {
+      // Stack hasn't mounted yet (or was unmounted mid-render). Keep the
+      // current value; the next notificationCount change will retry.
+      return
+    }
+
+    const measure = (): void => {
+      setStackHeightPx(stack.offsetHeight)
+    }
+    measure()
+
+    if (typeof ResizeObserver === 'undefined') {
+      return
+    }
+    const observer = new ResizeObserver(measure)
+    observer.observe(stack)
+    return () => observer.disconnect()
+  }, [notificationCount])
+
+  return stackHeightPx > 0 ? BASELINE_TOP_PX + stackHeightPx + STACK_TO_WIDGET_GAP_PX : BASELINE_TOP_PX
+}

--- a/src/renderer/src/components/sessions/usePRStackTopOffset.ts
+++ b/src/renderer/src/components/sessions/usePRStackTopOffset.ts
@@ -42,9 +42,22 @@ export function usePRStackTopOffset(): number {
 
     const stack = document.querySelector(PR_STACK_SELECTOR)
     if (!(stack instanceof HTMLElement)) {
-      // Stack hasn't mounted yet (or was unmounted mid-render). Keep the
-      // current value; the next notificationCount change will retry.
-      return
+      // Stack hasn't committed to the DOM yet for this render pass. Retry
+      // once on the next animation frame to close the race without relying on
+      // the next notificationCount change to trigger a re-measure.
+      let observer: ResizeObserver | null = null
+      const raf = requestAnimationFrame(() => {
+        const retryStack = document.querySelector(PR_STACK_SELECTOR)
+        if (!(retryStack instanceof HTMLElement)) return
+        setStackHeightPx(retryStack.offsetHeight)
+        if (typeof ResizeObserver === 'undefined') return
+        observer = new ResizeObserver(() => setStackHeightPx(retryStack.offsetHeight))
+        observer.observe(retryStack)
+      })
+      return () => {
+        cancelAnimationFrame(raf)
+        observer?.disconnect()
+      }
     }
 
     const measure = (): void => {

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -52,6 +52,7 @@ export interface AppSettings {
   autoPullBeforeWorktree: boolean
   breedType: 'dogs' | 'cats'
   vimModeEnabled: boolean
+  taskListCollapsed: boolean
   mergeConflictMode: MergeConflictMode
   boardMode: 'toggle' | 'sticky-tab'
   followUpTriggerColumn: FollowUpTriggerColumn
@@ -139,6 +140,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   autoPullBeforeWorktree: true,
   breedType: 'dogs',
   vimModeEnabled: false,
+  taskListCollapsed: false,
   mergeConflictMode: 'always-ask',
   boardMode: 'sticky-tab',
   followUpTriggerColumn: 'done',
@@ -292,6 +294,7 @@ function extractSettings(state: SettingsState): AppSettings {
     autoPullBeforeWorktree: state.autoPullBeforeWorktree,
     breedType: state.breedType,
     vimModeEnabled: state.vimModeEnabled,
+    taskListCollapsed: state.taskListCollapsed,
     mergeConflictMode: state.mergeConflictMode,
     boardMode: state.boardMode,
     followUpTriggerColumn: state.followUpTriggerColumn,
@@ -550,6 +553,7 @@ export const useSettingsStore = create<SettingsState>()(
         autoPullBeforeWorktree: state.autoPullBeforeWorktree,
         breedType: state.breedType,
         vimModeEnabled: state.vimModeEnabled,
+        taskListCollapsed: state.taskListCollapsed,
         mergeConflictMode: state.mergeConflictMode,
         boardMode: state.boardMode,
         followUpTriggerColumn: state.followUpTriggerColumn,

--- a/test/task-list/session-stream-panel-widget.test.tsx
+++ b/test/task-list/session-stream-panel-widget.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { act } from 'react'
+
+// -----------------------------------------------------------------------------
+// Test strategy: Option B — mount the real SessionStreamPanel with
+// useSessionStream mocked. This exercises the actual integration site in
+// SessionStreamPanel (import, useMemo streaming message, useLatestTodoList,
+// TaskListWidget render gate) rather than a stand-in harness. The mock is
+// tiny (~10 lines) and the hook has no side effects on the rendered subtree
+// once its return value is fixed.
+// -----------------------------------------------------------------------------
+
+type MockStreamResult = {
+  messages: unknown[]
+  streamingParts: unknown[]
+  streamingContent: string
+  isStreaming: boolean
+  isLoading: boolean
+}
+
+const mockReturnRef: { current: MockStreamResult } = {
+  current: {
+    messages: [],
+    streamingParts: [],
+    streamingContent: '',
+    isStreaming: false,
+    isLoading: false
+  }
+}
+
+vi.mock('@/hooks/useSessionStream', () => ({
+  useSessionStream: () => mockReturnRef.current
+}))
+
+// Mock MessageRenderer to keep the test focused on widget gating (MessageRenderer
+// itself has heavy dependencies on stores, theming, etc.).
+vi.mock('@/components/sessions/MessageRenderer', () => ({
+  MessageRenderer: ({ message }: { message: { id: string } }) => (
+    <div data-testid={`message-${message.id}`} />
+  )
+}))
+
+// Mock ScrollToBottomFab — irrelevant to this test but pulls in icons etc.
+vi.mock('@/components/sessions/ScrollToBottomFab', () => ({
+  ScrollToBottomFab: () => null
+}))
+
+import { SessionStreamPanel } from '@/components/kanban/SessionStreamPanel'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import type {
+  OpenCodeMessage,
+  StreamingPart
+} from '@/components/sessions/SessionView'
+import type { TodoItem } from '@/components/sessions/tools/todoIcons'
+
+const originalSettingsState = useSettingsStore.getState()
+
+function setMockStream(partial: Partial<MockStreamResult>): void {
+  mockReturnRef.current = {
+    messages: [],
+    streamingParts: [],
+    streamingContent: '',
+    isStreaming: false,
+    isLoading: false,
+    ...partial
+  }
+}
+
+function makeTodo(
+  id: string,
+  content: string,
+  status: TodoItem['status'] = 'pending',
+  priority: TodoItem['priority'] = 'medium'
+): TodoItem {
+  return { id, content, status, priority }
+}
+
+function makeTodoWritePart(todos: TodoItem[]): StreamingPart {
+  return {
+    type: 'tool_use',
+    toolUse: {
+      id: 'tool-todo-1',
+      name: 'TodoWrite',
+      input: { todos } as unknown as Record<string, unknown>,
+      status: 'success',
+      startTime: 0
+    }
+  }
+}
+
+function makeTextPart(text: string): StreamingPart {
+  return { type: 'text', text }
+}
+
+function makeMessage(id: string, parts: StreamingPart[]): OpenCodeMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: '',
+    timestamp: new Date(0).toISOString(),
+    parts
+  }
+}
+
+function renderPanel(): ReturnType<typeof render> {
+  return render(
+    <SessionStreamPanel
+      sessionId="session-1"
+      worktreePath="/tmp/wt"
+      opencodeSessionId="opc-1"
+    />
+  )
+}
+
+describe('SessionStreamPanel TaskListWidget integration', () => {
+  beforeEach(() => {
+    // jsdom doesn't implement Element.scrollIntoView — SessionStreamPanel's
+    // auto-scroll effect calls it unconditionally once messages are present.
+    if (typeof Element.prototype.scrollIntoView !== 'function') {
+      Element.prototype.scrollIntoView = vi.fn()
+    }
+
+    // Reset the mock stream result + settings store to a clean baseline.
+    setMockStream({})
+    act(() => {
+      useSettingsStore.setState({
+        ...originalSettingsState,
+        taskListCollapsed: false
+      })
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    act(() => {
+      useSettingsStore.setState(originalSettingsState)
+    })
+  })
+
+  it('does not render TaskListWidget when messages contain no TodoWrite', () => {
+    setMockStream({
+      messages: [makeMessage('m1', [makeTextPart('hello world')])]
+    })
+
+    renderPanel()
+
+    expect(screen.queryByTestId('task-list-widget')).not.toBeInTheDocument()
+  })
+
+  it('does not render TaskListWidget when the latest TodoWrite is all completed or cancelled', () => {
+    setMockStream({
+      messages: [
+        makeMessage('m1', [
+          makeTodoWritePart([
+            makeTodo('a', 'one', 'completed'),
+            makeTodo('b', 'two', 'cancelled'),
+            makeTodo('c', 'three', 'completed')
+          ])
+        ])
+      ]
+    })
+
+    renderPanel()
+
+    expect(screen.queryByTestId('task-list-widget')).not.toBeInTheDocument()
+  })
+
+  it('renders TaskListWidget when the latest TodoWrite has any pending or in_progress todo', () => {
+    setMockStream({
+      messages: [
+        makeMessage('m1', [
+          makeTodoWritePart([
+            makeTodo('a', 'Done one', 'completed'),
+            makeTodo('b', 'Still working', 'in_progress'),
+            makeTodo('c', 'Queued', 'pending')
+          ])
+        ])
+      ]
+    })
+
+    renderPanel()
+
+    const widget = screen.getByTestId('task-list-widget')
+    expect(widget).toBeInTheDocument()
+  })
+
+  it('positions the widget at the 16px baseline (BASELINE_TOP_PX)', () => {
+    setMockStream({
+      messages: [
+        makeMessage('m1', [
+          makeTodoWritePart([makeTodo('a', 'Pending item', 'pending')])
+        ])
+      ]
+    })
+
+    renderPanel()
+
+    const widget = screen.getByTestId('task-list-widget')
+    // Design decision: inside the kanban ticket modal we always use the 16px
+    // baseline — we do NOT call usePRStackTopOffset because the PR stack is
+    // hidden behind the modal backdrop.
+    expect(widget.style.top).toBe('16px')
+  })
+})

--- a/test/task-list/task-list-integration.test.tsx
+++ b/test/task-list/task-list-integration.test.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { act } from 'react'
+import { TaskListWidget } from '@/components/sessions/TaskListWidget'
+import { useLatestTodoList } from '@/components/sessions/useLatestTodoList'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import type {
+  OpenCodeMessage,
+  StreamingPart
+} from '@/components/sessions/SessionView'
+import type { TodoItem } from '@/components/sessions/tools/todoIcons'
+
+// -----------------------------------------------------------------------------
+// Test strategy: Option A — lightweight observation wrapper.
+//
+// Rendering the full SessionView would require ~20 mocks (IPC, routing, many
+// stores, etc.). Instead this wrapper mirrors the integration site's wiring:
+//   * feeds visibleMessages/streamingMessage into useLatestTodoList
+//   * selects prNotificationCount from usePRNotificationStore
+//   * conditionally renders <TaskListWidget> with the same topOffsetClass logic
+// That proves the integration semantics (hook result + gating condition +
+// top-offset toggle) without needing SessionView itself.
+// -----------------------------------------------------------------------------
+
+function TestHarness({
+  messages,
+  streaming = null
+}: {
+  messages: OpenCodeMessage[]
+  streaming?: OpenCodeMessage | null
+}): React.JSX.Element {
+  const { todos: latestTodos, isIncomplete: latestTodosIncomplete } = useLatestTodoList(
+    messages,
+    streaming
+  )
+  const prNotificationCount = usePRNotificationStore((s) => s.notifications.length)
+  const taskListTopOffsetClass = prNotificationCount > 0 ? 'top-20' : 'top-4'
+
+  return (
+    <div>
+      {latestTodos && latestTodosIncomplete && (
+        <TaskListWidget todos={latestTodos} topOffsetClass={taskListTopOffsetClass} />
+      )}
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Store helpers
+// -----------------------------------------------------------------------------
+
+const originalPRState = usePRNotificationStore.getState()
+const originalSettingsState = useSettingsStore.getState()
+
+function setPRNotifications(count: number): void {
+  const notifications = Array.from({ length: count }, (_, i) => ({
+    id: `pr-test-${i}`,
+    status: 'info' as const,
+    message: `Test notification ${i}`
+  }))
+  act(() => {
+    usePRNotificationStore.setState({ notifications })
+  })
+}
+
+// -----------------------------------------------------------------------------
+// Data builders
+// -----------------------------------------------------------------------------
+
+function makeTodo(
+  id: string,
+  content: string,
+  status: TodoItem['status'] = 'pending',
+  priority: TodoItem['priority'] = 'medium'
+): TodoItem {
+  return { id, content, status, priority }
+}
+
+function makeTodoWritePart(todos: TodoItem[]): StreamingPart {
+  return {
+    type: 'tool_use',
+    toolUse: {
+      id: 'tool-todo-1',
+      name: 'TodoWrite',
+      input: { todos } as unknown as Record<string, unknown>,
+      status: 'success',
+      startTime: 0
+    }
+  }
+}
+
+function makeTextPart(text: string): StreamingPart {
+  return { type: 'text', text }
+}
+
+function makeMessage(id: string, parts: StreamingPart[]): OpenCodeMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: '',
+    timestamp: new Date(0).toISOString(),
+    parts
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+describe('TaskListWidget SessionView integration', () => {
+  beforeEach(() => {
+    act(() => {
+      usePRNotificationStore.setState({ ...originalPRState, notifications: [] })
+      useSettingsStore.setState({ ...originalSettingsState, taskListCollapsed: false })
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    act(() => {
+      usePRNotificationStore.setState(originalPRState)
+      useSettingsStore.setState(originalSettingsState)
+    })
+  })
+
+  it('does not render TaskListWidget when visibleMessages has no TodoWrite', () => {
+    const messages: OpenCodeMessage[] = [makeMessage('m1', [makeTextPart('hello world')])]
+
+    render(<TestHarness messages={messages} />)
+
+    expect(screen.queryByTestId('task-list-widget')).not.toBeInTheDocument()
+  })
+
+  it('does not render TaskListWidget when the latest TodoWrite is all completed or cancelled', () => {
+    const allDoneMessages: OpenCodeMessage[] = [
+      makeMessage('m1', [
+        makeTodoWritePart([
+          makeTodo('a', 'one', 'completed'),
+          makeTodo('b', 'two', 'cancelled'),
+          makeTodo('c', 'three', 'completed')
+        ])
+      ])
+    ]
+
+    const { unmount } = render(<TestHarness messages={allDoneMessages} />)
+    expect(screen.queryByTestId('task-list-widget')).not.toBeInTheDocument()
+    unmount()
+
+    // All cancelled
+    const allCancelled: OpenCodeMessage[] = [
+      makeMessage('m1', [
+        makeTodoWritePart([
+          makeTodo('a', 'one', 'cancelled'),
+          makeTodo('b', 'two', 'cancelled')
+        ])
+      ])
+    ]
+    const second = render(<TestHarness messages={allCancelled} />)
+    expect(screen.queryByTestId('task-list-widget')).not.toBeInTheDocument()
+    second.unmount()
+
+    // All completed
+    const allCompleted: OpenCodeMessage[] = [
+      makeMessage('m1', [
+        makeTodoWritePart([
+          makeTodo('a', 'one', 'completed'),
+          makeTodo('b', 'two', 'completed')
+        ])
+      ])
+    ]
+    render(<TestHarness messages={allCompleted} />)
+    expect(screen.queryByTestId('task-list-widget')).not.toBeInTheDocument()
+  })
+
+  it('renders TaskListWidget when the latest TodoWrite has any pending or in_progress todo', () => {
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [
+        makeTodoWritePart([
+          makeTodo('a', 'Done one', 'completed'),
+          makeTodo('b', 'Still working', 'in_progress'),
+          makeTodo('c', 'Queued', 'pending')
+        ])
+      ])
+    ]
+
+    render(<TestHarness messages={messages} />)
+
+    const widget = screen.getByTestId('task-list-widget')
+    expect(widget).toBeInTheDocument()
+  })
+
+  it('toggles topOffsetClass between top-4 (no PR notifications) and top-20 (>=1 PR notification)', () => {
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [
+        makeTodoWritePart([makeTodo('a', 'Pending item', 'pending')])
+      ])
+    ]
+
+    // Start with zero PR notifications → top-4
+    setPRNotifications(0)
+    const { rerender } = render(<TestHarness messages={messages} />)
+    let widget = screen.getByTestId('task-list-widget')
+    expect(widget.className).toContain('top-4')
+    expect(widget.className).not.toContain('top-20')
+
+    // One notification → top-20
+    setPRNotifications(1)
+    rerender(<TestHarness messages={messages} />)
+    widget = screen.getByTestId('task-list-widget')
+    expect(widget.className).toContain('top-20')
+    expect(widget.className).not.toContain('top-4')
+
+    // Several notifications → still top-20
+    setPRNotifications(3)
+    rerender(<TestHarness messages={messages} />)
+    widget = screen.getByTestId('task-list-widget')
+    expect(widget.className).toContain('top-20')
+
+    // Back to zero → top-4 again
+    setPRNotifications(0)
+    rerender(<TestHarness messages={messages} />)
+    widget = screen.getByTestId('task-list-widget')
+    expect(widget.className).toContain('top-4')
+    expect(widget.className).not.toContain('top-20')
+  })
+})

--- a/test/task-list/task-list-integration.test.tsx
+++ b/test/task-list/task-list-integration.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 import { act } from 'react'
 import { TaskListWidget } from '@/components/sessions/TaskListWidget'
 import { useLatestTodoList } from '@/components/sessions/useLatestTodoList'
+import { usePRStackTopOffset } from '@/components/sessions/usePRStackTopOffset'
 import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import type {
@@ -17,11 +18,46 @@ import type { TodoItem } from '@/components/sessions/tools/todoIcons'
 // Rendering the full SessionView would require ~20 mocks (IPC, routing, many
 // stores, etc.). Instead this wrapper mirrors the integration site's wiring:
 //   * feeds visibleMessages/streamingMessage into useLatestTodoList
-//   * selects prNotificationCount from usePRNotificationStore
-//   * conditionally renders <TaskListWidget> with the same topOffsetClass logic
+//   * uses usePRStackTopOffset to compute the pixel offset from the measured
+//     PR notification stack height
+//   * conditionally renders <TaskListWidget> with the resulting topOffsetPx
 // That proves the integration semantics (hook result + gating condition +
-// top-offset toggle) without needing SessionView itself.
+// measured offset) without needing SessionView itself.
 // -----------------------------------------------------------------------------
+
+// jsdom doesn't ship ResizeObserver — stub a minimal version so the measurement
+// hook doesn't throw. Tests that want to simulate a size change can reach into
+// `observers` and fire the callback manually.
+
+const observers: MockResizeObserver[] = []
+
+class MockResizeObserver {
+  observe = vi.fn((target: Element) => {
+    this.target = target
+  })
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+  private callback: ResizeObserverCallback
+  private target: Element | null = null
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    observers.push(this)
+  }
+
+  trigger(): void {
+    if (!this.target) return
+    this.callback(
+      [
+        {
+          target: this.target,
+          contentRect: this.target.getBoundingClientRect()
+        } as ResizeObserverEntry
+      ],
+      this as unknown as ResizeObserver
+    )
+  }
+}
 
 function TestHarness({
   messages,
@@ -34,20 +70,19 @@ function TestHarness({
     messages,
     streaming
   )
-  const prNotificationCount = usePRNotificationStore((s) => s.notifications.length)
-  const taskListTopOffsetClass = prNotificationCount > 0 ? 'top-20' : 'top-4'
+  const taskListTopOffsetPx = usePRStackTopOffset()
 
   return (
     <div>
       {latestTodos && latestTodosIncomplete && (
-        <TaskListWidget todos={latestTodos} topOffsetClass={taskListTopOffsetClass} />
+        <TaskListWidget todos={latestTodos} topOffsetPx={taskListTopOffsetPx} />
       )}
     </div>
   )
 }
 
 // -----------------------------------------------------------------------------
-// Store helpers
+// Store / DOM helpers
 // -----------------------------------------------------------------------------
 
 const originalPRState = usePRNotificationStore.getState()
@@ -62,6 +97,22 @@ function setPRNotifications(count: number): void {
   act(() => {
     usePRNotificationStore.setState({ notifications })
   })
+}
+
+/**
+ * Mount a fake PR notification stack element with the given offsetHeight so the
+ * usePRStackTopOffset hook's `document.querySelector` call finds it and
+ * `.offsetHeight` returns a known value (jsdom returns 0 by default).
+ */
+function mountFakeStack(height: number): HTMLElement {
+  const stack = document.createElement('div')
+  stack.setAttribute('data-testid', 'pr-notification-stack')
+  Object.defineProperty(stack, 'offsetHeight', {
+    configurable: true,
+    value: height
+  })
+  document.body.appendChild(stack)
+  return stack
 }
 
 // -----------------------------------------------------------------------------
@@ -110,6 +161,8 @@ function makeMessage(id: string, parts: StreamingPart[]): OpenCodeMessage {
 
 describe('TaskListWidget SessionView integration', () => {
   beforeEach(() => {
+    observers.length = 0
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
     act(() => {
       usePRNotificationStore.setState({ ...originalPRState, notifications: [] })
       useSettingsStore.setState({ ...originalSettingsState, taskListCollapsed: false })
@@ -118,6 +171,9 @@ describe('TaskListWidget SessionView integration', () => {
 
   afterEach(() => {
     cleanup()
+    // Clean out any fake stack elements between tests.
+    document.body.innerHTML = ''
+    vi.unstubAllGlobals()
     act(() => {
       usePRNotificationStore.setState(originalPRState)
       useSettingsStore.setState(originalSettingsState)
@@ -190,38 +246,63 @@ describe('TaskListWidget SessionView integration', () => {
     expect(widget).toBeInTheDocument()
   })
 
-  it('toggles topOffsetClass between top-4 (no PR notifications) and top-20 (>=1 PR notification)', () => {
+  it('positions the widget at the 16px baseline when there are no PR notifications', () => {
     const messages: OpenCodeMessage[] = [
-      makeMessage('m1', [
-        makeTodoWritePart([makeTodo('a', 'Pending item', 'pending')])
-      ])
+      makeMessage('m1', [makeTodoWritePart([makeTodo('a', 'Pending item', 'pending')])])
     ]
 
-    // Start with zero PR notifications → top-4
     setPRNotifications(0)
-    const { rerender } = render(<TestHarness messages={messages} />)
-    let widget = screen.getByTestId('task-list-widget')
-    expect(widget.className).toContain('top-4')
-    expect(widget.className).not.toContain('top-20')
+    render(<TestHarness messages={messages} />)
+    const widget = screen.getByTestId('task-list-widget')
+    expect(widget.style.top).toBe('16px')
+  })
 
-    // One notification → top-20
+  it('positions the widget below the measured PR stack when notifications exist', () => {
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [makeTodoWritePart([makeTodo('a', 'Pending item', 'pending')])])
+    ]
+
+    // A PR stack that's 100px tall — e.g. a single card with a 2-line
+    // description and an action row. `top-20` (=80px) alone would have put
+    // the widget squarely on top of this stack; the new hook puts it below.
+    mountFakeStack(100)
     setPRNotifications(1)
-    rerender(<TestHarness messages={messages} />)
-    widget = screen.getByTestId('task-list-widget')
-    expect(widget.className).toContain('top-20')
-    expect(widget.className).not.toContain('top-4')
+    render(<TestHarness messages={messages} />)
+    const widget = screen.getByTestId('task-list-widget')
+    // 16 (stack's own top-4) + 100 (measured height) + 8 (gap) = 124
+    expect(widget.style.top).toBe('124px')
+  })
 
-    // Several notifications → still top-20
+  it('positions the widget well below a tall stack of multiple notifications (regression for fixed top-20)', () => {
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [makeTodoWritePart([makeTodo('a', 'Pending item', 'pending')])])
+    ]
+
+    // Three stacked notification cards — each ~72px + 8px gaps ≈ 232px.
+    // The old `top-20` (=80px) constant would have put the widget roughly in
+    // the middle of the stack; the measurement-based approach puts it cleanly
+    // below the entire stack.
+    mountFakeStack(232)
     setPRNotifications(3)
-    rerender(<TestHarness messages={messages} />)
-    widget = screen.getByTestId('task-list-widget')
-    expect(widget.className).toContain('top-20')
+    render(<TestHarness messages={messages} />)
+    const widget = screen.getByTestId('task-list-widget')
+    // 16 + 232 + 8 = 256
+    expect(widget.style.top).toBe('256px')
+  })
 
-    // Back to zero → top-4 again
+  it('returns to the baseline offset when all notifications are dismissed', () => {
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [makeTodoWritePart([makeTodo('a', 'Pending item', 'pending')])])
+    ]
+
+    mountFakeStack(120)
+    setPRNotifications(2)
+    const { rerender } = render(<TestHarness messages={messages} />)
+    expect(screen.getByTestId('task-list-widget').style.top).toBe('144px')
+
+    // User dismisses all notifications.
     setPRNotifications(0)
     rerender(<TestHarness messages={messages} />)
-    widget = screen.getByTestId('task-list-widget')
-    expect(widget.className).toContain('top-4')
-    expect(widget.className).not.toContain('top-20')
+    expect(screen.getByTestId('task-list-widget').style.top).toBe('16px')
   })
 })

--- a/test/task-list/task-list-widget.test.tsx
+++ b/test/task-list/task-list-widget.test.tsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { act } from 'react'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { TaskListWidget } from '@/components/sessions/TaskListWidget'
+import type { TodoItem } from '@/components/sessions/tools/todoIcons'
+
+// Snapshot the store's state before each test so we can restore it.
+const originalState = useSettingsStore.getState()
+
+function setCollapsed(value: boolean): void {
+  act(() => {
+    useSettingsStore.setState({ taskListCollapsed: value })
+  })
+}
+
+function makeTodo(
+  id: string,
+  content: string,
+  status: TodoItem['status'] = 'pending',
+  priority: TodoItem['priority'] = 'medium'
+): TodoItem {
+  return { id, content, status, priority }
+}
+
+describe('TaskListWidget', () => {
+  beforeEach(() => {
+    // Reset the store to a clean baseline. We preserve the original action
+    // implementations so clicks that call updateSetting actually work.
+    act(() => {
+      useSettingsStore.setState({
+        ...originalState,
+        taskListCollapsed: false
+      })
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    act(() => {
+      useSettingsStore.setState(originalState)
+    })
+  })
+
+  it('renders the collapsed pill with counter when taskListCollapsed is true', () => {
+    setCollapsed(true)
+    const todos: TodoItem[] = [
+      makeTodo('a', 'First', 'completed'),
+      makeTodo('b', 'Second', 'pending'),
+      makeTodo('c', 'Third', 'in_progress')
+    ]
+
+    render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+
+    const widget = screen.getByTestId('task-list-widget')
+    expect(widget).toBeInTheDocument()
+
+    const toggle = screen.getByTestId('task-list-widget-toggle')
+    expect(toggle).toHaveTextContent('1/3')
+
+    // Body rows are not in the DOM when collapsed
+    expect(screen.queryByText('First')).not.toBeInTheDocument()
+    expect(screen.queryByText('Second')).not.toBeInTheDocument()
+    expect(screen.queryByText('Third')).not.toBeInTheDocument()
+
+    // "Tasks" header should not be present in collapsed state
+    expect(screen.queryByText('Tasks')).not.toBeInTheDocument()
+  })
+
+  it('renders the expanded header, counter and all todo rows when taskListCollapsed is false', () => {
+    setCollapsed(false)
+    const todos: TodoItem[] = [
+      makeTodo('a', 'First task', 'completed'),
+      makeTodo('b', 'Second task', 'in_progress'),
+      makeTodo('c', 'Third task', 'pending')
+    ]
+
+    render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+
+    const widget = screen.getByTestId('task-list-widget')
+    expect(widget).toBeInTheDocument()
+
+    // Header shows "Tasks"
+    expect(screen.getByText('Tasks')).toBeInTheDocument()
+
+    // Header toggle shows counter
+    const toggle = screen.getByTestId('task-list-widget-toggle')
+    expect(toggle).toHaveTextContent('1/3')
+
+    // All rows are rendered in the body
+    expect(screen.getByText('First task')).toBeInTheDocument()
+    expect(screen.getByText('Second task')).toBeInTheDocument()
+    expect(screen.getByText('Third task')).toBeInTheDocument()
+  })
+
+  it('renders the correct status icon for each status (by lucide color class)', () => {
+    setCollapsed(false)
+    const todos: TodoItem[] = [
+      makeTodo('a', 'Completed', 'completed'),
+      makeTodo('b', 'In progress', 'in_progress'),
+      makeTodo('c', 'Cancelled', 'cancelled'),
+      makeTodo('d', 'Pending', 'pending')
+    ]
+
+    const { container } = render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+
+    // completed → CircleCheck with text-green-500
+    expect(container.querySelector('.text-green-500')).not.toBeNull()
+    // in_progress → CircleDot with text-blue-500 AND animate-pulse
+    expect(container.querySelector('.animate-pulse')).not.toBeNull()
+    // cancelled → CircleX with text-muted-foreground/50 (also shared with completed strikethrough span;
+    // we match on the combined shrink-0 icon class which is unique to the status icons)
+    expect(container.querySelectorAll('.shrink-0').length).toBeGreaterThanOrEqual(4)
+    // pending → Circle with text-muted-foreground/40 (unique class)
+    expect(container.querySelector('.text-muted-foreground\\/40')).not.toBeNull()
+  })
+
+  it('renders the correct priority chevron for each priority', () => {
+    setCollapsed(false)
+    const todos: TodoItem[] = [
+      makeTodo('a', 'High pri', 'pending', 'high'),
+      makeTodo('b', 'Medium pri', 'pending', 'medium'),
+      makeTodo('c', 'Low pri', 'pending', 'low')
+    ]
+
+    const { container } = render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+
+    // high → ChevronsUp with text-red-500
+    expect(container.querySelector('.text-red-500')).not.toBeNull()
+    // medium → ChevronUp with text-amber-500
+    expect(container.querySelector('.text-amber-500')).not.toBeNull()
+    // low → ChevronDown with text-blue-500 (also possible via in_progress, but we have no in_progress here)
+    expect(container.querySelector('.text-blue-500')).not.toBeNull()
+  })
+
+  it('applies strikethrough to completed and cancelled rows but not pending or in_progress', () => {
+    setCollapsed(false)
+    const todos: TodoItem[] = [
+      makeTodo('a', 'Done item', 'completed'),
+      makeTodo('b', 'Cancelled item', 'cancelled'),
+      makeTodo('c', 'Pending item', 'pending'),
+      makeTodo('d', 'In progress item', 'in_progress')
+    ]
+
+    render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+
+    const doneSpan = screen.getByText('Done item')
+    expect(doneSpan.className).toContain('line-through')
+
+    const cancelledSpan = screen.getByText('Cancelled item')
+    expect(cancelledSpan.className).toContain('line-through')
+
+    const pendingSpan = screen.getByText('Pending item')
+    expect(pendingSpan.className).not.toContain('line-through')
+
+    const inProgressSpan = screen.getByText('In progress item')
+    expect(inProgressSpan.className).not.toContain('line-through')
+  })
+
+  it('clicking the collapsed pill calls updateSetting("taskListCollapsed", false)', () => {
+    setCollapsed(true)
+    const updateSetting = vi.fn()
+    act(() => {
+      useSettingsStore.setState({ updateSetting })
+    })
+
+    const todos: TodoItem[] = [makeTodo('a', 'Task')]
+    render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+
+    const toggle = screen.getByTestId('task-list-widget-toggle')
+    fireEvent.click(toggle)
+
+    expect(updateSetting).toHaveBeenCalledTimes(1)
+    expect(updateSetting).toHaveBeenCalledWith('taskListCollapsed', false)
+  })
+
+  it('clicking the expanded header calls updateSetting("taskListCollapsed", true)', () => {
+    setCollapsed(false)
+    const updateSetting = vi.fn()
+    act(() => {
+      useSettingsStore.setState({ updateSetting })
+    })
+
+    const todos: TodoItem[] = [makeTodo('a', 'Task')]
+    render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+
+    const toggle = screen.getByTestId('task-list-widget-toggle')
+    fireEvent.click(toggle)
+
+    expect(updateSetting).toHaveBeenCalledTimes(1)
+    expect(updateSetting).toHaveBeenCalledWith('taskListCollapsed', true)
+  })
+
+  it('applies topOffsetClass prop to the container', () => {
+    setCollapsed(false)
+    const todos: TodoItem[] = [makeTodo('a', 'Task')]
+    render(<TaskListWidget todos={todos} topOffsetClass="top-20" />)
+
+    const widget = screen.getByTestId('task-list-widget')
+    expect(widget.className).toContain('top-20')
+  })
+
+  it('counter reflects the number of completed vs total todos', () => {
+    setCollapsed(true)
+
+    const todosThreeOfFive: TodoItem[] = [
+      makeTodo('a', '1', 'completed'),
+      makeTodo('b', '2', 'completed'),
+      makeTodo('c', '3', 'completed'),
+      makeTodo('d', '4', 'pending'),
+      makeTodo('e', '5', 'in_progress')
+    ]
+
+    const { rerender } = render(
+      <TaskListWidget todos={todosThreeOfFive} topOffsetClass="top-4" />
+    )
+    expect(screen.getByTestId('task-list-widget-toggle')).toHaveTextContent('3/5')
+
+    const todosNoneOfThree: TodoItem[] = [
+      makeTodo('a', '1', 'pending'),
+      makeTodo('b', '2', 'in_progress'),
+      makeTodo('c', '3', 'cancelled')
+    ]
+
+    rerender(<TaskListWidget todos={todosNoneOfThree} topOffsetClass="top-4" />)
+    expect(screen.getByTestId('task-list-widget-toggle')).toHaveTextContent('0/3')
+  })
+})

--- a/test/task-list/task-list-widget.test.tsx
+++ b/test/task-list/task-list-widget.test.tsx
@@ -50,7 +50,7 @@ describe('TaskListWidget', () => {
       makeTodo('c', 'Third', 'in_progress')
     ]
 
-    render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+    render(<TaskListWidget todos={todos} topOffsetPx={16} />)
 
     const widget = screen.getByTestId('task-list-widget')
     expect(widget).toBeInTheDocument()
@@ -75,7 +75,7 @@ describe('TaskListWidget', () => {
       makeTodo('c', 'Third task', 'pending')
     ]
 
-    render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+    render(<TaskListWidget todos={todos} topOffsetPx={16} />)
 
     const widget = screen.getByTestId('task-list-widget')
     expect(widget).toBeInTheDocument()
@@ -102,7 +102,7 @@ describe('TaskListWidget', () => {
       makeTodo('d', 'Pending', 'pending')
     ]
 
-    const { container } = render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+    const { container } = render(<TaskListWidget todos={todos} topOffsetPx={16} />)
 
     // completed → CircleCheck with text-green-500
     expect(container.querySelector('.text-green-500')).not.toBeNull()
@@ -123,7 +123,7 @@ describe('TaskListWidget', () => {
       makeTodo('c', 'Low pri', 'pending', 'low')
     ]
 
-    const { container } = render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+    const { container } = render(<TaskListWidget todos={todos} topOffsetPx={16} />)
 
     // high → ChevronsUp with text-red-500
     expect(container.querySelector('.text-red-500')).not.toBeNull()
@@ -142,7 +142,7 @@ describe('TaskListWidget', () => {
       makeTodo('d', 'In progress item', 'in_progress')
     ]
 
-    render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+    render(<TaskListWidget todos={todos} topOffsetPx={16} />)
 
     const doneSpan = screen.getByText('Done item')
     expect(doneSpan.className).toContain('line-through')
@@ -165,7 +165,7 @@ describe('TaskListWidget', () => {
     })
 
     const todos: TodoItem[] = [makeTodo('a', 'Task')]
-    render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+    render(<TaskListWidget todos={todos} topOffsetPx={16} />)
 
     const toggle = screen.getByTestId('task-list-widget-toggle')
     fireEvent.click(toggle)
@@ -182,7 +182,7 @@ describe('TaskListWidget', () => {
     })
 
     const todos: TodoItem[] = [makeTodo('a', 'Task')]
-    render(<TaskListWidget todos={todos} topOffsetClass="top-4" />)
+    render(<TaskListWidget todos={todos} topOffsetPx={16} />)
 
     const toggle = screen.getByTestId('task-list-widget-toggle')
     fireEvent.click(toggle)
@@ -191,13 +191,16 @@ describe('TaskListWidget', () => {
     expect(updateSetting).toHaveBeenCalledWith('taskListCollapsed', true)
   })
 
-  it('applies topOffsetClass prop to the container', () => {
+  it('applies topOffsetPx prop as inline top style on the container', () => {
     setCollapsed(false)
     const todos: TodoItem[] = [makeTodo('a', 'Task')]
-    render(<TaskListWidget todos={todos} topOffsetClass="top-20" />)
+    render(<TaskListWidget todos={todos} topOffsetPx={124} />)
 
     const widget = screen.getByTestId('task-list-widget')
-    expect(widget.className).toContain('top-20')
+    expect(widget.style.top).toBe('124px')
+    // The old fixed `top-4` / `top-20` Tailwind classes must not leak into the
+    // class list — the offset is now driven purely by inline style.
+    expect(widget.className).not.toMatch(/\btop-\d/)
   })
 
   it('counter reflects the number of completed vs total todos', () => {
@@ -212,7 +215,7 @@ describe('TaskListWidget', () => {
     ]
 
     const { rerender } = render(
-      <TaskListWidget todos={todosThreeOfFive} topOffsetClass="top-4" />
+      <TaskListWidget todos={todosThreeOfFive} topOffsetPx={16} />
     )
     expect(screen.getByTestId('task-list-widget-toggle')).toHaveTextContent('3/5')
 
@@ -222,7 +225,7 @@ describe('TaskListWidget', () => {
       makeTodo('c', '3', 'cancelled')
     ]
 
-    rerender(<TaskListWidget todos={todosNoneOfThree} topOffsetClass="top-4" />)
+    rerender(<TaskListWidget todos={todosNoneOfThree} topOffsetPx={16} />)
     expect(screen.getByTestId('task-list-widget-toggle')).toHaveTextContent('0/3')
   })
 })

--- a/test/task-list/use-latest-todo-list.test.ts
+++ b/test/task-list/use-latest-todo-list.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useLatestTodoList } from '../../src/renderer/src/components/sessions/useLatestTodoList'
+import type {
+  OpenCodeMessage,
+  StreamingPart
+} from '../../src/renderer/src/components/sessions/SessionView'
+import type { TodoItem } from '../../src/renderer/src/components/sessions/tools/todoIcons'
+
+function makeTodo(
+  id: string,
+  content: string,
+  status: TodoItem['status'] = 'pending',
+  priority: TodoItem['priority'] = 'medium'
+): TodoItem {
+  return { id, content, status, priority }
+}
+
+function makeTodoWritePart(
+  todos: unknown,
+  opts: { id?: string; name?: string } = {}
+): StreamingPart {
+  return {
+    type: 'tool_use',
+    toolUse: {
+      id: opts.id ?? 'tool-1',
+      name: opts.name ?? 'TodoWrite',
+      input: { todos } as Record<string, unknown>,
+      status: 'success',
+      startTime: 0
+    }
+  }
+}
+
+function makeTextPart(text: string): StreamingPart {
+  return { type: 'text', text }
+}
+
+function makeOtherToolPart(name: string, input: Record<string, unknown> = {}): StreamingPart {
+  return {
+    type: 'tool_use',
+    toolUse: {
+      id: 'tool-other',
+      name,
+      input,
+      status: 'success',
+      startTime: 0
+    }
+  }
+}
+
+function makeMessage(id: string, parts: StreamingPart[]): OpenCodeMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: '',
+    timestamp: new Date(0).toISOString(),
+    parts
+  }
+}
+
+describe('useLatestTodoList', () => {
+  it('returns null todos when there are no messages and no streaming message', () => {
+    const { result } = renderHook(() => useLatestTodoList([], null))
+    expect(result.current.todos).toBeNull()
+    expect(result.current.isIncomplete).toBe(false)
+  })
+
+  it('returns null when no TodoWrite tool_use exists anywhere', () => {
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [makeTextPart('hello'), makeOtherToolPart('Bash', { command: 'ls' })]),
+      makeMessage('m2', [makeTextPart('world')])
+    ]
+    const { result } = renderHook(() => useLatestTodoList(messages, null))
+    expect(result.current.todos).toBeNull()
+    expect(result.current.isIncomplete).toBe(false)
+  })
+
+  it('returns todos from the latest TodoWrite in committed messages when no streaming', () => {
+    const todos = [makeTodo('1', 'Do thing', 'pending')]
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [makeTextPart('hi'), makeTodoWritePart(todos)])
+    ]
+    const { result } = renderHook(() => useLatestTodoList(messages, null))
+    expect(result.current.todos).toEqual(todos)
+    expect(result.current.isIncomplete).toBe(true)
+  })
+
+  it('prefers streaming message TodoWrite over committed messages', () => {
+    const committedTodos = [makeTodo('c1', 'Committed', 'completed')]
+    const streamingTodos = [makeTodo('s1', 'Streaming', 'in_progress')]
+
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [makeTodoWritePart(committedTodos)])
+    ]
+    const streamingMessage = makeMessage('stream', [makeTodoWritePart(streamingTodos)])
+
+    const { result } = renderHook(() => useLatestTodoList(messages, streamingMessage))
+    expect(result.current.todos).toEqual(streamingTodos)
+    expect(result.current.isIncomplete).toBe(true)
+  })
+
+  it('returns the latest TodoWrite when there are multiple in committed messages', () => {
+    const olderTodos = [makeTodo('o1', 'Older', 'completed')]
+    const newerTodos = [makeTodo('n1', 'Newer', 'pending')]
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [makeTodoWritePart(olderTodos, { id: 'older' })]),
+      makeMessage('m2', [makeTextPart('separator')]),
+      makeMessage('m3', [makeTodoWritePart(newerTodos, { id: 'newer' })])
+    ]
+    const { result } = renderHook(() => useLatestTodoList(messages, null))
+    expect(result.current.todos).toEqual(newerTodos)
+    expect(result.current.isIncomplete).toBe(true)
+  })
+
+  it('returns the latest TodoWrite within the last message when multiple are present', () => {
+    const older = [makeTodo('o1', 'Older')]
+    const newer = [makeTodo('n1', 'Newer')]
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [
+        makeTodoWritePart(older, { id: 'older' }),
+        makeTextPart('mid'),
+        makeTodoWritePart(newer, { id: 'newer' })
+      ])
+    ]
+    const { result } = renderHook(() => useLatestTodoList(messages, null))
+    expect(result.current.todos).toEqual(newer)
+  })
+
+  it('marks isIncomplete=true when any todo is pending', () => {
+    const todos = [makeTodo('1', 'Done', 'completed'), makeTodo('2', 'Waiting', 'pending')]
+    const messages: OpenCodeMessage[] = [makeMessage('m1', [makeTodoWritePart(todos)])]
+    const { result } = renderHook(() => useLatestTodoList(messages, null))
+    expect(result.current.isIncomplete).toBe(true)
+  })
+
+  it('marks isIncomplete=true when any todo is in_progress', () => {
+    const todos = [
+      makeTodo('1', 'Done', 'completed'),
+      makeTodo('2', 'Working', 'in_progress')
+    ]
+    const messages: OpenCodeMessage[] = [makeMessage('m1', [makeTodoWritePart(todos)])]
+    const { result } = renderHook(() => useLatestTodoList(messages, null))
+    expect(result.current.isIncomplete).toBe(true)
+  })
+
+  it('marks isIncomplete=false when all todos are completed and/or cancelled', () => {
+    const todos = [
+      makeTodo('1', 'Done', 'completed'),
+      makeTodo('2', 'Skipped', 'cancelled'),
+      makeTodo('3', 'Also done', 'completed')
+    ]
+    const messages: OpenCodeMessage[] = [makeMessage('m1', [makeTodoWritePart(todos)])]
+    const { result } = renderHook(() => useLatestTodoList(messages, null))
+    expect(result.current.todos).toEqual(todos)
+    expect(result.current.isIncomplete).toBe(false)
+  })
+
+  it('skips TodoWrite parts whose input.todos is not an array and keeps walking back', () => {
+    const goodTodos = [makeTodo('g1', 'Good', 'pending')]
+    const messages: OpenCodeMessage[] = [
+      // Older message: has a valid TodoWrite
+      makeMessage('m1', [makeTodoWritePart(goodTodos, { id: 'good' })]),
+      // Newer messages: malformed inputs that should all be skipped
+      makeMessage('m2', [makeTodoWritePart('not-an-array', { id: 'bad-string' })]),
+      makeMessage('m3', [makeTodoWritePart({ foo: 'bar' }, { id: 'bad-object' })]),
+      makeMessage('m4', [makeTodoWritePart(undefined, { id: 'bad-undefined' })])
+    ]
+    const { result } = renderHook(() => useLatestTodoList(messages, null))
+    expect(result.current.todos).toEqual(goodTodos)
+    expect(result.current.isIncomplete).toBe(true)
+  })
+
+  it('falls back to committed messages when streaming has no tool_use parts', () => {
+    const committedTodos = [makeTodo('c1', 'Committed', 'pending')]
+    const streamingMessage = makeMessage('stream', [makeTextPart('partial response')])
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [makeTodoWritePart(committedTodos)])
+    ]
+    const { result } = renderHook(() => useLatestTodoList(messages, streamingMessage))
+    expect(result.current.todos).toEqual(committedTodos)
+    expect(result.current.isIncomplete).toBe(true)
+  })
+
+  it('falls back to committed messages when streaming has non-TodoWrite tool_use', () => {
+    const committedTodos = [makeTodo('c1', 'Committed', 'completed')]
+    const streamingMessage = makeMessage('stream', [
+      makeOtherToolPart('Bash', { command: 'echo hi' })
+    ])
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [makeTodoWritePart(committedTodos)])
+    ]
+    const { result } = renderHook(() => useLatestTodoList(messages, streamingMessage))
+    expect(result.current.todos).toEqual(committedTodos)
+    expect(result.current.isIncomplete).toBe(false)
+  })
+})

--- a/test/task-list/use-pr-stack-top-offset.test.tsx
+++ b/test/task-list/use-pr-stack-top-offset.test.tsx
@@ -162,4 +162,62 @@ describe('usePRStackTopOffset', () => {
     // Should still do the initial measurement.
     expect(result.current).toBe(16 + 64 + 8)
   })
+
+  it('retries measurement on the next animation frame when the stack is not yet in the DOM', async () => {
+    // Override the synchronous rAF mock (from test/setup.ts) with a deferred
+    // queue so we can observe the race: the hook's effect runs and schedules
+    // a raf while the stack is missing, then the stack mounts, then the raf
+    // fires and finds it.
+    const pending: Array<FrameRequestCallback> = []
+    let nextId = 1
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      ((cb: FrameRequestCallback) => {
+        pending.push(cb)
+        return nextId++
+      }) as typeof requestAnimationFrame
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    // Simulate the race: store has a notification but the stack element has
+    // not committed to the DOM yet for this render pass.
+    setPRNotifications(1)
+    const { result } = renderHook(() => usePRStackTopOffset())
+    // Without the retry, the hook would stay at baseline forever.
+    expect(result.current).toBe(16)
+
+    // Stack mounts a tick later (as it would after the sibling's commit).
+    mountFakeStack(80)
+
+    // Fire the pending rafs. The hook's raf runs, measures, and commits the
+    // state update. Wrap in act so the resulting re-render flushes.
+    await act(async () => {
+      const drained = pending.splice(0, pending.length)
+      drained.forEach((cb) => cb(performance.now()))
+    })
+
+    expect(result.current).toBe(16 + 80 + 8)
+  })
+
+  it('cancels the pending animation frame when the hook unmounts before the retry fires', () => {
+    // Same deferred-raf setup so the raf stays queued across unmount.
+    const pending: Array<FrameRequestCallback> = []
+    let nextId = 1
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      ((cb: FrameRequestCallback) => {
+        pending.push(cb)
+        return nextId++
+      }) as typeof requestAnimationFrame
+    )
+    const cancelSpy = vi.fn()
+    vi.stubGlobal('cancelAnimationFrame', cancelSpy)
+
+    setPRNotifications(1)
+    const { unmount } = renderHook(() => usePRStackTopOffset())
+    // No stack is in the DOM, so the null branch scheduled a raf.
+    expect(pending.length).toBe(1)
+    expect(() => unmount()).not.toThrow()
+    expect(cancelSpy).toHaveBeenCalledWith(1)
+  })
 })

--- a/test/task-list/use-pr-stack-top-offset.test.tsx
+++ b/test/task-list/use-pr-stack-top-offset.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { usePRStackTopOffset } from '@/components/sessions/usePRStackTopOffset'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
+
+// -----------------------------------------------------------------------------
+// Mock ResizeObserver — jsdom does not implement it natively. We also expose a
+// trigger() so tests can simulate size-change notifications.
+// -----------------------------------------------------------------------------
+
+const observers: MockResizeObserver[] = []
+
+class MockResizeObserver {
+  observe = vi.fn((target: Element) => {
+    this.target = target
+  })
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+  private callback: ResizeObserverCallback
+  private target: Element | null = null
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    observers.push(this)
+  }
+
+  trigger(): void {
+    if (!this.target) return
+    this.callback(
+      [
+        {
+          target: this.target,
+          contentRect: this.target.getBoundingClientRect()
+        } as ResizeObserverEntry
+      ],
+      this as unknown as ResizeObserver
+    )
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+const originalPRState = usePRNotificationStore.getState()
+
+function setPRNotifications(count: number): void {
+  const notifications = Array.from({ length: count }, (_, i) => ({
+    id: `pr-${i}`,
+    status: 'info' as const,
+    message: `Notification ${i}`
+  }))
+  act(() => {
+    usePRNotificationStore.setState({ notifications })
+  })
+}
+
+function mountFakeStack(height: number): HTMLElement {
+  const stack = document.createElement('div')
+  stack.setAttribute('data-testid', 'pr-notification-stack')
+  Object.defineProperty(stack, 'offsetHeight', {
+    configurable: true,
+    value: height
+  })
+  document.body.appendChild(stack)
+  return stack
+}
+
+function setStackHeight(stack: HTMLElement, height: number): void {
+  Object.defineProperty(stack, 'offsetHeight', {
+    configurable: true,
+    value: height
+  })
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+describe('usePRStackTopOffset', () => {
+  beforeEach(() => {
+    observers.length = 0
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+    act(() => {
+      usePRNotificationStore.setState({ ...originalPRState, notifications: [] })
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.unstubAllGlobals()
+    act(() => {
+      usePRNotificationStore.setState(originalPRState)
+    })
+  })
+
+  it('returns the baseline 16px offset when there are no PR notifications', () => {
+    const { result } = renderHook(() => usePRStackTopOffset())
+    expect(result.current).toBe(16)
+  })
+
+  it('returns the baseline 16px offset when notifications exist but no stack element is in the DOM', () => {
+    // Store says count > 0, but PRNotificationStack is not mounted (e.g.
+    // hasn't rendered yet or was unmounted). The hook should gracefully
+    // fall back to the baseline rather than throwing.
+    setPRNotifications(1)
+    const { result } = renderHook(() => usePRStackTopOffset())
+    expect(result.current).toBe(16)
+  })
+
+  it('returns 16 + stack.offsetHeight + 8 when a PR stack element is present and notifications exist', () => {
+    mountFakeStack(100)
+    setPRNotifications(1)
+    const { result } = renderHook(() => usePRStackTopOffset())
+    // 16 (top-4 of the stack) + 100 (measured stack height) + 8 (gap) = 124
+    expect(result.current).toBe(124)
+  })
+
+  it('re-measures when the ResizeObserver fires (stack grew in place)', () => {
+    const stack = mountFakeStack(80)
+    setPRNotifications(1)
+    const { result } = renderHook(() => usePRStackTopOffset())
+    expect(result.current).toBe(16 + 80 + 8)
+
+    // Stack grew — e.g. a card expanded with an action row. Trigger observer.
+    setStackHeight(stack, 160)
+    act(() => {
+      observers[observers.length - 1]?.trigger()
+    })
+    expect(result.current).toBe(16 + 160 + 8)
+  })
+
+  it('returns to baseline when notifications are dismissed', () => {
+    mountFakeStack(120)
+    setPRNotifications(2)
+    const { result, rerender } = renderHook(() => usePRStackTopOffset())
+    expect(result.current).toBe(16 + 120 + 8)
+
+    // User dismisses all notifications. PRNotificationStack unmounts, and
+    // the hook's effect re-runs because `count` changed.
+    setPRNotifications(0)
+    rerender()
+    expect(result.current).toBe(16)
+  })
+
+  it('disconnects the ResizeObserver on unmount', () => {
+    mountFakeStack(80)
+    setPRNotifications(1)
+    const { unmount } = renderHook(() => usePRStackTopOffset())
+    const observer = observers[observers.length - 1]
+    expect(observer).toBeDefined()
+    unmount()
+    expect(observer!.disconnect).toHaveBeenCalled()
+  })
+
+  it('falls back gracefully when ResizeObserver is not available', () => {
+    // Simulate an environment without ResizeObserver (e.g. older test runtime).
+    vi.stubGlobal('ResizeObserver', undefined)
+    mountFakeStack(64)
+    setPRNotifications(1)
+    const { result } = renderHook(() => usePRStackTopOffset())
+    // Should still do the initial measurement.
+    expect(result.current).toBe(16 + 64 + 8)
+  })
+})


### PR DESCRIPTION
## Summary

- **TaskListWidget component**: Displays todo items in a collapsible floating panel positioned in the bottom-right corner
  - Shows task count (completed/total) in both expanded and collapsed states
  - Renders status icons (pending, in-progress, completed, cancelled) and priority badges
  - Collapsed state shows minimal pill with counter; expanded shows full task list with scrolling
  - Collapse state persists via `taskListCollapsed` setting in `useSettingsStore`

- **useLatestTodoList hook**: Extracts the most recent TodoWrite tool output from message history
  - Scans streaming message first, then walks backward through message history
  - Returns `{ todos, isIncomplete }` where `isIncomplete` flags any pending/in-progress tasks
  - Widget only renders when `isIncomplete` is true (hides when all tasks are done or cancelled)

- **usePRStackTopOffset hook**: Dynamically measures PR notification stack height for collision-free positioning
  - Queries `data-testid="pr-notification-stack"` element and measures its `offsetHeight`
  - Uses `ResizeObserver` to track stack size changes (cards added/removed, descriptions toggled)
  - Returns baseline 16px (`BASELINE_TOP_PX`) when no notifications; adds measured height + 8px gap otherwise
  - Gracefully degrades if `ResizeObserver` unavailable (older runtimes, some test environments)
  - Retries measurement on next animation frame if DOM element hasn't committed yet

- **SessionView & SessionStreamPanel integration**:
  - SessionView uses `usePRStackTopOffset()` for full-screen positioning
  - SessionStreamPanel uses fixed `BASELINE_TOP_PX` (16px) because PR stack is hidden behind modal backdrop

- **Refactoring**:
  - Extracted `StatusIcon` and `PriorityBadge` components to new `todoIcons.tsx` shared module
  - Exported `isTodoWriteTool` from `ToolCard.tsx` for reuse in `useLatestTodoList`
  - Added `taskListCollapsed` to `AppSettings` with default `false`

- **Test coverage**: 4 new test files with 14+ test cases covering:
  - TaskListWidget rendering logic (collapsed/expanded states, icon rendering, priority display)
  - useLatestTodoList hook (message scanning, incomplete detection, streaming message priority)
  - usePRStackTopOffset hook (baseline positioning, stack measurement, ResizeObserver integration)
  - SessionStreamPanel integration (widget gating condition, correct offset in modal context)
  - SessionView integration (full positioning stack with measured offsets, notification dismissal flow)

## Testing

- Unit tests for `TaskListWidget`: toggle behavior, collapsed/expanded rendering, icon and priority badge display
- Unit tests for `useLatestTodoList`: message history scanning, incomplete status detection, streaming message precedence
- Unit tests for `usePRStackTopOffset`: baseline offset, ResizeObserver measurement, notification count changes, animation frame retry logic
- Integration test for SessionStreamPanel: widget gating condition verified with real component mount
- Integration test for SessionView: full positioning logic with mocked notification store and settings store
- All tests mock jsdom-unsupported features (`ResizeObserver`, `Element.scrollIntoView`) or expensive dependencies (MessageRenderer, ScrollToBottomFab)
- Snapshot of original store state preserved and restored in beforeEach/afterEach blocks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/state change that adds new message-parsing logic and DOM measurement via `ResizeObserver`, which could affect session rendering/positioning but is not security-sensitive.
> 
> **Overview**
> Adds a new floating `TaskListWidget` to `SessionView` and kanban `SessionStreamPanel` that shows the *latest* `TodoWrite` task list and only appears while any tasks are still pending/in progress.
> 
> Introduces `useLatestTodoList` to scan committed + streaming message parts for the most recent TodoWrite-style `tool_use`, and `usePRStackTopOffset` to dynamically position the widget below the PR notification stack (with a baseline offset in the modal panel). The widget’s collapsed/expanded state is persisted via a new `taskListCollapsed` setting, and todo status/priority icon rendering is refactored into shared `todoIcons` utilities.
> 
> Adds comprehensive unit/integration tests covering todo extraction, widget behavior, dynamic top offset measurement (including `ResizeObserver`/rAF retry paths), and the SessionView/SessionStreamPanel render gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61e527bc9b6fed35dbf1de9cda6821d9d0b2f86b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->