### PR TITLE
Track last-message time when sending follow-ups

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -49,6 +49,7 @@ import { isBlockerSatisfied } from '@/lib/blocker-utils'
 import { useGitStore } from '@/stores/useGitStore'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
+import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
 import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
 import { buildSdkPlanImplementationPrompt } from '@/lib/proposedPlan'
@@ -229,7 +230,7 @@ async function sendFollowupToSession(opts: {
     throw new Error(`Session not found: ${opts.sessionId}`)
   }
 
-  const { session, workingPath } = result
+  const { session, workingPath, connectionId } = result
 
   if (!workingPath) {
     console.error(`[KanbanTicketModal] sendFollowupToSession: workingPath is null — sessionId=${opts.sessionId}, worktree_id=${session.worktree_id}, connection_id=${session.connection_id}`)
@@ -266,6 +267,10 @@ async function sendFollowupToSession(opts: {
   useWorktreeStatusStore
     .getState()
     .setSessionStatus(opts.sessionId, isPlanLike(opts.followUpMode) ? 'planning' : 'working')
+  bumpWorktreeLastMessage({
+    worktreeId: session.worktree_id,
+    connectionId: session.connection_id ?? connectionId
+  })
 
   // Resolve model AFTER setSessionMode (which may have applied a mode-specific default)
   const model = resolveSessionModel(opts.sessionId, result.session)
@@ -1574,7 +1579,9 @@ function PlanReviewModeContent({
         onClose()
         void (async () => {
           await setModePromise
-          await eagerHandoffStart(connectionPath, newSessionId, handoffPrompt)
+          await eagerHandoffStart(connectionPath, newSessionId, handoffPrompt, {
+            connectionId: sessionRecord.connection_id
+          })
           toast.success('Handoff session started')
         })().catch((error) => {
           console.error('[KanbanTicketModal] handoff (connection) background start failed:', error)
@@ -1627,7 +1634,7 @@ function PlanReviewModeContent({
       onClose()
       void (async () => {
         await setModePromise
-        await eagerHandoffStart(localWorktreePath, newSessionId, handoffPrompt)
+        await eagerHandoffStart(localWorktreePath, newSessionId, handoffPrompt, { worktreeId })
         toast.success('Handoff session started')
       })().catch((error) => {
         console.error('[KanbanTicketModal] handoff background start failed:', error)
@@ -1678,7 +1685,8 @@ function PlanReviewModeContent({
   // ── Shared: eagerly connect, send /using-superpowers, queue follow-up for global listener ──
   const eagerSuperchargeStart = useCallback(async (
     worktreePath: string,
-    newSessionId: string
+    newSessionId: string,
+    bumpTarget: { worktreeId?: string | null; connectionId?: string | null }
   ) => {
     // Connect to OpenCode. Surface failure so the caller can alert the user — staying silent
     // here would leave optimistic UI state with no work running and no error feedback.
@@ -1700,6 +1708,7 @@ function PlanReviewModeContent({
     snapshotTokenBaseline(newSessionId)
     lastSendMode.set(newSessionId, 'build')
     useWorktreeStatusStore.getState().setSessionStatus(newSessionId, 'working')
+    bumpWorktreeLastMessage(bumpTarget)
 
     // Queue the follow-up for the global idle listener to dispatch after /using-superpowers completes
     useSessionStore.getState().setPendingFollowUpMessages(newSessionId, [
@@ -1716,7 +1725,8 @@ function PlanReviewModeContent({
   const eagerHandoffStart = useCallback(async (
     workingPath: string,
     newSessionId: string,
-    handoffPrompt: string
+    handoffPrompt: string,
+    bumpTarget: { worktreeId?: string | null; connectionId?: string | null }
   ) => {
     const connectResult = await window.opencodeOps.connect(workingPath, newSessionId)
     if (!connectResult.success || !connectResult.sessionId) {
@@ -1733,6 +1743,7 @@ function PlanReviewModeContent({
     snapshotTokenBaseline(newSessionId)
     lastSendMode.set(newSessionId, 'build')
     useWorktreeStatusStore.getState().setSessionStatus(newSessionId, 'working')
+    bumpWorktreeLastMessage(bumpTarget)
 
     const model = resolveSessionModel(newSessionId)
     await window.opencodeOps.prompt(
@@ -1792,7 +1803,9 @@ function PlanReviewModeContent({
         // happened and retrying (via a new supercharge click) creates a fresh session.
         void (async () => {
           await setModePromise
-          await eagerSuperchargeStart(connectionPath, newSessionId)
+          await eagerSuperchargeStart(connectionPath, newSessionId, {
+            connectionId: sessionRecord.connection_id
+          })
           toast.success('Supercharge session started')
         })().catch((error) => {
           console.error('[KanbanTicketModal] supercharge (connection) background start failed:', error)
@@ -1850,6 +1863,7 @@ function PlanReviewModeContent({
       const newSessionId = sessionResult.session.id
       const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
       // Hoist into a const so TS narrowing survives across the background IIFE closure.
+      const newWorktreeId = dupResult.worktree.id
       const newWorktreePath = dupResult.worktree.path
 
       prepareTicketBuildSession(newSessionId)
@@ -1860,7 +1874,7 @@ function PlanReviewModeContent({
       // otherwise we'd announce success and then have to follow it with a failure toast.
       void (async () => {
         await setModePromise
-        await eagerSuperchargeStart(newWorktreePath, newSessionId)
+        await eagerSuperchargeStart(newWorktreePath, newSessionId, { worktreeId: newWorktreeId })
         toast.success('Supercharge session started')
       })().catch((error) => {
         console.error('[KanbanTicketModal] supercharge background start failed:', error)
@@ -1915,7 +1929,7 @@ function PlanReviewModeContent({
       // otherwise we'd announce success and then have to follow it with a failure toast.
       void (async () => {
         await setModePromise
-        await eagerSuperchargeStart(localWorktreePath, newSessionId)
+        await eagerSuperchargeStart(localWorktreePath, newSessionId, { worktreeId: ticket.worktree_id })
         toast.success('Local supercharge session started')
       })().catch((error) => {
         console.error('[KanbanTicketModal] local supercharge background start failed:', error)

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -24,6 +24,7 @@ import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageSto
 import { ModelSelector } from '@/components/sessions/ModelSelector'
 import { CodexFastToggle } from '@/components/sessions/CodexFastToggle'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
+import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
 import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
 import { toast } from '@/lib/toast'
@@ -442,6 +443,7 @@ export function WorktreePickerModal({
             useSessionStore.getState().setSessionMode(sessionId, 'plan')
           }
 
+          bumpWorktreeLastMessage({ connectionId })
           await window.opencodeOps.prompt(connectionPath, connectResult.sessionId, [
             { type: 'text', text: fullPrompt }
           ], effectiveModel, promptOptions)
@@ -659,6 +661,7 @@ export function WorktreePickerModal({
           useSessionStore.getState().setSessionMode(sessionId, 'plan')
         }
 
+        bumpWorktreeLastMessage({ worktreeId })
         await window.opencodeOps.prompt(worktree.path, connectResult.sessionId, [
           { type: 'text', text: fullPrompt }
         ], effectiveModel, promptOptions)

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -73,7 +73,6 @@ import { usePromptHistoryStore } from '@/stores/usePromptHistoryStore'
 import { useWorktreeStore, useDropAttachmentStore } from '@/stores'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
-import { useConnectionStore } from '@/stores/useConnectionStore'
 import { usePRReviewStore } from '@/stores/usePRReviewStore'
 import { useDiffCommentStore } from '@/stores/useDiffCommentStore'
 import { useFileTreeStore } from '@/stores/useFileTreeStore'
@@ -83,6 +82,7 @@ import { deriveCodexTimelineMessages, mergeCodexActivityMessages } from '@/lib/c
 import { correlateSubtasksIntoTaskTools } from '@/lib/codex-subtask-correlation'
 import { COMPLETION_WORDS } from '@/lib/format-utils'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
+import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline, computeTokenDelta } from '@/lib/token-baselines'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
@@ -4226,7 +4226,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           // Record prompt to history
           if (worktreeId) {
             usePromptHistoryStore.getState().addPrompt(worktreeId, question)
-            useWorktreeStatusStore.getState().setLastMessageTime(worktreeId, Date.now())
+            bumpWorktreeLastMessage({ worktreeId })
           }
 
           // Build message parts (support file attachments if any)
@@ -4371,18 +4371,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           usePromptHistoryStore.getState().addPrompt(hKey, trimmedValue)
         }
         if (worktreeId) {
-          useWorktreeStatusStore.getState().setLastMessageTime(worktreeId, Date.now())
+          bumpWorktreeLastMessage({ worktreeId })
         } else if (connectionId) {
-          // Connection session — update all member worktrees
-          const connection = useConnectionStore
-            .getState()
-            .connections.find((c) => c.id === connectionId)
-          if (connection) {
-            const now = Date.now()
-            for (const member of connection.members) {
-              useWorktreeStatusStore.getState().setLastMessageTime(member.worktree_id, now)
-            }
-          }
+          bumpWorktreeLastMessage({ connectionId })
         }
         setHistoryIndex(null)
         savedDraftRef.current = ''

--- a/src/renderer/src/hooks/useLifecycleActions.ts
+++ b/src/renderer/src/hooks/useLifecycleActions.ts
@@ -8,6 +8,7 @@ import { toast } from '@/lib/toast'
 import { REVIEW_PROMPTS, DEFAULT_REVIEW_PROMPT_TYPE } from '@/constants/reviewPrompts'
 import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
 import { messageSendTimes, userExplicitSendTimes, lastSendMode } from '@/lib/message-send-times'
+import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
 
 interface AttachedPR {
@@ -239,6 +240,7 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
           snapshotTokenBaseline(sessionId)
           lastSendMode.set(sessionId, 'build')
           useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+          bumpWorktreeLastMessage({ worktreeId })
 
           await window.opencodeOps.prompt(worktreePath, connectResult.sessionId, [
             { type: 'text', text: prompt }

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -12,6 +12,7 @@ import { useRecentStore } from '@/stores/useRecentStore'
 import { useUsageStore, resolveUsageProvider } from '@/stores'
 import { extractTokens, extractCost, extractModelRef, extractModelUsage } from '@/lib/token-utils'
 import { COMPLETION_WORDS } from '@/lib/format-utils'
+import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { computeTokenDelta } from '@/lib/token-baselines'
 import { messageSendTimes } from '@/lib/message-send-times'
 import { checkAutoApprove } from '@/lib/permissionUtils'
@@ -127,7 +128,7 @@ function markBackgroundSessionCompleted(sessionId: string): void {
   let found = false
   for (const [worktreeId, wSessions] of sessions) {
     if (wSessions.some((s) => s.id === sessionId)) {
-      useWorktreeStatusStore.getState().setLastMessageTime(worktreeId, now)
+      bumpWorktreeLastMessage({ worktreeId, timestamp: now })
       useRecentStore.getState().addWorktreeToRecent(worktreeId)
       found = true
       break
@@ -135,28 +136,17 @@ function markBackgroundSessionCompleted(sessionId: string): void {
   }
 
   const connectionSessions = useSessionStore.getState().sessionsByConnection
+  let completedConnectionId: string | null = null
   for (const [connectionId, cSessions] of connectionSessions) {
     if (cSessions.some((s) => s.id === sessionId)) {
       useRecentStore.getState().addConnectionToRecent(connectionId)
+      completedConnectionId = connectionId
       break
     }
   }
 
-  if (!found) {
-    const connSessions = useSessionStore.getState().sessionsByConnection
-    for (const [connectionId, cSessions] of connSessions) {
-      if (cSessions.some((s) => s.id === sessionId)) {
-        const connection = useConnectionStore
-          .getState()
-          .connections.find((c) => c.id === connectionId)
-        if (connection) {
-          for (const member of connection.members) {
-            useWorktreeStatusStore.getState().setLastMessageTime(member.worktree_id, now)
-          }
-        }
-        break
-      }
-    }
+  if (!found && completedConnectionId) {
+    bumpWorktreeLastMessage({ connectionId: completedConnectionId, timestamp: now })
   }
 }
 

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -7,6 +7,7 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
+import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
 import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
 import { toast } from '@/lib/toast'
@@ -122,6 +123,7 @@ export async function autoLaunchTicket(ticket: KanbanTicket): Promise<void> {
         useSessionStore.getState().setSessionMode(sessionId, 'plan')
       }
 
+      bumpWorktreeLastMessage({ worktreeId })
       await window.opencodeOps.prompt(worktree.path, connectResult.sessionId, [
         { type: 'text', text: fullPrompt }
       ], effectiveModel, promptOptions)

--- a/src/renderer/src/lib/last-message-utils.ts
+++ b/src/renderer/src/lib/last-message-utils.ts
@@ -1,0 +1,34 @@
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+
+/**
+ * Bump worktree.last_message_at to "now" when a prompt is being sent.
+ *
+ * Worktree-bound sessions update their own worktree. Connection-bound sessions
+ * fan out to every member worktree. Board-assistant sessions pass neither value
+ * and intentionally become a no-op.
+ */
+export function bumpWorktreeLastMessage(opts: {
+  worktreeId?: string | null
+  connectionId?: string | null
+  timestamp?: number
+}): void {
+  const timestamp = opts.timestamp ?? Date.now()
+  const setLastMessageTime = useWorktreeStatusStore.getState().setLastMessageTime
+
+  if (opts.worktreeId) {
+    setLastMessageTime(opts.worktreeId, timestamp)
+    return
+  }
+
+  if (opts.connectionId) {
+    const connection = useConnectionStore
+      .getState()
+      .connections.find((item) => item.id === opts.connectionId)
+    if (!connection) return
+
+    for (const member of connection.members) {
+      setLastMessageTime(member.worktree_id, timestamp)
+    }
+  }
+}

--- a/test/kanban/plan-review-followup-dispatch.test.tsx
+++ b/test/kanban/plan-review-followup-dispatch.test.tsx
@@ -298,7 +298,8 @@ describe('Plan review followup dispatch', () => {
         pendingFollowUpMessages: new Map()
       })
       useWorktreeStatusStore.setState({
-        sessionStatuses: {}
+        sessionStatuses: {},
+        lastMessageTimeByWorktree: {}
       })
       useProjectStore.setState({
         projects: [makeProject()]
@@ -368,6 +369,26 @@ describe('Plan review followup dispatch', () => {
 
     const statuses = useWorktreeStatusStore.getState().sessionStatuses
     expect(statuses['session-1']?.status).toBe('planning')
+  })
+
+  test('bumps worktree last message time when rejecting plan with feedback', async () => {
+    const beforeSend = Date.now()
+
+    render(<KanbanTicketModal />)
+
+    const input = screen.getByTestId('plan-review-followup-input') as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: 'Add more detail' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('plan-review-send-followup-btn'))
+    })
+
+    await waitFor(() => {
+      const bumpedAt = useWorktreeStatusStore.getState().getLastMessageTime('wt-1')
+      expect(bumpedAt).not.toBeNull()
+      expect(bumpedAt!).toBeGreaterThanOrEqual(beforeSend)
+      expect(bumpedAt!).toBeLessThanOrEqual(Date.now())
+    })
   })
 
   test('closes modal immediately without blocking on prompt', async () => {

--- a/test/kanban/ticket-last-message-bump.test.ts
+++ b/test/kanban/ticket-last-message-bump.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+
+Object.defineProperty(window, 'db', {
+  writable: true,
+  configurable: true,
+  value: {
+    worktree: {
+      update: vi.fn().mockResolvedValue(undefined)
+    }
+  }
+})
+
+describe('ticket last message bump', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useWorktreeStatusStore.setState({ lastMessageTimeByWorktree: {} })
+    useConnectionStore.setState({
+      connections: [
+        {
+          id: 'conn-1',
+          name: 'Connection 1',
+          custom_name: null,
+          status: 'active',
+          path: '/test/conn-1',
+          color: null,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          members: [
+            {
+              id: 'member-1',
+              connection_id: 'conn-1',
+              worktree_id: 'wt-a',
+              project_id: 'proj-1',
+              symlink_name: 'a',
+              added_at: '2026-01-01T00:00:00Z',
+              worktree_name: 'A',
+              worktree_branch: 'feature-a',
+              worktree_path: '/test/a',
+              project_name: 'Project'
+            },
+            {
+              id: 'member-2',
+              connection_id: 'conn-1',
+              worktree_id: 'wt-b',
+              project_id: 'proj-1',
+              symlink_name: 'b',
+              added_at: '2026-01-01T00:00:00Z',
+              worktree_name: 'B',
+              worktree_branch: 'feature-b',
+              worktree_path: '/test/b',
+              project_name: 'Project'
+            }
+          ]
+        }
+      ]
+    })
+  })
+
+  test('bumps a worktree-bound ticket send', () => {
+    bumpWorktreeLastMessage({ worktreeId: 'wt-1', timestamp: 1234 })
+
+    expect(useWorktreeStatusStore.getState().getLastMessageTime('wt-1')).toBe(1234)
+  })
+
+  test('fans out a connection-bound ticket send to every member worktree', () => {
+    bumpWorktreeLastMessage({ connectionId: 'conn-1', timestamp: 5678 })
+
+    expect(useWorktreeStatusStore.getState().getLastMessageTime('wt-a')).toBe(5678)
+    expect(useWorktreeStatusStore.getState().getLastMessageTime('wt-b')).toBe(5678)
+  })
+
+  test('does nothing for board-assistant sends with no worktree or connection', () => {
+    bumpWorktreeLastMessage({ worktreeId: null, connectionId: null, timestamp: 9999 })
+
+    expect(useWorktreeStatusStore.getState().lastMessageTimeByWorktree).toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary
- Introduce `bumpWorktreeLastMessage` to centralize updates to `worktree.last_message_at`.
- Update kanban, session, lifecycle, auto-launch, and global listener flows to bump the relevant worktree or connection members when prompts are sent or sessions complete.
- Remove duplicated ad hoc last-message updates from session handling and connection fan-out paths.
- Add coverage for worktree-bound, connection-bound, and no-op board-assistant cases, plus a kanban follow-up regression test.

## Testing
- `Not run`
- Added unit coverage in `test/kanban/ticket-last-message-bump.test.ts` for the new bump helper.
- Added regression coverage in `test/kanban/plan-review-followup-dispatch.test.tsx` to verify follow-up sends update `lastMessageTime`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple prompt-dispatch paths (kanban followups, session view, lifecycle actions, auto-launch, and global listener) and changes how connection sessions fan out last-message timestamps, so regressions could affect recency/unread ordering across worktrees.
> 
> **Overview**
> Introduces `bumpWorktreeLastMessage` to centralize updating `worktree.last_message_at`, including connection-session fan-out to all member worktrees and a no-op for board-only sends.
> 
> Replaces scattered `setLastMessageTime` calls across kanban flows (followups, handoff, supercharge), `SessionView`, lifecycle/auto-launch prompt sends, and the OpenCode global completion handler with calls to the new helper, and simplifies connection-session handling by removing ad-hoc member iteration.
> 
> Adds tests covering worktree-bound vs connection-bound timestamp bumps and a regression test ensuring plan-review followups bump last-message time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 647857a19dc83694e823552f98bd92d966769864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->