### PR TITLE
Hide TaskListWidget when session stops streaming or user sends follow-up

### DIFF
--- a/src/renderer/src/components/kanban/SessionStreamPanel.tsx
+++ b/src/renderer/src/components/kanban/SessionStreamPanel.tsx
@@ -7,6 +7,8 @@ import { useLatestTodoList } from '@/components/sessions/useLatestTodoList'
 import { BASELINE_TOP_PX } from '@/components/sessions/usePRStackTopOffset'
 import type { OpenCodeMessage } from '@/components/sessions/SessionView'
 
+const EMPTY_MESSAGE_ARRAY: OpenCodeMessage[] = []
+
 export interface SessionStreamPanelProps {
   sessionId: string
   worktreePath: string
@@ -170,8 +172,25 @@ export function SessionStreamPanel({
     }
   }, [hasStreamingContent, streamingContent, streamingParts])
 
+  // Only consider the current turn when deciding whether to show the
+  // TaskListWidget. If the session is not actively streaming, fall back to an
+  // empty slice so the widget disappears on abort / idle. If streaming, walk
+  // backward from the latest message to the most recent user message and
+  // return everything after it — this ensures that once the user sends a
+  // follow-up, stale todos from previous turns are hidden until the new turn
+  // emits its own TodoWrite.
+  const currentTurnMessages = useMemo(() => {
+    if (!isStreaming) return EMPTY_MESSAGE_ARRAY
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') {
+        return messages.slice(i + 1)
+      }
+    }
+    return messages
+  }, [isStreaming, messages])
+
   const { todos: latestTodos, isIncomplete: latestTodosIncomplete } =
-    useLatestTodoList(messages, streamingMessage)
+    useLatestTodoList(currentTurnMessages, streamingMessage)
 
   return (
     <div className={`flex flex-col h-full bg-background flex-1 min-w-0${fullWidth ? '' : ' border-l border-border/60'}`}>

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -89,6 +89,7 @@ import { buildSdkPlanImplementationPrompt, looksLikeCodexProposedPlan } from '@/
 // Stable empty array to avoid creating new references in selectors
 const EMPTY_FILE_INDEX: FlatFile[] = []
 const EMPTY_STRING_ARRAY: string[] = []
+const EMPTY_MESSAGE_ARRAY: OpenCodeMessage[] = []
 import { QuestionPrompt } from './QuestionPrompt'
 import { PermissionPrompt } from './PermissionPrompt'
 import { CommandApprovalPrompt } from './CommandApprovalPrompt'
@@ -5481,8 +5482,25 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     }
   }, [hasStreamingContent, sessionRecord?.agent_sdk, streamingContent, streamingParts])
 
+  // Only consider the current turn when deciding whether to show the
+  // TaskListWidget. If the session is not actively streaming, fall back to an
+  // empty slice so the widget disappears on abort / idle. If streaming, walk
+  // backward from the latest message to the most recent user message and
+  // return everything after it — this ensures that once the user sends a
+  // follow-up, stale todos from previous turns are hidden until the new turn
+  // emits its own TodoWrite.
+  const currentTurnMessages = useMemo(() => {
+    if (!isStreaming) return EMPTY_MESSAGE_ARRAY
+    for (let i = visibleMessages.length - 1; i >= 0; i--) {
+      if (visibleMessages[i].role === 'user') {
+        return visibleMessages.slice(i + 1)
+      }
+    }
+    return visibleMessages
+  }, [isStreaming, visibleMessages])
+
   const { todos: latestTodos, isIncomplete: latestTodosIncomplete } =
