### PR TITLE
Add per-SDK model selection in settings

### DIFF
--- a/src/renderer/src/components/kanban/BoardAssistantView.tsx
+++ b/src/renderer/src/components/kanban/BoardAssistantView.tsx
@@ -1,12 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, type RefObject } from 'react'
-import {
-  Bot,
-  CheckSquare,
-  Loader2,
-  Send,
-  Sparkles,
-  Trash2
-} from 'lucide-react'
+import { Bot, CheckSquare, Loader2, Send, Sparkles, Trash2 } from 'lucide-react'
 import { ModelSelector } from '@/components/sessions/ModelSelector'
 import { AssistantCanvas } from '@/components/sessions/AssistantCanvas'
 import { UserBubble } from '@/components/sessions/UserBubble'
@@ -16,12 +9,26 @@ import { CommandApprovalPrompt } from '@/components/sessions/CommandApprovalProm
 import { MarkdownRenderer } from '@/components/sessions/MarkdownRenderer'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import { Textarea } from '@/components/ui/textarea'
 import { useSessionStream } from '@/hooks/useSessionStream'
 import { parseBoardAssistantDraftSet } from '@/lib/board-assistant-drafts'
 import { toast } from '@/lib/toast'
-import { useBoardChatStore, type BoardChatMessage, type BoardChatScope, type TicketDraft, stripBoardAssistantScaffolding, stripBoardDraftBlocks, resolveBoardChatAgentSdk, resolveBoardChatDefaultModel } from '@/stores/useBoardChatStore'
+import {
+  useBoardChatStore,
+  type BoardChatMessage,
+  type BoardChatScope,
+  type TicketDraft,
+  stripBoardAssistantScaffolding,
+  stripBoardDraftBlocks,
+  resolveBoardChatAgentSdk,
+  resolveBoardChatDefaultModel
+} from '@/stores/useBoardChatStore'
 import { useCommandApprovalStore } from '@/stores/useCommandApprovalStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
@@ -69,7 +76,10 @@ function sanitizeBoardMessageContent(message: BoardChatMessage): string {
   return withoutScaffolding
 }
 
