### PR TITLE
Sync Codex goal state from global listener events

### DIFF
--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -1,11 +1,12 @@
 import { useEffect } from 'react'
 import { useSessionStore } from '@/stores/useSessionStore'
+import type { CodexThreadGoal } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useQuestionStore } from '@/stores/useQuestionStore'
 import { usePermissionStore } from '@/stores/usePermissionStore'
-import { useCommandApprovalStore, type CommandApprovalRequest } from '@/stores/useCommandApprovalStore'
+import { useCommandApprovalStore } from '@/stores/useCommandApprovalStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useContextStore, type TokenInfo, type SessionModelRef } from '@/stores/useContextStore'
 import { useRecentStore } from '@/stores/useRecentStore'
@@ -420,6 +421,19 @@ export function useOpenCodeGlobalListener(): void {
             return
           }
 
+          if (event.type === 'codex.goal.updated') {
+            const data = event.data as Record<string, unknown> | undefined
+            const goal = (data?.goal ?? null) as CodexThreadGoal | null
+            if (goal && typeof goal === 'object') {
+              useSessionStore.getState().setCodexGoal(sessionId, goal)
+            }
+            return
+          }
+
+          if (event.type === 'codex.goal.cleared') {
+            useSessionStore.getState().clearCodexGoal(sessionId)
+            return
+          }
 
           // Handle plan approval events globally so pending state survives tab switches.
           if (event.type === 'plan.ready') {

--- a/test/phase-16/session-4/global-listener-follow-up-dispatch.test.ts
+++ b/test/phase-16/session-4/global-listener-follow-up-dispatch.test.ts
@@ -74,6 +74,8 @@ const sessionStoreState = {
   getSessionMode: vi.fn(() => 'build'),
   getPendingPlan: vi.fn(() => null),
   updateSessionName: vi.fn(),
+  setCodexGoal: vi.fn(),
+  clearCodexGoal: vi.fn(),
   sessionsByWorktree: new Map<string, Array<{ id: string; opencode_session_id: string | null }>>(),
   sessionsByConnection: new Map<
     string,
@@ -419,5 +421,40 @@ describe('Global listener background follow-up dispatcher', () => {
       { type: 'text', text: 'follow-up 2' }
     ])
     expect(followUpQueues.has('session-B')).toBe(false)
+  })
+
+  test('goal update events update Codex goal state for background sessions', () => {
+    const goal = {
+      threadId: 'thread-1',
+      objective: 'finish the narrow fix',
+      status: 'complete',
+      tokenBudget: null,
+      tokensUsed: 42,
+      timeUsedSeconds: 12,
+      createdAt: 100,
+      updatedAt: 200
+    }
+
+    const cb = mountAndGetCallback()
+    cb({
+      type: 'codex.goal.updated',
+      sessionId: 'session-B',
+      data: { goal }
+    })
+
+    expect(sessionStoreState.setCodexGoal).toHaveBeenCalledWith('session-B', goal)
+  })
+
+  test('goal cleared events clear Codex goal state for active sessions too', () => {
+    sessionStoreState.activeSessionId = 'session-A'
+
+    const cb = mountAndGetCallback()
+    cb({
+      type: 'codex.goal.cleared',
+      sessionId: 'session-A',
+      data: {}
+    })
+
+    expect(sessionStoreState.clearCodexGoal).toHaveBeenCalledWith('session-A')
   })
 })


### PR DESCRIPTION
## Summary
- Handle `codex.goal.updated` events in the global listener and persist the latest goal in session state.
- Handle `codex.goal.cleared` events so completed goals are removed from session state for both background and active sessions.
- Add regression coverage for goal update and goal cleared dispatch paths.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new OpenCode stream event handlers that only mutate in-memory session goal state, plus targeted test coverage.
> 
> **Overview**
> The global OpenCode stream listener now reacts to `codex.goal.updated` by persisting the latest goal payload into session state, and to `codex.goal.cleared` by removing the stored goal for that session.
> 
> Adds regression tests ensuring both goal update and goal clear events dispatch to `useSessionStore` for background and active sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c6461092117f81cc1b81553c98422dde486e247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->