### PR TITLE
Harden Anthropic usage normalization

### DIFF
--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useLayoutEffect, Fragment } from 'react'
+import { useState, useCallback, useRef, useLayoutEffect } from 'react'
 import { motion } from 'motion/react'
 import { ChevronRight, ChevronDown, Plus, Zap, Archive } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -386,6 +386,13 @@ export function KanbanColumn({ column, tickets, archivedTickets, projectId, conn
                       ? branchStatResult.commitsAhead
                       : 0
 
+                    if (!branchStatResult.success) {
+                      toast.warning(
+                        `Could not verify merge status: ${branchStatResult.error ?? 'unknown error'}`
+                      )
+                      return
+                    }
+
                     if (hasUncommitted || commitsAhead > 0) {
                       const sortOrder = store.computeSortOrder(tickets, targetIndex)
                       store.setPendingDoneMove({ ticketId, projectId: ticketProjectId, sortOrder })
@@ -395,8 +402,11 @@ export function KanbanColumn({ column, tickets, archivedTickets, projectId, conn
                   // No base worktree OR nothing to commit/merge — fall through to normal move
                 }
               }
-            } catch {
-              // Fall through to normal move on error
+            } catch (err) {
+              toast.warning(
+                `Could not verify merge status: ${err instanceof Error ? err.message : String(err)}`
+              )
+              return
             }
           }
         }
