### PR TITLE
Fix handoff to use pendingPlan.planContent instead of last assistant message

### DIFF
--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -4750,12 +4750,12 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   )
 
   const handlePlanReadyHandoff = useCallback(async (override?: HandoffSelectionOverride) => {
-    const lastAssistantMessage = [...messages]
-      .reverse()
-      .find((message) => message.role === 'assistant' && message.content.trim().length > 0)
-
-    if (!lastAssistantMessage) {
-      toast.error('No assistant plan message to hand off')
+    const planContent =
+      pendingPlan?.planContent ??
+      [...messages].reverse().find((m) => m.role === 'assistant' && m.content.trim().length > 0)
+        ?.content
+    if (!planContent) {
+      toast.error('No plan content found to hand off')
       return
     }
 
@@ -4770,7 +4770,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     }
 
     if (connectionId) {
-      const handoffPrompt = `Implement the following plan\n${lastAssistantMessage.content}`
+      const handoffPrompt = `Implement the following plan\n${planContent}`
       const sessionStore = useSessionStore.getState()
       const result = await sessionStore.createConnectionSession(
         connectionId,
@@ -4799,7 +4799,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       return
     }
 
-    const handoffPrompt = `Implement the following plan\n${lastAssistantMessage.content}`
+    const handoffPrompt = `Implement the following plan\n${planContent}`
 
     const sessionStore = useSessionStore.getState()
     const result = await sessionStore.createSession(
@@ -4828,7 +4828,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     connectionId,
     sessionId,
     worktreePath,
-    opencodeSessionId
+    opencodeSessionId,
+    pendingPlan
   ])
 
   const handlePlanReadySuperpowers = useCallback(async () => {

--- a/test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx
+++ b/test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx
@@ -473,6 +473,37 @@ describe('SessionView handoff ticket relinking', () => {
     )
   })
 
+  test('handoff uses pendingPlan.planContent instead of last assistant message content', async () => {
+    useSessionStore.setState({
+      pendingPlans: new Map([
+        [
+          'session-plan-old',
+          {
+            requestId: 'req-plan-1',
+            planContent: '# Real plan\n1. Step one\n2. Step two',
+            toolUseID: 'tool-plan-1'
+          }
+        ]
+      ])
+    })
+
+    render(<SessionView sessionId="session-plan-old" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plan-ready-handoff-fab')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('plan-ready-handoff-fab'))
+    })
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().pendingMessages.get('session-build-new')).toBe(
+        'Implement the following plan\n# Real plan\n1. Step one\n2. Step two'
+      )
+    })
+  })
+
   test('supercharge derives a slug from the plan heading and passes it as nameHint', async () => {
     useSessionStore.setState({
       pendingPlans: new Map([


### PR DESCRIPTION
## Summary

- **Issue**: The handoff feature was extracting the plan from the last assistant message in the chat history, which could be incorrect if a newer plan was generated but not yet reflected in the messages array
- **Fix**: Updated `handlePlanReadyHandoff` to prioritize `pendingPlan?.planContent` over the last assistant message, ensuring the correct plan is handed off
- **Changes**: 
  - Modified plan extraction logic to check `pendingPlan` first
  - Updated both connection-based and direct session handoff paths
  - Added `pendingPlan` to the dependency array of the `useCallback` hook
  - Added test case to verify the fix works correctly

## Testing

- Added test: `handoff uses pendingPlan.planContent instead of last assistant message content`
  - Verifies that when a `pendingPlan` exists, its `planContent` is used for the handoff prompt
  - Confirms the handoff message contains the correct plan content
- Existing handoff tests should continue to pass, ensuring backward compatibility
- Manual testing: Verify handoff works correctly when a plan is ready and when falling back to last assistant message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state fix that only changes which plan text is used when creating a handoff session; main risk is altered handoff prompt content in edge cases where `pendingPlan` and chat history diverge.
> 
> **Overview**
> Fixes plan handoff to **prefer `pendingPlan.planContent`** over scraping the last assistant message, ensuring the handoff prompt uses the latest generated plan in both connection-based and local session creation paths.
> 
> Updates the `handlePlanReadyHandoff` hook dependencies accordingly and adds a regression test asserting the handoff prompt is built from `pendingPlan.planContent` when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce73a89385fa5c0926c6a808eb98bc13d9ec2440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->