### PR TITLE
Add goal mode toggle for Codex handoffs

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -73,7 +73,7 @@ import { usePinAndActivateSession } from '@/hooks/usePinAndActivateSession'
 import { TicketAttachmentEditor } from './TicketAttachmentEditor'
 import { TicketDiscardChangesDialog } from './TicketDiscardChangesDialog'
 import { useImagePaste } from '@/hooks/useImagePaste'
-import type { HandoffSelectionOverride } from '@/lib/handoffSelection'
+import { buildHandoffPrompt, type HandoffSelectionOverride } from '@/lib/handoffSelection'
 import { canonicalizeTicketTitle, extractPlanTitle } from '@shared/types/branch-utils'
 import type { KanbanTicket, KanbanTicketUpdate, Worktree } from '../../../../main/db/types'
 
@@ -1587,7 +1587,7 @@ function PlanReviewModeContent({
           return
         }
 
-        const handoffPrompt = `Implement the following plan\n${planContent}`
+        const handoffPrompt = buildHandoffPrompt(planContent, override)
         const newSessionId = result.session.id
         const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
 
@@ -1639,7 +1639,7 @@ function PlanReviewModeContent({
         return
       }
 
-      const handoffPrompt = `Implement the following plan\n${planContent}`
+      const handoffPrompt = buildHandoffPrompt(planContent, override)
       const newSessionId = result.session.id
       const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
       const localWorktreePath = findWorktreePathById(worktreeId)

--- a/src/renderer/src/components/sessions/HandoffSplitButton.tsx
+++ b/src/renderer/src/components/sessions/HandoffSplitButton.tsx
@@ -48,6 +48,7 @@ export function HandoffSplitButton({
   const selectedModelByProvider = useSettingsStore((state) => state.selectedModelByProvider)
   const [pickerOpen, setPickerOpen] = useState(false)
   const [catalogVersion, setCatalogVersion] = useState(0)
+  const [goalMode, setGoalMode] = useState(false)
 
   const showChevron = getAvailableHandoffAgentSdks(availableAgentSdks).length > 1
   void availableAgentSdks
@@ -58,6 +59,7 @@ export function HandoffSplitButton({
   void selectedModelByProvider
   void catalogVersion
   const effective = getEffectiveHandoffSelection({ worktreeId })
+  const isGoalModeActive = goalMode && effective.agentSdk === 'codex'
 
   useEffect(() => {
     let active = true
@@ -72,22 +74,43 @@ export function HandoffSplitButton({
     }
   }, [effective.agentSdk])
 
+  useEffect(() => {
+    if (effective.agentSdk !== 'codex') {
+      setGoalMode(false)
+    }
+  }, [effective.agentSdk])
+
+  const withGoalMode = (override: HandoffSelectionOverride): HandoffSelectionOverride => {
+    const finalGoalMode = override.agentSdk === 'codex' ? isGoalModeActive : false
+    return { ...override, goalMode: finalGoalMode }
+  }
+
   const labelTitle = `Handoff · ${effective.display.sdkName} / ${effective.display.modelName}${
     effective.display.variant ? ` ${effective.display.variant.toUpperCase()}` : ''
   }`
   const leftButtonTestId =
-    testIdPrefix === 'plan-review'
-      ? `${testIdPrefix}-handoff-btn`
-      : `${testIdPrefix}-handoff-fab`
+    testIdPrefix === 'plan-review' ? `${testIdPrefix}-handoff-btn` : `${testIdPrefix}-handoff-fab`
   const chevronTestId = `${testIdPrefix}-handoff-chevron`
 
   return (
     <div
       className={cn(
-        'inline-flex h-8 items-center rounded-full border border-border bg-muted/80 text-foreground shadow-md transition-colors duration-200',
-        disabled ? 'opacity-60' : 'hover:bg-muted'
+        'inline-flex h-8 items-center rounded-full border text-foreground shadow-md transition-colors duration-200',
+        isGoalModeActive ? 'relative border-primary/40 bg-primary/15' : 'border-border bg-muted/80',
+        disabled ? 'opacity-60' : isGoalModeActive ? 'hover:bg-primary/20' : 'hover:bg-muted'
       )}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        if (disabled) return
+        if (effective.agentSdk !== 'codex') return
+        setGoalMode((current) => !current)
+      }}
     >
+      {isGoalModeActive && (
+        <span className="pointer-events-none absolute -top-4 left-1/2 -translate-x-1/2 text-[10px] font-semibold uppercase tracking-wide text-primary">
+          Goal mode
+        </span>
+      )}
       <button
         type="button"
         title={labelTitle}
@@ -95,7 +118,7 @@ export function HandoffSplitButton({
         disabled={disabled}
         data-testid={leftButtonTestId}
         onClick={() => {
-          onHandoff({ agentSdk: effective.agentSdk, model: effective.model })
+          onHandoff(withGoalMode({ agentSdk: effective.agentSdk, model: effective.model }))
         }}
         className={cn(
           'flex min-w-0 items-center gap-1.5 rounded-full px-3 text-xs font-medium',
@@ -124,7 +147,9 @@ export function HandoffSplitButton({
               if (!disabled) setPickerOpen(open)
             }}
             worktreeId={worktreeId}
-            onConfirm={onHandoff}
+            onConfirm={(override) => {
+              onHandoff(withGoalMode(override))
+            }}
             anchor={
               <button
                 type="button"

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -90,7 +90,7 @@ import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
 import { buildSdkPlanImplementationPrompt, looksLikeCodexProposedPlan } from '@/lib/proposedPlan'
-import type { HandoffSelectionOverride } from '@/lib/handoffSelection'
+import { buildHandoffPrompt, type HandoffSelectionOverride } from '@/lib/handoffSelection'
 
 // Stable empty array to avoid creating new references in selectors
 const EMPTY_FILE_INDEX: FlatFile[] = []
@@ -4980,7 +4980,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       }
 
       if (connectionId) {
-        const handoffPrompt = `Implement the following plan\n${planContent}`
+        const handoffPrompt = buildHandoffPrompt(planContent, override)
         const sessionStore = useSessionStore.getState()
         const result = await sessionStore.createConnectionSession(
           connectionId,
@@ -5007,7 +5007,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         return
       }
 
-      const handoffPrompt = `Implement the following plan\n${planContent}`
+      const handoffPrompt = buildHandoffPrompt(planContent, override)
 
       const sessionStore = useSessionStore.getState()
       const result = await sessionStore.createSession(

--- a/src/renderer/src/lib/__tests__/handoffSelection.test.ts
+++ b/src/renderer/src/lib/__tests__/handoffSelection.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { buildHandoffPrompt, type HandoffSelectionOverride } from '../handoffSelection'
+
+const model = { providerID: 'codex', modelID: 'gpt-5.5' }
+
+describe('buildHandoffPrompt', () => {
+  it('prefixes goal mode only for codex handoffs', () => {
+    const planContent = '1. Build the thing'
+    const codexGoal: HandoffSelectionOverride = {
+      agentSdk: 'codex',
+      model,
+      goalMode: true
+    }
+    const codexPlain: HandoffSelectionOverride = {
+      agentSdk: 'codex',
+      model,
+      goalMode: false
+    }
+    const claudeGoal: HandoffSelectionOverride = {
+      agentSdk: 'claude-code',
+      model,
+      goalMode: true
+    }
+
+    expect(buildHandoffPrompt(planContent, codexGoal)).toBe(
+      '/goal Implement the following plan\n1. Build the thing'
+    )
+    expect(buildHandoffPrompt(planContent, codexPlain)).toBe(
+      'Implement the following plan\n1. Build the thing'
+    )
+    expect(buildHandoffPrompt(planContent, claudeGoal)).toBe(
+      'Implement the following plan\n1. Build the thing'
+    )
+    expect(buildHandoffPrompt(planContent)).toBe('Implement the following plan\n1. Build the thing')
+  })
+})

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -28,6 +28,15 @@ export interface EffectiveHandoffSelection {
 export interface HandoffSelectionOverride {
   agentSdk: HandoffAgentSdk
   model: SelectedModel
+  goalMode?: boolean
+}
+
+export function buildHandoffPrompt(
+  planContent: string,
+  override?: HandoffSelectionOverride
+): string {
+  const goalPrefix = override?.goalMode && override.agentSdk === 'codex' ? '/goal ' : ''
+  return `${goalPrefix}Implement the following plan\n${planContent}`
 }
 
 const SDK_DISPLAY_NAMES: Record<HandoffAgentSdk, string> = {

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -447,6 +447,7 @@ describe('handoff model picker', () => {
     })
     expect(onHandoff).toHaveBeenCalledWith({
       agentSdk: 'codex',
+      goalMode: false,
       model: {
         providerID: 'codex',
         modelID: 'gpt-5.5',


### PR DESCRIPTION
## Summary
- Added a goal mode flag to handoff selection so Codex handoffs can be prefixed with `/goal` when enabled.
- Wired the new behavior into session and kanban handoff flows by centralizing prompt construction in `buildHandoffPrompt`.
- Added a UI toggle on the handoff split button, including automatic reset when switching away from Codex.
- Covered the new prompt behavior with unit tests and updated the handoff model picker test to include the new override shape.

## Testing
- Added `src/renderer/src/lib/__tests__/handoffSelection.test.ts` to verify goal mode only affects Codex handoffs.
- Updated `test/phase-22/session-11/handoff-model-picker.test.tsx` expectations for the new `goalMode` field.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to prompt construction and a small UI toggle, with coverage added to prevent affecting non-Codex handoffs.
> 
> **Overview**
> Introduces a `goalMode` flag on `HandoffSelectionOverride` and centralizes handoff prompt creation in `buildHandoffPrompt`, which conditionally prefixes Codex handoffs with `/goal`.
> 
> Updates Kanban (`KanbanTicketModal`) and session handoff flows (`SessionView`) to use the shared prompt builder, and enhances `HandoffSplitButton` with a context-menu toggle + visual indicator that auto-resets when switching away from Codex.
> 
> Adds unit coverage for `buildHandoffPrompt` and updates the handoff model picker test to expect the new `goalMode` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0518a85edaba39731ae144c417954ebcc5989963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->