### PR TITLE
Preserve input focus during branch rename

### DIFF
--- a/src/renderer/src/components/layout/PinnedList.tsx
+++ b/src/renderer/src/components/layout/PinnedList.tsx
@@ -71,6 +71,7 @@ import { ArchiveConfirmDialog } from '@/components/worktrees/ArchiveConfirmDialo
 import { AddAttachmentDialog } from '@/components/worktrees/AddAttachmentDialog'
 import { ManageConnectionWorktreesDialog } from '@/components/connections/ManageConnectionWorktreesDialog'
 import { useSiblingAggregate, type SiblingBucket } from '@/hooks/useSiblingAggregate'
+import { useGhosttySuppression } from '@/hooks'
 
 type PinnedItem = { kind: 'worktree'; id: string } | { kind: 'connection'; id: string }
 
@@ -220,6 +221,8 @@ function PinnedWorktreeItem({ worktreeId }: { worktreeId: string }): React.JSX.E
   const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const intentionalCloseRef = useRef(false)
   const renameStartTimeRef = useRef<number>(0)
+
+  useGhosttySuppression(`pinned-worktree-branch-rename:${worktreeId}`, isRenamingBranch)
 
   // Focus rename input when it appears (deferred to run after menu closes)
   useEffect(() => {

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -4,6 +4,7 @@ import { useTerminalTabStore } from '@/stores/useTerminalTabStore'
 import { useSettingsStore, type EmbeddedTerminalBackend } from '@/stores/useSettingsStore'
 import { useLayoutStore } from '@/stores/useLayoutStore'
 import { useThemeStore } from '@/stores/useThemeStore'
+import { hasFocusedEditableElement } from '@/lib/focus-utils'
 import { TerminalToolbar } from './TerminalToolbar'
 import { XtermBackend } from './backends/XtermBackend'
 import { GhosttyBackend } from './backends/GhosttyBackend'
@@ -95,8 +96,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   // Re-fit and focus when becoming visible.
   // Note: GhosttyBackend.setVisible(true) already restores macOS first responder
   // directly; the focus() call below is a belt-and-suspenders backup for Ghostty
-  // and the primary focus path for xterm. The xterm fit() requires the delayed
-  // call because layout dimensions need a frame to settle.
+  // and the primary focus path for xterm. When a Chromium input already owns
+  // focus (for example inline rename immediately after a menu closes), Ghostty
+  // must not reclaim it during passive visibility restoration.
   useEffect(() => {
     if (!backendRef.current) return
 
@@ -108,6 +110,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       const backend = backendRef.current
       if (backend && backend.type === 'xterm') {
         ;(backend as XtermBackend).fit()
+      }
+      if (backend?.type === 'ghostty' && hasFocusedEditableElement()) {
+        return
       }
       backend?.focus()
     }, 50)

--- a/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
@@ -1,5 +1,6 @@
 import type { TerminalBackend, TerminalOpts, TerminalBackendCallbacks } from './types'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { hasFocusedEditableElement } from '@/lib/focus-utils'
 
 /**
  * Native Ghostty terminal backend (macOS only).
@@ -154,7 +155,9 @@ export class GhosttyBackend implements TerminalBackend {
 
         if (this.visible) {
           this.syncFrame()
-          await window.terminalOps.ghosttySetFocus(this.terminalId, true)
+          if (!hasFocusedEditableElement()) {
+            await window.terminalOps.ghosttySetFocus(this.terminalId, true)
+          }
         } else {
           this.hideSurface()
         }
@@ -206,9 +209,11 @@ export class GhosttyBackend implements TerminalBackend {
     // and the menu paste handler routes Cmd+V correctly. Without this, focus
     // restoration depends on a fragile setTimeout in TerminalView that can be
     // cancelled by rapid effectiveVisible changes (e.g. overlay suppression race).
-    window.terminalOps.ghosttySetFocus(this.terminalId, true).catch(() => {
-      // Ignore focus errors
-    })
+    if (!hasFocusedEditableElement()) {
+      window.terminalOps.ghosttySetFocus(this.terminalId, true).catch(() => {
+        // Ignore focus errors
+      })
+    }
   }
 
   /**

--- a/src/renderer/src/components/worktrees/WorktreeItem.tsx
+++ b/src/renderer/src/components/worktrees/WorktreeItem.tsx
@@ -62,6 +62,7 @@ import { useScriptStore } from '@/stores/useScriptStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { toast, gitToast, clipboardToast } from '@/lib/toast'
 import { formatRelativeTime } from '@/lib/format-utils'
+import { useGhosttySuppression } from '@/hooks'
 import { PulseAnimation } from './PulseAnimation'
 import { ModelIcon } from './ModelIcon'
 import { ArchiveConfirmDialog } from './ArchiveConfirmDialog'
@@ -247,6 +248,8 @@ export function WorktreeItem({
   const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const intentionalCloseRef = useRef(false)
   const renameStartTimeRef = useRef<number>(0)
+
+  useGhosttySuppression(`worktree-branch-rename:${worktree.id}`, isRenamingBranch)
 
   // Auto-focus the rename input when it appears (deferred to run after menu closes)
   useEffect(() => {

--- a/src/renderer/src/lib/focus-utils.ts
+++ b/src/renderer/src/lib/focus-utils.ts
@@ -1,0 +1,10 @@
+export function isEditableElement(element: Element | null): element is HTMLElement {
+  return (
+    element instanceof HTMLElement &&
+    (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA' || element.isContentEditable)
+  )
+}
+
+export function hasFocusedEditableElement(): boolean {
+  return isEditableElement(document.activeElement)
+}

--- a/test/phase-7/session-3/branch-duplication.test.ts
+++ b/test/phase-7/session-3/branch-duplication.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-library/react'
 import React from 'react'
+import { useLayoutStore } from '../../../src/renderer/src/stores/useLayoutStore'
 
 // ---------------------------------------------------------------------------
 // Version naming logic tests (unit tests for the naming algorithm)
@@ -165,6 +166,15 @@ describe('Session 3: Branch Duplication', () => {
     }
 
     beforeEach(() => {
+      vi.stubGlobal(
+        'requestAnimationFrame',
+        ((callback: FrameRequestCallback) => setTimeout(() => callback(0), 0)) as typeof requestAnimationFrame
+      )
+      vi.stubGlobal(
+        'cancelAnimationFrame',
+        ((id: number) => clearTimeout(id)) as typeof cancelAnimationFrame
+      )
+
       Object.defineProperty(window, 'worktreeOps', {
         writable: true,
         value: mockWorktreeOps
@@ -177,6 +187,8 @@ describe('Session 3: Branch Duplication', () => {
         writable: true,
         value: mockDb
       })
+
+      useLayoutStore.setState({ ghosttyOverlaySuppressed: false })
     })
 
     test('Duplicate shown in context menu for non-default worktree', async () => {
@@ -241,6 +253,90 @@ describe('Session 3: Branch Duplication', () => {
       // "Duplicate" should not appear for default worktree
       const duplicateItems = screen.queryAllByText('Duplicate')
       expect(duplicateItems.length).toBe(0)
+    })
+
+    test('Rename Branch from the context menu focuses the inline rename input', async () => {
+      const { WorktreeItem } =
+        await import('../../../src/renderer/src/components/worktrees/WorktreeItem')
+
+      const worktree = {
+        id: 'wt-1',
+        project_id: 'proj-1',
+        name: 'feature-auth',
+        branch_name: 'feature-auth',
+        path: '/path/to/worktree',
+        status: 'active' as const,
+        is_default: false,
+        created_at: new Date().toISOString(),
+        last_accessed_at: new Date().toISOString()
+      }
+
+      render(
+        React.createElement(WorktreeItem, {
+          worktree,
+          projectPath: '/path/to/project'
+        })
+      )
+
+      fireEvent.contextMenu(screen.getByTestId('worktree-item-wt-1'))
+      fireEvent.click(screen.getByText('Rename Branch'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('branch-rename-input')).toBeInTheDocument()
+        expect(screen.getByTestId('branch-rename-input')).toHaveFocus()
+        expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+      })
+
+      fireEvent.keyDown(screen.getByTestId('branch-rename-input'), { key: 'Escape' })
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('branch-rename-input')).not.toBeInTheDocument()
+        expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(false)
+      })
+    })
+
+    test('Rename Branch from the overflow dropdown focuses the inline rename input', async () => {
+      const { WorktreeItem } =
+        await import('../../../src/renderer/src/components/worktrees/WorktreeItem')
+
+      const worktree = {
+        id: 'wt-1',
+        project_id: 'proj-1',
+        name: 'feature-auth',
+        branch_name: 'feature-auth',
+        path: '/path/to/worktree',
+        status: 'active' as const,
+        is_default: false,
+        created_at: new Date().toISOString(),
+        last_accessed_at: new Date().toISOString()
+      }
+
+      render(
+        React.createElement(WorktreeItem, {
+          worktree,
+          projectPath: '/path/to/project'
+        })
+      )
+
+      const item = screen.getByTestId('worktree-item-wt-1')
+      fireEvent.pointerDown(within(item).getByRole('button'), { button: 0, ctrlKey: false })
+      await waitFor(() => {
+        expect(screen.getByText('Rename Branch')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByText('Rename Branch'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('branch-rename-input')).toBeInTheDocument()
+        expect(screen.getByTestId('branch-rename-input')).toHaveFocus()
+        expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(true)
+      })
+
+      fireEvent.keyDown(screen.getByTestId('branch-rename-input'), { key: 'Escape' })
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('branch-rename-input')).not.toBeInTheDocument()
+        expect(useLayoutStore.getState().ghosttyOverlaySuppressed).toBe(false)
+      })
     })
   })
 

--- a/test/terminal/ghostty-backend-visibility.test.ts
+++ b/test/terminal/ghostty-backend-visibility.test.ts
@@ -113,6 +113,55 @@ describe('GhosttyBackend visibility', () => {
     backend.dispose()
   })
 
+  test('restores the surface frame without stealing focus from an active web input', async () => {
+    const backend = new GhosttyBackend()
+    const container = document.createElement('div')
+    container.getBoundingClientRect = vi.fn(() => ({
+      left: 100,
+      top: 80,
+      width: 640,
+      height: 360,
+      right: 740,
+      bottom: 440,
+      x: 100,
+      y: 80,
+      toJSON: () => ({})
+    }))
+
+    backend.mount(
+      container,
+      {
+        terminalId: 'wt-1',
+        cwd: '/tmp/wt-1'
+      },
+      {
+        onStatusChange: vi.fn()
+      }
+    )
+
+    await flushPromises()
+
+    const visibilityBackend = backend as unknown as { setVisible: (visible: boolean) => void }
+    visibilityBackend.setVisible(false)
+    mockTerminalOps.ghosttySetFocus.mockClear()
+    mockTerminalOps.ghosttySetFrame.mockClear()
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+    expect(document.activeElement).toBe(input)
+
+    visibilityBackend.setVisible(true)
+
+    const visibleFrame = mockTerminalOps.ghosttySetFrame.mock.calls.at(-1)?.[1]
+    expect(visibleFrame).toEqual({ x: 100, y: 80, w: 640, h: 360 })
+    expect(mockTerminalOps.ghosttySetFocus).not.toHaveBeenCalledWith('wt-1', true)
+    expect(document.activeElement).toBe(input)
+
+    input.remove()
+    backend.dispose()
+  })
+
   test('waits for a measurable container instead of failing on initial zero-size mount', async () => {
     const backend = new GhosttyBackend()
     const onStatusChange = vi.fn()

--- a/test/terminal/terminal-view-focus-restore.test.tsx
+++ b/test/terminal/terminal-view-focus-restore.test.tsx
@@ -1,0 +1,126 @@
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { TerminalView } from '../../src/renderer/src/components/terminal/TerminalView'
+import { useLayoutStore } from '../../src/renderer/src/stores/useLayoutStore'
+import { useSettingsStore } from '../../src/renderer/src/stores/useSettingsStore'
+
+const ghosttyMount = vi.fn()
+const ghosttyFocus = vi.fn()
+const ghosttySetVisible = vi.fn()
+const ghosttyClear = vi.fn()
+const ghosttyDispose = vi.fn()
+const ghosttyUpdateTheme = vi.fn()
+const xtermFit = vi.fn()
+const xtermFocus = vi.fn()
+const xtermSetVisible = vi.fn()
+const xtermClear = vi.fn()
+const xtermDispose = vi.fn()
+const xtermUpdateTheme = vi.fn()
+
+vi.mock('@/components/terminal/backends/GhosttyBackend', () => ({
+  GhosttyBackend: class MockGhosttyBackend {
+    readonly type = 'ghostty' as const
+    readonly supportsSearch = false
+    mount = ghosttyMount
+    resize = vi.fn()
+    focus = ghosttyFocus
+    setVisible = ghosttySetVisible
+    clear = ghosttyClear
+    dispose = ghosttyDispose
+    updateTheme = ghosttyUpdateTheme
+  },
+  isGhosttyAvailable: vi.fn().mockResolvedValue(true)
+}))
+
+vi.mock('@/components/terminal/backends/XtermBackend', () => ({
+  XtermBackend: class MockXtermBackend {
+    readonly type = 'xterm' as const
+    readonly supportsSearch = true
+    onSearchToggle?: () => void
+    mount = vi.fn()
+    resize = vi.fn()
+    fit = xtermFit
+    focus = xtermFocus
+    setVisible = xtermSetVisible
+    clear = xtermClear
+    dispose = xtermDispose
+    updateTheme = xtermUpdateTheme
+    searchNext = vi.fn()
+    searchPrevious = vi.fn()
+    searchClose = vi.fn()
+  }
+}))
+
+describe('TerminalView Ghostty focus restoration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+
+    act(() => {
+      useSettingsStore.setState({
+        embeddedTerminalBackend: 'ghostty',
+        ghosttyFontSize: 14
+      })
+      useLayoutStore.setState({ ghosttyOverlaySuppressed: true })
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('does not auto-focus Ghostty when a web input already owns focus as suppression ends', async () => {
+    render(<TerminalView terminalId="term-1" cwd="/tmp/project" isVisible />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(ghosttyMount).toHaveBeenCalledTimes(1)
+    ghosttyFocus.mockClear()
+    ghosttySetVisible.mockClear()
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+    expect(document.activeElement).toBe(input)
+
+    await act(async () => {
+      useLayoutStore.setState({ ghosttyOverlaySuppressed: false })
+      await Promise.resolve()
+      vi.advanceTimersByTime(60)
+      await Promise.resolve()
+    })
+
+    expect(ghosttySetVisible).toHaveBeenCalledWith(true)
+    expect(ghosttyFocus).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(input)
+
+    input.remove()
+  })
+
+  test('still auto-focuses Ghostty when no editable web element is focused', async () => {
+    render(<TerminalView terminalId="term-1" cwd="/tmp/project" isVisible />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(ghosttyMount).toHaveBeenCalledTimes(1)
+
+    ghosttyFocus.mockClear()
+    ghosttySetVisible.mockClear()
+
+    await act(async () => {
+      useLayoutStore.setState({ ghosttyOverlaySuppressed: false })
+      await Promise.resolve()
+      vi.advanceTimersByTime(60)
+      await Promise.resolve()
+    })
+
+    expect(ghosttySetVisible).toHaveBeenCalledWith(true)
+    expect(ghosttyFocus).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Prevent Ghostty terminal focus restoration from stealing focus when an inline rename input is active.
- Suppress Ghostty overlay focus during branch rename flows in both worktree and pinned worktree UIs.
- Add shared focus helpers and tests covering rename focus behavior and Ghostty visibility restoration.

## Testing
- `vitest test/terminal/ghostty-backend-visibility.test.ts`
- `vitest test/terminal/terminal-view-focus-restore.test.tsx`
- `vitest test/phase-7/session-3/branch-duplication.test.ts`
- Not run: full repository test suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Ghostty focus restoration and overlay suppression behavior, which can affect terminal usability and macOS paste/focus routing. Risk is moderate due to timing/focus edge cases across multiple UI surfaces, but scope is contained and covered by new tests.
> 
> **Overview**
> Prevents the embedded Ghostty terminal from stealing focus when it becomes visible while a web text input (e.g. inline branch rename) is already focused.
> 
> Adds focus detection via new `focus-utils` helpers, gates Ghostty focus restoration in both `TerminalView` and `GhosttyBackend`, and suppresses the Ghostty overlay during inline branch rename in both `WorktreeItem` and `PinnedList`. Expands and adds tests to cover rename-input focusing/suppression and Ghostty visibility restore without focus theft.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b5f544d5c7088f0a7c4f5b71d98ba8d41b41fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->