### PR TITLE
Add copy-to-clipboard functionality for plan markdown

### DIFF
--- a/src/renderer/src/components/sessions/PlanReadyImplementFab.tsx
+++ b/src/renderer/src/components/sessions/PlanReadyImplementFab.tsx
@@ -20,6 +20,7 @@ function MnemonicLabel({ letter, label }: { letter: string; label: string }): Re
 interface PlanReadyImplementFabProps {
   onImplement: () => void
   onHandoff: (override: HandoffSelectionOverride) => void
+  onCopyPlan: () => void
   visible: boolean
   onSuperpowers?: () => void
   onSuperpowersLocal?: () => void
@@ -32,6 +33,7 @@ interface PlanReadyImplementFabProps {
 export function PlanReadyImplementFab({
   onImplement,
   onHandoff,
+  onCopyPlan,
   visible,
   onSuperpowers,
   onSuperpowersLocal,
@@ -68,6 +70,21 @@ export function PlanReadyImplementFab({
           {vimModeEnabled ? <MnemonicLabel letter="s" label="Save as ticket" /> : 'Save as ticket'}
         </button>
       )}
+      <button
+        onClick={onCopyPlan}
+        className={cn(
+          'h-8 rounded-full px-3',
+          'text-xs font-medium',
+          'bg-muted/80 text-foreground border border-border',
+          'shadow-md hover:bg-muted transition-colors duration-200',
+          'cursor-pointer',
+          visible ? 'opacity-100' : 'opacity-0'
+        )}
+        aria-label="Copy plan markdown"
+        data-testid="plan-ready-copy-plan-fab"
+      >
+        {vimModeEnabled ? <MnemonicLabel letter="c" label="Copy plan" /> : 'Copy plan'}
+      </button>
       <div className={cn(visible ? 'opacity-100' : 'opacity-0')}>
         <HandoffSplitButton
           worktreeId={worktreeId}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -4831,6 +4831,24 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     opencodeSessionId
   ])
 
+  const handlePlanReadyCopyPlan = useCallback(async () => {
+    const planContent =
+      pendingPlan?.planContent ??
+      [...messages].reverse().find((m) => m.role === 'assistant' && m.content.trim().length > 0)
+        ?.content
+    if (!planContent || !planContent.trim()) {
+      toast.error('No plan content to copy')
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(planContent)
+      toast.success('Plan copied to clipboard')
+    } catch {
+      toast.error('Failed to copy')
+    }
+  }, [messages, pendingPlan?.planContent])
+
   const handlePlanReadySuperpowers = useCallback(async () => {
     // 1. Extract plan content
     const planContent =
@@ -5732,6 +5750,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         <PlanReadyImplementFab
           onImplement={handlePlanReadyImplement}
           onHandoff={handlePlanReadyHandoff}
+          onCopyPlan={handlePlanReadyCopyPlan}
           worktreeId={worktreeId ?? undefined}
           visible={showPlanReadyImplementFab}
           superpowersAvailable={hasSuperpowers}

--- a/src/renderer/src/components/sessions/ToolCallContextMenu.tsx
+++ b/src/renderer/src/components/sessions/ToolCallContextMenu.tsx
@@ -7,6 +7,7 @@ import {
   ContextMenuContent,
   ContextMenuItem
 } from '@/components/ui/context-menu'
+import { useSessionStore } from '@/stores/useSessionStore'
 import { ToolCallDebugModal } from './ToolCallDebugModal'
 import type { ToolUseInfo } from './ToolCard'
 
@@ -17,6 +18,39 @@ interface ToolCallContextMenuProps {
 
 export function ToolCallContextMenu({ children, toolUse }: ToolCallContextMenuProps) {
   const [debugOpen, setDebugOpen] = useState(false)
+
+  const isExitPlanMode = toolUse.name.toLowerCase() === 'exitplanmode'
+
+  // Mirror the fallback in ToolCard.tsx: when the ExitPlanMode tool's input.plan
+  // hasn't streamed in yet, the plan content may live in the pendingPlans store
+  // (set by the plan.ready event). Only subscribe when this is an ExitPlanMode
+  // card to avoid re-rendering every other tool card on store changes.
+  const pendingPlanContent = useSessionStore((state) => {
+    if (!isExitPlanMode) return ''
+    const inputPlan = (toolUse.input?.plan as string | undefined) ?? ''
+    if (inputPlan) return ''
+    for (const [, plan] of state.pendingPlans) {
+      if (plan.toolUseID === toolUse.id && plan.planContent) {
+        return plan.planContent
+      }
+    }
+    return ''
+  })
+
+  const handleCopyPlan = async () => {
+    const planContent = ((toolUse.input?.plan as string | undefined) || pendingPlanContent || '').trim()
+    if (!planContent) {
+      toast.error('No plan content to copy')
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(planContent)
+      toast.success('Plan copied to clipboard')
+    } catch {
+      toast.error('Failed to copy')
+    }
+  }
 
   const handleCopyCommand = async () => {
     let textToCopy = ''
@@ -67,6 +101,16 @@ export function ToolCallContextMenu({ children, toolUse }: ToolCallContextMenuPr
       <ContextMenu>
         <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
         <ContextMenuContent>
+          {isExitPlanMode && (
+            <ContextMenuItem
+              onClick={handleCopyPlan}
+              className="gap-2"
+              data-testid="context-menu-copy-plan"
+            >
+              <Copy className="h-3.5 w-3.5" />
+              Copy plan
+            </ContextMenuItem>
+          )}
           <ContextMenuItem onClick={handleCopyCommand} className="gap-2">
             <Copy className="h-3.5 w-3.5" />
             Copy Details

--- a/test/phase-23/session-4/copy-plan-markdown.test.tsx
+++ b/test/phase-23/session-4/copy-plan-markdown.test.tsx
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+// Mock the toast helpers used by SessionView / FAB. The context menu imports
+// toast from sonner directly, so we mock that module too.
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (msg: string) => toastSuccess(msg),
+    error: (msg: string) => toastError(msg)
+  }
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: (msg: string) => toastSuccess(msg),
+    error: (msg: string) => toastError(msg),
+    warning: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn()
+  },
+  default: {
+    success: (msg: string) => toastSuccess(msg),
+    error: (msg: string) => toastError(msg)
+  }
+}))
+
+// ToolCallDebugModal has heavy UI dependencies and is not under test here.
+vi.mock('../../../src/renderer/src/components/sessions/ToolCallDebugModal', () => ({
+  ToolCallDebugModal: () => null
+}))
+
+// HandoffSplitButton pulls in settings store + model catalog. We stub it to a
+// simple sentinel so we can assert the FAB button ordering and interactions.
+vi.mock('../../../src/renderer/src/components/sessions/HandoffSplitButton', () => ({
+  HandoffSplitButton: () => <button data-testid="handoff-stub">Handoff</button>
+}))
+
+import { ToolCallContextMenu } from '../../../src/renderer/src/components/sessions/ToolCallContextMenu'
+import { PlanReadyImplementFab } from '../../../src/renderer/src/components/sessions/PlanReadyImplementFab'
+import { useSessionStore } from '../../../src/renderer/src/stores/useSessionStore'
+import type { ToolUseInfo } from '../../../src/renderer/src/components/sessions/ToolCard'
+
+function makeToolUse(overrides: Partial<ToolUseInfo> = {}): ToolUseInfo {
+  return {
+    id: 'tool-use-1',
+    name: 'ExitPlanMode',
+    input: {},
+    status: 'success',
+    startTime: 0,
+    ...overrides
+  }
+}
+
+const PLAN_MARKDOWN = '# Plan\n\n- step one\n- step two\n\n```ts\nconst x = 1\n```\n'
+
+// Install a clipboard mock that we can observe between tests.
+let writeTextMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  writeTextMock = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: writeTextMock },
+    configurable: true,
+    writable: true
+  })
+  toastSuccess.mockClear()
+  toastError.mockClear()
+  // Reset the pendingPlans map between tests.
+  useSessionStore.setState({ pendingPlans: new Map() })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ToolCallContextMenu — Copy plan item', () => {
+  test('renders "Copy plan" menu item only for ExitPlanMode tool calls', async () => {
+    const toolUse = makeToolUse({ input: { plan: PLAN_MARKDOWN } })
+    render(
+      <ToolCallContextMenu toolUse={toolUse}>
+        <div data-testid="plan-card">plan card</div>
+      </ToolCallContextMenu>
+    )
+
+    fireEvent.contextMenu(screen.getByTestId('plan-card'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('context-menu-copy-plan')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Copy plan')).toBeInTheDocument()
+    expect(screen.getByText('Copy Details')).toBeInTheDocument()
+  })
+
+  test('does NOT render "Copy plan" for non-ExitPlanMode tools', async () => {
+    const toolUse = makeToolUse({ name: 'Bash', input: { command: 'ls' } })
+    render(
+      <ToolCallContextMenu toolUse={toolUse}>
+        <div data-testid="bash-card">bash card</div>
+      </ToolCallContextMenu>
+    )
+
+    fireEvent.contextMenu(screen.getByTestId('bash-card'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Copy Details')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('context-menu-copy-plan')).not.toBeInTheDocument()
+    expect(screen.queryByText('Copy plan')).not.toBeInTheDocument()
+  })
+
+  test('clicking "Copy plan" copies input.plan and fires success toast', async () => {
+    const toolUse = makeToolUse({ input: { plan: PLAN_MARKDOWN } })
+    render(
+      <ToolCallContextMenu toolUse={toolUse}>
+        <div data-testid="plan-card">plan card</div>
+      </ToolCallContextMenu>
+    )
+
+    fireEvent.contextMenu(screen.getByTestId('plan-card'))
+    await waitFor(() => {
+      expect(screen.getByTestId('context-menu-copy-plan')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId('context-menu-copy-plan'))
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledTimes(1)
+    })
+    expect(writeTextMock.mock.calls[0][0]).toBe(PLAN_MARKDOWN.trim())
+    expect(toastSuccess).toHaveBeenCalledWith('Plan copied to clipboard')
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  test('falls back to pendingPlans store when input.plan is empty', async () => {
+    const toolUse = makeToolUse({ id: 'tool-streaming-1', input: {} })
+
+    useSessionStore.getState().setPendingPlan('session-abc', {
+      requestId: 'req-1',
+      toolUseID: 'tool-streaming-1',
+      planContent: PLAN_MARKDOWN
+    })
+
+    render(
+      <ToolCallContextMenu toolUse={toolUse}>
+        <div data-testid="plan-card">plan card</div>
+      </ToolCallContextMenu>
+    )
+
+    fireEvent.contextMenu(screen.getByTestId('plan-card'))
+    await waitFor(() => {
+      expect(screen.getByTestId('context-menu-copy-plan')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId('context-menu-copy-plan'))
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledTimes(1)
+    })
+    expect(writeTextMock.mock.calls[0][0]).toBe(PLAN_MARKDOWN.trim())
+    expect(toastSuccess).toHaveBeenCalledWith('Plan copied to clipboard')
+  })
+
+  test('shows error toast and skips clipboard when plan is empty from both sources', async () => {
+    const toolUse = makeToolUse({ id: 'tool-empty', input: {} })
+    // pendingPlans intentionally empty — reset in beforeEach.
+
+    render(
+      <ToolCallContextMenu toolUse={toolUse}>
+        <div data-testid="plan-card">plan card</div>
+      </ToolCallContextMenu>
+    )
+
+    fireEvent.contextMenu(screen.getByTestId('plan-card'))
+    await waitFor(() => {
+      expect(screen.getByTestId('context-menu-copy-plan')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId('context-menu-copy-plan'))
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith('No plan content to copy')
+    })
+    expect(writeTextMock).not.toHaveBeenCalled()
+    expect(toastSuccess).not.toHaveBeenCalled()
+  })
+})
+
+describe('PlanReadyImplementFab — Copy plan button', () => {
+  function renderFab(overrides: Partial<React.ComponentProps<typeof PlanReadyImplementFab>> = {}) {
+    const defaults = {
+      onImplement: vi.fn(),
+      onHandoff: vi.fn(),
+      onCopyPlan: vi.fn(),
+      visible: true,
+      onSaveAsTicket: vi.fn()
+    }
+    const props = { ...defaults, ...overrides }
+    return { ...render(<PlanReadyImplementFab {...props} />), props }
+  }
+
+  test('renders Copy plan button with the expected test id when visible', () => {
+    renderFab()
+    const btn = screen.getByTestId('plan-ready-copy-plan-fab')
+    expect(btn).toBeInTheDocument()
+    expect(btn).toHaveAccessibleName('Copy plan markdown')
+    expect(btn).toHaveTextContent('Copy plan')
+  })
+
+  test('button sits between Save-as-ticket and Handoff in DOM order', () => {
+    renderFab()
+    const saveBtn = screen.getByTestId('plan-ready-save-ticket-fab')
+    const copyBtn = screen.getByTestId('plan-ready-copy-plan-fab')
+    const handoffBtn = screen.getByTestId('handoff-stub')
+
+    expect(
+      saveBtn.compareDocumentPosition(copyBtn) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(
+      copyBtn.compareDocumentPosition(handoffBtn) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  test('clicking invokes the onCopyPlan prop', () => {
+    const { props } = renderFab()
+    fireEvent.click(screen.getByTestId('plan-ready-copy-plan-fab'))
+    expect(props.onCopyPlan).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- Add "Copy plan" button to PlanReadyImplementFab (positioned between "Save as ticket" and "Handoff")
- Add right-click context menu option to copy plan from ExitPlanMode tool cards
- Support copying plan markdown from both `input.plan` field and fallback to `pendingPlans` store when streaming
- Clipboard copy includes success/error toast notifications
- Full test coverage for both UI components and copy interactions

## Testing

- Verify "Copy plan" button appears in PlanReadyImplementFab and copies plan content to clipboard with success toast
- Verify right-click context menu on ExitPlanMode cards shows "Copy plan" option (not visible for other tool types)
- Verify copy works from pendingPlans store fallback when plan input hasn't streamed yet
- Verify error toast displays when plan content is empty
- Verify button positioning: "Save as ticket" → "Copy plan" → "Handoff"
- All 8 test cases in `copy-plan-markdown.test.tsx` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds clipboard writes and toast notifications; main risk is minor UX/regression around when plan content is available (streaming vs stored fallback).
> 
> **Overview**
> Adds a new **“Copy plan”** action in two places: a button in `PlanReadyImplementFab` (wired from `SessionView` to copy the latest plan content) and a context-menu item on `ExitPlanMode` tool cards to copy `input.plan` with a fallback to `pendingPlans` when streaming.
> 
> Includes success/error toast feedback for empty/failed clipboard writes, plus a new Vitest suite covering menu visibility, clipboard interactions, fallback behavior, and FAB button ordering/callback wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16156bb285e724c0a6abe4b65f7e46e633616feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->