### PR TITLE
Sync provider segment with mode defaults

### DIFF
--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -187,7 +187,7 @@ export function WorktreePickerModal({
   const codexFastModeAccepted = useSettingsStore((s) => s.codexFastModeAccepted)
   const updateSetting = useSettingsStore((s) => s.updateSetting)
   const defaultSdkNormalized = defaultAgentSdk === 'terminal' ? 'opencode' : defaultAgentSdk
-  const agentSdk = selectedSdk ?? defaultSdkNormalized
+  const baseAgentSdk = selectedSdk ?? defaultSdkNormalized
 
   const autoResolvedModel = useMemo(() => {
     const settings = useSettingsStore.getState()
@@ -195,8 +195,10 @@ export function WorktreePickerModal({
     const modeModel = settings.getModelForMode(mode)
     if (modeModel && (!selectedSdk || modeModel.agentSdk === selectedSdk)) return modeModel
     // Priority 2: per-provider / global default
-    return resolveModelForSdk(agentSdk) ?? null
-  }, [mode, agentSdk, selectedSdk])
+    return resolveModelForSdk(baseAgentSdk) ?? null
+  }, [mode, baseAgentSdk, selectedSdk])
+
+  const agentSdk = selectedSdk ?? autoResolvedModel?.agentSdk ?? baseAgentSdk
 
   // ── Count in-progress tickets per worktree ──────────────────────
   const ticketCountByWorktree = useMemo(() => {

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -99,7 +99,9 @@ export function ModelSelector({
   const [providers, setProviders] = useState<SelectableProviderModels[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [filter, setFilter] = useState('')
-  const [agentSdkFilter, setAgentSdkFilter] = useState<HandoffAgentSdk | null>(null)
+  const [agentSdkFilter, setAgentSdkFilter] = useState<HandoffAgentSdk | null>(() =>
+    allowAgentSdkSelection ? (value?.agentSdk ?? null) : null
+  )
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const filterInputRef = useRef<HTMLInputElement>(null)
   const rememberedModelBySdkRef = useRef<Partial<Record<HandoffAgentSdk, SelectedModel>>>({})
@@ -340,7 +342,13 @@ export function ModelSelector({
   }, [providers, catalogAgentSdks])
 
   useEffect(() => {
+    if (!allowAgentSdkSelection) return
+    setAgentSdkFilter(value?.agentSdk ?? null)
+  }, [allowAgentSdkSelection, value?.agentSdk])
+
+  useEffect(() => {
     if (!agentSdkFilter) return
+    if (sdkFilterOptions.length === 0) return
     if (!sdkFilterOptions.some((option) => option.agentSdk === agentSdkFilter)) {
       setAgentSdkFilter(null)
     }

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -105,6 +105,7 @@ function resolveSessionSelection(opts: {
   let resolvedSdk = requestedSdk
 
   const modeDefault = settings.getModelForMode(getModeDefaultKey(opts.mode))
+  // A mode default with its own agentSdk takes precedence over the requested SDK.
   if (modeDefault && (modeDefault.agentSdk || requestedSdk === configuredDefaultSdk)) {
     model = modeDefault
     resolvedSdk = normalizeHandoffSdk(modeDefault.agentSdk ?? requestedSdk)

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -1376,19 +1376,13 @@ export const useSessionStore = create<SessionState>()(
         const sessionSdk = session?.agent_sdk ?? settings.defaultAgentSdk ?? 'opencode'
         if (sessionSdk === 'terminal') return
 
-        const configuredDefaultSdk = settings.defaultAgentSdk ?? 'opencode'
+        const modeDefault = settings.getModelForMode(newMode)
+        // Cross-SDK mode default on a live session is impossible to apply because the
+        // provider cannot change in an existing session. The mode still flips; model stays.
+        if (modeDefault?.agentSdk && modeDefault.agentSdk !== sessionSdk) return
 
-        // Mode defaults are configured in the context of the default SDK.
-        // Only apply them when the session SDK matches; otherwise fall back to per-SDK default.
-        const modeDefault =
-          sessionSdk === configuredDefaultSdk ? settings.getModelForMode(newMode) : null
         const newModeDefault = modeDefault ?? resolveModelForSdk(sessionSdk, settings)
-        if (!newModeDefault) {
-          // No defaults configured, keep current model
-          return
-        }
-
-        // Apply the new mode's default model (without rewriting global preferences)
+        if (!newModeDefault) return
         await get().setSessionModel(sessionId, newModeDefault, { skipGlobalUpdate: true })
       },
 

--- a/test/kanban/session-9/worktree-picker-modal.test.tsx
+++ b/test/kanban/session-9/worktree-picker-modal.test.tsx
@@ -309,6 +309,12 @@ describe('Session 9: Worktree Picker Modal', () => {
       useSettingsStore.setState({
         availableAgentSdks: { opencode: true, claude: true, codex: true },
         defaultAgentSdk: 'opencode',
+        defaultModels: {
+          build: null,
+          plan: null,
+          ask: null,
+          review: null
+        },
         codexFastMode: false,
         codexFastModeAccepted: false
       })
@@ -463,6 +469,45 @@ describe('Session 9: Worktree Picker Modal', () => {
     fireEvent.keyDown(modal, { key: 'Tab' })
     expect(toggle).toHaveAttribute('data-mode', 'plan')
     expect(document.activeElement).toBe(textarea)
+  })
+
+  test('Tab to plan mode reflects a cross-SDK mode default in the provider segment', async () => {
+    act(() => {
+      useSettingsStore.setState({
+        defaultAgentSdk: 'opencode',
+        defaultModels: {
+          build: null,
+          plan: {
+            agentSdk: 'claude-code',
+            providerID: 'anthropic',
+            modelID: 'opus-4.5',
+            variant: 'high'
+          },
+          ask: null,
+          review: null
+        }
+      })
+    })
+
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    const modal = screen.getByTestId('worktree-picker-modal')
+
+    expect(screen.getByTestId('sdk-toggle-opencode')).toHaveClass('bg-primary')
+    fireEvent.keyDown(modal, { key: 'Tab' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sdk-toggle-claude-code')).toHaveClass('bg-primary')
+    })
+    expect(screen.getByTestId('sdk-toggle-opencode')).not.toHaveClass('bg-primary')
+    expect(screen.getByTestId('model-selector')).toHaveTextContent('opus-4.5')
   })
 
   test('Tab still toggles mode when prompt textarea is already focused', () => {

--- a/test/phase-22/session-11/apply-mode-default-model.test.ts
+++ b/test/phase-22/session-11/apply-mode-default-model.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSettingsStore, type AgentSdk, type SelectedModel } from '@/stores/useSettingsStore'
+
+const baseSession = {
+  id: 'session-1',
+  worktree_id: 'wt-1',
+  project_id: 'project-1',
+  connection_id: null,
+  name: 'Session 1',
+  status: 'active',
+  opencode_session_id: null,
+  agent_sdk: 'claude-code',
+  mode: 'build',
+  session_type: 'default',
+  model_provider_id: 'anthropic',
+  model_id: 'opus-4.5',
+  model_variant: 'high',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  completed_at: null
+} as const
+
+const claudePlanDefault: SelectedModel = {
+  agentSdk: 'claude-code',
+  providerID: 'anthropic',
+  modelID: 'sonnet-4.6',
+  variant: 'high'
+}
+
+const codexPlanDefault: SelectedModel = {
+  agentSdk: 'codex',
+  providerID: 'codex',
+  modelID: 'gpt-5.5',
+  variant: 'xhigh'
+}
+
+const claudeUnsetSdkDefault: SelectedModel = {
+  providerID: 'anthropic',
+  modelID: 'sonnet-4.6',
+  variant: 'high'
+}
+
+const claudeFallback: SelectedModel = {
+  providerID: 'anthropic',
+  modelID: 'opus-4.5',
+  variant: 'high'
+}
+
+function seedSession(agentSdk: AgentSdk = 'claude-code'): void {
+  useSessionStore.setState({
+    sessionsByWorktree: new Map([
+      [
+        'wt-1',
+        [
+          {
+            ...baseSession,
+            agent_sdk: agentSdk
+          }
+        ]
+      ]
+    ]),
+    sessionsByConnection: new Map(),
+    boardAssistantByProject: new Map()
+  })
+}
+
+function seedSettings(planDefault: SelectedModel | null, fallback?: SelectedModel): void {
+  useSettingsStore.setState({
+    defaultAgentSdk: 'claude-code',
+    defaultModels: {
+      build: null,
+      plan: planDefault,
+      ask: null,
+      review: null
+    },
+    selectedModel: null,
+    selectedModelByProvider: fallback
+      ? {
+          'claude-code': fallback
+        }
+      : {}
+  })
+}
+
+describe('applyModeDefaultModel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    seedSession()
+    seedSettings(null)
+  })
+
+  test('applies mode default when modeDefault.agentSdk matches the session SDK', async () => {
+    seedSettings(claudePlanDefault)
+    const setSessionModel = vi
+      .spyOn(useSessionStore.getState(), 'setSessionModel')
+      .mockResolvedValue(undefined)
+
+    await useSessionStore.getState().applyModeDefaultModel('session-1', 'plan')
+
+    expect(setSessionModel).toHaveBeenCalledWith('session-1', claudePlanDefault, {
+      skipGlobalUpdate: true
+    })
+  })
+
+  test('applies mode default when modeDefault.agentSdk is unset', async () => {
+    seedSettings(claudeUnsetSdkDefault)
+    const setSessionModel = vi
+      .spyOn(useSessionStore.getState(), 'setSessionModel')
+      .mockResolvedValue(undefined)
+
+    await useSessionStore.getState().applyModeDefaultModel('session-1', 'plan')
+
+    expect(setSessionModel).toHaveBeenCalledWith('session-1', claudeUnsetSdkDefault, {
+      skipGlobalUpdate: true
+    })
+  })
+
+  test('does not change the model when modeDefault.agentSdk differs from the session SDK', async () => {
+    seedSettings(codexPlanDefault)
+    const setSessionModel = vi
+      .spyOn(useSessionStore.getState(), 'setSessionModel')
+      .mockResolvedValue(undefined)
+
+    await useSessionStore.getState().applyModeDefaultModel('session-1', 'plan')
+
+    expect(setSessionModel).not.toHaveBeenCalled()
+  })
+
+  test('falls back to the session SDK default when no mode default is configured', async () => {
+    seedSettings(null, claudeFallback)
+    const setSessionModel = vi
+      .spyOn(useSessionStore.getState(), 'setSessionModel')
+      .mockResolvedValue(undefined)
+
+    await useSessionStore.getState().applyModeDefaultModel('session-1', 'plan')
+
+    expect(setSessionModel).toHaveBeenCalledWith('session-1', claudeFallback, {
+      skipGlobalUpdate: true
+    })
+  })
+
+  test('does not change terminal session models', async () => {
+    seedSession('terminal')
+    seedSettings(claudePlanDefault)
+    const setSessionModel = vi
+      .spyOn(useSessionStore.getState(), 'setSessionModel')
+      .mockResolvedValue(undefined)
+
+    await useSessionStore.getState().applyModeDefaultModel('session-1', 'plan')
+
+    expect(setSessionModel).not.toHaveBeenCalled()
+  })
+})

--- a/test/phase-22/session-11/model-selector-provider-pill.test.tsx
+++ b/test/phase-22/session-11/model-selector-provider-pill.test.tsx
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+
+const claudeProviders = [
+  {
+    id: 'anthropic',
+    name: 'Anthropic',
+    models: {
+      'opus-4.5': {
+        id: 'opus-4.5',
+        name: 'Opus 4.5'
+      }
+    }
+  }
+]
+
+const codexProviders = [
+  {
+    id: 'codex',
+    name: 'Codex',
+    models: {
+      'gpt-5.5': {
+        id: 'gpt-5.5',
+        name: 'GPT-5.5'
+      }
+    }
+  }
+]
+
+Object.defineProperty(window, 'opencodeOps', {
+  writable: true,
+  configurable: true,
+  value: {
+    listModels: vi.fn().mockImplementation(async ({ agentSdk }: { agentSdk?: string } = {}) => {
+      if (agentSdk === 'codex') {
+        return { success: true, providers: codexProviders }
+      }
+
+      return { success: true, providers: claudeProviders }
+    })
+  }
+})
+
+import { ModelSelector } from '@/components/sessions/ModelSelector'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+
+describe('ModelSelector provider filter pill', () => {
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+
+    useSettingsStore.setState({
+      defaultAgentSdk: 'claude-code',
+      selectedModel: null,
+      selectedModelByProvider: {
+        'claude-code': {
+          providerID: 'anthropic',
+          modelID: 'opus-4.5'
+        },
+        codex: {
+          providerID: 'codex',
+          modelID: 'gpt-5.5'
+        }
+      },
+      availableAgentSdks: {
+        opencode: false,
+        claude: true,
+        codex: true
+      }
+    })
+  })
+
+  test('shows the controlled SDK label on first paint', async () => {
+    render(
+      <ModelSelector
+        value={{ agentSdk: 'codex', providerID: 'codex', modelID: 'gpt-5.5' }}
+        onChange={vi.fn()}
+        allowAgentSdkSelection
+      />
+    )
+
+    expect(await screen.findByTestId('model-provider-filter')).toHaveTextContent('Codex')
+  })
+
+  test('updates the provider pill when the controlled SDK changes', async () => {
+    const { rerender } = render(
+      <ModelSelector
+        value={{ agentSdk: 'codex', providerID: 'codex', modelID: 'gpt-5.5' }}
+        onChange={vi.fn()}
+        allowAgentSdkSelection
+      />
+    )
+
+    expect(await screen.findByTestId('model-provider-filter')).toHaveTextContent('Codex')
+
+    rerender(
+      <ModelSelector
+        value={{ agentSdk: 'claude-code', providerID: 'anthropic', modelID: 'opus-4.5' }}
+        onChange={vi.fn()}
+        allowAgentSdkSelection
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('model-provider-filter')).toHaveTextContent('Claude Code')
+    })
+  })
+
+  test('does not render the provider filter without agent SDK selection', async () => {
+    render(
+      <ModelSelector
+        value={{ agentSdk: 'codex', providerID: 'codex', modelID: 'gpt-5.5' }}
+        onChange={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(window.opencodeOps.listModels).toHaveBeenCalled()
+    })
+
+    expect(screen.queryByTestId('model-provider-filter')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Keep the provider segment in sync with the active mode default so cross-SDK mode switches surface the correct provider and model.
- Preserve mode-default application on live sessions while avoiding invalid cross-SDK model changes when the session provider cannot change.
- Initialize and refresh the model selector's provider filter from the controlled value so the pill reflects the current SDK immediately.
- Add coverage for worktree picker tab switching, mode-default application rules, and provider pill rendering updates.

## Testing
- Not run
- Added/updated tests covering provider-segment sync in the worktree picker modal.
- Added/updated tests covering `applyModeDefaultModel` behavior across matching, mismatched, unset, and terminal SDK cases.
- Added/updated tests covering `ModelSelector` provider pill initialization and controlled value changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core model-selection logic for both new sessions and live mode toggles; mistakes could cause surprising provider/model changes or failure to apply expected defaults. Changes are localized and covered by new unit tests, lowering regression risk.
> 
> **Overview**
> Keeps the worktree picker’s **provider segment (SDK toggle + model)** in sync with the active mode default, including cross-SDK defaults when switching build/plan, by deriving `agentSdk` from the auto-resolved mode model rather than only the user/default SDK.
> 
> Updates `ModelSelector` so the provider filter pill initializes from (and stays synced with) the controlled `value.agentSdk`, avoiding a first-paint mismatch and clearing invalid filters only after options are available.
> 
> Refines session/default resolution to treat mode defaults with an explicit `agentSdk` as higher priority, while `applyModeDefaultModel` now avoids attempting impossible cross-SDK model changes on existing sessions (mode still changes, model does not). Adds test coverage for these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9857cb14b1fab56173bbbc4a1eb6bf99a77d0999. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->