### PR TITLE
Support Cmd-hover and Cmd-click links in run output

### DIFF
--- a/src/renderer/src/components/layout/RunOutputLine.tsx
+++ b/src/renderer/src/components/layout/RunOutputLine.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import Ansi from 'ansi-to-react'
 import { parseAnsiSegments } from '@/lib/ansi-utils'
+import { splitLineByUrls } from '@/lib/url-utils'
+import { useSettingsStore } from '@/stores/useSettingsStore'
 
 export interface SearchHighlight {
   /** Character offset where the match starts (in the stripped-ANSI plain text) */
@@ -14,6 +16,29 @@ export interface SearchHighlight {
 interface RunOutputLineProps {
   line: string
   highlight?: SearchHighlight
+}
+
+function RunUrlSpan({ url, display }: { url: string; display: string }): React.JSX.Element {
+  const onClick = (e: React.MouseEvent): void => {
+    if (e.button !== 0) return
+    if (!(e.metaKey || e.ctrlKey)) return
+
+    e.preventDefault()
+    e.stopPropagation()
+
+    const customCommand = useSettingsStore.getState().customChromeCommand || undefined
+    window.systemOps.openInChrome(url, customCommand)
+  }
+  const onContextMenu = (e: React.MouseEvent): void => {
+    e.preventDefault()
+    e.stopPropagation()
+  }
+
+  return (
+    <span className="run-url" onClick={onClick} onContextMenu={onContextMenu} data-url={url}>
+      {display}
+    </span>
+  )
 }
 
 // When a search highlight is active, ANSI coloring is intentionally dropped
@@ -91,9 +116,24 @@ function RunOutputLineInner({ line, highlight }: RunOutputLineProps): React.JSX.
     return renderHighlightedLine(line, highlight)
   }
 
+  const chunks = splitLineByUrls(line)
+  if (chunks.length === 1 && chunks[0].type === 'text') {
+    return (
+      <div className="whitespace-pre-wrap break-all [&_code]:all-unset">
+        <Ansi>{line}</Ansi>
+      </div>
+    )
+  }
+
   return (
     <div className="whitespace-pre-wrap break-all [&_code]:all-unset">
-      <Ansi>{line}</Ansi>
+      {chunks.map((chunk, index) =>
+        chunk.type === 'url' ? (
+          <RunUrlSpan key={index} url={chunk.url} display={chunk.content} />
+        ) : (
+          <Ansi key={index}>{chunk.content}</Ansi>
+        )
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/layout/RunTab.tsx
+++ b/src/renderer/src/components/layout/RunTab.tsx
@@ -88,6 +88,34 @@ export function RunTab({ worktreeId }: RunTabProps): React.JSX.Element {
     return () => document.removeEventListener('keydown', handleKeyDown, true)
   }, [])
 
+  useEffect(() => {
+    const setModifierHeld = (held: boolean): void => {
+      const el = outputRef.current
+      if (el) el.dataset.metaHeld = held ? 'true' : 'false'
+    }
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (e.metaKey || e.ctrlKey) setModifierHeld(true)
+    }
+    const handleKeyUp = (e: KeyboardEvent): void => {
+      if (!e.metaKey && !e.ctrlKey) setModifierHeld(false)
+    }
+    const handleBlur = (): void => setModifierHeld(false)
+    const handleVisibilityChange = (): void => {
+      if (document.hidden) setModifierHeld(false)
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('keyup', handleKeyUp)
+    window.addEventListener('blur', handleBlur)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('keyup', handleKeyUp)
+      window.removeEventListener('blur', handleBlur)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [])
+
   // Build highlight map for O(1) lookup per visible row.
   // Limitation: only one highlight per line is stored. When a line has multiple
   // matches, the current match takes priority; otherwise the first match wins.
@@ -221,6 +249,7 @@ export function RunTab({ worktreeId }: RunTabProps): React.JSX.Element {
       <div
         ref={outputRef}
         className="flex-1 min-h-0 overflow-auto p-2 font-mono text-xs leading-relaxed"
+        data-meta-held="false"
         data-testid="run-tab-output"
       >
         {lineCount === 0 && !runRunning && (

--- a/src/renderer/src/lib/url-utils.ts
+++ b/src/renderer/src/lib/url-utils.ts
@@ -1,0 +1,68 @@
+const URL_RE = /\bhttps?:\/\/[^\s<>"'`]+/g
+const TRAILING_PUNCT_CHARS = new Set([')', '.', ',', ';', ':', '!', '?', ']', "'", '"', '`'])
+
+export function trimTrailingPunct(url: string): string {
+  let out = url
+
+  while (out.length > 0) {
+    const last = out[out.length - 1]
+    if (!TRAILING_PUNCT_CHARS.has(last)) break
+
+    if (last === ')') {
+      const withoutLast = out.slice(0, -1)
+      const opens = (withoutLast.match(/\(/g) || []).length
+      const closes = (withoutLast.match(/\)/g) || []).length
+      if (opens > closes) break
+    }
+
+    out = out.slice(0, -1)
+  }
+
+  return out
+}
+
+export type LineChunk =
+  | { type: 'text'; content: string }
+  | { type: 'url'; content: string; url: string }
+
+export function splitLineByUrls(line: string): LineChunk[] {
+  URL_RE.lastIndex = 0
+
+  const chunks: LineChunk[] = []
+  const pushText = (content: string): void => {
+    const previous = chunks[chunks.length - 1]
+    if (previous?.type === 'text') {
+      previous.content += content
+      return
+    }
+    chunks.push({ type: 'text', content })
+  }
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = URL_RE.exec(line)) !== null) {
+    const rawUrl = match[0]
+    const url = trimTrailingPunct(rawUrl)
+
+    pushText(line.slice(lastIndex, match.index))
+
+    if (url.length > 0) {
+      chunks.push({ type: 'url', content: url, url })
+    }
+
+    const trailingStart = match.index + url.length
+    const trailingEnd = match.index + rawUrl.length
+    if (trailingStart < trailingEnd) {
+      pushText(line.slice(trailingStart, trailingEnd))
+    }
+
+    lastIndex = trailingEnd
+  }
+
+  if (chunks.length === 0) {
+    return [{ type: 'text', content: line }]
+  }
+
+  pushText(line.slice(lastIndex))
+  return chunks
+}

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -3,6 +3,12 @@
 @import 'highlight.js/styles/github-dark-dimmed.css';
 @import './xterm.css';
 
+[data-meta-held='true'] .run-url:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
 @font-face {
   font-family: 'DM Sans';
   src: url('../assets/fonts/DMSans-Variable.woff2') format('woff2');

--- a/test/run-pane-redesign/run-output-line.test.tsx
+++ b/test/run-pane-redesign/run-output-line.test.tsx
@@ -1,10 +1,11 @@
-import { describe, expect, test, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import {
   RunOutputLine,
   SearchHighlight
 } from '../../src/renderer/src/components/layout/RunOutputLine'
+import { useSettingsStore } from '../../src/renderer/src/stores/useSettingsStore'
 
 // Mock ansi-to-react so we can verify the raw text is passed through
 vi.mock('ansi-to-react', () => ({
@@ -12,6 +13,11 @@ vi.mock('ansi-to-react', () => ({
 }))
 
 describe('RunOutputLine', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(window.systemOps.openInChrome).mockClear()
+  })
+
   describe('marker lines', () => {
     test('renders truncation marker with \x00TRUNC: prefix', () => {
       const { container } = render(
@@ -192,6 +198,90 @@ describe('RunOutputLine', () => {
         <RunOutputLine line="hello world" highlight={highlight} />
       )
       expect(screen.queryByTestId('ansi')).toBeNull()
+    })
+  })
+
+  describe('URL linkification', () => {
+    test('plain line still uses Ansi component', () => {
+      render(<RunOutputLine line="plain output" />)
+      const ansi = screen.getByTestId('ansi')
+      expect(ansi.textContent).toBe('plain output')
+    })
+
+    test('line with one URL renders a data-url span', () => {
+      const { container } = render(<RunOutputLine line="Local: http://localhost:5173/" />)
+      const span = container.querySelector('[data-url="http://localhost:5173/"]')
+      expect(span).not.toBeNull()
+      expect(span?.textContent).toBe('http://localhost:5173/')
+    })
+
+    test('Cmd+click opens URL with custom Chrome command', () => {
+      vi.spyOn(useSettingsStore, 'getState').mockReturnValue({
+        customChromeCommand: 'open -a Firefox {url}'
+      } as ReturnType<typeof useSettingsStore.getState>)
+
+      const { container } = render(<RunOutputLine line="Local: http://localhost:5173/" />)
+      const span = container.querySelector('[data-url="http://localhost:5173/"]')!
+
+      fireEvent.click(span, { metaKey: true, button: 0 })
+
+      expect(window.systemOps.openInChrome).toHaveBeenCalledWith(
+        'http://localhost:5173/',
+        'open -a Firefox {url}'
+      )
+    })
+
+    test('plain click does not open URL', () => {
+      const { container } = render(<RunOutputLine line="Local: http://localhost:5173/" />)
+      const span = container.querySelector('[data-url="http://localhost:5173/"]')!
+
+      fireEvent.click(span, { button: 0 })
+
+      expect(window.systemOps.openInChrome).not.toHaveBeenCalled()
+    })
+
+    test('right-click context menu is suppressed without opening URL', () => {
+      const { container } = render(<RunOutputLine line="Local: http://localhost:5173/" />)
+      const span = container.querySelector('[data-url="http://localhost:5173/"]')!
+      const event = new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        button: 2
+      })
+
+      span.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(true)
+      expect(window.systemOps.openInChrome).not.toHaveBeenCalled()
+    })
+
+    test('empty custom Chrome command is passed as undefined', () => {
+      vi.spyOn(useSettingsStore, 'getState').mockReturnValue({
+        customChromeCommand: ''
+      } as ReturnType<typeof useSettingsStore.getState>)
+
+      const { container } = render(<RunOutputLine line="Local: http://localhost:5173/" />)
+      const span = container.querySelector('[data-url="http://localhost:5173/"]')!
+
+      fireEvent.click(span, { metaKey: true, button: 0 })
+
+      expect(window.systemOps.openInChrome).toHaveBeenCalledWith(
+        'http://localhost:5173/',
+        undefined
+      )
+    })
+
+    test('highlighted URL line is not linkified', () => {
+      const highlight: SearchHighlight = {
+        matchStart: 7,
+        matchEnd: 11,
+        isCurrent: true
+      }
+      const { container } = render(
+        <RunOutputLine line="Local: http://localhost:5173/" highlight={highlight} />
+      )
+
+      expect(container.querySelector('[data-url]')).toBeNull()
     })
   })
 

--- a/test/run-pane-redesign/url-utils.test.ts
+++ b/test/run-pane-redesign/url-utils.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'vitest'
+import { splitLineByUrls, trimTrailingPunct } from '../../src/renderer/src/lib/url-utils'
+
+describe('url-utils', () => {
+  describe('splitLineByUrls', () => {
+    test('returns a single text chunk when no URL is present', () => {
+      expect(splitLineByUrls('server started on port 5173')).toEqual([
+        { type: 'text', content: 'server started on port 5173' }
+      ])
+    })
+
+    test('splits a single URL surrounded by text into three chunks', () => {
+      expect(splitLineByUrls('Local: http://localhost:5173/ ready')).toEqual([
+        { type: 'text', content: 'Local: ' },
+        { type: 'url', content: 'http://localhost:5173/', url: 'http://localhost:5173/' },
+        { type: 'text', content: ' ready' }
+      ])
+    })
+
+    test('splits two URLs in one line into five chunks', () => {
+      expect(splitLineByUrls('open http://localhost:5173/ or https://example.com/docs')).toEqual([
+        { type: 'text', content: 'open ' },
+        { type: 'url', content: 'http://localhost:5173/', url: 'http://localhost:5173/' },
+        { type: 'text', content: ' or ' },
+        { type: 'url', content: 'https://example.com/docs', url: 'https://example.com/docs' },
+        { type: 'text', content: '' }
+      ])
+    })
+
+    test('moves trailing punctuation into text chunks', () => {
+      expect(splitLineByUrls('See https://example.com/a.,)];: next')).toEqual([
+        { type: 'text', content: 'See ' },
+        { type: 'url', content: 'https://example.com/a', url: 'https://example.com/a' },
+        { type: 'text', content: '.,)];: next' }
+      ])
+    })
+
+    test('keeps balanced Wikipedia-style closing parenthesis', () => {
+      expect(splitLineByUrls('See https://en.wikipedia.org/wiki/Foo_(bar)')).toEqual([
+        { type: 'text', content: 'See ' },
+        {
+          type: 'url',
+          content: 'https://en.wikipedia.org/wiki/Foo_(bar)',
+          url: 'https://en.wikipedia.org/wiki/Foo_(bar)'
+        },
+        { type: 'text', content: '' }
+      ])
+    })
+
+    test('angle brackets terminate URL detection', () => {
+      expect(splitLineByUrls('<https://example.com>')).toEqual([
+        { type: 'text', content: '<' },
+        { type: 'url', content: 'https://example.com', url: 'https://example.com' },
+        { type: 'text', content: '>' }
+      ])
+    })
+  })
+
+  describe('trimTrailingPunct', () => {
+    test.each(['.', ',', ']', ';', ':'])('strips trailing %s', (punct) => {
+      expect(trimTrailingPunct(`https://example.com/path${punct}`)).toBe(
+        'https://example.com/path'
+      )
+    })
+
+    test('strips an unbalanced trailing closing parenthesis', () => {
+      expect(trimTrailingPunct('https://example.com/path)')).toBe('https://example.com/path')
+    })
+
+    test('keeps a balanced trailing closing parenthesis', () => {
+      expect(trimTrailingPunct('https://en.wikipedia.org/wiki/Foo_(bar)')).toBe(
+        'https://en.wikipedia.org/wiki/Foo_(bar)'
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Linkifies HTTP/HTTPS URLs in run output lines while preserving ANSI rendering for non-URL text.
- Adds Cmd/Ctrl-hover underline affordance and Cmd/Ctrl-click handling to open links in Chrome, with optional custom Chrome command support.
- Includes URL parsing utilities and tests for punctuation trimming, bracket handling, and click behavior.

## Testing
- `Not run`
- Added unit coverage for URL splitting and trailing punctuation handling.
- Added component tests for link rendering, modifier-click opening, and suppression of plain/right clicks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/UX behavior change in the run output pane that adds click handling and URL parsing; risk is mainly incorrect URL detection or unintended click interception, with minimal security impact since it only opens external URLs via an existing system API.
> 
> **Overview**
> Adds URL linkification to run output rendering: HTTP/HTTPS URLs are detected and rendered as `run-url` spans while preserving ANSI rendering for surrounding text, and *linkification is skipped when search highlighting is active*.
> 
> Implements Cmd/Ctrl-modifier UX: Run output tracks whether the modifier key is held via a `data-meta-held` attribute (reset on keyup/blur/visibility changes) to enable underline-on-hover styling, and Cmd/Ctrl+left-click opens the URL via `window.systemOps.openInChrome` using the optional `customChromeCommand` setting.
> 
> Introduces `url-utils` (`splitLineByUrls`, `trimTrailingPunct`) with edge-case handling for trailing punctuation/parentheses, and adds unit/component tests covering parsing and click/context-menu behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59fb989d4fbd9692b671428ddc573eae562a192f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->