### PR TITLE
Fix Ghostty terminal visibility during bottom panel collapse

### DIFF
--- a/src/renderer/src/components/layout/RightSidebar.tsx
+++ b/src/renderer/src/components/layout/RightSidebar.tsx
@@ -10,6 +10,7 @@ import { BottomPanel } from './BottomPanel'
 import { useTerminalPortal } from '@/contexts/TerminalPortalContext'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { ErrorBoundary, ErrorFallback } from '@/components/error'
+import { cn } from '@/lib/utils'
 
 export function RightSidebar(): React.JSX.Element {
   const { rightSidebarWidth, rightSidebarCollapsed, setRightSidebarWidth, toggleRightSidebar } =
@@ -85,12 +86,23 @@ export function RightSidebar(): React.JSX.Element {
     }
   }
 
-  if (rightSidebarCollapsed) {
-    return <div data-testid="right-sidebar-collapsed" />
-  }
-
+  // CRITICAL: when collapsed, do NOT early-return / unmount the sidebar tree.
+  // Doing so unmounts BottomPanel and the terminal portal target div, which
+  // detaches the createPortal container that TerminalManagerPortal points to.
+  // The Ghostty backends would survive (their NSViews live on the Electron
+  // contentView, not in the DOM), but the prop-change → useEffect →
+  // setVisible(false) chain has been observed to leave previously-active
+  // tabs' NSViews on-screen across collapse. Keeping the tree mounted with
+  // CSS `display:none` keeps the portal target alive, preserves PTY state,
+  // and lets visibility flow through normally on collapse.
   return (
-    <div className="flex flex-shrink-0" data-testid="right-sidebar-container">
+    <div
+      className={cn(
+        'flex flex-shrink-0',
+        rightSidebarCollapsed && 'hidden'
+      )}
+      data-testid={rightSidebarCollapsed ? 'right-sidebar-collapsed' : 'right-sidebar-container'}
+    >
       <ResizeHandle onResize={handleResize} direction="right" />
       <aside
         ref={sidebarRef}

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -44,6 +44,20 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   const initializedRef = useRef<string | null>(null)
   /** Track which backend type is currently mounted */
   const activeBackendTypeRef = useRef<TerminalBackendType | null>(null)
+  /**
+   * Per-setupTerminal-invocation abort token. Each new setupTerminal call
+   * invalidates the previous token; the useEffect cleanup also invalidates
+   * the current token. After the `await getConfig()` checkpoint, we bail
+   * if our captured token has been invalidated. Without this, React
+   * StrictMode's double-mount races two parallel setupTerminal calls past
+   * the pre-await dispose check (both see backendRef=null), so BOTH end
+   * up creating GhosttyBackend instances. The earlier one becomes orphaned
+   * but stays alive — its ResizeObserver keeps firing on-screen syncFrame
+   * IPCs against the same native NSView (surfaces are keyed by terminalId
+   * in main, so both backends share one NSView), undoing every hide the
+   * "current" backend performs on collapse.
+   */
+  const setupAbortRef = useRef<{ aborted: boolean } | null>(null)
 
   const [searchVisible, setSearchVisible] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -62,6 +76,15 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   const ghosttyOverlaySuppressed = useLayoutStore((s) => s.ghosttyOverlaySuppressed)
 
   const effectiveVisible = isVisible && !ghosttyOverlaySuppressed
+
+  // Always-current ref so setupTerminal (a useCallback whose deps intentionally
+  // do NOT include effectiveVisible) can read the latest value when it
+  // recreates the backend. Without this, a recreate that happens while the
+  // panel is collapsed (cwd change, fontSize change, backend swap, StrictMode
+  // double-mount) defaults the new backend's `visible` to true and pins the
+  // NSView on-screen even though the UI is hidden — see GhosttyBackend.mount.
+  const effectiveVisibleRef = useRef(effectiveVisible)
+  effectiveVisibleRef.current = effectiveVisible
 
   // Expose imperative methods to parent via ref
   useImperativeHandle(
@@ -186,6 +209,15 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       const container = containerRef.current
       if (!container) return
 
+      // Invalidate any prior in-flight setupTerminal so its post-await
+      // continuation bails before mounting a backend. Capture our own token
+      // we'll re-check after every async checkpoint below.
+      if (setupAbortRef.current) {
+        setupAbortRef.current.aborted = true
+      }
+      const myAbort = { aborted: false }
+      setupAbortRef.current = myAbort
+
       // Prevent re-initializing for the same terminal+backend combo
       if (initializedRef.current === terminalId && activeBackendTypeRef.current === backendType) {
         return
@@ -200,6 +232,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       // If switching backends on an existing terminal, destroy the old PTY
       if (initializedRef.current === terminalId && activeBackendTypeRef.current !== backendType) {
         await destroyTerminal(terminalId)
+        if (myAbort.aborted) return
       }
 
       initializedRef.current = terminalId
@@ -214,6 +247,16 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       } catch {
         // Failed to fetch config, use defaults
       }
+
+      // CRITICAL: bail out if a newer setupTerminal (StrictMode double-mount,
+      // backend swap, cwd change, or our useEffect cleanup) has superseded
+      // us. Without this guard, React StrictMode races two parallel
+      // setupTerminal calls past the pre-await dispose check and ends up
+      // creating two GhosttyBackend instances for the same terminalId. The
+      // older one becomes orphaned but its ResizeObserver and syncFrame()
+      // keep firing on-screen setFrame IPCs to the shared native NSView,
+      // undoing every hideSurface() the "current" backend performs.
+      if (myAbort.aborted) return
 
       const backend = createBackend(backendType)
 
@@ -231,7 +274,14 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
           fontSize: config.fontSize,
           cursorStyle: config.cursorStyle,
           scrollback: config.scrollbackLimit,
-          shell: config.shell
+          shell: config.shell,
+          // Seed visibility from the current UI state. Critical when the
+          // backend is recreated (e.g. fontSize change, cwd change, StrictMode
+          // double-mount) while the bottom panel is collapsed: defaulting to
+          // `true` would pin the Ghostty NSView on-screen and no later
+          // setVisible call would move it (because effectiveVisible never
+          // changes after recreation).
+          initialVisible: effectiveVisibleRef.current
         },
         {
           onStatusChange: (status, code) => {
@@ -276,6 +326,13 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     setupTerminal(embeddedTerminalBackend || 'xterm')
 
     return () => {
+      // Invalidate the in-flight setupTerminal so its post-await continuation
+      // bails before mounting a backend after we're (potentially fake-)unmounted.
+      // Required to avoid orphaned GhosttyBackend instances under React
+      // StrictMode's double-mount.
+      if (setupAbortRef.current) {
+        setupAbortRef.current.aborted = true
+      }
       if (backendRef.current) {
         backendRef.current.dispose()
         backendRef.current = null

--- a/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
@@ -181,6 +181,14 @@ export class GhosttyBackend implements TerminalBackend {
   private hideSurface(): void {
     if (!this.surfaceCreated) return
 
+    // Drop any rAF-scheduled syncFrame so a ResizeObserver firing that
+    // landed microseconds before setVisible(false) cannot race the hide
+    // IPC and leave the NSView on-screen with a shrinking height.
+    if (this.syncFrameTimer !== null) {
+      cancelAnimationFrame(this.syncFrameTimer)
+      this.syncFrameTimer = null
+    }
+
     window.terminalOps.ghosttySetFocus(this.terminalId, false).catch(() => {
       // Ignore focus errors
     })
@@ -255,8 +263,14 @@ export class GhosttyBackend implements TerminalBackend {
   /**
    * Schedule a syncFrame on the next animation frame.
    * Coalesces rapid ResizeObserver firings into a single update.
+   *
+   * Defense-in-depth: while hidden, don't even schedule — avoids a race
+   * where a rAF scheduled by the ResizeObserver during a collapse
+   * transition could land between hideSurface()'s cancel and the actual
+   * setFrame IPC, re-positioning the NSView back on-screen.
    */
   private debouncedSyncFrame(): void {
+    if (!this.visible) return
     if (this.syncFrameTimer !== null) return
     this.syncFrameTimer = requestAnimationFrame(() => {
       this.syncFrameTimer = null
@@ -280,6 +294,13 @@ export class GhosttyBackend implements TerminalBackend {
       }
       return
     }
+
+    // While hidden, never update the native frame. Without this guard, a
+    // ResizeObserver firing during a collapse transition (or the window
+    // resize listener, or resize(cols,rows)) would re-position the NSView
+    // back on-screen after hideSurface() moved it off-screen — leaving a
+    // thin strip of terminal visible below the collapsed bottom bar.
+    if (!this.visible) return
 
     const rect = this.getContainerRect()
     if (!rect) return

--- a/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
@@ -38,7 +38,15 @@ export class GhosttyBackend implements TerminalBackend {
     this.opts = opts
     this.callbacks = callbacks
     this.mounted = true
-    this.visible = true
+    // Seed visibility from the host's current UI state. If the host (e.g. the
+    // bottom-panel terminal) is collapsed at recreation time — common after a
+    // cwd/fontSize/backend-setting change or a React StrictMode double-mount —
+    // defaulting to `true` would let ensureSurface() run the on-screen
+    // syncFrame branch and pin the NSView to a stale on-screen rect that no
+    // later setVisible(false) can move (because effectiveVisible never
+    // changes). Honoring opts.initialVisible avoids that "ghost terminal"
+    // state on collapse.
+    this.visible = opts.initialVisible ?? true
     this.runtimeReady = false
     this.runtimeInitPromise = null
     this.createSurfacePromise = null
@@ -126,8 +134,25 @@ export class GhosttyBackend implements TerminalBackend {
       if (!rect) return
       this.lastVisibleRect = rect
 
+      // If we already know the backend should be hidden (e.g., user collapsed
+      // the panel before this surface finished creating, or initialVisible was
+      // false from mount because the panel was already collapsed), pass
+      // off-screen x/y to ghosttyCreateSurface so the native NSView is BORN
+      // off-screen instead of flashing at the container's last on-screen
+      // position before our follow-up hideSurface IPC arrives. We keep w/h
+      // from the real rect so the PTY grid sizes correctly for when the
+      // surface eventually becomes visible.
+      const createRect = this.visible
+        ? rect
+        : {
+            x: GhosttyBackend.HIDDEN_RECT.x,
+            y: GhosttyBackend.HIDDEN_RECT.y,
+            w: rect.w,
+            h: rect.h
+          }
+
       try {
-        const result = await window.terminalOps.ghosttyCreateSurface(this.terminalId, rect, {
+        const result = await window.terminalOps.ghosttyCreateSurface(this.terminalId, createRect, {
           cwd: this.opts.cwd,
           shell: this.opts.shell,
           scaleFactor: window.devicePixelRatio || 2.0,

--- a/src/renderer/src/components/terminal/backends/types.ts
+++ b/src/renderer/src/components/terminal/backends/types.ts
@@ -14,6 +14,24 @@ export interface TerminalOpts {
   scrollback?: number
   theme?: Record<string, string>
   shell?: string
+  /**
+   * Whether the terminal is visible at the moment of mount.
+   *
+   * Critical for Ghostty: the native NSView is positioned exclusively from JS
+   * via setFrame IPC. When the host (TerminalView) recreates the backend
+   * — e.g. after `cwd` change, font-size change, backend setting change, or
+   * React StrictMode double-mount — the visibility useEffect does NOT re-fire
+   * unless `effectiveVisible` itself changes. If the panel is already
+   * collapsed at recreation time and we default `this.visible = true`,
+   * ensureSurface() will run the on-screen syncFrame branch and the NSView
+   * will be positioned at the (still-measurable) container's rect — which
+   * during a collapse CSS transition is a shrinking on-screen rect that no
+   * later setVisible call can move. Pass the current `effectiveVisible` so
+   * mount() seeds the backend's visible flag correctly.
+   *
+   * Defaults to `true` for back-compat; the xterm backend ignores it.
+   */
+  initialVisible?: boolean
 }
 
 /**

--- a/test/terminal/ghostty-backend-visibility.test.ts
+++ b/test/terminal/ghostty-backend-visibility.test.ts
@@ -268,4 +268,151 @@ describe('GhosttyBackend visibility', () => {
     // The orphaned native surface must be destroyed to avoid leaking NSViews.
     expect(mockTerminalOps.ghosttyDestroySurface).toHaveBeenCalledWith('wt-1')
   })
+
+  test('cancels pending rAF when setVisible(false) races an already-scheduled syncFrame', async () => {
+    // Regression test for a subtle ordering of the "thin line" bug:
+    // When the panel collapses, the browser fires ResizeObserver BEFORE React
+    // runs useEffect (RO callbacks run in the pre-paint step, useEffect runs
+    // after paint). That schedules a rAF that, if allowed to run, would send
+    // an on-screen setFrame IPC with the shrinking-height rect RIGHT BEFORE
+    // setVisible(false) sends its off-screen IPC — leaving the NSView on-screen
+    // with a tiny height (the "thin line" the user sees). The fix:
+    //   - hideSurface() cancels this.syncFrameTimer before sending its IPC
+    //   - debouncedSyncFrame() early-returns while hidden as defense-in-depth
+    const backend = new GhosttyBackend()
+    const container = document.createElement('div')
+    let rect = {
+      left: 100,
+      top: 80,
+      width: 640,
+      height: 360,
+      right: 740,
+      bottom: 440,
+      x: 100,
+      y: 80,
+      toJSON: () => ({})
+    }
+    container.getBoundingClientRect = vi.fn(() => rect)
+
+    backend.mount(
+      container,
+      {
+        terminalId: 'wt-1',
+        cwd: '/tmp/wt-1'
+      },
+      {
+        onStatusChange: vi.fn()
+      }
+    )
+
+    await flushPromises()
+
+    const visibilityBackend = backend as unknown as {
+      setVisible: (visible: boolean) => void
+    }
+
+    mockTerminalOps.ghosttySetFrame.mockClear()
+
+    // RO fires first with a shrinking rect and schedules an rAF for syncFrame.
+    rect = { ...rect, height: 60, bottom: rect.top + 60 }
+    observers[0].trigger(container)
+
+    // CRITICAL: do NOT flush the rAF yet — setVisible(false) must race it.
+    visibilityBackend.setVisible(false)
+
+    // Now flush the rAF. If hideSurface() didn't cancel it and the guard
+    // didn't block syncFrame, an on-screen IPC with the shrinking rect
+    // would fire AFTER the off-screen one, leaving a thin line of terminal.
+    await flushPromises()
+    await flushPromises()
+
+    // The final IPC must be off-screen, and no intermediate on-screen IPC
+    // may exist between the hide and the end of the flush.
+    const calls = mockTerminalOps.ghosttySetFrame.mock.calls
+    expect(calls.length).toBeGreaterThan(0)
+    const lastFrame = calls.at(-1)?.[1] as { x: number; y: number }
+    expect(lastFrame.x).toBeLessThan(0)
+    expect(lastFrame.y).toBeLessThan(0)
+
+    // Stronger claim: no on-screen frame ever made it through while hidden.
+    for (const call of calls) {
+      const frame = call[1] as { x: number; y: number }
+      expect(frame.x).toBeLessThan(0)
+      expect(frame.y).toBeLessThan(0)
+    }
+
+    backend.dispose()
+  })
+
+  test('ignores ResizeObserver triggers after setVisible(false) during a collapse transition', async () => {
+    // Regression test for the "thin line" bug: when the bottom panel is
+    // collapsed with a CSS `height` transition, ResizeObserver fires
+    // repeatedly with shrinking-height on-screen rects. Those firings must
+    // NOT re-position the native NSView back on-screen after setVisible(false)
+    // has moved it off-screen via hideSurface().
+    const backend = new GhosttyBackend()
+    const container = document.createElement('div')
+    let rect = {
+      left: 100,
+      top: 80,
+      width: 640,
+      height: 360,
+      right: 740,
+      bottom: 440,
+      x: 100,
+      y: 80,
+      toJSON: () => ({})
+    }
+    container.getBoundingClientRect = vi.fn(() => rect)
+
+    backend.mount(
+      container,
+      {
+        terminalId: 'wt-1',
+        cwd: '/tmp/wt-1'
+      },
+      {
+        onStatusChange: vi.fn()
+      }
+    )
+
+    await flushPromises()
+
+    const visibilityBackend = backend as unknown as {
+      setVisible: (visible: boolean) => void
+    }
+
+    // Collapse the panel: setVisible(false) fires hideSurface() → off-screen IPC.
+    visibilityBackend.setVisible(false)
+
+    const hiddenFrame = mockTerminalOps.ghosttySetFrame.mock.calls.at(-1)?.[1]
+    expect(hiddenFrame.x).toBeLessThan(0)
+    expect(hiddenFrame.y).toBeLessThan(0)
+
+    mockTerminalOps.ghosttySetFrame.mockClear()
+
+    // Simulate a CSS height transition firing ResizeObserver repeatedly with
+    // shrinking on-screen rects (180 → 60 → 5 pixels tall, still visible).
+    for (const height of [180, 60, 5]) {
+      rect = {
+        ...rect,
+        height,
+        bottom: rect.top + height
+      }
+      observers[0].trigger(container)
+      // Flush the requestAnimationFrame-scheduled syncFrame.
+      await flushPromises()
+    }
+
+    // None of those ResizeObserver-driven frames should have updated the
+    // native NSView position back to an on-screen rect. Either no call was
+    // made, or the call kept the off-screen x/y.
+    for (const call of mockTerminalOps.ghosttySetFrame.mock.calls) {
+      const frame = call[1] as { x: number; y: number; w: number; h: number }
+      expect(frame.x).toBeLessThan(0)
+      expect(frame.y).toBeLessThan(0)
+    }
+
+    backend.dispose()
+  })
 })

--- a/test/terminal/ghostty-backend-visibility.test.ts
+++ b/test/terminal/ghostty-backend-visibility.test.ts
@@ -269,6 +269,135 @@ describe('GhosttyBackend visibility', () => {
     expect(mockTerminalOps.ghosttyDestroySurface).toHaveBeenCalledWith('wt-1')
   })
 
+  test('passes off-screen rect to ghosttyCreateSurface when initialVisible=false', async () => {
+    // Regression test for "terminal pops from the bottom" on collapse-with-new-tab:
+    // when the user opens a new tab and immediately collapses the panel, the new
+    // tab's setVisible(false) fires before its surface has been created. hideSurface
+    // early-returns. ensureSurface's IPC continues to fire with the *container's
+    // on-screen rect captured before collapse* — native creates the NSView at that
+    // on-screen position, then ensureSurface's else branch fires hideSurface to
+    // move it off-screen. The user sees a 20-50 ms visible flash at the panel's
+    // bottom rect ("popping from the bottom").
+    //
+    // Fix: when this.visible is false at IPC-send time, pass HIDDEN_RECT.x/y
+    // (with the real container w/h to keep the PTY grid sized correctly) so
+    // the native NSView is born off-screen — no flash possible.
+    const backend = new GhosttyBackend()
+    const container = document.createElement('div')
+    container.getBoundingClientRect = vi.fn(() => ({
+      left: 100,
+      top: 80,
+      width: 640,
+      height: 360,
+      right: 740,
+      bottom: 440,
+      x: 100,
+      y: 80,
+      toJSON: () => ({})
+    }))
+
+    backend.mount(
+      container,
+      {
+        terminalId: 'wt-1',
+        cwd: '/tmp/wt-1',
+        initialVisible: false
+      },
+      {
+        onStatusChange: vi.fn()
+      }
+    )
+
+    await flushPromises()
+    await flushPromises()
+
+    expect(mockTerminalOps.ghosttyCreateSurface).toHaveBeenCalledTimes(1)
+
+    // The rect passed to ghosttyCreateSurface itself must already be off-screen.
+    const createRect = mockTerminalOps.ghosttyCreateSurface.mock.calls[0][1] as {
+      x: number
+      y: number
+      w: number
+      h: number
+    }
+    expect(createRect.x).toBeLessThan(0)
+    expect(createRect.y).toBeLessThan(0)
+    // ...and dimensions must match the container so the PTY grid is sized
+    // correctly when we later move the surface on-screen.
+    expect(createRect.w).toBe(640)
+    expect(createRect.h).toBe(360)
+
+    backend.dispose()
+  })
+
+  test('respects initialVisible=false from mount and never shows surface on-screen', async () => {
+    // Regression test for: when TerminalView recreates a GhosttyBackend (e.g.,
+    // after cwd change, fontSize change, or React StrictMode double-mount)
+    // while the bottom panel is collapsed, the new backend must not flash the
+    // native surface on-screen.
+    //
+    // Before the fix, mount() always set this.visible = true regardless of
+    // the UI's actual visibility. The visibility useEffect in TerminalView
+    // only re-fires on effectiveVisible *changes*, so if the panel was
+    // already collapsed when the new backend was created, this.visible
+    // stayed stale-true. ensureSurface() would then run the on-screen
+    // syncFrame() branch when the container had any non-zero size (e.g.
+    // mid-CSS-collapse-transition), positioning the NSView at an on-screen
+    // shrinking-height rect that no later setVisible call could move (because
+    // effectiveVisible never changed).
+    //
+    // The fix: TerminalOpts.initialVisible lets the host pass the current
+    // effectiveVisible, so mount() seeds this.visible correctly. When the
+    // surface eventually resolves, ensureSurface() takes the hideSurface
+    // branch and the NSView goes off-screen.
+    const backend = new GhosttyBackend()
+    const container = document.createElement('div')
+    container.getBoundingClientRect = vi.fn(() => ({
+      left: 100,
+      top: 80,
+      width: 640,
+      height: 360,
+      right: 740,
+      bottom: 440,
+      x: 100,
+      y: 80,
+      toJSON: () => ({})
+    }))
+
+    backend.mount(
+      container,
+      {
+        terminalId: 'wt-1',
+        cwd: '/tmp/wt-1',
+        initialVisible: false
+      },
+      {
+        onStatusChange: vi.fn()
+      }
+    )
+
+    await flushPromises()
+    await flushPromises()
+
+    // Surface gets created because the container is measurable.
+    expect(mockTerminalOps.ghosttyCreateSurface).toHaveBeenCalledTimes(1)
+
+    // The post-creation setFrame call must position the NSView OFF-screen,
+    // because initialVisible=false → ensureSurface takes hideSurface branch.
+    expect(mockTerminalOps.ghosttySetFrame).toHaveBeenCalled()
+    for (const call of mockTerminalOps.ghosttySetFrame.mock.calls) {
+      const frame = call[1] as { x: number; y: number }
+      expect(frame.x).toBeLessThan(0)
+      expect(frame.y).toBeLessThan(0)
+    }
+
+    // Focus(true) must NOT have been requested — that path runs only on the
+    // visible branch and would race a focused web input on initial mount.
+    expect(mockTerminalOps.ghosttySetFocus).not.toHaveBeenCalledWith('wt-1', true)
+
+    backend.dispose()
+  })
+
   test('cancels pending rAF when setVisible(false) races an already-scheduled syncFrame', async () => {
     // Regression test for a subtle ordering of the "thin line" bug:
     // When the panel collapses, the browser fires ResizeObserver BEFORE React


### PR DESCRIPTION
## Summary
- Keep the right sidebar mounted when collapsed so the terminal portal target survives and visibility updates continue to flow.
- Seed Ghostty backend visibility from the current UI state on mount, preventing recreated backends from flashing on-screen while the panel is collapsed.
- Add guards to cancel stale setup work and block hidden-frame updates/rAF syncs that could re-position the native surface during collapse transitions.
- Add regression tests covering off-screen surface creation, hidden re-mount behavior, and collapse race conditions.

## Testing
- Added `test/terminal/ghostty-backend-visibility.test.ts` coverage for collapsed mount, recreate-after-collapse, rAF cancellation, and ResizeObserver collapse transitions.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal backend lifecycle and native Ghostty surface positioning, with several race-condition fixes (StrictMode, ResizeObserver, portal unmount) that could regress visibility or resource cleanup if incorrect.
> 
> **Overview**
> Fixes Ghostty terminal visibility glitches during sidebar/bottom-panel collapse by **keeping the right sidebar tree mounted** (hide via CSS instead of unmounting) so the terminal portal target and state remain stable.
> 
> Adds lifecycle and race-condition guards in `TerminalView` and `GhosttyBackend`: `setupTerminal` calls are now abortable to prevent orphaned backends under React StrictMode, Ghostty mounts now take an `initialVisible` hint, hidden surfaces are created off-screen, and hidden-state frame syncs/rAF updates are suppressed/cancelled to avoid “thin line”/flash-on-collapse artifacts.
> 
> Extends `GhosttyBackend` visibility test coverage with regressions for off-screen creation, hidden remount behavior, rAF cancellation, and ResizeObserver collapse transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1adbf9cca83302492995468e485722d414a36678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->