### PR TITLE
Preserve sidebar filters when entering connection mode

### DIFF
--- a/src/renderer/src/components/layout/LeftSidebar.tsx
+++ b/src/renderer/src/components/layout/LeftSidebar.tsx
@@ -46,14 +46,6 @@ export function LeftSidebar(): React.JSX.Element {
 
   const canFinalize = connectionModeSelectedIds.size >= 2
 
-  // Clear filter when entering connection mode
-  useEffect(() => {
-    if (connectionModeActive) {
-      setFilterQuery('')
-      clearAllFilters()
-    }
-  }, [connectionModeActive, clearAllFilters])
-
   // Clear language filters on space switch
   useEffect(() => {
     clearAllFilters()

--- a/test/worktree-connection/session-10/left-sidebar-filter-persistence.test.tsx
+++ b/test/worktree-connection/session-10/left-sidebar-filter-persistence.test.tsx
@@ -1,0 +1,172 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { LeftSidebar } from '../../../src/renderer/src/components/layout/LeftSidebar'
+import { useConnectionStore } from '../../../src/renderer/src/stores/useConnectionStore'
+import { useFilterStore } from '../../../src/renderer/src/stores/useFilterStore'
+import { useLayoutStore } from '../../../src/renderer/src/stores/useLayoutStore'
+import { useProjectStore } from '../../../src/renderer/src/stores/useProjectStore'
+import { useSpaceStore } from '../../../src/renderer/src/stores/useSpaceStore'
+
+vi.mock('@/components/projects', () => ({
+  ProjectList: ({
+    filterQuery,
+    activeLanguages
+  }: {
+    filterQuery: string
+    activeLanguages: string[]
+  }) => (
+    <div
+      data-testid="project-list"
+      data-filter-query={filterQuery}
+      data-active-languages={activeLanguages.join(',')}
+    />
+  ),
+  AddProjectButton: () => <button data-testid="add-project-button" type="button" />,
+  SortProjectsButton: () => <button data-testid="sort-projects-button" type="button" />,
+  RecentToggleButton: () => <button data-testid="recent-toggle-button" type="button" />,
+  FilterChips: ({ languages }: { languages: string[] }) => (
+    <div data-testid="filter-chips">{languages.join(',')}</div>
+  )
+}))
+
+vi.mock('@/components/connections', () => ({
+  ConnectionList: () => <div data-testid="mock-connection-list" />
+}))
+
+vi.mock('@/components/spaces', () => ({
+  SpacesTabBar: () => <div data-testid="mock-spaces-tab-bar" />
+}))
+
+vi.mock('../../../src/renderer/src/components/layout/UsageIndicator', () => ({
+  UsageIndicator: () => <div data-testid="mock-usage-indicator" />
+}))
+
+vi.mock('../../../src/renderer/src/components/layout/PinnedList', () => ({
+  PinnedList: () => <div data-testid="mock-pinned-list" />
+}))
+
+vi.mock('../../../src/renderer/src/components/layout/RecentList', () => ({
+  RecentList: () => <div data-testid="mock-recent-list" />
+}))
+
+vi.mock('../../../src/renderer/src/components/layout/ResizeHandle', () => ({
+  ResizeHandle: () => <div data-testid="mock-resize-handle" />
+}))
+
+function makeProject(id: string, name: string, language: string | null) {
+  return {
+    id,
+    name,
+    path: `/repos/${name.toLowerCase()}`,
+    description: null,
+    tags: null,
+    language,
+    custom_icon: null,
+    detected_icon: null,
+    setup_script: null,
+    run_script: null,
+    archive_script: null,
+    auto_assign_port: false,
+    sort_order: 0,
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_accessed_at: '2026-01-01T00:00:00.000Z'
+  }
+}
+
+describe('Session 10: LeftSidebar filter persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    useProjectStore.setState({
+      projects: [],
+      isLoading: false,
+      error: null,
+      selectedProjectId: null,
+      expandedProjectIds: new Set(),
+      editingProjectId: null,
+      settingsProjectId: null
+    })
+
+    useFilterStore.setState({ activeLanguages: [] })
+
+    useConnectionStore.setState({
+      connections: [],
+      isLoading: false,
+      error: null,
+      loaded: true,
+      selectedConnectionId: null,
+      connectionModeActive: false,
+      connectionModeSourceWorktreeId: null,
+      connectionModeSelectedIds: new Set(),
+      connectionModeSubmitting: false
+    })
+
+    useLayoutStore.setState({
+      leftSidebarWidth: 240,
+      leftSidebarCollapsed: false
+    })
+
+    useSpaceStore.setState({
+      spaces: [],
+      activeSpaceId: null,
+      projectSpaceMap: {}
+    })
+  })
+
+  test('keeps the typed search query after enterConnectionMode is fired', async () => {
+    const user = userEvent.setup()
+
+    useProjectStore.setState({
+      projects: [
+        makeProject('p1', 'Frontend', 'typescript'),
+        makeProject('p2', 'Backend', 'go')
+      ]
+    })
+
+    render(<LeftSidebar />)
+
+    const filterInput = screen.getByTestId('project-filter-input')
+    await user.type(filterInput, 'front')
+    expect(filterInput).toHaveValue('front')
+    expect(screen.getByTestId('project-list')).toHaveAttribute('data-filter-query', 'front')
+
+    act(() => {
+      useConnectionStore.getState().enterConnectionMode('wt-1')
+    })
+
+    expect(screen.getByTestId('project-filter-input')).toHaveValue('front')
+    expect(screen.getByTestId('project-list')).toHaveAttribute('data-filter-query', 'front')
+  })
+
+  test('keeps active language filters after enterConnectionMode is fired', () => {
+    useProjectStore.setState({
+      projects: [
+        makeProject('p1', 'Frontend', 'typescript'),
+        makeProject('p2', 'Backend', 'go')
+      ]
+    })
+
+    render(<LeftSidebar />)
+
+    act(() => {
+      useFilterStore.setState({ activeLanguages: ['typescript'] })
+    })
+
+    expect(useFilterStore.getState().activeLanguages).toEqual(['typescript'])
+    expect(screen.getByTestId('project-list')).toHaveAttribute(
+      'data-active-languages',
+      'typescript'
+    )
+
+    act(() => {
+      useConnectionStore.getState().enterConnectionMode('wt-1')
+    })
+
+    expect(useFilterStore.getState().activeLanguages).toEqual(['typescript'])
+    expect(screen.getByTestId('project-list')).toHaveAttribute(
+      'data-active-languages',
+      'typescript'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Stop clearing the project search query and language filters when connection mode is entered.
- Keep the left sidebar state intact so users can continue filtering while selecting connection mode projects.
- Add regression coverage for both typed search text and active language filters.

## Testing
- Added `left-sidebar-filter-persistence.test.tsx` covering search query persistence after `enterConnectionMode`.
- Added regression coverage verifying active language filters are not cleared in connection mode.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change limited to LeftSidebar behavior plus new tests; primary risk is unintended persistence of stale filters across mode transitions.
> 
> **Overview**
> Preserves the LeftSidebar’s current project search query and active language filters when `enterConnectionMode` is triggered (removes the effect that previously cleared them on connection-mode entry).
> 
> Adds `left-sidebar-filter-persistence.test.tsx` to regress search text and language filter persistence across connection-mode activation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70b722a102e6fc4a8a17d93d7c2a55a93284504e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->