### PR TITLE
Add GPT-5.5 support and set as default model

### DIFF
--- a/src/main/services/codex-models.ts
+++ b/src/main/services/codex-models.ts
@@ -18,6 +18,13 @@ const CODEX_EFFORT_VARIANTS: Record<string, Record<string, never>> = {
 
 export const CODEX_MODELS: CodexModelInfo[] = [
   {
+    id: 'gpt-5.5',
+    name: 'GPT-5.5',
+    limit: { context: 258400, output: 32000 },
+    variants: CODEX_EFFORT_VARIANTS,
+    defaultVariant: 'high'
+  },
+  {
     id: 'gpt-5.4',
     name: 'GPT-5.4',
     limit: { context: 258400, output: 32000 },
@@ -47,7 +54,7 @@ export const CODEX_MODELS: CodexModelInfo[] = [
   }
 ]
 
-export const CODEX_DEFAULT_MODEL = 'gpt-5.4'
+export const CODEX_DEFAULT_MODEL = 'gpt-5.5'
 
 /**
  * Returns all available Codex models in the format expected by the renderer.
@@ -96,6 +103,7 @@ export function getCodexModelInfo(
 // ── Model slug normalization ──────────────────────────────────────
 
 export const CODEX_MODEL_ALIASES: Record<string, string> = {
+  '5.5': 'gpt-5.5',
   '5.4': 'gpt-5.4',
   '5.3': 'gpt-5.3-codex',
   'gpt-5.3': 'gpt-5.3-codex',

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -3043,6 +3043,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         // renders immediately before the first thread/tokenUsage/updated event.
         if (sessionRecord?.agent_sdk === 'codex') {
           const codexModels = [
+            { id: 'gpt-5.5', context: 258400 },
             { id: 'gpt-5.4', context: 258400 },
             { id: 'gpt-5.3-codex', context: 258400 },
             { id: 'gpt-5.3-codex-spark', context: 258400 },

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -34,7 +34,7 @@ const SDK_DISPLAY_NAMES: Record<HandoffAgentSdk, string> = {
 const FALLBACK_MODELS: Record<HandoffAgentSdk, SelectedModel> = {
   opencode: { providerID: 'anthropic', modelID: 'claude-opus-4-5-20251101' },
   'claude-code': { providerID: 'anthropic', modelID: 'claude-opus-4-5-20251101' },
-  codex: { providerID: 'codex', modelID: 'gpt-5.4' }
+  codex: { providerID: 'codex', modelID: 'gpt-5.5' }
 }
 
 const modelCatalogCache = new Map<HandoffAgentSdk, ProviderModels[]>()

--- a/test/kanban/session-9/worktree-picker-modal.test.tsx
+++ b/test/kanban/session-9/worktree-picker-modal.test.tsx
@@ -126,6 +126,7 @@ const mockOpencodeOps = {
         id: 'openai',
         name: 'OpenAI',
         models: {
+          'gpt-5.5': { id: 'gpt-5.5', name: 'GPT-5.5' },
           'gpt-5.4': { id: 'gpt-5.4', name: 'GPT-5.4' },
           'gpt-5.4-mini': { id: 'gpt-5.4-mini', name: 'GPT-5.4 Mini' }
         }

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -29,6 +29,14 @@ const codexProviders = [
     id: 'codex',
     name: 'Codex',
     models: {
+      'gpt-5.5': {
+        id: 'gpt-5.5',
+        name: 'GPT-5.5',
+        variants: {
+          high: {},
+          xhigh: {}
+        }
+      },
       'gpt-5.4': {
         id: 'gpt-5.4',
         name: 'GPT-5.4',
@@ -105,7 +113,7 @@ describe('handoff model picker', () => {
         },
         codex: {
           providerID: 'codex',
-          modelID: 'gpt-5.4',
+          modelID: 'gpt-5.5',
           variant: 'high'
         }
       },
@@ -137,7 +145,7 @@ describe('handoff model picker', () => {
       lastHandoffOverride: {
         agentSdk: 'codex',
         providerID: 'codex',
-        modelID: 'gpt-5.4',
+        modelID: 'gpt-5.5',
         variant: 'xhigh'
       }
     })
@@ -147,12 +155,12 @@ describe('handoff model picker', () => {
     expect(effective.agentSdk).toBe('codex')
     expect(effective.model).toEqual({
       providerID: 'codex',
-      modelID: 'gpt-5.4',
+      modelID: 'gpt-5.5',
       variant: 'xhigh'
     })
     expect(effective.display).toEqual({
       sdkName: 'Codex',
-      modelName: 'GPT-5.4',
+      modelName: 'GPT-5.5',
       variant: 'xhigh'
     })
   })
@@ -194,14 +202,14 @@ describe('handoff model picker', () => {
       useSettingsStore.getState().setLastHandoffOverride({
         agentSdk: 'codex',
         providerID: 'codex',
-        modelID: 'gpt-5.4',
+        modelID: 'gpt-5.5',
         variant: 'xhigh'
       })
     })
 
     await waitFor(() => {
       expect(handoffButton).toHaveTextContent('Codex /')
-      expect(handoffButton).toHaveTextContent('GPT-5.4')
+      expect(handoffButton).toHaveTextContent('GPT-5.5')
       expect(handoffButton).toHaveTextContent('xhigh')
     })
   })
@@ -241,7 +249,7 @@ describe('handoff model picker', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Select handoff model' })).toHaveTextContent(
-        'GPT-5.4'
+        'GPT-5.5'
       )
     })
 
@@ -260,7 +268,7 @@ describe('handoff model picker', () => {
     await user.click(await screen.findByText('Codex'))
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Select handoff model' })).toHaveTextContent(
-        'GPT-5.4'
+        'GPT-5.5'
       )
     })
 
@@ -270,7 +278,7 @@ describe('handoff model picker', () => {
       expect(useSettingsStore.getState().lastHandoffOverride).toEqual({
         agentSdk: 'codex',
         providerID: 'codex',
-        modelID: 'gpt-5.4',
+        modelID: 'gpt-5.5',
         variant: 'high'
       })
     })
@@ -278,7 +286,7 @@ describe('handoff model picker', () => {
       agentSdk: 'codex',
       model: {
         providerID: 'codex',
-        modelID: 'gpt-5.4',
+        modelID: 'gpt-5.5',
         variant: 'high'
       }
     })

--- a/test/phase-22/session-3/codex-implementer-skeleton.test.ts
+++ b/test/phase-22/session-3/codex-implementer-skeleton.test.ts
@@ -59,15 +59,33 @@ describe('CodexImplementer skeleton', () => {
       expect(result[0].id).toBe('codex')
     })
 
-    it('provider contains all 4 models', async () => {
+    it('provider contains all 5 models', async () => {
       const result = (await impl.getAvailableModels()) as any[]
       const models = result[0].models
-      expect(Object.keys(models)).toHaveLength(4)
+      expect(Object.keys(models)).toHaveLength(5)
+      expect(models['gpt-5.5']).toMatchObject({
+        id: 'gpt-5.5',
+        name: 'GPT-5.5'
+      })
     })
   })
 
   describe('getModelInfo', () => {
     it('returns info for a known model', async () => {
+      const info = await impl.getModelInfo('/path', 'gpt-5.5')
+      expect(info).not.toBeNull()
+      expect(info!.id).toBe('gpt-5.5')
+      expect(info!.name).toBe('GPT-5.5')
+    })
+
+    it('resolves aliased model slugs', async () => {
+      const info = await impl.getModelInfo('/path', '5.5')
+      expect(info).not.toBeNull()
+      expect(info!.id).toBe('gpt-5.5')
+      expect(info!.name).toBe('GPT-5.5')
+    })
+
+    it('still returns info for legacy codex models', async () => {
       const info = await impl.getModelInfo('/path', 'gpt-5.4')
       expect(info).not.toBeNull()
       expect(info!.id).toBe('gpt-5.4')
@@ -93,7 +111,7 @@ describe('CodexImplementer skeleton', () => {
       expect(impl.getSelectedVariant()).toBe('xhigh')
     })
 
-    it('defaults to gpt-5.4 before any selection', () => {
+    it('defaults to gpt-5.5 before any selection', () => {
       expect(impl.getSelectedModel()).toBe(CODEX_DEFAULT_MODEL)
     })
   })

--- a/test/phase-22/session-3/codex-model-catalog.test.ts
+++ b/test/phase-22/session-3/codex-model-catalog.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CODEX_DEFAULT_MODEL,
+  CODEX_MODELS,
+  getAvailableCodexModels,
+  getCodexModelInfo,
+  normalizeCodexModelSlug,
+  resolveCodexModelSlug
+} from '../../../src/main/services/codex-models'
+
+describe('codex model catalog', () => {
+  it('includes gpt-5.5 with the same effort variants as gpt-5.4', () => {
+    const gpt55 = CODEX_MODELS.find((model) => model.id === 'gpt-5.5')
+    const gpt54 = CODEX_MODELS.find((model) => model.id === 'gpt-5.4')
+
+    expect(gpt55).toBeDefined()
+    expect(gpt54).toBeDefined()
+    expect(gpt55?.variants).toEqual(gpt54?.variants)
+    expect(gpt55?.defaultVariant).toBe('high')
+  })
+
+  it('uses gpt-5.5 as the default codex model', () => {
+    expect(CODEX_DEFAULT_MODEL).toBe('gpt-5.5')
+  })
+
+  it('normalizes the 5.5 shorthand slug', () => {
+    expect(normalizeCodexModelSlug('5.5')).toBe('gpt-5.5')
+    expect(resolveCodexModelSlug('5.5')).toBe('gpt-5.5')
+  })
+
+  it('returns gpt-5.5 model info through the shared lookup', () => {
+    expect(getCodexModelInfo('5.5')).toEqual({
+      id: 'gpt-5.5',
+      name: 'GPT-5.5',
+      limit: { context: 258400, output: 32000 }
+    })
+  })
+
+  it('publishes gpt-5.5 in the renderer-facing provider catalog', () => {
+    const providers = getAvailableCodexModels()
+    expect(providers).toHaveLength(1)
+    expect(providers[0]?.models['gpt-5.5']).toMatchObject({
+      id: 'gpt-5.5',
+      name: 'GPT-5.5',
+      variants: {
+        xhigh: {},
+        high: {},
+        medium: {},
+        low: {}
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add GPT-5.5 model to the Codex model catalog with 258400 context window and 32000 output token limits
- Set GPT-5.5 as the default Codex model (replacing GPT-5.4)
- Add '5.5' model slug alias for easy reference
- Update SessionView component to include GPT-5.5 in model context limits
- Update handoff selection fallback to use GPT-5.5 for Codex SDK
- Add comprehensive test coverage for GPT-5.5 model info and integration
- Update existing test expectations to reflect new default model

## Testing

- Verify GPT-5.5 appears in available models list (5 total instead of 4)
- Confirm GPT-5.5 is selected as default when no model preference exists
- Test model slug normalization: '5.5' resolves to 'gpt-5.5'
- Verify getCodexModelInfo('5.5') returns correct model metadata
- Check handoff model picker displays 'GPT-5.5' in UI when Codex is selected
- Validate context window limits (258400) are correct for GPT-5.5 in SessionView
- Run all updated test suites:
  - codex-model-catalog.test.ts (new, 5 test cases)
  - codex-implementer-skeleton.test.ts (updated defaults)
  - handoff-model-picker.test.tsx (updated model references)
  - worktree-picker-modal.test.tsx (OpenAI models updated)
- Verify no regressions in legacy model support (GPT-5.4, 5.3, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to model catalog/default selection and UI pre-seeding, with broad test updates to match the new default. Main risk is unintended behavior if any consumers assume the previous `gpt-5.4` default/model count.
> 
> **Overview**
> Adds **Codex support for `gpt-5.5`** (same effort variants as `gpt-5.4`) and switches the Codex default model from `gpt-5.4` to `gpt-5.5`, including a new shorthand alias `5.5` for slug resolution.
> 
> Updates renderer behavior to pre-seed context limits for `gpt-5.5` and changes Codex handoff/model-picker fallbacks to prefer `gpt-5.5`. Tests are updated and expanded (including a new `codex-model-catalog.test.ts`) to validate the new model, aliasing, default selection, and UI expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34e2f948ae5eaf9bfa9368da818defc65e9b2f92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->