-function sanitizeStreamingParts(parts: StreamingPart[] | undefined, role: BoardChatMessage['role']): StreamingPart[] | undefined {
+function sanitizeStreamingParts(
+  parts: StreamingPart[] | undefined,
+  role: BoardChatMessage['role']
+): StreamingPart[] | undefined {
   if (!parts?.length) return parts
 
   return parts.map((part) => {
@@ -114,11 +124,15 @@ function truncateDescription(description: string | null | undefined): string | n
   return description.length > 240 ? `${description.slice(0, 237)}...` : description
 }
 
-async function resolveProjectRuntime(projectId: string): Promise<{ worktreeId: string; path: string } | null> {
+async function resolveProjectRuntime(
+  projectId: string
+): Promise<{ worktreeId: string; path: string } | null> {
   const worktreeStore = useWorktreeStore.getState()
   const selectedWorktreeId = worktreeStore.selectedWorktreeId
   const projectWorktrees = worktreeStore.getWorktreesForProject(projectId)
-  const selectedProjectWorktree = projectWorktrees.find((worktree) => worktree.id === selectedWorktreeId)
+  const selectedProjectWorktree = projectWorktrees.find(
+    (worktree) => worktree.id === selectedWorktreeId
+  )
   const chosenWorktree =
     selectedProjectWorktree ??
     worktreeStore.getDefaultWorktree(projectId) ??
@@ -130,7 +144,8 @@ async function resolveProjectRuntime(projectId: string): Promise<{ worktreeId: s
   }
 
   const fallbackWorktrees = await window.db.worktree.getActiveByProject(projectId)
-  const fallback = fallbackWorktrees.find((worktree) => worktree.is_default) ?? fallbackWorktrees[0] ?? null
+  const fallback =
+    fallbackWorktrees.find((worktree) => worktree.is_default) ?? fallbackWorktrees[0] ?? null
 
   return fallback?.path ? { worktreeId: fallback.id, path: fallback.path } : null
 }
@@ -187,7 +202,10 @@ function buildBoardPrompt(input: string, scope: BoardChatScope, targetProjectId:
   ].join('\n')
 }
 
-async function ensureRuntimeSession(scope: BoardChatScope, targetProjectId: string): Promise<{
+async function ensureRuntimeSession(
+  scope: BoardChatScope,
+  targetProjectId: string
+): Promise<{
   sessionId: string
   opencodeSessionId: string
   runtimePath: string
@@ -202,8 +220,11 @@ async function ensureRuntimeSession(scope: BoardChatScope, targetProjectId: stri
   }
 
   const settings = useSettingsStore.getState()
-  const agentSdk = currentState.selectedAgentSdkOverride ?? resolveBoardChatAgentSdk(settings.defaultAgentSdk)
-  const selectedModel = currentState.selectedModelOverride ?? resolveBoardChatDefaultModel(settings, agentSdk)
+  const baseAgentSdk =
+    currentState.selectedAgentSdkOverride ?? resolveBoardChatAgentSdk(settings.defaultAgentSdk)
+  const selectedModel =
+    currentState.selectedModelOverride ?? resolveBoardChatDefaultModel(settings, baseAgentSdk)
+  const agentSdk = currentState.selectedAgentSdkOverride ?? selectedModel?.agentSdk ?? baseAgentSdk
 
   let runtimePath: string | null = null
   let worktreeId: string | null = null
@@ -228,7 +249,9 @@ async function ensureRuntimeSession(scope: BoardChatScope, targetProjectId: stri
   // Reuse the session already created by the session store (from createBoardAssistantSession)
   // rather than creating a duplicate. Only create if none exists.
   const { useSessionStore } = await import('@/stores/useSessionStore')
-  const existingStoreSession = useSessionStore.getState().boardAssistantByProject.get(targetProjectId)
+  const existingStoreSession = useSessionStore
+    .getState()
+    .boardAssistantByProject.get(targetProjectId)
 
   let session: { id: string }
   const isReused = Boolean(existingStoreSession)
@@ -564,7 +587,11 @@ function BoardChatMessageList({
   hasInvalidDrafts: boolean
   onQuestionReply: (requestId: string, answers: QuestionAnswer[]) => void
   onQuestionReject: (requestId: string) => void
-  onPermissionReply: (requestId: string, reply: 'once' | 'always' | 'reject', message?: string) => void
+  onPermissionReply: (
+    requestId: string,
+    reply: 'once' | 'always' | 'reject',
+    message?: string
+  ) => void
   onCommandApprovalReply: (
     requestId: string,
     approved: boolean,
@@ -583,7 +610,15 @@ function BoardChatMessageList({
     const element = scrollRef.current
     if (!element) return
     element.scrollTop = element.scrollHeight
-  }, [messages, drafts, draftSourceMessageId, streamingMessage, activeQuestion, activePermission, activeApproval])
+  }, [
+    messages,
+    drafts,
+    draftSourceMessageId,
+    streamingMessage,
+    activeQuestion,
+    activePermission,
+    activeApproval
+  ])
 
   return (
     <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto px-4 py-4">
@@ -599,7 +634,8 @@ function BoardChatMessageList({
           )
         }
 
-        const parsedDrafts = message.role === 'assistant' ? parseBoardAssistantDraftSet(message.content) : null
+        const parsedDrafts =
+          message.role === 'assistant' ? parseBoardAssistantDraftSet(message.content) : null
         const sanitizedContent = sanitizeBoardMessageContent(message)
         const sanitizedParts = sanitizeStreamingParts(message.parts, message.role)
 
@@ -623,16 +659,20 @@ function BoardChatMessageList({
                 </div>
                 <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                   <span>{drafts.length} drafts</span>
-                  <span>{dependencyCount} dependenc{dependencyCount === 1 ? 'y' : 'ies'}</span>
+                  <span>
+                    {dependencyCount} dependenc{dependencyCount === 1 ? 'y' : 'ies'}
+                  </span>
                   {invalidDraftCount > 0 && (
-                    <span className="text-destructive">
-                      {invalidDraftCount} invalid
-                    </span>
+                    <span className="text-destructive">{invalidDraftCount} invalid</span>
                   )}
                 </div>
                 <div className="space-y-2">
                   {drafts.map((draft) => (
-                    <BoardChatDraftProposalCard key={draft.id} draft={draft} onToggle={onToggleDraft} />
+                    <BoardChatDraftProposalCard
+                      key={draft.id}
+                      draft={draft}
+                      onToggle={onToggleDraft}
+                    />
                   ))}
                 </div>
                 <div className="flex flex-wrap items-center gap-2 border-t border-border/70 pt-3">
@@ -738,7 +778,9 @@ function BoardChatComposer({
           }}
         />
         <div className="flex items-center justify-between gap-3 px-2 pb-1">
-          <span className="text-xs text-muted-foreground">Enter to send. Shift+Enter for a new line.</span>
+          <span className="text-xs text-muted-foreground">
+            Enter to send. Shift+Enter for a new line.
+          </span>
           <Button type="button" size="sm" onClick={onSend} disabled={!canSend}>
             {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
             Send
@@ -749,7 +791,9 @@ function BoardChatComposer({
   )
 }
 
-export function BoardAssistantView({ projectId }: BoardAssistantViewProps): React.JSX.Element | null {
+export function BoardAssistantView({
+  projectId
+}: BoardAssistantViewProps): React.JSX.Element | null {
   const projects = useProjectStore((state) => state.projects)
   const project = projects.find((p) => p.id === projectId)
   const worktree = useWorktreeStore((state) => {
@@ -794,7 +838,9 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
   const toggleDraftSelected = useBoardChatStore((state) => state.toggleDraftSelected)
   const setStatus = useBoardChatStore((state) => state.setStatus)
   const setSelectedTargetProjectId = useBoardChatStore((state) => state.setSelectedTargetProjectId)
-  const setSelectedAgentSdkOverride = useBoardChatStore((state) => state.setSelectedAgentSdkOverride)
+  const setSelectedAgentSdkOverride = useBoardChatStore(
+    (state) => state.setSelectedAgentSdkOverride
+  )
   const setSelectedModelOverride = useBoardChatStore((state) => state.setSelectedModelOverride)
   const setError = useBoardChatStore((state) => state.setError)
   const updateOpencodeSessionId = useBoardChatStore((state) => state.updateOpencodeSessionId)
@@ -804,10 +850,16 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
 
   const composerFocusRef = useRef<HTMLTextAreaElement | null>(null)
   const availableAgentSdks = useSettingsStore((state) => state.availableAgentSdks)
-  const defaultBoardAgentSdk = useSettingsStore((state) => resolveBoardChatAgentSdk(state.defaultAgentSdk))
-  const effectiveAgentSdk = selectedAgentSdkOverride ?? defaultBoardAgentSdk
-  const resolvedDefaultModel = useSettingsStore((state) => resolveBoardChatDefaultModel(state, effectiveAgentSdk))
+  const defaultBoardAgentSdk = useSettingsStore((state) =>
+    resolveBoardChatAgentSdk(state.defaultAgentSdk)
+  )
+  const baseAgentSdk = selectedAgentSdkOverride ?? defaultBoardAgentSdk
+  const resolvedDefaultModel = useSettingsStore((state) =>
+    resolveBoardChatDefaultModel(state, baseAgentSdk)
+  )
   const effectiveSelectedModel = selectedModelOverride ?? resolvedDefaultModel
+  const effectiveAgentSdk =
+    selectedAgentSdkOverride ?? effectiveSelectedModel?.agentSdk ?? defaultBoardAgentSdk
   const agentSdkOptions = useMemo(() => {
     const options: Array<'opencode' | 'claude-code' | 'codex'> = []
     if (!availableAgentSdks) return [effectiveAgentSdk]
@@ -816,14 +868,19 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
     if (availableAgentSdks.codex) options.push('codex')
     return options.length > 0 ? options : [effectiveAgentSdk]
   }, [availableAgentSdks, effectiveAgentSdk])
-  const handleMaterializedSessionId = useCallback((nextOpencodeSessionId: string) => {
-    updateOpencodeSessionId(nextOpencodeSessionId)
-    if (sessionId) {
-      void window.db.session.update(sessionId, {
-        opencode_session_id: nextOpencodeSessionId
-      }).catch(() => {})
-    }
-  }, [sessionId, updateOpencodeSessionId])
+  const handleMaterializedSessionId = useCallback(
+    (nextOpencodeSessionId: string) => {
+      updateOpencodeSessionId(nextOpencodeSessionId)
+      if (sessionId) {
+        void window.db.session
+          .update(sessionId, {
+            opencode_session_id: nextOpencodeSessionId
+          })
+          .catch(() => {})
+      }
+    },
+    [sessionId, updateOpencodeSessionId]
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -842,7 +899,7 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
           scope?.kind === 'project'
             ? scope.projectId
             : scope?.kind === 'connection'
-              ? scope.availableProjects[0]?.id ?? null
+              ? (scope.availableProjects[0]?.id ?? null)
               : null
       })
 
@@ -885,7 +942,12 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
   // - The scope changes to a different project (scope sync above)
   // - The user clicks "Clear" (handleClear)
 
-  const { messages: transcriptMessages, streamingParts, streamingContent, isStreaming } = useSessionStream({
+  const {
+    messages: transcriptMessages,
+    streamingParts,
+    streamingContent,
+    isStreaming
+  } = useSessionStream({
     sessionId: sessionId ?? '',
     worktreePath: runtimePath ?? '',
     opencodeSessionId: opencodeSessionId ?? '',
@@ -905,10 +967,7 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
 
   const latestDraftResult = useMemo(() => {
     const strictProjectId = scope?.kind === 'project' ? scope.projectId : undefined
-    const fallbackProjectId =
-      scope?.kind === 'project'
-        ? scope.projectId
-        : selectedTargetProjectId
+    const fallbackProjectId = scope?.kind === 'project' ? scope.projectId : selectedTargetProjectId
 
     for (let index = messages.length - 1; index >= 0; index -= 1) {
       const message = messages[index]
@@ -947,7 +1006,7 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
 
     setDrafts(
       latestDraftResult.drafts.map((draft) => ({
-        id: `${latestDraftResult.messageId}:${draft.draftKey}:${scope.kind === 'project' ? targetProjectId : (draft.projectId || targetProjectId)}`,
+        id: `${latestDraftResult.messageId}:${draft.draftKey}:${scope.kind === 'project' ? targetProjectId : draft.projectId || targetProjectId}`,
         draftKey: draft.draftKey,
         title: draft.title,
         description: draft.description,
@@ -957,12 +1016,13 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
         ),
         warnings: draft.warnings,
         validationIssues: draft.validationIssues,
-        projectId: scope.kind === 'project' ? targetProjectId : (draft.projectId || targetProjectId),
+        projectId: scope.kind === 'project' ? targetProjectId : draft.projectId || targetProjectId,
         projectName:
-          projects.find((project) =>
-            project.id === (scope.kind === 'project' ? targetProjectId : (draft.projectId || targetProjectId))
-          )?.name ??
-          'Unknown project',
+          projects.find(
+            (project) =>
+              project.id ===
+              (scope.kind === 'project' ? targetProjectId : draft.projectId || targetProjectId)
+          )?.name ?? 'Unknown project',
         selected: true
       })),
       latestDraftResult.messageId
@@ -1014,7 +1074,10 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
   const hasInvalidDrafts = drafts.some((draft) => draft.validationIssues.length > 0)
   const canSend =
     canInteract &&
-    Boolean((scope?.kind === 'project' ? scope.projectId : selectedTargetProjectId) && composerValue.trim()) &&
+    Boolean(
+      (scope?.kind === 'project' ? scope.projectId : selectedTargetProjectId) &&
+      composerValue.trim()
+    ) &&
     status !== 'starting' &&
     status !== 'thinking'
 
@@ -1054,14 +1117,13 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
           (activeScope?.kind === 'project'
             ? activeScope.projectId
             : activeScope?.kind === 'connection'
-              ? activeScope.availableProjects[0]?.id ?? null
+              ? (activeScope.availableProjects[0]?.id ?? null)
               : null),
         selectedAgentSdkOverride:
           options?.nextSelectedAgentSdkOverride ??
           useBoardChatStore.getState().selectedAgentSdkOverride,
         selectedModelOverride:
-          options?.nextSelectedModelOverride ??
-          useBoardChatStore.getState().selectedModelOverride
+          options?.nextSelectedModelOverride ?? useBoardChatStore.getState().selectedModelOverride
       })
     },
     [resetState]
@@ -1073,8 +1135,7 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
     const input = composerValue.trim()
     if (!input) return
 
-    const targetProjectId =
-      scope.kind === 'project' ? scope.projectId : selectedTargetProjectId
+    const targetProjectId = scope.kind === 'project' ? scope.projectId : selectedTargetProjectId
 
     if (!targetProjectId) {
       setError('Select a target project before starting the assistant.')
@@ -1094,61 +1155,80 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
       }
 
       const prompt = buildBoardPrompt(input, scope, targetProjectId)
-      const result = await window.opencodeOps.prompt(runtime.runtimePath, runtime.opencodeSessionId, prompt)
+      const result = await window.opencodeOps.prompt(
+        runtime.runtimePath,
+        runtime.opencodeSessionId,
+        prompt
+      )
       if (!result.success) {
         throw new Error(result.error || 'The assistant could not send your message.')
       }
     } catch (sendError) {
-      const message = sendError instanceof Error ? sendError.message : 'Failed to send assistant message.'
+      const message =
+        sendError instanceof Error ? sendError.message : 'Failed to send assistant message.'
       setError(message)
       setStatus('error')
       addLocalSystemMessage(message)
       toast.error(message)
     }
-  }, [addLocalSystemMessage, addLocalUserMessage, composerValue, scope, selectedTargetProjectId, sessionId, setComposerValue, setError, setStatus])
+  }, [
+    addLocalSystemMessage,
+    addLocalUserMessage,
+    composerValue,
+    scope,
+    selectedTargetProjectId,
+    sessionId,
+    setComposerValue,
+    setError,
+    setStatus
+  ])
 
-  const handleCreateDrafts = useCallback(async (onlySelected: boolean) => {
-    const draftsToCreate = drafts.filter(
-      (draft) => !draft.createdAt && (!onlySelected || draft.selected)
-    )
-    if (draftsToCreate.length === 0) {
-      return
-    }
-
-    try {
-      const invalidDrafts = draftsToCreate.filter((draft) => draft.validationIssues.length > 0)
-      if (invalidDrafts.length > 0) {
-        throw new Error('Fix draft validation issues before creating tickets.')
+  const handleCreateDrafts = useCallback(
+    async (onlySelected: boolean) => {
+      const draftsToCreate = drafts.filter(
+        (draft) => !draft.createdAt && (!onlySelected || draft.selected)
+      )
+      if (draftsToCreate.length === 0) {
+        return
       }
 
-      const draftKeysInBatch = new Set(draftsToCreate.map((draft) => draft.draftKey))
-      const result = await window.kanban.ticket.createBatch({
-        drafts: draftsToCreate.map((draft) => ({
-          draft_key: draft.draftKey,
-          project_id: draft.projectId,
-          title: draft.title,
-          description: draft.description,
-          column: 'todo',
-          depends_on: draft.dependsOn.filter((key) => draftKeysInBatch.has(key))
-        }))
-      })
+      try {
+        const invalidDrafts = draftsToCreate.filter((draft) => draft.validationIssues.length > 0)
+        if (invalidDrafts.length > 0) {
+          throw new Error('Fix draft validation issues before creating tickets.')
+        }
 
-      await useKanbanStore.getState().loadTickets(draftsToCreate[0].projectId)
-      await useKanbanStore.getState().loadDependencies(draftsToCreate[0].projectId)
+        const draftKeysInBatch = new Set(draftsToCreate.map((draft) => draft.draftKey))
+        const result = await window.kanban.ticket.createBatch({
+          drafts: draftsToCreate.map((draft) => ({
+            draft_key: draft.draftKey,
+            project_id: draft.projectId,
+            title: draft.title,
+            description: draft.description,
+            column: 'todo',
+            depends_on: draft.dependsOn.filter((key) => draftKeysInBatch.has(key))
+          }))
+        })
 
-      markDraftsCreated(draftsToCreate.map((draft) => draft.id))
-      addLocalSystemMessage(
-        `Created ${result.tickets.length} ticket${result.tickets.length === 1 ? '' : 's'} and ${result.dependencies.length} dependenc${result.dependencies.length === 1 ? 'y' : 'ies'} in ${draftsToCreate[0].projectName}.`
-      )
-      navigateToBoard()
-      toast.success(
-        `Created ${result.tickets.length} ticket${result.tickets.length === 1 ? '' : 's'}.`
-      )
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to create one or more tickets.'
-      toast.error(message)
-    }
-  }, [addLocalSystemMessage, drafts, markDraftsCreated, navigateToBoard])
+        await useKanbanStore.getState().loadTickets(draftsToCreate[0].projectId)
+        await useKanbanStore.getState().loadDependencies(draftsToCreate[0].projectId)
+
+        markDraftsCreated(draftsToCreate.map((draft) => draft.id))
+        addLocalSystemMessage(
+          `Created ${result.tickets.length} ticket${result.tickets.length === 1 ? '' : 's'} and ${result.dependencies.length} dependenc${result.dependencies.length === 1 ? 'y' : 'ies'} in ${draftsToCreate[0].projectName}.`
+        )
+        navigateToBoard()
+        toast.success(
+          `Created ${result.tickets.length} ticket${result.tickets.length === 1 ? '' : 's'}.`
+        )
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Failed to create one or more tickets.'
+        toast.error(message)
+      }
+    },
+    [addLocalSystemMessage, drafts, markDraftsCreated, navigateToBoard]
+  )
 
   const handleClear = useCallback(async () => {
     await handleDiscardConversation({ preserveOpen: true })
@@ -1157,14 +1237,19 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
     }
   }, [addLocalSystemMessage, handleDiscardConversation, storedScope])
 
-  const handleSelectModel = useCallback(async (model: SelectedModel) => {
-    setSelectedModelOverride(model)
-    await handleDiscardConversation({
-      preserveOpen: true,
-      nextSelectedModelOverride: model
-    })
-    addLocalSystemMessage(`Board assistant model changed to ${model.providerID}/${model.modelID}.`)
-  }, [addLocalSystemMessage, handleDiscardConversation, setSelectedModelOverride])
+  const handleSelectModel = useCallback(
+    async (model: SelectedModel) => {
+      setSelectedModelOverride(model)
+      await handleDiscardConversation({
+        preserveOpen: true,
+        nextSelectedModelOverride: model
+      })
+      addLocalSystemMessage(
+        `Board assistant model changed to ${model.providerID}/${model.modelID}.`
+      )
+    },
+    [addLocalSystemMessage, handleDiscardConversation, setSelectedModelOverride]
+  )
 
   const handleResetModel = useCallback(async () => {
     setSelectedModelOverride(null)
@@ -1175,20 +1260,33 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
     addLocalSystemMessage('Board assistant model reset to the app default.')
   }, [addLocalSystemMessage, handleDiscardConversation, setSelectedModelOverride])
 
-  const handleSelectAgentSdk = useCallback(async (nextAgentSdk: 'opencode' | 'claude-code' | 'codex') => {
-    const nextOverride = nextAgentSdk === defaultBoardAgentSdk ? null : nextAgentSdk
-    setSelectedAgentSdkOverride(nextOverride)
-    setSelectedModelOverride(null)
-    await handleDiscardConversation({
-      preserveOpen: true,
-      nextSelectedAgentSdkOverride: nextOverride,
-      nextSelectedModelOverride: null
-    })
-    addLocalSystemMessage(`Board assistant provider changed to ${getAgentSdkLabel(nextAgentSdk)}.`)
-  }, [addLocalSystemMessage, defaultBoardAgentSdk, handleDiscardConversation, setSelectedAgentSdkOverride, setSelectedModelOverride])
+  const handleSelectAgentSdk = useCallback(
+    async (nextAgentSdk: 'opencode' | 'claude-code' | 'codex') => {
+      const nextOverride = nextAgentSdk === defaultBoardAgentSdk ? null : nextAgentSdk
+      setSelectedAgentSdkOverride(nextOverride)
+      setSelectedModelOverride(null)
+      await handleDiscardConversation({
+        preserveOpen: true,
+        nextSelectedAgentSdkOverride: nextOverride,
+        nextSelectedModelOverride: null
+      })
+      addLocalSystemMessage(
+        `Board assistant provider changed to ${getAgentSdkLabel(nextAgentSdk)}.`
+      )
+    },
+    [
+      addLocalSystemMessage,
+      defaultBoardAgentSdk,
+      handleDiscardConversation,
+      setSelectedAgentSdkOverride,
+      setSelectedModelOverride
+    ]
+  )
 
   const handleRevise = useCallback(() => {
-    setComposerValue('Revise the current draft tickets. Keep them small, specific, and implementation-ready.')
+    setComposerValue(
+      'Revise the current draft tickets. Keep them small, specific, and implementation-ready.'
+    )
     composerFocusRef.current?.focus()
   }, [setComposerValue])
 
@@ -1197,12 +1295,16 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
     addLocalSystemMessage('Draft proposals discarded.')
   }, [addLocalSystemMessage, clearDrafts])
 
-  const handleSelectTargetProject = useCallback(async (nextProjectId: string) => {
-    await setSelectedTargetProjectId(nextProjectId)
-    await handleDiscardConversation({ preserveOpen: true, nextTargetProjectId: nextProjectId })
-    const projectName = projects.find((project) => project.id === nextProjectId)?.name ?? 'the selected project'
-    addLocalSystemMessage(`Target project changed to ${projectName}.`)
-  }, [addLocalSystemMessage, handleDiscardConversation, projects, setSelectedTargetProjectId])
+  const handleSelectTargetProject = useCallback(
+    async (nextProjectId: string) => {
+      await setSelectedTargetProjectId(nextProjectId)
+      await handleDiscardConversation({ preserveOpen: true, nextTargetProjectId: nextProjectId })
+      const projectName =
+        projects.find((project) => project.id === nextProjectId)?.name ?? 'the selected project'
+      addLocalSystemMessage(`Target project changed to ${projectName}.`)
+    },
+    [addLocalSystemMessage, handleDiscardConversation, projects, setSelectedTargetProjectId]
+  )
 
   const handleQuestionReply = useCallback(
     async (requestId: string, answers: QuestionAnswer[]) => {
@@ -1235,7 +1337,12 @@ export function BoardAssistantView({ projectId }: BoardAssistantViewProps): Reac
   const handlePermissionReply = useCallback(
     async (requestId: string, reply: 'once' | 'always' | 'reject', message?: string) => {
       try {
-        await window.opencodeOps.permissionReply(requestId, reply, runtimePath || undefined, message)
+        await window.opencodeOps.permissionReply(
+          requestId,
+          reply,
+          runtimePath || undefined,
+          message
+        )
         if (sessionId) {
           usePermissionStore.getState().removePermission(sessionId, requestId)
         }

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -1,5 +1,15 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
-import { Hammer, Map, Sparkles, Plus, GitBranch, Send, ChevronDown, Loader2, Search } from 'lucide-react'
+import {
+  Hammer,
+  Map,
+  Sparkles,
+  Plus,
+  GitBranch,
+  Send,
+  ChevronDown,
+  Loader2,
+  Search
+} from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -78,17 +88,21 @@ function getModePrefix(mode: PickerMode): string {
 function swapModePrefix(text: string, fromMode: PickerMode, toMode: PickerMode): string {
   const fromPrefix = getModePrefix(fromMode)
   const toPrefix = getModePrefix(toMode)
-  if (fromPrefix === toPrefix) return text          // plan ↔ super-plan: same prefix
+  if (fromPrefix === toPrefix) return text // plan ↔ super-plan: same prefix
   if (text.startsWith(fromPrefix)) {
-    return toPrefix + text.slice(fromPrefix.length)  // swap prefix, keep the rest
+    return toPrefix + text.slice(fromPrefix.length) // swap prefix, keep the rest
   }
-  return text                                        // prefix not found: don't touch
+  return text // prefix not found: don't touch
 }
 
 function buildPrompt(mode: PickerMode, ticket: KanbanTicket): string {
   const prefix = getModePrefix(mode)
   const description = ticket.description ?? ''
-  const attachments = (ticket.attachments ?? []) as Array<{ type: string; url: string; label: string }>
+  const attachments = (ticket.attachments ?? []) as Array<{
+    type: string
+    url: string
+    label: string
+  }>
 
   let attachmentsXml = ''
   if (attachments.length > 0) {
@@ -131,23 +145,20 @@ export function WorktreePickerModal({
   const [branchFilter, setBranchFilter] = useState('')
   const [branchesLoading, setBranchesLoading] = useState(false)
   const [selectedModel, setSelectedModel] = useState<{
-    providerID: string; modelID: string; variant?: string
+    agentSdk?: 'opencode' | 'claude-code' | 'codex'
+    providerID: string
+    modelID: string
+    variant?: string
   } | null>(null)
   const [selectedSdk, setSelectedSdk] = useState<'opencode' | 'claude-code' | 'codex' | null>(null)
 
   // ── Store access ────────────────────────────────────────────────
   const worktrees = useWorktreeStore(
-    useCallback(
-      (state) => state.worktreesByProject.get(projectId) ?? EMPTY_ARRAY,
-      [projectId]
-    )
+    useCallback((state) => state.worktreesByProject.get(projectId) ?? EMPTY_ARRAY, [projectId])
   )
 
   const ticketsForProject = useKanbanStore(
-    useCallback(
-      (state) => state.tickets.get(projectId) ?? EMPTY_ARRAY,
-      [projectId]
-    )
+    useCallback((state) => state.tickets.get(projectId) ?? EMPTY_ARRAY, [projectId])
   )
 
   const updateTicket = useKanbanStore((state) => state.updateTicket)
@@ -156,14 +167,11 @@ export function WorktreePickerModal({
   const syncWorktrees = useWorktreeStore((state) => state.syncWorktrees)
 
   const project = useProjectStore(
-    useCallback(
-      (state) => state.projects.find((p) => p.id === projectId) ?? null,
-      [projectId]
-    )
+    useCallback((state) => state.projects.find((p) => p.id === projectId) ?? null, [projectId])
   )
 
   const defaultBranchName = useMemo(() => {
-    const defaultWt = worktrees.find(w => w.is_default)
+    const defaultWt = worktrees.find((w) => w.is_default)
     return defaultWt?.branch_name ?? 'main'
   }, [worktrees])
 
@@ -184,10 +192,10 @@ export function WorktreePickerModal({
     const settings = useSettingsStore.getState()
     // Priority 1: mode-specific default
     const modeModel = settings.getModelForMode(mode)
-    if (modeModel) return modeModel
+    if (modeModel && (!selectedSdk || modeModel.agentSdk === selectedSdk)) return modeModel
     // Priority 2: per-provider / global default
     return resolveModelForSdk(agentSdk) ?? null
-  }, [mode, agentSdk])
+  }, [mode, agentSdk, selectedSdk])
 
   // ── Count in-progress tickets per worktree ──────────────────────
   const ticketCountByWorktree = useMemo(() => {
@@ -205,12 +213,13 @@ export function WorktreePickerModal({
     // branches.length guard: only fetch once per modal-open cycle (reset clears branches on close)
     if (!isNewWorktree || !project?.path || branches.length > 0) return
     setBranchesLoading(true)
-    window.gitOps.listBranchesWithStatus(project.path)
+    window.gitOps
+      .listBranchesWithStatus(project.path)
       .then((result) => {
         if (result.success) {
           setBranches(result.branches)
           const remembered = _lastSourceBranchByProject[projectId]
-          if (remembered && !result.branches.some(b => b.name === remembered)) {
+          if (remembered && !result.branches.some((b) => b.name === remembered)) {
             setSourceBranch(null)
           }
         }
@@ -248,7 +257,7 @@ export function WorktreePickerModal({
   const filteredBranches = useMemo(() => {
     const lower = branchFilter.toLowerCase()
     return branches
-      .filter(b => b.name.toLowerCase().includes(lower))
+      .filter((b) => b.name.toLowerCase().includes(lower))
       .sort((a, b) => {
         if (a.isRemote !== b.isRemote) return a.isRemote ? 1 : -1
         return a.name.localeCompare(b.name)
@@ -258,15 +267,13 @@ export function WorktreePickerModal({
   // ── Handle SDK change ───────────────────────────────────────────
   const handleSdkChange = useCallback((sdk: 'opencode' | 'claude-code' | 'codex') => {
     setSelectedSdk(sdk)
-    setSelectedModel(null)  // reset model — new SDK has different models
+    setSelectedModel(null) // reset model — new SDK has different models
   }, [])
 
   // ── Handle mode toggle ──────────────────────────────────────────
   const toggleMode = useCallback(() => {
     setMode((prev) => {
-      const next: PickerMode = prev === 'build'
-        ? (superArmed ? 'super-plan' : 'plan')
-        : 'build'
+      const next: PickerMode = prev === 'build' ? (superArmed ? 'super-plan' : 'plan') : 'build'
       setPromptText((current) => swapModePrefix(current, prev, next))
       return next
     })
@@ -300,7 +307,7 @@ export function WorktreePickerModal({
     if (!open || preAssignOnly) return
     const handler = (e: KeyboardEvent): void => {
       if (e.key !== 'Tab' || e.ctrlKey || e.metaKey || e.altKey) return
-      if (branchPopoverOpen) return  // Don't toggle mode while picking a branch
+      if (branchPopoverOpen) return // Don't toggle mode while picking a branch
       e.preventDefault()
       e.stopImmediatePropagation()
 
@@ -381,7 +388,9 @@ export function WorktreePickerModal({
         userExplicitSendTimes.set(sessionId, Date.now())
         snapshotTokenBaseline(sessionId)
         lastSendMode.set(sessionId, mode)
-        useWorktreeStatusStore.getState().setSessionStatus(sessionId, isPlanLike(mode) ? 'planning' : 'working')
+        useWorktreeStatusStore
+          .getState()
+          .setSessionStatus(sessionId, isPlanLike(mode) ? 'planning' : 'working')
 
         // Apply model override
         const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
@@ -390,10 +399,12 @@ export function WorktreePickerModal({
         }
 
         // Update ticket — worktree_id stays null for connection sessions
-        const sortOrder = useKanbanStore.getState().computeSortOrder(
-          useKanbanStore.getState().getTicketsByColumnForConnection(connectionId, 'in_progress'),
-          0
-        )
+        const sortOrder = useKanbanStore
+          .getState()
+          .computeSortOrder(
+            useKanbanStore.getState().getTicketsByColumnForConnection(connectionId, 'in_progress'),
+            0
+          )
 
         await updateTicket(ticket.id, ticket.project_id, {
           current_session_id: sessionId,
@@ -419,7 +430,9 @@ export function WorktreePickerModal({
         toast.success('Session started')
 
         // Connect to opencode using connection path
-        const connectionPath = useConnectionStore.getState().connections.find(c => c.id === connectionId)?.path
+        const connectionPath = useConnectionStore
+          .getState()
+          .connections.find((c) => c.id === connectionId)?.path
         if (!connectionPath) return
 
         const connectResult = await window.opencodeOps.connect(connectionPath, sessionId)
@@ -431,28 +444,34 @@ export function WorktreePickerModal({
         // Send prompt
         if (promptText.trim()) {
           const skipPrefix = sessionAgentSdk === 'claude-code' || sessionAgentSdk === 'codex'
-          const modePrefix = mode === 'super-plan' ? getSuperPlanModePrefix(sessionAgentSdk)
-            : mode === 'plan' && !skipPrefix ? PLAN_MODE_PREFIX
-            : ''
+          const modePrefix =
+            mode === 'super-plan'
+              ? getSuperPlanModePrefix(sessionAgentSdk)
+              : mode === 'plan' && !skipPrefix
+                ? PLAN_MODE_PREFIX
+                : ''
           const fullPrompt = modePrefix + promptText.trim()
-          const promptOptions =
-            sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
+          const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
 
           if (mode === 'super-plan') {
             useSessionStore.getState().setSessionMode(sessionId, 'plan')
           }
 
-          await window.opencodeOps.prompt(connectionPath, connectResult.sessionId, [
-            { type: 'text', text: fullPrompt }
-          ], effectiveModel, promptOptions)
+          await window.opencodeOps.prompt(
+            connectionPath,
+            connectResult.sessionId,
+            [{ type: 'text', text: fullPrompt }],
+            effectiveModel,
+            promptOptions
+          )
         }
-        return  // Done with connection path
+        return // Done with connection path
       } catch {
         toast.error('Failed to start session')
       } finally {
         setIsSending(false)
       }
-      return  // Don't fall through to worktree logic
+      return // Don't fall through to worktree logic
     }
 
     try {
@@ -471,10 +490,12 @@ export function WorktreePickerModal({
           codexFastMode
         }
 
-        const sortOrder = useKanbanStore.getState().computeSortOrder(
-          useKanbanStore.getState().getTicketsByColumn(projectId, 'in_progress'),
-          0
-        )
+        const sortOrder = useKanbanStore
+          .getState()
+          .computeSortOrder(
+            useKanbanStore.getState().getTicketsByColumn(projectId, 'in_progress'),
+            0
+          )
 
         await updateTicket(ticket.id, projectId, {
           pending_launch_config: JSON.stringify(pendingConfig),
@@ -596,10 +617,7 @@ export function WorktreePickerModal({
       // Update the ticket with session info and move to in_progress
       const sortOrder = useKanbanStore
         .getState()
-        .computeSortOrder(
-          useKanbanStore.getState().getTicketsByColumn(projectId, 'in_progress'),
-          0
-        )
+        .computeSortOrder(useKanbanStore.getState().getTicketsByColumn(projectId, 'in_progress'), 0)
 
       await updateTicket(ticket.id, projectId, {
         current_session_id: sessionId,
@@ -646,12 +664,13 @@ export function WorktreePickerModal({
       if (promptText.trim()) {
         const skipPrefix = sessionAgentSdk === 'claude-code' || sessionAgentSdk === 'codex'
         const modePrefix =
-          mode === 'super-plan' ? getSuperPlanModePrefix(sessionAgentSdk)
-          : mode === 'plan' && !skipPrefix ? PLAN_MODE_PREFIX
-          : ''
+          mode === 'super-plan'
+            ? getSuperPlanModePrefix(sessionAgentSdk)
+            : mode === 'plan' && !skipPrefix
+              ? PLAN_MODE_PREFIX
+              : ''
         const fullPrompt = modePrefix + promptText.trim()
-        const promptOptions =
-          sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
+        const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
 
         // Auto-revert super-plan → plan immediately (one-shot mode).
         // The prefix is already captured in fullPrompt above.
@@ -659,9 +678,13 @@ export function WorktreePickerModal({
           useSessionStore.getState().setSessionMode(sessionId, 'plan')
         }
 
-        await window.opencodeOps.prompt(worktree.path, connectResult.sessionId, [
-          { type: 'text', text: fullPrompt }
-        ], effectiveModel, promptOptions)
+        await window.opencodeOps.prompt(
+          worktree.path,
+          connectResult.sessionId,
+          [{ type: 'text', text: fullPrompt }],
+          effectiveModel,
+          promptOptions
+        )
       }
     } catch {
       toast.error('Failed to start session')
@@ -709,207 +732,219 @@ export function WorktreePickerModal({
       >
         <DialogHeader className="space-y-2.5 pb-1">
           <DialogTitle className="text-base">
-            {saveConfigOnly ? 'Pre-configure Launch' : preAssignOnly ? 'Assign Worktree' : 'Start Session'}
+            {saveConfigOnly
+              ? 'Pre-configure Launch'
+              : preAssignOnly
+                ? 'Assign Worktree'
+                : 'Start Session'}
           </DialogTitle>
           <DialogDescription>
-            {preAssignOnly ? 'Pre-assign a worktree to' : isConnectionMode ? 'Start a session for' : 'Pick a worktree for'}{' '}
+            {preAssignOnly
+              ? 'Pre-assign a worktree to'
+              : isConnectionMode
+                ? 'Start a session for'
+                : 'Pick a worktree for'}{' '}
             <span className="font-medium text-foreground">{ticket.title}</span>
           </DialogDescription>
           {/* Build/Plan chip toggle — below description to avoid overlapping the X close button */}
-          {!preAssignOnly && <div className="flex items-center gap-1.5">
-            <button
-              data-testid="wt-picker-mode-toggle"
-              data-mode={mode}
-              type="button"
-              onClick={toggleMode}
-              className={cn(
-                'flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors',
-                'border select-none',
-                mode === 'build'
-                  ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
-                  : 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
-              )}
-              title={`${modeLabel} mode`}
-              aria-label={`Current mode: ${modeLabel}. Click to switch`}
-            >
-              <ModeIcon className="h-3.5 w-3.5" aria-hidden="true" />
-              <span>{modeLabel}</span>
-            </button>
-            <div
-              className={cn(
-                'transition-all duration-200 overflow-hidden',
-                mode === 'plan' || mode === 'super-plan'
-                  ? 'opacity-100 translate-x-0 max-w-[80px]'
-                  : 'opacity-0 -translate-x-2 max-w-0 pointer-events-none'
-              )}
-            >
+          {!preAssignOnly && (
+            <div className="flex items-center gap-1.5">
               <button
+                data-testid="wt-picker-mode-toggle"
+                data-mode={mode}
                 type="button"
-                onClick={toggleSuper}
-                aria-pressed={mode === 'super-plan'}
-                aria-label={`Super mode ${mode === 'super-plan' ? 'enabled' : 'disabled'}`}
-                data-testid="wt-picker-super-toggle"
+                onClick={toggleMode}
                 className={cn(
-                  'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
-                  'border select-none whitespace-nowrap',
-                  mode === 'super-plan'
-                    ? 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20 super-sparkle'
-                    : 'bg-muted/50 border-border text-muted-foreground hover:bg-muted hover:text-foreground'
+                  'flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors',
+                  'border select-none',
+                  mode === 'build'
+                    ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
+                    : 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
+                )}
+                title={`${modeLabel} mode`}
+                aria-label={`Current mode: ${modeLabel}. Click to switch`}
+              >
+                <ModeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                <span>{modeLabel}</span>
+              </button>
+              <div
+                className={cn(
+                  'transition-all duration-200 overflow-hidden',
+                  mode === 'plan' || mode === 'super-plan'
+                    ? 'opacity-100 translate-x-0 max-w-[80px]'
+                    : 'opacity-0 -translate-x-2 max-w-0 pointer-events-none'
                 )}
               >
-                SUPER
-              </button>
+                <button
+                  type="button"
+                  onClick={toggleSuper}
+                  aria-pressed={mode === 'super-plan'}
+                  aria-label={`Super mode ${mode === 'super-plan' ? 'enabled' : 'disabled'}`}
+                  data-testid="wt-picker-super-toggle"
+                  className={cn(
+                    'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
+                    'border select-none whitespace-nowrap',
+                    mode === 'super-plan'
+                      ? 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20 super-sparkle'
+                      : 'bg-muted/50 border-border text-muted-foreground hover:bg-muted hover:text-foreground'
+                  )}
+                >
+                  SUPER
+                </button>
+              </div>
             </div>
-          </div>}
+          )}
         </DialogHeader>
 
         <div className="space-y-5">
           {/* ── Worktree list (hidden in connection mode) ────── */}
-          {!isConnectionMode && <div className="space-y-2">
-            <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Worktree
-            </label>
-            <div
-              data-testid="worktree-list"
-              className="max-h-[200px] overflow-y-auto rounded-lg border border-border/60"
-            >
-              {/* "New worktree" option — always at top */}
-              <button
-                data-testid="worktree-item-new"
-                type="button"
-                onClick={handleSelectNewWorktree}
-                className={cn(
-                  'flex w-full items-center gap-3 px-3.5 py-2.5 text-sm transition-colors',
-                  'border-b border-border/40',
-                  'hover:bg-muted/30',
-                  isNewWorktree && 'bg-primary/8 ring-1 ring-inset ring-primary/20'
-                )}
+          {!isConnectionMode && (
+            <div className="space-y-2">
+              <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Worktree
+              </label>
+              <div
+                data-testid="worktree-list"
+                className="max-h-[200px] overflow-y-auto rounded-lg border border-border/60"
               >
-                <span
+                {/* "New worktree" option — always at top */}
+                <button
+                  data-testid="worktree-item-new"
+                  type="button"
+                  onClick={handleSelectNewWorktree}
                   className={cn(
-                    'flex h-7 w-7 shrink-0 items-center justify-center rounded-md',
-                    'bg-primary/10 text-primary'
+                    'flex w-full items-center gap-3 px-3.5 py-2.5 text-sm transition-colors',
+                    'border-b border-border/40',
+                    'hover:bg-muted/30',
+                    isNewWorktree && 'bg-primary/8 ring-1 ring-inset ring-primary/20'
                   )}
                 >
-                  <Plus className="h-3.5 w-3.5" />
-                </span>
-                <span className="font-medium text-foreground">New worktree</span>
-              </button>
-
-              {isNewWorktree && (
-                <div className="flex items-center gap-2 px-3.5 py-2 border-b border-border/40 bg-muted/5">
-                  <span className="text-xs text-muted-foreground whitespace-nowrap">from</span>
-                  <Popover open={branchPopoverOpen} onOpenChange={setBranchPopoverOpen}>
-                    <PopoverTrigger asChild>
-                      <button
-                        type="button"
-                        data-testid="source-branch-trigger"
-                        className="inline-flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-md border border-border/60 hover:bg-muted/30 transition-colors"
-                      >
-                        <GitBranch className="h-3 w-3 text-muted-foreground" />
-                        <span className="truncate max-w-[180px]">
-                          {sourceBranch ?? defaultBranchName}
-                        </span>
-                        <ChevronDown className="h-3 w-3 text-muted-foreground" />
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-72 p-0" align="start">
-                      <div className="p-2 border-b border-border/40">
-                        <div className="relative">
-                          <Search className="absolute left-2 top-2 h-3.5 w-3.5 text-muted-foreground" />
-                          <Input
-                            placeholder="Filter branches..."
-                            value={branchFilter}
-                            onChange={(e) => setBranchFilter(e.target.value)}
-                            className="pl-7 h-8 text-xs"
-                            autoFocus
-                          />
-                        </div>
-                      </div>
-                      <div className="max-h-[200px] overflow-y-auto py-1">
-                        {branchesLoading ? (
-                          <div className="flex items-center justify-center py-4">
-                            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-                          </div>
-                        ) : filteredBranches.length === 0 ? (
-                          <div className="px-3 py-4 text-center text-xs text-muted-foreground">
-                            No branches found
-                          </div>
-                        ) : (
-                          filteredBranches.map((branch) => (
-                            <button
-                              type="button"
-                              key={`${branch.name}-${branch.isRemote}`}
-                              data-testid={`source-branch-${branch.name}`}
-                              className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left hover:bg-muted/30 transition-colors"
-                              onClick={() => {
-                                setSourceBranch(branch.name)
-                                _lastSourceBranchByProject[projectId] = branch.name
-                                setBranchPopoverOpen(false)
-                                setBranchFilter('')
-                              }}
-                            >
-                              <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
-                              <span className="flex-1 truncate">{branch.name}</span>
-                              {branch.isRemote && (
-                                <span className="text-[10px] text-muted-foreground">remote</span>
-                              )}
-                              {branch.isCheckedOut && (
-                                <span className="text-[10px] text-primary">active</span>
-                              )}
-                            </button>
-                          ))
-                        )}
-                      </div>
-                    </PopoverContent>
-                  </Popover>
-                  {worktreeNamePreview && (
-                    <span className="ml-auto text-xs text-muted-foreground font-mono truncate max-w-[180px]">
-                      {worktreeNamePreview}
-                    </span>
-                  )}
-                </div>
-              )}
-
-              {/* Existing worktrees */}
-              {worktrees.map((wt) => {
-                const count = ticketCountByWorktree[wt.id] || 0
-                const isSelected = selectedWorktreeId === wt.id
-
-                return (
-                  <button
-                    key={wt.id}
-                    data-testid={`worktree-item-${wt.id}`}
-                    type="button"
-                    onClick={() => handleSelectWorktree(wt.id)}
+                  <span
                     className={cn(
-                      'flex w-full items-center gap-3 px-3.5 py-2.5 text-sm transition-colors',
-                      'border-b border-border/40 last:border-b-0',
-                      'hover:bg-muted/30',
-                      isSelected && 'bg-primary/8 ring-1 ring-inset ring-primary/20'
+                      'flex h-7 w-7 shrink-0 items-center justify-center rounded-md',
+                      'bg-primary/10 text-primary'
                     )}
                   >
-                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted/40 text-muted-foreground">
-                      <GitBranch className="h-3.5 w-3.5" />
-                    </span>
-                    <span className="flex-1 truncate text-left font-medium text-foreground">
-                      {wt.name}
-                    </span>
-                    {wt.is_default && (
-                      <span className="rounded-full bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                        default
+                    <Plus className="h-3.5 w-3.5" />
+                  </span>
+                  <span className="font-medium text-foreground">New worktree</span>
+                </button>
+
+                {isNewWorktree && (
+                  <div className="flex items-center gap-2 px-3.5 py-2 border-b border-border/40 bg-muted/5">
+                    <span className="text-xs text-muted-foreground whitespace-nowrap">from</span>
+                    <Popover open={branchPopoverOpen} onOpenChange={setBranchPopoverOpen}>
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          data-testid="source-branch-trigger"
+                          className="inline-flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-md border border-border/60 hover:bg-muted/30 transition-colors"
+                        >
+                          <GitBranch className="h-3 w-3 text-muted-foreground" />
+                          <span className="truncate max-w-[180px]">
+                            {sourceBranch ?? defaultBranchName}
+                          </span>
+                          <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-72 p-0" align="start">
+                        <div className="p-2 border-b border-border/40">
+                          <div className="relative">
+                            <Search className="absolute left-2 top-2 h-3.5 w-3.5 text-muted-foreground" />
+                            <Input
+                              placeholder="Filter branches..."
+                              value={branchFilter}
+                              onChange={(e) => setBranchFilter(e.target.value)}
+                              className="pl-7 h-8 text-xs"
+                              autoFocus
+                            />
+                          </div>
+                        </div>
+                        <div className="max-h-[200px] overflow-y-auto py-1">
+                          {branchesLoading ? (
+                            <div className="flex items-center justify-center py-4">
+                              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                            </div>
+                          ) : filteredBranches.length === 0 ? (
+                            <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                              No branches found
+                            </div>
+                          ) : (
+                            filteredBranches.map((branch) => (
+                              <button
+                                type="button"
+                                key={`${branch.name}-${branch.isRemote}`}
+                                data-testid={`source-branch-${branch.name}`}
+                                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left hover:bg-muted/30 transition-colors"
+                                onClick={() => {
+                                  setSourceBranch(branch.name)
+                                  _lastSourceBranchByProject[projectId] = branch.name
+                                  setBranchPopoverOpen(false)
+                                  setBranchFilter('')
+                                }}
+                              >
+                                <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
+                                <span className="flex-1 truncate">{branch.name}</span>
+                                {branch.isRemote && (
+                                  <span className="text-[10px] text-muted-foreground">remote</span>
+                                )}
+                                {branch.isCheckedOut && (
+                                  <span className="text-[10px] text-primary">active</span>
+                                )}
+                              </button>
+                            ))
+                          )}
+                        </div>
+                      </PopoverContent>
+                    </Popover>
+                    {worktreeNamePreview && (
+                      <span className="ml-auto text-xs text-muted-foreground font-mono truncate max-w-[180px]">
+                        {worktreeNamePreview}
                       </span>
                     )}
-                    {count > 0 && (
-                      <span className="inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-blue-500/10 px-1.5 text-[11px] font-medium text-blue-500">
-                        {count}
+                  </div>
+                )}
+
+                {/* Existing worktrees */}
+                {worktrees.map((wt) => {
+                  const count = ticketCountByWorktree[wt.id] || 0
+                  const isSelected = selectedWorktreeId === wt.id
+
+                  return (
+                    <button
+                      key={wt.id}
+                      data-testid={`worktree-item-${wt.id}`}
+                      type="button"
+                      onClick={() => handleSelectWorktree(wt.id)}
+                      className={cn(
+                        'flex w-full items-center gap-3 px-3.5 py-2.5 text-sm transition-colors',
+                        'border-b border-border/40 last:border-b-0',
+                        'hover:bg-muted/30',
+                        isSelected && 'bg-primary/8 ring-1 ring-inset ring-primary/20'
+                      )}
+                    >
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted/40 text-muted-foreground">
+                        <GitBranch className="h-3.5 w-3.5" />
                       </span>
-                    )}
-                  </button>
-                )
-              })}
+                      <span className="flex-1 truncate text-left font-medium text-foreground">
+                        {wt.name}
+                      </span>
+                      {wt.is_default && (
+                        <span className="rounded-full bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          default
+                        </span>
+                      )}
+                      {count > 0 && (
+                        <span className="inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-blue-500/10 px-1.5 text-[11px] font-medium text-blue-500">
+                          {count}
+                        </span>
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
             </div>
-          </div>}
+          )}
 
           {/* ── Provider & Model picker (hidden in pre-assign mode) ── */}
           {!preAssignOnly && (
@@ -918,63 +953,68 @@ export function WorktreePickerModal({
                 Provider & Model
               </label>
               {/* SDK toggle — only when 2+ SDKs are available */}
-              {availableAgentSdks && (
-                [availableAgentSdks.opencode, availableAgentSdks.claude, availableAgentSdks.codex].filter(Boolean).length >= 2
-              ) && (
-                <div className="flex gap-1.5" data-testid="sdk-toggle">
-                  {availableAgentSdks.opencode && (
-                    <button
-                      type="button"
-                      data-testid="sdk-toggle-opencode"
-                      onClick={() => handleSdkChange('opencode')}
-                      className={cn(
-                        'px-2.5 py-1 rounded-md text-xs border transition-colors',
-                        agentSdk === 'opencode'
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
-                      )}
-                    >
-                      OpenCode
-                    </button>
-                  )}
-                  {availableAgentSdks.claude && (
-                    <button
-                      type="button"
-                      data-testid="sdk-toggle-claude-code"
-                      onClick={() => handleSdkChange('claude-code')}
-                      className={cn(
-                        'px-2.5 py-1 rounded-md text-xs border transition-colors',
-                        agentSdk === 'claude-code'
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
-                      )}
-                    >
-                      Claude Code
-                    </button>
-                  )}
-                  {availableAgentSdks.codex && (
-                    <button
-                      type="button"
-                      data-testid="sdk-toggle-codex"
-                      onClick={() => handleSdkChange('codex')}
-                      className={cn(
-                        'px-2.5 py-1 rounded-md text-xs border transition-colors',
-                        agentSdk === 'codex'
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
-                      )}
-                    >
-                      Codex
-                    </button>
-                  )}
-                </div>
-              )}
+              {availableAgentSdks &&
+                [
+                  availableAgentSdks.opencode,
+                  availableAgentSdks.claude,
+                  availableAgentSdks.codex
+                ].filter(Boolean).length >= 2 && (
+                  <div className="flex gap-1.5" data-testid="sdk-toggle">
+                    {availableAgentSdks.opencode && (
+                      <button
+                        type="button"
+                        data-testid="sdk-toggle-opencode"
+                        onClick={() => handleSdkChange('opencode')}
+                        className={cn(
+                          'px-2.5 py-1 rounded-md text-xs border transition-colors',
+                          agentSdk === 'opencode'
+                            ? 'bg-primary text-primary-foreground border-primary'
+                            : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+                        )}
+                      >
+                        OpenCode
+                      </button>
+                    )}
+                    {availableAgentSdks.claude && (
+                      <button
+                        type="button"
+                        data-testid="sdk-toggle-claude-code"
+                        onClick={() => handleSdkChange('claude-code')}
+                        className={cn(
+                          'px-2.5 py-1 rounded-md text-xs border transition-colors',
+                          agentSdk === 'claude-code'
+                            ? 'bg-primary text-primary-foreground border-primary'
+                            : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+                        )}
+                      >
+                        Claude Code
+                      </button>
+                    )}
+                    {availableAgentSdks.codex && (
+                      <button
+                        type="button"
+                        data-testid="sdk-toggle-codex"
+                        onClick={() => handleSdkChange('codex')}
+                        className={cn(
+                          'px-2.5 py-1 rounded-md text-xs border transition-colors',
+                          agentSdk === 'codex'
+                            ? 'bg-primary text-primary-foreground border-primary'
+                            : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+                        )}
+                      >
+                        Codex
+                      </button>
+                    )}
+                  </div>
+                )}
               <div className="flex items-center gap-2 flex-wrap">
                 <div className="min-w-0">
                   <ModelSelector
                     value={selectedModel ?? autoResolvedModel}
                     onChange={setSelectedModel}
-                    agentSdkOverride={agentSdk}
+                    agentSdkOverride={
+                      selectedModel?.agentSdk ?? autoResolvedModel?.agentSdk ?? agentSdk
+                    }
                   />
                 </div>
                 {agentSdk === 'codex' && (

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Check, ChevronDown, Search, Star } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { cacheHandoffModelCatalog, type HandoffAgentSdk } from '@/lib/handoffSelection'
+import {
+  cacheHandoffModelCatalog,
+  getAvailableHandoffAgentSdks,
+  getHandoffSdkDisplayName
+} from '@/lib/handoffSelection'
 import {
   findModelInfo,
   getModelDisplayName,
@@ -10,7 +14,12 @@ import {
   type ModelInfo,
   type ProviderModels
 } from '@/lib/parseProviders'
-import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
+import {
+  useSettingsStore,
+  resolveModelForSdk,
+  type SelectedModel,
+  type HandoffAgentSdk
+} from '@/stores/useSettingsStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { toast } from '@/lib/toast'
 import {
@@ -25,12 +34,23 @@ import {
 interface ModelSelectorProps {
   sessionId?: string
   // Controlled mode (for settings)
-  value?: { providerID: string; modelID: string; variant?: string } | null
-  onChange?: (model: { providerID: string; modelID: string; variant?: string }) => void
+  value?: SelectedModel | null
+  onChange?: (model: SelectedModel) => void
   // Override the SDK used for model listing (e.g. force 'opencode' in settings when defaultAgentSdk is 'terminal')
   agentSdkOverride?: 'opencode' | 'claude-code' | 'codex'
   disableTitleTooltip?: boolean
   hideProviderPrefix?: boolean
+  allowAgentSdkSelection?: boolean
+}
+
+type SelectableModelInfo = ModelInfo & { agentSdk: HandoffAgentSdk }
+type SelectableProviderModels = Omit<ProviderModels, 'models'> & {
+  agentSdk: HandoffAgentSdk
+  models: SelectableModelInfo[]
+}
+type SdkFilterOption = {
+  agentSdk: HandoffAgentSdk
+  label: string
 }
 
 export function ModelSelector({
@@ -39,7 +59,8 @@ export function ModelSelector({
   onChange,
   agentSdkOverride,
   disableTitleTooltip = false,
-  hideProviderPrefix = false
+  hideProviderPrefix = false,
+  allowAgentSdkSelection = false
 }: ModelSelectorProps): React.JSX.Element {
   // Read per-session model from session store (with global fallback)
   const session = useSessionStore((state) => {
@@ -59,6 +80,7 @@ export function ModelSelector({
   // Terminal SDK has no models — fall back to opencode for model listing
   const agentSdk = rawAgentSdk === 'terminal' ? 'opencode' : rawAgentSdk
   const globalModel = useSettingsStore((state) => resolveModelForSdk(agentSdk, state))
+  const availableAgentSdks = useSettingsStore((s) => s.availableAgentSdks)
   const sessionModel =
     session?.model_id && session.model_provider_id
       ? {
@@ -74,11 +96,18 @@ export function ModelSelector({
   const showModelProvider = useSettingsStore((s) => s.showModelProvider)
   const favoriteModels = useSettingsStore((s) => s.favoriteModels)
   const toggleFavoriteModel = useSettingsStore((s) => s.toggleFavoriteModel)
-  const [providers, setProviders] = useState<ProviderModels[]>([])
+  const [providers, setProviders] = useState<SelectableProviderModels[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [filter, setFilter] = useState('')
+  const [agentSdkFilter, setAgentSdkFilter] = useState<HandoffAgentSdk | null>(null)
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const filterInputRef = useRef<HTMLInputElement>(null)
+  const rememberedModelBySdkRef = useRef<Partial<Record<HandoffAgentSdk, SelectedModel>>>({})
+
+  const catalogAgentSdks = useMemo((): HandoffAgentSdk[] => {
+    if (!allowAgentSdkSelection) return [agentSdk as HandoffAgentSdk]
+    return getAvailableHandoffAgentSdks(availableAgentSdks)
+  }, [agentSdk, allowAgentSdkSelection, availableAgentSdks])
 
   // Load available models on mount
   useEffect(() => {
@@ -86,14 +115,24 @@ export function ModelSelector({
 
     async function loadModels(): Promise<void> {
       try {
-        const result = await window.opencodeOps.listModels({ agentSdk })
         if (!mounted) return
-
-        if (result.success && result.providers) {
-          const parsed = parseProviders(result.providers)
-          setProviders(parsed)
-          cacheHandoffModelCatalog(agentSdk as HandoffAgentSdk, result.providers)
-        }
+        setIsLoading(true)
+        const catalogs = await Promise.all(
+          catalogAgentSdks.map(async (sdk) => {
+            const result = await window.opencodeOps.listModels({ agentSdk: sdk })
+            if (!result.success || !result.providers) return []
+            const parsed = parseProviders(result.providers)
+            cacheHandoffModelCatalog(sdk, result.providers)
+            return parsed.map(
+              (provider): SelectableProviderModels => ({
+                ...provider,
+                agentSdk: sdk,
+                models: provider.models.map((model) => ({ ...model, agentSdk: sdk }))
+              })
+            )
+          })
+        )
+        if (mounted) setProviders(catalogs.flat())
       } catch (error) {
         console.error('Failed to load models:', error)
       } finally {
@@ -105,9 +144,69 @@ export function ModelSelector({
     return () => {
       mounted = false
     }
-  }, [agentSdk])
+  }, [catalogAgentSdks])
 
-  function handleSelectModel(model: ModelInfo): void {
+  const buildSelectedModel = useCallback(
+    (model: SelectableModelInfo, variant?: string): SelectedModel => {
+      return {
+        ...(allowAgentSdkSelection ? { agentSdk: model.agentSdk } : {}),
+        providerID: model.providerID,
+        modelID: model.id,
+        variant
+      }
+    },
+    [allowAgentSdkSelection]
+  )
+
+  const rememberSelectedModel = useCallback((model: SelectedModel, sdk: HandoffAgentSdk): void => {
+    rememberedModelBySdkRef.current[sdk] = {
+      ...model,
+      agentSdk: sdk
+    }
+  }, [])
+
+  const applySelectedModel = useCallback(
+    (model: SelectedModel, sdk: HandoffAgentSdk): void => {
+      rememberSelectedModel(model, sdk)
+      if (onChange) {
+        onChange(model)
+      } else if (sessionId) {
+        useSessionStore.getState().setSessionModel(sessionId, model)
+      } else {
+        useSettingsStore.getState().setSelectedModelForSdk(sdk, model)
+      }
+    },
+    [onChange, rememberSelectedModel, sessionId]
+  )
+
+  function getFallbackModelForSdk(sdk: HandoffAgentSdk): SelectableModelInfo | null {
+    return providers.find((provider) => provider.agentSdk === sdk)?.models[0] ?? null
+  }
+
+  function resolveSelectableModelForSdk(sdk: HandoffAgentSdk): SelectedModel | null {
+    const remembered =
+      rememberedModelBySdkRef.current[sdk] ?? resolveModelForSdk(sdk, useSettingsStore.getState())
+    if (remembered) {
+      const sdkProviders = providers.filter((provider) => provider.agentSdk === sdk)
+      const modelInfo = findModelInfo(
+        sdkProviders,
+        remembered.providerID,
+        remembered.modelID
+      ) as SelectableModelInfo | null
+      if (modelInfo) {
+        return {
+          ...remembered,
+          agentSdk: sdk
+        }
+      }
+    }
+
+    const fallbackModel = getFallbackModelForSdk(sdk)
+    if (!fallbackModel) return null
+    return buildSelectedModel(fallbackModel, getModelVariantKeys(fallbackModel)[0])
+  }
+
+  function handleSelectModel(model: SelectableModelInfo): void {
     const variantKeys = getModelVariantKeys(model)
     const remembered = useSettingsStore
       .getState()
@@ -118,57 +217,72 @@ export function ModelSelector({
         : variantKeys.length > 0
           ? variantKeys[0]
           : undefined
-    const newModel = { providerID: model.providerID, modelID: model.id, variant }
+    const newModel = buildSelectedModel(model, variant)
 
     // Use controlled onChange if provided (for settings), otherwise update store
-    if (onChange) {
-      onChange(newModel)
-    } else if (sessionId) {
-      useSessionStore.getState().setSessionModel(sessionId, newModel)
-    } else {
-      useSettingsStore.getState().setSelectedModelForSdk(agentSdk, newModel)
-    }
+    applySelectedModel(newModel, model.agentSdk)
   }
 
-  function handleSelectVariant(model: ModelInfo, variant: string): void {
-    const newModel = { providerID: model.providerID, modelID: model.id, variant }
+  function handleSelectVariant(model: SelectableModelInfo, variant: string): void {
+    const newModel = buildSelectedModel(model, variant)
 
     // Use controlled onChange if provided (for settings), otherwise update store
     if (onChange) {
       // In controlled mode, just notify parent - don't update global variant preference
-      onChange(newModel)
+      applySelectedModel(newModel, model.agentSdk)
     } else {
       // In uncontrolled mode, persist variant preference globally
       useSettingsStore.getState().setModelVariantDefault(model.providerID, model.id, variant)
-      if (sessionId) {
-        useSessionStore.getState().setSessionModel(sessionId, newModel)
-      } else {
-        useSettingsStore.getState().setSelectedModelForSdk(agentSdk, newModel)
-      }
+      applySelectedModel(newModel, model.agentSdk)
     }
   }
 
-  function isActiveModel(model: ModelInfo): boolean {
+  function handleSelectAgentSdkFilter(sdk: HandoffAgentSdk | null): void {
+    setAgentSdkFilter(sdk)
+    if (!sdk) return
+    const nextModel = resolveSelectableModelForSdk(sdk)
+    if (nextModel) applySelectedModel(nextModel, sdk)
+  }
+
+  function isActiveModel(model: SelectableModelInfo): boolean {
     if (!selectedModel) {
       return model.providerID === 'anthropic' && model.id === 'claude-opus-4-5-20251101'
     }
-    return selectedModel.providerID === model.providerID && selectedModel.modelID === model.id
+    const selectedAgentSdk = selectedModel.agentSdk ?? agentSdk
+    return (
+      selectedAgentSdk === model.agentSdk &&
+      selectedModel.providerID === model.providerID &&
+      selectedModel.modelID === model.id
+    )
   }
 
   // Find the currently selected model info
-  const currentModel = useMemo((): ModelInfo | null => {
+  const currentModel = useMemo((): SelectableModelInfo | null => {
     const modelID = selectedModel?.modelID || 'claude-opus-4-5-20251101'
     const providerID = selectedModel?.providerID || 'anthropic'
-    return findModelInfo(providers, providerID, modelID)
-  }, [selectedModel, providers])
+    const selectedAgentSdk = selectedModel?.agentSdk ?? agentSdk
+    const sdkProviders = providers.filter((provider) => provider.agentSdk === selectedAgentSdk)
+    return findModelInfo(sdkProviders, providerID, modelID) as SelectableModelInfo | null
+  }, [selectedModel, providers, agentSdk])
 
   const providerPrefix = useMemo(() => {
     if (hideProviderPrefix || !showModelProvider) return null
+    if (allowAgentSdkSelection) {
+      const selectedAgentSdk = currentModel?.agentSdk ?? selectedModel?.agentSdk ?? agentSdk
+      return getHandoffSdkDisplayName(selectedAgentSdk as HandoffAgentSdk)
+    }
     if (agentSdk === 'claude-code') return 'ANTHROPIC'
     return (
       currentModel?.providerID?.toUpperCase() ?? selectedModel?.providerID?.toUpperCase() ?? null
     )
-  }, [hideProviderPrefix, showModelProvider, agentSdk, currentModel, selectedModel])
+  }, [
+    hideProviderPrefix,
+    showModelProvider,
+    allowAgentSdkSelection,
+    agentSdk,
+    currentModel,
+    selectedModel
+  ])
 
   // Cycle thinking-level variant for Alt+T
   const cycleVariant = useCallback(() => {
@@ -181,29 +295,21 @@ export function ModelSelector({
     const nextIndex = (currentIndex + 1) % variantKeys.length
     const nextVariant = variantKeys[nextIndex]
 
-    const newModel = {
-      providerID: currentModel.providerID,
-      modelID: currentModel.id,
-      variant: nextVariant
-    }
+    const newModel = buildSelectedModel(currentModel, nextVariant)
 
     // Use controlled onChange if provided (for settings), otherwise update store
     if (onChange) {
       // In controlled mode, just notify parent - don't update global variant preference
-      onChange(newModel)
+      applySelectedModel(newModel, currentModel.agentSdk)
     } else {
       // In uncontrolled mode, persist variant preference globally
       useSettingsStore
         .getState()
         .setModelVariantDefault(currentModel.providerID, currentModel.id, nextVariant)
-      if (sessionId) {
-        useSessionStore.getState().setSessionModel(sessionId, newModel)
-      } else {
-        useSettingsStore.getState().setSelectedModelForSdk(agentSdk, newModel)
-      }
+      applySelectedModel(newModel, currentModel.agentSdk)
     }
     toast.success(`Variant: ${nextVariant}`)
-  }, [selectedModel, currentModel, agentSdk, sessionId, onChange])
+  }, [selectedModel, currentModel, onChange, buildSelectedModel, applySelectedModel])
 
   // Listen for centralized Alt+T shortcut via custom event (session selectors only).
   // Controlled-mode selectors (e.g. Settings > Models) must not react to the global
@@ -220,13 +326,39 @@ export function ModelSelector({
     ? getModelDisplayName(currentModel)
     : getModelDisplayName({
         id: selectedModel?.modelID || 'claude-opus-4-5-20251101',
-        providerID: 'anthropic'
+        providerID: selectedModel?.providerID || 'anthropic'
       })
 
+  const sdkFilterOptions = useMemo((): SdkFilterOption[] => {
+    const availableSdks = new Set(providers.map((provider) => provider.agentSdk))
+    return catalogAgentSdks
+      .filter((sdk) => availableSdks.has(sdk))
+      .map((sdk) => ({
+        agentSdk: sdk,
+        label: getHandoffSdkDisplayName(sdk)
+      }))
+  }, [providers, catalogAgentSdks])
+
+  useEffect(() => {
+    if (!agentSdkFilter) return
+    if (!sdkFilterOptions.some((option) => option.agentSdk === agentSdkFilter)) {
+      setAgentSdkFilter(null)
+    }
+  }, [agentSdkFilter, sdkFilterOptions])
+
+  const selectedProviderFilterLabel =
+    sdkFilterOptions.find((option) => option.agentSdk === agentSdkFilter)?.label ?? 'All providers'
+  const showProviderFilter = sdkFilterOptions.length > 1
+
+  const providerScopedProviders = useMemo(() => {
+    if (!agentSdkFilter) return providers
+    return providers.filter((provider) => provider.agentSdk === agentSdkFilter)
+  }, [providers, agentSdkFilter])
+
   const filteredProviders = useMemo(() => {
-    if (!filter.trim()) return providers
+    if (!filter.trim()) return providerScopedProviders
     const q = filter.toLowerCase()
-    return providers
+    return providerScopedProviders
       .map((provider) => ({
         ...provider,
         models: provider.models.filter(
@@ -237,7 +369,7 @@ export function ModelSelector({
         )
       }))
       .filter((p) => p.models.length > 0)
-  }, [providers, filter])
+  }, [providerScopedProviders, filter])
 
   const isFavorite = useCallback(
     (model: ModelInfo) => favoriteModels.includes(`${model.providerID}::${model.id}`),
@@ -245,8 +377,8 @@ export function ModelSelector({
   )
 
   const favoriteModelObjects = useMemo(
-    () => providers.flatMap((p) => p.models.filter((m) => isFavorite(m))),
-    [providers, isFavorite]
+    () => providerScopedProviders.flatMap((p) => p.models.filter((m) => isFavorite(m))),
+    [providerScopedProviders, isFavorite]
   )
 
   const currentVariantKeys = currentModel ? getModelVariantKeys(currentModel) : []
@@ -258,6 +390,49 @@ export function ModelSelector({
         <span className="text-[10px] font-medium text-muted-foreground uppercase shrink-0">
           {providerPrefix}
         </span>
+      )}
+      {showProviderFilter && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              className={cn(
+                'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
+                'border select-none',
+                'bg-background border-border text-muted-foreground hover:bg-muted hover:text-foreground'
+              )}
+              title="Filter providers"
+              aria-label={`Provider filter: ${selectedProviderFilterLabel}`}
+              data-testid="model-provider-filter"
+            >
+              <span className="truncate max-w-[130px]">{selectedProviderFilterLabel}</span>
+              <ChevronDown className="h-3 w-3 shrink-0 opacity-50" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-56">
+            <DropdownMenuItem
+              onClick={() => handleSelectAgentSdkFilter(null)}
+              className="flex items-center justify-between gap-2 cursor-pointer"
+              data-testid="model-provider-filter-option-all"
+            >
+              <span className="truncate text-sm">All providers</span>
+              {!agentSdkFilter && <Check className="h-4 w-4 shrink-0 text-primary" />}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            {sdkFilterOptions.map((option) => (
+              <DropdownMenuItem
+                key={option.agentSdk}
+                onClick={() => handleSelectAgentSdkFilter(option.agentSdk)}
+                className="flex items-center justify-between gap-2 cursor-pointer"
+                data-testid={`model-provider-filter-option-${option.agentSdk}`}
+              >
+                <span className="truncate text-sm">{option.label}</span>
+                {agentSdkFilter === option.agentSdk && (
+                  <Check className="h-4 w-4 shrink-0 text-primary" />
+                )}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
       )}
       <DropdownMenu
         open={dropdownOpen}
@@ -312,7 +487,7 @@ export function ModelSelector({
                 const favActive = isActiveModel(model)
                 const favVariantKeys = getModelVariantKeys(model)
                 return (
-                  <div key={`fav-${model.providerID}:${model.id}`}>
+                  <div key={`fav-${model.agentSdk}:${model.providerID}:${model.id}`}>
                     <DropdownMenuItem
                       onClick={() => handleSelectModel(model)}
                       onContextMenu={(e) => {
@@ -330,8 +505,7 @@ export function ModelSelector({
                     {favVariantKeys.length > 0 && (
                       <div className="flex gap-1 pl-6 pb-1">
                         {favVariantKeys.map((variant) => {
-                          const isActiveVariant =
-                            favActive && selectedModel?.variant === variant
+                          const isActiveVariant = favActive && selectedModel?.variant === variant
                           return (
                             <button
                               key={variant}
@@ -359,16 +533,18 @@ export function ModelSelector({
             </>
           )}
           {filteredProviders.map((provider, index) => (
-            <div key={provider.providerID}>
+            <div key={`${provider.agentSdk}:${provider.providerID}`}>
               {index > 0 && <DropdownMenuSeparator />}
               <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {provider.providerName}
+                {allowAgentSdkSelection
+                  ? `${getHandoffSdkDisplayName(provider.agentSdk)} / ${provider.providerName}`
+                  : provider.providerName}
               </DropdownMenuLabel>
               {provider.models.map((model) => {
                 const active = isActiveModel(model)
                 const variantKeys = getModelVariantKeys(model)
                 return (
-                  <div key={`${model.providerID}:${model.id}`}>
+                  <div key={`${model.agentSdk}:${model.providerID}:${model.id}`}>
                     <DropdownMenuItem
                       onClick={() => handleSelectModel(model)}
                       onContextMenu={(e) => {
@@ -392,8 +568,7 @@ export function ModelSelector({
                         data-testid={`variant-chips-${model.id}`}
                       >
                         {variantKeys.map((variant) => {
-                          const isActiveVariant =
-                            active && selectedModel?.variant === variant
+                          const isActiveVariant = active && selectedModel?.variant === variant
                           return (
                             <button
                               key={variant}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -626,7 +626,12 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     isStreamingRef.current = isStreaming
   }, [isStreaming])
   const [isCompacting, setIsCompacting] = useState(false)
-  const { runs: bashRuns, isRunning: isBashRunning, runCommand: runBashCommand, abort: abortBash } = useBashRuns(sessionId)
+  const {
+    runs: bashRuns,
+    isRunning: isBashRunning,
+    runCommand: runBashCommand,
+    abort: abortBash
+  } = useBashRuns(sessionId)
   const isBashMode = inputValue.startsWith('!') && !!worktreePath
   const [sessionRetry, setSessionRetry] = useState<SessionRetryState | null>(null)
   const [sessionErrorMessage, setSessionErrorMessage] = useState<string | null>(null)
@@ -660,7 +665,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     setQueuedMessages((prev) => {
       const sameLength = prev.length === persistedFollowUpMessages.length
       const sameContent =
-        sameLength && prev.every((entry, index) => entry.content === persistedFollowUpMessages[index])
+        sameLength &&
+        prev.every((entry, index) => entry.content === persistedFollowUpMessages[index])
       if (sameContent) return prev
 
       const matched = new Set<number>()
@@ -700,7 +706,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const sessionAgentSdk = sessionRecord?.agent_sdk ?? 'opencode'
   // Steer capability: available when backend supports it AND a turn is actively streaming
   // Falls back to checking sessionAgentSdk when capabilities haven't loaded yet (race condition)
-  const canSteer = (sessionCapabilities?.supportsSteer ?? sessionAgentSdk === 'codex') && isStreaming
+  const canSteer =
+    (sessionCapabilities?.supportsSteer ?? sessionAgentSdk === 'codex') && isStreaming
   const globalModel = useSettingsStore((state) => resolveModelForSdk(sessionAgentSdk, state))
   const effectiveModel: SelectedModel | null =
     sessionRecord?.model_provider_id && sessionRecord.model_id
@@ -980,9 +987,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
   const setMessages = useCallback(
     (
-      nextMessages:
-        | OpenCodeMessage[]
-        | ((currentMessages: OpenCodeMessage[]) => OpenCodeMessage[])
+      nextMessages: OpenCodeMessage[] | ((currentMessages: OpenCodeMessage[]) => OpenCodeMessage[])
     ) => {
       const shouldRestoreViewport = captureLockedViewportAnchor()
       setMessagesState(nextMessages)
@@ -3955,7 +3960,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           }
 
           // Remove the steered message from the follow-up queue by content
-          const currentFollowUps = useSessionStore.getState().pendingFollowUpMessages.get(sessionId) ?? []
+          const currentFollowUps =
+            useSessionStore.getState().pendingFollowUpMessages.get(sessionId) ?? []
           const indexToRemove = currentFollowUps.indexOf(content)
           if (indexToRemove >= 0) {
             const updatedFollowUps = [
@@ -4195,8 +4201,16 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           // Use the ask-specific model if configured, otherwise use session model
           const { useSettingsStore } = await import('@/stores/useSettingsStore')
           const settings = useSettingsStore.getState()
-          const askModel = settings.getModelForMode('ask') ?? settings.selectedModel
-          const selectedModel = askModel || getModelForRequests()
+          const configuredAskModel = settings.getModelForMode('ask')
+          const askModel =
+            !configuredAskModel?.agentSdk || configuredAskModel.agentSdk === sessionAgentSdk
+              ? configuredAskModel
+              : null
+          const fallbackModel =
+            !settings.selectedModel?.agentSdk || settings.selectedModel.agentSdk === sessionAgentSdk
+              ? settings.selectedModel
+              : null
+          const selectedModel = askModel ?? fallbackModel ?? getModelForRequests()
 
           // Build PR review comment context for /ask
           const prAskComments = usePRReviewStore.getState().attachedComments
@@ -4760,31 +4774,61 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     ]
   )
 
-  const handlePlanReadyHandoff = useCallback(async (override?: HandoffSelectionOverride) => {
-    const planContent =
-      pendingPlan?.planContent ??
-      [...messages].reverse().find((m) => m.role === 'assistant' && m.content.trim().length > 0)
-        ?.content
-    if (!planContent) {
-      toast.error('No plan content found to hand off')
-      return
-    }
+  const handlePlanReadyHandoff = useCallback(
+    async (override?: HandoffSelectionOverride) => {
+      const planContent =
+        pendingPlan?.planContent ??
+        [...messages].reverse().find((m) => m.role === 'assistant' && m.content.trim().length > 0)
+          ?.content
+      if (!planContent) {
+        toast.error('No plan content found to hand off')
+        return
+      }
 
-    useSessionStore.getState().clearPendingPlan(sessionId)
-    useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
-    lastSendMode.delete(sessionId)
+      useSessionStore.getState().clearPendingPlan(sessionId)
+      useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+      lastSendMode.delete(sessionId)
 
-    // Abort the original backend session so it stops spinning
-    if (worktreePath && opencodeSessionId) {
-      useCommandApprovalStore.getState().clearSession(sessionId)
-      await window.opencodeOps.abort(worktreePath, opencodeSessionId)
-    }
+      // Abort the original backend session so it stops spinning
+      if (worktreePath && opencodeSessionId) {
+        useCommandApprovalStore.getState().clearSession(sessionId)
+        await window.opencodeOps.abort(worktreePath, opencodeSessionId)
+      }
 
-    if (connectionId) {
+      if (connectionId) {
+        const handoffPrompt = `Implement the following plan\n${planContent}`
+        const sessionStore = useSessionStore.getState()
+        const result = await sessionStore.createConnectionSession(
+          connectionId,
+          override?.agentSdk,
+          undefined,
+          { modelOverride: override?.model }
+        )
+        if (!result.success || !result.session) {
+          toast.error(result.error ?? 'Failed to create handoff session')
+          return
+        }
+        const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
+        sessionStore.setPendingMessage(result.session.id, handoffPrompt)
+        await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
+        sessionStore.setActiveConnectionSession(result.session.id)
+        await setModePromise
+        return
+      }
+
+      const currentWorktreeId = worktreeId
+      const currentProjectId = sessionRecord?.project_id
+      if (!currentWorktreeId || !currentProjectId) {
+        toast.error('Could not start handoff session')
+        return
+      }
+
       const handoffPrompt = `Implement the following plan\n${planContent}`
+
       const sessionStore = useSessionStore.getState()
-      const result = await sessionStore.createConnectionSession(
-        connectionId,
+      const result = await sessionStore.createSession(
+        currentWorktreeId,
+        currentProjectId,
         override?.agentSdk,
         undefined,
         { modelOverride: override?.model }
@@ -4793,55 +4837,24 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         toast.error(result.error ?? 'Failed to create handoff session')
         return
       }
+
       const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
       sessionStore.setPendingMessage(result.session.id, handoffPrompt)
-      await useKanbanStore
-        .getState()
-        .relinkTicketsForHandoff(sessionId, result.session.id)
-      sessionStore.setActiveConnectionSession(result.session.id)
+      await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
+      sessionStore.setActiveSession(result.session.id)
       await setModePromise
-      return
-    }
-
-    const currentWorktreeId = worktreeId
-    const currentProjectId = sessionRecord?.project_id
-    if (!currentWorktreeId || !currentProjectId) {
-      toast.error('Could not start handoff session')
-      return
-    }
-
-    const handoffPrompt = `Implement the following plan\n${planContent}`
-
-    const sessionStore = useSessionStore.getState()
-    const result = await sessionStore.createSession(
-      currentWorktreeId,
-      currentProjectId,
-      override?.agentSdk,
-      undefined,
-      { modelOverride: override?.model }
-    )
-    if (!result.success || !result.session) {
-      toast.error(result.error ?? 'Failed to create handoff session')
-      return
-    }
-
-    const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
-    sessionStore.setPendingMessage(result.session.id, handoffPrompt)
-    await useKanbanStore
-      .getState()
-      .relinkTicketsForHandoff(sessionId, result.session.id)
-    sessionStore.setActiveSession(result.session.id)
-    await setModePromise
-  }, [
-    messages,
-    worktreeId,
-    sessionRecord?.project_id,
-    connectionId,
-    sessionId,
-    worktreePath,
-    opencodeSessionId,
-    pendingPlan
-  ])
+    },
+    [
+      messages,
+      worktreeId,
+      sessionRecord?.project_id,
+      connectionId,
+      sessionId,
+      worktreePath,
+      opencodeSessionId,
+      pendingPlan
+    ]
+  )
 
   const handlePlanReadyCopyPlan = useCallback(async () => {
     const planContent =
@@ -5544,8 +5557,10 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     return visibleMessages
   }, [isStreaming, visibleMessages])
 
-  const { todos: latestTodos, isIncomplete: latestTodosIncomplete } =
-    useLatestTodoList(currentTurnMessages, streamingMessage)
+  const { todos: latestTodos, isIncomplete: latestTodosIncomplete } = useLatestTodoList(
+    currentTurnMessages,
+    streamingMessage
+  )
   const taskListTopOffsetPx = usePRStackTopOffset()
 
   const handleRedoRevert = useCallback(() => {
@@ -5905,7 +5920,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
               disabled={!!activePermission || isOrphanedSession}
               placeholder={
                 isBashMode
-                  ? (inputValue.slice(1).trim() ? 'Press Enter to run' : 'Type a command')
+                  ? inputValue.slice(1).trim()
+                    ? 'Press Enter to run'
+                    : 'Type a command'
                   : isOrphanedSession
                     ? 'Read-only mode - cannot send messages'
                     : activePermission

--- a/src/renderer/src/components/settings/SettingsModels.tsx
+++ b/src/renderer/src/components/settings/SettingsModels.tsx
@@ -87,6 +87,7 @@ export function SettingsModels(): React.JSX.Element {
               <ModelSelector
                 value={defaultModels?.build || null}
                 onChange={(model) => setModeDefaultModel('build', model)}
+                allowAgentSdkSelection
               />
               {defaultModels?.build && (
                 <button
@@ -109,6 +110,7 @@ export function SettingsModels(): React.JSX.Element {
               <ModelSelector
                 value={defaultModels?.plan || null}
                 onChange={(model) => setModeDefaultModel('plan', model)}
+                allowAgentSdkSelection
               />
               {defaultModels?.plan && (
                 <button
@@ -131,10 +133,34 @@ export function SettingsModels(): React.JSX.Element {
               <ModelSelector
                 value={defaultModels?.ask || null}
                 onChange={(model) => setModeDefaultModel('ask', model)}
+                allowAgentSdkSelection
               />
               {defaultModels?.ask && (
                 <button
                   onClick={() => setModeDefaultModel('ask', null)}
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Use global
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* Review */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Review Default</label>
+            <p className="text-xs text-muted-foreground">
+              Model used when starting a Code Review session
+            </p>
+            <div className="flex items-center gap-2">
+              <ModelSelector
+                value={defaultModels?.review || null}
+                onChange={(model) => setModeDefaultModel('review', model)}
+                allowAgentSdkSelection
+              />
+              {defaultModels?.review && (
+                <button
+                  onClick={() => setModeDefaultModel('review', null)}
                   className="text-xs text-muted-foreground hover:text-foreground transition-colors"
                 >
                   Use global

--- a/src/renderer/src/hooks/useLifecycleActions.ts
+++ b/src/renderer/src/hooks/useLifecycleActions.ts
@@ -97,9 +97,7 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
     return null
   })
 
-  const remoteInfo = useGitStore((s) =>
-    worktreeId ? s.remoteInfo.get(worktreeId) : undefined
-  )
+  const remoteInfo = useGitStore((s) => (worktreeId ? s.remoteInfo.get(worktreeId) : undefined))
 
   const storeAttachedPR = useGitStore((s) =>
     worktreeId ? s.attachedPR.get(worktreeId) : undefined
@@ -114,7 +112,7 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
   )
 
   const branchInfo = useGitStore((s) =>
-    worktree?.path ? s.branchInfoByWorktree.get(worktree.path) ?? null : null
+    worktree?.path ? (s.branchInfoByWorktree.get(worktree.path) ?? null) : null
   )
 
   const fileStatuses = useGitStore((s) =>
@@ -178,81 +176,105 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
 
   // --- Actions ---
 
-  const createCodeReview = useCallback(async (targetBranch?: string): Promise<string | null> => {
-    if (!worktreeId || !worktree?.path) return null
+  const createCodeReview = useCallback(
+    async (targetBranch?: string): Promise<string | null> => {
+      if (!worktreeId || !worktree?.path) return null
 
-    const projectId = resolveProjectId(worktreeId)
-    if (!projectId) {
-      toast.error('Could not find project for worktree')
-      return null
-    }
+      const projectId = resolveProjectId(worktreeId)
+      if (!projectId) {
+        toast.error('Could not find project for worktree')
+        return null
+      }
 
-    const currentBranchInfo = useGitStore.getState().branchInfoByWorktree.get(worktree.path)
-    const currentReviewTarget = useGitStore.getState().reviewTargetBranch.get(worktreeId)
-    const target = targetBranch || currentReviewTarget || currentBranchInfo?.tracking || 'origin/main'
-    const branchName = currentBranchInfo?.name || 'unknown'
+      const currentBranchInfo = useGitStore.getState().branchInfoByWorktree.get(worktree.path)
+      const currentReviewTarget = useGitStore.getState().reviewTargetBranch.get(worktreeId)
+      const target =
+        targetBranch || currentReviewTarget || currentBranchInfo?.tracking || 'origin/main'
+      const branchName = currentBranchInfo?.name || 'unknown'
 
-    const promptType = useSettingsStore.getState().reviewPromptType || DEFAULT_REVIEW_PROMPT_TYPE
-    const reviewTemplate = REVIEW_PROMPTS[promptType]
+      const promptType = useSettingsStore.getState().reviewPromptType || DEFAULT_REVIEW_PROMPT_TYPE
+      const reviewDefaultModel = useSettingsStore.getState().defaultModels?.review ?? undefined
+      const reviewTemplate = REVIEW_PROMPTS[promptType]
 
-    const prompt = [
-      reviewTemplate,
-      '',
-      '---',
-      '',
-      `Compare the current branch (${branchName}) against ${target}.`,
-      `Use \`git diff ${target}...HEAD\` to see all changes.`
-    ].join('\n')
+      const prompt = [
+        reviewTemplate,
+        '',
+        '---',
+        '',
+        `Compare the current branch (${branchName}) against ${target}.`,
+        `Use \`git diff ${target}...HEAD\` to see all changes.`
+      ].join('\n')
 
-    const sessionStore = useSessionStore.getState()
-    const result = await sessionStore.createSession(worktreeId, projectId, undefined, undefined, { autoFocus: false })
-    if (!result.success || !result.session) {
-      toast.error('Failed to create review session')
-      return null
-    }
+      const sessionStore = useSessionStore.getState()
+      const result = await sessionStore.createSession(
+        worktreeId,
+        projectId,
+        reviewDefaultModel?.agentSdk,
+        undefined,
+        {
+          autoFocus: false,
+          modelOverride: reviewDefaultModel
+        }
+      )
+      if (!result.success || !result.session) {
+        toast.error('Failed to create review session')
+        return null
+      }
 
-    await sessionStore.updateSessionName(
-      result.session.id,
-      `Code Review — ${branchName} vs ${target}`
-    )
-    // Register the review session so ticket cards can show "Reviewing" indicator
-    useWorktreeStatusStore.getState().setReviewSession(worktreeId, result.session.id)
+      await sessionStore.updateSessionName(
+        result.session.id,
+        `Code Review — ${branchName} vs ${target}`
+      )
+      // Register the review session so ticket cards can show "Reviewing" indicator
+      useWorktreeStatusStore.getState().setReviewSession(worktreeId, result.session.id)
 
-    // Fire-and-forget: eagerly connect and send the review prompt in the background
-    // so it starts without waiting for SessionView to mount.
-    const sessionId = result.session.id
-    const worktreePath = worktree.path
-    const agentSdk = result.session.agent_sdk
-    const sessionModel = result.session.model_provider_id && result.session.model_id
-      ? { providerID: result.session.model_provider_id, modelID: result.session.model_id, variant: result.session.model_variant ?? undefined }
-      : resolveModelForSdk(agentSdk || 'opencode') ?? undefined
+      // Fire-and-forget: eagerly connect and send the review prompt in the background
+      // so it starts without waiting for SessionView to mount.
+      const sessionId = result.session.id
+      const worktreePath = worktree.path
+      const agentSdk = result.session.agent_sdk
+      const sessionModel =
+        result.session.model_provider_id && result.session.model_id
+          ? {
+              providerID: result.session.model_provider_id,
+              modelID: result.session.model_id,
+              variant: result.session.model_variant ?? undefined
+            }
+          : (resolveModelForSdk(agentSdk || 'opencode') ?? undefined)
 
-    void (async () => {
-      try {
-        const connectResult = await window.opencodeOps.connect(worktreePath, sessionId)
-        if (connectResult.success && connectResult.sessionId) {
-          sessionStore.setOpenCodeSessionId(sessionId, connectResult.sessionId)
-          window.db.session.update(sessionId, { opencode_session_id: connectResult.sessionId }).catch(() => {})
+      void (async () => {
+        try {
+          const connectResult = await window.opencodeOps.connect(worktreePath, sessionId)
+          if (connectResult.success && connectResult.sessionId) {
+            sessionStore.setOpenCodeSessionId(sessionId, connectResult.sessionId)
+            window.db.session
+              .update(sessionId, { opencode_session_id: connectResult.sessionId })
+              .catch(() => {})
 
-          messageSendTimes.set(sessionId, Date.now())
-          userExplicitSendTimes.set(sessionId, Date.now())
-          snapshotTokenBaseline(sessionId)
-          lastSendMode.set(sessionId, 'build')
-          useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+            messageSendTimes.set(sessionId, Date.now())
+            userExplicitSendTimes.set(sessionId, Date.now())
+            snapshotTokenBaseline(sessionId)
+            lastSendMode.set(sessionId, 'build')
+            useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
 
-          await window.opencodeOps.prompt(worktreePath, connectResult.sessionId, [
-            { type: 'text', text: prompt }
-          ], sessionModel)
-        } else {
+            await window.opencodeOps.prompt(
+              worktreePath,
+              connectResult.sessionId,
+              [{ type: 'text', text: prompt }],
+              sessionModel
+            )
+          } else {
+            sessionStore.setPendingMessage(sessionId, prompt)
+          }
+        } catch {
           sessionStore.setPendingMessage(sessionId, prompt)
         }
-      } catch {
-        sessionStore.setPendingMessage(sessionId, prompt)
-      }
-    })()
+      })()
 
-    return result.session.id
-  }, [worktreeId, worktree?.path])
+      return result.session.id
+    },
+    [worktreeId, worktree?.path]
+  )
 
   const mergePR = useCallback(async (): Promise<boolean> => {
     if (!worktreeId || !worktree?.path) return false
@@ -332,9 +354,9 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
     const projectPath = resolveProjectPath(worktreeId)
     if (!projectPath) return []
 
-    const currentBranchInfo = useGitStore.getState().branchInfoByWorktree.get(
-      resolveWorktree(worktreeId)?.path ?? ''
-    )
+    const currentBranchInfo = useGitStore
+      .getState()
+      .branchInfoByWorktree.get(resolveWorktree(worktreeId)?.path ?? '')
     const currentBranch = currentBranchInfo?.name ?? ''
 
     try {

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -7,7 +7,12 @@ import {
   parseProviders,
   type ProviderModels
 } from './parseProviders'
-import { resolveModelForSdk, useSettingsStore, type HandoffAgentSdk, type SelectedModel } from '@/stores/useSettingsStore'
+import {
+  resolveModelForSdk,
+  useSettingsStore,
+  type HandoffAgentSdk,
+  type SelectedModel
+} from '@/stores/useSettingsStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 
 export interface EffectiveHandoffSelection {
@@ -47,7 +52,14 @@ function normalizeHandoffSdk(
   return 'opencode'
 }
 
-function buildModelSelection(model: SelectedModel | null, agentSdk: HandoffAgentSdk): SelectedModel {
+function getModeDefaultKey(mode: 'build' | 'plan' | 'super-plan' | undefined): 'build' | 'plan' {
+  return mode === 'plan' || mode === 'super-plan' ? 'plan' : 'build'
+}
+
+function buildModelSelection(
+  model: SelectedModel | null,
+  agentSdk: HandoffAgentSdk
+): SelectedModel {
   if (model) return model
 
   const cachedProviders = getCachedModelCatalog(agentSdk)
@@ -90,27 +102,30 @@ function resolveSessionSelection(opts: {
   const requestedSdk = normalizeHandoffSdk(opts.agentSdk ?? settings.defaultAgentSdk ?? 'opencode')
   const configuredDefaultSdk = normalizeHandoffSdk(settings.defaultAgentSdk ?? 'opencode')
   let model: SelectedModel | null = null
+  let resolvedSdk = requestedSdk
 
-  if (requestedSdk === configuredDefaultSdk && (opts.mode ?? 'build') === 'build') {
-    model = settings.defaultModels?.build ?? null
+  const modeDefault = settings.getModelForMode(getModeDefaultKey(opts.mode))
+  if (modeDefault && (modeDefault.agentSdk || requestedSdk === configuredDefaultSdk)) {
+    model = modeDefault
+    resolvedSdk = normalizeHandoffSdk(modeDefault.agentSdk ?? requestedSdk)
   }
 
   if (!model) {
-    model = resolveModelForSdk(requestedSdk, settings)
+    model = resolveModelForSdk(resolvedSdk, settings)
   }
 
   if (!model && Object.keys(settings.selectedModelByProvider).length === 0) {
     model = getWorktreeFallbackModel(opts.worktreeId)
   }
 
-  const resolvedModel = buildModelSelection(model, requestedSdk)
-  const modelInfo = getModelInfoFromCache(requestedSdk, resolvedModel)
+  const resolvedModel = buildModelSelection(model, resolvedSdk)
+  const modelInfo = getModelInfoFromCache(resolvedSdk, resolvedModel)
 
   return {
-    agentSdk: requestedSdk,
+    agentSdk: resolvedSdk,
     model: resolvedModel,
     display: {
-      sdkName: SDK_DISPLAY_NAMES[requestedSdk],
+      sdkName: SDK_DISPLAY_NAMES[resolvedSdk],
       modelName: modelInfo ? getModelDisplayName(modelInfo) : resolvedModel.modelID,
       variant: resolvedModel.variant
     }
@@ -155,7 +170,9 @@ export function clearHandoffModelCatalogCache(): void {
   inflightModelCatalogRequests.clear()
 }
 
-export async function loadHandoffModelCatalog(agentSdk: HandoffAgentSdk): Promise<ProviderModels[]> {
+export async function loadHandoffModelCatalog(
+  agentSdk: HandoffAgentSdk
+): Promise<ProviderModels[]> {
   const cached = getCachedModelCatalog(agentSdk)
   if (cached) return cached
 
@@ -200,10 +217,7 @@ export function getEffectiveHandoffSelection(opts: {
   if (!isAgentSdkAvailable(override.agentSdk, settings.availableAgentSdks)) return fallback
 
   const cachedProviders = getCachedModelCatalog(override.agentSdk)
-  if (
-    cachedProviders &&
-    !findModelInfo(cachedProviders, override.providerID, override.modelID)
-  ) {
+  if (cachedProviders && !findModelInfo(cachedProviders, override.providerID, override.modelID)) {
     return fallback
   }
 
@@ -235,7 +249,8 @@ export function resolveSessionCreationSelection(opts: {
   model: SelectedModel | null
 } {
   const settings = useSettingsStore.getState()
-  const agentSdk = opts.agentSdkOverride ?? settings.defaultAgentSdk ?? 'opencode'
+  const agentSdk =
+    opts.modelOverride?.agentSdk ?? opts.agentSdkOverride ?? settings.defaultAgentSdk ?? 'opencode'
 
   if (agentSdk === 'terminal') {
     return { agentSdk, model: null }
@@ -250,5 +265,5 @@ export function resolveSessionCreationSelection(opts: {
     agentSdk,
     mode: opts.initialMode
   })
-  return { agentSdk, model: resolved.model }
+  return { agentSdk: resolved.agentSdk, model: resolved.model }
 }

--- a/src/renderer/src/stores/useBoardChatStore.ts
+++ b/src/renderer/src/stores/useBoardChatStore.ts
@@ -6,12 +6,7 @@ import type { SelectedModel } from '@/stores/useSettingsStore'
 import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
 import { BOARD_ASSISTANT_SESSION_NAME_PREFIX } from '@/stores/useSessionStore'
 
-export type BoardChatStatus =
-  | 'idle'
-  | 'starting'
-  | 'thinking'
-  | 'awaiting_confirmation'
-  | 'error'
+export type BoardChatStatus = 'idle' | 'starting' | 'thinking' | 'awaiting_confirmation' | 'error'
 
 export type BoardChatScope =
   | {
@@ -123,7 +118,10 @@ interface BoardChatState extends BoardChatSnapshot {
 }
 
 export function resolveBoardChatAgentSdk(
-  defaultAgentSdk: ReturnType<typeof useSettingsStore.getState>['defaultAgentSdk'] | null | undefined
+  defaultAgentSdk:
+    | ReturnType<typeof useSettingsStore.getState>['defaultAgentSdk']
+    | null
+    | undefined
 ): 'opencode' | 'claude-code' | 'codex' {
   const sdk = defaultAgentSdk ?? 'opencode'
   return sdk === 'terminal' ? 'opencode' : sdk
@@ -137,7 +135,11 @@ export function resolveBoardChatDefaultModel(
   agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | null
 ): SelectedModel | null {
   const agentSdk = agentSdkOverride ?? resolveBoardChatAgentSdk(settings.defaultAgentSdk)
-  return settings.getModelForMode('ask') ?? resolveModelForSdk(agentSdk, settings) ?? settings.selectedModel
+  return (
+    settings.getModelForMode('ask') ??
+    resolveModelForSdk(agentSdk, settings) ??
+    settings.selectedModel
+  )
 }
 
 const BOARD_RULES_TAG_RE = /<board-assistant-rules>[\s\S]*?<\/board-assistant-rules>/gi
@@ -146,9 +148,7 @@ const BOARD_DRAFT_BLOCK_RE = /```board-ticket-drafts[\s\S]*?```/gi
 const BOARD_DRAFT_BLOCK_CAPTURE_RE = /```board-ticket-drafts\s*([\s\S]*?)```/i
 
 export function stripBoardAssistantScaffolding(content: string): string {
-  const withoutTags = content
-    .replace(BOARD_RULES_TAG_RE, '')
-    .replace(BOARD_CONTEXT_TAG_RE, '')
+  const withoutTags = content.replace(BOARD_RULES_TAG_RE, '').replace(BOARD_CONTEXT_TAG_RE, '')
 
   const marker = 'User request:'
   const markerIndex = withoutTags.lastIndexOf(marker)
@@ -225,8 +225,7 @@ function createInitialSnapshot(options?: ResetBoardChatOptions): BoardChatSnapsh
     createdDraftIds: [],
     draftSourceMessageId: null,
     status: 'idle',
-    selectedTargetProjectId:
-      options?.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope),
+    selectedTargetProjectId: options?.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope),
     error: null,
     sessionId: null,
     opencodeSessionId: null,
@@ -367,7 +366,9 @@ function getProjectName(scope: BoardChatScope | null, projectId: string): string
   if (!scope) return 'Unknown project'
   if (scope.kind === 'project') return scope.projectName
   if (scope.kind === 'connection') {
-    return scope.availableProjects.find((project) => project.id === projectId)?.name ?? 'Unknown project'
+    return (
+      scope.availableProjects.find((project) => project.id === projectId)?.name ?? 'Unknown project'
+    )
   }
   return 'Pinned projects'
 }
@@ -411,7 +412,11 @@ function parseDraftsFromMessage(
   return drafts.filter((draft) => draft.projectId.length > 0)
 }
 
-async function cleanupRuntime(sessionId: string | null, opencodeSessionId: string | null, runtimePath: string | null): Promise<void> {
+async function cleanupRuntime(
+  sessionId: string | null,
+  opencodeSessionId: string | null,
+  runtimePath: string | null
+): Promise<void> {
   try {
     if (opencodeSessionId && runtimePath) {
       await window.opencodeOps.disconnect(runtimePath, opencodeSessionId)
@@ -429,7 +434,10 @@ async function cleanupRuntime(sessionId: string | null, opencodeSessionId: strin
   }
 }
 
-async function buildBoardContext(scope: BoardChatScope, selectedTargetProjectId: string | null): Promise<string> {
+async function buildBoardContext(
+  scope: BoardChatScope,
+  selectedTargetProjectId: string | null
+): Promise<string> {
   if (scope.kind === 'project') {
     const tickets = await window.kanban.ticket.getByProject(scope.projectId, false)
     return [
@@ -454,7 +462,9 @@ async function buildBoardContext(scope: BoardChatScope, selectedTargetProjectId:
       `Projects in scope: ${scope.availableProjects.map((project) => project.name).join(', ')}`,
       ...ticketGroups.flatMap(({ project, tickets }) => [
         `${project.name}:`,
-        ...tickets.slice(0, 20).map((ticket: KanbanTicket) => `- [${ticket.column}] ${ticket.title}`)
+        ...tickets
+          .slice(0, 20)
+          .map((ticket: KanbanTicket) => `- [${ticket.column}] ${ticket.title}`)
       ])
     ].join('\n')
   }
@@ -468,10 +478,7 @@ function buildAssistantPrompt(
   boardContext: string,
   userMessage: string
 ): string {
-  const targetProjectId =
-    scope.kind === 'project'
-      ? scope.projectId
-      : selectedTargetProjectId
+  const targetProjectId = scope.kind === 'project' ? scope.projectId : selectedTargetProjectId
 
   return [
     '<board-assistant-rules>',
@@ -528,13 +535,12 @@ async function ensureRuntime(): Promise<{
   }
 
   const settings = useSettingsStore.getState()
-  const agentSdk = state.selectedAgentSdkOverride ?? resolveBoardChatAgentSdk(settings.defaultAgentSdk)
-  const model = state.selectedModelOverride ?? resolveBoardChatDefaultModel(settings, agentSdk)
+  const baseAgentSdk =
+    state.selectedAgentSdkOverride ?? resolveBoardChatAgentSdk(settings.defaultAgentSdk)
+  const model = state.selectedModelOverride ?? resolveBoardChatDefaultModel(settings, baseAgentSdk)
+  const agentSdk = state.selectedAgentSdkOverride ?? model?.agentSdk ?? baseAgentSdk
 
-  const projectId =
-    scope.kind === 'project'
-      ? scope.projectId
-      : state.selectedTargetProjectId
+  const projectId = scope.kind === 'project' ? scope.projectId : state.selectedTargetProjectId
 
   if (!projectId) {
     throw new Error('Select a target project before starting the board assistant.')
@@ -578,7 +584,9 @@ async function ensureRuntime(): Promise<{
   }
 }
 
-async function resetAndCleanup(state: Pick<BoardChatState, 'sessionId' | 'opencodeSessionId' | 'runtimePath'>): Promise<void> {
+async function resetAndCleanup(
+  state: Pick<BoardChatState, 'sessionId' | 'opencodeSessionId' | 'runtimePath'>
+): Promise<void> {
   await cleanupRuntime(state.sessionId, state.opencodeSessionId, state.runtimePath)
 }
 
@@ -637,7 +645,7 @@ export const useBoardChatStore = create<BoardChatState>((set, get) => ({
           selectedTargetProjectId:
             scope?.kind === 'project'
               ? scope.projectId
-              : existing.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope)
+              : (existing.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope))
         }
         return replaceActiveSnapshot(state, hydrated, scopeKey)
       }
@@ -712,7 +720,7 @@ export const useBoardChatStore = create<BoardChatState>((set, get) => ({
           selectedTargetProjectId:
             scope?.kind === 'project'
               ? scope.projectId
-              : current.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope)
+              : (current.selectedTargetProjectId ?? buildDefaultTargetProjectId(scope))
         })
       )
       return
@@ -789,7 +797,12 @@ export const useBoardChatStore = create<BoardChatState>((set, get) => ({
     try {
       const runtime = await ensureRuntime()
       const boardContext = await buildBoardContext(scope, get().selectedTargetProjectId)
-      const prompt = buildAssistantPrompt(scope, get().selectedTargetProjectId, boardContext, trimmed)
+      const prompt = buildAssistantPrompt(
+        scope,
+        get().selectedTargetProjectId,
+        boardContext,
+        trimmed
+      )
       set((state) => patchActiveSnapshot(state, { status: 'thinking' }))
 
       const result = await window.opencodeOps.prompt(
@@ -959,14 +972,18 @@ export const useBoardChatStore = create<BoardChatState>((set, get) => ({
   updateOpencodeSessionId: (opencodeSessionId) =>
     set((state) => patchActiveSnapshot(state, { opencodeSessionId })),
   clearRuntimeSession: () =>
-    set((state) => patchActiveSnapshot(state, { sessionId: null, opencodeSessionId: null, runtimePath: null })),
+    set((state) =>
+      patchActiveSnapshot(state, { sessionId: null, opencodeSessionId: null, runtimePath: null })
+    ),
   setComposerValue: (composerValue) =>
     set((state) => patchActiveSnapshot(state, { composerValue })),
   resetState: (options) =>
     set((state) =>
       replaceActiveSnapshot(
         state,
-        createInitialSnapshot(options ? { ...options, scope: options.scope ?? state.scope } : { scope: state.scope }),
+        createInitialSnapshot(
+          options ? { ...options, scope: options.scope ?? state.scope } : { scope: state.scope }
+        ),
         state.activeScopeKey
       )
     )

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -25,19 +25,21 @@ export type TerminalPosition = 'sidebar' | 'bottom'
 export type MergeConflictMode = 'build' | 'plan' | 'always-ask'
 export type FollowUpTriggerColumn = 'review' | 'done'
 
+export type AgentSdk = 'opencode' | 'claude-code' | 'codex' | 'terminal'
+export type HandoffAgentSdk = Exclude<AgentSdk, 'terminal'>
+
 export interface SelectedModel {
+  agentSdk?: HandoffAgentSdk
   providerID: string
   modelID: string
   variant?: string
 }
 
-export type AgentSdk = 'opencode' | 'claude-code' | 'codex' | 'terminal'
-export type HandoffAgentSdk = Exclude<AgentSdk, 'terminal'>
-
 export interface ModeDefaultModels {
   build: SelectedModel | null
   plan: SelectedModel | null
   ask: SelectedModel | null
+  review: SelectedModel | null
 }
 
 export type QuickActionType = 'cursor' | 'terminal' | 'copy-path' | 'finder'
@@ -243,10 +245,12 @@ interface SettingsState extends AppSettings {
     options?: { skipBackendPush?: boolean }
   ) => Promise<void>
   setModeDefaultModel: (
-    mode: 'build' | 'plan' | 'ask',
+    mode: 'build' | 'plan' | 'ask' | 'review',
     model: SelectedModel | null
   ) => Promise<void>
-  getModelForMode: (mode: 'build' | 'plan' | 'ask') => SelectedModel | null
+  getModelForMode: (
+    mode: 'build' | 'plan' | 'super-plan' | 'ask' | 'review'
+  ) => SelectedModel | null
   setLastHandoffOverride: (value: AppSettings['lastHandoffOverride']) => void
   toggleFavoriteModel: (providerID: string, modelID: string) => void
   setModelVariantDefault: (providerID: string, modelID: string, variant: string) => void
@@ -432,36 +436,33 @@ export const useSettingsStore = create<SettingsState>()(
           // setTimeout ensures the state update completes before side effects run.
           // Dynamic import() avoids circular dependency (useSessionStore imports useSettingsStore).
           setTimeout(() => {
-            Promise.all([
-              import('./useKanbanStore'),
-              import('./useSessionStore')
-            ]).then(([{ useKanbanStore }, { useSessionStore, BOARD_TAB_ID }]) => {
-              if (value === 'sticky-tab') {
-                // Toggle → Sticky Tab: deactivate toggle board view, activate board tab
-                if (useKanbanStore.getState().isBoardViewActive) {
-                  useKanbanStore.getState().toggleBoardView()
-                }
-                useSessionStore.getState().setActiveSession(BOARD_TAB_ID)
-              } else {
-                // Sticky Tab → Toggle: if on board tab, fall back to first real session
-                const sessionStore = useSessionStore.getState()
-                if (sessionStore.activeSessionId === BOARD_TAB_ID) {
-                  const worktreeId = sessionStore.activeWorktreeId
-                  if (worktreeId) {
-                    const tabOrder =
-                      sessionStore.tabOrderByWorktree.get(worktreeId) || []
-                    const sessions =
-                      sessionStore.sessionsByWorktree.get(worktreeId) || []
-                    const fallbackId =
-                      tabOrder.find((id) => id !== BOARD_TAB_ID) ||
-                      (sessions.length > 0 ? sessions[0].id : null)
-                    sessionStore.setActiveSession(fallbackId)
-                  } else {
-                    sessionStore.setActiveSession(null)
+            Promise.all([import('./useKanbanStore'), import('./useSessionStore')])
+              .then(([{ useKanbanStore }, { useSessionStore, BOARD_TAB_ID }]) => {
+                if (value === 'sticky-tab') {
+                  // Toggle → Sticky Tab: deactivate toggle board view, activate board tab
+                  if (useKanbanStore.getState().isBoardViewActive) {
+                    useKanbanStore.getState().toggleBoardView()
+                  }
+                  useSessionStore.getState().setActiveSession(BOARD_TAB_ID)
+                } else {
+                  // Sticky Tab → Toggle: if on board tab, fall back to first real session
+                  const sessionStore = useSessionStore.getState()
+                  if (sessionStore.activeSessionId === BOARD_TAB_ID) {
+                    const worktreeId = sessionStore.activeWorktreeId
+                    if (worktreeId) {
+                      const tabOrder = sessionStore.tabOrderByWorktree.get(worktreeId) || []
+                      const sessions = sessionStore.sessionsByWorktree.get(worktreeId) || []
+                      const fallbackId =
+                        tabOrder.find((id) => id !== BOARD_TAB_ID) ||
+                        (sessions.length > 0 ? sessions[0].id : null)
+                      sessionStore.setActiveSession(fallbackId)
+                    } else {
+                      sessionStore.setActiveSession(null)
+                    }
                   }
                 }
-              }
-            }).catch(console.error)
+              })
+              .catch(console.error)
           }, 0)
         }
       },
@@ -514,8 +515,16 @@ export const useSettingsStore = create<SettingsState>()(
         saveToDatabase(settings)
       },
 
-      setModeDefaultModel: async (mode: 'build' | 'plan' | 'ask', model: SelectedModel | null) => {
-        const currentDefaults = get().defaultModels || { build: null, plan: null, ask: null }
+      setModeDefaultModel: async (
+        mode: 'build' | 'plan' | 'ask' | 'review',
+        model: SelectedModel | null
+      ) => {
+        const currentDefaults = get().defaultModels || {
+          build: null,
+          plan: null,
+          ask: null,
+          review: null
+        }
         const updated = { ...currentDefaults, [mode]: model }
         set({ defaultModels: updated })
 
@@ -524,10 +533,11 @@ export const useSettingsStore = create<SettingsState>()(
         await saveToDatabase(settings)
       },
 
-      getModelForMode: (mode: 'build' | 'plan' | 'ask') => {
+      getModelForMode: (mode: 'build' | 'plan' | 'super-plan' | 'ask' | 'review') => {
         // Return only the mode-specific default (no global fallback).
         // Callers that need a fallback chain should check selectedModel separately.
-        return get().defaultModels?.[mode] ?? null
+        const key = mode === 'super-plan' ? 'plan' : mode
+        return get().defaultModels?.[key] ?? null
       },
 
       setLastHandoffOverride: (value) => {

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -90,9 +90,11 @@ Object.defineProperty(window, 'opencodeOps', {
 import {
   cacheHandoffModelCatalog,
   clearHandoffModelCatalogCache,
-  getEffectiveHandoffSelection
+  getEffectiveHandoffSelection,
+  resolveSessionCreationSelection
 } from '@/lib/handoffSelection'
 import { HandoffSplitButton } from '@/components/sessions/HandoffSplitButton'
+import { ModelSelector } from '@/components/sessions/ModelSelector'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 
@@ -124,7 +126,8 @@ describe('handoff model picker', () => {
           variant: 'high'
         },
         plan: null,
-        ask: null
+        ask: null,
+        review: null
       },
       lastHandoffOverride: null,
       defaultAgentSdk: 'claude-code',
@@ -186,6 +189,166 @@ describe('handoff model picker', () => {
       variant: 'high'
     })
     expect(effective.display.modelName).toBe('Sonnet 4.6')
+  })
+
+  test('resolveSessionCreationSelection uses a mode default from a different SDK', () => {
+    cacheHandoffModelCatalog('codex', codexProviders)
+    useSettingsStore.setState({
+      defaultAgentSdk: 'claude-code',
+      defaultModels: {
+        build: {
+          agentSdk: 'codex',
+          providerID: 'codex',
+          modelID: 'gpt-5.5',
+          variant: 'xhigh'
+        },
+        plan: null,
+        ask: null,
+        review: null
+      }
+    })
+
+    const selection = resolveSessionCreationSelection({ initialMode: 'build' })
+
+    expect(selection).toEqual({
+      agentSdk: 'codex',
+      model: {
+        agentSdk: 'codex',
+        providerID: 'codex',
+        modelID: 'gpt-5.5',
+        variant: 'xhigh'
+      }
+    })
+  })
+
+  test('controlled model selector can choose a model from another SDK catalog', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ModelSelector value={null} onChange={onChange} allowAgentSdkSelection />)
+
+    await waitFor(() => {
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'claude-code' })
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'codex' })
+    })
+
+    await user.click(screen.getByTestId('model-selector'))
+    await user.click(await screen.findByTestId('model-item-gpt-5.5'))
+
+    expect(onChange).toHaveBeenCalledWith({
+      agentSdk: 'codex',
+      providerID: 'codex',
+      modelID: 'gpt-5.5',
+      variant: 'high'
+    })
+  })
+
+  test('controlled model selector can filter models by SDK provider', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ModelSelector value={null} onChange={onChange} allowAgentSdkSelection />)
+
+    await waitFor(() => {
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'claude-code' })
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'codex' })
+    })
+
+    await user.click(await screen.findByTestId('model-provider-filter'))
+    expect(await screen.findByTestId('model-provider-filter-option-claude-code')).toHaveTextContent(
+      'Claude Code'
+    )
+    expect(screen.getByTestId('model-provider-filter-option-codex')).toHaveTextContent('Codex')
+    expect(screen.queryByText('Claude Code / Anthropic')).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('model-provider-filter-option-codex'))
+
+    await user.click(screen.getByTestId('model-selector'))
+
+    expect(await screen.findByTestId('model-item-gpt-5.5')).toBeInTheDocument()
+    expect(screen.queryByTestId('model-item-sonnet-4.6')).not.toBeInTheDocument()
+  })
+
+  test('controlled model selector selects the remembered model when switching SDK provider', async () => {
+    useSettingsStore.setState({
+      selectedModelByProvider: {
+        'claude-code': {
+          providerID: 'anthropic',
+          modelID: 'sonnet-4.6',
+          variant: 'high'
+        },
+        codex: {
+          providerID: 'codex',
+          modelID: 'gpt-5.4',
+          variant: 'xhigh'
+        }
+      }
+    })
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ModelSelector value={null} onChange={onChange} allowAgentSdkSelection />)
+
+    await waitFor(() => {
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'codex' })
+    })
+
+    await user.click(await screen.findByTestId('model-provider-filter'))
+    await user.click(await screen.findByTestId('model-provider-filter-option-codex'))
+
+    expect(onChange).toHaveBeenCalledWith({
+      agentSdk: 'codex',
+      providerID: 'codex',
+      modelID: 'gpt-5.4',
+      variant: 'xhigh'
+    })
+  })
+
+  test('controlled model selector remembers the last model selected in the picker per SDK provider', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ModelSelector value={null} onChange={onChange} allowAgentSdkSelection />)
+
+    await waitFor(() => {
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'codex' })
+    })
+
+    await user.click(await screen.findByTestId('model-provider-filter'))
+    await user.click(await screen.findByTestId('model-provider-filter-option-codex'))
+    await user.click(screen.getByTestId('model-selector'))
+    await user.click(await screen.findByTestId('model-item-gpt-5.4'))
+
+    await user.click(screen.getByTestId('model-provider-filter'))
+    await user.click(await screen.findByTestId('model-provider-filter-option-claude-code'))
+
+    await user.click(screen.getByTestId('model-provider-filter'))
+    await user.click(await screen.findByTestId('model-provider-filter-option-codex'))
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      agentSdk: 'codex',
+      providerID: 'codex',
+      modelID: 'gpt-5.4',
+      variant: 'high'
+    })
+  })
+
+  test('controlled model selector hides provider filter when only one provider is available', async () => {
+    useSettingsStore.setState({
+      availableAgentSdks: {
+        opencode: false,
+        claude: true,
+        codex: false
+      }
+    })
+
+    render(<ModelSelector value={null} onChange={vi.fn()} allowAgentSdkSelection />)
+
+    await waitFor(() => {
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'claude-code' })
+    })
+
+    expect(screen.queryByTestId('model-provider-filter')).not.toBeInTheDocument()
   })
 
   test('button label rerenders when lastHandoffOverride changes', async () => {

--- a/test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx
+++ b/test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx
@@ -196,7 +196,8 @@ describe('SessionView handoff ticket relinking', () => {
       defaultModels: {
         build: null,
         plan: null,
-        ask: null
+        ask: null,
+        review: null
       },
       selectedModel: null,
       selectedModelByProvider: {},

--- a/test/phase-7/session-4/code-review.test.ts
+++ b/test/phase-7/session-4/code-review.test.ts
@@ -6,6 +6,7 @@ import { cleanup } from '@testing-library/react'
 // Mock setup
 // ---------------------------------------------------------------------------
 const mockGitOps = {
+  listBranchesWithStatus: vi.fn().mockResolvedValue({ success: false, branches: [] }),
   getFileStatuses: vi.fn().mockResolvedValue({ success: true, files: [] }),
   getBranchInfo: vi.fn().mockResolvedValue({
     success: true,
@@ -117,6 +118,13 @@ describe('Session 4: Code Review', () => {
     Object.defineProperty(window, 'db', { writable: true, value: mockDb })
     Object.defineProperty(window, 'worktreeOps', { writable: true, value: mockWorktreeOps })
     Object.defineProperty(window, 'projectOps', { writable: true, value: mockProjectOps })
+    Object.defineProperty(window, 'opencodeOps', {
+      writable: true,
+      value: {
+        connect: vi.fn().mockResolvedValue({ success: false }),
+        prompt: vi.fn().mockResolvedValue({ success: true })
+      }
+    })
   })
 
   // ---------------------------------------------------------------------------
@@ -186,9 +194,8 @@ describe('Session 4: Code Review', () => {
     })
 
     test('default review prompt type is standard', async () => {
-      const { DEFAULT_REVIEW_PROMPT_TYPE } = await import(
-        '../../../src/renderer/src/constants/reviewPrompts'
-      )
+      const { DEFAULT_REVIEW_PROMPT_TYPE } =
+        await import('../../../src/renderer/src/constants/reviewPrompts')
 
       expect(DEFAULT_REVIEW_PROMPT_TYPE).toBe('standard')
     })
@@ -207,9 +214,11 @@ describe('Session 4: Code Review', () => {
     test('loading persisted superpowers review prompt preserves existing user preference', async () => {
       const { useSettingsStore } = await import('../../../src/renderer/src/stores/useSettingsStore')
 
-      mockDb.setting.get.mockResolvedValueOnce(JSON.stringify({
-        reviewPromptType: 'superpowers'
-      }))
+      mockDb.setting.get.mockResolvedValueOnce(
+        JSON.stringify({
+          reviewPromptType: 'superpowers'
+        })
+      )
 
       await useSettingsStore.getState().loadFromDatabase()
 
@@ -290,9 +299,8 @@ describe('Session 4: Code Review', () => {
     })
 
     test('REVIEW_PROMPT_LABELS has human-readable labels for all types', async () => {
-      const { REVIEW_PROMPT_LABELS } = await import(
-        '../../../src/renderer/src/constants/reviewPrompts'
-      )
+      const { REVIEW_PROMPT_LABELS } =
+        await import('../../../src/renderer/src/constants/reviewPrompts')
 
       expect(REVIEW_PROMPT_LABELS.superpowers).toBe('Superpowers')
       expect(REVIEW_PROMPT_LABELS.adversarial).toBe('Adversarial')
@@ -318,8 +326,118 @@ describe('Session 4: Code Review', () => {
       expect(sessionName).toBe('Code Review — unknown vs origin/main')
     })
 
+    test('uses the review default model when creating a review session', async () => {
+      const { useGitStore } = await import('../../../src/renderer/src/stores/useGitStore')
+      const { useSessionStore } = await import('../../../src/renderer/src/stores/useSessionStore')
+      const { useSettingsStore } = await import('../../../src/renderer/src/stores/useSettingsStore')
+      const { useWorktreeStore } = await import('../../../src/renderer/src/stores/useWorktreeStore')
+      const { useLifecycleActions } =
+        await import('../../../src/renderer/src/hooks/useLifecycleActions')
+
+      const reviewModel = {
+        agentSdk: 'codex' as const,
+        providerID: 'codex',
+        modelID: 'gpt-5.5',
+        variant: 'high'
+      }
+      const createSession = vi.fn().mockResolvedValue({
+        success: true,
+        session: {
+          id: 'review-session-model',
+          worktree_id: 'wt-1',
+          project_id: 'proj-1',
+          connection_id: null,
+          name: 'Session 14:00',
+          status: 'active',
+          opencode_session_id: null,
+          agent_sdk: 'codex',
+          mode: 'build',
+          model_provider_id: 'codex',
+          model_id: 'gpt-5.5',
+          model_variant: 'high',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          completed_at: null
+        }
+      })
+      const updateSessionName = vi.fn().mockResolvedValue(undefined)
+
+      act(() => {
+        useWorktreeStore.setState({
+          worktreesByProject: new Map([
+            [
+              'proj-1',
+              [
+                {
+                  id: 'wt-1',
+                  project_id: 'proj-1',
+                  name: 'feature-auth',
+                  branch_name: 'feature-auth',
+                  path: '/tmp/review-model-worktree',
+                  status: 'active',
+                  is_default: false,
+                  branch_renamed: 0,
+                  last_message_at: null,
+                  session_titles: '[]',
+                  last_model_provider_id: null,
+                  last_model_id: null,
+                  last_model_variant: null,
+                  attachments: '[]',
+                  pinned: 0,
+                  context: null,
+                  github_pr_number: null,
+                  github_pr_url: null,
+                  base_branch: null,
+                  created_at: new Date().toISOString(),
+                  last_accessed_at: new Date().toISOString()
+                }
+              ]
+            ]
+          ])
+        })
+        useGitStore.setState({
+          branchInfoByWorktree: new Map([
+            [
+              '/tmp/review-model-worktree',
+              { name: 'feature-auth', tracking: 'origin/main', ahead: 0, behind: 0 }
+            ]
+          ]),
+          remoteInfo: new Map([
+            ['wt-1', { hasRemote: true, isGitHub: true, remoteUrl: 'git@github.com:test/repo.git' }]
+          ])
+        })
+        useSettingsStore.setState({
+          defaultModels: {
+            build: null,
+            plan: null,
+            ask: null,
+            review: reviewModel
+          }
+        })
+        useSessionStore.setState({
+          createSession,
+          updateSessionName
+        })
+      })
+
+      const { result } = renderHook(() => useLifecycleActions('wt-1'))
+
+      await result.current.createCodeReview('origin/main')
+
+      expect(createSession).toHaveBeenCalledWith('wt-1', 'proj-1', 'codex', undefined, {
+        autoFocus: false,
+        modelOverride: reviewModel
+      })
+    })
+
     test('focuses the new review tab when not currently on the board', async () => {
-      const [{ usePinAndActivateSession }, { useSessionStore }, { useKanbanStore }, { useSettingsStore }, { useFileViewerStore }] = await Promise.all([
+      const [
+        { usePinAndActivateSession },
+        { useSessionStore },
+        { useKanbanStore },
+        { useSettingsStore },
+        { useFileViewerStore }
+      ] = await Promise.all([
         import('../../../src/renderer/src/hooks/usePinAndActivateSession'),
         import('../../../src/renderer/src/stores/useSessionStore'),
         import('../../../src/renderer/src/stores/useKanbanStore'),
@@ -357,7 +475,13 @@ describe('Session 4: Code Review', () => {
     })
 
     test('keeps focus on toggle board when the board is visible', async () => {
-      const [{ usePinAndActivateSession }, { useSessionStore }, { useKanbanStore }, { useSettingsStore }, { useFileViewerStore }] = await Promise.all([
+      const [
+        { usePinAndActivateSession },
+        { useSessionStore },
+        { useKanbanStore },
+        { useSettingsStore },
+        { useFileViewerStore }
+      ] = await Promise.all([
         import('../../../src/renderer/src/hooks/usePinAndActivateSession'),
         import('../../../src/renderer/src/stores/useSessionStore'),
         import('../../../src/renderer/src/stores/useKanbanStore'),
@@ -394,7 +518,13 @@ describe('Session 4: Code Review', () => {
     })
 
     test('keeps focus on sticky board when the board tab is visible', async () => {
-      const [{ usePinAndActivateSession }, { useSessionStore, BOARD_TAB_ID }, { useKanbanStore }, { useSettingsStore }, { useFileViewerStore }] = await Promise.all([
+      const [
+        { usePinAndActivateSession },
+        { useSessionStore, BOARD_TAB_ID },
+        { useKanbanStore },
+        { useSettingsStore },
+        { useFileViewerStore }
+      ] = await Promise.all([
         import('../../../src/renderer/src/hooks/usePinAndActivateSession'),
         import('../../../src/renderer/src/stores/useSessionStore'),
         import('../../../src/renderer/src/stores/useKanbanStore'),
@@ -431,7 +561,13 @@ describe('Session 4: Code Review', () => {
     })
 
     test('focuses the new review tab when board mode is active but an overlay is covering it', async () => {
-      const [{ usePinAndActivateSession }, { useSessionStore }, { useKanbanStore }, { useSettingsStore }, { useFileViewerStore }] = await Promise.all([
+      const [
+        { usePinAndActivateSession },
+        { useSessionStore },
+        { useKanbanStore },
+        { useSettingsStore },
+        { useFileViewerStore }
+      ] = await Promise.all([
         import('../../../src/renderer/src/hooks/usePinAndActivateSession'),
         import('../../../src/renderer/src/stores/useSessionStore'),
         import('../../../src/renderer/src/stores/useKanbanStore'),


### PR DESCRIPTION
## Summary
- Adds model selection controls to Settings so defaults can be configured per SDK and per mode.
- Updates model resolution and handoff flows to respect SDK-specific defaults, remembered selections, and fallback behavior.
- Refactors session, board, and worktree picker components to use the new model selection logic consistently.
- Expands coverage with tests for handoff model picking, session relinking, and code review model selection.

## Testing
- Not run (PR content only).
- Added/updated tests cover handoff picker behavior, session ticket relinking, and review model selection paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model/SDK resolution used when creating sessions (board assistant, worktree launch, /ask, code review, and handoff), so mis-resolution could start sessions with the wrong provider/model. Changes are localized but span multiple entry points and add new settings shape (`SelectedModel.agentSdk`/`defaultModels.review`).
> 
> **Overview**
> **Adds per-SDK model defaults and selection.** `SelectedModel` can now include an `agentSdk`, Settings adds a new `review` default, and `getModelForMode` supports `super-plan` and `review`.
> 
> **Upgrades `ModelSelector` for multi-SDK catalogs.** When `allowAgentSdkSelection` is enabled (used in Settings), the picker loads model catalogs for all available SDKs, adds a provider/SDK filter, and remembers the last chosen model per SDK.
> 
> **Aligns session/runtime creation with model’s SDK.** Board assistant and worktree/session launch paths now derive the effective `agentSdk` from the selected model when present, `/ask` only applies configured models when their `agentSdk` matches the session SDK, handoff selection honors mode defaults from a different SDK, and code review session creation uses the new `review` default model.
> 
> **Tests expanded/updated** to cover cross-SDK mode defaults, multi-SDK model picking/filtering/remembering, and review-default model usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19affb38e0081352dddbcb086380e15a163cff81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->