### PR TITLE
Add one-time first-pet hatch tip

### DIFF
--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -123,8 +123,14 @@ export function Header(): React.JSX.Element {
   const isBoardViewActive = useKanbanStore((s) => s.isBoardViewActive)
   const toggleBoardView = useKanbanStore((s) => s.toggleBoardView)
   const kanbanIconSeen = useTipStore((s) => s.isTipSeen('kanban-icon'))
+  const hatchFirstPetSeen = useTipStore((s) => s.isTipSeen('hatch-first-pet'))
   const nonDefaultProviderChosen = useTipStore((s) => s.nonDefaultProviderChosen)
+  const petEnabled = useSettingsStore((s) => s.pet.enabled)
   const [conflictFixFlow, setConflictFixFlow] = useState<ConflictFixFlow | null>(null)
+
+  const showHatchTip = !hatchFirstPetSeen && !petEnabled
+  const settingsTipId = showHatchTip ? 'hatch-first-pet' : 'settings-default-provider'
+  const settingsTipEnabled = showHatchTip ? true : nonDefaultProviderChosen
 
   // Track first-time kanban exit for the kanban-reenter tip
   const [justExitedKanban, setJustExitedKanban] = useState(false)
@@ -814,7 +820,7 @@ export function Header(): React.JSX.Element {
         >
           <History className="h-4 w-4" />
         </Button>
-        <Tip tipId="settings-default-provider" enabled={nonDefaultProviderChosen}>
+        <Tip tipId={settingsTipId} enabled={settingsTipEnabled}>
           <Button
             variant="ghost"
             size="icon"

--- a/src/renderer/src/lib/__tests__/tip-definitions.test.ts
+++ b/src/renderer/src/lib/__tests__/tip-definitions.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { TIP_DEFINITIONS } from '../tip-definitions'
+
+describe('TIP_DEFINITIONS', () => {
+  it('defines the hatch-first-pet discovery tip for the settings gear', () => {
+    expect(TIP_DEFINITIONS['hatch-first-pet']).toEqual({
+      id: 'hatch-first-pet',
+      description:
+        'Hatch your first pet — a desktop companion that reflects the worktree needing the most attention.',
+      trigger: 'mount',
+      priority: 0,
+      side: 'bottom',
+      align: 'end'
+    })
+  })
+})

--- a/src/renderer/src/lib/tip-definitions.ts
+++ b/src/renderer/src/lib/tip-definitions.ts
@@ -10,6 +10,15 @@ export interface TipDefinition {
 }
 
 export const TIP_DEFINITIONS: Record<string, TipDefinition> = {
+  'hatch-first-pet': {
+    id: 'hatch-first-pet',
+    description:
+      'Hatch your first pet — a desktop companion that reflects the worktree needing the most attention.',
+    trigger: 'mount',
+    priority: 0,
+    side: 'bottom',
+    align: 'end'
+  },
   'kanban-icon': {
     id: 'kanban-icon',
     description: 'You can manage your tickets as a kanban board from this icon.',


### PR DESCRIPTION
## Summary
- Add a new `hatch-first-pet` discovery tip for the settings gear to introduce pet hatching.
- Update the header tip selection logic so the new tip shows first when pets are disabled and the tip has not been seen.
- Add a unit test covering the new tip definition.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts which `Tip` appears on the settings button based on pet enablement/seen state, plus a small unit test for the new tip definition.
> 
> **Overview**
> Adds a new `hatch-first-pet` discovery tip and prioritizes it on the Settings gear when pets are disabled and the tip hasn’t been seen yet.
> 
> Updates the header’s settings-tip selection logic to dynamically choose between `hatch-first-pet` and the existing `settings-default-provider` tip, and adds a unit test to lock in the new `TIP_DEFINITIONS` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 483c2182434e6af6d6d15d5c1e423b7277a007c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->