### PR TITLE
Add goal mode support for ticket launches

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -159,6 +159,8 @@ export class DatabaseService {
       mark: (row.mark as TicketMark) ?? null,
       total_tokens: (row.total_tokens as number) ?? 0,
       pending_launch_config: (row.pending_launch_config as string) ?? null,
+      goal_mode: row.goal_mode === 1,
+      goal_success_criteria: (row.goal_success_criteria as string) ?? null,
       note: (row.note as string) ?? null
     }
   }
@@ -412,6 +414,8 @@ export class DatabaseService {
     this.safeAddColumn('kanban_tickets', 'github_pr_url', 'TEXT DEFAULT NULL')
     this.safeAddColumn('kanban_tickets', 'mark', 'TEXT DEFAULT NULL')
     this.safeAddColumn('kanban_tickets', 'note', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('kanban_tickets', 'goal_mode', 'INTEGER NOT NULL DEFAULT 0')
+    this.safeAddColumn('kanban_tickets', 'goal_success_criteria', 'TEXT DEFAULT NULL')
     this.safeAddColumn('sessions', 'session_type', "TEXT NOT NULL DEFAULT 'default'")
 
     db.exec(`
@@ -2069,6 +2073,14 @@ export class DatabaseService {
     if (data.pending_launch_config !== undefined) {
       updates.push('pending_launch_config = ?')
       values.push(data.pending_launch_config)
+    }
+    if (data.goal_mode !== undefined) {
+      updates.push('goal_mode = ?')
+      values.push(data.goal_mode ? 1 : 0)
+    }
+    if (data.goal_success_criteria !== undefined) {
+      updates.push('goal_success_criteria = ?')
+      values.push(data.goal_success_criteria)
     }
     if (data.note !== undefined) {
       updates.push('note = ?')

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 25
+export const CURRENT_SCHEMA_VERSION = 26
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -478,5 +478,14 @@ CREATE INDEX IF NOT EXISTS idx_diff_comments_worktree_file ON diff_comments(work
     down: `DROP INDEX IF EXISTS idx_diff_comments_worktree_file;
 DROP INDEX IF EXISTS idx_diff_comments_worktree;
 DROP TABLE IF EXISTS diff_comments;`
+  },
+  {
+    version: 26,
+    name: 'add_ticket_goal',
+    up: `
+      ALTER TABLE kanban_tickets ADD COLUMN goal_mode INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE kanban_tickets ADD COLUMN goal_success_criteria TEXT DEFAULT NULL;
+    `,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -367,6 +367,8 @@ export interface KanbanTicket {
   mark: TicketMark | null
   total_tokens: number
   pending_launch_config: string | null
+  goal_mode: boolean
+  goal_success_criteria: string | null
   /** Personal annotation. MUST NOT be included in any LLM prompt. */
   note: string | null
 }
@@ -405,6 +407,8 @@ export interface KanbanTicketUpdate {
   github_pr_url?: string | null
   mark?: TicketMark | null
   pending_launch_config?: string | null
+  goal_mode?: boolean
+  goal_success_criteria?: string | null
   note?: string | null
 }
 
@@ -497,6 +501,8 @@ export interface PendingLaunchConfig {
   model: { providerID: string; modelID: string; variant?: string } | null
   sdk: 'opencode' | 'claude-code' | 'codex'
   codexFastMode: boolean
+  goalMode: boolean
+  goalSuccessCriteria: string | null
 }
 
 // Ticket followup message types

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -315,6 +315,32 @@ function resolveModalMode(ticket: KanbanTicket, sessionStatus: string | null): M
   return 'edit'
 }
 
+function TicketGoalSection({
+  ticket,
+  isEditMode = false
+}: {
+  ticket: KanbanTicket
+  isEditMode?: boolean
+}) {
+  if (!ticket.goal_mode || !ticket.goal_success_criteria) return null
+
+  return (
+    <div className="space-y-1.5" data-testid="ticket-goal-section">
+      <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        Goal
+        {isEditMode && (
+          <span className="ml-2 normal-case text-[10px] text-muted-foreground/70">
+            set when launched — read only
+          </span>
+        )}
+      </label>
+      <div className="rounded-md border border-border/40 bg-muted/20 px-3 py-2 text-sm whitespace-pre-wrap">
+        {ticket.goal_success_criteria}
+      </div>
+    </div>
+  )
+}
+
 // ── Component ───────────────────────────────────────────────────────
 export function KanbanTicketModal() {
   const selectedTicketId = useKanbanStore((s) => s.selectedTicketId)
@@ -765,6 +791,7 @@ function KanbanTicketModalContent({
                     <MarkdownRenderer content={ticket.description} />
                   </div>
                 )}
+                <TicketGoalSection ticket={ticket} />
               </div>
             )}
             {modeContent}
@@ -1032,6 +1059,8 @@ function EditModeContent({
             />
           )}
         </div>
+
+        <TicketGoalSection ticket={ticket} isEditMode />
 
         {/* Attachments */}
         <TicketAttachmentEditor
@@ -1964,6 +1993,8 @@ function PlanReviewModeContent({
         <MarkdownRenderer content={planContent} />
       </div>
 
+      <TicketGoalSection ticket={ticket} />
+
       {/* Followup input — iterate on the plan */}
       <FollowupInput
         text={followUpText}
@@ -2408,6 +2439,7 @@ function ReviewModeContent({
           ) : (
             <p className="text-sm text-muted-foreground">Session completed.</p>
           )}
+          <TicketGoalSection ticket={ticket} />
           <p data-testid="review-session-notice" className="text-xs text-muted-foreground/80">
             View the full session conversation by clicking &quot;Jump to session&quot; above.
           </p>

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
+import { Switch } from '@/components/ui/switch'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
@@ -121,6 +122,11 @@ function buildPrompt(mode: PickerMode, ticket: KanbanTicket): string {
   return `${prefix}\n\n<ticket title="${ticket.title}">${description}${attachmentsXml}</ticket>`
 }
 
+function wrapGoalPrompt(prompt: string, criteria: string): string {
+  const stripped = prompt.replace(/^\/goal\s+/, '')
+  return `/goal ${stripped}. Goal success criteria: ${criteria}`
+}
+
 // ── Component ───────────────────────────────────────────────────────
 export function WorktreePickerModal({
   ticket,
@@ -139,6 +145,8 @@ export function WorktreePickerModal({
   const [isNewWorktree, setIsNewWorktree] = useState(false)
   const [promptText, setPromptText] = useState('')
   const [isSending, setIsSending] = useState(false)
+  const [goalMode, setGoalMode] = useState(false)
+  const [goalCriteria, setGoalCriteria] = useState('')
   const promptRef = useRef<HTMLTextAreaElement>(null)
   const [sourceBranch, setSourceBranch] = useState<string | null>(null) // null = default
   const [branchPopoverOpen, setBranchPopoverOpen] = useState(false)
@@ -199,6 +207,7 @@ export function WorktreePickerModal({
   }, [mode, baseAgentSdk, selectedSdk])
 
   const agentSdk = selectedSdk ?? autoResolvedModel?.agentSdk ?? baseAgentSdk
+  const goalAvailable = agentSdk === 'codex' && mode === 'build' && !preAssignOnly
 
   // ── Count in-progress tickets per worktree ──────────────────────
   const ticketCountByWorktree = useMemo(() => {
@@ -243,6 +252,8 @@ export function WorktreePickerModal({
       setIsNewWorktree(true)
       setPromptText(buildPrompt('build', ticket))
       setIsSending(false)
+      setGoalMode(false)
+      setGoalCriteria('')
       setSelectedModel(null)
       setSelectedSdk(null)
       setSourceBranch(_lastSourceBranchByProject[projectId] ?? null)
@@ -271,6 +282,10 @@ export function WorktreePickerModal({
   const handleSdkChange = useCallback((sdk: 'opencode' | 'claude-code' | 'codex') => {
     setSelectedSdk(sdk)
     setSelectedModel(null) // reset model — new SDK has different models
+    if (sdk !== 'codex') {
+      setGoalMode(false)
+      setGoalCriteria('')
+    }
   }, [])
 
   // ── Handle mode toggle ──────────────────────────────────────────
@@ -278,6 +293,10 @@ export function WorktreePickerModal({
     setMode((prev) => {
       const next: PickerMode = prev === 'build' ? (superArmed ? 'super-plan' : 'plan') : 'build'
       setPromptText((current) => swapModePrefix(current, prev, next))
+      if (next !== 'build') {
+        setGoalMode(false)
+        setGoalCriteria('')
+      }
       return next
     })
   }, [superArmed])
@@ -287,6 +306,8 @@ export function WorktreePickerModal({
     if (mode === 'plan') {
       setMode('super-plan')
       setSuperArmed(true)
+      setGoalMode(false)
+      setGoalCriteria('')
     } else if (mode === 'super-plan') {
       setMode('plan')
       setSuperArmed(false)
@@ -298,6 +319,10 @@ export function WorktreePickerModal({
     setMode((prev) => {
       const next: PickerMode = prev === 'super-plan' ? 'plan' : 'super-plan'
       setPromptText((current) => swapModePrefix(current, prev, next))
+      if (next !== 'build') {
+        setGoalMode(false)
+        setGoalCriteria('')
+      }
       return next
     })
   }, [])
@@ -362,9 +387,10 @@ export function WorktreePickerModal({
   }, [])
 
   // ── Send flow ───────────────────────────────────────────────────
-  const canSend = isConnectionMode
+  const goalCriteriaValid = !goalMode || goalCriteria.trim().length > 0
+  const canSend = (isConnectionMode
     ? !isSending
-    : (selectedWorktreeId !== null || isNewWorktree) && !isSending
+    : (selectedWorktreeId !== null || isNewWorktree) && !isSending) && goalCriteriaValid
 
   const handleSend = useCallback(async () => {
     if (!canSend) return
@@ -415,7 +441,9 @@ export function WorktreePickerModal({
           mode,
           column: 'in_progress',
           sort_order: sortOrder,
-          plan_ready: false
+          plan_ready: false,
+          goal_mode: goalMode,
+          goal_success_criteria: goalMode ? goalCriteria.trim() : null
         })
 
         // Trigger usage refresh so the board shows up-to-date usage (debounced in store)
@@ -454,6 +482,10 @@ export function WorktreePickerModal({
                 ? PLAN_MODE_PREFIX
                 : ''
           const fullPrompt = modePrefix + promptText.trim()
+          const outboundPrompt =
+            goalMode && goalCriteria.trim()
+              ? wrapGoalPrompt(fullPrompt, goalCriteria.trim())
+              : fullPrompt
           const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
 
           if (mode === 'super-plan') {
@@ -464,7 +496,7 @@ export function WorktreePickerModal({
           await window.opencodeOps.prompt(
             connectionPath,
             connectResult.sessionId,
-            [{ type: 'text', text: fullPrompt }],
+            [{ type: 'text', text: outboundPrompt }],
             effectiveModel,
             promptOptions
           )
@@ -491,7 +523,9 @@ export function WorktreePickerModal({
           mode,
           model: selectedModel ?? null,
           sdk: agentSdk,
-          codexFastMode
+          codexFastMode,
+          goalMode,
+          goalSuccessCriteria: goalMode ? goalCriteria.trim() : null
         }
 
         const sortOrder = useKanbanStore
@@ -505,7 +539,9 @@ export function WorktreePickerModal({
           pending_launch_config: JSON.stringify(pendingConfig),
           column: 'in_progress',
           sort_order: sortOrder,
-          mode
+          mode,
+          goal_mode: goalMode,
+          goal_success_criteria: goalMode ? goalCriteria.trim() : null
         })
 
         onSendComplete?.()
@@ -629,7 +665,9 @@ export function WorktreePickerModal({
         mode,
         column: 'in_progress',
         sort_order: sortOrder,
-        plan_ready: false
+        plan_ready: false,
+        goal_mode: goalMode,
+        goal_success_criteria: goalMode ? goalCriteria.trim() : null
       })
 
       // Trigger usage refresh so the board shows up-to-date usage (debounced in store)
@@ -674,6 +712,10 @@ export function WorktreePickerModal({
               ? PLAN_MODE_PREFIX
               : ''
         const fullPrompt = modePrefix + promptText.trim()
+        const outboundPrompt =
+          goalMode && goalCriteria.trim()
+            ? wrapGoalPrompt(fullPrompt, goalCriteria.trim())
+            : fullPrompt
         const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
 
         // Auto-revert super-plan → plan immediately (one-shot mode).
@@ -686,7 +728,7 @@ export function WorktreePickerModal({
         await window.opencodeOps.prompt(
           worktree.path,
           connectResult.sessionId,
-          [{ type: 'text', text: fullPrompt }],
+          [{ type: 'text', text: outboundPrompt }],
           effectiveModel,
           promptOptions
         )
@@ -710,9 +752,7 @@ export function WorktreePickerModal({
     mode,
     promptText,
     updateTicket,
-    ticket.id,
-    ticket.title,
-    ticket.project_id,
+    ticket,
     onSendComplete,
     onOpenChange,
     preAssignOnly,
@@ -720,6 +760,8 @@ export function WorktreePickerModal({
     selectedModel,
     autoResolvedModel,
     codexFastMode,
+    goalMode,
+    goalCriteria,
     isConnectionMode,
     connectionId
   ])
@@ -1012,6 +1054,40 @@ export function WorktreePickerModal({
                     )}
                   </div>
                 )}
+              {goalAvailable && (
+                <div className="space-y-2 rounded-md border border-border/50 bg-muted/20 px-3 py-2.5">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-foreground">Goal mode</span>
+                    <Switch
+                      checked={goalMode}
+                      onCheckedChange={setGoalMode}
+                      data-testid="goal-mode-toggle"
+                    />
+                  </div>
+                  {goalMode && (
+                    <div className="space-y-1.5">
+                      <label
+                        htmlFor="goal-success-criteria"
+                        className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+                      >
+                        Success criteria <span className="text-destructive">*</span>
+                      </label>
+                      <Textarea
+                        id="goal-success-criteria"
+                        value={goalCriteria}
+                        onChange={(e) => setGoalCriteria(e.target.value)}
+                        placeholder="What does success look like?"
+                        data-testid="goal-success-criteria"
+                        rows={3}
+                        className="resize-y text-sm"
+                      />
+                      {goalCriteria.trim().length === 0 && (
+                        <p className="text-xs text-destructive">Required</p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
               <div className="flex items-center gap-2 flex-wrap">
                 <div className="min-w-0">
                   <ModelSelector

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -13,6 +13,11 @@ import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/cons
 import { toast } from '@/lib/toast'
 import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
 
+function wrapGoalPrompt(prompt: string, criteria: string): string {
+  const stripped = prompt.replace(/^\/goal\s+/, '')
+  return `/goal ${stripped}. Goal success criteria: ${criteria}`
+}
+
 export async function autoLaunchTicket(ticket: KanbanTicket): Promise<void> {
   if (!ticket.pending_launch_config) return
 
@@ -23,6 +28,8 @@ export async function autoLaunchTicket(ticket: KanbanTicket): Promise<void> {
     console.error('Failed to parse pending_launch_config for ticket:', ticket.id)
     return
   }
+  const configGoalMode = config.goalMode === true
+  const configGoalSuccessCriteria = config.goalSuccessCriteria?.trim() || null
 
   const project = useProjectStore.getState().projects.find(p => p.id === ticket.project_id)
   if (!project) {
@@ -88,7 +95,9 @@ export async function autoLaunchTicket(ticket: KanbanTicket): Promise<void> {
       pending_launch_config: null,
       current_session_id: sessionId,
       worktree_id: worktreeId,
-      mode: config.mode
+      mode: config.mode,
+      goal_mode: configGoalMode,
+      goal_success_criteria: configGoalMode ? configGoalSuccessCriteria : null
     })
 
     // 6. Trigger usage refresh
@@ -116,6 +125,10 @@ export async function autoLaunchTicket(ticket: KanbanTicket): Promise<void> {
         : config.mode === 'plan' && !skipPrefix ? PLAN_MODE_PREFIX
         : ''
       const fullPrompt = modePrefix + config.prompt.trim()
+      const outboundPrompt =
+        configGoalMode && configGoalSuccessCriteria
+          ? wrapGoalPrompt(fullPrompt, configGoalSuccessCriteria)
+          : fullPrompt
       const promptOptions =
         sessionAgentSdk === 'codex' ? { codexFastMode: config.codexFastMode } : undefined
 
@@ -125,7 +138,7 @@ export async function autoLaunchTicket(ticket: KanbanTicket): Promise<void> {
 
       bumpWorktreeLastMessage({ worktreeId })
       await window.opencodeOps.prompt(worktree.path, connectResult.sessionId, [
-        { type: 'text', text: fullPrompt }
+        { type: 'text', text: outboundPrompt }
       ], effectiveModel, promptOptions)
     }
   } catch (err) {

--- a/test/kanban/auto-launch-goal-mode.test.ts
+++ b/test/kanban/auto-launch-goal-mode.test.ts
@@ -1,0 +1,214 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { act } from '@testing-library/react'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn()
+  }
+}))
+
+const mockKanban = {
+  ticket: {
+    update: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+const mockDbSession = {
+  create: vi.fn().mockImplementation(async (input: Record<string, unknown>) => ({
+    id: 'session-1',
+    worktree_id: input.worktree_id,
+    project_id: input.project_id,
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    agent_sdk: input.agent_sdk,
+    mode: input.mode,
+    session_type: 'default',
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    completed_at: null
+  })),
+  update: vi.fn().mockResolvedValue(undefined)
+}
+
+const mockOpencodeOps = {
+  connect: vi.fn().mockResolvedValue({ success: true, sessionId: 'oc-session-1' }),
+  prompt: vi.fn().mockResolvedValue({ success: true })
+}
+
+Object.defineProperty(window, 'kanban', {
+  writable: true,
+  configurable: true,
+  value: mockKanban
+})
+
+Object.defineProperty(window, 'db', {
+  writable: true,
+  configurable: true,
+  value: {
+    session: mockDbSession
+  }
+})
+
+Object.defineProperty(window, 'opencodeOps', {
+  writable: true,
+  configurable: true,
+  value: mockOpencodeOps
+})
+
+Object.defineProperty(window, 'usageOps', {
+  writable: true,
+  configurable: true,
+  value: {
+    fetch: vi.fn().mockResolvedValue({ success: true, data: null }),
+    fetchOpenai: vi.fn().mockResolvedValue({ success: true, data: null })
+  }
+})
+
+import { autoLaunchTicket } from '@/lib/auto-launch'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket } from '../../src/main/db/types'
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'proj-1',
+    title: 'Implement auth flow',
+    description: 'Add login and signup pages',
+    attachments: [],
+    column: 'in_progress',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: null,
+    mode: null,
+    plan_ready: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
+    ...overrides
+  }
+}
+
+describe('autoLaunchTicket goal mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    act(() => {
+      useProjectStore.setState({
+        projects: [
+          {
+            id: 'proj-1',
+            name: 'Project',
+            path: '/test/project',
+            description: null,
+            tags: null,
+            language: null,
+            setup_script: null,
+            run_script: null,
+            archive_script: null,
+            custom_icon: null,
+            auto_assign_port: false,
+            sort_order: 0,
+            created_at: '2026-01-01T00:00:00Z',
+            last_accessed_at: '2026-01-01T00:00:00Z'
+          }
+        ]
+      })
+      useWorktreeStore.setState({
+        worktreesByProject: new Map([
+          [
+            'proj-1',
+            [
+              {
+                id: 'wt-1',
+                project_id: 'proj-1',
+                name: 'feature-auth',
+                branch_name: 'feature-auth',
+                path: '/test/feature-auth',
+                status: 'active',
+                is_default: false,
+                branch_renamed: 0,
+                last_message_at: null,
+                session_titles: '[]',
+                last_model_provider_id: null,
+                last_model_id: null,
+                last_model_variant: null,
+                created_at: '2026-01-01T00:00:00Z',
+                last_accessed_at: '2026-01-01T00:00:00Z',
+                github_pr_number: null,
+                github_pr_url: null
+              }
+            ]
+          ]
+        ])
+      })
+      useKanbanStore.setState({
+        tickets: new Map([['proj-1', [makeTicket()]]])
+      })
+      useSessionStore.setState({
+        sessionsByWorktree: new Map(),
+        modeBySession: new Map()
+      })
+      useSettingsStore.setState({
+        availableAgentSdks: { opencode: true, claude: true, codex: true },
+        defaultAgentSdk: 'codex',
+        defaultModels: { build: null, plan: null, ask: null, review: null }
+      })
+    })
+  })
+
+  test('wraps queued Codex prompt in /goal and persists goal columns', async () => {
+    const ticket = makeTicket({
+      pending_launch_config: JSON.stringify({
+        worktree: { type: 'existing', worktreeId: 'wt-1' },
+        prompt: '/goal Build auth',
+        mode: 'build',
+        model: null,
+        sdk: 'codex',
+        codexFastMode: false,
+        goalMode: true,
+        goalSuccessCriteria: 'Auth works end to end'
+      })
+    })
+
+    await autoLaunchTicket(ticket)
+
+    expect(mockKanban.ticket.update).toHaveBeenCalledWith(
+      'ticket-1',
+      expect.objectContaining({
+        pending_launch_config: null,
+        current_session_id: 'session-1',
+        worktree_id: 'wt-1',
+        mode: 'build',
+        goal_mode: true,
+        goal_success_criteria: 'Auth works end to end'
+      })
+    )
+    expect(mockOpencodeOps.prompt).toHaveBeenCalled()
+    const promptParts = mockOpencodeOps.prompt.mock.calls.at(-1)?.[2] as Array<{
+      type: string
+      text: string
+    }>
+    expect(promptParts[0]?.text).toBe('/goal Build auth. Goal success criteria: Auth works end to end')
+  })
+})

--- a/test/kanban/session-9/worktree-picker-modal.test.tsx
+++ b/test/kanban/session-9/worktree-picker-modal.test.tsx
@@ -171,6 +171,20 @@ Object.defineProperty(window, 'usageOps', {
   }
 })
 
+Object.defineProperty(window, 'connectionOps', {
+  writable: true,
+  configurable: true,
+  value: {
+    get: vi.fn().mockResolvedValue({
+      success: true,
+      connection: {
+        id: 'conn-1',
+        members: [{ project_id: 'proj-1' }]
+      }
+    })
+  }
+})
+
 Object.defineProperty(window, 'opencodeOps', {
   writable: true,
   configurable: true,
@@ -183,6 +197,7 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
 import { getSuperPlanModePrefix } from '@/lib/constants'
 
 // ── Import component under test ─────────────────────────────────────
@@ -206,6 +221,18 @@ function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
     plan_ready: false,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
     ...overrides
   }
 }
@@ -317,6 +344,22 @@ describe('Session 9: Worktree Picker Modal', () => {
         },
         codexFastMode: false,
         codexFastModeAccepted: false
+      })
+      useConnectionStore.setState({
+        connections: [
+          {
+            id: 'conn-1',
+            name: 'Main connection',
+            path: '/test/connection',
+            status: 'active',
+            pinned: false,
+            color: null,
+            custom_name: null,
+            members: [{ project_id: 'proj-1' }],
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          }
+        ],
       })
     })
     vi.clearAllMocks()
@@ -709,6 +752,257 @@ describe('Session 9: Worktree Picker Modal', () => {
       expect(useSettingsStore.getState().codexFastModeAccepted).toBe(true)
       expect(useSettingsStore.getState().codexFastMode).toBe(true)
     })
+  })
+
+  test('Goal switch only renders for codex+build', () => {
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    expect(screen.queryByTestId('goal-mode-toggle')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    expect(screen.getByTestId('goal-mode-toggle')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('wt-picker-mode-toggle'))
+    expect(screen.queryByTestId('goal-mode-toggle')).not.toBeInTheDocument()
+  })
+
+  test('Goal switch hides and clears criteria on SDK switch away from codex', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    fireEvent.click(screen.getByTestId('goal-mode-toggle'))
+    fireEvent.change(screen.getByTestId('goal-success-criteria'), {
+      target: { value: 'Ship tested auth flow' }
+    })
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-opencode'))
+    expect(screen.queryByTestId('goal-mode-toggle')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    const goalSwitch = screen.getByTestId('goal-mode-toggle')
+    expect(goalSwitch).toHaveAttribute('aria-checked', 'false')
+    expect(screen.queryByTestId('goal-success-criteria')).not.toBeInTheDocument()
+  })
+
+  test('Goal switch hides and clears criteria on mode switch to plan/super-plan', () => {
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    fireEvent.click(screen.getByTestId('goal-mode-toggle'))
+    fireEvent.change(screen.getByTestId('goal-success-criteria'), {
+      target: { value: 'Complete the implementation' }
+    })
+
+    fireEvent.click(screen.getByTestId('wt-picker-mode-toggle'))
+    expect(screen.queryByTestId('goal-mode-toggle')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('wt-picker-super-toggle'))
+    expect(screen.queryByTestId('goal-mode-toggle')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('wt-picker-mode-toggle'))
+    const goalSwitch = screen.getByTestId('goal-mode-toggle')
+    expect(goalSwitch).toHaveAttribute('aria-checked', 'false')
+    expect(screen.queryByTestId('goal-success-criteria')).not.toBeInTheDocument()
+  })
+
+  test('Send disabled when goalMode is on and criteria is empty', () => {
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    fireEvent.click(screen.getByTestId('goal-mode-toggle'))
+
+    expect(screen.getByText('Required')).toBeInTheDocument()
+    expect(screen.getByTestId('wt-picker-send-btn')).toBeDisabled()
+
+    fireEvent.change(screen.getByTestId('goal-success-criteria'), {
+      target: { value: 'All tests pass' }
+    })
+    expect(screen.getByTestId('wt-picker-send-btn')).not.toBeDisabled()
+  })
+
+  test('worktree-mode Codex goal launch wraps prompt and persists goal columns', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    fireEvent.change(screen.getByTestId('wt-picker-prompt'), {
+      target: { value: 'Build auth' }
+    })
+    fireEvent.click(screen.getByTestId('goal-mode-toggle'))
+    fireEvent.change(screen.getByTestId('goal-success-criteria'), {
+      target: { value: '  Login and signup work  ' }
+    })
+    fireEvent.click(screen.getByTestId('worktree-item-wt-1'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('wt-picker-send-btn'))
+    })
+
+    await waitFor(() => {
+      expect(mockOpencodeOps.prompt).toHaveBeenCalled()
+    })
+
+    const promptParts = mockOpencodeOps.prompt.mock.calls.at(-1)?.[2] as Array<{
+      type: string
+      text: string
+    }>
+    expect(promptParts[0]?.text).toBe('/goal Build auth. Goal success criteria: Login and signup work')
+    expect(mockKanban.ticket.update).toHaveBeenCalledWith(
+      'ticket-1',
+      expect.objectContaining({
+        column: 'in_progress',
+        goal_mode: true,
+        goal_success_criteria: 'Login and signup work'
+      })
+    )
+  })
+
+  test('connection-mode Codex goal launch wraps prompt', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+        connectionId="conn-1"
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    fireEvent.change(screen.getByTestId('wt-picker-prompt'), {
+      target: { value: 'Build auth' }
+    })
+    fireEvent.click(screen.getByTestId('goal-mode-toggle'))
+    fireEvent.change(screen.getByTestId('goal-success-criteria'), {
+      target: { value: 'Auth works end to end' }
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('wt-picker-send-btn'))
+    })
+
+    await waitFor(() => {
+      expect(mockOpencodeOps.prompt).toHaveBeenCalled()
+    })
+
+    const promptParts = mockOpencodeOps.prompt.mock.calls.at(-1)?.[2] as Array<{
+      type: string
+      text: string
+    }>
+    expect(promptParts[0]?.text).toBe('/goal Build auth. Goal success criteria: Auth works end to end')
+  })
+
+  test('saveConfigOnly persists goalMode and goalSuccessCriteria in pending config JSON', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+        saveConfigOnly
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    fireEvent.click(screen.getByTestId('goal-mode-toggle'))
+    fireEvent.change(screen.getByTestId('goal-success-criteria'), {
+      target: { value: '  Criteria are met  ' }
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('wt-picker-send-btn'))
+    })
+
+    await waitFor(() => {
+      expect(mockKanban.ticket.update).toHaveBeenCalled()
+    })
+
+    const updatePayload = mockKanban.ticket.update.mock.calls.at(-1)?.[1] as {
+      pending_launch_config: string
+      goal_mode: boolean
+      goal_success_criteria: string | null
+    }
+    expect(JSON.parse(updatePayload.pending_launch_config)).toEqual(
+      expect.objectContaining({
+        goalMode: true,
+        goalSuccessCriteria: 'Criteria are met'
+      })
+    )
+    expect(updatePayload).toEqual(
+      expect.objectContaining({
+        goal_mode: true,
+        goal_success_criteria: 'Criteria are met'
+      })
+    )
+  })
+
+  test('Double-wrap guard: prompt that already starts with /goal produces a single prefix', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    fireEvent.change(screen.getByTestId('wt-picker-prompt'), {
+      target: { value: '/goal Build auth' }
+    })
+    fireEvent.click(screen.getByTestId('goal-mode-toggle'))
+    fireEvent.change(screen.getByTestId('goal-success-criteria'), {
+      target: { value: 'No duplicate goal command' }
+    })
+    fireEvent.click(screen.getByTestId('worktree-item-wt-1'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('wt-picker-send-btn'))
+    })
+
+    await waitFor(() => {
+      expect(mockOpencodeOps.prompt).toHaveBeenCalled()
+    })
+
+    const promptParts = mockOpencodeOps.prompt.mock.calls.at(-1)?.[2] as Array<{
+      type: string
+      text: string
+    }>
+    expect(promptParts[0]?.text).toBe('/goal Build auth. Goal success criteria: No duplicate goal command')
   })
 
   // ── Submit flow tests ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Added `goal_mode` and `goal_success_criteria` to kanban ticket storage and schema, including migration to schema version 26.
- Extended the worktree picker to let users enable Goal mode for Codex build launches, require success criteria, and persist the values through launch config.
- Updated auto-launch and ticket modals to carry goal metadata forward and surface the stored goal on the ticket UI.
- Added coverage for launch persistence, prompt wrapping, UI visibility, validation, and read-only goal display.

## Testing
- Added Vitest coverage for auto-launch goal mode prompt wrapping and ticket update persistence.
- Added Vitest coverage for worktree picker goal-mode toggle behavior, validation, and config serialization.
- Added Vitest coverage for goal metadata rendering in the kanban ticket modal.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persisted ticket fields and changes prompt composition during launches/auto-launch, which could affect existing launch flows and stored ticket state if mishandled.
> 
> **Overview**
> Adds **Goal mode** support for Kanban ticket launches by persisting `goal_mode` and `goal_success_criteria` on tickets (DB mapping, update logic, and a new schema migration bumping to v26).
> 
> Extends the Worktree Picker launch flow (Codex + build only) with a goal toggle and required success-criteria input; when enabled it *wraps outbound prompts* as `/goal … Goal success criteria: …` (with a guard against double-prefixing) and propagates the same metadata through `pending_launch_config` and auto-launch.
> 
> Surfaces the stored goal read-only in the ticket modal across relevant views, and adds Vitest coverage for prompt wrapping, persistence, visibility/validation, and config serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e62efca5b12d45664d79c773ab08c16b9e314b06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->