### PR TITLE
Track provider metadata in worktree model icon

### DIFF
--- a/src/renderer/src/components/worktrees/ModelIcon.test.tsx
+++ b/src/renderer/src/components/worktrees/ModelIcon.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ModelIcon } from './ModelIcon'
+import { useSettingsStore, useSessionStore, useWorktreeStore } from '@/stores'
+
+const baseWorktree = {
+  id: 'worktree-1',
+  project_id: 'project-1',
+  name: 'Feature',
+  branch_name: 'feature',
+  path: '/tmp/feature',
+  status: 'active' as const,
+  is_default: false,
+  branch_renamed: 0,
+  last_message_at: null,
+  session_titles: '[]',
+  last_model_provider_id: null,
+  last_model_id: null,
+  last_model_variant: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  last_accessed_at: '2026-01-01T00:00:00.000Z',
+  github_pr_number: null,
+  github_pr_url: null
+}
+
+describe('ModelIcon', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ showModelIcons: true })
+    useWorktreeStore.setState({
+      worktreesByProject: new Map(),
+      worktreeOrderByProject: new Map()
+    })
+    useSessionStore.setState({
+      sessionsByWorktree: new Map()
+    })
+  })
+
+  it('renders Claude for the Claude Agent SDK provider recorded on the worktree', () => {
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        [
+          'project-1',
+          [
+            {
+              ...baseWorktree,
+              last_model_provider_id: 'claude-code',
+              last_model_id: 'opus'
+            }
+          ]
+        ]
+      ])
+    })
+
+    render(<ModelIcon worktreeId="worktree-1" />)
+
+    expect(screen.getByRole('img', { name: 'Claude' })).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/worktrees/ModelIcon.tsx
+++ b/src/renderer/src/components/worktrees/ModelIcon.tsx
@@ -3,11 +3,15 @@ import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useWorktreeStore, useSessionStore } from '@/stores'
 import claudeIcon from '@/assets/model-icons/claude.svg'
 import openaiIcon from '@/assets/model-icons/openai.svg'
+import { useShallow } from 'zustand/react/shallow'
 
 const MODEL_ICON_MATCHERS = [
   { pattern: /^claude/i, icon: claudeIcon, label: 'Claude' },
   { pattern: /^gpt/i, icon: openaiIcon, label: 'OpenAI' }
 ] as const
+
+const CLAUDE_PROVIDER_IDS = new Set(['anthropic', 'claude-code'])
+const OPENAI_PROVIDER_IDS = new Set(['codex', 'openai'])
 
 function getModelIcon(
   modelId: string | null | undefined
@@ -27,34 +31,54 @@ interface ModelIconProps {
 export function ModelIcon({ worktreeId, className }: ModelIconProps): React.JSX.Element | null {
   const showModelIcons = useSettingsStore((s) => s.showModelIcons)
 
-  const lastModelId = useWorktreeStore((s) => {
-    for (const worktrees of s.worktreesByProject.values()) {
-      const wt = worktrees.find((w) => w.id === worktreeId)
-      if (wt) return wt.last_model_id
-    }
-    return null
-  })
+  const lastModelInfo = useWorktreeStore(
+    useShallow((s) => {
+      for (const worktrees of s.worktreesByProject.values()) {
+        const wt = worktrees.find((w) => w.id === worktreeId)
+        if (wt) {
+          return {
+            providerId: wt.last_model_provider_id,
+            modelId: wt.last_model_id
+          }
+        }
+      }
+      return null
+    })
+  )
 
   const latestAgentSdk = useSessionStore((s) => {
     const sessions = s.sessionsByWorktree.get(worktreeId)
     if (!sessions?.length) return null
-    return sessions[sessions.length - 1].agent_sdk ?? null
+    return sessions[0].agent_sdk ?? null
   })
 
   if (!showModelIcons) return null
 
-  // Claude Agent SDK always uses Claude models
-  if (latestAgentSdk === 'claude-code') {
+  const matched = getModelIcon(lastModelInfo?.modelId)
+  if (
+    (lastModelInfo?.providerId && CLAUDE_PROVIDER_IDS.has(lastModelInfo.providerId)) ||
+    matched?.label === 'Claude'
+  ) {
     return <img src={claudeIcon} alt="Claude" className={cn(className)} draggable={false} />
   }
 
-  // Codex SDK always uses OpenAI/GPT models
-  if (latestAgentSdk === 'codex') {
+  if (
+    (lastModelInfo?.providerId && OPENAI_PROVIDER_IDS.has(lastModelInfo.providerId)) ||
+    matched?.label === 'OpenAI'
+  ) {
     return <img src={openaiIcon} alt="OpenAI" className={cn(className)} draggable={false} />
   }
 
-  const matched = getModelIcon(lastModelId)
-  if (!matched) return null
+  if (!lastModelInfo?.providerId && !lastModelInfo?.modelId) {
+    // No prompt has been sent yet, so infer from the newest session SDK.
+    if (latestAgentSdk === 'claude-code') {
+      return <img src={claudeIcon} alt="Claude" className={cn(className)} draggable={false} />
+    }
 
-  return <img src={matched.icon} alt={matched.label} className={cn(className)} draggable={false} />
+    if (latestAgentSdk === 'codex') {
+      return <img src={openaiIcon} alt="OpenAI" className={cn(className)} draggable={false} />
+    }
+  }
+
+  return null
 }


### PR DESCRIPTION
## Summary
- Update `ModelIcon` to prefer the last recorded model provider and model ID from the worktree when choosing Claude vs OpenAI icons.
- Fall back to the newest session SDK only when no model has been recorded yet.
- Add coverage for rendering the Claude icon when the worktree stores a Claude Agent SDK provider.

## Testing
- Added a unit test in `src/renderer/src/components/worktrees/ModelIcon.test.tsx` covering the Claude provider case.
- Not run: full test suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display logic change plus a small test addition; risk is limited to incorrect icon selection due to provider/model matching edge cases.
> 
> **Overview**
> `ModelIcon` now chooses the Claude/OpenAI icon primarily from the worktree’s recorded `last_model_provider_id`/`last_model_id` (including provider ID sets like `claude-code`/`anthropic` and `codex`/`openai`), and only falls back to inferring from the newest session’s `agent_sdk` when no model has been recorded yet.
> 
> Adds a unit test verifying the Claude icon renders when the worktree stores a Claude provider (`claude-code`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41996a10a274eb361d9782197aa0d1cdb660eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->