### PR TITLE
Add xhigh effort level support for Claude Opus

### DIFF
--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -20,7 +20,7 @@ import { APP_SETTINGS_DB_KEY } from '@shared/types/settings'
 const log = createLogger({ component: 'ClaudeCodeImplementer' })
 
 const CLAUDE_EFFORT_VARIANTS = { low: {}, medium: {}, high: {} }
-const CLAUDE_OPUS_EFFORT_VARIANTS = { low: {}, medium: {}, high: {}, max: {} }
+const CLAUDE_OPUS_EFFORT_VARIANTS = { low: {}, medium: {}, high: {}, xhigh: {}, max: {} }
 
 const CLAUDE_MODELS = [
   {


### PR DESCRIPTION
## Summary

- Adds `xhigh` effort level to `CLAUDE_OPUS_EFFORT_VARIANTS` object
- Enables extended high-effort processing option for Opus 4.7 model
- Maintains backward compatibility with existing `low`, `medium`, `high`, and `max` effort levels

## Testing

- Verify `xhigh` effort level can be selected in Claude Opus configuration
- Confirm existing effort levels (`low`, `medium`, `high`, `max`) still function correctly
- Check that effort level selection in UI/API accepts the new `xhigh` option
- Not run: integration tests (requires full environment setup)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `xhigh` effort variant option for the Opus model without changing execution flow or defaults.
> 
> **Overview**
> Adds support for selecting an additional `xhigh` effort level for the Claude Opus (`Opus 4.7`) model by extending `CLAUDE_OPUS_EFFORT_VARIANTS` so the new variant is surfaced alongside existing effort options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2325cde61e50ee117b90c134b185204a46080404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->