### PR TITLE
feat: add keep-awake feature to prevent display sleep during sessions

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,6 +65,7 @@ import { registerTicketImportHandlers } from './ipc/ticket-import-handlers'
 import { initTicketProviderManager, GitHubProvider, JiraProvider } from './services/ticket-providers'
 import { APP_SETTINGS_DB_KEY } from '../shared/types/settings'
 import { openCodeService } from './services/opencode-service'
+import { setKeepAwake, cleanupPowerSaveBlocker } from './services/power-save-blocker'
 
 const log = createLogger({ component: 'Main' })
 
@@ -404,6 +405,13 @@ function registerSystemHandlers(openCodeLaunchSpec: OpenCodeLaunchSpec | null): 
     return process.platform
   })
 
+  // Prevent display sleep while renderer-driven sessions are active.
+  // The renderer owns the decision of when to hold the blocker; this handler
+  // simply forwards the desired state to the idempotent service.
+  ipcMain.handle('system:setKeepAwake', (_event, active: boolean) => {
+    setKeepAwake(Boolean(active))
+  })
+
   // Mirror renderer-side follow-up message queue state into the main process so
   // notification-service can suppress session-complete notifications while more
   // queued messages are about to be auto-sent.
@@ -696,6 +704,8 @@ app.on('will-quit', async () => {
   cleanupScripts()
   // Cleanup running bash runs (best-effort, no await)
   bashService.killAll()
+  // Release any held power save blocker so the display can sleep again
+  cleanupPowerSaveBlocker()
   // Cleanup file tree watchers
   await cleanupFileTreeWatchers()
   // Cleanup worktree watchers (git status monitoring)

--- a/src/main/services/power-save-blocker.ts
+++ b/src/main/services/power-save-blocker.ts
@@ -1,0 +1,63 @@
+import { powerSaveBlocker } from 'electron'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'PowerSaveBlocker' })
+
+/**
+ * Wraps Electron's `powerSaveBlocker` API with idempotent state management.
+ *
+ * The blocker uses the `prevent-display-sleep` mode, which keeps the display
+ * awake and (on macOS) prevents lid-close-triggered sleep. A single
+ * module-level blocker id is tracked so repeated calls with the same desired
+ * state are no-ops.
+ */
+
+let currentBlockerId: number | null = null
+
+/**
+ * Idempotently set whether the system should stay awake.
+ *
+ * - `active === true`: starts a `prevent-display-sleep` blocker if none is held.
+ * - `active === false`: stops the held blocker if any.
+ * - Already in desired state: no-op.
+ */
+export function setKeepAwake(active: boolean): void {
+  if (active) {
+    if (currentBlockerId !== null) return
+    try {
+      const id = powerSaveBlocker.start('prevent-display-sleep')
+      currentBlockerId = id
+      log.info('Started power save blocker', { id })
+    } catch (err) {
+      log.error(
+        'Failed to start power save blocker',
+        err instanceof Error ? err : new Error(String(err))
+      )
+    }
+  } else {
+    if (currentBlockerId === null) return
+    const id = currentBlockerId
+    try {
+      powerSaveBlocker.stop(id)
+      log.info('Stopped power save blocker', { id })
+    } catch (err) {
+      log.error(
+        'Failed to stop power save blocker',
+        err instanceof Error ? err : new Error(String(err)),
+        { id }
+      )
+    } finally {
+      currentBlockerId = null
+    }
+  }
+}
+
+/** Returns whether a power save blocker is currently held (diagnostics). */
+export function isKeepAwakeActive(): boolean {
+  return currentBlockerId !== null
+}
+
+/** Release any active blocker. Safe to call when none is held. */
+export function cleanupPowerSaveBlocker(): void {
+  setKeepAwake(false)
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -599,6 +599,7 @@ declare global {
       onMenuAction: (channel: string, callback: () => void) => () => void
       isPackaged: () => Promise<boolean>
       getPlatform: () => Promise<string>
+      setKeepAwake: (active: boolean) => Promise<void>
       setSessionQueuedState: (sessionId: string, hasQueued: boolean) => Promise<void>
     }
     loggingOps: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -550,6 +550,11 @@ const systemOps = {
   // Get the current platform (darwin, win32, linux)
   getPlatform: (): Promise<string> => ipcRenderer.invoke('system:getPlatform'),
 
+  // Ask the main process to hold (or release) a power save blocker so the
+  // display stays awake while a session is streaming.
+  setKeepAwake: (active: boolean): Promise<void> =>
+    ipcRenderer.invoke('system:setKeepAwake', active),
+
   // Push the renderer's follow-up-message queue state into the main process so
   // `notificationService.showSessionComplete` can suppress notifications while
   // more queued messages are about to be auto-sent.

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -19,6 +19,7 @@ import { useWindowFocusRefresh } from '@/hooks/useWindowFocusRefresh'
 import { useWorktreeWatcher } from '@/hooks/useWorktreeWatcher'
 import { useConnectionWatcher } from '@/hooks/useConnectionWatcher'
 import { useAutoUpdate } from '@/hooks/useAutoUpdate'
+import { useKeepAwake } from '@/hooks/useKeepAwake'
 import { ErrorBoundary, ErrorFallback } from '@/components/error'
 import { CreatePRModal } from '@/components/pr/CreatePRModal'
 import { ProjectSettingsDialog } from '@/components/projects/ProjectSettingsDialog'
@@ -134,6 +135,8 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
   useConnectionWatcher()
   // Auto-update notifications
   useAutoUpdate()
+  // Keep the computer awake while any session is actively streaming (opt-in via settings)
+  useKeepAwake()
 
   // Drag-and-drop from Finder
   const activeSessionId = useSessionStore((s) => s.activeSessionId)

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -335,7 +335,9 @@ export function Header(): React.JSX.Element {
                 <Coffee className="h-4 w-4" />
               </span>
             </TooltipTrigger>
-            <TooltipContent>Prevents your computer from sleeping while a session is running</TooltipContent>
+            <TooltipContent side="bottom" sideOffset={8}>
+              Prevents your computer from sleeping while a session is running
+            </TooltipContent>
           </Tooltip>
         )}
         {vimModeEnabled && (

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -118,7 +118,6 @@ export function Header(): React.JSX.Element {
       (entry) => entry && (entry.status === 'working' || entry.status === 'planning')
     ).length
   )
-  const keepAwakeActive = keepAwakeEnabled && streamingCount > 0
   const showVimHints = vimModeEnabled && vimMode === 'normal'
   const isBoardViewActive = useKanbanStore((s) => s.isBoardViewActive)
   const toggleBoardView = useKanbanStore((s) => s.toggleBoardView)
@@ -325,10 +324,14 @@ export function Header(): React.JSX.Element {
         ) : (
           <span className="text-sm font-medium">Hive</span>
         )}
-        {keepAwakeActive && (
+        {keepAwakeEnabled && (
           <span
-            title={`Keeping computer awake (${streamingCount} session${streamingCount === 1 ? '' : 's'} active)`}
-            className="text-amber-500 shrink-0"
+            title={
+              streamingCount > 0
+                ? `Keeping computer awake (${streamingCount} session${streamingCount === 1 ? '' : 's'} active)`
+                : 'Keep-awake enabled (no active sessions)'
+            }
+            className={cn('shrink-0', streamingCount > 0 ? 'text-amber-500' : 'text-muted-foreground')}
             data-testid="keep-awake-indicator"
           >
             <Coffee className="h-4 w-4" />

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenuItem
 } from '@/components/ui/dropdown-menu'
 import { Popover, PopoverTrigger, PopoverContent, PopoverAnchor } from '@/components/ui/popover'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import {
   ContextMenu,
   ContextMenuTrigger,
@@ -325,17 +326,17 @@ export function Header(): React.JSX.Element {
           <span className="text-sm font-medium">Hive</span>
         )}
         {keepAwakeEnabled && (
-          <span
-            title={
-              streamingCount > 0
-                ? `Keeping computer awake (${streamingCount} session${streamingCount === 1 ? '' : 's'} active)`
-                : 'Keep-awake enabled (no active sessions)'
-            }
-            className={cn('shrink-0', streamingCount > 0 ? 'text-amber-500' : 'text-muted-foreground')}
-            data-testid="keep-awake-indicator"
-          >
-            <Coffee className="h-4 w-4" />
-          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className={cn('shrink-0', streamingCount > 0 ? 'text-amber-500' : 'text-muted-foreground')}
+                data-testid="keep-awake-indicator"
+              >
+                <Coffee className="h-4 w-4" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>Prevents your computer from sleeping while a session is running</TooltipContent>
+          </Tooltip>
         )}
         {vimModeEnabled && (
           <span

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -11,6 +11,7 @@ import {
   GitMerge,
   Archive,
   ChevronDown,
+  Coffee,
   FileSearch,
   X,
   ExternalLink,
@@ -111,6 +112,13 @@ export function Header(): React.JSX.Element {
   const boardMode = useSettingsStore((s) => s.boardMode)
   const currentReviewPromptType = useSettingsStore((s) => s.reviewPromptType)
   const updateSetting = useSettingsStore((s) => s.updateSetting)
+  const keepAwakeEnabled = useSettingsStore((s) => s.keepAwakeEnabled)
+  const streamingCount = useWorktreeStatusStore((state) =>
+    Object.values(state.sessionStatuses).filter(
+      (entry) => entry && (entry.status === 'working' || entry.status === 'planning')
+    ).length
+  )
+  const keepAwakeActive = keepAwakeEnabled && streamingCount > 0
   const showVimHints = vimModeEnabled && vimMode === 'normal'
   const isBoardViewActive = useKanbanStore((s) => s.isBoardViewActive)
   const toggleBoardView = useKanbanStore((s) => s.toggleBoardView)
@@ -316,6 +324,15 @@ export function Header(): React.JSX.Element {
           </span>
         ) : (
           <span className="text-sm font-medium">Hive</span>
+        )}
+        {keepAwakeActive && (
+          <span
+            title={`Keeping computer awake (${streamingCount} session${streamingCount === 1 ? '' : 's'} active)`}
+            className="text-amber-500 shrink-0"
+            data-testid="keep-awake-indicator"
+          >
+            <Coffee className="h-4 w-4" />
+          </span>
         )}
         {vimModeEnabled && (
           <span

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -19,6 +19,7 @@ export function SettingsGeneral(): React.JSX.Element {
     boardMode,
     followUpTriggerColumn,
     vimModeEnabled,
+    keepAwakeEnabled,
     mergeConflictMode,
     tipsEnabled,
     breedType,
@@ -204,6 +205,33 @@ export function SettingsGeneral(): React.JSX.Element {
             className={cn(
               'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
               vimModeEnabled ? 'translate-x-4' : 'translate-x-0'
+            )}
+          />
+        </button>
+      </div>
+
+      {/* Keep computer awake during sessions */}
+      <div className="flex items-center justify-between">
+        <div>
+          <label className="text-sm font-medium">Keep computer awake during sessions</label>
+          <p className="text-xs text-muted-foreground">
+            Prevent your computer from sleeping while any worktree has an AI session actively running.
+          </p>
+        </div>
+        <button
+          role="switch"
+          aria-checked={keepAwakeEnabled}
+          onClick={() => updateSetting('keepAwakeEnabled', !keepAwakeEnabled)}
+          className={cn(
+            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+            keepAwakeEnabled ? 'bg-primary' : 'bg-muted'
+          )}
+          data-testid="keep-awake-enabled-toggle"
+        >
+          <span
+            className={cn(
+              'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+              keepAwakeEnabled ? 'translate-x-4' : 'translate-x-0'
             )}
           />
         </button>

--- a/src/renderer/src/hooks/useKeepAwake.ts
+++ b/src/renderer/src/hooks/useKeepAwake.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+
+/**
+ * Drives the main-process powerSaveBlocker based on the user's keep-awake
+ * setting and whether any session is actively streaming ('working' or
+ * 'planning'). Other statuses (answering, permission, command_approval,
+ * completed, etc.) do not count as streaming for this purpose.
+ */
+export function useKeepAwake(): void {
+  const enabled = useSettingsStore((s) => s.keepAwakeEnabled)
+
+  const hasStreamingSession = useWorktreeStatusStore((state) =>
+    Object.values(state.sessionStatuses).some(
+      (entry) => entry && (entry.status === 'working' || entry.status === 'planning')
+    )
+  )
+
+  const shouldBeAwake = enabled && hasStreamingSession
+
+  useEffect(() => {
+    window.systemOps?.setKeepAwake?.(shouldBeAwake).catch((err) => {
+      console.error('[keepAwake] setKeepAwake failed', err)
+    })
+  }, [shouldBeAwake])
+}

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -52,6 +52,7 @@ export interface AppSettings {
   autoPullBeforeWorktree: boolean
   breedType: 'dogs' | 'cats'
   vimModeEnabled: boolean
+  keepAwakeEnabled: boolean
   taskListCollapsed: boolean
   mergeConflictMode: MergeConflictMode
   boardMode: 'toggle' | 'sticky-tab'
@@ -140,6 +141,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   autoPullBeforeWorktree: true,
   breedType: 'dogs',
   vimModeEnabled: false,
+  keepAwakeEnabled: false,
   taskListCollapsed: false,
   mergeConflictMode: 'always-ask',
   boardMode: 'sticky-tab',
@@ -294,6 +296,7 @@ function extractSettings(state: SettingsState): AppSettings {
     autoPullBeforeWorktree: state.autoPullBeforeWorktree,
     breedType: state.breedType,
     vimModeEnabled: state.vimModeEnabled,
+    keepAwakeEnabled: state.keepAwakeEnabled,
     taskListCollapsed: state.taskListCollapsed,
     mergeConflictMode: state.mergeConflictMode,
     boardMode: state.boardMode,
@@ -553,6 +556,7 @@ export const useSettingsStore = create<SettingsState>()(
         autoPullBeforeWorktree: state.autoPullBeforeWorktree,
         breedType: state.breedType,
         vimModeEnabled: state.vimModeEnabled,
+        keepAwakeEnabled: state.keepAwakeEnabled,
         taskListCollapsed: state.taskListCollapsed,
         mergeConflictMode: state.mergeConflictMode,
         boardMode: state.boardMode,


### PR DESCRIPTION
## Summary

- Add `powerSaveBlocker` service in main process to idempotently manage display-sleep prevention
- Add `keepAwakeEnabled` setting (default: false) with toggle UI in General settings
- Implement `useKeepAwake()` hook to drive blocker based on active streaming sessions ('working' or 'planning' status)
- Display Coffee icon indicator in header when feature is enabled, with amber highlight when sessions are actively streaming
- Add tooltip explaining the feature on the Coffee icon
- IPC bridge between renderer and main process via `system:setKeepAwake` handler
- Ensure blocker is cleaned up on app quit

## Testing

- Verify toggle in Settings > General enables/disables the feature
- Confirm Coffee icon appears in header only when `keepAwakeEnabled` is true
- Verify Coffee icon is muted (text-muted-foreground) when no sessions are streaming
- Verify Coffee icon turns amber (text-amber-500) when at least one session is in 'working' or 'planning' status
- Hover over Coffee icon and confirm tooltip displays: "Prevents your computer from sleeping while a session is running"
- Start a session and confirm display remains awake (OS-level verification)
- Stop all sessions and confirm display can sleep again
- Toggle setting off and confirm blocker is released immediately
- Verify blocker is cleaned up when app quits
- Confirm feature does not affect sessions in 'answering', 'permission', 'command_approval', 'completed' or other non-streaming statuses

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new main-process `powerSaveBlocker` flow controlled by renderer state over IPC, which can inadvertently keep users’ displays awake if session-state detection or cleanup misbehaves. Scope is limited and opt-in via a new setting, reducing blast radius.
> 
> **Overview**
> Adds an **opt-in “keep awake during sessions” feature** that prevents display sleep while any worktree session is actively streaming.
> 
> Implements an idempotent main-process `powerSaveBlocker` service and exposes it via a new `system:setKeepAwake` IPC/preload bridge, driven by a new renderer `useKeepAwake()` hook (based on `working`/`planning` statuses). Includes a new `keepAwakeEnabled` persisted setting with a toggle in General settings, a header coffee indicator/tooltip, and releases the blocker on app quit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14556d0f89b22e385f5c7c2f7d5b3934b35390e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->