### PR TITLE
Prevent pet drag from activating Hive

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -67,7 +67,12 @@ import { initTicketProviderManager, GitHubProvider, JiraProvider } from './servi
 import { APP_SETTINGS_DB_KEY } from '../shared/types/settings'
 import { openCodeService } from './services/opencode-service'
 import { setKeepAwake, cleanupPowerSaveBlocker } from './services/power-save-blocker'
-import { configurePetWindow, destroyPetWindow, getPetWindow } from './services/pet-window'
+import {
+  configurePetWindow,
+  destroyPetWindow,
+  getPetWindow,
+  shouldSuppressMainWindowActivationFromPet
+} from './services/pet-window'
 
 const log = createLogger({ component: 'Main' })
 
@@ -696,6 +701,10 @@ app.whenReady().then(async () => {
 
   app.on('activate', function () {
     ensureDockVisible('activate')
+
+    if (shouldSuppressMainWindowActivationFromPet()) {
+      return
+    }
 
     // The pet overlay is an auxiliary window and should not count as a main app
     // window for Dock activation. If only the pet exists, re-create Hive.

--- a/src/main/ipc/pet-handlers.ts
+++ b/src/main/ipc/pet-handlers.ts
@@ -1,8 +1,10 @@
 import { ipcMain } from 'electron'
 import type { PetPosition, PetSettings, PetStatusPayload } from '../../shared/types/pet'
 import {
+  beginPetPointerInteraction,
   createPetWindow,
   destroyPetWindow,
+  endPetPointerInteraction,
   focusMainWindowFromPet,
   forwardStatusToPet,
   getCurrentPetStatus,
@@ -28,6 +30,14 @@ export function registerPetHandlers(): void {
 
   ipcMain.on('pet:set-ignore-mouse', (_event, payload: { ignore: boolean }) => {
     setPetIgnoreMouseEvents(Boolean(payload.ignore))
+  })
+
+  ipcMain.on('pet:begin-pointer-interaction', () => {
+    beginPetPointerInteraction()
+  })
+
+  ipcMain.on('pet:end-pointer-interaction', () => {
+    endPetPointerInteraction()
   })
 
   ipcMain.on('pet:move', (_event, payload: PetPosition) => {

--- a/src/main/services/pet-window.ts
+++ b/src/main/services/pet-window.ts
@@ -15,6 +15,7 @@ import type {
 const PET_POSITION_FILE = join(app.getPath('userData'), 'pet-position.json')
 const PET_PADDING = 48
 const SCREEN_MARGIN = 24
+const PET_POINTER_INTERACTION_SUPPRESSION_MS = 250
 
 export const DEFAULT_PET_SETTINGS: PetSettings = {
   enabled: false,
@@ -81,6 +82,8 @@ let petWindow: BrowserWindow | null = null
 let getMainWindow: (() => BrowserWindow | null) | null = null
 let latestStatus: PetStatusPayload = { state: 'idle', sourceWorktreeId: null }
 let latestSettings: PetSettings = DEFAULT_PET_SETTINGS
+let petPointerInteractionActive = false
+let petPointerInteractionTimer: NodeJS.Timeout | null = null
 
 function ensureRegularMacAppActivation(): void {
   if (process.platform !== 'darwin') return
@@ -180,6 +183,30 @@ export function getPetWindow(): BrowserWindow | null {
   return petWindow
 }
 
+function clearPetPointerInteractionTimer(): void {
+  if (petPointerInteractionTimer) {
+    clearTimeout(petPointerInteractionTimer)
+    petPointerInteractionTimer = null
+  }
+}
+
+export function beginPetPointerInteraction(): void {
+  clearPetPointerInteractionTimer()
+  petPointerInteractionActive = true
+}
+
+export function endPetPointerInteraction(): void {
+  clearPetPointerInteractionTimer()
+  petPointerInteractionTimer = setTimeout(() => {
+    petPointerInteractionActive = false
+    petPointerInteractionTimer = null
+  }, PET_POINTER_INTERACTION_SUPPRESSION_MS)
+}
+
+export function shouldSuppressMainWindowActivationFromPet(): boolean {
+  return petPointerInteractionActive
+}
+
 export function getCurrentPetStatus(): PetStatusPayload {
   return latestStatus
 }
@@ -216,6 +243,7 @@ export function createPetWindow(): BrowserWindow | null {
     x: position.x,
     y: position.y,
     transparent: true,
+    type: 'panel',
     frame: false,
     hasShadow: false,
     skipTaskbar: true,
@@ -321,6 +349,8 @@ export function persistPetSettings(partial: Partial<PetSettings>): void {
 }
 
 export function focusMainWindowFromPet(worktreeId: string | null): void {
+  clearPetPointerInteractionTimer()
+  petPointerInteractionActive = false
   ensureRegularMacAppActivation()
   const mainWindow = getMainWindow?.() ?? null
   if (!mainWindow || mainWindow.isDestroyed()) return

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -656,6 +656,8 @@ declare global {
       hide: () => Promise<void>
       publishStatus: (payload: PetStatusPayload) => void
       setIgnoreMouse: (ignore: boolean) => void
+      beginPointerInteraction: () => void
+      endPointerInteraction: () => void
       move: (position: PetPosition) => void
       focusMain: (payload: { worktreeId: string | null }) => Promise<void>
       getConfig: () => Promise<{

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -606,6 +606,12 @@ const petOps = {
   setIgnoreMouse: (ignore: boolean): void => {
     ipcRenderer.send('pet:set-ignore-mouse', { ignore })
   },
+  beginPointerInteraction: (): void => {
+    ipcRenderer.send('pet:begin-pointer-interaction')
+  },
+  endPointerInteraction: (): void => {
+    ipcRenderer.send('pet:end-pointer-interaction')
+  },
   move: (position: PetPosition): void => {
     ipcRenderer.send('pet:move', position)
   },

--- a/src/renderer/src/pet/PetApp.tsx
+++ b/src/renderer/src/pet/PetApp.tsx
@@ -58,8 +58,10 @@ export function PetApp(): React.JSX.Element {
     window.petOps.markHatched()
   }, [])
 
-  const handleClick = useCallback(() => {
+  const handleClick = useCallback((event: React.MouseEvent<HTMLElement>) => {
     if (wasDraggedRef.current) {
+      event.preventDefault()
+      event.stopPropagation()
       wasDraggedRef.current = false
       return
     }

--- a/src/renderer/src/pet/PetSprite.tsx
+++ b/src/renderer/src/pet/PetSprite.tsx
@@ -60,7 +60,7 @@ export function PetSprite({
   onPointerDown: (event: React.PointerEvent<HTMLElement>) => void
   onMouseEnter: () => void
   onMouseLeave: () => void
-  onClick: () => void
+  onClick: (event: React.MouseEvent<HTMLElement>) => void
   onContextMenu: (event: React.MouseEvent<HTMLElement>) => void
 }): React.JSX.Element {
   const size = SIZE_PX[settings.size]

--- a/src/renderer/src/pet/usePetDrag.ts
+++ b/src/renderer/src/pet/usePetDrag.ts
@@ -1,6 +1,8 @@
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import type * as React from 'react'
 import type { PetPosition } from '@shared/types/pet'
+
+const RESTORE_IGNORE_MOUSE_DELAY_MS = 100
 
 export function usePetDrag(initialPosition: PetPosition | null): {
   isDraggingRef: React.MutableRefObject<boolean>
@@ -19,10 +21,28 @@ export function usePetDrag(initialPosition: PetPosition | null): {
   } | null>(null)
   const isDraggingRef = useRef(false)
   const wasDraggedRef = useRef(false)
+  const restoreIgnoreMouseTimerRef = useRef<number | null>(null)
 
   if (initialPosition) {
     positionRef.current = initialPosition
   }
+
+  const clearRestoreIgnoreMouseTimer = useCallback(() => {
+    if (restoreIgnoreMouseTimerRef.current !== null) {
+      window.clearTimeout(restoreIgnoreMouseTimerRef.current)
+      restoreIgnoreMouseTimerRef.current = null
+    }
+  }, [])
+
+  const restoreIgnoreMouseAfterClick = useCallback(() => {
+    clearRestoreIgnoreMouseTimer()
+    restoreIgnoreMouseTimerRef.current = window.setTimeout(() => {
+      restoreIgnoreMouseTimerRef.current = null
+      window.petOps.setIgnoreMouse(true)
+    }, RESTORE_IGNORE_MOUSE_DELAY_MS)
+  }, [clearRestoreIgnoreMouseTimer])
+
+  useEffect(() => clearRestoreIgnoreMouseTimer, [clearRestoreIgnoreMouseTimer])
 
   const flushMove = useCallback(() => {
     const drag = dragRef.current
@@ -39,8 +59,10 @@ export function usePetDrag(initialPosition: PetPosition | null): {
       if (event.button !== 0) return
 
       event.currentTarget.setPointerCapture(event.pointerId)
+      clearRestoreIgnoreMouseTimer()
       isDraggingRef.current = true
       wasDraggedRef.current = false
+      window.petOps.beginPointerInteraction()
       window.petOps.setIgnoreMouse(false)
 
       dragRef.current = {
@@ -82,7 +104,8 @@ export function usePetDrag(initialPosition: PetPosition | null): {
         }
         dragRef.current = null
         isDraggingRef.current = false
-        window.petOps.setIgnoreMouse(true)
+        window.petOps.endPointerInteraction()
+        restoreIgnoreMouseAfterClick()
         window.removeEventListener('pointermove', handlePointerMove)
         window.removeEventListener('pointerup', stopDrag)
         window.removeEventListener('pointercancel', stopDrag)
@@ -92,7 +115,7 @@ export function usePetDrag(initialPosition: PetPosition | null): {
       window.addEventListener('pointerup', stopDrag)
       window.addEventListener('pointercancel', stopDrag)
     },
-    [flushMove, isDraggingRef, wasDraggedRef]
+    [clearRestoreIgnoreMouseTimer, flushMove, isDraggingRef, restoreIgnoreMouseAfterClick, wasDraggedRef]
   )
 
   return { isDraggingRef, wasDraggedRef, onPointerDown }

--- a/test/main/pet-window-activation.test.ts
+++ b/test/main/pet-window-activation.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronMock = vi.hoisted(() => {
+  const windows: Array<Record<string, unknown>> = []
+  const BrowserWindow = vi.fn((options: Record<string, unknown>) => {
+    const window = {
+      options,
+      isDestroyed: vi.fn(() => false),
+      getPosition: vi.fn(() => [options.x ?? 0, options.y ?? 0]),
+      getBounds: vi.fn(() => ({ width: options.width ?? 0, height: options.height ?? 0 })),
+      setVisibleOnAllWorkspaces: vi.fn(),
+      setAlwaysOnTop: vi.fn(),
+      setFullScreenable: vi.fn(),
+      setIgnoreMouseEvents: vi.fn(),
+      on: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn(),
+      showInactive: vi.fn(),
+      destroy: vi.fn(),
+      webContents: {
+        send: vi.fn()
+      }
+    }
+    windows.push(window)
+    return window
+  })
+  Object.assign(BrowserWindow, {
+    getAllWindows: vi.fn(() => windows)
+  })
+
+  return {
+    windows,
+    BrowserWindow,
+    app: {
+      getPath: vi.fn(() => '/tmp/hive-pet-window-test'),
+      setActivationPolicy: vi.fn(),
+      dock: {
+        show: vi.fn().mockResolvedValue(undefined)
+      }
+    }
+  }
+})
+
+vi.mock('electron', () => ({
+  app: electronMock.app,
+  BrowserWindow: electronMock.BrowserWindow,
+  screen: {
+    getAllDisplays: vi.fn(() => [
+      { workArea: { x: 0, y: 0, width: 1440, height: 900 } }
+    ]),
+    getDisplayNearestPoint: vi.fn(() => ({
+      workArea: { x: 0, y: 0, width: 1440, height: 900 }
+    })),
+    getPrimaryDisplay: vi.fn(() => ({
+      workArea: { x: 0, y: 0, width: 1440, height: 900 }
+    }))
+  }
+}))
+
+vi.mock('@electron-toolkit/utils', () => ({
+  is: { dev: false }
+}))
+
+vi.mock('../../src/main/db', () => ({
+  getDatabase: vi.fn()
+}))
+
+import {
+  beginPetPointerInteraction,
+  configurePetWindow,
+  createPetWindow,
+  destroyPetWindow,
+  endPetPointerInteraction,
+  focusMainWindowFromPet,
+  shouldSuppressMainWindowActivationFromPet
+} from '../../src/main/services/pet-window'
+
+describe('pet window activation suppression', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    destroyPetWindow()
+    endPetPointerInteraction()
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+    electronMock.windows.length = 0
+    electronMock.BrowserWindow.mockClear()
+  })
+
+  it('suppresses main-window activation during pet pointer interaction until the grace period ends', () => {
+    expect(shouldSuppressMainWindowActivationFromPet()).toBe(false)
+
+    beginPetPointerInteraction()
+    expect(shouldSuppressMainWindowActivationFromPet()).toBe(true)
+
+    endPetPointerInteraction()
+    expect(shouldSuppressMainWindowActivationFromPet()).toBe(true)
+
+    vi.advanceTimersByTime(249)
+    expect(shouldSuppressMainWindowActivationFromPet()).toBe(true)
+
+    vi.advanceTimersByTime(1)
+    expect(shouldSuppressMainWindowActivationFromPet()).toBe(false)
+  })
+
+  it('clears suppression when an explicit pet click focuses the main window', () => {
+    const mainWindow = {
+      isDestroyed: vi.fn(() => false),
+      isMinimized: vi.fn(() => false),
+      restore: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn(),
+      webContents: {
+        send: vi.fn()
+      }
+    }
+
+    configurePetWindow({ getMainWindow: () => mainWindow as never })
+
+    beginPetPointerInteraction()
+    expect(shouldSuppressMainWindowActivationFromPet()).toBe(true)
+
+    focusMainWindowFromPet(null)
+
+    expect(shouldSuppressMainWindowActivationFromPet()).toBe(false)
+    expect(mainWindow.show).toHaveBeenCalledTimes(1)
+    expect(mainWindow.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates the pet as a non-activating macOS panel', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+
+    createPetWindow()
+
+    expect(electronMock.BrowserWindow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'panel',
+        focusable: false,
+        alwaysOnTop: true,
+        skipTaskbar: true
+      })
+    )
+  })
+})

--- a/test/pet/pet-drag-click.test.tsx
+++ b/test/pet/pet-drag-click.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type * as React from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PetApp } from '@/pet/PetApp'
 
 vi.mock('motion/react', () => ({
@@ -49,6 +49,10 @@ describe('PetApp drag and click behavior', () => {
     petOps().onSettingsUpdated.mockReturnValue(() => {})
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('does not open the hive after a drag that moves the pet', async () => {
     render(<PetApp />)
 
@@ -64,6 +68,31 @@ describe('PetApp drag and click behavior', () => {
 
     expect(petOps().move).toHaveBeenCalledWith({ x: 12, y: 20 })
     expect(petOps().focusMain).not.toHaveBeenCalled()
+  })
+
+  it('keeps mouse events captured until the post-drag click has been swallowed', async () => {
+    render(<PetApp />)
+
+    const pet = await screen.findByRole('button', { name: 'Hive pet' })
+    vi.useFakeTimers()
+
+    fireEvent(
+      pet,
+      pointerEvent('pointerdown', { pointerId: 1, button: 0, screenX: 100, screenY: 100 })
+    )
+    window.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, screenX: 120, screenY: 100 }))
+    window.dispatchEvent(pointerEvent('pointerup', { pointerId: 1, screenX: 120, screenY: 100 }))
+
+    expect(petOps().setIgnoreMouse).toHaveBeenLastCalledWith(false)
+
+    fireEvent.click(pet)
+    vi.runOnlyPendingTimers()
+
+    expect(petOps().beginPointerInteraction).toHaveBeenCalledTimes(1)
+    expect(petOps().endPointerInteraction).toHaveBeenCalledTimes(1)
+    expect(petOps().focusMain).not.toHaveBeenCalled()
+    expect(petOps().setIgnoreMouse).toHaveBeenLastCalledWith(true)
+    vi.useRealTimers()
   })
 
   it('opens the hive on an intentional click', async () => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -149,6 +149,8 @@ if (typeof window !== 'undefined') {
         hide: vi.fn().mockResolvedValue(undefined),
         publishStatus: vi.fn(),
         setIgnoreMouse: vi.fn(),
+        beginPointerInteraction: vi.fn(),
+        endPointerInteraction: vi.fn(),
         move: vi.fn(),
         focusMain: vi.fn().mockResolvedValue(undefined),
         getConfig: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- Added a pet pointer-interaction suppression path so dragging the pet no longer reopens or focuses the main window.
- Wired renderer and IPC hooks to mark drag start/end, swallow the post-drag click, and temporarily restore mouse ignoring after drag completion.
- Updated main-process activation handling and pet window configuration to treat the pet overlay as a non-activating panel on macOS.
- Added tests covering activation suppression, focus clearing, panel creation, and drag/click behavior.

## Testing
- `vitest test/main/pet-window-activation.test.ts`
- `vitest test/pet/pet-drag-click.test.tsx`
- Not run: full repository test suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Electron window activation behavior (macOS `app.activate`) and adds new IPC-driven pointer-interaction state that could affect focus/activation edge cases.
> 
> **Overview**
> **Prevents the pet overlay from re-activating Hive during/after drag interactions.** The renderer now signals `beginPointerInteraction`/`endPointerInteraction` around pet drags, swallows the first post-drag click, and delays restoring `setIgnoreMouse(true)` so the click doesn’t reach the Dock/app activation path.
> 
> On the main side, `pet-window` adds a short suppression window for pointer interactions and `src/main/index.ts` skips `app.on('activate')` window activation while suppression is active; the pet `BrowserWindow` is also created as a macOS non-activating `panel`. New tests cover activation suppression timing, focus clearing, panel creation, and drag/click behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58dba5e36ddbcc4186603ee62d1a74c884b38d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->