### PR TITLE
Reset archive state when reopening Merge On Done

### DIFF
--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -54,6 +54,10 @@ export function MergeOnDoneDialog() {
     const init = async () => {
       setStep('loading')
       setResolved(null)
+      setCommittingBase(false)
+      setCommitting(false)
+      setMerging(false)
+      setArchiving(false)
 
       try {
         // Look up ticket from store

--- a/test/kanban/merge-on-done-dialog.test.tsx
+++ b/test/kanban/merge-on-done-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { KanbanTicket, Project, Worktree } from '../../src/main/db/types'
 import { MergeOnDoneDialog } from '../../src/renderer/src/components/kanban/MergeOnDoneDialog'
@@ -262,5 +262,69 @@ describe('MergeOnDoneDialog', () => {
     await waitFor(() => {
       expect(toastSuccess).toHaveBeenCalledWith('Worktree archived')
     })
+  })
+
+  test('starts a new done-move archive step with the archive button enabled while a previous archive is still running', async () => {
+    const secondTicket = makeTicket({
+      id: 'ticket-2',
+      title: 'Fix second issue',
+      worktree_id: 'feature-wt-2'
+    })
+    const secondWorktree = makeWorktree({
+      id: 'feature-wt-2',
+      name: 'feature-two',
+      branch_name: 'feature-two',
+      path: '/repo/feature-two'
+    })
+    ;(window.db.worktree.get as ReturnType<typeof vi.fn>).mockImplementation((id: string) =>
+      Promise.resolve(id === 'feature-wt-2' ? secondWorktree : makeWorktree())
+    )
+    ;(window.db.worktree.getActiveByProject as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makeWorktree(),
+      secondWorktree,
+      baseWorktree
+    ])
+    merge.mockResolvedValue({ success: true })
+    const archiveWorktree = vi.fn(
+      () =>
+        new Promise<{ success: boolean }>(() => {
+          // Keep the first archive pending to reproduce the leaked loading state.
+        })
+    )
+    useWorktreeStore.setState({ archiveWorktree })
+
+    render(<MergeOnDoneDialog />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /^merge$/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^archive$/i }))
+
+    await waitFor(() => {
+      expect(ticketMove).toHaveBeenCalledWith('ticket-1', 'done', 100)
+    })
+    expect(useKanbanStore.getState().pendingDoneMove).toBeNull()
+
+    act(() => {
+      useKanbanStore.setState({
+        tickets: new Map([
+          [
+            'project-1',
+            [
+              makeTicket({ column: 'done', sort_order: 100 }),
+              secondTicket
+            ]
+          ]
+        ]),
+        pendingDoneMove: {
+          ticketId: 'ticket-2',
+          projectId: 'project-1',
+          sortOrder: 200
+        }
+      })
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: /^merge$/i }))
+    const secondArchiveButton = await screen.findByRole('button', { name: /^archive$/i })
+
+    expect(secondArchiveButton).toBeEnabled()
   })
 })


### PR DESCRIPTION
## Summary
- Reset all merge/archive loading flags when the Merge On Done dialog reinitializes.
- Prevent a stale in-progress archive from disabling the archive button on a subsequent done move.
- Add a regression test covering a second done move while a previous archive is still pending.

## Testing
- `Not run`
- Added/updated unit coverage in `test/kanban/merge-on-done-dialog.test.tsx` for the stale archive-button state case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state fix limited to resetting local loading flags and adding test coverage; main risk is minor behavior change in button enabled/disabled states during rapid successive done-moves.
> 
> **Overview**
> Fixes a state leak in `MergeOnDoneDialog` where reopening the dialog for a new `pendingDoneMove` could inherit prior in-progress `commit/merge/archive` loading flags (notably leaving *Archive* disabled).
> 
> On dialog re-initialization, all step-specific loading booleans are reset, and a new regression test covers starting a second done-move while the first archive promise is still pending to ensure the new archive button remains enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec02201130cd92c27b6fa8d78b2516cf64fe0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->