@@ -479,7 +489,7 @@ export function KanbanColumn({ column, tickets, archivedTickets, projectId, conn
     }
 
     setPendingBackwardDrag(null)
-  }, [pendingBackwardDrag, projectId, findTicketProjectId, findTicket])
+  }, [pendingBackwardDrag, findTicketProjectId, findTicket])
 
   // ── Drop indicator element ────────────────────────────────────────
   const dropIndicator = (

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -33,6 +33,7 @@ interface ResolvedState {
 export function MergeOnDoneDialog() {
   const pendingDoneMove = useKanbanStore((s) => s.pendingDoneMove)
   const completeDoneMove = useKanbanStore((s) => s.completeDoneMove)
+  const clearPendingDoneMove = useKanbanStore((s) => s.clearPendingDoneMove)
 
   const [step, setStep] = useState<Step>('loading')
   const [resolved, setResolved] = useState<ResolvedState | null>(null)
@@ -60,14 +61,15 @@ export function MergeOnDoneDialog() {
         const ticket = tickets.find((t) => t.id === pending.ticketId)
 
         if (!ticket || !ticket.worktree_id) {
-          await completeDoneMove()
+          clearPendingDoneMove()
           return
         }
 
         // Fetch feature worktree
         const featureWorktree = await window.db.worktree.get(ticket.worktree_id)
         if (!featureWorktree || featureWorktree.status !== 'active') {
-          await completeDoneMove()
+          toast.warning('Cannot merge — feature worktree is not active')
+          clearPendingDoneMove()
           return
         }
 
@@ -78,7 +80,7 @@ export function MergeOnDoneDialog() {
 
         if (!resolvedBaseBranch) {
           toast.warning('Cannot merge — no base branch resolved')
-          await completeDoneMove()
+          clearPendingDoneMove()
           return
         }
 
@@ -89,7 +91,7 @@ export function MergeOnDoneDialog() {
 
         if (!baseWorktree) {
           toast.warning(`Cannot merge — no worktree for ${resolvedBaseBranch}`)
-          await completeDoneMove()
+          clearPendingDoneMove()
           return
         }
 
@@ -132,14 +134,18 @@ export function MergeOnDoneDialog() {
 
         if (cancelled) return
 
-        const branchStats: BranchStats = branchStatResult.success
-          ? {
-              filesChanged: branchStatResult.filesChanged,
-              insertions: branchStatResult.insertions,
-              deletions: branchStatResult.deletions,
-              commitsAhead: branchStatResult.commitsAhead
-            }
-          : { filesChanged: 0, insertions: 0, deletions: 0, commitsAhead: 0 }
+        if (!branchStatResult.success) {
+          toast.warning(`Cannot verify merge status: ${branchStatResult.error ?? 'unknown error'}`)
+          clearPendingDoneMove()
+          return
+        }
+
+        const branchStats: BranchStats = {
+          filesChanged: branchStatResult.filesChanged,
+          insertions: branchStatResult.insertions,
+          deletions: branchStatResult.deletions,
+          commitsAhead: branchStatResult.commitsAhead
+        }
 
         // If no diffs at all, just move to done
         if (!hasUncommitted && branchStats.commitsAhead === 0) {
@@ -170,7 +176,7 @@ export function MergeOnDoneDialog() {
       } catch (err) {
         if (!cancelled) {
           toast.error(`Failed to check branch: ${err instanceof Error ? err.message : String(err)}`)
-          await completeDoneMove()
+          clearPendingDoneMove()
         }
       }
     }
@@ -179,7 +185,7 @@ export function MergeOnDoneDialog() {
     return () => {
       cancelled = true
     }
-  }, [pendingDoneMove, completeDoneMove])
+  }, [pendingDoneMove, completeDoneMove, clearPendingDoneMove])
 
   const handleCommit = useCallback(async () => {
     if (!resolved || !commitMessage.trim()) return
@@ -208,7 +214,13 @@ export function MergeOnDoneDialog() {
         resolved.baseBranch
       )
 
-      if (statResult.success && statResult.commitsAhead > 0) {
+      if (!statResult.success) {
+        toast.warning(`Cannot verify merge status: ${statResult.error ?? 'unknown error'}`)
+        clearPendingDoneMove()
+        return
+      }
+
+      if (statResult.commitsAhead > 0) {
         setResolved((prev) =>
           prev
             ? {
@@ -232,7 +244,7 @@ export function MergeOnDoneDialog() {
     } finally {
       setCommitting(false)
     }
-  }, [resolved, commitMessage, completeDoneMove])
+  }, [resolved, commitMessage, completeDoneMove, clearPendingDoneMove])
 
   const handleCommitBase = useCallback(async () => {
     if (!resolved || !baseCommitMessage.trim()) return
@@ -268,7 +280,13 @@ export function MergeOnDoneDialog() {
           resolved.featureWorktreePath,
           resolved.baseBranch
         )
-        if (statResult.success && statResult.commitsAhead > 0) {
+        if (!statResult.success) {
+          toast.warning(`Cannot verify merge status: ${statResult.error ?? 'unknown error'}`)
+          clearPendingDoneMove()
+          return
+        }
+
+        if (statResult.commitsAhead > 0) {
           setResolved((prev) =>
             prev
               ? {
@@ -292,7 +310,7 @@ export function MergeOnDoneDialog() {
     } finally {
       setCommittingBase(false)
     }
-  }, [resolved, baseCommitMessage, completeDoneMove])
+  }, [resolved, baseCommitMessage, completeDoneMove, clearPendingDoneMove])
 
   const handleMerge = useCallback(async () => {
     if (!resolved) return
@@ -323,7 +341,7 @@ export function MergeOnDoneDialog() {
         } else {
           toast.error(`Merge failed: ${mergeResult.error}`)
         }
-        await completeDoneMove()
+        clearPendingDoneMove()
         return
       }
 
@@ -331,11 +349,11 @@ export function MergeOnDoneDialog() {
       setStep('archive')
     } catch (err) {
       toast.error(`Merge failed: ${err instanceof Error ? err.message : String(err)}`)
-      await completeDoneMove()
+      clearPendingDoneMove()
     } finally {
       setMerging(false)
     }
-  }, [resolved, completeDoneMove])
+  }, [resolved, clearPendingDoneMove])
 
   const handleArchive = useCallback(async () => {
     if (!resolved) return
@@ -381,7 +399,7 @@ export function MergeOnDoneDialog() {
     <Dialog
       open={!!pendingDoneMove}
       onOpenChange={(open) => {
-        if (!open) completeDoneMove()
+        if (!open) clearPendingDoneMove()
       }}
     >
       <DialogContent className="max-w-md">
@@ -415,10 +433,10 @@ export function MergeOnDoneDialog() {
             />
             <div className="flex items-center justify-between">
               <button
-                onClick={() => completeDoneMove()}
+                onClick={() => clearPendingDoneMove()}
                 className="text-xs text-muted-foreground hover:text-foreground"
               >
-                Skip, just move to Done
+                Keep in Review
               </button>
               <Button
                 size="sm"
@@ -450,10 +468,10 @@ export function MergeOnDoneDialog() {
             />
             <div className="flex items-center justify-between">
               <button
-                onClick={() => completeDoneMove()}
+                onClick={() => clearPendingDoneMove()}
                 className="text-xs text-muted-foreground hover:text-foreground"
               >
-                Skip, just move to Done
+                Keep in Review
               </button>
               <Button
                 size="sm"
@@ -486,10 +504,10 @@ export function MergeOnDoneDialog() {
             </p>
             <div className="flex items-center justify-between">
               <button
-                onClick={() => completeDoneMove()}
+                onClick={() => clearPendingDoneMove()}
                 className="text-xs text-muted-foreground hover:text-foreground"
               >
-                Skip, just move to Done
+                Keep in Review
               </button>
               <Button size="sm" onClick={handleMerge} disabled={merging}>
                 {merging ? (

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -137,13 +137,25 @@ export function resolveDefaultUsageProvider(
   return 'anthropic'
 }
 
+function hasUsageWindow(value: unknown): value is { utilization: number; resets_at: string } {
+  if (typeof value !== 'object' || value === null) return false
+  const record = value as Record<string, unknown>
+  return typeof record.utilization === 'number' && typeof record.resets_at === 'string'
+}
+
+function isAnthropicUsageData(value: unknown): value is UsageData {
+  if (typeof value !== 'object' || value === null) return false
+  const record = value as Record<string, unknown>
+  return hasUsageWindow(record.five_hour) && hasUsageWindow(record.seven_day)
+}
+
 export function normalizeUsage(
   provider: UsageProvider,
   anthropicUsage: UsageData | null | undefined,
   openaiUsage: OpenAIUsageData | null | undefined
 ): UsageData | null {
   if (provider === 'anthropic') {
-    return anthropicUsage ?? null
+    return isAnthropicUsageData(anthropicUsage) ? anthropicUsage : null
   }
 
   if (!openaiUsage) return null

--- a/test/kanban/merge-on-done-dialog.test.tsx
+++ b/test/kanban/merge-on-done-dialog.test.tsx
@@ -1,0 +1,225 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { KanbanTicket, Project, Worktree } from '../../src/main/db/types'
+import { MergeOnDoneDialog } from '../../src/renderer/src/components/kanban/MergeOnDoneDialog'
+import { useKanbanStore } from '../../src/renderer/src/stores/useKanbanStore'
+
+const toastError = vi.fn()
+const toastSuccess = vi.fn()
+const toastWarning = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+    warning: (...args: unknown[]) => toastWarning(...args)
+  }
+}))
+
+const ticketMove = vi.fn()
+const mergeAbort = vi.fn()
+const merge = vi.fn()
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'project-1',
+    title: 'Fix merge issue',
+    description: null,
+    attachments: [],
+    column: 'review',
+    sort_order: 10,
+    current_session_id: null,
+    worktree_id: 'feature-wt',
+    mode: 'build',
+    plan_ready: false,
+    created_at: '2026-04-26T00:00:00.000Z',
+    updated_at: '2026-04-26T00:00:00.000Z',
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    note: null,
+    ...overrides
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'feature-wt',
+    project_id: 'project-1',
+    name: 'feature',
+    branch_name: 'feature',
+    path: '/repo/feature',
+    status: 'active',
+    is_default: false,
+    branch_renamed: 1,
+    last_message_at: null,
+    session_titles: '[]',
+    last_model_provider_id: null,
+    last_model_id: null,
+    last_model_variant: null,
+    attachments: '[]',
+    pinned: 0,
+    context: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    base_branch: 'main',
+    created_at: '2026-04-26T00:00:00.000Z',
+    last_accessed_at: '2026-04-26T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+const baseWorktree = makeWorktree({
+  id: 'base-wt',
+  name: 'main',
+  branch_name: 'main',
+  path: '/repo/main',
+  is_default: true,
+  base_branch: null
+})
+
+const project: Project = {
+  id: 'project-1',
+  name: 'Project',
+  path: '/repo/main',
+  description: null,
+  tags: null,
+  language: null,
+  custom_icon: null,
+  detected_icon: null,
+  setup_script: null,
+  run_script: null,
+  archive_script: null,
+  auto_assign_port: false,
+  sort_order: 0,
+  created_at: '2026-04-26T00:00:00.000Z',
+  last_accessed_at: '2026-04-26T00:00:00.000Z'
+}
+
+describe('MergeOnDoneDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    Object.defineProperty(window, 'kanban', {
+      writable: true,
+      configurable: true,
+      value: {
+        ticket: {
+          move: ticketMove.mockResolvedValue(undefined)
+        }
+      }
+    })
+
+    Object.defineProperty(window, 'db', {
+      writable: true,
+      configurable: true,
+      value: {
+        worktree: {
+          get: vi.fn().mockResolvedValue(makeWorktree()),
+          getActiveByProject: vi.fn().mockResolvedValue([makeWorktree(), baseWorktree])
+        },
+        project: {
+          get: vi.fn().mockResolvedValue(project)
+        }
+      }
+    })
+
+    Object.defineProperty(window, 'gitOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        hasUncommittedChanges: vi.fn().mockResolvedValue(false),
+        branchDiffShortStat: vi.fn().mockResolvedValue({
+          success: true,
+          filesChanged: 2,
+          insertions: 4,
+          deletions: 1,
+          commitsAhead: 1
+        }),
+        getDiffStat: vi.fn(),
+        getRemoteUrl: vi.fn().mockResolvedValue({ success: true, url: null, remote: null }),
+        pull: vi.fn().mockResolvedValue({ success: true }),
+        merge,
+        mergeAbort
+      }
+    })
+
+    useKanbanStore.setState({
+      tickets: new Map([['project-1', [makeTicket()]]]),
+      pendingDoneMove: {
+        ticketId: 'ticket-1',
+        projectId: 'project-1',
+        sortOrder: 100
+      }
+    })
+  })
+
+  test('keeps ticket in review when merge returns conflicts', async () => {
+    merge.mockResolvedValue({
+      success: false,
+      error: 'Merge conflicts in 1 file(s). Resolve conflicts before continuing.',
+      conflicts: ['src/file.ts']
+    })
+    mergeAbort.mockResolvedValue({ success: true })
+
+    render(<MergeOnDoneDialog />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /^merge$/i }))
+
+    await waitFor(() => {
+      expect(mergeAbort).toHaveBeenCalledWith('/repo/main')
+    })
+
+    expect(ticketMove).not.toHaveBeenCalled()
+    expect(useKanbanStore.getState().tickets.get('project-1')?.[0]?.column).toBe('review')
+    expect(useKanbanStore.getState().pendingDoneMove).toBeNull()
+    expect(toastError).toHaveBeenCalledWith('Merge conflicts in 1 file — merge manually')
+  })
+
+  test('keeps ticket in review when merge fails without conflicts', async () => {
+    merge.mockResolvedValue({
+      success: false,
+      error: 'merge failed'
+    })
+
+    render(<MergeOnDoneDialog />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /^merge$/i }))
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith('Merge failed: merge failed')
+    })
+
+    expect(mergeAbort).not.toHaveBeenCalled()
+    expect(ticketMove).not.toHaveBeenCalled()
+    expect(useKanbanStore.getState().tickets.get('project-1')?.[0]?.column).toBe('review')
+    expect(useKanbanStore.getState().pendingDoneMove).toBeNull()
+  })
+
+  test('moves ticket to done only after a successful merge reaches the archive step', async () => {
+    merge.mockResolvedValue({ success: true })
+
+    render(<MergeOnDoneDialog />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /^merge$/i }))
+
+    const keepButton = await screen.findByRole('button', { name: 'Keep' })
+    expect(ticketMove).not.toHaveBeenCalled()
+
+    fireEvent.click(keepButton)
+
+    await waitFor(() => {
+      expect(ticketMove).toHaveBeenCalledWith('ticket-1', 'done', 100)
+    })
+    expect(useKanbanStore.getState().tickets.get('project-1')?.[0]?.column).toBe('done')
+    expect(useKanbanStore.getState().pendingDoneMove).toBeNull()
+    expect(toastSuccess).toHaveBeenCalledWith('Branch merged successfully')
+  })
+})

