### PR TITLE
Increase GPT-5.5 context window to 400k

### DIFF
--- a/src/main/services/codex-models.ts
+++ b/src/main/services/codex-models.ts
@@ -20,7 +20,7 @@ export const CODEX_MODELS: CodexModelInfo[] = [
   {
     id: 'gpt-5.5',
     name: 'GPT-5.5',
-    limit: { context: 258400, output: 32000 },
+    limit: { context: 400000, output: 32000 },
     variants: CODEX_EFFORT_VARIANTS,
     defaultVariant: 'high'
   },

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -3043,7 +3043,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         // renders immediately before the first thread/tokenUsage/updated event.
         if (sessionRecord?.agent_sdk === 'codex') {
           const codexModels = [
-            { id: 'gpt-5.5', context: 258400 },
+            { id: 'gpt-5.5', context: 400000 },
             { id: 'gpt-5.4', context: 258400 },
             { id: 'gpt-5.3-codex', context: 258400 },
             { id: 'gpt-5.3-codex-spark', context: 258400 },

--- a/test/phase-22/session-3/codex-model-catalog.test.ts
+++ b/test/phase-22/session-3/codex-model-catalog.test.ts
@@ -33,7 +33,7 @@ describe('codex model catalog', () => {
     expect(getCodexModelInfo('5.5')).toEqual({
       id: 'gpt-5.5',
       name: 'GPT-5.5',
-      limit: { context: 258400, output: 32000 }
+      limit: { context: 400000, output: 32000 }
     })
   })
 
@@ -43,6 +43,7 @@ describe('codex model catalog', () => {
     expect(providers[0]?.models['gpt-5.5']).toMatchObject({
       id: 'gpt-5.5',
       name: 'GPT-5.5',
+      limit: { context: 400000, output: 32000 },
       variants: {
         xhigh: {},
         high: {},


### PR DESCRIPTION
## Summary
- Updated the GPT-5.5 model catalog entry to reflect a 400,000 token context window.
- Aligned the session UI fallback metadata so GPT-5.5 is displayed with the new context limit.
- Adjusted catalog tests to verify the updated GPT-5.5 limits in both direct lookup and provider metadata.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only updates to model limits plus aligned UI fallback and test expectations; no behavioral or security-sensitive logic changes.
> 
> **Overview**
> Updates the Codex model catalog to set `gpt-5.5`’s context limit to **400,000** tokens.
> 
> Aligns the session UI’s Codex fallback model-limit seeding so the context indicator renders the new limit immediately, and updates catalog tests to assert the revised `gpt-5.5` limits in both lookup and renderer-facing provider metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d63e776f71eb72e67287f561ed5a03bc1203a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->