### PR TITLE
Show PR title in notification widget

### DIFF
--- a/src/renderer/src/components/pr/CreatePRModal.tsx
+++ b/src/renderer/src/components/pr/CreatePRModal.tsx
@@ -28,6 +28,7 @@ import { useGitStore, type GitFileStatus } from '@/stores/useGitStore'
 import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useProjectStore } from '@/stores/useProjectStore'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -390,12 +391,35 @@ export function CreatePRModal({
           // Auto-attach the existing PR
           await attachPR(worktreeId, existingNumber, existingUrl)
 
+          let existingTitle: string | undefined
+          try {
+            const worktreeStore = useWorktreeStore.getState()
+            let projectId: string | null = null
+            for (const [pid, worktrees] of worktreeStore.worktreesByProject) {
+              if (worktrees.some((w) => w.id === worktreeId)) {
+                projectId = pid
+                break
+              }
+            }
+
+            const projectPath = projectId
+              ? useProjectStore.getState().projects.find((p) => p.id === projectId)?.path
+              : undefined
+            if (projectPath) {
+              const state = await window.gitOps.getPRState(projectPath, existingNumber)
+              if (state.success) existingTitle = state.title
+            }
+          } catch {
+            // Best-effort: existing PR notification still works without a title.
+          }
+
           update(notifId, {
             status: 'info',
             message: `PR #${existingNumber} already exists`,
             description: 'Attached to workspace',
             prUrl: existingUrl,
             prNumber: existingNumber,
+            prTitle: existingTitle,
             worktreeId
           })
           return
@@ -420,6 +444,7 @@ export function CreatePRModal({
           : undefined,
         prUrl,
         prNumber,
+        prTitle: finalTitle,
         worktreeId
       })
     } catch (err) {

--- a/src/renderer/src/components/pr/PRNotificationStack.tsx
+++ b/src/renderer/src/components/pr/PRNotificationStack.tsx
@@ -38,6 +38,7 @@ function PRNotificationCard({
   status,
   message,
   description,
+  prTitle,
   prUrl,
   prNumber,
   worktreeId
@@ -46,6 +47,7 @@ function PRNotificationCard({
   status: string
   message: string
   description?: string
+  prTitle?: string
   prUrl?: string
   prNumber?: number
   worktreeId?: string
@@ -166,6 +168,14 @@ function PRNotificationCard({
       {/* Content */}
       <div className="flex-1 min-w-0 space-y-1">
         <p className="text-sm font-medium text-foreground leading-snug">{message}</p>
+        {prTitle && (
+          <p
+            className="text-xs text-muted-foreground leading-snug line-clamp-2"
+            title={prTitle}
+          >
+            {prTitle}
+          </p>
+        )}
         {description && (
           <p className="text-xs text-muted-foreground leading-snug line-clamp-2">
             {description}
@@ -286,6 +296,7 @@ export function PRNotificationStack(): React.JSX.Element | null {
           status={n.status}
           message={n.message}
           description={n.description}
+          prTitle={n.prTitle}
           prUrl={n.prUrl}
           prNumber={n.prNumber}
           worktreeId={n.worktreeId}

--- a/src/renderer/src/stores/usePRNotificationStore.ts
+++ b/src/renderer/src/stores/usePRNotificationStore.ts
@@ -13,6 +13,7 @@ interface PRNotification {
   description?: string
   prUrl?: string
   prNumber?: number
+  prTitle?: string
   worktreeId?: string
 }
 

--- a/test/phase-20/session-6/pr-notification-stack-layering.test.tsx
+++ b/test/phase-20/session-6/pr-notification-stack-layering.test.tsx
@@ -54,4 +54,21 @@ describe('Session 6: PR notification stack layering', () => {
     expect(dialog).toHaveClass('z-50')
     expect(screen.getByText('PR created')).toBeInTheDocument()
   })
+
+  test('renders pull request title below the notification message', async () => {
+    act(() => {
+      usePRNotificationStore.getState().show({
+        status: 'success',
+        message: 'Pull request #123 created',
+        prTitle: 'Test: title visible in widget'
+      })
+    })
+
+    render(<PRNotificationStack />)
+
+    expect(screen.getByText('Pull request #123 created')).toBeInTheDocument()
+    const title = await screen.findByText('Test: title visible in widget')
+    expect(title).toHaveClass('text-xs', 'text-muted-foreground', 'line-clamp-2')
+    expect(title).toHaveAttribute('title', 'Test: title visible in widget')
+  })
 })


### PR DESCRIPTION
## Summary
- Adds `prTitle` to PR notifications so the widget can display the pull request title below the main message.
- Populates the title when creating a PR, including a best-effort lookup for an already-existing attached PR.
- Updates the notification stack to render the title with truncated, muted styling.
- Adds a UI test covering title rendering and styling in the notification stack.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: adds a new optional field to notification state and introduces an extra `gitOps.getPRState` lookup path when a PR already exists, which could surface IPC/runtime edge cases but is non-critical UI behavior.
> 
> **Overview**
> PR notifications now include an optional `prTitle` and render it beneath the main message in `PRNotificationStack` with muted, truncated styling.
> 
> `CreatePRModal` populates `prTitle` for newly created PRs and, when a PR already exists, attempts a best-effort title lookup via `gitOps.getPRState` before updating the info notification. A UI test was added to assert the title renders with the expected attributes/classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c13ad4e78829f6d04b8d510de1134f7f4d0088d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->