### PR TITLE
Allow skipping commit or merge when moving ticket to Done

### DIFF
--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -438,18 +438,28 @@ export function MergeOnDoneDialog() {
               >
                 Keep in Review
               </button>
-              <Button
-                size="sm"
-                onClick={handleCommitBase}
-                disabled={!baseCommitMessage.trim() || committingBase}
-              >
-                {committingBase ? (
-                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                ) : (
-                  <GitCommit className="h-3 w-3 mr-1" />
-                )}
-                Commit
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => completeDoneMove()}
+                  disabled={committingBase}
+                >
+                  Move to Done anyway
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleCommitBase}
+                  disabled={!baseCommitMessage.trim() || committingBase}
+                >
+                  {committingBase ? (
+                    <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                  ) : (
+                    <GitCommit className="h-3 w-3 mr-1" />
+                  )}
+                  Commit
+                </Button>
+              </div>
             </div>
           </div>
         )}
@@ -473,18 +483,28 @@ export function MergeOnDoneDialog() {
               >
                 Keep in Review
               </button>
-              <Button
-                size="sm"
-                onClick={handleCommit}
-                disabled={!commitMessage.trim() || committing}
-              >
-                {committing ? (
-                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                ) : (
-                  <GitCommit className="h-3 w-3 mr-1" />
-                )}
-                Commit
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => completeDoneMove()}
+                  disabled={committing}
+                >
+                  Move to Done anyway
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleCommit}
+                  disabled={!commitMessage.trim() || committing}
+                >
+                  {committing ? (
+                    <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                  ) : (
+                    <GitCommit className="h-3 w-3 mr-1" />
+                  )}
+                  Commit
+                </Button>
+              </div>
             </div>
           </div>
         )}
@@ -509,14 +529,24 @@ export function MergeOnDoneDialog() {
               >
                 Keep in Review
               </button>
-              <Button size="sm" onClick={handleMerge} disabled={merging}>
-                {merging ? (
-                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                ) : (
-                  <GitMerge className="h-3 w-3 mr-1" />
-                )}
-                Merge
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => completeDoneMove()}
+                  disabled={merging}
+                >
+                  Move to Done anyway
+                </Button>
+                <Button size="sm" onClick={handleMerge} disabled={merging}>
+                  {merging ? (
+                    <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                  ) : (
+                    <GitMerge className="h-3 w-3 mr-1" />
+                  )}
+                  Merge
+                </Button>
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Adds a "Move to Done anyway" action to the merge-on-done dialog.
- Keeps the existing commit and merge flows intact while letting users complete the Done move without creating a commit or merge.
- Applies the new escape hatch across the base commit, regular commit, and merge states.

## Testing
- Not run.
- Reviewed the dialog diff to confirm the new button calls `completeDoneMove()` and existing commit/merge actions remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new workflow path that lets users bypass commit/merge steps, which could result in tickets being marked Done while Git state remains dirty or unmerged. Change is UI-only but impacts a core “move to Done” workflow.
> 
> **Overview**
> Allows users to complete a ticket’s move to **Done** even when the merge-on-done dialog detects uncommitted changes or pending merges.
> 
> In `MergeOnDoneDialog`, each of the `commit_base`, `commit`, and `merge` steps now shows a new *Move to Done anyway* button that calls `completeDoneMove()` while preserving the existing commit/merge actions and disabling the skip action during in-progress operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d03914a8a24a9dd3fa68c501fcbd41a722b38b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->