### PR TITLE
Add hunk view for Monaco diffs

### DIFF
--- a/src/renderer/src/components/diff/HunkViewDecorations.tsx
+++ b/src/renderer/src/components/diff/HunkViewDecorations.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { ChevronDown, ChevronUp, ChevronsUpDown, Minus, Plus, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { HiddenAreasResult, Hunk } from '@/lib/diff-utils'
+import type { editor } from 'monaco-editor'
+
+export interface HunkHeaderActions {
+  staged: boolean
+  loadingHunkIndex: number | null
+  onStage: (hunk: Hunk) => void
+  onUnstage: (hunk: Hunk) => void
+  onDiscard: (hunk: Hunk) => void
+}
+
+interface HunkViewDecorationsProps {
+  modifiedEditor: editor.IStandaloneCodeEditor | null
+  hunks: Hunk[]
+  gaps: HiddenAreasResult['gaps']
+  contextLines: number
+  enabled: boolean
+  onExpand: (gapIndex: number, direction: 'up' | 'down' | 'all') => void
+  hunkActions?: HunkHeaderActions
+}
+
+type PortalTarget =
+  | { type: 'header'; key: string; domNode: HTMLDivElement; hunk: Hunk }
+  | {
+      type: 'gap'
+      key: string
+      domNode: HTMLDivElement
+      gap: HiddenAreasResult['gaps'][number]
+      gapIndex: number
+    }
+
+export function HunkViewDecorations({
+  modifiedEditor,
+  hunks,
+  gaps,
+  contextLines,
+  enabled,
+  onExpand,
+  hunkActions
+}: HunkViewDecorationsProps): React.JSX.Element | null {
+  const [portalTargets, setPortalTargets] = useState<PortalTarget[]>([])
+  const zoneIdsRef = useRef<string[]>([])
+  const hasHunkActions = Boolean(hunkActions)
+
+  useEffect(() => {
+    if (!modifiedEditor) return
+
+    const removeExistingZones = (): void => {
+      if (zoneIdsRef.current.length === 0) return
+      modifiedEditor.changeViewZones((acc) => {
+        for (const zoneId of zoneIdsRef.current) acc.removeZone(zoneId)
+      })
+      zoneIdsRef.current = []
+    }
+
+    removeExistingZones()
+
+    if (!enabled) {
+      setPortalTargets([])
+      return
+    }
+
+    const nextTargets: PortalTarget[] = []
+    const nextZoneIds: string[] = []
+
+    modifiedEditor.changeViewZones((acc) => {
+      for (const hunk of hunks) {
+        const domNode = createZoneNode()
+        const firstVisibleLine = getVisibleHunkAnchor(hunk, contextLines)
+        const zoneId = acc.addZone({
+          afterLineNumber: Math.max(0, firstVisibleLine - 1),
+          heightInPx: hasHunkActions ? 34 : 22,
+          domNode,
+          showInHiddenAreas: true,
+          suppressMouseDown: true
+        })
+        nextZoneIds.push(zoneId)
+        nextTargets.push({
+          type: 'header',
+          key: `hunk-header-${hunk.index}`,
+          domNode,
+          hunk
+        })
+      }
+
+      gaps.forEach((gap, gapIndex) => {
+        const domNode = createZoneNode()
+        const zoneId = acc.addZone({
+          afterLineNumber: Math.max(0, gap.afterLine),
+          heightInPx: 28,
+          domNode,
+          showInHiddenAreas: true,
+          suppressMouseDown: true
+        })
+        nextZoneIds.push(zoneId)
+        nextTargets.push({
+          type: 'gap',
+          key: `hunk-gap-${gap.firstHiddenModified}-${gap.lastHiddenModified}`,
+          domNode,
+          gap,
+          gapIndex
+        })
+      })
+    })
+
+    zoneIdsRef.current = nextZoneIds
+    setPortalTargets(nextTargets)
+
+    return () => {
+      modifiedEditor.changeViewZones((acc) => {
+        for (const zoneId of nextZoneIds) acc.removeZone(zoneId)
+      })
+      zoneIdsRef.current = []
+    }
+  }, [modifiedEditor, hunks, gaps, contextLines, enabled, hasHunkActions])
+
+  if (!modifiedEditor || !enabled) return null
+
+  return (
+    <>
+      {portalTargets.map((target) =>
+        createPortal(
+          target.type === 'header' ? (
+            <HunkHeader hunk={target.hunk} actions={hunkActions} />
+          ) : (
+            <GapControls
+              gap={target.gap}
+              onExpand={(direction) => onExpand(target.gapIndex, direction)}
+            />
+          ),
+          target.domNode,
+          target.key
+        )
+      )}
+    </>
+  )
+}
+
+function createZoneNode(): HTMLDivElement {
+  const domNode = document.createElement('div')
+  domNode.style.pointerEvents = 'auto'
+  domNode.style.position = 'relative'
+  domNode.style.zIndex = '1'
+  return domNode
+}
+
+function getVisibleHunkAnchor(hunk: Hunk, contextLines: number): number {
+  return Math.max(1, hunk.modifiedStartLine - contextLines)
+}
+
+function formatHunkHeader(hunk: Hunk): string {
+  const originalCount =
+    hunk.originalEndLine === 0 ? 0 : hunk.originalEndLine - hunk.originalStartLine + 1
+  const modifiedCount =
+    hunk.modifiedEndLine === 0 ? 0 : hunk.modifiedEndLine - hunk.modifiedStartLine + 1
+
+  return `@@ -${hunk.originalStartLine},${originalCount} +${hunk.modifiedStartLine},${modifiedCount} @@`
+}
+
+function HunkHeader({
+  hunk,
+  actions
+}: {
+  hunk: Hunk
+  actions?: HunkHeaderActions
+}): React.JSX.Element {
+  const stopMouseDown = (event: React.MouseEvent): void => {
+    event.preventDefault()
+    event.stopPropagation()
+    event.nativeEvent.stopImmediatePropagation()
+  }
+  const isLoading = actions?.loadingHunkIndex === hunk.index
+
+  return (
+    <div
+      className="h-full min-h-[22px] flex items-center justify-between gap-3 px-4 bg-muted/35 border-y border-border/50"
+      onMouseDown={stopMouseDown}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <span className="font-mono text-[11px] leading-none text-muted-foreground truncate">
+        {formatHunkHeader(hunk)}
+      </span>
+      {actions && (
+        <div className="flex items-center gap-1 shrink-0">
+          {actions.staged ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 gap-1 px-2 text-[11px] text-orange-400 hover:bg-orange-500/15 hover:text-orange-300"
+              disabled={isLoading}
+              title="Unstage hunk"
+              onClick={() => actions.onUnstage(hunk)}
+            >
+              <Minus className="h-3 w-3" />
+              Unstage hunk
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 gap-1 px-2 text-[11px] text-green-400 hover:bg-green-500/15 hover:text-green-300"
+                disabled={isLoading}
+                title="Stage hunk"
+                onClick={() => actions.onStage(hunk)}
+              >
+                <Plus className="h-3 w-3" />
+                Stage hunk
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 gap-1 px-2 text-[11px] text-red-400 hover:bg-red-500/15 hover:text-red-300"
+                disabled={isLoading}
+                title="Discard hunk"
+                onClick={() => actions.onDiscard(hunk)}
+              >
+                <Trash2 className="h-3 w-3" />
+                Discard hunk
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function GapControls({
+  gap,
+  onExpand
+}: {
+  gap: HiddenAreasResult['gaps'][number]
+  onExpand: (direction: 'up' | 'down' | 'all') => void
+}): React.JSX.Element {
+  const handleMouseDown = (event: React.MouseEvent): void => {
+    event.preventDefault()
+    event.stopPropagation()
+    event.nativeEvent.stopImmediatePropagation()
+  }
+
+  return (
+    <div
+      className="h-[28px] flex items-center justify-center gap-1 bg-muted/20 border-y border-border/40 text-[11px] text-muted-foreground"
+      onMouseDown={handleMouseDown}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-5 w-5"
+        title="Show 10 hidden lines above"
+        onClick={() => onExpand('up')}
+      >
+        <ChevronUp className="h-3.5 w-3.5" />
+      </Button>
+      <span className="min-w-[92px] text-center tabular-nums">
+        {gap.hiddenLineCount} hidden lines
+      </span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-5 w-5"
+        title="Show 10 hidden lines below"
+        onClick={() => onExpand('down')}
+      >
+        <ChevronDown className="h-3.5 w-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-5 w-5"
+        title="Show all hidden lines"
+        onClick={() => onExpand('all')}
+      >
+        <ChevronsUpDown className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/diff/MonacoDiffToolbar.tsx
+++ b/src/renderer/src/components/diff/MonacoDiffToolbar.tsx
@@ -1,15 +1,17 @@
 import { useCallback } from 'react'
-import { ChevronUp, ChevronDown, Columns2, AlignJustify, Copy, X } from 'lucide-react'
+import { ChevronUp, ChevronDown, Columns2, AlignJustify, Copy, Rows3, X } from 'lucide-react'
 import { toast } from '@/lib/toast'
 import { Button } from '@/components/ui/button'
+import type { DiffViewMode } from '@/stores/useDiffPrefsStore'
 
 interface MonacoDiffToolbarProps {
   fileName: string
   staged: boolean
   isUntracked: boolean
   compareBranch?: string
-  sideBySide: boolean
-  onToggleSideBySide: () => void
+  viewMode: DiffViewMode
+  onSetViewMode: (viewMode: DiffViewMode) => void
+  splitDisabled?: boolean
   onPrevHunk: () => void
   onNextHunk: () => void
   onCopy: () => void
@@ -21,8 +23,9 @@ export function MonacoDiffToolbar({
   staged,
   isUntracked,
   compareBranch,
-  sideBySide,
-  onToggleSideBySide,
+  viewMode,
+  onSetViewMode,
+  splitDisabled = false,
   onPrevHunk,
   onNextHunk,
   onCopy,
@@ -74,21 +77,43 @@ export function MonacoDiffToolbar({
 
         <div className="w-px h-4 bg-border mx-1" />
 
-        {/* View mode toggle */}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6"
-          onClick={onToggleSideBySide}
-          title={sideBySide ? 'Switch to inline view' : 'Switch to side-by-side view'}
-          data-testid="monaco-diff-view-toggle"
+        {/* View mode segmented control */}
+        <div
+          className="flex items-center rounded-sm bg-muted p-0.5"
+          data-testid="monaco-diff-view-mode"
         >
-          {sideBySide ? (
-            <AlignJustify className="h-3.5 w-3.5" />
-          ) : (
+          <Button
+            variant={viewMode === 'split' ? 'secondary' : 'ghost'}
+            size="icon"
+            className="h-6 w-6"
+            onClick={() => onSetViewMode('split')}
+            disabled={splitDisabled}
+            title={splitDisabled ? 'Split view is unavailable in PR review' : 'Split view'}
+            data-testid="monaco-diff-view-split"
+          >
             <Columns2 className="h-3.5 w-3.5" />
-          )}
-        </Button>
+          </Button>
+          <Button
+            variant={viewMode === 'inline' ? 'secondary' : 'ghost'}
+            size="icon"
+            className="h-6 w-6"
+            onClick={() => onSetViewMode('inline')}
+            title="Inline view"
+            data-testid="monaco-diff-view-inline"
+          >
+            <AlignJustify className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant={viewMode === 'hunk' ? 'secondary' : 'ghost'}
+            size="icon"
+            className="h-6 w-6"
+            onClick={() => onSetViewMode('hunk')}
+            title="Hunk view"
+            data-testid="monaco-diff-view-hunk"
+          >
+            <Rows3 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
 
         {/* Copy */}
         <Button

--- a/src/renderer/src/components/diff/MonacoDiffView.tsx
+++ b/src/renderer/src/components/diff/MonacoDiffView.tsx
@@ -42,7 +42,7 @@ interface MonacoDiffViewProps {
 }
 
 interface HiddenAreasEditor extends editor.IStandaloneCodeEditor {
-  setHiddenAreas: (ranges: HiddenAreasResult['modifiedRanges']) => void
+  setHiddenAreas?: (ranges: HiddenAreasResult['modifiedRanges']) => void
 }
 
 const EMPTY_COMMENTS: PRReviewComment[] = []
@@ -82,6 +82,7 @@ export default function MonacoDiffView({
   const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null)
   const modifiedEditorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
   const [editorReady, setEditorReady] = useState(false)
+  const [diffComputed, setDiffComputed] = useState(false)
   const [zonesReady, setZonesReady] = useState(!prReviewWorktreeId)
 
   // Worktree ID for diff comment toolbar
@@ -205,6 +206,7 @@ export default function MonacoDiffView({
 
   useEffect(() => {
     setExpandedRanges([])
+    setDiffComputed(false)
   }, [worktreePath, filePath, staged, compareBranch])
 
   // Listen for external file changes (but skip if we just did a manual action)
@@ -225,11 +227,15 @@ export default function MonacoDiffView({
     // Get initial diff changes
     const changes = diffEd.getLineChanges()
     setHunks(parseHunks(changes))
+    if (changes !== null) {
+      setDiffComputed(true)
+    }
 
     // Listen for diff updates
     diffEd.onDidUpdateDiff(() => {
       const newChanges = diffEd.getLineChanges()
       setHunks(parseHunks(newChanges))
+      setDiffComputed(true)
     })
 
     // Signal that the editor is mounted and ready for scrolling
@@ -486,7 +492,7 @@ export default function MonacoDiffView({
   }, [worktreePath, filePath, staged, isUntracked, compareBranch])
 
   const language = getMonacoLanguage(filePath)
-  const isNoChangesInHunkView = renderedViewMode === 'hunk' && hunks.length === 0 && editorReady
+  const isNoChangesInHunkView = renderedViewMode === 'hunk' && hunks.length === 0 && diffComputed
 
   if (isLoading) {
     return (
@@ -496,7 +502,7 @@ export default function MonacoDiffView({
           staged={staged}
           isUntracked={isUntracked}
           compareBranch={compareBranch}
-          viewMode={effectiveViewMode}
+          viewMode={renderedViewMode}
           onSetViewMode={setViewMode}
           splitDisabled={Boolean(prReviewWorktreeId)}
           onPrevHunk={handlePrevHunk}
@@ -519,7 +525,7 @@ export default function MonacoDiffView({
           staged={staged}
           isUntracked={isUntracked}
           compareBranch={compareBranch}
-          viewMode={effectiveViewMode}
+          viewMode={renderedViewMode}
           onSetViewMode={setViewMode}
           splitDisabled={Boolean(prReviewWorktreeId)}
           onPrevHunk={handlePrevHunk}
@@ -544,7 +550,7 @@ export default function MonacoDiffView({
         staged={staged}
         isUntracked={isUntracked}
         compareBranch={compareBranch}
-        viewMode={effectiveViewMode}
+        viewMode={renderedViewMode}
         onSetViewMode={setViewMode}
         splitDisabled={Boolean(prReviewWorktreeId)}
         onPrevHunk={handlePrevHunk}
@@ -669,5 +675,12 @@ function setEditorHiddenAreas(
   ranges: HiddenAreasResult['modifiedRanges']
 ): void {
   const hiddenAreasEditor = editorInstance as HiddenAreasEditor
+  if (typeof hiddenAreasEditor.setHiddenAreas !== 'function') {
+    console.warn(
+      'Monaco editor setHiddenAreas API is unavailable; hunk view cannot collapse lines.'
+    )
+    return
+  }
+
   hiddenAreasEditor.setHiddenAreas(ranges)
 }

--- a/src/renderer/src/components/diff/MonacoDiffView.tsx
+++ b/src/renderer/src/components/diff/MonacoDiffView.tsx
@@ -3,16 +3,27 @@ import '@/lib/monaco-setup'
 import { DiffEditor, type Monaco } from '@monaco-editor/react'
 import { Loader2 } from 'lucide-react'
 import { registerHiveTheme, HIVE_THEME_NAME } from '@/lib/monaco-theme'
-import { parseHunks, getMonacoLanguage } from '@/lib/diff-utils'
-import type { Hunk } from '@/lib/diff-utils'
+import {
+  computeHiddenAreas,
+  createHunkPatch,
+  parseHunks,
+  getMonacoLanguage
+} from '@/lib/diff-utils'
+import type { HiddenAreasResult, Hunk } from '@/lib/diff-utils'
 import { MonacoDiffToolbar } from './MonacoDiffToolbar'
 import { HunkActionGutter } from './HunkActionGutter'
+import type { HunkHeaderActions } from './HunkViewDecorations'
+import { HunkViewDecorations } from './HunkViewDecorations'
 import { PrCommentGutter } from './PrCommentGutter'
 import { DiffCommentGutter } from './DiffCommentGutter'
 import { DiffCommentToolbar } from './DiffCommentToolbar'
 import { DiffCommentSidePanel } from './DiffCommentSidePanel'
 import { usePRReviewStore } from '@/stores/usePRReviewStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useDiffCommentStore } from '@/stores/useDiffCommentStore'
+import { useDiffPrefsStore } from '@/stores/useDiffPrefsStore'
+import { useGitStore } from '@/stores/useGitStore'
+import { toast } from '@/lib/toast'
 import type { PRReviewComment } from '@shared/types/git'
 import type { editor } from 'monaco-editor'
 
@@ -30,7 +41,19 @@ interface MonacoDiffViewProps {
   onClose: () => void
 }
 
+interface HiddenAreasEditor extends editor.IStandaloneCodeEditor {
+  setHiddenAreas: (ranges: HiddenAreasResult['modifiedRanges']) => void
+}
+
 const EMPTY_COMMENTS: PRReviewComment[] = []
+const EMPTY_DIFF_COMMENTS: DiffComment[] = []
+const HUNK_CONTEXT_LINES = 3
+const HUNK_EXPAND_LINES = 10
+const EMPTY_HIDDEN_AREAS: HiddenAreasResult = {
+  originalRanges: [],
+  modifiedRanges: [],
+  gaps: []
+}
 
 export default function MonacoDiffView({
   worktreePath,
@@ -49,9 +72,9 @@ export default function MonacoDiffView({
   const [modifiedContent, setModifiedContent] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  // PR review diffs always use inline mode so view zones render naturally
-  const [sideBySide, setSideBySide] = useState(!prReviewWorktreeId)
   const [hunks, setHunks] = useState<Hunk[]>([])
+  const [expandedRanges, setExpandedRanges] = useState<Array<{ start: number; end: number }>>([])
+  const [hunkActionLoading, setHunkActionLoading] = useState<number | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
   const isInitialLoad = useRef(true)
   const recentActionRef = useRef(false)
@@ -63,11 +86,13 @@ export default function MonacoDiffView({
 
   // Worktree ID for diff comment toolbar
   const worktreeId = useWorktreeStore((s) => s.selectedWorktreeId)
+  const viewMode = useDiffPrefsStore((s) => s.viewMode)
+  const setViewMode = useDiffPrefsStore((s) => s.setViewMode)
 
   const [sidePanelOpen, setSidePanelOpen] = useState(false)
 
   const handleToggleSidePanel = useCallback(() => {
-    setSidePanelOpen(prev => !prev)
+    setSidePanelOpen((prev) => !prev)
   }, [])
 
   // PR review comments for this file (when in PR review mode)
@@ -75,12 +100,26 @@ export default function MonacoDiffView({
     (s) => (prReviewWorktreeId ? s.comments.get(prReviewWorktreeId) : undefined) ?? EMPTY_COMMENTS
   )
   const fileComments = useMemo(
-    () =>
-      prReviewWorktreeId
-        ? allPrComments.filter((c) => c.path === filePath)
-        : EMPTY_COMMENTS,
+    () => (prReviewWorktreeId ? allPrComments.filter((c) => c.path === filePath) : EMPTY_COMMENTS),
     [allPrComments, filePath, prReviewWorktreeId]
   )
+  const allDiffComments =
+    useDiffCommentStore((s) =>
+      !prReviewWorktreeId && worktreeId ? s.comments.get(worktreeId) : undefined
+    ) ?? EMPTY_DIFF_COMMENTS
+  const fileDiffComments = useMemo(
+    () =>
+      !prReviewWorktreeId && worktreeId
+        ? allDiffComments.filter((c) => c.file_path === filePath)
+        : EMPTY_DIFF_COMMENTS,
+    [allDiffComments, filePath, prReviewWorktreeId, worktreeId]
+  )
+
+  const effectiveViewMode = prReviewWorktreeId && viewMode === 'split' ? 'inline' : viewMode
+  const fallsBackToInline =
+    effectiveViewMode === 'hunk' &&
+    (isUntracked || isNewFile || originalContent === '' || modifiedContent === '')
+  const renderedViewMode = fallsBackToInline ? 'inline' : effectiveViewMode
 
   // Fetch file contents for the diff
   const fetchContent = useCallback(async () => {
@@ -163,6 +202,10 @@ export default function MonacoDiffView({
   useEffect(() => {
     fetchContent()
   }, [fetchContent, refreshKey])
+
+  useEffect(() => {
+    setExpandedRanges([])
+  }, [worktreePath, filePath, staged, compareBranch])
 
   // Listen for external file changes (but skip if we just did a manual action)
   useEffect(() => {
@@ -251,10 +294,180 @@ export default function MonacoDiffView({
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [onClose, handleNextHunk, handlePrevHunk])
 
-  // Toggle side-by-side / inline
-  const handleToggleSideBySide = useCallback(() => {
-    setSideBySide((prev) => !prev)
+  const prCommentLines = useMemo(
+    () =>
+      fileComments
+        .map((comment) => comment.line ?? comment.originalLine ?? null)
+        .filter((line): line is number => typeof line === 'number' && line > 0),
+    [fileComments]
+  )
+
+  const diffCommentLines = useMemo(
+    () =>
+      fileDiffComments.flatMap((comment) => expandLineRange(comment.line_start, comment.line_end)),
+    [fileDiffComments]
+  )
+
+  const expandedLineNumbers = useMemo(
+    () => expandedRanges.flatMap((range) => expandLineRange(range.start, range.end)),
+    [expandedRanges]
+  )
+  const originalLines = useMemo(() => (originalContent ?? '').split('\n'), [originalContent])
+  const modifiedLines = useMemo(() => (modifiedContent ?? '').split('\n'), [modifiedContent])
+
+  const hiddenAreas = useMemo<HiddenAreasResult>(() => {
+    if (renderedViewMode !== 'hunk' || !editorReady) return EMPTY_HIDDEN_AREAS
+    const originalLineCount =
+      diffEditorRef.current?.getOriginalEditor().getModel()?.getLineCount() ??
+      getContentLineCount(originalContent)
+    const modifiedLineCount =
+      modifiedEditorRef.current?.getModel()?.getLineCount() ?? getContentLineCount(modifiedContent)
+
+    return computeHiddenAreas({
+      hunks,
+      contextLines: HUNK_CONTEXT_LINES,
+      originalLineCount,
+      modifiedLineCount,
+      extraVisibleModified: [...prCommentLines, ...diffCommentLines, ...expandedLineNumbers]
+    })
+  }, [
+    renderedViewMode,
+    hunks,
+    prCommentLines,
+    diffCommentLines,
+    expandedLineNumbers,
+    originalContent,
+    modifiedContent,
+    editorReady
+  ])
+
+  useEffect(() => {
+    const originalEditor = diffEditorRef.current?.getOriginalEditor()
+    const modifiedEditor = modifiedEditorRef.current
+    if (!originalEditor || !modifiedEditor) return
+
+    setEditorHiddenAreas(
+      originalEditor,
+      renderedViewMode === 'hunk' ? hiddenAreas.originalRanges : []
+    )
+    setEditorHiddenAreas(
+      modifiedEditor,
+      renderedViewMode === 'hunk' ? hiddenAreas.modifiedRanges : []
+    )
+  }, [hiddenAreas, renderedViewMode, editorReady])
+
+  const handleExpandGap = useCallback(
+    (gapIndex: number, direction: 'up' | 'down' | 'all') => {
+      const gap = hiddenAreas.gaps[gapIndex]
+      if (!gap) return
+
+      let start = gap.firstHiddenModified
+      let end = gap.lastHiddenModified
+      if (direction === 'up') {
+        end = Math.min(gap.lastHiddenModified, gap.firstHiddenModified + HUNK_EXPAND_LINES - 1)
+      } else if (direction === 'down') {
+        start = Math.max(gap.firstHiddenModified, gap.lastHiddenModified - HUNK_EXPAND_LINES + 1)
+      }
+
+      setExpandedRanges((prev) => [...prev, { start, end }])
+    },
+    [hiddenAreas.gaps]
+  )
+
+  // Trigger re-fetch after hunk actions — suppress watcher duplicate for 500ms
+  const handleContentChanged = useCallback(() => {
+    recentActionRef.current = true
+    setRefreshKey((k) => k + 1)
+    setTimeout(() => {
+      recentActionRef.current = false
+    }, 500)
   }, [])
+
+  const handleStageHunk = useCallback(
+    async (hunk: Hunk) => {
+      setHunkActionLoading(hunk.index)
+      try {
+        const patch = createHunkPatch(filePath, originalLines, modifiedLines, hunk)
+        const result = await window.gitOps.stageHunk(worktreePath, patch)
+        if (result.success) {
+          toast.success('Hunk staged')
+          useGitStore.getState().refreshStatuses(worktreePath)
+          handleContentChanged()
+        } else {
+          toast.error(result.error || 'Failed to stage hunk')
+        }
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : 'Failed to stage hunk')
+      } finally {
+        setHunkActionLoading(null)
+      }
+    },
+    [filePath, originalLines, modifiedLines, worktreePath, handleContentChanged]
+  )
+
+  const handleUnstageHunk = useCallback(
+    async (hunk: Hunk) => {
+      setHunkActionLoading(hunk.index)
+      try {
+        const patch = createHunkPatch(filePath, originalLines, modifiedLines, hunk)
+        const result = await window.gitOps.unstageHunk(worktreePath, patch)
+        if (result.success) {
+          toast.success('Hunk unstaged')
+          useGitStore.getState().refreshStatuses(worktreePath)
+          handleContentChanged()
+        } else {
+          toast.error(result.error || 'Failed to unstage hunk')
+        }
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : 'Failed to unstage hunk')
+      } finally {
+        setHunkActionLoading(null)
+      }
+    },
+    [filePath, originalLines, modifiedLines, worktreePath, handleContentChanged]
+  )
+
+  const handleDiscardHunk = useCallback(
+    async (hunk: Hunk) => {
+      setHunkActionLoading(hunk.index)
+      try {
+        const patch = createHunkPatch(filePath, originalLines, modifiedLines, hunk)
+        const result = await window.gitOps.revertHunk(worktreePath, patch)
+        if (result.success) {
+          toast.success('Hunk discarded')
+          useGitStore.getState().refreshStatuses(worktreePath)
+          handleContentChanged()
+        } else {
+          toast.error(result.error || 'Failed to discard hunk')
+        }
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : 'Failed to discard hunk')
+      } finally {
+        setHunkActionLoading(null)
+      }
+    },
+    [filePath, originalLines, modifiedLines, worktreePath, handleContentChanged]
+  )
+
+  const hunkHeaderActions = useMemo<HunkHeaderActions | undefined>(() => {
+    if (compareBranch || originalContent === null || modifiedContent === null) return undefined
+    return {
+      staged,
+      loadingHunkIndex: hunkActionLoading,
+      onStage: handleStageHunk,
+      onUnstage: handleUnstageHunk,
+      onDiscard: handleDiscardHunk
+    }
+  }, [
+    compareBranch,
+    originalContent,
+    modifiedContent,
+    staged,
+    hunkActionLoading,
+    handleStageHunk,
+    handleUnstageHunk,
+    handleDiscardHunk
+  ])
 
   // Copy diff content
   const handleCopy = useCallback(async () => {
@@ -272,16 +485,8 @@ export default function MonacoDiffView({
     }
   }, [worktreePath, filePath, staged, isUntracked, compareBranch])
 
-  // Trigger re-fetch after hunk actions — suppress watcher duplicate for 500ms
-  const handleContentChanged = useCallback(() => {
-    recentActionRef.current = true
-    setRefreshKey((k) => k + 1)
-    setTimeout(() => {
-      recentActionRef.current = false
-    }, 500)
-  }, [])
-
   const language = getMonacoLanguage(filePath)
+  const isNoChangesInHunkView = renderedViewMode === 'hunk' && hunks.length === 0 && editorReady
 
   if (isLoading) {
     return (
@@ -291,8 +496,9 @@ export default function MonacoDiffView({
           staged={staged}
           isUntracked={isUntracked}
           compareBranch={compareBranch}
-          sideBySide={sideBySide}
-          onToggleSideBySide={handleToggleSideBySide}
+          viewMode={effectiveViewMode}
+          onSetViewMode={setViewMode}
+          splitDisabled={Boolean(prReviewWorktreeId)}
           onPrevHunk={handlePrevHunk}
           onNextHunk={handleNextHunk}
           onCopy={handleCopy}
@@ -313,8 +519,9 @@ export default function MonacoDiffView({
           staged={staged}
           isUntracked={isUntracked}
           compareBranch={compareBranch}
-          sideBySide={sideBySide}
-          onToggleSideBySide={handleToggleSideBySide}
+          viewMode={effectiveViewMode}
+          onSetViewMode={setViewMode}
+          splitDisabled={Boolean(prReviewWorktreeId)}
           onPrevHunk={handlePrevHunk}
           onNextHunk={handleNextHunk}
           onCopy={handleCopy}
@@ -337,8 +544,9 @@ export default function MonacoDiffView({
         staged={staged}
         isUntracked={isUntracked}
         compareBranch={compareBranch}
-        sideBySide={sideBySide}
-        onToggleSideBySide={handleToggleSideBySide}
+        viewMode={effectiveViewMode}
+        onSetViewMode={setViewMode}
+        splitDisabled={Boolean(prReviewWorktreeId)}
         onPrevHunk={handlePrevHunk}
         onNextHunk={handleNextHunk}
         onCopy={handleCopy}
@@ -356,7 +564,7 @@ export default function MonacoDiffView({
             options={{
               readOnly: true,
               originalEditable: false,
-              renderSideBySide: sideBySide,
+              renderSideBySide: renderedViewMode === 'split',
               enableSplitViewResizing: true,
               ignoreTrimWhitespace: false,
               renderIndicators: true,
@@ -379,18 +587,30 @@ export default function MonacoDiffView({
               </div>
             }
           />
-          {!compareBranch && originalContent !== null && modifiedContent !== null && (
-            <HunkActionGutter
-              hunks={hunks}
-              staged={staged}
-              worktreePath={worktreePath}
-              filePath={filePath}
-              originalContent={originalContent}
-              modifiedContent={modifiedContent}
-              modifiedEditor={modifiedEditorRef.current}
-              onContentChanged={handleContentChanged}
-            />
-          )}
+          <HunkViewDecorations
+            modifiedEditor={modifiedEditorRef.current}
+            hunks={hunks}
+            gaps={hiddenAreas.gaps}
+            contextLines={HUNK_CONTEXT_LINES}
+            enabled={renderedViewMode === 'hunk'}
+            onExpand={handleExpandGap}
+            hunkActions={hunkHeaderActions}
+          />
+          {!compareBranch &&
+            renderedViewMode !== 'hunk' &&
+            originalContent !== null &&
+            modifiedContent !== null && (
+              <HunkActionGutter
+                hunks={hunks}
+                staged={staged}
+                worktreePath={worktreePath}
+                filePath={filePath}
+                originalContent={originalContent}
+                modifiedContent={modifiedContent}
+                modifiedEditor={modifiedEditorRef.current}
+                onContentChanged={handleContentChanged}
+              />
+            )}
           {prReviewWorktreeId &&
             fileComments.length > 0 &&
             originalContent !== null &&
@@ -403,18 +623,23 @@ export default function MonacoDiffView({
               />
             )}
           {!prReviewWorktreeId && originalContent !== null && modifiedContent !== null && (
-            <DiffCommentGutter
-              modifiedEditor={modifiedEditorRef.current}
-              filePath={filePath}
-            />
+            <DiffCommentGutter modifiedEditor={modifiedEditorRef.current} filePath={filePath} />
           )}
-          {!prReviewWorktreeId && originalContent !== null && modifiedContent !== null && worktreeId && (
-            <DiffCommentToolbar
-              worktreeId={worktreeId}
-              onToggleSidePanel={handleToggleSidePanel}
-              sidePanelOpen={sidePanelOpen}
-            />
+          {isNoChangesInHunkView && (
+            <div className="absolute inset-0 flex items-center justify-center pointer-events-none text-sm text-muted-foreground">
+              No changes
+            </div>
           )}
+          {!prReviewWorktreeId &&
+            originalContent !== null &&
+            modifiedContent !== null &&
+            worktreeId && (
+              <DiffCommentToolbar
+                worktreeId={worktreeId}
+                onToggleSidePanel={handleToggleSidePanel}
+                sidePanelOpen={sidePanelOpen}
+              />
+            )}
         </div>
         {!prReviewWorktreeId && sidePanelOpen && worktreeId && (
           <DiffCommentSidePanel
@@ -426,4 +651,23 @@ export default function MonacoDiffView({
       </div>
     </div>
   )
+}
+
+function getContentLineCount(content: string | null): number {
+  if (!content) return 0
+  return content.split('\n').length
+}
+
+function expandLineRange(start: number, end?: number | null): number[] {
+  const safeStart = Math.max(1, start)
+  const safeEnd = Math.max(safeStart, end ?? safeStart)
+  return Array.from({ length: safeEnd - safeStart + 1 }, (_, index) => safeStart + index)
+}
+
+function setEditorHiddenAreas(
+  editorInstance: editor.IStandaloneCodeEditor,
+  ranges: HiddenAreasResult['modifiedRanges']
+): void {
+  const hiddenAreasEditor = editorInstance as HiddenAreasEditor
+  hiddenAreasEditor.setHiddenAreas(ranges)
 }

--- a/src/renderer/src/lib/__tests__/diff-utils.test.ts
+++ b/src/renderer/src/lib/__tests__/diff-utils.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+import { computeHiddenAreas, type Hunk } from '../diff-utils'
+
+function modifyHunk(
+  originalStartLine: number,
+  originalEndLine: number,
+  modifiedStartLine = originalStartLine,
+  modifiedEndLine = originalEndLine
+): Hunk {
+  return {
+    index: 0,
+    originalStartLine,
+    originalEndLine,
+    modifiedStartLine,
+    modifiedEndLine,
+    type: 'modify'
+  }
+}
+
+function range(startLineNumber: number, endLineNumber: number) {
+  return {
+    startLineNumber,
+    startColumn: 1,
+    endLineNumber,
+    endColumn: 1
+  }
+}
+
+describe('computeHiddenAreas', () => {
+  it('returns no hidden ranges for empty hunks', () => {
+    expect(
+      computeHiddenAreas({
+        hunks: [],
+        contextLines: 3,
+        originalLineCount: 100,
+        modifiedLineCount: 100
+      })
+    ).toEqual({ originalRanges: [], modifiedRanges: [], gaps: [] })
+  })
+
+  it('hides unchanged content before and after a single middle hunk', () => {
+    const result = computeHiddenAreas({
+      hunks: [modifyHunk(40, 42)],
+      contextLines: 3,
+      originalLineCount: 100,
+      modifiedLineCount: 100
+    })
+
+    expect(result.originalRanges).toEqual([range(1, 36), range(46, 100)])
+    expect(result.modifiedRanges).toEqual([range(1, 36), range(46, 100)])
+    expect(result.gaps).toEqual([
+      {
+        side: 'modified',
+        afterLine: 0,
+        hiddenLineCount: 36,
+        firstHiddenOriginal: 1,
+        lastHiddenOriginal: 36,
+        firstHiddenModified: 1,
+        lastHiddenModified: 36
+      },
+      {
+        side: 'modified',
+        afterLine: 45,
+        hiddenLineCount: 55,
+        firstHiddenOriginal: 46,
+        lastHiddenOriginal: 100,
+        firstHiddenModified: 46,
+        lastHiddenModified: 100
+      }
+    ])
+  })
+
+  it('keeps the top of the file visible when hunk context reaches line one', () => {
+    const result = computeHiddenAreas({
+      hunks: [modifyHunk(2, 4)],
+      contextLines: 3,
+      originalLineCount: 50,
+      modifiedLineCount: 50
+    })
+
+    expect(result.originalRanges).toEqual([range(8, 50)])
+    expect(result.modifiedRanges).toEqual([range(8, 50)])
+  })
+
+  it('keeps the bottom of the file visible when hunk context reaches the end', () => {
+    const result = computeHiddenAreas({
+      hunks: [modifyHunk(47, 49)],
+      contextLines: 3,
+      originalLineCount: 50,
+      modifiedLineCount: 50
+    })
+
+    expect(result.originalRanges).toEqual([range(1, 43)])
+    expect(result.modifiedRanges).toEqual([range(1, 43)])
+  })
+
+  it('merges adjacent hunks when their context overlaps', () => {
+    const result = computeHiddenAreas({
+      hunks: [modifyHunk(20, 22), modifyHunk(25, 27)],
+      contextLines: 3,
+      originalLineCount: 60,
+      modifiedLineCount: 60
+    })
+
+    expect(result.modifiedRanges).toEqual([range(1, 16), range(31, 60)])
+    expect(result.gaps.map((gap) => [gap.firstHiddenModified, gap.lastHiddenModified])).toEqual([
+      [1, 16],
+      [31, 60]
+    ])
+  })
+
+  it('uses the original anchor for pure addition hunks', () => {
+    const result = computeHiddenAreas({
+      hunks: [
+        {
+          index: 0,
+          originalStartLine: 20,
+          originalEndLine: 0,
+          modifiedStartLine: 21,
+          modifiedEndLine: 24,
+          type: 'add'
+        }
+      ],
+      contextLines: 3,
+      originalLineCount: 80,
+      modifiedLineCount: 84
+    })
+
+    expect(result.originalRanges).toEqual([range(1, 16), range(24, 80)])
+    expect(result.modifiedRanges).toEqual([range(1, 17), range(28, 84)])
+  })
+
+  it('uses the modified anchor for pure deletion hunks', () => {
+    const result = computeHiddenAreas({
+      hunks: [
+        {
+          index: 0,
+          originalStartLine: 21,
+          originalEndLine: 24,
+          modifiedStartLine: 20,
+          modifiedEndLine: 0,
+          type: 'delete'
+        }
+      ],
+      contextLines: 3,
+      originalLineCount: 84,
+      modifiedLineCount: 80
+    })
+
+    expect(result.originalRanges).toEqual([range(1, 17), range(28, 84)])
+    expect(result.modifiedRanges).toEqual([range(1, 16), range(24, 80)])
+  })
+
+  it('keeps extra visible modified lines and splits gaps around them', () => {
+    const result = computeHiddenAreas({
+      hunks: [modifyHunk(40, 42)],
+      contextLines: 3,
+      originalLineCount: 100,
+      modifiedLineCount: 100,
+      extraVisibleModified: [70]
+    })
+
+    expect(result.modifiedRanges).toEqual([range(1, 36), range(46, 66), range(74, 100)])
+    expect(result.gaps.map((gap) => [gap.firstHiddenModified, gap.lastHiddenModified])).toEqual([
+      [1, 36],
+      [46, 66],
+      [74, 100]
+    ])
+  })
+
+  it('does not change hidden ranges when extra visible line is already in context', () => {
+    const withoutExtra = computeHiddenAreas({
+      hunks: [modifyHunk(40, 42)],
+      contextLines: 3,
+      originalLineCount: 100,
+      modifiedLineCount: 100
+    })
+    const withExtra = computeHiddenAreas({
+      hunks: [modifyHunk(40, 42)],
+      contextLines: 3,
+      originalLineCount: 100,
+      modifiedLineCount: 100,
+      extraVisibleModified: [41]
+    })
+
+    expect(withExtra.modifiedRanges).toEqual(withoutExtra.modifiedRanges)
+    expect(withExtra.gaps).toEqual(withoutExtra.gaps)
+  })
+
+  it('keeps user-expanded modified ranges visible', () => {
+    const result = computeHiddenAreas({
+      hunks: [modifyHunk(40, 42)],
+      contextLines: 3,
+      originalLineCount: 100,
+      modifiedLineCount: 100,
+      extraVisibleModified: Array.from({ length: 24 }, (_, index) => 46 + index)
+    })
+
+    expect(result.modifiedRanges).toEqual([range(1, 36), range(73, 100)])
+    expect(result.gaps.map((gap) => [gap.firstHiddenModified, gap.lastHiddenModified])).toEqual([
+      [1, 36],
+      [73, 100]
+    ])
+  })
+})

--- a/src/renderer/src/lib/__tests__/diff-utils.test.ts
+++ b/src/renderer/src/lib/__tests__/diff-utils.test.ts
@@ -168,6 +168,22 @@ describe('computeHiddenAreas', () => {
     ])
   })
 
+  it('keeps original gap coordinates aligned when extra modified visibility splits a gap', () => {
+    const result = computeHiddenAreas({
+      hunks: [modifyHunk(40, 42)],
+      contextLines: 3,
+      originalLineCount: 100,
+      modifiedLineCount: 100,
+      extraVisibleModified: [70]
+    })
+
+    expect(result.gaps.map((gap) => [gap.firstHiddenOriginal, gap.lastHiddenOriginal])).toEqual([
+      [1, 36],
+      [46, 66],
+      [74, 100]
+    ])
+  })
+
   it('does not change hidden ranges when extra visible line is already in context', () => {
     const withoutExtra = computeHiddenAreas({
       hunks: [modifyHunk(40, 42)],

--- a/src/renderer/src/lib/diff-utils.ts
+++ b/src/renderer/src/lib/diff-utils.ts
@@ -1,4 +1,4 @@
-import type { editor } from 'monaco-editor'
+import type { editor, IRange } from 'monaco-editor'
 
 /**
  * Structured hunk representation for rendering action buttons.
@@ -10,6 +10,34 @@ export interface Hunk {
   modifiedStartLine: number
   modifiedEndLine: number
   type: 'add' | 'delete' | 'modify'
+}
+
+interface LineRange {
+  start: number
+  end: number
+}
+
+export interface HiddenAreasInput {
+  hunks: Hunk[]
+  contextLines: number
+  originalLineCount: number
+  modifiedLineCount: number
+  extraVisibleOriginal?: number[]
+  extraVisibleModified?: number[]
+}
+
+export interface HiddenAreasResult {
+  originalRanges: IRange[]
+  modifiedRanges: IRange[]
+  gaps: Array<{
+    side: 'modified'
+    afterLine: number
+    hiddenLineCount: number
+    firstHiddenOriginal: number
+    lastHiddenOriginal: number
+    firstHiddenModified: number
+    lastHiddenModified: number
+  }>
 }
 
 /**
@@ -39,6 +67,136 @@ export function parseHunks(changes: editor.ILineChange[] | null): Hunk[] {
       type: isAdd ? 'add' : isDelete ? 'delete' : 'modify'
     }
   })
+}
+
+export function computeHiddenAreas({
+  hunks,
+  contextLines,
+  originalLineCount,
+  modifiedLineCount,
+  extraVisibleOriginal = [],
+  extraVisibleModified = []
+}: HiddenAreasInput): HiddenAreasResult {
+  if (hunks.length === 0) {
+    return { originalRanges: [], modifiedRanges: [], gaps: [] }
+  }
+
+  const originalVisible: LineRange[] = []
+  const modifiedVisible: LineRange[] = []
+
+  for (const hunk of hunks) {
+    addVisibleHunkRange(
+      originalVisible,
+      hunk.originalStartLine,
+      hunk.originalEndLine,
+      contextLines,
+      originalLineCount
+    )
+    addVisibleHunkRange(
+      modifiedVisible,
+      hunk.modifiedStartLine,
+      hunk.modifiedEndLine,
+      contextLines,
+      modifiedLineCount
+    )
+  }
+
+  for (const line of extraVisibleOriginal) {
+    addClampedRange(originalVisible, line - contextLines, line + contextLines, originalLineCount)
+  }
+  for (const line of extraVisibleModified) {
+    addClampedRange(modifiedVisible, line - contextLines, line + contextLines, modifiedLineCount)
+  }
+
+  const originalHidden = invertRanges(mergeRanges(originalVisible), originalLineCount)
+  const modifiedHidden = invertRanges(mergeRanges(modifiedVisible), modifiedLineCount)
+
+  return {
+    originalRanges: originalHidden.map(toMonacoRange),
+    modifiedRanges: modifiedHidden.map(toMonacoRange),
+    gaps: modifiedHidden.map((range, index) => {
+      const originalRange = originalHidden[index] ?? range
+      return {
+        side: 'modified' as const,
+        afterLine: range.start - 1,
+        hiddenLineCount: range.end - range.start + 1,
+        firstHiddenOriginal: originalRange.start,
+        lastHiddenOriginal: originalRange.end,
+        firstHiddenModified: range.start,
+        lastHiddenModified: range.end
+      }
+    })
+  }
+}
+
+function addVisibleHunkRange(
+  ranges: LineRange[],
+  startLine: number,
+  endLine: number,
+  contextLines: number,
+  lineCount: number
+): void {
+  const start = startLine
+  const end = endLine === 0 ? startLine : endLine
+  addClampedRange(ranges, start - contextLines, end + contextLines, lineCount)
+}
+
+function addClampedRange(ranges: LineRange[], start: number, end: number, lineCount: number): void {
+  if (lineCount <= 0) return
+
+  const clampedStart = Math.max(1, Math.min(start, lineCount))
+  const clampedEnd = Math.max(1, Math.min(end, lineCount))
+  if (clampedStart > clampedEnd) return
+
+  ranges.push({ start: clampedStart, end: clampedEnd })
+}
+
+function mergeRanges(ranges: LineRange[]): LineRange[] {
+  if (ranges.length === 0) return []
+
+  const sorted = [...ranges].sort((a, b) => a.start - b.start || a.end - b.end)
+  const merged: LineRange[] = [{ ...sorted[0] }]
+
+  for (const range of sorted.slice(1)) {
+    const previous = merged[merged.length - 1]
+    if (range.start <= previous.end + 1) {
+      previous.end = Math.max(previous.end, range.end)
+    } else {
+      merged.push({ ...range })
+    }
+  }
+
+  return merged
+}
+
+function invertRanges(visibleRanges: LineRange[], lineCount: number): LineRange[] {
+  if (lineCount <= 0) return []
+  if (visibleRanges.length === 0) return [{ start: 1, end: lineCount }]
+
+  const hidden: LineRange[] = []
+  let cursor = 1
+
+  for (const range of visibleRanges) {
+    if (cursor < range.start) {
+      hidden.push({ start: cursor, end: range.start - 1 })
+    }
+    cursor = range.end + 1
+  }
+
+  if (cursor <= lineCount) {
+    hidden.push({ start: cursor, end: lineCount })
+  }
+
+  return hidden
+}
+
+function toMonacoRange(range: LineRange): IRange {
+  return {
+    startLineNumber: range.start,
+    startColumn: 1,
+    endLineNumber: range.end,
+    endColumn: 1
+  }
 }
 
 /**

--- a/src/renderer/src/lib/diff-utils.ts
+++ b/src/renderer/src/lib/diff-utils.ts
@@ -33,8 +33,8 @@ export interface HiddenAreasResult {
     side: 'modified'
     afterLine: number
     hiddenLineCount: number
-    firstHiddenOriginal: number
-    lastHiddenOriginal: number
+    firstHiddenOriginal: number | null
+    lastHiddenOriginal: number | null
     firstHiddenModified: number
     lastHiddenModified: number
   }>
@@ -114,19 +114,80 @@ export function computeHiddenAreas({
   return {
     originalRanges: originalHidden.map(toMonacoRange),
     modifiedRanges: modifiedHidden.map(toMonacoRange),
-    gaps: modifiedHidden.map((range, index) => {
-      const originalRange = originalHidden[index] ?? range
+    gaps: modifiedHidden.map((range) => {
+      const originalRange = mapModifiedHiddenRangeToOriginal(range, hunks, originalLineCount)
       return {
         side: 'modified' as const,
         afterLine: range.start - 1,
         hiddenLineCount: range.end - range.start + 1,
-        firstHiddenOriginal: originalRange.start,
-        lastHiddenOriginal: originalRange.end,
+        firstHiddenOriginal: originalRange?.start ?? null,
+        lastHiddenOriginal: originalRange?.end ?? null,
         firstHiddenModified: range.start,
         lastHiddenModified: range.end
       }
     })
   }
+}
+
+function mapModifiedHiddenRangeToOriginal(
+  range: LineRange,
+  hunks: Hunk[],
+  originalLineCount: number
+): LineRange | null {
+  const start = mapModifiedLineToOriginal(range.start, hunks, originalLineCount)
+  const end = mapModifiedLineToOriginal(range.end, hunks, originalLineCount)
+
+  if (start === null || end === null) {
+    return null
+  }
+
+  return {
+    start: Math.min(start, end),
+    end: Math.max(start, end)
+  }
+}
+
+function mapModifiedLineToOriginal(
+  modifiedLine: number,
+  hunks: Hunk[],
+  originalLineCount: number
+): number | null {
+  let lineDelta = 0
+  const sortedHunks = [...hunks].sort(
+    (a, b) => a.modifiedStartLine - b.modifiedStartLine || a.modifiedEndLine - b.modifiedEndLine
+  )
+
+  for (const hunk of sortedHunks) {
+    const modifiedEndLine =
+      hunk.modifiedEndLine === 0 ? hunk.modifiedStartLine : hunk.modifiedEndLine
+
+    if (modifiedLine < hunk.modifiedStartLine) {
+      break
+    }
+
+    if (modifiedLine <= modifiedEndLine) {
+      return null
+    }
+
+    lineDelta += getOriginalLineCount(hunk) - getModifiedLineCount(hunk)
+  }
+
+  return clampLine(modifiedLine + lineDelta, originalLineCount)
+}
+
+function getOriginalLineCount(hunk: Hunk): number {
+  if (hunk.originalEndLine === 0) return 0
+  return hunk.originalEndLine - hunk.originalStartLine + 1
+}
+
+function getModifiedLineCount(hunk: Hunk): number {
+  if (hunk.modifiedEndLine === 0) return 0
+  return hunk.modifiedEndLine - hunk.modifiedStartLine + 1
+}
+
+function clampLine(line: number, lineCount: number): number {
+  if (lineCount <= 0) return 0
+  return Math.max(1, Math.min(line, lineCount))
 }
 
 function addVisibleHunkRange(

--- a/src/renderer/src/stores/useDiffPrefsStore.ts
+++ b/src/renderer/src/stores/useDiffPrefsStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+export type DiffViewMode = 'split' | 'inline' | 'hunk'
+
+interface DiffPrefsState {
+  viewMode: DiffViewMode
+  setViewMode: (viewMode: DiffViewMode) => void
+}
+
+export const useDiffPrefsStore = create<DiffPrefsState>()(
+  persist(
+    (set) => ({
+      viewMode: 'split',
+      setViewMode: (viewMode) => set({ viewMode })
+    }),
+    {
+      name: 'hive-diff-prefs',
+      storage: createJSONStorage(() => localStorage),
+      version: 1
+    }
+  )
+)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./test/setup.ts'],
-    include: ['test/**/*.test.{ts,tsx}']
+    include: ['test/**/*.test.{ts,tsx}', 'src/renderer/src/**/*.test.{ts,tsx}']
   },
   resolve: {
     alias: {

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -7,7 +7,7 @@ export default defineWorkspace([
     test: {
       name: 'renderer',
       environment: 'jsdom',
-      include: ['test/**/*.test.{ts,tsx}'],
+      include: ['test/**/*.test.{ts,tsx}', 'src/renderer/src/**/*.test.{ts,tsx}'],
       exclude: [
         'test/session-3/**/*.test.ts',
         'test/phase-9/session-2/**/*.test.ts',


### PR DESCRIPTION
## Summary
- Added a new hunk-focused diff mode with in-editor hunk headers and gap controls for expanding hidden context.
- Reworked the diff toolbar to support split, inline, and hunk view modes, including PR review fallback behavior.
- Added hunk stage/unstage/discard actions directly in the diff view and wired them to Git operations.
- Extended diff utilities and tests to compute hidden ranges and preserve visible areas around comments and user-expanded lines.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new diff rendering mode that programmatically hides/reveals editor ranges and adds in-editor hunk actions; errors could lead to confusing diff display or incorrect hunk staging/unstaging/discard operations.
> 
> **Overview**
> Adds a new **hunk-focused diff mode** that collapses unchanged lines using Monaco hidden areas and renders in-editor hunk headers + gap expand controls via the new `HunkViewDecorations` view zones.
> 
> Reworks the diff toolbar to a persisted `split`/`inline`/`hunk` segmented control (via new `useDiffPrefsStore`), with automatic fallback to inline for PR review and for file states where hunk collapsing isn’t supported.
> 
> Moves hunk stage/unstage/discard actions into the hunk header in hunk view (and disables the existing `HunkActionGutter` in that mode), wiring actions to `window.gitOps.*Hunk` with status refresh + toasts.
> 
> Extends `diff-utils` with `computeHiddenAreas` (and tests) to calculate hidden ranges/gaps while keeping comment lines and user-expanded ranges visible; updates Vitest config to include `src/renderer/src/**/*.test` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7462160055f1589898de2d6bd4ed6d7cb8f30213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->