### PR TITLE
Fix dirty-files merge dialog overflow

### DIFF
--- a/src/renderer/src/components/ui/alert-dialog.tsx
+++ b/src/renderer/src/components/ui/alert-dialog.tsx
@@ -50,7 +50,7 @@ function AlertDialogContent({
           data-slot="alert-dialog-content"
           data-size={size}
           className={cn(
-            'relative overflow-hidden bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg/5 duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+            'relative overflow-hidden bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid grid-cols-[minmax(0,1fr)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg/5 duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
             className
           )}
           {...props}
@@ -65,7 +65,7 @@ function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>)
     <div
       data-slot="alert-dialog-header"
       className={cn(
-        'grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]',
+        'grid min-w-0 grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]',
         className
       )}
       {...props}
@@ -78,7 +78,7 @@ function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>)
     <div
       data-slot="alert-dialog-footer"
       className={cn(
-        'flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:flex-wrap sm:justify-end',
+        'flex min-w-0 flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:flex-wrap sm:justify-end',
         className
       )}
       {...props}

--- a/src/renderer/src/components/worktrees/DirtyFilesConfirmDialog.tsx
+++ b/src/renderer/src/components/worktrees/DirtyFilesConfirmDialog.tsx
@@ -87,30 +87,35 @@ export function DirtyFilesConfirmDialog({
   return (
     <AlertDialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
       <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle className="flex items-center gap-2">
-            <AlertTriangle className="h-5 w-5 text-destructive" />
+        <AlertDialogHeader className="min-w-0">
+          <AlertDialogTitle className="flex min-w-0 items-center gap-2 text-left">
+            <AlertTriangle className="h-5 w-5 shrink-0 text-destructive" />
             Uncommitted Changes
           </AlertDialogTitle>
           <AlertDialogDescription asChild>
-            <div className="space-y-3">
-              <p>
+            <div className="min-w-0 space-y-3">
+              <p className="min-w-0 [overflow-wrap:anywhere]">
                 <span className="font-medium text-foreground">{worktreeName}</span> {description}
               </p>
 
-              <div className="rounded-md border bg-muted/50 overflow-hidden">
+              <div className="min-w-0 max-h-[40vh] overflow-y-auto overflow-x-hidden rounded-md border bg-muted/50">
                 <div className="divide-y divide-border">
                   {shownFiles.map((file) => (
                     <div
                       key={file.path}
-                      className="flex items-center gap-2 px-3 py-1.5 text-xs font-mono"
+                      className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-2 px-3 py-1.5 text-xs font-mono"
                     >
                       {getFileIcon(file)}
-                      <span className="truncate flex-1" title={file.path}>
+                      <span
+                        className="min-w-0 whitespace-normal leading-relaxed [overflow-wrap:anywhere]"
+                        title={file.path}
+                      >
                         <span className="text-muted-foreground">{fileDir(file.path)}</span>
                         <span className="text-foreground">{fileName(file.path)}</span>
                       </span>
-                      <span className="shrink-0 tabular-nums text-[11px]">{formatStat(file)}</span>
+                      <span className="mt-0.5 shrink-0 tabular-nums text-[11px]">
+                        {formatStat(file)}
+                      </span>
                     </div>
                   ))}
                 </div>

--- a/test/worktrees/dirty-files-confirm-dialog.test.tsx
+++ b/test/worktrees/dirty-files-confirm-dialog.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, test, vi } from 'vitest'
+import { DirtyFilesConfirmDialog } from '../../src/renderer/src/components/worktrees/DirtyFilesConfirmDialog'
+
+const longPath =
+  'docs/superpowers/plans/2026-04-23-replace-ad-library-api-with-play-mode-and-extra-long-file-name-that-would-previously-push-actions-outside-the-dialog.md'
+
+describe('DirtyFilesConfirmDialog', () => {
+  test('wraps long file paths without losing access to action buttons', async () => {
+    const user = userEvent.setup()
+    const onCancel = vi.fn()
+    const onConfirm = vi.fn()
+
+    render(
+      <DirtyFilesConfirmDialog
+        open
+        worktreeName="replace-ad-library-api-with-play-mode-and-a-very-long-worktree-name"
+        files={[
+          {
+            path: longPath,
+            additions: 12,
+            deletions: 3,
+            binary: false
+          }
+        ]}
+        description="has uncommitted changes that won't be included in the merge."
+        confirmLabel="Merge Anyway"
+        confirmVariant="destructive"
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />
+    )
+
+    const dialog = document.querySelector('[data-slot="alert-dialog-content"]')
+    expect(dialog).toHaveClass('grid-cols-[minmax(0,1fr)]')
+
+    const path = screen.getByTitle(longPath)
+    expect(path).toHaveClass('whitespace-normal')
+    expect(path).toHaveClass('[overflow-wrap:anywhere]')
+    expect(path).not.toHaveClass('truncate')
+
+    const cancel = screen.getByRole('button', { name: 'Cancel' })
+    const confirm = screen.getByRole('button', { name: 'Merge Anyway' })
+
+    expect(cancel).toBeVisible()
+    expect(confirm).toBeVisible()
+
+    await user.click(confirm)
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Prevent long file paths and worktree names from pushing the merge actions out of the dialog.
- Constrain alert dialog layout with zero-min-width grid columns and allow header/footer content to shrink correctly.
- Update the dirty files confirmation dialog to wrap long paths, cap the file list height, and keep action buttons visible.
- Add a regression test covering long-path rendering and button accessibility.

## Testing
- Added a Vitest test in `test/worktrees/dirty-files-confirm-dialog.test.tsx` for long file paths and visible actions.
- Not run: full test suite or UI browser verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout-only changes to dialog styling plus a regression test; main risk is unintended styling side effects in other `AlertDialog` usages.
> 
> **Overview**
> Prevents long worktree names and file paths from overflowing the dirty-files merge confirmation dialog by constraining `AlertDialogContent` to a `minmax(0,1fr)` grid column and allowing header/footer sections to shrink (`min-w-0`).
> 
> Updates `DirtyFilesConfirmDialog` to wrap long paths (`whitespace-normal` + `overflow-wrap:anywhere`), switch file rows to a grid layout, and cap the file list height with vertical scrolling so action buttons remain visible.
> 
> Adds a Vitest regression test ensuring long paths wrap, action buttons stay visible, and confirm still triggers `onConfirm`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8393e39b86e18fb9486b953ca8487f122425fb44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->