-    useLatestTodoList(visibleMessages, streamingMessage)
+    useLatestTodoList(currentTurnMessages, streamingMessage)
   const taskListTopOffsetPx = usePRStackTopOffset()
 
   const handleRedoRevert = useCallback(() => {

--- a/test/task-list/session-stream-panel-widget.test.tsx
+++ b/test/task-list/session-stream-panel-widget.test.tsx
@@ -93,10 +93,14 @@ function makeTextPart(text: string): StreamingPart {
   return { type: 'text', text }
 }
 
-function makeMessage(id: string, parts: StreamingPart[]): OpenCodeMessage {
+function makeMessage(
+  id: string,
+  parts: StreamingPart[],
+  role: OpenCodeMessage['role'] = 'assistant'
+): OpenCodeMessage {
   return {
     id,
-    role: 'assistant',
+    role,
     content: '',
     timestamp: new Date(0).toISOString(),
     parts
@@ -168,6 +172,7 @@ describe('SessionStreamPanel TaskListWidget integration', () => {
 
   it('renders TaskListWidget when the latest TodoWrite has any pending or in_progress todo', () => {
     setMockStream({
+      isStreaming: true,
       messages: [
         makeMessage('m1', [
           makeTodoWritePart([
@@ -187,6 +192,7 @@ describe('SessionStreamPanel TaskListWidget integration', () => {
 
   it('positions the widget at the 16px baseline (BASELINE_TOP_PX)', () => {
     setMockStream({
+      isStreaming: true,
       messages: [
         makeMessage('m1', [
           makeTodoWritePart([makeTodo('a', 'Pending item', 'pending')])
@@ -201,5 +207,44 @@ describe('SessionStreamPanel TaskListWidget integration', () => {
     // baseline — we do NOT call usePRStackTopOffset because the PR stack is
     // hidden behind the modal backdrop.
     expect(widget.style.top).toBe('16px')
+  })
+
+  it('does not render TaskListWidget when isStreaming is false, even with incomplete todos', () => {
+    setMockStream({
+      isStreaming: false,
+      messages: [
+        makeMessage('m1', [
+          makeTodoWritePart([
+            makeTodo('a', 'Done one', 'completed'),
+            makeTodo('b', 'Still working', 'in_progress'),
+            makeTodo('c', 'Queued', 'pending')
+          ])
+        ])
+      ]
+    })
+
+    renderPanel()
+
+    expect(screen.queryByTestId('task-list-widget')).not.toBeInTheDocument()
+  })
+
+  it('does not render TaskListWidget with only historical TodoWrite once a new user message has been sent', () => {
+    setMockStream({
+      isStreaming: true,
+      messages: [
+        makeMessage('m1', [
+          makeTodoWritePart([
+            makeTodo('a', 'Done one', 'completed'),
+            makeTodo('b', 'Still working', 'in_progress'),
+            makeTodo('c', 'Queued', 'pending')
+          ])
+        ]),
+        makeMessage('m2', [makeTextPart('follow up please')], 'user')
+      ]
+    })
+
+    renderPanel()
+
+    expect(screen.queryByTestId('task-list-widget')).not.toBeInTheDocument()
   })
 })

--- a/test/task-list/task-list-integration.test.tsx
+++ b/test/task-list/task-list-integration.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
-import { act } from 'react'
+import { act, useMemo } from 'react'
 import { TaskListWidget } from '@/components/sessions/TaskListWidget'
 import { useLatestTodoList } from '@/components/sessions/useLatestTodoList'
 import { usePRStackTopOffset } from '@/components/sessions/usePRStackTopOffset'
@@ -59,15 +59,33 @@ class MockResizeObserver {
   }
 }
 
+// Module-level stable reference for the "not streaming" case — mirrors the
+// EMPTY_MESSAGE_ARRAY constant used at the real render sites.
+const EMPTY_MESSAGE_ARRAY: OpenCodeMessage[] = []
+
 function TestHarness({
   messages,
-  streaming = null
+  streaming = null,
+  isStreaming = true
 }: {
   messages: OpenCodeMessage[]
   streaming?: OpenCodeMessage | null
+  isStreaming?: boolean
 }): React.JSX.Element {
+  // Mirror the real render sites: gate on isStreaming and only consider the
+  // current turn (everything after the most recent user message).
+  const currentTurnMessages = useMemo(() => {
+    if (!isStreaming) return EMPTY_MESSAGE_ARRAY
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') {
+        return messages.slice(i + 1)
+      }
+    }
+    return messages
+  }, [isStreaming, messages])
+
   const { todos: latestTodos, isIncomplete: latestTodosIncomplete } = useLatestTodoList(
-    messages,
+    currentTurnMessages,
     streaming
   )
   const taskListTopOffsetPx = usePRStackTopOffset()
@@ -244,6 +262,22 @@ describe('TaskListWidget SessionView integration', () => {
 
     const widget = screen.getByTestId('task-list-widget')
     expect(widget).toBeInTheDocument()
+  })
+
+  it('does not render TaskListWidget when isStreaming is false, even with incomplete todos', () => {
+    const messages: OpenCodeMessage[] = [
+      makeMessage('m1', [
+        makeTodoWritePart([
+          makeTodo('a', 'Done one', 'completed'),
+          makeTodo('b', 'Still working', 'in_progress'),
+          makeTodo('c', 'Queued', 'pending')
+        ])
+      ])
+    ]
+
+    render(<TestHarness messages={messages} isStreaming={false} />)
+
+    expect(screen.queryByTestId('task-list-widget')).not.toBeInTheDocument()
   })
 
   it('positions the widget at the 16px baseline when there are no PR notifications', () => {


### PR DESCRIPTION
## Summary

- Hide TaskListWidget when `isStreaming` is false (session idle or aborted)
- Hide TaskListWidget when a user sends a follow-up message until the new turn emits its own TodoWrite
- Introduce `currentTurnMessages` memo in both SessionStreamPanel and SessionView to track only messages from the current conversation turn
- Add comprehensive test coverage for non-streaming and follow-up message scenarios
- Ensure stale todos from previous turns don't persist after user sends new input

## Testing

- TaskListWidget renders when session is actively streaming with incomplete todos
- TaskListWidget disappears when `isStreaming` becomes false
- TaskListWidget disappears when user message is sent without corresponding assistant TodoWrite in current turn
- Widget positioning at 16px baseline maintained for active turns
- Integration tests updated to model `isStreaming` state in test harness
- All existing task-list rendering tests continue to pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating around which messages are scanned for todos, plus additional tests; low risk aside from potential edge cases in turn-boundary detection affecting widget visibility.
> 
> **Overview**
> Ensures the `TaskListWidget` only reflects *the current streaming turn*: it now disappears when `isStreaming` becomes false (idle/abort) and when a user sends a follow-up until the assistant emits a new `TodoWrite`.
> 
> Both `SessionView` and the kanban `SessionStreamPanel` introduce a memoized `currentTurnMessages` slice (messages after the most recent user message) and pass that into `useLatestTodoList`, preventing stale todos from previous turns from persisting. Tests were expanded/updated to cover non-streaming behavior and follow-up-message scenarios, including harness support for `isStreaming` and user-role messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c66b3d170dbf9329893357faedbd04b0b9ee4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->