--- a/test/usage/usage-normalization.test.ts
+++ b/test/usage/usage-normalization.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeUsage } from '@/stores/useUsageStore'
+
+describe('normalizeUsage', () => {
+  it('treats malformed Anthropic usage as unavailable', () => {
+    const usage = normalizeUsage(
+      'anthropic',
+      {
+        type: 'error',
+        message: 'An unexpected error occurred'
+      } as never,
+      null
+    )
+
+    expect(usage).toBeNull()
+  })
+
+  it('treats Anthropic usage with a null quota window as unavailable', () => {
+    const usage = normalizeUsage(
+      'anthropic',
+      {
+        five_hour: {
+          utilization: 12,
+          resets_at: '2026-04-29T18:00:00.000Z'
+        },
+        seven_day: null
+      } as never,
+      null
+    )
+
+    expect(usage).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Validate Anthropic usage payloads before treating them as available.
- Return `null` when the payload is malformed or missing quota windows instead of passing error-shaped data through.
- Add regression tests covering malformed Anthropic usage and a `null` quota window.

## Testing
- Added Vitest coverage in `test/usage/usage-normalization.test.ts` for malformed Anthropic data.
- Added Vitest coverage for Anthropic usage with a `null` `seven_day` window.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect kanban ticket state transitions around git merge checks; incorrect handling could block or mis-route tickets, though the scope is localized and covered by new tests.
> 
> **Overview**
> **Hardens Anthropic usage normalization** by validating the shape of the returned payload before treating it as available; malformed/missing quota-window data now normalizes to `null`, with new Vitest coverage for error-shaped and partially-null payloads.
> 
> **Tightens Kanban “merge-on-done” behavior** so failures to compute branch stats (or merge errors/conflicts) no longer silently fall back to moving the ticket to Done; instead the UI warns and clears the pending move to keep the ticket in Review, updates copy (“Keep in Review”), and adds regression tests covering merge failure/conflict and successful merge gating the final move to Done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd8def8711ea8f8879527bdc0cb50a79d34c3bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->