### PR TITLE
Preserve plan-based branch names when supercharging

### DIFF
--- a/src/main/services/worktree-ops.ts
+++ b/src/main/services/worktree-ops.ts
@@ -38,6 +38,7 @@ export interface DuplicateWorktreeParams {
   projectName: string
   sourceBranch: string
   sourceWorktreePath: string
+  nameHint?: string
 }
 
 export interface RenameBranchParams {
@@ -418,7 +419,8 @@ export async function duplicateWorktreeOp(
     const result = await gitService.duplicateWorktree(
       params.sourceBranch,
       params.sourceWorktreePath,
-      params.projectName
+      params.projectName,
+      params.nameHint
     )
 
     if (!result.success || !result.name || !result.path || !result.branchName) {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -525,6 +525,7 @@ declare global {
         projectName: string
         sourceBranch: string
         sourceWorktreePath: string
+        nameHint?: string
       }) => Promise<{
         success: boolean
         worktree?: Worktree

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -340,6 +340,7 @@ const worktreeOps = {
     projectName: string
     sourceBranch: string
     sourceWorktreePath: string
+    nameHint?: string
   }): Promise<{
     success: boolean
     worktree?: {

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -73,6 +73,7 @@ import { TicketAttachmentEditor } from './TicketAttachmentEditor'
 import { TicketDiscardChangesDialog } from './TicketDiscardChangesDialog'
 import { useImagePaste } from '@/hooks/useImagePaste'
 import type { HandoffSelectionOverride } from '@/lib/handoffSelection'
+import { canonicalizeTicketTitle, extractPlanTitle } from '@shared/types/branch-utils'
 import type { KanbanTicket, KanbanTicketUpdate, Worktree } from '../../../../main/db/types'
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -1820,13 +1821,18 @@ function PlanReviewModeContent({
         return
       }
 
+      const extractedTitle = extractPlanTitle(planContent)
+      const slug = extractedTitle ? canonicalizeTicketTitle(extractedTitle) : ''
+      const nameHint = slug.length > 0 ? slug : undefined
+
       // Duplicate worktree
       const dupResult = await useWorktreeStore.getState().duplicateWorktree(
         project.id,
         project.path,
         project.name,
         worktree.branch_name,
-        worktree.path
+        worktree.path,
+        nameHint
       )
       if (!dupResult.success || !dupResult.worktree) {
         toast.error(dupResult.error ?? 'Failed to duplicate worktree')

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -53,6 +53,7 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useContextStore } from '@/stores/useContextStore'
 import { maybeExtractJsonTitle } from '@shared/title-utils'
+import { canonicalizeTicketTitle, extractPlanTitle } from '@shared/types/branch-utils'
 import type { TokenInfo, SessionModelRef } from '@/stores/useContextStore'
 import {
   extractTokens,
@@ -4892,13 +4893,18 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       return
     }
 
+    const extractedTitle = extractPlanTitle(planContent)
+    const slug = extractedTitle ? canonicalizeTicketTitle(extractedTitle) : ''
+    const nameHint = slug.length > 0 ? slug : undefined
+
     // 3. Duplicate worktree
     const dupResult = await worktreeStore.duplicateWorktree(
       project.id,
       project.path,
       project.name,
       worktree.branch_name,
-      worktree.path
+      worktree.path,
+      nameHint
     )
     if (!dupResult.success || !dupResult.worktree) {
       toast.error(dupResult.error ?? 'Failed to duplicate worktree')
@@ -5012,15 +5018,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       return
     }
 
-    // Extract title from first markdown heading, or fall back to first non-empty line
-    const headingMatch = planContent.match(/^#+\s+(.+)$/m)
-    const title = headingMatch
-      ? headingMatch[1].trim()
-      : (planContent
-          .split('\n')
-          .find((line: string) => line.trim().length > 0)
-          ?.trim()
-          .slice(0, 100) ?? 'Plan ticket')
+    const extracted = extractPlanTitle(planContent)
+    const title = extracted ? extracted.slice(0, 100) : 'Plan ticket'
 
     try {
       await useKanbanStore.getState().createTicket(projectId, {

--- a/src/renderer/src/stores/useWorktreeStore.ts
+++ b/src/renderer/src/stores/useWorktreeStore.ts
@@ -139,7 +139,8 @@ interface WorktreeState {
     projectPath: string,
     projectName: string,
     sourceBranch: string,
-    sourceWorktreePath: string
+    sourceWorktreePath: string,
+    nameHint?: string
   ) => Promise<{ success: boolean; worktree?: Worktree; error?: string }>
   updateWorktreeBranch: (worktreeId: string, newBranch: string) => void
   updateWorktreeModel: (worktreeId: string, model: SelectedModel) => void
@@ -711,7 +712,8 @@ export const useWorktreeStore = create<WorktreeState>((set, get) => ({
     projectPath: string,
     projectName: string,
     sourceBranch: string,
-    sourceWorktreePath: string
+    sourceWorktreePath: string,
+    nameHint?: string
   ) => {
     try {
       const result = await window.worktreeOps.duplicate({
@@ -719,7 +721,8 @@ export const useWorktreeStore = create<WorktreeState>((set, get) => ({
         projectPath,
         projectName,
         sourceBranch,
-        sourceWorktreePath
+        sourceWorktreePath,
+        nameHint
       })
       if (result.success && result.worktree) {
         // Reload worktrees for the project

--- a/src/shared/types/branch-utils.ts
+++ b/src/shared/types/branch-utils.ts
@@ -21,3 +21,38 @@ export function canonicalizeTicketTitle(title: string): string {
     .slice(0, 32) // keep ticket-named worktrees under Windows path limits
     .replace(/-+$/, '') // strip trailing dashes after truncation
 }
+
+function normalizePlanTitle(title: string): string {
+  const trimmed = title.trim()
+  const withoutPrefix = trimmed.replace(/^plan\s*[:\-–—]\s*/i, '').trim()
+  return withoutPrefix.length > 0 ? withoutPrefix : trimmed
+}
+
+/**
+ * Extract a human-readable title from markdown plan content.
+ * Looks for the first markdown heading (any level), then falls back to
+ * the first non-empty line. Returns null if neither yields text.
+ *
+ * Used for both deriving a branch name (Supercharge) and deriving a
+ * ticket title (Save as Ticket). Lives in shared/ so both main and
+ * renderer can import it.
+ */
+export function extractPlanTitle(content: string): string | null {
+  if (!content) return null
+
+  const headingMatch = content.match(/^#+\s+(.+)$/m)
+  if (headingMatch) {
+    const stripped = normalizePlanTitle(headingMatch[1])
+    if (stripped.length > 0) return stripped
+  }
+
+  const firstLine = content
+    .split('\n')
+    .find((line) => line.trim().length > 0)
+    ?.trim()
+
+  if (!firstLine || firstLine.length === 0) return null
+
+  const normalizedFirstLine = normalizePlanTitle(firstLine)
+  return normalizedFirstLine.length > 0 ? normalizedFirstLine : null
+}

--- a/test/kanban/plan-review-followup-dispatch.test.tsx
+++ b/test/kanban/plan-review-followup-dispatch.test.tsx
@@ -562,6 +562,93 @@ describe('Plan review followup dispatch', () => {
     ])
   })
 
+  test('plan review supercharge derives a branch name from the plan heading', async () => {
+    const codexPlanTicket = makeTicket({
+      id: 'ticket-codex',
+      column: 'review',
+      plan_ready: true,
+      current_session_id: 'session-codex-old',
+      worktree_id: 'wt-1',
+      mode: 'plan',
+      description: '# Add `mul_998` function\n\nImplement the new helper'
+    })
+
+    mockWorktreeOps.duplicate.mockResolvedValueOnce({
+      success: true,
+      worktree: makeWorktree({
+        id: 'wt-2',
+        name: 'add-mul-998-function',
+        branch_name: 'add-mul-998-function',
+        path: '/test/add-mul-998-function'
+      })
+    })
+
+    mockDbSession.create.mockResolvedValueOnce(
+      makeSession({
+        id: 'session-codex-new',
+        agent_sdk: 'codex',
+        mode: 'build',
+        opencode_session_id: null,
+        worktree_id: 'wt-2'
+      })
+    )
+
+    act(() => {
+      useKanbanStore.setState({
+        tickets: new Map([['proj-1', [codexPlanTicket]]]),
+        isBoardViewActive: true,
+        selectedTicketId: 'ticket-codex'
+      })
+      useSessionStore.setState({
+        activeSessionId: null,
+        activeWorktreeId: null,
+        sessionsByWorktree: new Map([
+          [
+            'wt-1',
+            [makeSession({ id: 'session-codex-old', agent_sdk: 'codex', opencode_session_id: 'opc-session-1' })]
+          ]
+        ]),
+        pendingPlans: new Map([
+          [
+            'session-codex-old',
+            {
+              requestId: 'req-codex',
+              planContent: '# Add `mul_998` function\n\nImplement the new helper',
+              toolUseID: 'tool-codex'
+            }
+          ]
+        ]),
+        pendingMessages: new Map(),
+        pendingFollowUpMessages: new Map()
+      })
+      useWorktreeStatusStore.setState({
+        sessionStatuses: {}
+      })
+      useWorktreeStore.setState({
+        selectedWorktreeId: null,
+        worktreesByProject: new Map([['proj-1', [makeWorktree()]]])
+      })
+    })
+
+    render(<KanbanTicketModal />)
+
+    const superchargeBtn = await screen.findByTestId('plan-review-supercharge-btn')
+    await act(async () => {
+      fireEvent.click(superchargeBtn)
+    })
+
+    await waitFor(() => {
+      expect(mockWorktreeOps.duplicate).toHaveBeenCalledWith({
+        projectId: 'proj-1',
+        projectPath: '/test/my-project',
+        projectName: 'My Project',
+        sourceBranch: 'feature-auth',
+        sourceWorktreePath: '/test/feature-auth',
+        nameHint: 'add-mul-998-function'
+      })
+    })
+  })
+
   test('supercharge does not leave session stuck "working" when background connect fails', async () => {
     const codexPlanTicket = makeTicket({
       id: 'ticket-codex',

--- a/test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx
+++ b/test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx
@@ -52,26 +52,37 @@ vi.mock('../../../src/renderer/src/components/sessions/VirtualizedMessageList', 
 vi.mock('../../../src/renderer/src/components/sessions/PlanReadyImplementFab', () => ({
   PlanReadyImplementFab: ({
     visible,
-    onHandoff
+    onHandoff,
+    onSuperpowers
   }: {
     visible: boolean
     onHandoff: (override?: { agentSdk: 'claude-code' }) => void
+    onSuperpowers?: () => void
   }) =>
     visible ? (
-      <button
-        type="button"
-        data-testid="plan-ready-handoff-fab"
-        onClick={() => onHandoff({ agentSdk: 'claude-code' })}
-      >
-        Handoff
-      </button>
+      <>
+        <button
+          type="button"
+          data-testid="plan-ready-handoff-fab"
+          onClick={() => onHandoff({ agentSdk: 'claude-code' })}
+        >
+          Handoff
+        </button>
+        {onSuperpowers ? (
+          <button type="button" data-testid="plan-ready-supercharge-fab" onClick={onSuperpowers}>
+            Supercharge
+          </button>
+        ) : null}
+      </>
     ) : null
 }))
 
 import { SessionView } from '../../../src/renderer/src/components/sessions/SessionView'
 import { useKanbanStore } from '../../../src/renderer/src/stores/useKanbanStore'
+import { useProjectStore } from '../../../src/renderer/src/stores/useProjectStore'
 import { useSessionStore } from '../../../src/renderer/src/stores/useSessionStore'
 import { useSettingsStore } from '../../../src/renderer/src/stores/useSettingsStore'
+import { useWorktreeStore } from '../../../src/renderer/src/stores/useWorktreeStore'
 import { useWorktreeStatusStore } from '../../../src/renderer/src/stores/useWorktreeStatusStore'
 
 function createSessionRecord(
@@ -119,6 +130,10 @@ describe('SessionView handoff ticket relinking', () => {
       getBySession: vi.fn(),
       update: vi.fn()
     }
+  }
+
+  const mockWorktreeOps = {
+    duplicate: vi.fn()
   }
 
   const mockDbSession = {
@@ -187,6 +202,62 @@ describe('SessionView handoff ticket relinking', () => {
       selectedModelByProvider: {},
       lastHandoffOverride: null
     })
+    useProjectStore.setState({
+      projects: [
+        {
+          id: 'proj-1',
+          name: 'Project 1',
+          path: '/tmp/project-1',
+          description: null,
+          tags: null,
+          language: null,
+          custom_icon: null,
+          setup_script: null,
+          run_script: null,
+          archive_script: null,
+          auto_assign_port: false,
+          sort_order: 0,
+          created_at: new Date().toISOString(),
+          last_accessed_at: new Date().toISOString()
+        }
+      ]
+    })
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        [
+          'proj-1',
+          [
+            {
+              id: 'wt-1',
+              project_id: 'proj-1',
+              name: 'main',
+              branch_name: 'main',
+              path: '/tmp/worktree-handoff',
+              status: 'active',
+              is_default: true,
+              branch_renamed: 0,
+              last_message_at: null,
+              session_titles: '[]',
+              last_model_provider_id: null,
+              last_model_id: null,
+              last_model_variant: null,
+              attachments: '[]',
+              pinned: 0,
+              context: null,
+              github_pr_number: null,
+              github_pr_url: null,
+              base_branch: null,
+              created_at: new Date().toISOString(),
+              last_accessed_at: new Date().toISOString()
+            }
+          ]
+        ]
+      ]),
+      worktreeOrderByProject: new Map(),
+      selectedWorktreeId: 'wt-1',
+      creatingForProjectId: null,
+      archivingWorktreeIds: new Set()
+    })
 
     mockKanban.ticket.getBySession.mockResolvedValue([
       {
@@ -214,6 +285,32 @@ describe('SessionView handoff ticket relinking', () => {
         name: 'Session 2'
       })
     )
+    mockWorktreeOps.duplicate.mockResolvedValue({
+      success: true,
+      worktree: {
+        id: 'wt-2',
+        project_id: 'proj-1',
+        name: 'add-user-authentication',
+        branch_name: 'add-user-authentication',
+        path: '/tmp/worktree-supercharged',
+        status: 'active',
+        is_default: false,
+        branch_renamed: 0,
+        last_message_at: null,
+        session_titles: '[]',
+        last_model_provider_id: null,
+        last_model_id: null,
+        last_model_variant: null,
+        attachments: '[]',
+        pinned: 0,
+        context: null,
+        github_pr_number: null,
+        github_pr_url: null,
+        base_branch: null,
+        created_at: new Date().toISOString(),
+        last_accessed_at: new Date().toISOString()
+      }
+    })
 
     Object.defineProperty(window, 'kanban', {
       value: mockKanban,
@@ -335,6 +432,12 @@ describe('SessionView handoff ticket relinking', () => {
       writable: true,
       configurable: true
     })
+
+    Object.defineProperty(window, 'worktreeOps', {
+      value: mockWorktreeOps,
+      writable: true,
+      configurable: true
+    })
   })
 
   afterEach(() => {
@@ -368,5 +471,41 @@ describe('SessionView handoff ticket relinking', () => {
     expect(useSessionStore.getState().pendingMessages.get('session-build-new')).toBe(
       'Implement the following plan\n1. Add the relink helper\n2. Use it during handoff'
     )
+  })
+
+  test('supercharge derives a slug from the plan heading and passes it as nameHint', async () => {
+    useSessionStore.setState({
+      pendingPlans: new Map([
+        [
+          'session-plan-old',
+          {
+            requestId: 'req-plan-1',
+            planContent: '# Add user authentication\n\n1. Build login UI\n2. Wire auth API',
+            toolUseID: 'tool-plan-1'
+          }
+        ]
+      ])
+    })
+
+    render(<SessionView sessionId="session-plan-old" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plan-ready-supercharge-fab')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('plan-ready-supercharge-fab'))
+    })
+
+    await waitFor(() => {
+      expect(mockWorktreeOps.duplicate).toHaveBeenCalledWith({
+        projectId: 'proj-1',
+        projectPath: '/tmp/project-1',
+        projectName: 'Project 1',
+        sourceBranch: 'main',
+        sourceWorktreePath: '/tmp/worktree-handoff',
+        nameHint: 'add-user-authentication'
+      })
+    })
   })
 })

--- a/test/phase-23/session-2/extract-plan-title.test.ts
+++ b/test/phase-23/session-2/extract-plan-title.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest'
+
+import { extractPlanTitle } from '../../../src/shared/types/branch-utils'
+
+describe('extractPlanTitle', () => {
+  test('returns H1 heading text', () => {
+    expect(extractPlanTitle('# Add user authentication\n\nDetails')).toBe(
+      'Add user authentication'
+    )
+  })
+
+  test('returns lower-level heading text', () => {
+    expect(extractPlanTitle('## Fix login redirect\n\nDetails')).toBe('Fix login redirect')
+    expect(extractPlanTitle('### Handle OAuth callback\n\nDetails')).toBe('Handle OAuth callback')
+  })
+
+  test('trims a leading plan prefix from heading titles', () => {
+    expect(extractPlanTitle('# Plan: Add `mul_998` function\n\nDetails')).toBe(
+      'Add `mul_998` function'
+    )
+  })
+
+  test('falls back to first non-empty line when no heading exists', () => {
+    expect(extractPlanTitle('Add user authentication\n\n1. Build UI')).toBe(
+      'Add user authentication'
+    )
+  })
+
+  test('trims a leading plan prefix from first-line fallback titles', () => {
+    expect(extractPlanTitle('Plan: Add `mul_998` function\n\n1. Build UI')).toBe(
+      'Add `mul_998` function'
+    )
+  })
+
+  test('skips leading blank lines for fallback', () => {
+    expect(extractPlanTitle('\n\n  \nFix login redirect\n\nMore detail')).toBe('Fix login redirect')
+  })
+
+  test('returns null for empty or whitespace-only input', () => {
+    expect(extractPlanTitle('')).toBeNull()
+    expect(extractPlanTitle('   \n\t  ')).toBeNull()
+  })
+
+  test('returns raw heading text with formatting characters preserved', () => {
+    expect(extractPlanTitle('# Fix **OAuth** [redirect](https://example.com) `flow` 🔐')).toBe(
+      'Fix **OAuth** [redirect](https://example.com) `flow` 🔐'
+    )
+  })
+
+  test('returns the first heading when multiple headings exist', () => {
+    expect(extractPlanTitle('# First heading\n\n## Second heading')).toBe('First heading')
+  })
+
+  test('finds a heading after leading blank lines', () => {
+    expect(extractPlanTitle('\n\n# Add audit logging\n\nMore detail')).toBe('Add audit logging')
+  })
+
+  test('ignores empty markdown headings and falls back when possible', () => {
+    expect(extractPlanTitle('###\n\nFallback line')).toBe('Fallback line')
+  })
+})

--- a/test/phase-23/session-3/worktree-ops-duplicate-namehint.test.ts
+++ b/test/phase-23/session-3/worktree-ops-duplicate-namehint.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mockDuplicateWorktree = vi.fn()
+const mockCreateGitService = vi.fn(() => ({
+  duplicateWorktree: mockDuplicateWorktree
+}))
+
+vi.mock('../../../src/main/services/git-service', () => ({
+  createGitService: (...args: unknown[]) => mockCreateGitService(...args),
+  isAutoNamedBranch: vi.fn()
+}))
+
+vi.mock('../../../src/main/services/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { duplicateWorktreeOp } from '../../../src/main/services/worktree-ops'
+import type { DatabaseService } from '../../../src/main/db/database'
+
+function createMockDb(): DatabaseService {
+  return {
+    createWorktree: vi.fn().mockReturnValue({
+      id: 'wt-2',
+      project_id: 'proj-1',
+      name: 'add-mul-998-function',
+      branch_name: 'add-mul-998-function',
+      path: '/tmp/project--add-mul-998-function',
+      status: 'active',
+      created_at: '2026-01-01T00:00:00Z',
+      last_accessed_at: '2026-01-01T00:00:00Z'
+    }),
+    getWorktreeByPath: vi.fn().mockReturnValue(null),
+    getProject: vi.fn().mockReturnValue(null)
+  } as unknown as DatabaseService
+}
+
+describe('duplicateWorktreeOp nameHint forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDuplicateWorktree.mockResolvedValue({
+      success: true,
+      name: 'add-mul-998-function',
+      path: '/tmp/project--add-mul-998-function',
+      branchName: 'add-mul-998-function',
+      baseBranch: 'main'
+    })
+  })
+
+  test('forwards nameHint to gitService.duplicateWorktree', async () => {
+    const db = createMockDb()
+
+    const result = await duplicateWorktreeOp(db, {
+      projectId: 'proj-1',
+      projectPath: '/tmp/project',
+      projectName: 'project',
+      sourceBranch: 'main',
+      sourceWorktreePath: '/tmp/project',
+      nameHint: 'add-mul-998-function'
+    })
+
+    expect(mockCreateGitService).toHaveBeenCalledWith('/tmp/project')
+    expect(mockDuplicateWorktree).toHaveBeenCalledWith(
+      'main',
+      '/tmp/project',
+      'project',
+      'add-mul-998-function'
+    )
+    expect(result.success).toBe(true)
+  })
+
+  test('omitting nameHint preserves legacy fallback behavior', async () => {
+    const db = createMockDb()
+
+    const result = await duplicateWorktreeOp(db, {
+      projectId: 'proj-1',
+      projectPath: '/tmp/project',
+      projectName: 'project',
+      sourceBranch: 'main',
+      sourceWorktreePath: '/tmp/project'
+    })
+
+    expect(mockDuplicateWorktree).toHaveBeenCalledWith('main', '/tmp/project', 'project', undefined)
+    expect(result.success).toBe(true)
+  })
+})

--- a/test/phase-7/session-3/branch-duplication.test.ts
+++ b/test/phase-7/session-3/branch-duplication.test.ts
@@ -305,5 +305,71 @@ describe('Session 3: Branch Duplication', () => {
 
       expect(result.success).toBe(true)
     })
+
+    test('duplicateWorktree forwards nameHint when provided', async () => {
+      const mockDuplicate = vi.fn().mockResolvedValue({
+        success: true,
+        worktree: {
+          id: 'new-id',
+          project_id: 'proj-1',
+          name: 'add-user-authentication',
+          branch_name: 'add-user-authentication',
+          path: '/path',
+          status: 'active',
+          is_default: false,
+          created_at: new Date().toISOString(),
+          last_accessed_at: new Date().toISOString()
+        }
+      })
+
+      Object.defineProperty(window, 'worktreeOps', {
+        writable: true,
+        value: {
+          create: vi.fn(),
+          delete: vi.fn(),
+          sync: vi.fn(),
+          exists: vi.fn(),
+          openInTerminal: vi.fn(),
+          openInEditor: vi.fn(),
+          getBranches: vi.fn(),
+          branchExists: vi.fn(),
+          duplicate: mockDuplicate
+        }
+      })
+
+      Object.defineProperty(window, 'db', {
+        writable: true,
+        value: {
+          worktree: {
+            getActiveByProject: vi.fn().mockResolvedValue([]),
+            touch: vi.fn()
+          }
+        }
+      })
+
+      const { useWorktreeStore } = await import('../../../src/renderer/src/stores/useWorktreeStore')
+
+      const result = await useWorktreeStore
+        .getState()
+        .duplicateWorktree(
+          'proj-1',
+          '/project/path',
+          'my-project',
+          'feature',
+          '/worktree/path',
+          'add-user-authentication'
+        )
+
+      expect(mockDuplicate).toHaveBeenCalledWith({
+        projectId: 'proj-1',
+        projectPath: '/project/path',
+        projectName: 'my-project',
+        sourceBranch: 'feature',
+        sourceWorktreePath: '/worktree/path',
+        nameHint: 'add-user-authentication'
+      })
+
+      expect(result.success).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Add a shared plan-title extractor that derives a clean human-readable title from markdown plan content.
- Thread an optional `nameHint` through worktree duplication so Supercharge can preserve plan-derived branch names.
- Update SessionView and Kanban plan review flows to pass plan-based hints when duplicating worktrees.
- Add coverage for title extraction and `nameHint` forwarding across main and renderer paths.

## Testing
- `vitest test/phase-23/session-2/extract-plan-title.test.ts`
- `vitest test/phase-23/session-3/worktree-ops-duplicate-namehint.test.ts`
- `vitest test/phase-7/session-3/branch-duplication.test.ts`
- `vitest test/kanban/plan-review-followup-dispatch.test.tsx`
- `vitest test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx`
- Not run: full repository test suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Threads a new optional `nameHint` through the worktree duplication pipeline (renderer → preload → main → git service), which can change how branches/worktree folders are named during duplication. While scoped and covered by tests, it touches git/worktree creation behavior that could affect users’ local repo state if incorrect.
> 
> **Overview**
> **Preserves plan-based branch/worktree names during “Supercharge”.** The renderer now extracts a title from markdown plan content, canonicalizes it into a safe slug, and passes it as an optional `nameHint` when duplicating a worktree.
> 
> Adds a shared `extractPlanTitle` helper in `shared/types/branch-utils` and updates both SessionView and Kanban plan-review flows to use it (also reusing it for “Save as Ticket” title derivation). The `nameHint` parameter is plumbed through the preload typings/API and `duplicateWorktreeOp` into `gitService.duplicateWorktree`, with new/updated tests validating title extraction and `nameHint` forwarding end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd7028598351ca8cb5887195266cdbf9add84ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->