### PR TITLE
Fix kanban ticket loading on startup

### DIFF
--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -45,6 +45,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const activeBoardAssistantProjectId = useSessionStore((state) => state.activeBoardAssistantProjectId)
   const isBoardViewActive = useKanbanStore((state) => state.isBoardViewActive)
   const isPinnedBoardActive = useKanbanStore((state) => state.isPinnedBoardActive)
+  const connectionsLoaded = useConnectionStore((state) => state.loaded)
   const pinnedStoreLoaded = usePinnedStore((state) => state.loaded)
   const boardMode = useSettingsStore((s) => s.boardMode)
   const terminalPosition = useSettingsStore((s) => s.terminalPosition)
@@ -193,7 +194,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
         return <KanbanBoard projectId={selectedProjectId} projectPath={selectedProjectPath} />
       }
       // Connection mode: show connection board
-      if (selectedConnectionId) {
+      if (selectedConnectionId && connectionsLoaded) {
         return <KanbanBoard connectionId={selectedConnectionId} />
       }
       // No project selected: empty state
@@ -224,7 +225,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     }
 
     // Board view — connection-level
-    if (isBoardViewActive && selectedConnectionId && !activeFilePath && !activeDiff && !contextEditorWorktreeId) {
+    if (isBoardViewActive && selectedConnectionId && connectionsLoaded && !activeFilePath && !activeDiff && !contextEditorWorktreeId) {
       return <KanbanBoard connectionId={selectedConnectionId} />
     }
 

--- a/src/renderer/src/stores/useConnectionStore.ts
+++ b/src/renderer/src/stores/useConnectionStore.ts
@@ -35,6 +35,7 @@ interface ConnectionState {
   connections: Connection[]
   isLoading: boolean
   error: string | null
+  loaded: boolean
 
   // UI State
   selectedConnectionId: string | null
@@ -71,6 +72,7 @@ export const useConnectionStore = create<ConnectionState>()(
       connections: [],
       isLoading: false,
       error: null,
+      loaded: false,
       selectedConnectionId: null,
 
       // Connection mode initial state
@@ -84,13 +86,13 @@ export const useConnectionStore = create<ConnectionState>()(
         try {
           const result = await window.connectionOps.getAll()
           if (!result.success) {
-            set({ error: result.error || 'Failed to load connections', isLoading: false })
+            set({ error: result.error || 'Failed to load connections', isLoading: false, loaded: true })
             return
           }
-          set({ connections: result.connections || [], isLoading: false })
+          set({ connections: result.connections || [], isLoading: false, loaded: true })
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
-          set({ error: message, isLoading: false })
+          set({ error: message, isLoading: false, loaded: true })
         }
       },
 

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -819,8 +819,15 @@ export const useKanbanStore = create<KanbanState>()(
 
       // ── loadTicketsForConnection ────────────────────────────────
       loadTicketsForConnection: async (connectionId: string) => {
-        const projectIds = get().getConnectionProjectIds(connectionId)
-        if (projectIds.length === 0) return
+        let projectIds = get().getConnectionProjectIds(connectionId)
+        if (projectIds.length === 0) {
+          const connStore = useConnectionStore.getState()
+          if (!connStore.loaded) {
+            await connStore.loadConnections()
+            projectIds = get().getConnectionProjectIds(connectionId)
+          }
+          if (projectIds.length === 0) return
+        }
 
         set({ isLoading: true })
         try {
@@ -863,8 +870,15 @@ export const useKanbanStore = create<KanbanState>()(
 
       // ── loadTicketsForPinnedProjects ─────────────────────────────
       loadTicketsForPinnedProjects: async () => {
-        const projectIds = [...usePinnedStore.getState().pinnedProjectIds]
-        if (projectIds.length === 0) return
+        let projectIds = [...usePinnedStore.getState().pinnedProjectIds]
+        if (projectIds.length === 0) {
+          const pinnedStore = usePinnedStore.getState()
+          if (!pinnedStore.loaded) {
+            await pinnedStore.loadPinned()
+            projectIds = [...usePinnedStore.getState().pinnedProjectIds]
+          }
+          if (projectIds.length === 0) return
+        }
 
         set({ isLoading: true })
         try {

--- a/test/kanban/aggregate-board-startup-race.test.ts
+++ b/test/kanban/aggregate-board-startup-race.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { KanbanTicket } from '../../src/main/db/types'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { usePinnedStore } from '@/stores/usePinnedStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+const mockKanban = {
+  ticket: {
+    getByProject: vi.fn()
+  },
+  dependency: {
+    getForProject: vi.fn()
+  }
+}
+
+const mockConnectionOps = {
+  getAll: vi.fn(),
+  getPinned: vi.fn()
+}
+
+const mockDb = {
+  worktree: {
+    getPinned: vi.fn()
+  }
+}
+
+Object.defineProperty(window, 'kanban', {
+  writable: true,
+  configurable: true,
+  value: mockKanban
+})
+
+Object.defineProperty(window, 'connectionOps', {
+  writable: true,
+  configurable: true,
+  value: mockConnectionOps
+})
+
+Object.defineProperty(window, 'db', {
+  writable: true,
+  configurable: true,
+  value: mockDb
+})
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'proj-1',
+    title: 'Startup ticket',
+    description: null,
+    attachments: [],
+    column: 'todo',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: null,
+    mode: null,
+    plan_ready: false,
+    created_at: '2026-05-05T00:00:00.000Z',
+    updated_at: '2026-05-05T00:00:00.000Z',
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    ...overrides
+  }
+}
+
+const connection = {
+  id: 'conn-1',
+  name: 'Connection One',
+  custom_name: null,
+  status: 'active',
+  path: '/tmp/conn-1',
+  color: null,
+  created_at: '2026-05-05T00:00:00.000Z',
+  updated_at: '2026-05-05T00:00:00.000Z',
+  members: [
+    {
+      id: 'member-1',
+      connection_id: 'conn-1',
+      worktree_id: 'wt-1',
+      project_id: 'proj-1',
+      symlink_name: 'wt-1',
+      added_at: '2026-05-05T00:00:00.000Z',
+      worktree_name: 'Worktree One',
+      worktree_branch: 'main',
+      worktree_path: '/tmp/proj-1/wt-1',
+      project_name: 'Project One'
+    }
+  ]
+}
+
+const pinnedWorktree = {
+  id: 'wt-1',
+  project_id: 'proj-1',
+  name: 'Worktree One',
+  branch_name: 'main',
+  path: '/tmp/proj-1/wt-1',
+  status: 'active',
+  is_default: false,
+  branch_renamed: 0,
+  last_message_at: null,
+  session_titles: '[]',
+  last_model_provider_id: null,
+  last_model_id: null,
+  last_model_variant: null,
+  created_at: '2026-05-05T00:00:00.000Z',
+  last_accessed_at: '2026-05-05T00:00:00.000Z',
+  github_pr_number: null,
+  github_pr_url: null
+}
+
+describe('aggregate kanban board startup hydration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    useKanbanStore.setState({
+      tickets: new Map(),
+      isLoading: false,
+      showArchivedByProject: {},
+      dependencyMap: new Map()
+    })
+    useConnectionStore.setState({
+      connections: [],
+      isLoading: false,
+      error: null,
+      selectedConnectionId: null,
+      loaded: false
+    } as never)
+    usePinnedStore.setState({
+      loaded: false,
+      pinnedWorktreeIds: new Set(),
+      pinnedConnectionIds: new Set(),
+      pinnedProjectIds: new Set()
+    })
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([['proj-1', [pinnedWorktree]]])
+    } as never)
+
+    mockKanban.ticket.getByProject.mockResolvedValue([makeTicket()])
+    mockKanban.dependency.getForProject.mockResolvedValue([])
+    mockConnectionOps.getAll.mockResolvedValue({ success: true, connections: [connection] })
+    mockConnectionOps.getPinned.mockResolvedValue([])
+    mockDb.worktree.getPinned.mockResolvedValue([pinnedWorktree])
+  })
+
+  test('loadTicketsForConnection hydrates connections and retries when called before connections load', async () => {
+    await useKanbanStore.getState().loadTicketsForConnection('conn-1')
+
+    expect(mockConnectionOps.getAll).toHaveBeenCalledTimes(1)
+    expect(mockKanban.ticket.getByProject).toHaveBeenCalledWith('proj-1', false)
+    expect(useKanbanStore.getState().tickets.get('proj-1')).toEqual([makeTicket()])
+  })
+
+  test('loadTicketsForPinnedProjects hydrates pinned state and retries when called before pinned projects load', async () => {
+    await useKanbanStore.getState().loadTicketsForPinnedProjects()
+
+    expect(mockDb.worktree.getPinned).toHaveBeenCalledTimes(1)
+    expect(mockKanban.ticket.getByProject).toHaveBeenCalledWith('proj-1', false)
+    expect(useKanbanStore.getState().tickets.get('proj-1')).toEqual([makeTicket()])
+  })
+})


### PR DESCRIPTION
## Summary
- Prevents the connection board from rendering before connection data has finished loading.
- Makes kanban ticket hydration retry after loading connections or pinned projects if the initial lookup returns no project IDs.
- Adds regression coverage for the startup race in both connection-backed and pinned-project board loading.

## Testing
- Added `test/kanban/aggregate-board-startup-race.test.ts` covering connection hydration and pinned-project hydration paths.
- Not run