### PR TITLE
feat(kanban): support connection sessions in plan-review mode with exit-plan-mode interaction

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1245,6 +1245,33 @@ function PlanReviewModeContent({
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const dropZoneRef = useRef<HTMLDivElement>(null)
 
+  const isConnectionSession = !!sessionRecord?.connection_id
+  const hasWorkingContext = !!(sessionRecord?.worktree_id || sessionRecord?.connection_id)
+
+  const [slashCommands, setSlashCommands] = useState<{ name: string }[]>([])
+  const hasSuperpowers = useMemo(
+    () => slashCommands.some((c) => c.name === 'using-superpowers'),
+    [slashCommands]
+  )
+
+  useEffect(() => {
+    if (!worktreePath || !opcSessionId) return
+    let cancelled = false
+    window.opencodeOps
+      .commands(worktreePath, opcSessionId)
+      .then((result) => {
+        if (!cancelled && result.success && result.commands) {
+          setSlashCommands(result.commands)
+        }
+      })
+      .catch(() => {
+        /* non-fatal; supercharge buttons stay hidden */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [worktreePath, opcSessionId])
+
   const planContent = pendingPlan?.planContent ?? ticket.description ?? ''
 
   const handleAttach = useCallback((file: Omit<Attachment, 'id'>) => {
@@ -1490,7 +1517,7 @@ function PlanReviewModeContent({
 
   // ── Handoff handler ───────────────────────────────────────────────
   const handleHandoff = useCallback(async () => {
-    if (!ticket.current_session_id || !ticket.worktree_id || isActioning) return
+    if (!ticket.current_session_id || !hasWorkingContext || isActioning) return
     setIsActioning(true)
 
     try {
@@ -1499,8 +1526,47 @@ function PlanReviewModeContent({
       useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
       lastSendMode.delete(sessionId)
 
+      // Connection-session branch: mirrors SessionView.tsx handoff connection path.
+      if (sessionRecord?.connection_id) {
+        // Abort the original backend session so it stops spinning (parity with SessionView).
+        if (worktreePath && opcSessionId) {
+          useCommandApprovalStore.getState().clearSession(sessionId)
+          await window.opencodeOps.abort(worktreePath, opcSessionId)
+        }
+
+        const sessionStore = useSessionStore.getState()
+        const result = await sessionStore.createConnectionSession(sessionRecord.connection_id)
+        if (!result.success || !result.session) {
+          toast.error(result.error ?? 'Failed to create handoff session')
+          return
+        }
+
+        const handoffPrompt = `Implement the following plan\n${planContent}`
+        await sessionStore.setSessionMode(result.session.id, 'build')
+        sessionStore.setPendingMessage(result.session.id, handoffPrompt)
+        notifyKanbanSessionSync(sessionId, { type: 'supercharge', newSessionId: result.session.id })
+
+        // In sticky-tab mode, stay on the board; otherwise navigate to the new session
+        const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
+        if (useSettingsStore.getState().boardMode === 'sticky-tab') {
+          sessionStore.setActiveSession(BOARD_TAB_ID)
+        } else {
+          sessionStore.setActiveConnectionSession(result.session.id)
+        }
+
+        await useKanbanStore.getState().updateTicket(ticket.id, ticket.project_id, {
+          current_session_id: result.session.id,
+          plan_ready: false,
+          mode: 'build'
+        })
+
+        toast.success('Handoff session created')
+        onClose()
+        return
+      }
+
       const sessionStore = useSessionStore.getState()
-      const result = await sessionStore.createSession(ticket.worktree_id, ticket.project_id)
+      const result = await sessionStore.createSession(ticket.worktree_id!, ticket.project_id)
       if (!result.success || !result.session) {
         toast.error(result.error ?? 'Failed to create handoff session')
         return
@@ -1532,7 +1598,7 @@ function PlanReviewModeContent({
     } finally {
       setIsActioning(false)
     }
-  }, [ticket, isActioning, planContent, onClose])
+  }, [ticket, isActioning, planContent, onClose, hasWorkingContext, sessionRecord, worktreePath, opcSessionId])
 
   // Synchronously re-link the ticket to the new session and (if needed) move it to in_progress
   // so the kanban board reflects the supercharge before the modal closes. Per-session timing /
@@ -1603,7 +1669,7 @@ function PlanReviewModeContent({
 
   // ── Supercharge handler (new branch) ────────────────────────────
   const handleSupercharge = useCallback(async () => {
-    if (!ticket.current_session_id || !ticket.worktree_id || isActioning) return
+    if (!ticket.current_session_id || !hasWorkingContext || isActioning) return
     setIsActioning(true)
 
     try {
@@ -1616,6 +1682,32 @@ function PlanReviewModeContent({
       if (worktreePath && opcSessionId) {
         useCommandApprovalStore.getState().clearSession(sessionId)
         await window.opencodeOps.abort(worktreePath, opcSessionId)
+      }
+
+      // Connection-session branch: use eager start since modal closes to the board.
+      if (sessionRecord?.connection_id) {
+        const sessionStore = useSessionStore.getState()
+        const sessionResult = await sessionStore.createConnectionSession(sessionRecord.connection_id)
+        if (!sessionResult.success || !sessionResult.session) {
+          toast.error(sessionResult.error ?? 'Failed to create supercharge session')
+          return
+        }
+        const newSessionId = sessionResult.session.id
+        const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
+
+        prepareTicketSuperchargeSession(newSessionId)
+        onClose()
+
+        void (async () => {
+          await setModePromise
+          // worktreePath is the connection path for connection sessions (parent resolves it).
+          await eagerSuperchargeStart(worktreePath!, newSessionId)
+          toast.success('Supercharge session started')
+        })().catch((error) => {
+          console.error('[KanbanTicketModal] supercharge (connection) background start failed:', error)
+          toast.error('Failed to supercharge')
+        })
+        return
       }
 
       // Look up worktree and project for duplication
@@ -1676,7 +1768,7 @@ function PlanReviewModeContent({
     } finally {
       setIsActioning(false)
     }
-  }, [ticket, isActioning, onClose, eagerSuperchargeStart, prepareTicketSuperchargeSession, worktreePath, opcSessionId])
+  }, [ticket, isActioning, onClose, eagerSuperchargeStart, prepareTicketSuperchargeSession, worktreePath, opcSessionId, hasWorkingContext, sessionRecord])
 
   // ── Supercharge Local handler (same worktree, no duplication) ───
   const handleSuperchargeLocal = useCallback(async () => {
@@ -1797,7 +1889,7 @@ function PlanReviewModeContent({
           <Button
             type="button"
             data-testid="plan-review-handoff-btn"
-            disabled={isActioning || !ticket.worktree_id}
+            disabled={isActioning || !hasWorkingContext}
             onClick={handleHandoff}
             className="gap-1.5"
             variant="outline"
@@ -1805,27 +1897,31 @@ function PlanReviewModeContent({
             <ArrowRight className="h-3.5 w-3.5" />
             Handoff
           </Button>
-          <Button
-            type="button"
-            data-testid="plan-review-supercharge-local-btn"
-            disabled={isActioning || !ticket.worktree_id}
-            onClick={handleSuperchargeLocal}
-            className="gap-1.5 bg-violet-600 hover:bg-violet-700 text-white"
-          >
-            <Bolt className="h-3.5 w-3.5" />
-            Supercharge
-          </Button>
-          <Button
-            type="button"
-            data-testid="plan-review-supercharge-btn"
-            disabled={isActioning || !ticket.worktree_id}
-            onClick={handleSupercharge}
-            className="gap-1.5 bg-violet-600 hover:bg-violet-700 text-white"
-            variant="outline"
-          >
-            <Zap className="h-3.5 w-3.5" />
-            Supercharge (new branch)
-          </Button>
+          {!isConnectionSession && hasSuperpowers && (
+            <Button
+              type="button"
+              data-testid="plan-review-supercharge-local-btn"
+              disabled={isActioning || !hasWorkingContext}
+              onClick={handleSuperchargeLocal}
+              className="gap-1.5 border-violet-600 text-violet-600 hover:bg-violet-100 dark:hover:bg-violet-950"
+              variant="outline"
+            >
+              <Bolt className="h-3.5 w-3.5" />
+              Supercharge locally
+            </Button>
+          )}
+          {hasSuperpowers && (
+            <Button
+              type="button"
+              data-testid="plan-review-supercharge-btn"
+              disabled={isActioning || !hasWorkingContext}
+              onClick={handleSupercharge}
+              className="gap-1.5 bg-violet-600 hover:bg-violet-700 text-white"
+            >
+              <Zap className="h-3.5 w-3.5" />
+              Supercharge
+            </Button>
+          )}
           <Button
             type="button"
             data-testid="plan-review-implement-btn"

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1546,11 +1546,15 @@ function PlanReviewModeContent({
         sessionStore.setPendingMessage(result.session.id, handoffPrompt)
         notifyKanbanSessionSync(sessionId, { type: 'supercharge', newSessionId: result.session.id })
 
-        // In sticky-tab mode, stay on the board; otherwise navigate to the new session
+        // In sticky-tab mode, stay on the board; otherwise navigate to the new session.
+        // setActiveConnectionSession requires activeConnectionId to be set — which
+        // it isn't when the modal is opened from the kanban board — so we switch
+        // the active connection first, then nail down the session within it.
         const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
         if (useSettingsStore.getState().boardMode === 'sticky-tab') {
           sessionStore.setActiveSession(BOARD_TAB_ID)
         } else {
+          sessionStore.setActiveConnection(sessionRecord.connection_id)
           sessionStore.setActiveConnectionSession(result.session.id)
         }
 
@@ -1565,8 +1569,15 @@ function PlanReviewModeContent({
         return
       }
 
+      // Worktree-session branch. After the connection branch returns, TS can't
+      // narrow worktree_id from hasWorkingContext alone — use a local const
+      // rather than a non-null assertion so refactors of the branch above don't
+      // silently break this one.
+      const worktreeId = sessionRecord?.worktree_id
+      if (!worktreeId) return
+
       const sessionStore = useSessionStore.getState()
-      const result = await sessionStore.createSession(ticket.worktree_id!, ticket.project_id)
+      const result = await sessionStore.createSession(worktreeId, ticket.project_id)
       if (!result.success || !result.session) {
         toast.error(result.error ?? 'Failed to create handoff session')
         return
@@ -1725,8 +1736,15 @@ function PlanReviewModeContent({
         return
       }
 
+      // Worktree-session branch. After the connection branch returns, TS can't
+      // narrow worktree_id from hasWorkingContext alone — use a local const
+      // rather than a non-null assertion so refactors of the branch above don't
+      // silently break this one.
+      const worktreeId = sessionRecord?.worktree_id
+      if (!worktreeId) return
+
       // Look up worktree and project for duplication
-      const worktree = findWorktreeById(ticket.worktree_id!)
+      const worktree = findWorktreeById(worktreeId)
       if (!worktree) {
         toast.error('Could not find worktree')
         return

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1694,7 +1694,12 @@ function PlanReviewModeContent({
         // Narrow to const so TS narrowing survives across the background IIFE closure.
         const connectionPath = worktreePath
         const sessionStore = useSessionStore.getState()
-        const sessionResult = await sessionStore.createConnectionSession(sessionRecord.connection_id)
+        const sessionResult = await sessionStore.createConnectionSession(
+          sessionRecord.connection_id,
+          undefined,
+          undefined,
+          { autoFocus: false }
+        )
         if (!sessionResult.success || !sessionResult.session) {
           toast.error(sessionResult.error ?? 'Failed to create supercharge session')
           return

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1264,8 +1264,8 @@ function PlanReviewModeContent({
           setSlashCommands(result.commands)
         }
       })
-      .catch(() => {
-        /* non-fatal; supercharge buttons stay hidden */
+      .catch((err) => {
+        console.warn('[KanbanTicketModal] Failed to fetch slash commands:', err)
       })
     return () => {
       cancelled = true
@@ -1686,6 +1686,13 @@ function PlanReviewModeContent({
 
       // Connection-session branch: use eager start since modal closes to the board.
       if (sessionRecord?.connection_id) {
+        if (!worktreePath) {
+          toast.error('Connection path unavailable')
+          return
+        }
+        // worktreePath is the connection path for connection sessions (parent resolves it).
+        // Narrow to const so TS narrowing survives across the background IIFE closure.
+        const connectionPath = worktreePath
         const sessionStore = useSessionStore.getState()
         const sessionResult = await sessionStore.createConnectionSession(sessionRecord.connection_id)
         if (!sessionResult.success || !sessionResult.session) {
@@ -1698,10 +1705,13 @@ function PlanReviewModeContent({
         prepareTicketSuperchargeSession(newSessionId)
         onClose()
 
+        // NOTE: On IIFE failure, the ticket is left re-linked to the new session (via
+        // prepareTicketSuperchargeSession above) — same failure mode as the worktree
+        // branch below. We don't roll back because the error toast tells the user what
+        // happened and retrying (via a new supercharge click) creates a fresh session.
         void (async () => {
           await setModePromise
-          // worktreePath is the connection path for connection sessions (parent resolves it).
-          await eagerSuperchargeStart(worktreePath!, newSessionId)
+          await eagerSuperchargeStart(connectionPath, newSessionId)
           toast.success('Supercharge session started')
         })().catch((error) => {
           console.error('[KanbanTicketModal] supercharge (connection) background start failed:', error)

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -407,6 +407,12 @@ export function WorktreePickerModal({
         // Trigger usage refresh so the board shows up-to-date usage (debounced in store)
         useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(agentSdk))
 
+        // In sticky-tab mode, stay on the board instead of switching to the new session
+        if (useSettingsStore.getState().boardMode === 'sticky-tab') {
+          const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
+          useSessionStore.getState().setActiveSession(BOARD_TAB_ID)
+        }
+
         // Close modal
         onSendComplete?.()
         onOpenChange(false)

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -202,7 +202,8 @@ interface SessionState {
   createConnectionSession: (
     connectionId: string,
     agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
-    initialMode?: SessionMode
+    initialMode?: SessionMode,
+    opts?: { autoFocus?: boolean }
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
   setActiveConnectionSession: (sessionId: string | null) => void
   setActiveConnection: (connectionId: string | null) => void
@@ -1925,9 +1926,11 @@ export const useSessionStore = create<SessionState>()(
       createConnectionSession: async (
         connectionId: string,
         agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
-        initialMode?: SessionMode
+        initialMode?: SessionMode,
+        opts?: { autoFocus?: boolean }
       ) => {
         try {
+          const autoFocus = opts?.autoFocus ?? true
           // Look up the connection to get the first member's project_id
           const result = await window.connectionOps.get(connectionId)
           if (!result.success || !result.connection || result.connection.members.length === 0) {
@@ -1982,6 +1985,7 @@ export const useSessionStore = create<SessionState>()(
             connection_id: connectionId,
             name: isTerminal ? `Terminal ${sessionNumber}` : `Session ${sessionNumber}`,
             agent_sdk: defaultAgentSdk,
+            mode: initialMode || 'build',
             ...(defaultModel
               ? {
                   model_provider_id: defaultModel.providerID,
@@ -2003,16 +2007,25 @@ export const useSessionStore = create<SessionState>()(
             const newModeMap = new Map(state.modeBySession)
             newModeMap.set(session.id, session.mode || 'build')
 
-            return {
+            const base = {
               sessionsByConnection: newSessionsMap,
               tabOrderByConnection: newTabOrderMap,
-              modeBySession: newModeMap,
-              activeSessionId: session.id,
-              activeSessionByConnection: {
-                ...state.activeSessionByConnection,
-                [connectionId]: session.id
+              modeBySession: newModeMap
+            }
+
+            // Focus state — only when autoFocus is true
+            if (autoFocus) {
+              return {
+                ...base,
+                activeSessionId: session.id,
+                activeSessionByConnection: {
+                  ...state.activeSessionByConnection,
+                  [connectionId]: session.id
+                }
               }
             }
+
+            return base
           })
 
           return { success: true, session }

--- a/test/kanban/plan-review-followup-dispatch.test.tsx
+++ b/test/kanban/plan-review-followup-dispatch.test.tsx
@@ -51,7 +51,11 @@ const mockOpencodeOps = {
   reconnect: vi.fn().mockResolvedValue({ success: true }),
   getMessages: vi.fn().mockResolvedValue({ success: true, messages: [] }),
   planApprove: vi.fn().mockResolvedValue({ success: true }),
-  abort: vi.fn().mockResolvedValue({ success: true })
+  abort: vi.fn().mockResolvedValue({ success: true }),
+  commands: vi.fn().mockResolvedValue({
+    success: true,
+    commands: [{ name: 'using-superpowers' }]
+  })
 }
 
 const mockWorktreeOps = {
@@ -498,8 +502,9 @@ describe('Plan review followup dispatch', () => {
 
     render(<KanbanTicketModal />)
 
+    const superchargeLocalBtn = await screen.findByTestId('plan-review-supercharge-local-btn')
     await act(async () => {
-      fireEvent.click(screen.getByTestId('plan-review-supercharge-local-btn'))
+      fireEvent.click(superchargeLocalBtn)
     })
 
     await waitFor(() => {
@@ -596,8 +601,9 @@ describe('Plan review followup dispatch', () => {
 
     render(<KanbanTicketModal />)
 
+    const superchargeLocalBtn = await screen.findByTestId('plan-review-supercharge-local-btn')
     await act(async () => {
-      fireEvent.click(screen.getByTestId('plan-review-supercharge-local-btn'))
+      fireEvent.click(superchargeLocalBtn)
     })
 
     // Wait for the background IIFE to reach connect (which we've forced to fail).
@@ -689,8 +695,9 @@ describe('Plan review followup dispatch', () => {
 
     render(<KanbanTicketModal />)
 
+    const superchargeLocalBtn = await screen.findByTestId('plan-review-supercharge-local-btn')
     await act(async () => {
-      fireEvent.click(screen.getByTestId('plan-review-supercharge-local-btn'))
+      fireEvent.click(superchargeLocalBtn)
     })
 
     // Wait for the background work to reach prompt (still pending).

--- a/test/kanban/plan-review-followup-dispatch.test.tsx
+++ b/test/kanban/plan-review-followup-dispatch.test.tsx
@@ -67,6 +67,23 @@ const mockGitOps = {
   listBranchesWithStatus: vi.fn().mockResolvedValue({ success: true, branches: [] })
 }
 
+const mockConnectionOps = {
+  get: vi.fn().mockResolvedValue({
+    success: true,
+    connection: {
+      id: 'conn-1',
+      path: '/test/conn-1',
+      members: [{ project_id: 'proj-1', worktree_id: 'wt-1' }]
+    }
+  })
+}
+
+Object.defineProperty(window, 'connectionOps', {
+  writable: true,
+  configurable: true,
+  value: mockConnectionOps
+})
+
 Object.defineProperty(window, 'kanban', {
   writable: true,
   configurable: true,
@@ -142,6 +159,8 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useProjectStore } from '@/stores/useProjectStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
 
 // ── Import components under test ────────────────────────────────────
 import { KanbanTicketModal } from '@/components/kanban/KanbanTicketModal'
@@ -717,5 +736,138 @@ describe('Plan review followup dispatch', () => {
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('upercharge'))
     })
+  })
+
+  // ════════════════════════════════════════════════════════════════════
+  // REGRESSION: Handoff for a connection ticket from the kanban board
+  // must actually switch to the new session in non-sticky-tab mode.
+  // setActiveConnectionSession short-circuits when activeConnectionId is
+  // null (the common state when the modal is opened from the board), so
+  // the handler must also set the active connection.
+  // ════════════════════════════════════════════════════════════════════
+
+  test('handoff on connection ticket (non-sticky-tab) switches to the new connection session', async () => {
+    const connTicket = makeTicket({
+      id: 'ticket-conn',
+      column: 'in_progress',
+      plan_ready: true,
+      current_session_id: 'session-conn-old',
+      worktree_id: null, // connection ticket has no worktree
+      mode: 'plan',
+      description: '## Plan\n\nStep 1: Implement auth'
+    })
+
+    mockDbSession.create.mockResolvedValueOnce(
+      makeSession({
+        id: 'session-conn-new',
+        worktree_id: null,
+        connection_id: 'conn-1',
+        agent_sdk: 'claude-code',
+        mode: 'build',
+        opencode_session_id: null
+      })
+    )
+
+    act(() => {
+      useKanbanStore.setState({
+        tickets: new Map([['proj-1', [connTicket]]]),
+        isBoardViewActive: true,
+        selectedTicketId: 'ticket-conn'
+      })
+      useSessionStore.setState({
+        activeSessionId: null,
+        activeConnectionId: null, // user is on the board, not in a connection
+        activeWorktreeId: null,
+        sessionsByWorktree: new Map(),
+        sessionsByConnection: new Map([
+          [
+            'conn-1',
+            [
+              makeSession({
+                id: 'session-conn-old',
+                worktree_id: null,
+                connection_id: 'conn-1',
+                agent_sdk: 'claude-code',
+                opencode_session_id: 'opc-session-1'
+              })
+            ]
+          ]
+        ]),
+        tabOrderByConnection: new Map([['conn-1', ['session-conn-old']]]),
+        activeSessionByConnection: {},
+        pendingPlans: new Map([
+          [
+            'session-conn-old',
+            {
+              requestId: 'req-conn',
+              planContent: '## Detailed Plan\n\nStep 1: Implement auth',
+              toolUseID: 'tool-conn'
+            }
+          ]
+        ]),
+        pendingMessages: new Map(),
+        pendingFollowUpMessages: new Map()
+      })
+      useWorktreeStatusStore.setState({ sessionStatuses: {} })
+      useConnectionStore.setState({
+        connections: [
+          {
+            id: 'conn-1',
+            name: 'Test Conn',
+            custom_name: null,
+            status: 'active',
+            path: '/test/conn-1',
+            color: null,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+            members: [
+              {
+                id: 'mem-1',
+                connection_id: 'conn-1',
+                worktree_id: 'wt-1',
+                project_id: 'proj-1',
+                symlink_name: 'wt-1',
+                added_at: '2026-01-01T00:00:00Z',
+                worktree_name: 'feature-auth',
+                worktree_branch: 'feature-auth',
+                worktree_path: '/test/feature-auth',
+                project_name: 'My Project'
+              }
+            ]
+          }
+        ]
+      })
+      useSettingsStore.setState({ boardMode: 'toggle' })
+    })
+
+    render(<KanbanTicketModal />)
+
+    const handoffBtn = await screen.findByTestId('plan-review-handoff-btn')
+    await act(async () => {
+      fireEvent.click(handoffBtn)
+    })
+
+    // New session is created in the DB
+    await waitFor(() => {
+      expect(mockDbSession.create).toHaveBeenCalled()
+    })
+
+    // In non-sticky-tab mode, the user should be navigated to the new
+    // connection session — which requires activeConnectionId to be set so
+    // the shell can render the connection context (setActiveConnectionSession
+    // alone is a no-op when activeConnectionId is null).
+    await waitFor(() => {
+      expect(useSessionStore.getState().activeConnectionId).toBe('conn-1')
+    })
+    expect(useSessionStore.getState().activeSessionId).toBe('session-conn-new')
+
+    // Ticket is re-linked to the new session with plan_ready cleared.
+    const updatedTicket = useKanbanStore
+      .getState()
+      .tickets.get('proj-1')
+      ?.find((t) => t.id === 'ticket-conn')
+    expect(updatedTicket?.current_session_id).toBe('session-conn-new')
+    expect(updatedTicket?.plan_ready).toBe(false)
+    expect(updatedTicket?.mode).toBe('build')
   })
 })


### PR DESCRIPTION
## Summary

- **Connection session support**: Extended plan-review handoff and supercharge workflows to handle connection sessions alongside worktree sessions
- **Exit-plan-mode interaction**: Plans now exit plan-mode when handoff/supercharge actions complete on connection sessions, mirroring SessionView behavior
- **Sticky-tab mode respect**: Both plan-review actions and worktree-picker now respect the sticky-tab board mode setting to keep users on the kanban board when configured
- **Slash commands integration**: Added detection of `using-superpowers` command availability to conditionally display supercharge buttons only when the skill is accessible
- **Connection path handling**: Properly guard and pass connection paths through the supercharge workflow with type-safe narrowing
- **autoFocus option**: New optional parameter in `createConnectionSession()` allows callers to control session focus behavior (used during supercharge to avoid stealing focus from modal closure)
- **Test updates**: Fixed flaky test selectors by awaiting button elements before clicking

## Testing

- Unit tests updated for supercharge-local actions with proper async/await patterns
- Mock `opencodeOps.commands()` returns `using-superpowers` skill for button visibility in tests
- Verified handoff button disabled state uses `hasWorkingContext` (supports both worktree and connection)
- Verified supercharge buttons only show when `hasSuperpowers` and `!isConnectionSession` (local) or `hasSuperpowers` (standard)
- Connection-session branch mirrors SessionView.tsx handoff path for consistency
- Sticky-tab mode tested in WorktreePickerModal to keep board as active session
- Not run: Manual E2E testing of connection session handoff/supercharge flows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies kanban plan-review action flows and session focusing/navigation (including abort/connect behavior) for both worktree and connection sessions, which can impact user session state and ticket linkage if edge cases regress.
> 
> **Overview**
> Adds **connection-session support** to kanban plan-review actions: `Handoff` and `Supercharge` now work when a ticket’s session is tied to a `connection_id`, including aborting the original backend session, creating a new connection session, relinking the ticket, and navigating correctly (setting active connection first when needed).
> 
> Supercharge buttons are now **gated by slash-command availability** (fetches `opencodeOps.commands` and only shows Supercharge when `/using-superpowers` exists), and the UI enables actions based on `hasWorkingContext` (worktree or connection) rather than `worktree_id` alone. Sticky-tab board mode is respected in both plan-review flows and `WorktreePickerModal` so starting/handoff/supercharge can keep the user on the board.
> 
> Extends `useSessionStore.createConnectionSession` with an `opts.autoFocus` flag (default true) so callers can create sessions without stealing focus (used by supercharge), and updates tests/mocks to cover connection handoff navigation plus new async button rendering and slash-command mocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 474bda2ce7414ca3189ed80a36baf056355f094a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->