### PR TITLE
Add split-button handoff model picker

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1527,20 +1527,25 @@ function PlanReviewModeContent({
       useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
       lastSendMode.delete(sessionId)
 
-      // Connection-session branch: mirrors SessionView.tsx handoff connection path.
+      // Connection-session branch: eagerly start work even if the user stays on the board.
       if (sessionRecord?.connection_id) {
-        // Abort the original backend session so it stops spinning (parity with SessionView).
         if (worktreePath && opcSessionId) {
           useCommandApprovalStore.getState().clearSession(sessionId)
           await window.opencodeOps.abort(worktreePath, opcSessionId)
         }
 
+        if (!worktreePath) {
+          toast.error('Connection path unavailable')
+          return
+        }
+
+        const connectionPath = worktreePath
         const sessionStore = useSessionStore.getState()
         const result = await sessionStore.createConnectionSession(
           sessionRecord.connection_id,
           override?.agentSdk,
           undefined,
-          { modelOverride: override?.model }
+          { autoFocus: false, modelOverride: override?.model }
         )
         if (!result.success || !result.session) {
           toast.error(result.error ?? 'Failed to create handoff session')
@@ -1548,9 +1553,10 @@ function PlanReviewModeContent({
         }
 
         const handoffPrompt = `Implement the following plan\n${planContent}`
-        await sessionStore.setSessionMode(result.session.id, 'build')
-        sessionStore.setPendingMessage(result.session.id, handoffPrompt)
-        notifyKanbanSessionSync(sessionId, { type: 'supercharge', newSessionId: result.session.id })
+        const newSessionId = result.session.id
+        const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
+
+        prepareTicketBuildSession(newSessionId)
 
         // In sticky-tab mode, stay on the board; otherwise navigate to the new session.
         // setActiveConnectionSession requires activeConnectionId to be set — which
@@ -1561,17 +1567,18 @@ function PlanReviewModeContent({
           sessionStore.setActiveSession(BOARD_TAB_ID)
         } else {
           sessionStore.setActiveConnection(sessionRecord.connection_id)
-          sessionStore.setActiveConnectionSession(result.session.id)
+          sessionStore.setActiveConnectionSession(newSessionId)
         }
 
-        await useKanbanStore.getState().updateTicket(ticket.id, ticket.project_id, {
-          current_session_id: result.session.id,
-          plan_ready: false,
-          mode: 'build'
-        })
-
-        toast.success('Handoff session created')
         onClose()
+        void (async () => {
+          await setModePromise
+          await eagerHandoffStart(connectionPath, newSessionId, handoffPrompt)
+          toast.success('Handoff session started')
+        })().catch((error) => {
+          console.error('[KanbanTicketModal] handoff (connection) background start failed:', error)
+          toast.error('Failed to start handoff')
+        })
         return
       }
 
@@ -1588,7 +1595,7 @@ function PlanReviewModeContent({
         ticket.project_id,
         override?.agentSdk,
         undefined,
-        { modelOverride: override?.model }
+        { autoFocus: false, modelOverride: override?.model }
       )
       if (!result.success || !result.session) {
         toast.error(result.error ?? 'Failed to create handoff session')
@@ -1596,39 +1603,54 @@ function PlanReviewModeContent({
       }
 
       const handoffPrompt = `Implement the following plan\n${planContent}`
-      await sessionStore.setSessionMode(result.session.id, 'build')
-      sessionStore.setPendingMessage(result.session.id, handoffPrompt)
+      const newSessionId = result.session.id
+      const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
+      const localWorktreePath = findWorktreePathById(worktreeId)
+      if (!localWorktreePath) {
+        toast.error('Could not find worktree path')
+        return
+      }
+
+      prepareTicketBuildSession(newSessionId)
 
       // In sticky-tab mode, stay on the board; otherwise navigate to the new session
       const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
       if (useSettingsStore.getState().boardMode === 'sticky-tab') {
         sessionStore.setActiveSession(BOARD_TAB_ID)
       } else {
-        sessionStore.setActiveSession(result.session.id)
+        useWorktreeStore.getState().selectWorktree(worktreeId)
+        sessionStore.setActiveWorktree(worktreeId)
+        sessionStore.setActiveSession(newSessionId)
       }
 
-      // Clear plan_ready badge and link to new session
-      await useKanbanStore.getState().updateTicket(ticket.id, ticket.project_id, {
-        current_session_id: result.session.id,
-        plan_ready: false,
-        mode: 'build'
-      })
-
-      toast.success('Handoff session created')
       onClose()
+      void (async () => {
+        await setModePromise
+        await eagerHandoffStart(localWorktreePath, newSessionId, handoffPrompt)
+        toast.success('Handoff session started')
+      })().catch((error) => {
+        console.error('[KanbanTicketModal] handoff background start failed:', error)
+        toast.error('Failed to start handoff')
+      })
     } catch {
       toast.error('Failed to create handoff session')
     } finally {
       setIsActioning(false)
     }
-  }, [ticket, isActioning, planContent, onClose, hasWorkingContext, sessionRecord, worktreePath, opcSessionId])
+  }, [
+    ticket,
+    isActioning,
+    planContent,
+    onClose,
+    hasWorkingContext,
+    sessionRecord,
+    worktreePath,
+    opcSessionId
+  ])
 
-  // Synchronously re-link the ticket to the new session and (if needed) move it to in_progress
-  // so the kanban board reflects the supercharge before the modal closes. Per-session timing /
-  // status bookkeeping is intentionally deferred to eagerSuperchargeStart so it only runs once
-  // the OpenCode connection actually succeeds — otherwise a failed connect leaves the ticket
-  // permanently marked 'working' with no work running.
-  const prepareTicketSuperchargeSession = useCallback((newSessionId: string): void => {
+  // Synchronously re-link the ticket to a new build session and (if needed) move it to
+  // in_progress so the kanban board reflects the new work before the modal closes.
+  const prepareTicketBuildSession = useCallback((newSessionId: string): void => {
     useKanbanStore
       .getState()
       .updateTicket(ticket.id, ticket.project_id, {
@@ -1690,6 +1712,36 @@ function PlanReviewModeContent({
     ], model)
   }, [planContent])
 
+  const eagerHandoffStart = useCallback(async (
+    workingPath: string,
+    newSessionId: string,
+    handoffPrompt: string
+  ) => {
+    const connectResult = await window.opencodeOps.connect(workingPath, newSessionId)
+    if (!connectResult.success || !connectResult.sessionId) {
+      throw new Error('Failed to connect to handoff session')
+    }
+
+    useSessionStore.getState().setOpenCodeSessionId(newSessionId, connectResult.sessionId)
+    await window.db.session.update(newSessionId, {
+      opencode_session_id: connectResult.sessionId
+    })
+
+    messageSendTimes.set(newSessionId, Date.now())
+    userExplicitSendTimes.set(newSessionId, Date.now())
+    snapshotTokenBaseline(newSessionId)
+    lastSendMode.set(newSessionId, 'build')
+    useWorktreeStatusStore.getState().setSessionStatus(newSessionId, 'working')
+
+    const model = resolveSessionModel(newSessionId)
+    await window.opencodeOps.prompt(
+      workingPath,
+      connectResult.sessionId,
+      [{ type: 'text', text: handoffPrompt }],
+      model
+    )
+  }, [])
+
   // ── Supercharge handler (new branch) ────────────────────────────
   const handleSupercharge = useCallback(async () => {
     if (!ticket.current_session_id || !hasWorkingContext || isActioning) return
@@ -1730,11 +1782,11 @@ function PlanReviewModeContent({
         const newSessionId = sessionResult.session.id
         const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
 
-        prepareTicketSuperchargeSession(newSessionId)
+        prepareTicketBuildSession(newSessionId)
         onClose()
 
         // NOTE: On IIFE failure, the ticket is left re-linked to the new session (via
-        // prepareTicketSuperchargeSession above) — same failure mode as the worktree
+        // prepareTicketBuildSession above) — same failure mode as the worktree
         // branch below. We don't roll back because the error toast tells the user what
         // happened and retrying (via a new supercharge click) creates a fresh session.
         void (async () => {
@@ -1794,7 +1846,7 @@ function PlanReviewModeContent({
       // Hoist into a const so TS narrowing survives across the background IIFE closure.
       const newWorktreePath = dupResult.worktree.path
 
-      prepareTicketSuperchargeSession(newSessionId)
+      prepareTicketBuildSession(newSessionId)
       onClose()
 
       // Finish session configuration and startup in the background so the modal can close
@@ -1813,7 +1865,7 @@ function PlanReviewModeContent({
     } finally {
       setIsActioning(false)
     }
-  }, [ticket, isActioning, onClose, eagerSuperchargeStart, prepareTicketSuperchargeSession, worktreePath, opcSessionId, hasWorkingContext, sessionRecord])
+  }, [ticket, isActioning, onClose, eagerSuperchargeStart, prepareTicketBuildSession, worktreePath, opcSessionId, hasWorkingContext, sessionRecord])
 
   // ── Supercharge Local handler (same worktree, no duplication) ───
   const handleSuperchargeLocal = useCallback(async () => {
@@ -1849,7 +1901,7 @@ function PlanReviewModeContent({
       const newSessionId = sessionResult.session.id
       const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
 
-      prepareTicketSuperchargeSession(newSessionId)
+      prepareTicketBuildSession(newSessionId)
       onClose()
 
       // Finish session configuration and startup in the background so the modal can close
@@ -1868,7 +1920,7 @@ function PlanReviewModeContent({
     } finally {
       setIsActioning(false)
     }
-  }, [ticket, isActioning, onClose, eagerSuperchargeStart, prepareTicketSuperchargeSession, worktreePath, opcSessionId])
+  }, [ticket, isActioning, onClose, eagerSuperchargeStart, prepareTicketBuildSession, worktreePath, opcSessionId])
 
   return (
     <div ref={dropZoneRef} className="relative contents">

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -9,7 +9,6 @@ import {
   Hammer,
   Send,
   Zap,
-  ArrowRight,
   AlertCircle,
   Bolt,
   FileSearch,
@@ -36,6 +35,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { MarkdownRenderer } from '../sessions/MarkdownRenderer'
+import { HandoffSplitButton } from '../sessions/HandoffSplitButton'
 import { cn } from '@/lib/utils'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useSessionStore } from '@/stores/useSessionStore'
@@ -72,6 +72,7 @@ import { usePinAndActivateSession } from '@/hooks/usePinAndActivateSession'
 import { TicketAttachmentEditor } from './TicketAttachmentEditor'
 import { TicketDiscardChangesDialog } from './TicketDiscardChangesDialog'
 import { useImagePaste } from '@/hooks/useImagePaste'
+import type { HandoffSelectionOverride } from '@/lib/handoffSelection'
 import type { KanbanTicket, KanbanTicketUpdate, Worktree } from '../../../../main/db/types'
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -1516,7 +1517,7 @@ function PlanReviewModeContent({
   }, [ticket.current_session_id, ticket.id, ticket.project_id, isActioning, pendingPlan, sessionRecord, onClose])
 
   // ── Handoff handler ───────────────────────────────────────────────
-  const handleHandoff = useCallback(async () => {
+  const handleHandoff = useCallback(async (override?: HandoffSelectionOverride) => {
     if (!ticket.current_session_id || !hasWorkingContext || isActioning) return
     setIsActioning(true)
 
@@ -1535,7 +1536,12 @@ function PlanReviewModeContent({
         }
 
         const sessionStore = useSessionStore.getState()
-        const result = await sessionStore.createConnectionSession(sessionRecord.connection_id)
+        const result = await sessionStore.createConnectionSession(
+          sessionRecord.connection_id,
+          override?.agentSdk,
+          undefined,
+          { modelOverride: override?.model }
+        )
         if (!result.success || !result.session) {
           toast.error(result.error ?? 'Failed to create handoff session')
           return
@@ -1577,7 +1583,13 @@ function PlanReviewModeContent({
       if (!worktreeId) return
 
       const sessionStore = useSessionStore.getState()
-      const result = await sessionStore.createSession(worktreeId, ticket.project_id)
+      const result = await sessionStore.createSession(
+        worktreeId,
+        ticket.project_id,
+        override?.agentSdk,
+        undefined,
+        { modelOverride: override?.model }
+      )
       if (!result.success || !result.session) {
         toast.error(result.error ?? 'Failed to create handoff session')
         return
@@ -1919,17 +1931,12 @@ function PlanReviewModeContent({
           (matches SessionView's showPlanReadyImplementFab gating on !!pendingPlan) */}
       {!!pendingPlan && (
         <DialogFooter className="flex-shrink-0 gap-1.5 flex-wrap">
-          <Button
-            type="button"
-            data-testid="plan-review-handoff-btn"
+          <HandoffSplitButton
+            worktreeId={sessionRecord?.worktree_id ?? undefined}
+            onHandoff={handleHandoff}
+            testIdPrefix="plan-review"
             disabled={isActioning || !hasWorkingContext}
-            onClick={handleHandoff}
-            className="gap-1.5"
-            variant="outline"
-          >
-            <ArrowRight className="h-3.5 w-3.5" />
-            Handoff
-          </Button>
+          />
           {!isConnectionSession && hasSuperpowers && (
             <Button
               type="button"

--- a/src/renderer/src/components/sessions/HandoffModelPicker.tsx
+++ b/src/renderer/src/components/sessions/HandoffModelPicker.tsx
@@ -1,0 +1,298 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Check, ChevronDown } from 'lucide-react'
+import {
+  getAvailableHandoffAgentSdks,
+  getCachedModelCatalog,
+  getEffectiveHandoffSelection,
+  getHandoffSdkDisplayName,
+  loadHandoffModelCatalog,
+  resolveModelForSdkDefault,
+  type HandoffSelectionOverride
+} from '@/lib/handoffSelection'
+import {
+  findModelInfo,
+  getFirstModelInfo,
+  getModelDisplayName,
+  getModelVariantKeys,
+  type ProviderModels
+} from '@/lib/parseProviders'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useSettingsStore, type HandoffAgentSdk, type SelectedModel } from '@/stores/useSettingsStore'
+
+interface HandoffModelPickerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  anchor: React.ReactNode
+  worktreeId?: string
+  onConfirm: (override: HandoffSelectionOverride) => void
+}
+
+function buildModelFromInfo(
+  modelInfo: NonNullable<ReturnType<typeof getFirstModelInfo>>,
+  preferredVariant?: string
+): SelectedModel {
+  const variantKeys = getModelVariantKeys(modelInfo)
+  const rememberedVariant = useSettingsStore
+    .getState()
+    .getModelVariantDefault(modelInfo.providerID, modelInfo.id)
+  const variant =
+    preferredVariant && variantKeys.includes(preferredVariant)
+      ? preferredVariant
+      : rememberedVariant && variantKeys.includes(rememberedVariant)
+        ? rememberedVariant
+        : variantKeys[0]
+
+  return {
+    providerID: modelInfo.providerID,
+    modelID: modelInfo.id,
+    variant
+  }
+}
+
+export function HandoffModelPicker({
+  open,
+  onOpenChange,
+  anchor,
+  worktreeId,
+  onConfirm
+}: HandoffModelPickerProps): React.JSX.Element {
+  const availableAgentSdks = useSettingsStore((state) => state.availableAgentSdks)
+  const visibleSdks = useMemo(
+    () => getAvailableHandoffAgentSdks(availableAgentSdks),
+    [availableAgentSdks]
+  )
+  const [pickedSdk, setPickedSdk] = useState<HandoffAgentSdk>('opencode')
+  const [pickedModel, setPickedModel] = useState<SelectedModel | null>(null)
+  const [providersBySdk, setProvidersBySdk] = useState<Partial<Record<HandoffAgentSdk, ProviderModels[]>>>({})
+  const [loadingSdks, setLoadingSdks] = useState<Partial<Record<HandoffAgentSdk, boolean>>>({})
+
+  const ensureProviders = useCallback(async (agentSdk: HandoffAgentSdk): Promise<ProviderModels[]> => {
+    const cached = getCachedModelCatalog(agentSdk)
+    if (cached) {
+      setProvidersBySdk((current) => ({ ...current, [agentSdk]: cached }))
+      return cached
+    }
+
+    setLoadingSdks((current) => ({ ...current, [agentSdk]: true }))
+    const loaded = await loadHandoffModelCatalog(agentSdk)
+    setProvidersBySdk((current) => ({ ...current, [agentSdk]: loaded }))
+    setLoadingSdks((current) => ({ ...current, [agentSdk]: false }))
+    return loaded
+  }, [])
+
+  const resolveModelForCatalog = useCallback(
+    (providers: ProviderModels[], model: SelectedModel): SelectedModel => {
+      const info = findModelInfo(providers, model.providerID, model.modelID)
+      if (info) return buildModelFromInfo(info, model.variant)
+
+      const fallbackInfo = getFirstModelInfo(providers)
+      return fallbackInfo ? buildModelFromInfo(fallbackInfo) : model
+    },
+    []
+  )
+
+  useEffect(() => {
+    if (!open) return
+
+    let active = true
+    const effective = getEffectiveHandoffSelection({ worktreeId })
+    setPickedSdk(effective.agentSdk)
+    setPickedModel(effective.model)
+
+    void ensureProviders(effective.agentSdk).then((providers) => {
+      if (!active) return
+      setPickedModel(resolveModelForCatalog(providers, effective.model))
+    })
+
+    return () => {
+      active = false
+    }
+  }, [open, worktreeId, ensureProviders, resolveModelForCatalog])
+
+  const currentProviders = useMemo(
+    () => providersBySdk[pickedSdk] ?? getCachedModelCatalog(pickedSdk) ?? [],
+    [pickedSdk, providersBySdk]
+  )
+  const currentModelInfo = pickedModel
+    ? findModelInfo(currentProviders, pickedModel.providerID, pickedModel.modelID)
+    : null
+  const variantKeys = currentModelInfo ? getModelVariantKeys(currentModelInfo) : []
+
+  const handleSelectSdk = useCallback(
+    async (nextSdk: HandoffAgentSdk) => {
+      setPickedSdk(nextSdk)
+      setPickedModel(null)
+
+      const providers = await ensureProviders(nextSdk)
+      const configuredDefault = resolveModelForSdkDefault(nextSdk)
+      const configuredInfo = findModelInfo(
+        providers,
+        configuredDefault.providerID,
+        configuredDefault.modelID
+      )
+      const nextInfo = configuredInfo ?? getFirstModelInfo(providers)
+      setPickedModel(nextInfo ? buildModelFromInfo(nextInfo, configuredDefault.variant) : configuredDefault)
+    },
+    [ensureProviders]
+  )
+
+  const handleSelectModel = useCallback((model: SelectedModel) => {
+    const info = findModelInfo(currentProviders, model.providerID, model.modelID)
+    setPickedModel(info ? buildModelFromInfo(info, model.variant) : model)
+  }, [currentProviders])
+
+  const handleConfirm = useCallback(() => {
+    if (!pickedModel) return
+
+    const nextOverride = {
+      agentSdk: pickedSdk,
+      providerID: pickedModel.providerID,
+      modelID: pickedModel.modelID,
+      variant: pickedModel.variant
+    }
+    useSettingsStore.getState().setLastHandoffOverride(nextOverride)
+    onConfirm({ agentSdk: pickedSdk, model: pickedModel })
+    onOpenChange(false)
+  }, [onConfirm, onOpenChange, pickedModel, pickedSdk])
+
+  const modelLabel = currentModelInfo
+    ? getModelDisplayName(currentModelInfo)
+    : pickedModel?.modelID ?? (loadingSdks[pickedSdk] ? 'Loading…' : 'Select model')
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{anchor}</PopoverTrigger>
+      <PopoverContent align="end" className="w-[360px] p-3">
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Select handoff SDK"
+                  className={cn(
+                    'flex h-8 items-center justify-between gap-2 rounded-full border border-border bg-muted/50 px-3 text-left text-xs font-medium text-foreground',
+                    'hover:bg-muted transition-colors'
+                  )}
+                >
+                  <span className="truncate">{getHandoffSdkDisplayName(pickedSdk)}</span>
+                  <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-52">
+                {visibleSdks.map((sdkOption) => (
+                  <DropdownMenuItem
+                    key={sdkOption}
+                    onSelect={() => {
+                      void handleSelectSdk(sdkOption)
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        'h-3.5 w-3.5',
+                        pickedSdk === sdkOption ? 'opacity-100' : 'opacity-0'
+                      )}
+                    />
+                    <span>{getHandoffSdkDisplayName(sdkOption)}</span>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Select handoff model"
+                  className={cn(
+                    'flex h-8 items-center justify-between gap-2 rounded-full border border-border bg-muted/50 px-3 text-left text-xs font-medium text-foreground',
+                    'hover:bg-muted transition-colors'
+                  )}
+                >
+                  <span className="truncate">{modelLabel}</span>
+                  <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-72">
+                {currentProviders.length === 0 && (
+                  <DropdownMenuItem disabled>
+                    <span>{loadingSdks[pickedSdk] ? 'Loading models…' : 'No models available'}</span>
+                  </DropdownMenuItem>
+                )}
+                {currentProviders.map((provider, index) => (
+                  <div key={provider.providerID}>
+                    {index > 0 && <DropdownMenuSeparator />}
+                    <DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
+                      {provider.providerName}
+                    </DropdownMenuLabel>
+                    {provider.models.map((model) => {
+                      const selected =
+                        pickedModel?.providerID === model.providerID && pickedModel.modelID === model.id
+
+                      return (
+                        <DropdownMenuItem
+                          key={`${model.providerID}:${model.id}`}
+                          onSelect={() => {
+                            handleSelectModel(buildModelFromInfo(model, pickedModel?.variant))
+                          }}
+                        >
+                          <Check className={cn('h-3.5 w-3.5', selected ? 'opacity-100' : 'opacity-0')} />
+                          <span className="truncate">{getModelDisplayName(model)}</span>
+                        </DropdownMenuItem>
+                      )
+                    })}
+                  </div>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          {variantKeys.length > 0 && pickedModel && (
+            <div className="flex flex-wrap gap-1.5">
+              {variantKeys.map((variant) => {
+                const active = pickedModel.variant === variant
+                return (
+                  <button
+                    key={variant}
+                    type="button"
+                    onClick={() => {
+                      setPickedModel({ ...pickedModel, variant })
+                    }}
+                    className={cn(
+                      'rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide transition-colors',
+                      active
+                        ? 'border-foreground bg-foreground text-background'
+                        : 'border-border bg-muted/40 text-muted-foreground hover:bg-muted hover:text-foreground'
+                    )}
+                  >
+                    {variant}
+                  </button>
+                )
+              })}
+            </div>
+          )}
+
+          <Button
+            type="button"
+            size="sm"
+            className="h-8 w-full rounded-full text-xs"
+            disabled={!pickedModel}
+            onClick={handleConfirm}
+          >
+            Handoff
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/sessions/HandoffSplitButton.tsx
+++ b/src/renderer/src/components/sessions/HandoffSplitButton.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import {
+  getAvailableHandoffAgentSdks,
+  getEffectiveHandoffSelection,
+  loadHandoffModelCatalog,
+  type HandoffSelectionOverride
+} from '@/lib/handoffSelection'
+import { cn } from '@/lib/utils'
+import { HandoffModelPicker } from './HandoffModelPicker'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+
+function MnemonicLabel({ letter, label }: { letter: string; label: string }): React.JSX.Element {
+  const index = label.toLowerCase().indexOf(letter.toLowerCase())
+  if (index === -1) return <span>{label}</span>
+
+  return (
+    <span>
+      {label.slice(0, index)}
+      <span className="font-semibold underline underline-offset-2 decoration-2">
+        {label[index]}
+      </span>
+      {label.slice(index + 1)}
+    </span>
+  )
+}
+
+interface HandoffSplitButtonProps {
+  worktreeId?: string
+  onHandoff: (override: HandoffSelectionOverride) => void
+  vimModeEnabled?: boolean
+  testIdPrefix?: string
+  disabled?: boolean
+}
+
+export function HandoffSplitButton({
+  worktreeId,
+  onHandoff,
+  vimModeEnabled = false,
+  testIdPrefix = 'plan-ready',
+  disabled = false
+}: HandoffSplitButtonProps): React.JSX.Element {
+  const availableAgentSdks = useSettingsStore((state) => state.availableAgentSdks)
+  const lastHandoffOverride = useSettingsStore((state) => state.lastHandoffOverride)
+  const defaultAgentSdk = useSettingsStore((state) => state.defaultAgentSdk)
+  const defaultModels = useSettingsStore((state) => state.defaultModels)
+  const selectedModel = useSettingsStore((state) => state.selectedModel)
+  const selectedModelByProvider = useSettingsStore((state) => state.selectedModelByProvider)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [catalogVersion, setCatalogVersion] = useState(0)
+
+  const showChevron = getAvailableHandoffAgentSdks(availableAgentSdks).length > 1
+  void availableAgentSdks
+  void lastHandoffOverride
+  void defaultAgentSdk
+  void defaultModels
+  void selectedModel
+  void selectedModelByProvider
+  void catalogVersion
+  const effective = getEffectiveHandoffSelection({ worktreeId })
+
+  useEffect(() => {
+    let active = true
+    void loadHandoffModelCatalog(effective.agentSdk).then(() => {
+      if (active) {
+        setCatalogVersion((current) => current + 1)
+      }
+    })
+
+    return () => {
+      active = false
+    }
+  }, [effective.agentSdk])
+
+  const labelTitle = `Handoff · ${effective.display.sdkName} / ${effective.display.modelName}${
+    effective.display.variant ? ` ${effective.display.variant.toUpperCase()}` : ''
+  }`
+  const leftButtonTestId =
+    testIdPrefix === 'plan-review'
+      ? `${testIdPrefix}-handoff-btn`
+      : `${testIdPrefix}-handoff-fab`
+  const chevronTestId = `${testIdPrefix}-handoff-chevron`
+
+  return (
+    <div
+      className={cn(
+        'inline-flex h-8 items-center rounded-full border border-border bg-muted/80 text-foreground shadow-md transition-colors duration-200',
+        disabled ? 'opacity-60' : 'hover:bg-muted'
+      )}
+    >
+      <button
+        type="button"
+        title={labelTitle}
+        aria-label={labelTitle}
+        disabled={disabled}
+        data-testid={leftButtonTestId}
+        onClick={() => {
+          onHandoff({ agentSdk: effective.agentSdk, model: effective.model })
+        }}
+        className={cn(
+          'flex min-w-0 items-center gap-1.5 rounded-full px-3 text-xs font-medium',
+          'disabled:pointer-events-none'
+        )}
+      >
+        <span className="shrink-0">
+          {vimModeEnabled ? <MnemonicLabel letter="a" label="Handoff" /> : 'Handoff'}
+        </span>
+        <span className="text-muted-foreground">·</span>
+        <span className="shrink-0">{effective.display.sdkName} /</span>
+        <span className="max-w-[180px] truncate">{effective.display.modelName}</span>
+        {effective.display.variant && (
+          <span className="rounded-full border border-border/80 bg-background/70 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
+            {effective.display.variant}
+          </span>
+        )}
+      </button>
+
+      {showChevron && (
+        <>
+          <div className="h-5 w-px self-center bg-border" />
+          <HandoffModelPicker
+            open={pickerOpen}
+            onOpenChange={(open) => {
+              if (!disabled) setPickerOpen(open)
+            }}
+            worktreeId={worktreeId}
+            onConfirm={onHandoff}
+            anchor={
+              <button
+                type="button"
+                aria-label="Open handoff model picker"
+                disabled={disabled}
+                data-testid={chevronTestId}
+                className={cn(
+                  'flex h-full items-center justify-center rounded-r-full px-2.5 text-muted-foreground transition-colors',
+                  'hover:text-foreground disabled:pointer-events-none'
+                )}
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+              </button>
+            }
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -1,6 +1,15 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Check, ChevronDown, Search, Star } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { cacheHandoffModelCatalog, type HandoffAgentSdk } from '@/lib/handoffSelection'
+import {
+  findModelInfo,
+  getModelDisplayName,
+  getModelVariantKeys,
+  parseProviders,
+  type ModelInfo,
+  type ProviderModels
+} from '@/lib/parseProviders'
 import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { toast } from '@/lib/toast'
@@ -12,28 +21,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
-
-interface ModelInfo {
-  id: string
-  name?: string
-  providerID: string
-  variants?: Record<string, Record<string, unknown>>
-}
-
-interface ProviderModels {
-  providerID: string
-  providerName: string
-  models: ModelInfo[]
-}
-
-function getDisplayName(model: ModelInfo): string {
-  return model.name || model.id
-}
-
-function getVariantKeys(model: ModelInfo): string[] {
-  if (!model.variants) return []
-  return Object.keys(model.variants)
-}
 
 interface ModelSelectorProps {
   sessionId?: string
@@ -105,6 +92,7 @@ export function ModelSelector({
         if (result.success && result.providers) {
           const parsed = parseProviders(result.providers)
           setProviders(parsed)
+          cacheHandoffModelCatalog(agentSdk as HandoffAgentSdk, result.providers)
         }
       } catch (error) {
         console.error('Failed to load models:', error)
@@ -119,47 +107,8 @@ export function ModelSelector({
     }
   }, [agentSdk])
 
-  // Parse the providers response into a structured format
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function parseProviders(data: any): ProviderModels[] {
-    const list = Array.isArray(data) ? data : data?.providers || []
-    const result: ProviderModels[] = []
-
-    for (const provider of list) {
-      const models: ModelInfo[] = []
-      const providerID = provider?.id || 'unknown'
-
-      if (provider?.models && typeof provider.models === 'object') {
-        for (const [modelID, modelData] of Object.entries(provider.models)) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const md = modelData as any
-          const variants =
-            md?.variants && typeof md.variants === 'object'
-              ? (md.variants as Record<string, Record<string, unknown>>)
-              : undefined
-          models.push({
-            id: md?.id || modelID,
-            name: md?.name,
-            providerID,
-            variants
-          })
-        }
-      }
-
-      if (models.length > 0) {
-        result.push({
-          providerID,
-          providerName: provider?.name || providerID.charAt(0).toUpperCase() + providerID.slice(1),
-          models
-        })
-      }
-    }
-
-    return result
-  }
-
   function handleSelectModel(model: ModelInfo): void {
-    const variantKeys = getVariantKeys(model)
+    const variantKeys = getModelVariantKeys(model)
     const remembered = useSettingsStore
       .getState()
       .getModelVariantDefault(model.providerID, model.id)
@@ -210,13 +159,7 @@ export function ModelSelector({
   const currentModel = useMemo((): ModelInfo | null => {
     const modelID = selectedModel?.modelID || 'claude-opus-4-5-20251101'
     const providerID = selectedModel?.providerID || 'anthropic'
-    for (const provider of providers) {
-      if (provider.providerID === providerID) {
-        const found = provider.models.find((m) => m.id === modelID)
-        if (found) return found
-      }
-    }
-    return null
+    return findModelInfo(providers, providerID, modelID)
   }, [selectedModel, providers])
 
   const providerPrefix = useMemo(() => {
@@ -230,7 +173,7 @@ export function ModelSelector({
   // Cycle thinking-level variant for Alt+T
   const cycleVariant = useCallback(() => {
     if (!currentModel) return
-    const variantKeys = getVariantKeys(currentModel)
+    const variantKeys = getModelVariantKeys(currentModel)
     if (variantKeys.length <= 1) return
 
     const currentVariant = selectedModel?.variant
@@ -274,8 +217,8 @@ export function ModelSelector({
 
   // Determine display name for the pill
   const displayName = currentModel
-    ? getDisplayName(currentModel)
-    : getDisplayName({
+    ? getModelDisplayName(currentModel)
+    : getModelDisplayName({
         id: selectedModel?.modelID || 'claude-opus-4-5-20251101',
         providerID: 'anthropic'
       })
@@ -288,7 +231,7 @@ export function ModelSelector({
         ...provider,
         models: provider.models.filter(
           (m) =>
-            getDisplayName(m).toLowerCase().includes(q) ||
+            getModelDisplayName(m).toLowerCase().includes(q) ||
             m.id.toLowerCase().includes(q) ||
             provider.providerName.toLowerCase().includes(q)
         )
@@ -306,7 +249,7 @@ export function ModelSelector({
     [providers, isFavorite]
   )
 
-  const currentVariantKeys = currentModel ? getVariantKeys(currentModel) : []
+  const currentVariantKeys = currentModel ? getModelVariantKeys(currentModel) : []
   const hasVariants = currentVariantKeys.length > 0
 
   return (
@@ -367,7 +310,7 @@ export function ModelSelector({
               </DropdownMenuLabel>
               {favoriteModelObjects.map((model) => {
                 const favActive = isActiveModel(model)
-                const favVariantKeys = getVariantKeys(model)
+                const favVariantKeys = getModelVariantKeys(model)
                 return (
                   <div key={`fav-${model.providerID}:${model.id}`}>
                     <DropdownMenuItem
@@ -380,7 +323,7 @@ export function ModelSelector({
                     >
                       <span className="flex items-center gap-1.5">
                         <Star className="h-3 w-3 text-yellow-500 fill-yellow-500 shrink-0" />
-                        <span className="truncate text-sm">{getDisplayName(model)}</span>
+                        <span className="truncate text-sm">{getModelDisplayName(model)}</span>
                       </span>
                       {favActive && <Check className="h-4 w-4 shrink-0 text-primary" />}
                     </DropdownMenuItem>
@@ -423,7 +366,7 @@ export function ModelSelector({
               </DropdownMenuLabel>
               {provider.models.map((model) => {
                 const active = isActiveModel(model)
-                const variantKeys = getVariantKeys(model)
+                const variantKeys = getModelVariantKeys(model)
                 return (
                   <div key={`${model.providerID}:${model.id}`}>
                     <DropdownMenuItem
@@ -439,7 +382,7 @@ export function ModelSelector({
                         {isFavorite(model) && (
                           <Star className="h-3 w-3 text-yellow-500 fill-yellow-500 shrink-0" />
                         )}
-                        <span className="truncate text-sm">{getDisplayName(model)}</span>
+                        <span className="truncate text-sm">{getModelDisplayName(model)}</span>
                       </span>
                       {active && <Check className="h-4 w-4 shrink-0 text-primary" />}
                     </DropdownMenuItem>

--- a/src/renderer/src/components/sessions/PlanReadyImplementFab.tsx
+++ b/src/renderer/src/components/sessions/PlanReadyImplementFab.tsx
@@ -1,4 +1,6 @@
 import { cn } from '@/lib/utils'
+import { HandoffSplitButton } from './HandoffSplitButton'
+import type { HandoffSelectionOverride } from '@/lib/handoffSelection'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 
 function MnemonicLabel({ letter, label }: { letter: string; label: string }): React.JSX.Element {
@@ -17,13 +19,14 @@ function MnemonicLabel({ letter, label }: { letter: string; label: string }): Re
 
 interface PlanReadyImplementFabProps {
   onImplement: () => void
-  onHandoff: () => void
+  onHandoff: (override: HandoffSelectionOverride) => void
   visible: boolean
   onSuperpowers?: () => void
   onSuperpowersLocal?: () => void
   superpowersAvailable?: boolean
   isConnectionSession?: boolean
   onSaveAsTicket?: () => void
+  worktreeId?: string
 }
 
 export function PlanReadyImplementFab({
@@ -34,7 +37,8 @@ export function PlanReadyImplementFab({
   onSuperpowersLocal,
   superpowersAvailable,
   isConnectionSession,
-  onSaveAsTicket
+  onSaveAsTicket,
+  worktreeId
 }: PlanReadyImplementFabProps): React.JSX.Element {
   const vimModeEnabled = useSettingsStore((s) => s.vimModeEnabled)
 
@@ -64,21 +68,14 @@ export function PlanReadyImplementFab({
           {vimModeEnabled ? <MnemonicLabel letter="s" label="Save as ticket" /> : 'Save as ticket'}
         </button>
       )}
-      <button
-        onClick={onHandoff}
-        className={cn(
-          'h-8 rounded-full px-3',
-          'text-xs font-medium',
-          'bg-muted/80 text-foreground border border-border',
-          'shadow-md hover:bg-muted transition-colors duration-200',
-          'cursor-pointer',
-          visible ? 'opacity-100' : 'opacity-0'
-        )}
-        aria-label="Handoff plan"
-        data-testid="plan-ready-handoff-fab"
-      >
-        {vimModeEnabled ? <MnemonicLabel letter="a" label="Handoff" /> : 'Handoff'}
-      </button>
+      <div className={cn(visible ? 'opacity-100' : 'opacity-0')}>
+        <HandoffSplitButton
+          worktreeId={worktreeId}
+          onHandoff={onHandoff}
+          vimModeEnabled={vimModeEnabled}
+          testIdPrefix="plan-ready"
+        />
+      </div>
       {superpowersAvailable && !isConnectionSession && onSuperpowersLocal && (
         <button
           onClick={onSuperpowersLocal}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -4783,7 +4783,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       }
       const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
       sessionStore.setPendingMessage(result.session.id, handoffPrompt)
-      notifyKanbanSessionSync(sessionId, { type: 'supercharge', newSessionId: result.session.id })
+      await useKanbanStore
+        .getState()
+        .relinkTicketsForHandoff(sessionId, result.session.id)
       sessionStore.setActiveConnectionSession(result.session.id)
       await setModePromise
       return
@@ -4813,7 +4815,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
     const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
     sessionStore.setPendingMessage(result.session.id, handoffPrompt)
-    notifyKanbanSessionSync(sessionId, { type: 'supercharge', newSessionId: result.session.id })
+    await useKanbanStore
+      .getState()
+      .relinkTicketsForHandoff(sessionId, result.session.id)
     sessionStore.setActiveSession(result.session.id)
     await setModePromise
   }, [

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -85,6 +85,7 @@ import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
 import { buildSdkPlanImplementationPrompt, looksLikeCodexProposedPlan } from '@/lib/proposedPlan'
+import type { HandoffSelectionOverride } from '@/lib/handoffSelection'
 
 // Stable empty array to avoid creating new references in selectors
 const EMPTY_FILE_INDEX: FlatFile[] = []
@@ -4747,7 +4748,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     ]
   )
 
-  const handlePlanReadyHandoff = useCallback(async () => {
+  const handlePlanReadyHandoff = useCallback(async (override?: HandoffSelectionOverride) => {
     const lastAssistantMessage = [...messages]
       .reverse()
       .find((message) => message.role === 'assistant' && message.content.trim().length > 0)
@@ -4770,7 +4771,12 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     if (connectionId) {
       const handoffPrompt = `Implement the following plan\n${lastAssistantMessage.content}`
       const sessionStore = useSessionStore.getState()
-      const result = await sessionStore.createConnectionSession(connectionId)
+      const result = await sessionStore.createConnectionSession(
+        connectionId,
+        override?.agentSdk,
+        undefined,
+        { modelOverride: override?.model }
+      )
       if (!result.success || !result.session) {
         toast.error(result.error ?? 'Failed to create handoff session')
         return
@@ -4793,7 +4799,13 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     const handoffPrompt = `Implement the following plan\n${lastAssistantMessage.content}`
 
     const sessionStore = useSessionStore.getState()
-    const result = await sessionStore.createSession(currentWorktreeId, currentProjectId)
+    const result = await sessionStore.createSession(
+      currentWorktreeId,
+      currentProjectId,
+      override?.agentSdk,
+      undefined,
+      { modelOverride: override?.model }
+    )
     if (!result.success || !result.session) {
       toast.error(result.error ?? 'Failed to create handoff session')
       return
@@ -5717,6 +5729,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         <PlanReadyImplementFab
           onImplement={handlePlanReadyImplement}
           onHandoff={handlePlanReadyHandoff}
+          worktreeId={worktreeId ?? undefined}
           visible={showPlanReadyImplementFab}
           superpowersAvailable={hasSuperpowers}
           onSuperpowers={handlePlanReadySuperpowers}

--- a/src/renderer/src/hooks/useVimNavigation.ts
+++ b/src/renderer/src/hooks/useVimNavigation.ts
@@ -67,6 +67,7 @@ export function useVimNavigation(): void {
       const keyToTestId: Record<string, string> = {
         m: 'plan-ready-implement-fab',
         a: 'plan-ready-handoff-fab',
+        A: 'plan-ready-handoff-chevron',
         u: 'plan-ready-supercharge-fab',
         o: 'plan-ready-supercharge-local-fab',
         s: 'plan-ready-save-ticket-fab'
@@ -185,7 +186,14 @@ export function useVimNavigation(): void {
       }
 
       // --- Plan FAB shortcuts: activate plan action buttons ---
-      if (event.key === 'm' || event.key === 'u' || event.key === 'o' || event.key === 'a' || event.key === 's') {
+      if (
+        event.key === 'm' ||
+        event.key === 'u' ||
+        event.key === 'o' ||
+        event.key === 'a' ||
+        event.key === 'A' ||
+        event.key === 's'
+      ) {
         if (clickPlanFabButton(event.key)) {
           event.preventDefault()
           return

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -1,0 +1,254 @@
+import { isAgentSdkAvailable, type AvailableAgentSdks } from './agent-sdk-availability'
+import {
+  findModelInfo,
+  getFirstModelInfo,
+  getModelDisplayName,
+  getModelVariantKeys,
+  parseProviders,
+  type ProviderModels
+} from './parseProviders'
+import { resolveModelForSdk, useSettingsStore, type HandoffAgentSdk, type SelectedModel } from '@/stores/useSettingsStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+export interface EffectiveHandoffSelection {
+  agentSdk: HandoffAgentSdk
+  model: SelectedModel
+  display: {
+    sdkName: string
+    modelName: string
+    variant?: string
+  }
+}
+
+export interface HandoffSelectionOverride {
+  agentSdk: HandoffAgentSdk
+  model: SelectedModel
+}
+
+const SDK_DISPLAY_NAMES: Record<HandoffAgentSdk, string> = {
+  opencode: 'OpenCode',
+  'claude-code': 'Claude Code',
+  codex: 'Codex'
+}
+
+const FALLBACK_MODELS: Record<HandoffAgentSdk, SelectedModel> = {
+  opencode: { providerID: 'anthropic', modelID: 'claude-opus-4-5-20251101' },
+  'claude-code': { providerID: 'anthropic', modelID: 'claude-opus-4-5-20251101' },
+  codex: { providerID: 'codex', modelID: 'gpt-5.4' }
+}
+
+const modelCatalogCache = new Map<HandoffAgentSdk, ProviderModels[]>()
+const inflightModelCatalogRequests = new Map<HandoffAgentSdk, Promise<ProviderModels[]>>()
+
+function normalizeHandoffSdk(
+  sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal' | null | undefined
+): HandoffAgentSdk {
+  if (sdk === 'claude-code' || sdk === 'codex') return sdk
+  return 'opencode'
+}
+
+function buildModelSelection(model: SelectedModel | null, agentSdk: HandoffAgentSdk): SelectedModel {
+  if (model) return model
+
+  const cachedProviders = getCachedModelCatalog(agentSdk)
+  const firstModel = cachedProviders ? getFirstModelInfo(cachedProviders) : null
+  if (firstModel) {
+    const variants = getModelVariantKeys(firstModel)
+    return {
+      providerID: firstModel.providerID,
+      modelID: firstModel.id,
+      variant: variants[0]
+    }
+  }
+
+  return FALLBACK_MODELS[agentSdk]
+}
+
+function getWorktreeFallbackModel(worktreeId?: string): SelectedModel | null {
+  if (!worktreeId) return null
+
+  for (const worktrees of useWorktreeStore.getState().worktreesByProject.values()) {
+    const worktree = worktrees.find((candidate) => candidate.id === worktreeId)
+    if (!worktree?.last_model_id || !worktree.last_model_provider_id) continue
+
+    return {
+      providerID: worktree.last_model_provider_id,
+      modelID: worktree.last_model_id,
+      variant: worktree.last_model_variant ?? undefined
+    }
+  }
+
+  return null
+}
+
+function resolveSessionSelection(opts: {
+  worktreeId?: string
+  agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  mode?: 'build' | 'plan' | 'super-plan'
+}): EffectiveHandoffSelection {
+  const settings = useSettingsStore.getState()
+  const requestedSdk = normalizeHandoffSdk(opts.agentSdk ?? settings.defaultAgentSdk ?? 'opencode')
+  const configuredDefaultSdk = normalizeHandoffSdk(settings.defaultAgentSdk ?? 'opencode')
+  let model: SelectedModel | null = null
+
+  if (requestedSdk === configuredDefaultSdk && (opts.mode ?? 'build') === 'build') {
+    model = settings.defaultModels?.build ?? null
+  }
+
+  if (!model) {
+    model = resolveModelForSdk(requestedSdk, settings)
+  }
+
+  if (!model && Object.keys(settings.selectedModelByProvider).length === 0) {
+    model = getWorktreeFallbackModel(opts.worktreeId)
+  }
+
+  const resolvedModel = buildModelSelection(model, requestedSdk)
+  const modelInfo = getModelInfoFromCache(requestedSdk, resolvedModel)
+
+  return {
+    agentSdk: requestedSdk,
+    model: resolvedModel,
+    display: {
+      sdkName: SDK_DISPLAY_NAMES[requestedSdk],
+      modelName: modelInfo ? getModelDisplayName(modelInfo) : resolvedModel.modelID,
+      variant: resolvedModel.variant
+    }
+  }
+}
+
+function getModelInfoFromCache(
+  agentSdk: HandoffAgentSdk,
+  model: SelectedModel
+): ReturnType<typeof findModelInfo> {
+  const providers = getCachedModelCatalog(agentSdk)
+  if (!providers) return null
+  return findModelInfo(providers, model.providerID, model.modelID)
+}
+
+export function getHandoffSdkDisplayName(agentSdk: HandoffAgentSdk): string {
+  return SDK_DISPLAY_NAMES[agentSdk]
+}
+
+export function getAvailableHandoffAgentSdks(
+  availableAgentSdks?: AvailableAgentSdks | null
+): HandoffAgentSdk[] {
+  const orderedSdks: HandoffAgentSdk[] = ['opencode', 'claude-code', 'codex']
+  return orderedSdks.filter((sdk) => isAgentSdkAvailable(sdk, availableAgentSdks))
+}
+
+export function cacheHandoffModelCatalog(
+  agentSdk: HandoffAgentSdk,
+  providerData: unknown
+): ProviderModels[] {
+  const parsed = parseProviders(providerData)
+  modelCatalogCache.set(agentSdk, parsed)
+  return parsed
+}
+
+export function getCachedModelCatalog(agentSdk: HandoffAgentSdk): ProviderModels[] | null {
+  return modelCatalogCache.get(agentSdk) ?? null
+}
+
+export function clearHandoffModelCatalogCache(): void {
+  modelCatalogCache.clear()
+  inflightModelCatalogRequests.clear()
+}
+
+export async function loadHandoffModelCatalog(agentSdk: HandoffAgentSdk): Promise<ProviderModels[]> {
+  const cached = getCachedModelCatalog(agentSdk)
+  if (cached) return cached
+
+  const inflight = inflightModelCatalogRequests.get(agentSdk)
+  if (inflight) return inflight
+  if (typeof window.opencodeOps?.listModels !== 'function') return []
+
+  const request = window.opencodeOps
+    .listModels({ agentSdk })
+    .then((result) => {
+      const parsed = result.success ? cacheHandoffModelCatalog(agentSdk, result.providers) : []
+      inflightModelCatalogRequests.delete(agentSdk)
+      return parsed
+    })
+    .catch((error) => {
+      inflightModelCatalogRequests.delete(agentSdk)
+      console.error('Failed to load handoff model catalog:', error)
+      return []
+    })
+
+  inflightModelCatalogRequests.set(agentSdk, request)
+  return request
+}
+
+export function resolveModelForSdkDefault(agentSdk: HandoffAgentSdk): SelectedModel {
+  const configured = resolveModelForSdk(agentSdk)
+  return buildModelSelection(configured, agentSdk)
+}
+
+export function resolveHandoffDefault(opts: { worktreeId?: string }): EffectiveHandoffSelection {
+  return resolveSessionSelection({ worktreeId: opts.worktreeId, mode: 'build' })
+}
+
+export function getEffectiveHandoffSelection(opts: {
+  worktreeId?: string
+}): EffectiveHandoffSelection {
+  const settings = useSettingsStore.getState()
+  const fallback = resolveHandoffDefault(opts)
+  const override = settings.lastHandoffOverride
+
+  if (!override) return fallback
+  if (!isAgentSdkAvailable(override.agentSdk, settings.availableAgentSdks)) return fallback
+
+  const cachedProviders = getCachedModelCatalog(override.agentSdk)
+  if (
+    cachedProviders &&
+    !findModelInfo(cachedProviders, override.providerID, override.modelID)
+  ) {
+    return fallback
+  }
+
+  const model: SelectedModel = {
+    providerID: override.providerID,
+    modelID: override.modelID,
+    variant: override.variant
+  }
+  const modelInfo = getModelInfoFromCache(override.agentSdk, model)
+
+  return {
+    agentSdk: override.agentSdk,
+    model,
+    display: {
+      sdkName: SDK_DISPLAY_NAMES[override.agentSdk],
+      modelName: modelInfo ? getModelDisplayName(modelInfo) : override.modelID,
+      variant: override.variant
+    }
+  }
+}
+
+export function resolveSessionCreationSelection(opts: {
+  worktreeId?: string
+  agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  initialMode?: 'build' | 'plan' | 'super-plan'
+  modelOverride?: SelectedModel
+}): {
+  agentSdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  model: SelectedModel | null
+} {
+  const settings = useSettingsStore.getState()
+  const agentSdk = opts.agentSdkOverride ?? settings.defaultAgentSdk ?? 'opencode'
+
+  if (agentSdk === 'terminal') {
+    return { agentSdk, model: null }
+  }
+
+  if (opts.modelOverride) {
+    return { agentSdk, model: opts.modelOverride }
+  }
+
+  const resolved = resolveSessionSelection({
+    worktreeId: opts.worktreeId,
+    agentSdk,
+    mode: opts.initialMode
+  })
+  return { agentSdk, model: resolved.model }
+}

--- a/src/renderer/src/lib/parseProviders.ts
+++ b/src/renderer/src/lib/parseProviders.ts
@@ -1,0 +1,108 @@
+export interface ModelInfo {
+  id: string
+  name?: string
+  providerID: string
+  variants?: Record<string, Record<string, unknown>>
+}
+
+export interface ProviderModels {
+  providerID: string
+  providerName: string
+  models: ModelInfo[]
+}
+
+function toProviderList(data: unknown): unknown[] {
+  if (Array.isArray(data)) return data
+  if (typeof data !== 'object' || data === null) return []
+
+  const record = data as { providers?: unknown }
+  return Array.isArray(record.providers) ? record.providers : []
+}
+
+export function parseProviders(data: unknown): ProviderModels[] {
+  const providers = toProviderList(data)
+  const result: ProviderModels[] = []
+
+  for (const provider of providers) {
+    if (typeof provider !== 'object' || provider === null) continue
+
+    const providerRecord = provider as {
+      id?: unknown
+      name?: unknown
+      models?: unknown
+    }
+    const providerID = typeof providerRecord.id === 'string' ? providerRecord.id : 'unknown'
+    const modelsRecord =
+      typeof providerRecord.models === 'object' && providerRecord.models !== null
+        ? (providerRecord.models as Record<string, unknown>)
+        : {}
+
+    const models: ModelInfo[] = []
+    for (const [modelID, modelData] of Object.entries(modelsRecord)) {
+      if (typeof modelData !== 'object' || modelData === null) continue
+
+      const modelRecord = modelData as {
+        id?: unknown
+        name?: unknown
+        variants?: unknown
+      }
+      const variants =
+        typeof modelRecord.variants === 'object' && modelRecord.variants !== null
+          ? (modelRecord.variants as Record<string, Record<string, unknown>>)
+          : undefined
+
+      models.push({
+        id: typeof modelRecord.id === 'string' ? modelRecord.id : modelID,
+        name: typeof modelRecord.name === 'string' ? modelRecord.name : undefined,
+        providerID,
+        variants
+      })
+    }
+
+    if (models.length === 0) continue
+
+    result.push({
+      providerID,
+      providerName:
+        typeof providerRecord.name === 'string' && providerRecord.name.trim().length > 0
+          ? providerRecord.name
+          : providerID.charAt(0).toUpperCase() + providerID.slice(1),
+      models
+    })
+  }
+
+  return result
+}
+
+export function getModelDisplayName(model: Pick<ModelInfo, 'id' | 'name'>): string {
+  return model.name || model.id
+}
+
+export function getModelVariantKeys(model: Pick<ModelInfo, 'variants'>): string[] {
+  if (!model.variants) return []
+  return Object.keys(model.variants)
+}
+
+export function findModelInfo(
+  providers: ProviderModels[],
+  providerID: string,
+  modelID: string
+): ModelInfo | null {
+  for (const provider of providers) {
+    if (provider.providerID !== providerID) continue
+
+    const match = provider.models.find((model) => model.id === modelID)
+    if (match) return match
+  }
+
+  return null
+}
+
+export function getFirstModelInfo(providers: ProviderModels[]): ModelInfo | null {
+  for (const provider of providers) {
+    const firstModel = provider.models[0]
+    if (firstModel) return firstModel
+  }
+
+  return null
+}

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -126,6 +126,7 @@ interface KanbanState {
 
   // ── Session coordination ────────────────────────────────────────────
   syncTicketWithSession: (sessionId: string, event: KanbanSessionEvent) => void
+  relinkTicketsForHandoff: (oldSessionId: string, newSessionId: string) => Promise<void>
 
   // ── Getters ────────────────────────────────────────────────────────
   getTicketsForProject: (projectId: string) => KanbanTicket[]
@@ -709,6 +710,62 @@ export const useKanbanStore = create<KanbanState>()(
             }
           }
         }
+      },
+
+      relinkTicketsForHandoff: async (oldSessionId: string, newSessionId: string) => {
+        const linkedTickets = await window.kanban.ticket.getBySession(oldSessionId)
+        if (!linkedTickets || linkedTickets.length === 0) return
+
+        const relinkedById = new Map<string, KanbanTicket>()
+
+        for (const ticket of linkedTickets) {
+          const alreadyRelinked =
+            ticket.current_session_id === newSessionId &&
+            ticket.plan_ready === false &&
+            ticket.mode === 'build'
+
+          if (!alreadyRelinked) {
+            await window.kanban.ticket.update(ticket.id, {
+              current_session_id: newSessionId,
+              plan_ready: false,
+              mode: 'build'
+            })
+          }
+
+          relinkedById.set(ticket.id, {
+            ...ticket,
+            current_session_id: newSessionId,
+            plan_ready: false,
+            mode: 'build'
+          })
+        }
+
+        set((state) => {
+          const next = new Map(state.tickets)
+          let changed = false
+
+          for (const [projectId, projectTickets] of next.entries()) {
+            let projectChanged = false
+            const updatedTickets = projectTickets.map((ticket) => {
+              const relinked = relinkedById.get(ticket.id)
+              if (!relinked) return ticket
+              projectChanged = true
+              return {
+                ...ticket,
+                current_session_id: relinked.current_session_id,
+                plan_ready: relinked.plan_ready,
+                mode: relinked.mode
+              }
+            })
+
+            if (projectChanged) {
+              changed = true
+              next.set(projectId, updatedTickets)
+            }
+          }
+
+          return changed ? { tickets: next } : {}
+        })
       },
 
       // ── Merge-on-done state ──────────────────────────────────────────

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -5,6 +5,7 @@ import { useWorktreeStore } from './useWorktreeStore'
 import { notifyKanbanSessionSync, notifyKanbanNewSession } from './store-coordination'
 import { useSettingsStore } from './useSettingsStore'
 import { getUnavailableAgentSdkMessage } from '@/lib/agent-sdk-availability'
+import { resolveSessionCreationSelection } from '@/lib/handoffSelection'
 
 /**
  * Push the follow-up-message queue state for a session into the main process
@@ -132,7 +133,7 @@ interface SessionState {
     projectId: string,
     agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
     initialMode?: SessionMode,
-    options?: { autoFocus?: boolean }
+    options?: { autoFocus?: boolean; modelOverride?: SelectedModel }
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
   closeSession: (sessionId: string) => Promise<{ success: boolean; error?: string }>
   reopenSession: (
@@ -203,7 +204,7 @@ interface SessionState {
     connectionId: string,
     agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
     initialMode?: SessionMode,
-    opts?: { autoFocus?: boolean }
+    opts?: { autoFocus?: boolean; modelOverride?: SelectedModel }
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
   setActiveConnectionSession: (sessionId: string | null) => void
   setActiveConnection: (connectionId: string | null) => void
@@ -402,70 +403,22 @@ export const useSessionStore = create<SessionState>()(
         projectId: string,
         agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
         initialMode?: SessionMode,
-        options?: { autoFocus?: boolean }
+        options?: { autoFocus?: boolean; modelOverride?: SelectedModel }
       ) => {
         try {
           const autoFocus = options?.autoFocus !== false
-          // Resolve default agent SDK from settings
-          const { useSettingsStore } = await import('./useSettingsStore')
-          const defaultAgentSdk =
-            agentSdkOverride ?? useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
+          const { agentSdk: defaultAgentSdk, model: defaultModel } = resolveSessionCreationSelection({
+            worktreeId,
+            agentSdkOverride,
+            initialMode,
+            modelOverride: options?.modelOverride
+          })
           const unavailableProviderError = getUnavailableProviderError(defaultAgentSdk)
           if (unavailableProviderError) {
             return { success: false, error: unavailableProviderError }
           }
 
           const isTerminal = defaultAgentSdk === 'terminal'
-
-          // Terminal sessions skip model resolution entirely
-          let defaultModel: { providerID: string; modelID: string; variant?: string } | null = null
-
-          if (!isTerminal) {
-            const { resolveModelForSdk } = await import('./useSettingsStore')
-            const configuredDefaultSdk = useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
-
-            // Priority 1: mode-specific default (only when session SDK matches the
-            // configured default — mode defaults are set in that SDK's context)
-            if (defaultAgentSdk === configuredDefaultSdk) {
-              const modeModel = useSettingsStore.getState().getModelForMode(initialMode ?? 'build')
-              if (modeModel) {
-                defaultModel = modeModel
-              }
-            }
-
-            // Priority 2: per-provider default → (legacy) global default
-            if (!defaultModel) {
-              defaultModel = resolveModelForSdk(defaultAgentSdk)
-            }
-
-            // Legacy worktree fallback only when per-provider feature not yet active
-            if (!defaultModel) {
-              const settingsState = useSettingsStore.getState()
-              const hasPerProviderDefaults =
-                Object.keys(settingsState.selectedModelByProvider).length > 0
-              if (!hasPerProviderDefaults) {
-                const worktree = useWorktreeStore.getState().worktreesByProject
-                let worktreeRecord:
-                  | {
-                      last_model_provider_id: string | null
-                      last_model_id: string | null
-                      last_model_variant: string | null
-                    }
-                  | undefined
-                for (const worktrees of worktree.values()) {
-                  worktreeRecord = worktrees.find((w) => w.id === worktreeId)
-                  if (worktreeRecord) break
-                }
-                if (worktreeRecord?.last_model_id) {
-                  defaultModel = {
-                    providerID: worktreeRecord.last_model_provider_id!,
-                    modelID: worktreeRecord.last_model_id,
-                    variant: worktreeRecord.last_model_variant ?? undefined
-                  }
-                }
-              }
-            }
-          }
 
           const existingSessions = get().sessionsByWorktree.get(worktreeId) || []
           const sessionNumber = existingSessions.length + 1
@@ -1927,7 +1880,7 @@ export const useSessionStore = create<SessionState>()(
         connectionId: string,
         agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
         initialMode?: SessionMode,
-        opts?: { autoFocus?: boolean }
+        opts?: { autoFocus?: boolean; modelOverride?: SelectedModel }
       ) => {
         try {
           const autoFocus = opts?.autoFocus ?? true
@@ -1939,40 +1892,14 @@ export const useSessionStore = create<SessionState>()(
 
           const projectId = result.connection.members[0].project_id
 
-          // Determine default model and agent SDK from global settings
-          let defaultModel: { providerID: string; modelID: string; variant?: string } | null = null
-          let defaultAgentSdk: 'opencode' | 'claude-code' | 'codex' | 'terminal' = 'opencode'
-          try {
-            const { useSettingsStore } = await import('./useSettingsStore')
-            defaultAgentSdk =
-              agentSdkOverride ?? useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
-            const unavailableProviderError = getUnavailableProviderError(defaultAgentSdk)
-            if (unavailableProviderError) {
-              return { success: false, error: unavailableProviderError }
-            }
-            // Terminal sessions skip model resolution
-            if (defaultAgentSdk !== 'terminal') {
-              const configuredDefaultSdk = useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
-
-              // Priority 1: mode-specific default (only when session SDK matches the
-              // configured default — mode defaults are set in that SDK's context)
-              if (defaultAgentSdk === configuredDefaultSdk) {
-                const modeModel = useSettingsStore
-                  .getState()
-                  .getModelForMode(initialMode ?? 'build')
-                if (modeModel) {
-                  defaultModel = modeModel
-                }
-              }
-
-              // Priority 2: per-provider default → (legacy) global default
-              if (!defaultModel) {
-                const { resolveModelForSdk } = await import('./useSettingsStore')
-                defaultModel = resolveModelForSdk(defaultAgentSdk)
-              }
-            }
-          } catch {
-            /* non-critical */
+          const { agentSdk: defaultAgentSdk, model: defaultModel } = resolveSessionCreationSelection({
+            agentSdkOverride,
+            initialMode,
+            modelOverride: opts?.modelOverride
+          })
+          const unavailableProviderError = getUnavailableProviderError(defaultAgentSdk)
+          if (unavailableProviderError) {
+            return { success: false, error: unavailableProviderError }
           }
 
           const isTerminal = defaultAgentSdk === 'terminal'

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -30,6 +30,9 @@ export interface SelectedModel {
   variant?: string
 }
 
+export type AgentSdk = 'opencode' | 'claude-code' | 'codex' | 'terminal'
+export type HandoffAgentSdk = Exclude<AgentSdk, 'terminal'>
+
 export interface ModeDefaultModels {
   build: SelectedModel | null
   plan: SelectedModel | null
@@ -74,6 +77,12 @@ export interface AppSettings {
   selectedModel: SelectedModel | null
   selectedModelByProvider: Record<string, SelectedModel>
   defaultModels: ModeDefaultModels | null
+  lastHandoffOverride: {
+    agentSdk: HandoffAgentSdk
+    providerID: string
+    modelID: string
+    variant?: string
+  } | null
 
   // Quick Actions
   lastOpenAction: QuickActionType | null
@@ -98,7 +107,7 @@ export interface AppSettings {
   usageIndicatorProviders: UsageProvider[]
 
   // Agent SDK
-  defaultAgentSdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  defaultAgentSdk: AgentSdk
 
   // Setup
   initialSetupComplete: boolean
@@ -157,6 +166,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   selectedModel: null,
   selectedModelByProvider: {},
   defaultModels: null,
+  lastHandoffOverride: null,
   lastOpenAction: null,
   favoriteModels: [],
   customChromeCommand: '',
@@ -226,6 +236,7 @@ interface SettingsState extends AppSettings {
     model: SelectedModel | null
   ) => Promise<void>
   getModelForMode: (mode: 'build' | 'plan' | 'ask') => SelectedModel | null
+  setLastHandoffOverride: (value: AppSettings['lastHandoffOverride']) => void
   toggleFavoriteModel: (providerID: string, modelID: string) => void
   setModelVariantDefault: (providerID: string, modelID: string, variant: string) => void
   getModelVariantDefault: (providerID: string, modelID: string) => string | undefined
@@ -312,6 +323,7 @@ function extractSettings(state: SettingsState): AppSettings {
     selectedModel: state.selectedModel,
     selectedModelByProvider: state.selectedModelByProvider,
     defaultModels: state.defaultModels,
+    lastHandoffOverride: state.lastHandoffOverride,
     lastOpenAction: state.lastOpenAction,
     favoriteModels: state.favoriteModels,
     customChromeCommand: state.customChromeCommand,
@@ -493,6 +505,12 @@ export const useSettingsStore = create<SettingsState>()(
         return get().defaultModels?.[mode] ?? null
       },
 
+      setLastHandoffOverride: (value) => {
+        set({ lastHandoffOverride: value })
+        const settings = extractSettings({ ...get(), lastHandoffOverride: value } as SettingsState)
+        saveToDatabase(settings)
+      },
+
       setModelVariantDefault: (providerID: string, modelID: string, variant: string) => {
         const key = `${providerID}::${modelID}`
         const updated = { ...get().modelVariantDefaults, [key]: variant }
@@ -572,6 +590,7 @@ export const useSettingsStore = create<SettingsState>()(
         selectedModel: state.selectedModel,
         selectedModelByProvider: state.selectedModelByProvider,
         defaultModels: state.defaultModels,
+        lastHandoffOverride: state.lastHandoffOverride,
         lastOpenAction: state.lastOpenAction,
         favoriteModels: state.favoriteModels,
         customChromeCommand: state.customChromeCommand,

--- a/test/kanban/plan-review-followup-dispatch.test.tsx
+++ b/test/kanban/plan-review-followup-dispatch.test.tsx
@@ -305,6 +305,10 @@ describe('Plan review followup dispatch', () => {
       })
     })
     vi.clearAllMocks()
+    mockKanban.ticket.getBySession.mockImplementation(async (sessionId: string) => {
+      const tickets = [...useKanbanStore.getState().tickets.values()].flat()
+      return tickets.filter((ticket) => ticket.current_session_id === sessionId)
+    })
   })
 
   // ════════════════════════════════════════════════════════════════════
@@ -860,6 +864,13 @@ describe('Plan review followup dispatch', () => {
       expect(useSessionStore.getState().activeConnectionId).toBe('conn-1')
     })
     expect(useSessionStore.getState().activeSessionId).toBe('session-conn-new')
+    expect(mockOpencodeOps.connect).toHaveBeenCalledWith('/test/conn-1', 'session-conn-new')
+    expect(mockOpencodeOps.prompt).toHaveBeenCalledWith(
+      '/test/conn-1',
+      'opc-session-1',
+      [{ type: 'text', text: 'Implement the following plan\n## Detailed Plan\n\nStep 1: Implement auth' }],
+      undefined
+    )
 
     // Ticket is re-linked to the new session with plan_ready cleared.
     const updatedTicket = useKanbanStore
@@ -869,5 +880,86 @@ describe('Plan review followup dispatch', () => {
     expect(updatedTicket?.current_session_id).toBe('session-conn-new')
     expect(updatedTicket?.plan_ready).toBe(false)
     expect(updatedTicket?.mode).toBe('build')
+    expect(updatedTicket?.column).toBe('in_progress')
+    expect(useWorktreeStatusStore.getState().sessionStatuses['session-conn-new']?.status).toBe('working')
+  })
+
+  test('handoff on worktree ticket relinks the ticket to the new session', async () => {
+    mockDbSession.create.mockResolvedValueOnce(
+      makeSession({
+        id: 'session-worktree-new',
+        worktree_id: 'wt-1',
+        connection_id: null,
+        agent_sdk: 'claude-code',
+        mode: 'build',
+        opencode_session_id: null
+      })
+    )
+
+    act(() => {
+      useKanbanStore.setState({
+        tickets: new Map([['proj-1', [planTicket]]]),
+        isBoardViewActive: true,
+        selectedTicketId: 'ticket-plan'
+      })
+      useSessionStore.setState({
+        activeSessionId: null,
+        activeWorktreeId: 'wt-1',
+        sessionsByWorktree: new Map([['wt-1', [makeSession({ id: 'session-1' })]]]),
+        sessionsByConnection: new Map(),
+        tabOrderByWorktree: new Map([['wt-1', ['session-1']]]),
+        activeSessionByWorktree: {},
+        pendingPlans: new Map([
+          [
+            'session-1',
+            {
+              requestId: 'req-1',
+              planContent: '## Detailed Plan\n\nStep 1: Setup routes\nStep 2: Add auth',
+              toolUseID: 'tool-1'
+            }
+          ]
+        ]),
+        pendingMessages: new Map(),
+        pendingFollowUpMessages: new Map()
+      })
+      useWorktreeStore.setState({
+        selectedWorktreeId: 'wt-1',
+        worktreesByProject: new Map([['proj-1', [makeWorktree()]]])
+      })
+      useWorktreeStatusStore.setState({ sessionStatuses: {} })
+      useSettingsStore.setState({ boardMode: 'toggle' })
+    })
+
+    render(<KanbanTicketModal />)
+
+    const handoffBtn = await screen.findByTestId('plan-review-handoff-btn')
+    await act(async () => {
+      fireEvent.click(handoffBtn)
+    })
+
+    await waitFor(() => {
+      expect(mockDbSession.create).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().activeSessionId).toBe('session-worktree-new')
+    })
+    expect(mockOpencodeOps.connect).toHaveBeenCalledWith('/test/feature-auth', 'session-worktree-new')
+    expect(mockOpencodeOps.prompt).toHaveBeenCalledWith(
+      '/test/feature-auth',
+      'opc-session-1',
+      [{ type: 'text', text: 'Implement the following plan\n## Detailed Plan\n\nStep 1: Setup routes\nStep 2: Add auth' }],
+      undefined
+    )
+
+    const updatedTicket = useKanbanStore
+      .getState()
+      .tickets.get('proj-1')
+      ?.find((t) => t.id === 'ticket-plan')
+    expect(updatedTicket?.current_session_id).toBe('session-worktree-new')
+    expect(updatedTicket?.plan_ready).toBe(false)
+    expect(updatedTicket?.mode).toBe('build')
+    expect(updatedTicket?.column).toBe('in_progress')
+    expect(useWorktreeStatusStore.getState().sessionStatuses['session-worktree-new']?.status).toBe('working')
   })
 })

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockSettingsDb = {
+  get: vi.fn().mockResolvedValue(null),
+  set: vi.fn().mockResolvedValue(undefined)
+}
+
+const claudeProviders = [
+  {
+    id: 'anthropic',
+    name: 'Anthropic',
+    models: {
+      'sonnet-4.6': {
+        id: 'sonnet-4.6',
+        name: 'Sonnet 4.6',
+        variants: {
+          high: {},
+          xhigh: {}
+        }
+      }
+    }
+  }
+]
+
+const codexProviders = [
+  {
+    id: 'codex',
+    name: 'Codex',
+    models: {
+      'gpt-5.4': {
+        id: 'gpt-5.4',
+        name: 'GPT-5.4',
+        variants: {
+          high: {},
+          xhigh: {}
+        }
+      },
+      'gpt-5.4-mini': {
+        id: 'gpt-5.4-mini',
+        name: 'GPT-5.4 Mini'
+      }
+    }
+  }
+]
+
+Object.defineProperty(window, 'db', {
+  writable: true,
+  configurable: true,
+  value: {
+    setting: mockSettingsDb
+  }
+})
+
+Object.defineProperty(window, 'systemOps', {
+  writable: true,
+  configurable: true,
+  value: {
+    detectAgentSdks: vi.fn().mockResolvedValue({
+      opencode: true,
+      claude: true,
+      codex: true
+    })
+  }
+})
+
+Object.defineProperty(window, 'opencodeOps', {
+  writable: true,
+  configurable: true,
+  value: {
+    listModels: vi.fn().mockImplementation(async ({ agentSdk }: { agentSdk?: string } = {}) => {
+      if (agentSdk === 'codex') {
+        return { success: true, providers: codexProviders }
+      }
+
+      return { success: true, providers: claudeProviders }
+    })
+  }
+})
+
+import {
+  cacheHandoffModelCatalog,
+  clearHandoffModelCatalogCache,
+  getEffectiveHandoffSelection
+} from '@/lib/handoffSelection'
+import { HandoffSplitButton } from '@/components/sessions/HandoffSplitButton'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+describe('handoff model picker', () => {
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    clearHandoffModelCatalogCache()
+    localStorage.clear()
+
+    useSettingsStore.setState({
+      selectedModel: null,
+      selectedModelByProvider: {
+        'claude-code': {
+          providerID: 'anthropic',
+          modelID: 'sonnet-4.6',
+          variant: 'high'
+        },
+        codex: {
+          providerID: 'codex',
+          modelID: 'gpt-5.4',
+          variant: 'high'
+        }
+      },
+      defaultModels: {
+        build: {
+          providerID: 'anthropic',
+          modelID: 'sonnet-4.6',
+          variant: 'high'
+        },
+        plan: null,
+        ask: null
+      },
+      lastHandoffOverride: null,
+      defaultAgentSdk: 'claude-code',
+      availableAgentSdks: {
+        opencode: true,
+        claude: true,
+        codex: true
+      }
+    })
+    useWorktreeStore.setState({
+      worktreesByProject: new Map()
+    })
+  })
+
+  test('getEffectiveHandoffSelection returns the override when it is valid', () => {
+    cacheHandoffModelCatalog('codex', codexProviders)
+    useSettingsStore.setState({
+      lastHandoffOverride: {
+        agentSdk: 'codex',
+        providerID: 'codex',
+        modelID: 'gpt-5.4',
+        variant: 'xhigh'
+      }
+    })
+
+    const effective = getEffectiveHandoffSelection({})
+
+    expect(effective.agentSdk).toBe('codex')
+    expect(effective.model).toEqual({
+      providerID: 'codex',
+      modelID: 'gpt-5.4',
+      variant: 'xhigh'
+    })
+    expect(effective.display).toEqual({
+      sdkName: 'Codex',
+      modelName: 'GPT-5.4',
+      variant: 'xhigh'
+    })
+  })
+
+  test('getEffectiveHandoffSelection falls back to the default when the override is stale', () => {
+    cacheHandoffModelCatalog('codex', codexProviders)
+    cacheHandoffModelCatalog('claude-code', claudeProviders)
+    useSettingsStore.setState({
+      lastHandoffOverride: {
+        agentSdk: 'codex',
+        providerID: 'codex',
+        modelID: 'missing-model',
+        variant: 'high'
+      }
+    })
+
+    const effective = getEffectiveHandoffSelection({})
+
+    expect(effective.agentSdk).toBe('claude-code')
+    expect(effective.model).toEqual({
+      providerID: 'anthropic',
+      modelID: 'sonnet-4.6',
+      variant: 'high'
+    })
+    expect(effective.display.modelName).toBe('Sonnet 4.6')
+  })
+
+  test('button label rerenders when lastHandoffOverride changes', async () => {
+    cacheHandoffModelCatalog('claude-code', claudeProviders)
+    cacheHandoffModelCatalog('codex', codexProviders)
+
+    render(<HandoffSplitButton onHandoff={vi.fn()} testIdPrefix="plan-ready" />)
+
+    const handoffButton = await screen.findByTestId('plan-ready-handoff-fab')
+    expect(handoffButton).toHaveTextContent('Claude Code /')
+    expect(handoffButton).toHaveTextContent('Sonnet 4.6')
+
+    act(() => {
+      useSettingsStore.getState().setLastHandoffOverride({
+        agentSdk: 'codex',
+        providerID: 'codex',
+        modelID: 'gpt-5.4',
+        variant: 'xhigh'
+      })
+    })
+
+    await waitFor(() => {
+      expect(handoffButton).toHaveTextContent('Codex /')
+      expect(handoffButton).toHaveTextContent('GPT-5.4')
+      expect(handoffButton).toHaveTextContent('xhigh')
+    })
+  })
+
+  test('single-sdk rendering hides the chevron control', async () => {
+    cacheHandoffModelCatalog('claude-code', claudeProviders)
+    useSettingsStore.setState({
+      availableAgentSdks: {
+        opencode: false,
+        claude: true,
+        codex: false
+      }
+    })
+
+    render(<HandoffSplitButton onHandoff={vi.fn()} testIdPrefix="plan-ready" />)
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('plan-ready-handoff-chevron')).not.toBeInTheDocument()
+    })
+  })
+
+  test('picker only persists on confirm and switching SDK resets the model selection', async () => {
+    cacheHandoffModelCatalog('claude-code', claudeProviders)
+    cacheHandoffModelCatalog('codex', codexProviders)
+    const onHandoff = vi.fn()
+    const user = userEvent.setup()
+
+    render(<HandoffSplitButton onHandoff={onHandoff} testIdPrefix="plan-ready" />)
+
+    await user.click(await screen.findByTestId('plan-ready-handoff-chevron'))
+    expect(await screen.findByRole('button', { name: 'Select handoff model' })).toHaveTextContent(
+      'Sonnet 4.6'
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Select handoff SDK' }))
+    await user.click(await screen.findByText('Codex'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Select handoff model' })).toHaveTextContent(
+        'GPT-5.4'
+      )
+    })
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Select handoff model' })).not.toBeInTheDocument()
+    })
+    expect(useSettingsStore.getState().lastHandoffOverride).toBeNull()
+
+    await user.click(screen.getByTestId('plan-ready-handoff-chevron'))
+    expect(await screen.findByRole('button', { name: 'Select handoff model' })).toHaveTextContent(
+      'Sonnet 4.6'
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Select handoff SDK' }))
+    await user.click(await screen.findByText('Codex'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Select handoff model' })).toHaveTextContent(
+        'GPT-5.4'
+      )
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Handoff' }))
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().lastHandoffOverride).toEqual({
+        agentSdk: 'codex',
+        providerID: 'codex',
+        modelID: 'gpt-5.4',
+        variant: 'high'
+      })
+    })
+    expect(onHandoff).toHaveBeenCalledWith({
+      agentSdk: 'codex',
+      model: {
+        providerID: 'codex',
+        modelID: 'gpt-5.4',
+        variant: 'high'
+      }
+    })
+  })
+})

--- a/test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx
+++ b/test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx
@@ -1,0 +1,372 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { forwardRef } from 'react'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn()
+  },
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn()
+  }
+}))
+
+vi.mock('../../../src/renderer/src/components/sessions/ForkMessageButton', () => ({
+  ForkMessageButton: () => null
+}))
+
+vi.mock('../../../src/renderer/src/components/sessions/VirtualizedMessageList', () => ({
+  VirtualizedMessageList: forwardRef(function MockVirtualizedMessageList(
+    {
+      messages
+    }: {
+      messages: Array<{ id: string; role: 'user' | 'assistant'; content: string }>
+    },
+    _ref
+  ) {
+    return (
+      <div data-testid="message-list">
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            data-testid={message.role === 'user' ? 'message-user' : 'message-assistant'}
+          >
+            {message.content}
+          </div>
+        ))}
+      </div>
+    )
+  })
+}))
+
+vi.mock('../../../src/renderer/src/components/sessions/PlanReadyImplementFab', () => ({
+  PlanReadyImplementFab: ({
+    visible,
+    onHandoff
+  }: {
+    visible: boolean
+    onHandoff: (override?: { agentSdk: 'claude-code' }) => void
+  }) =>
+    visible ? (
+      <button
+        type="button"
+        data-testid="plan-ready-handoff-fab"
+        onClick={() => onHandoff({ agentSdk: 'claude-code' })}
+      >
+        Handoff
+      </button>
+    ) : null
+}))
+
+import { SessionView } from '../../../src/renderer/src/components/sessions/SessionView'
+import { useKanbanStore } from '../../../src/renderer/src/stores/useKanbanStore'
+import { useSessionStore } from '../../../src/renderer/src/stores/useSessionStore'
+import { useSettingsStore } from '../../../src/renderer/src/stores/useSettingsStore'
+import { useWorktreeStatusStore } from '../../../src/renderer/src/stores/useWorktreeStatusStore'
+
+function createSessionRecord(
+  overrides: Partial<{
+    id: string
+    worktree_id: string | null
+    project_id: string
+    connection_id: string | null
+    name: string | null
+    status: 'active' | 'completed' | 'error'
+    opencode_session_id: string | null
+    agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+    mode: 'build' | 'plan'
+    model_provider_id: string | null
+    model_id: string | null
+    model_variant: string | null
+    created_at: string
+    updated_at: string
+    completed_at: string | null
+  }> = {}
+) {
+  return {
+    id: 'session-plan-old',
+    worktree_id: 'wt-1',
+    project_id: 'proj-1',
+    connection_id: null,
+    name: 'Plan Session',
+    status: 'active' as const,
+    opencode_session_id: 'opc-session-old',
+    agent_sdk: 'claude-code' as const,
+    mode: 'plan' as const,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    completed_at: null,
+    ...overrides
+  }
+}
+
+describe('SessionView handoff ticket relinking', () => {
+  const mockKanban = {
+    ticket: {
+      getBySession: vi.fn(),
+      update: vi.fn()
+    }
+  }
+
+  const mockDbSession = {
+    get: vi.fn(),
+    getDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    update: vi.fn(),
+    create: vi.fn()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cleanup()
+    localStorage.clear()
+
+    useKanbanStore.setState({
+      tickets: new Map(),
+      isLoading: false,
+      isBoardViewActive: false,
+      simpleModeByProject: {},
+      selectedTicketId: null
+    })
+
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([['wt-1', [createSessionRecord()]]]),
+      tabOrderByWorktree: new Map([['wt-1', ['session-plan-old']]]),
+      modeBySession: new Map([['session-plan-old', 'plan']]),
+      pendingMessages: new Map(),
+      pendingPlans: new Map([
+        [
+          'session-plan-old',
+          {
+            requestId: 'req-plan-1',
+            planContent: '1. Add the relink helper\n2. Use it during handoff',
+            toolUseID: 'tool-plan-1'
+          }
+        ]
+      ]),
+      pendingFollowUpMessages: new Map(),
+      isLoading: false,
+      error: null,
+      activeSessionId: 'session-plan-old',
+      activeWorktreeId: 'wt-1',
+      activeSessionByWorktree: { 'wt-1': 'session-plan-old' },
+      sessionsByConnection: new Map(),
+      tabOrderByConnection: new Map(),
+      activeSessionByConnection: {},
+      activeConnectionId: null,
+      inlineConnectionSessionId: null,
+      closedTerminalSessionIds: new Set()
+    })
+    useWorktreeStatusStore.setState({ sessionStatuses: {}, lastMessageTimeByWorktree: {} })
+    useSettingsStore.setState({
+      defaultAgentSdk: 'claude-code',
+      availableAgentSdks: {
+        opencode: false,
+        claude: true,
+        codex: false
+      },
+      defaultModels: {
+        build: null,
+        plan: null,
+        ask: null
+      },
+      selectedModel: null,
+      selectedModelByProvider: {},
+      lastHandoffOverride: null
+    })
+
+    mockKanban.ticket.getBySession.mockResolvedValue([
+      {
+        id: 'ticket-1',
+        project_id: 'proj-1',
+        current_session_id: 'session-plan-old',
+        plan_ready: true,
+        mode: 'plan'
+      }
+    ])
+    mockKanban.ticket.update.mockResolvedValue(undefined)
+
+    mockDbSession.get.mockResolvedValue(createSessionRecord())
+    mockDbSession.getDraft.mockResolvedValue(null)
+    mockDbSession.updateDraft.mockResolvedValue(undefined)
+    mockDbSession.update.mockImplementation(async (sessionId: string, data: Record<string, unknown>) => ({
+      ...createSessionRecord({ id: sessionId }),
+      ...data
+    }))
+    mockDbSession.create.mockResolvedValue(
+      createSessionRecord({
+        id: 'session-build-new',
+        mode: 'build',
+        opencode_session_id: null,
+        name: 'Session 2'
+      })
+    )
+
+    Object.defineProperty(window, 'kanban', {
+      value: mockKanban,
+      writable: true,
+      configurable: true
+    })
+
+    Object.defineProperty(window, 'db', {
+      value: {
+        session: mockDbSession,
+        worktree: {
+          get: vi.fn().mockResolvedValue({
+            id: 'wt-1',
+            project_id: 'proj-1',
+            name: 'WT',
+            branch_name: 'main',
+            path: '/tmp/worktree-handoff',
+            status: 'active',
+            is_default: true,
+            created_at: new Date().toISOString(),
+            last_accessed_at: new Date().toISOString()
+          }),
+          update: vi.fn().mockResolvedValue(null)
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+
+    Object.defineProperty(window, 'opencodeOps', {
+      value: {
+        reconnect: vi.fn().mockResolvedValue({ success: true }),
+        connect: vi.fn().mockResolvedValue({ success: false }),
+        prompt: vi.fn().mockResolvedValue({ success: true }),
+        command: vi.fn().mockResolvedValue({ success: true }),
+        fork: vi.fn().mockResolvedValue({ success: true }),
+        sessionInfo: vi
+          .fn()
+          .mockResolvedValue({ success: true, revertMessageID: null, revertDiff: null }),
+        undo: vi.fn().mockResolvedValue({ success: true }),
+        redo: vi.fn().mockResolvedValue({ success: true }),
+        disconnect: vi.fn().mockResolvedValue({ success: true }),
+        abort: vi.fn().mockResolvedValue({ success: true }),
+        getMessages: vi.fn().mockResolvedValue({
+          success: true,
+          messages: [
+            {
+              info: {
+                id: 'turn-1:user',
+                role: 'user',
+                time: { created: Date.now() - 2000 }
+              },
+              parts: [{ type: 'text', text: 'Please draft a plan' }]
+            },
+            {
+              info: {
+                id: 'turn-1:assistant',
+                role: 'assistant',
+                time: { created: Date.now() - 1000 }
+              },
+              parts: [{ type: 'text', text: '1. Add the relink helper\n2. Use it during handoff' }]
+            }
+          ]
+        }),
+        listModels: vi.fn().mockResolvedValue({ success: true, providers: [] }),
+        setModel: vi.fn().mockResolvedValue({ success: true }),
+        modelInfo: vi.fn().mockResolvedValue({ success: true }),
+        questionReply: vi.fn().mockResolvedValue({ success: true }),
+        questionReject: vi.fn().mockResolvedValue({ success: true }),
+        permissionReply: vi.fn().mockResolvedValue({ success: true }),
+        permissionList: vi.fn().mockResolvedValue({ success: true, permissions: [] }),
+        commands: vi.fn().mockResolvedValue({ success: true, commands: [] }),
+        capabilities: vi.fn().mockResolvedValue({
+          success: true,
+          capabilities: {
+            supportsUndo: true,
+            supportsRedo: true,
+            supportsCommands: true,
+            supportsPermissionRequests: true,
+            supportsQuestionPrompts: true,
+            supportsModelSelection: true,
+            supportsReconnect: true,
+            supportsPartialStreaming: true,
+            supportsSteer: true
+          }
+        }),
+        onStream: vi.fn().mockImplementation(() => () => {})
+      },
+      writable: true,
+      configurable: true
+    })
+
+    Object.defineProperty(window, 'systemOps', {
+      value: {
+        isLogMode: vi.fn().mockResolvedValue(false),
+        getLogDir: vi.fn().mockResolvedValue('/tmp/logs'),
+        getAppVersion: vi.fn().mockResolvedValue('1.0.0'),
+        getAppPaths: vi.fn().mockResolvedValue({ userData: '/tmp', home: '/tmp', logs: '/tmp/logs' }),
+        setSessionQueuedState: vi.fn().mockResolvedValue(undefined)
+      },
+      writable: true,
+      configurable: true
+    })
+
+    Object.defineProperty(window, 'loggingOps', {
+      value: {
+        createResponseLog: vi.fn().mockResolvedValue('/tmp/log.jsonl'),
+        appendResponseLog: vi.fn().mockResolvedValue(undefined)
+      },
+      writable: true,
+      configurable: true
+    })
+
+    Object.defineProperty(window, 'bash', {
+      value: {
+        getRun: vi.fn().mockResolvedValue(null),
+        onStream: vi.fn().mockImplementation(() => () => {})
+      },
+      writable: true,
+      configurable: true
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  test('handoff persists ticket relink even when kanban store has not loaded the ticket', async () => {
+    render(<SessionView sessionId="session-plan-old" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plan-ready-handoff-fab')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('plan-ready-handoff-fab'))
+    })
+
+    await waitFor(() => {
+      expect(mockKanban.ticket.getBySession).toHaveBeenCalledWith('session-plan-old')
+    })
+
+    await waitFor(() => {
+      expect(mockKanban.ticket.update).toHaveBeenCalledWith('ticket-1', {
+        current_session_id: 'session-build-new',
+        plan_ready: false,
+        mode: 'build'
+      })
+    })
+
+    expect(useSessionStore.getState().activeSessionId).toBe('session-build-new')
+    expect(useSessionStore.getState().pendingMessages.get('session-build-new')).toBe(
+      'Implement the following plan\n1. Add the relink helper\n2. Use it during handoff'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Replaced the single handoff action with a split button that exposes the currently selected agent SDK and model, plus a picker for alternate handoff targets.
- Added shared handoff selection/catalog helpers so session and kanban flows resolve the same defaults, model variants, and persisted overrides.
- Updated handoff creation to eagerly connect and start the target session in the background, while keeping kanban and session state in sync.
- Refactored model parsing/caching so the general model selector and the new handoff UI share the same provider/model metadata.
- Added coverage for handoff model selection, session re-linking, and plan-review dispatch behavior.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies handoff/session creation flows (including model selection defaults and ticket relinking) and introduces background session startup, which could impact session state consistency if edge cases aren’t covered.
> 
> **Overview**
> Replaces the single **Handoff** action with a split button that shows the effective agent SDK/model and optionally opens a picker to override the handoff target (SDK, model, variant), persisting the last override in settings.
> 
> Unifies handoff selection/model-catalog logic via new `handoffSelection` + `parseProviders` helpers, wires `ModelSelector` to cache provider catalogs, and updates `createSession`/`createConnectionSession` to accept a `modelOverride` resolved through shared selection rules.
> 
> Changes kanban + session handoff behavior to **relink tickets via a store helper** and to eagerly connect/start the new session in the background (setting status/telemetry and prompting immediately), with updated vim shortcuts and new/expanded test coverage around model picking, ticket relinking, and handoff startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec7ad64e107b3445db7c16f4c9881b080a6e113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->