### PR TITLE
Adopt Effect for main-process bash service

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "cmdk": "0.2.1",
     "codemirror": "^6.0.2",
     "diff2html": "^3.4.56",
+    "effect": "^3.18.0",
     "electron-updater": "^6.8.3",
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.468.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       diff2html:
         specifier: ^3.4.56
         version: 3.4.56
+      effect:
+        specifier: ^3.18.0
+        version: 3.21.2
       electron-updater:
         specifier: ^6.8.3
         version: 6.8.3
@@ -2085,6 +2088,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -3218,6 +3224,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -3489,6 +3498,10 @@ packages:
   extsprintf@1.4.1:
     resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
     engines: {'0': node >=0.6.0}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -5176,6 +5189,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qrcode-terminal@0.12.0:
     resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
@@ -8363,6 +8379,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -9699,6 +9717,11 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  effect@3.21.2:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
@@ -10172,6 +10195,10 @@ snapshots:
 
   extsprintf@1.4.1:
     optional: true
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -12091,6 +12118,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   qrcode-terminal@0.12.0: {}
 

--- a/src/main/effect-island/README.md
+++ b/src/main/effect-island/README.md
@@ -1,0 +1,47 @@
+# Effect Island
+
+This directory is a contained pilot for adopting `effect` in the Electron main process. It is deliberately isolated from `src/main/services` so the experiment can be evaluated and deleted as a unit.
+
+## Scope
+
+- Only the bash service lives here.
+- No renderer code, IPC bridge types, Zustand stores, or React components should import Effect types.
+- Do not add other services to this island without re-evaluating the pilot criteria.
+- No `@effect/platform` or `@effect/schema` in this pilot.
+
+The public boundary remains the existing bash-service facade: callers get promises and the current IPC envelope shape.
+
+## Why This Exists
+
+The pilot tests whether Effect improves four concrete pain points in this service:
+
+- Typed errors at the IPC boundary.
+- Testability through Layer-based dependency injection.
+- Resource safety for child processes, listeners, timers, and shutdown.
+- Streaming plus cancellation for bash output and abort behavior.
+
+## Kill Criteria
+
+Evaluate 30 days after the Effect implementation ships to canary.
+
+The pilot succeeds if all of these are true:
+
+- Zero P0/P1 bug reports tagged `bash`.
+- Effect-version LOC is at most 110% of the original bash service. Original: 431 LOC. Budget: 474 LOC.
+- At least two of the four motivations show measurable wins:
+  - At least one typed error path is covered by a test that did not exist before.
+  - Zombie-process count after `killAll` is 0 across 100 stress runs.
+  - The TestClock-driven abort escalation test runs in under 50 ms.
+  - Abort latency p95 stays within 50 ms of the previous baseline.
+- A teammate other than the author lands an unrelated PR touching this island without help.
+
+The pilot fails and should be reverted if any of these happen:
+
+- One or more P0 incidents are traceable to Effect semantics such as interruption, scope, or runtime behavior.
+- LOC exceeds 130% of the original and no runtime or test wins materialize.
+- Two reviewers independently report they cannot debug an issue inside the island within 30 minutes.
+- Main-process bundle size increases by more than 500 KB.
+
+## Boundary Rule
+
+Effect stays inside this directory. Export plain TypeScript types and promise-returning facade methods at the boundary.

--- a/src/main/effect-island/bash/__tests__/bash-service.effect.test.ts
+++ b/src/main/effect-island/bash/__tests__/bash-service.effect.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment node
+import { EventEmitter } from 'events'
+import type { ChildProcess } from 'child_process'
+import { describe, expect, it } from 'vitest'
+import { Effect, Either, Layer, Ref, TestClock, TestContext } from 'effect'
+
+import { BashAlreadyRunning } from '../errors'
+import { Bash, EventSink, Spawner } from '../service'
+import { BashLive } from '../layers'
+import type { BashStreamEvent } from '../types'
+
+class FakeProc extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  stdin = { end: () => undefined }
+  pid = 12345
+  exitCode: number | null = null
+  signalCode: NodeJS.Signals | null = null
+
+  close(code: number | null = null): void {
+    this.exitCode = code
+    this.emit('close', code)
+  }
+
+  kill(signal?: NodeJS.Signals): boolean {
+    this.signalCode = signal ?? 'SIGTERM'
+    return true
+  }
+}
+
+interface FakeSpawner {
+  proc: FakeProc
+  signals: Ref.Ref<ReadonlyArray<NodeJS.Signals>>
+}
+
+const testLayer = (
+  events: Ref.Ref<ReadonlyArray<BashStreamEvent>>,
+  fake: FakeSpawner
+) => {
+  const dependencies = Layer.mergeAll(
+    Layer.succeed(EventSink, {
+      send: (event: BashStreamEvent) => Ref.update(events, (xs) => [...xs, event])
+    }),
+    Layer.succeed(Spawner, {
+      spawn: () => Effect.succeed(fake.proc as unknown as ChildProcess),
+      signalTree: (_proc: ChildProcess, signal: NodeJS.Signals) =>
+        Ref.update(fake.signals, (xs) => [...xs, signal])
+    })
+  )
+
+  return Layer.provide(BashLive, dependencies)
+}
+
+describe('Bash Effect island', () => {
+  it('returns BashAlreadyRunning as a typed failure instead of throwing', async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const events = yield* Ref.make<ReadonlyArray<BashStreamEvent>>([])
+        const signals = yield* Ref.make<ReadonlyArray<NodeJS.Signals>>([])
+        const fake = { proc: new FakeProc(), signals }
+        const layer = testLayer(events, fake)
+
+        return yield* Effect.either(
+          Effect.gen(function* () {
+            const bash = yield* Bash
+            yield* bash.run('session-a', 'sleep 30', '/tmp')
+            yield* bash.run('session-a', 'echo second', '/tmp')
+          }).pipe(Effect.provide(layer))
+        )
+      })
+    )
+
+    expect(Either.isLeft(result)).toBe(true)
+    if (Either.isLeft(result)) {
+      expect(result.left).toBeInstanceOf(BashAlreadyRunning)
+      expect(result.left._tag).toBe('BashAlreadyRunning')
+      if (result.left instanceof BashAlreadyRunning) {
+        expect(result.left.sessionId).toBe('session-a')
+      }
+    }
+  })
+
+  it('escalates abort from SIGTERM to SIGKILL after 2 seconds with TestClock', async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const events = yield* Ref.make<ReadonlyArray<BashStreamEvent>>([])
+        const signals = yield* Ref.make<ReadonlyArray<NodeJS.Signals>>([])
+        const fake = { proc: new FakeProc(), signals }
+        const layer = testLayer(events, fake)
+
+        return yield* Effect.gen(function* () {
+          const bash = yield* Bash
+          yield* bash.run('session-abort', 'sleep 30', '/tmp')
+
+          const abortFiber = yield* Effect.fork(bash.abort('session-abort'))
+          yield* Effect.yieldNow()
+          const afterTerm = yield* Ref.get(signals)
+
+          yield* TestClock.adjust('2 seconds')
+          const aborted = yield* abortFiber
+          const finalSignals = yield* Ref.get(signals)
+
+          return { aborted, afterTerm, finalSignals }
+        }).pipe(Effect.provide(layer), Effect.provide(TestContext.TestContext))
+      })
+    )
+
+    expect(result.aborted).toBe(true)
+    expect(result.afterTerm).toEqual(['SIGTERM'])
+    expect(result.finalSignals).toEqual(['SIGTERM', 'SIGKILL'])
+  })
+
+  it('emits a truncated end event when the output cap is reached', async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const events = yield* Ref.make<ReadonlyArray<BashStreamEvent>>([])
+        const signals = yield* Ref.make<ReadonlyArray<NodeJS.Signals>>([])
+        const fake = { proc: new FakeProc(), signals }
+        const layer = testLayer(events, fake)
+
+        return yield* Effect.gen(function* () {
+          const bash = yield* Bash
+          yield* bash.run('session-truncated', 'cat /dev/zero', '/tmp')
+
+          fake.proc.stdout.emit('data', Buffer.alloc(1024 * 1024 + 32, 'A'))
+          fake.proc.close(null)
+
+          yield* TestClock.adjust('16 millis')
+
+          const recordedEvents = yield* Ref.get(events)
+          const recordedSignals = yield* Ref.get(signals)
+          const snapshot = yield* bash.getRun('session-truncated')
+
+          return { recordedEvents, recordedSignals, snapshot }
+        }).pipe(Effect.provide(layer), Effect.provide(TestContext.TestContext))
+      })
+    )
+
+    const end = result.recordedEvents.find(
+      (event): event is Extract<BashStreamEvent, { type: 'end' }> => event.type === 'end'
+    )
+
+    expect(end?.status).toBe('truncated')
+    expect(result.recordedSignals).toContain('SIGKILL')
+    expect(result.snapshot?.status).toBe('truncated')
+    expect(result.snapshot?.outputBuffer).toContain('[output truncated at 1 MB')
+  })
+})

--- a/src/main/effect-island/bash/errors.ts
+++ b/src/main/effect-island/bash/errors.ts
@@ -1,0 +1,32 @@
+import { Data } from 'effect'
+
+export class BashAlreadyRunning extends Data.TaggedError('BashAlreadyRunning')<{
+  readonly sessionId: string
+}> {}
+
+export class BashSpawnFailed extends Data.TaggedError('BashSpawnFailed')<{
+  readonly sessionId: string
+  readonly command: string
+  readonly cause: unknown
+}> {}
+
+export class BashOutputCapReached extends Data.TaggedError('BashOutputCapReached')<{
+  readonly sessionId: string
+  readonly bytes: number
+}> {}
+
+export class BashAborted extends Data.TaggedError('BashAborted')<{
+  readonly sessionId: string
+  readonly escalatedToKill: boolean
+}> {}
+
+export class BashWindowMissing extends Data.TaggedError('BashWindowMissing')<{
+  readonly reason: 'not-set' | 'destroyed'
+}> {}
+
+export type BashError =
+  | BashAlreadyRunning
+  | BashSpawnFailed
+  | BashOutputCapReached
+  | BashAborted
+  | BashWindowMissing

--- a/src/main/effect-island/bash/facade.ts
+++ b/src/main/effect-island/bash/facade.ts
@@ -1,0 +1,82 @@
+import type { BrowserWindow } from 'electron'
+import { Cause, Effect, Exit, Option } from 'effect'
+
+import type { BashError } from './errors'
+import {
+  BashAlreadyRunning,
+  BashSpawnFailed,
+  BashWindowMissing
+} from './errors'
+import { Bash } from './service'
+import type { BashRunSnapshot } from './types'
+import { getRuntime, setMainWindow } from './runtime'
+
+type RunSuccessEnvelope = { success: true; runId: string }
+type RunErrorEnvelope = { success: false; errorCode: string; error: string }
+type RunEnvelope = RunSuccessEnvelope | RunErrorEnvelope
+
+export const humanMessage = (error: BashError): string => {
+  if (error instanceof BashAlreadyRunning) {
+    return `A bash command is already running for session ${error.sessionId}`
+  }
+  if (error instanceof BashSpawnFailed) {
+    const cause =
+      error.cause instanceof Error ? error.cause.message : String(error.cause)
+    return `Failed to start bash command "${error.command}": ${cause}`
+  }
+  if (error instanceof BashWindowMissing) {
+    return error.reason === 'not-set'
+      ? 'Bash output window is not set'
+      : 'Bash output window has been destroyed'
+  }
+  return error.message
+}
+
+export const toEnvelope = (exit: Exit.Exit<{ runId: string }, BashError>): RunEnvelope =>
+  Exit.match(exit, {
+    onSuccess: (value) => ({ success: true as const, ...value }),
+    onFailure: (cause) => {
+      const failure = Cause.failureOption(cause)
+      if (Option.isSome(failure)) {
+        const error = failure.value
+        return {
+          success: false as const,
+          errorCode: error._tag,
+          error: humanMessage(error)
+        }
+      }
+
+      return {
+        success: false as const,
+        errorCode: 'Defect',
+        error: Cause.pretty(cause)
+      }
+    }
+  })
+
+class BashFacade {
+  setMainWindow(win: BrowserWindow): void {
+    setMainWindow(win)
+  }
+
+  async run(sessionId: string, command: string, cwd: string): Promise<RunEnvelope> {
+    const exit = await getRuntime().runPromiseExit(
+      Effect.flatMap(Bash, (bash) => bash.run(sessionId, command, cwd))
+    )
+    return toEnvelope(exit)
+  }
+
+  async abort(sessionId: string): Promise<boolean> {
+    return getRuntime().runPromise(Effect.flatMap(Bash, (bash) => bash.abort(sessionId)))
+  }
+
+  async getRun(sessionId: string): Promise<BashRunSnapshot | null> {
+    return getRuntime().runPromise(Effect.flatMap(Bash, (bash) => bash.getRun(sessionId)))
+  }
+
+  killAll(): void {
+    void getRuntime().runPromise(Effect.flatMap(Bash, (bash) => bash.killAll))
+  }
+}
+
+export const bashService = new BashFacade()

--- a/src/main/effect-island/bash/layers.ts
+++ b/src/main/effect-island/bash/layers.ts
@@ -1,0 +1,513 @@
+import { spawn, type ChildProcess } from 'child_process'
+import { randomUUID } from 'crypto'
+import type { BrowserWindow } from 'electron'
+import {
+  Cause,
+  Chunk,
+  Deferred,
+  Effect,
+  Fiber,
+  Layer,
+  Ref,
+  Stream
+} from 'effect'
+
+import { createLogger } from '../../services/logger'
+import {
+  BashAlreadyRunning,
+  BashSpawnFailed,
+  BashWindowMissing
+} from './errors'
+import { Bash, EventSink, Spawner } from './service'
+import type { BashRunSnapshot, BashRunStatus, BashStreamEvent } from './types'
+
+const log = createLogger({ component: 'BashEffectIsland' })
+
+const OUTPUT_BYTES_LIMIT = 1 * 1024 * 1024
+const TRUNCATION_SENTINEL = '\n\n[output truncated at 1 MB — process killed]\n'
+
+interface ActiveRun extends BashRunSnapshot {
+  status: BashRunStatus
+  proc?: ChildProcess
+  fiber?: Fiber.RuntimeFiber<void, never>
+  abortRequested?: boolean
+}
+
+type CloseOutcome =
+  | { readonly _tag: 'closed'; readonly code: number | null }
+  | { readonly _tag: 'error'; readonly error: Error }
+
+type SpawnerApi = {
+  readonly spawn: (
+    sessionId: string,
+    command: string,
+    cwd: string
+  ) => Effect.Effect<ChildProcess, BashSpawnFailed>
+  readonly signalTree: (proc: ChildProcess, signal: NodeJS.Signals) => Effect.Effect<void>
+}
+
+type SendEvent = (event: BashStreamEvent) => Effect.Effect<void, BashWindowMissing>
+type SendEventBestEffort = (event: BashStreamEvent) => Effect.Effect<void>
+
+function getColorEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    FORCE_COLOR: '3',
+    TERM: 'xterm-256color',
+    COLORTERM: 'truecolor',
+    CLICOLOR_FORCE: '1'
+  }
+}
+
+const isAlive = (proc: ChildProcess): boolean =>
+  proc.exitCode === null && proc.signalCode === null
+
+const waitForExit = (proc: ChildProcess) => {
+  if (!isAlive(proc)) return Effect.void
+
+  return Effect.async<void>((resume, signal) => {
+    let settled = false
+
+    const cleanup = (): void => {
+      proc.off('close', onExit)
+      proc.off('exit', onExit)
+      signal.removeEventListener('abort', onAbort)
+    }
+
+    const settle = (): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resume(Effect.void)
+    }
+
+    const onExit = (): void => settle()
+    const onAbort = (): void => settle()
+
+    proc.once('close', onExit)
+    proc.once('exit', onExit)
+    signal.addEventListener('abort', onAbort, { once: true })
+
+    return Effect.sync(cleanup)
+  })
+}
+
+const waitForCloseOrError = (
+  proc: ChildProcess,
+  ready: Deferred.Deferred<void>
+) =>
+  Effect.async<CloseOutcome>((resume, signal) => {
+    let settled = false
+
+    const cleanup = (): void => {
+      proc.off('close', onClose)
+      proc.off('error', onError)
+      signal.removeEventListener('abort', onAbort)
+    }
+
+    const settle = (outcome: CloseOutcome): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resume(Effect.succeed(outcome))
+    }
+
+    const onClose = (code: number | null): void => settle({ _tag: 'closed', code })
+    const onError = (error: Error): void => settle({ _tag: 'error', error })
+    const onAbort = (): void => {
+      if (settled) return
+      cleanup()
+    }
+
+    proc.once('close', onClose)
+    proc.once('error', onError)
+    signal.addEventListener('abort', onAbort, { once: true })
+    Effect.runFork(Deferred.succeed(ready, undefined))
+
+    return Effect.sync(cleanup)
+  })
+
+const procToStream = (
+  proc: ChildProcess,
+  ready: Deferred.Deferred<void>
+) =>
+  Stream.asyncPush<string>((emit) =>
+    Effect.gen(function* () {
+      const onStdout = (chunk: Buffer | string): void => {
+        emit.single(Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk))
+      }
+      const onStderr = (chunk: Buffer | string): void => {
+        emit.single(Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk))
+      }
+      const onEnd = (): void => {
+        emit.end()
+      }
+      const onError = (error: Error): void => {
+        emit.single(error.message ?? String(error))
+        emit.end()
+      }
+      const cleanup = (): void => {
+        proc.stdout?.off('data', onStdout)
+        proc.stderr?.off('data', onStderr)
+        proc.off('close', onEnd)
+        proc.off('error', onError)
+      }
+
+      proc.stdout?.on('data', onStdout)
+      proc.stderr?.on('data', onStderr)
+      proc.once('close', onEnd)
+      proc.once('error', onError)
+
+      yield* Deferred.succeed(ready, undefined)
+      yield* Effect.addFinalizer(() => Effect.sync(cleanup))
+    }),
+    { bufferSize: 'unbounded' }
+  )
+
+const appendOutput = (run: ActiveRun, chunk: string, spawner: SpawnerApi) =>
+  Effect.gen(function* () {
+    if (run.status === 'truncated') return { data: '', done: true }
+
+    const chunkBytes = Buffer.byteLength(chunk, 'utf-8')
+    const remaining = OUTPUT_BYTES_LIMIT - run.outputBytes
+    if (chunkBytes <= remaining) {
+      run.outputBuffer += chunk
+      run.outputBytes += chunkBytes
+      return { data: chunk, done: false }
+    }
+
+    const allowed =
+      remaining > 0
+        ? Buffer.from(chunk, 'utf-8').subarray(0, remaining).toString('utf-8')
+        : ''
+    const data = `${allowed}${TRUNCATION_SENTINEL}`
+
+    if (allowed.length > 0) {
+      run.outputBuffer += allowed
+      run.outputBytes += Buffer.byteLength(allowed, 'utf-8')
+    }
+
+    run.outputBuffer += TRUNCATION_SENTINEL
+    run.outputBytes += Buffer.byteLength(TRUNCATION_SENTINEL, 'utf-8')
+    run.status = 'truncated'
+    run.abortRequested = true
+
+    if (run.proc) {
+      yield* spawner.signalTree(run.proc, 'SIGKILL')
+    }
+
+    return { data, done: true }
+  })
+
+const streamOutput = (
+  run: ActiveRun,
+  proc: ChildProcess,
+  ready: Deferred.Deferred<void>,
+  spawner: SpawnerApi,
+  sendBestEffort: SendEventBestEffort
+) =>
+  procToStream(proc, ready).pipe(
+    Stream.groupedWithin(Number.MAX_SAFE_INTEGER, '16 millis'),
+    Stream.map((chunks) => Chunk.toReadonlyArray(chunks).join('')),
+    Stream.mapEffect((chunk) => appendOutput(run, chunk, spawner)),
+    Stream.tap((result) =>
+      result.data.length > 0
+        ? sendBestEffort({
+            type: 'output',
+            sessionId: run.sessionId,
+            runId: run.id,
+            data: result.data
+          })
+        : Effect.void
+    ),
+    Stream.takeUntil((result) => result.done),
+    Stream.runDrain
+  )
+
+const releaseProcess = (run: ActiveRun, proc: ChildProcess, spawner: SpawnerApi) =>
+  Effect.gen(function* () {
+    if (!isAlive(proc) || run.proc !== proc) return
+
+    yield* spawner.signalTree(proc, 'SIGTERM')
+    yield* waitForExit(proc).pipe(
+      Effect.timeout('2 seconds'),
+      Effect.catchTag('TimeoutException', () => spawner.signalTree(proc, 'SIGKILL')),
+      Effect.catchAll(() => Effect.void)
+    )
+  }).pipe(Effect.catchAll(() => Effect.void))
+
+const runLifecycle = (
+  runs: Map<string, ActiveRun>,
+  run: ActiveRun,
+  proc: ChildProcess,
+  ready: Deferred.Deferred<void>,
+  spawner: SpawnerApi,
+  sendBestEffort: SendEventBestEffort
+) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      yield* Effect.addFinalizer(() => releaseProcess(run, proc, spawner))
+
+      const closeReady = yield* Deferred.make<void>()
+      const outputReady = yield* Deferred.make<void>()
+      const closeFiber = yield* waitForCloseOrError(proc, closeReady).pipe(Effect.forkScoped)
+      const outputFiber = yield* streamOutput(
+        run,
+        proc,
+        outputReady,
+        spawner,
+        sendBestEffort
+      ).pipe(Effect.forkScoped)
+
+      yield* Deferred.await(closeReady)
+      yield* Deferred.await(outputReady)
+      yield* Deferred.succeed(ready, undefined)
+
+      const outcome = yield* closeFiber
+      yield* outputFiber.await
+
+      if (outcome._tag === 'error') {
+        const message = outcome.error.message ?? String(outcome.error)
+        const result = yield* appendOutput(run, message, spawner)
+        if (result.data.length > 0) {
+          yield* sendBestEffort({
+            type: 'output',
+            sessionId: run.sessionId,
+            runId: run.id,
+            data: result.data
+          })
+        }
+      }
+
+      let finalStatus: 'exited' | 'killed' | 'truncated' | 'error' = 'exited'
+      if (run.status === 'truncated') {
+        finalStatus = 'truncated'
+      } else if (outcome._tag === 'error') {
+        finalStatus = 'error'
+      } else if (run.abortRequested) {
+        finalStatus = 'killed'
+      }
+
+      run.status = finalStatus
+      run.exitCode = outcome._tag === 'closed' ? outcome.code ?? undefined : run.exitCode
+      run.proc = undefined
+
+      log.info('Bash run finished', {
+        sessionId: run.sessionId,
+        runId: run.id,
+        status: finalStatus,
+        exitCode: run.exitCode
+      })
+
+      yield* sendBestEffort({
+        type: 'end',
+        sessionId: run.sessionId,
+        runId: run.id,
+        status: finalStatus,
+        exitCode: run.exitCode
+      })
+
+      runs.set(run.sessionId, run)
+    })
+  ).pipe(Effect.catchAllCause((cause) => Effect.sync(() => log.error('Bash lifecycle failed', new Error(Cause.pretty(cause))))))
+
+const snapshot = (run: ActiveRun): BashRunSnapshot => ({
+  sessionId: run.sessionId,
+  id: run.id,
+  command: run.command,
+  cwd: run.cwd,
+  startedAt: run.startedAt,
+  status: run.status,
+  outputBuffer: run.outputBuffer,
+  outputBytes: run.outputBytes,
+  exitCode: run.exitCode
+})
+
+export const BashLive = Layer.effect(
+  Bash,
+  Effect.gen(function* () {
+    const runsRef = yield* Ref.make(new Map<string, ActiveRun>())
+    const spawner = yield* Spawner
+    const eventSink = yield* EventSink
+    const send: SendEvent = (event) => eventSink.send(event)
+    const sendBestEffort: SendEventBestEffort = (event) =>
+      send(event).pipe(Effect.catchAll(() => Effect.void))
+
+    const run = (sessionId: string, command: string, cwd: string) =>
+      Effect.gen(function* () {
+        const runs = yield* Ref.get(runsRef)
+        const existing = runs.get(sessionId)
+        if (existing && existing.status === 'running') {
+          return yield* Effect.fail(new BashAlreadyRunning({ sessionId }))
+        }
+
+        const proc = yield* spawner.spawn(sessionId, command, cwd)
+        const runId = randomUUID()
+        const startedAt = Date.now()
+        const active: ActiveRun = {
+          sessionId,
+          id: runId,
+          command,
+          cwd,
+          startedAt,
+          status: 'running',
+          outputBuffer: '',
+          outputBytes: 0,
+          proc
+        }
+
+        runs.set(sessionId, active)
+        yield* Ref.set(runsRef, runs)
+
+        yield* send({
+          type: 'start',
+          sessionId,
+          runId,
+          command,
+          cwd,
+          startedAt
+        }).pipe(
+          Effect.tapError(() => spawner.signalTree(proc, 'SIGKILL')),
+          Effect.tapError(() =>
+            Effect.sync(() => {
+              runs.delete(sessionId)
+            })
+          )
+        )
+
+        const ready = yield* Deferred.make<void>()
+        const fiber = yield* runLifecycle(
+          runs,
+          active,
+          proc,
+          ready,
+          spawner,
+          sendBestEffort
+        ).pipe(Effect.forkDaemon)
+        active.fiber = fiber
+        yield* Deferred.await(ready)
+
+        log.info('Bash run started', { sessionId, runId, command, cwd, pid: proc.pid })
+        return { runId }
+      }).pipe(Effect.withSpan('bash.run'))
+
+    const abort = (sessionId: string) =>
+      Effect.gen(function* () {
+        const runs = yield* Ref.get(runsRef)
+        const active = runs.get(sessionId)
+        if (!active || active.status !== 'running' || !active.proc) return false
+
+        active.abortRequested = true
+        yield* spawner.signalTree(active.proc, 'SIGTERM')
+        yield* waitForExit(active.proc).pipe(
+          Effect.timeout('2 seconds'),
+          Effect.catchTag('TimeoutException', () => spawner.signalTree(active.proc!, 'SIGKILL'))
+        )
+
+        return true
+      }).pipe(Effect.withSpan('bash.abort'))
+
+    const getRun = (sessionId: string) =>
+      Ref.get(runsRef).pipe(Effect.map((runs) => {
+        const active = runs.get(sessionId)
+        return active ? snapshot(active) : null
+      }))
+
+    const killAll = Effect.gen(function* () {
+      const runs = yield* Ref.get(runsRef)
+
+      for (const active of runs.values()) {
+        active.abortRequested = true
+        if (active.proc && active.status === 'running') {
+          yield* spawner.signalTree(active.proc, 'SIGKILL')
+          active.proc = undefined
+        }
+        if (active.fiber) {
+          yield* Fiber.interrupt(active.fiber).pipe(Effect.asVoid)
+        }
+      }
+
+      runs.clear()
+      yield* Ref.set(runsRef, runs)
+    }).pipe(Effect.withSpan('bash.killAll'))
+
+    return { run, abort, getRun, killAll }
+  })
+)
+
+export const EventSinkLive = (windowRef: { current: BrowserWindow | null }) =>
+  Layer.succeed(EventSink, {
+    send: (event: BashStreamEvent) =>
+      Effect.gen(function* () {
+        const win = windowRef.current
+        if (!win) {
+          return yield* Effect.fail(new BashWindowMissing({ reason: 'not-set' }))
+        }
+        if (win.isDestroyed()) {
+          return yield* Effect.fail(new BashWindowMissing({ reason: 'destroyed' }))
+        }
+        yield* Effect.sync(() => {
+          win.webContents.send('bash:stream', event)
+        })
+      })
+  })
+
+export const SpawnerLive = Layer.succeed(Spawner, {
+  spawn: (sessionId: string, command: string, cwd: string) =>
+    Effect.try({
+      try: () => {
+        const proc = spawn('sh', ['-c', command], {
+          cwd,
+          env: getColorEnv(),
+          stdio: ['pipe', 'pipe', 'pipe'],
+          detached: process.platform !== 'win32'
+        })
+        proc.stdin?.end()
+        return proc
+      },
+      catch: (cause) => new BashSpawnFailed({ sessionId, command, cause })
+    }),
+  signalTree: (proc: ChildProcess, signal: NodeJS.Signals) =>
+    Effect.sync(() => {
+      const pid = proc.pid
+      if (!pid) {
+        try {
+          proc.kill(signal)
+        } catch {
+          // already dead
+        }
+        return
+      }
+
+      if (process.platform === 'win32') {
+        const args = ['/pid', String(pid), '/t']
+        if (signal === 'SIGKILL') args.push('/f')
+        const taskkill = spawn('taskkill', args, { stdio: 'ignore' })
+        taskkill.on('error', () => {
+          try {
+            proc.kill(signal)
+          } catch {
+            // already dead
+          }
+        })
+        return
+      }
+
+      try {
+        process.kill(-pid, signal)
+      } catch {
+        log.warn('Failed to signal process group; falling back to direct process kill', {
+          pid,
+          signal
+        })
+        try {
+          proc.kill(signal)
+        } catch {
+          // already dead
+        }
+      }
+    })
+})
+
+export const AppLive = (windowRef: { current: BrowserWindow | null }) =>
+  Layer.provide(BashLive, Layer.mergeAll(EventSinkLive(windowRef), SpawnerLive))

--- a/src/main/effect-island/bash/runtime.ts
+++ b/src/main/effect-island/bash/runtime.ts
@@ -1,0 +1,23 @@
+import type { BrowserWindow } from 'electron'
+import { ManagedRuntime } from 'effect'
+
+import { Bash } from './service'
+import { AppLive } from './layers'
+
+let runtime: ManagedRuntime.ManagedRuntime<Bash, never> | null = null
+const windowRef: { current: BrowserWindow | null } = { current: null }
+
+export const getRuntime = (): ManagedRuntime.ManagedRuntime<Bash, never> =>
+  runtime ??= ManagedRuntime.make(AppLive(windowRef))
+
+export const setMainWindow = (win: BrowserWindow): void => {
+  windowRef.current = win
+}
+
+export const disposeRuntime = async (): Promise<void> => {
+  const current = runtime
+  runtime = null
+  if (current) {
+    await current.dispose()
+  }
+}

--- a/src/main/effect-island/bash/service.ts
+++ b/src/main/effect-island/bash/service.ts
@@ -1,0 +1,44 @@
+import type { ChildProcess } from 'child_process'
+import { Context, Effect } from 'effect'
+
+import type { BashAlreadyRunning, BashSpawnFailed, BashWindowMissing } from './errors'
+import type { BashRunSnapshot, BashStreamEvent } from './types'
+
+export class EventSink extends Context.Tag('BashIsland/EventSink')<
+  EventSink,
+  {
+    readonly send: (event: BashStreamEvent) => Effect.Effect<void, BashWindowMissing>
+  }
+>() {}
+
+export class Spawner extends Context.Tag('BashIsland/Spawner')<
+  Spawner,
+  {
+    readonly spawn: (
+      sessionId: string,
+      command: string,
+      cwd: string
+    ) => Effect.Effect<ChildProcess, BashSpawnFailed>
+    readonly signalTree: (
+      proc: ChildProcess,
+      signal: NodeJS.Signals
+    ) => Effect.Effect<void>
+  }
+>() {}
+
+export class Bash extends Context.Tag('BashIsland/Bash')<
+  Bash,
+  {
+    readonly run: (
+      sessionId: string,
+      command: string,
+      cwd: string
+    ) => Effect.Effect<
+      { runId: string },
+      BashAlreadyRunning | BashSpawnFailed | BashWindowMissing
+    >
+    readonly abort: (sessionId: string) => Effect.Effect<boolean>
+    readonly getRun: (sessionId: string) => Effect.Effect<BashRunSnapshot | null>
+    readonly killAll: Effect.Effect<void>
+  }
+>() {}

--- a/src/main/effect-island/bash/types.ts
+++ b/src/main/effect-island/bash/types.ts
@@ -1,0 +1,36 @@
+export type BashRunStatus = 'running' | 'exited' | 'killed' | 'truncated' | 'error'
+
+export interface BashRunSnapshot {
+  sessionId: string
+  id: string
+  command: string
+  cwd: string
+  startedAt: number
+  status: BashRunStatus
+  outputBuffer: string
+  outputBytes: number
+  exitCode?: number
+}
+
+export type BashStreamEvent =
+  | {
+      type: 'start'
+      sessionId: string
+      runId: string
+      command: string
+      cwd: string
+      startedAt: number
+    }
+  | {
+      type: 'output'
+      sessionId: string
+      runId: string
+      data: string
+    }
+  | {
+      type: 'end'
+      sessionId: string
+      runId: string
+      status: 'exited' | 'killed' | 'truncated' | 'error'
+      exitCode?: number
+    }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -61,7 +61,8 @@ import { perfDiagnostics } from './services/perf-diagnostics'
 import { configure as configureCodexDebugLogger } from './services/codex-debug-logger'
 import { ptyService } from './services/pty-service'
 import { scriptRunner } from './services/script-runner'
-import { bashService } from './services/bash-service'
+import { bashService } from './effect-island/bash/facade'
+import { disposeRuntime } from './effect-island/bash/runtime'
 import { registerBashHandlers } from './ipc/bash-handlers'
 import { registerTicketImportHandlers } from './ipc/ticket-import-handlers'
 import { initTicketProviderManager, GitHubProvider, JiraProvider } from './services/ticket-providers'
@@ -763,6 +764,7 @@ app.on('will-quit', async () => {
   cleanupScripts()
   // Cleanup running bash runs (best-effort, no await)
   bashService.killAll()
+  await disposeRuntime()
   // Release any held power save blocker so the display can sleep again
   cleanupPowerSaveBlocker()
   // Cleanup file tree watchers

--- a/src/main/ipc/bash-handlers.ts
+++ b/src/main/ipc/bash-handlers.ts
@@ -1,5 +1,5 @@
 import { ipcMain, BrowserWindow } from 'electron'
-import { bashService } from '../services/bash-service'
+import { bashService } from '../effect-island/bash/facade'
 import { createLogger } from '../services/logger'
 
 const log = createLogger({ component: 'BashHandlers' })
@@ -16,10 +16,12 @@ export function registerBashHandlers(mainWindow: BrowserWindow): void {
         cwd: payload.cwd
       })
       try {
-        const result = await bashService.run(payload.sessionId, payload.command, payload.cwd)
-        return { success: true, ...result }
+        return await bashService.run(payload.sessionId, payload.command, payload.cwd)
       } catch (error) {
-        log.error('IPC: bash:run failed', { error })
+        log.error(
+          'IPC: bash:run failed',
+          error instanceof Error ? error : new Error(String(error))
+        )
         return {
           success: false,
           error: error instanceof Error ? error.message : 'Unknown error'
@@ -33,16 +35,22 @@ export function registerBashHandlers(mainWindow: BrowserWindow): void {
     try {
       return await bashService.abort(sessionId)
     } catch (error) {
-      log.error('IPC: bash:abort failed', { error })
+      log.error(
+        'IPC: bash:abort failed',
+        error instanceof Error ? error : new Error(String(error))
+      )
       return false
     }
   })
 
   ipcMain.handle('bash:getRun', async (_event, sessionId: string) => {
     try {
-      return bashService.getRun(sessionId)
+      return await bashService.getRun(sessionId)
     } catch (error) {
-      log.error('IPC: bash:getRun failed', { error })
+      log.error(
+        'IPC: bash:getRun failed',
+        error instanceof Error ? error : new Error(String(error))
+      )
       return null
     }
   })

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -34,7 +34,8 @@ export default defineWorkspace([
         'test/kanban/session-1/**/*.test.ts',
         'test/kanban/session-2/**/*.test.ts',
         'test/kanban/session-3/**/*.test.ts',
-        'test/codex-migration/**/*.test.ts'
+        'test/codex-migration/**/*.test.ts',
+        'src/main/effect-island/**/*.test.ts'
       ],
       globals: true
     },


### PR DESCRIPTION
## Summary
- Introduce an isolated `effect` pilot for the Electron main-process bash service under `src/main/effect-island`.
- Replace the bash service implementation with Effect layers, typed errors, runtime management, and a promise-returning facade that preserves the existing IPC boundary.
- Add coverage for typed failure handling, abort escalation, and output truncation behavior with Effect test utilities.
- Wire the new runtime into main-process startup and shutdown, and update IPC handlers to use the facade.
- Add the `effect` dependency and include the new test workspace path.

## Testing
- `Not run`
- Added Vitest coverage for typed `BashAlreadyRunning` failures.
- Added a TestClock-driven abort escalation check from `SIGTERM` to `SIGKILL`.
- Added a truncation test that verifies the end event and snapshot state when output exceeds the cap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces the main-process bash execution service and its process lifecycle management, which can affect command execution, cancellation, and shutdown behavior. The change is scoped to the bash service boundary but introduces a new Effect runtime and error/envelope mapping that could alter IPC responses if mis-specified.
> 
> **Overview**
> Swaps the Electron main-process `bash` implementation to a new, isolated `src/main/effect-island` pilot built on `effect`, while keeping the external IPC-facing API promise-based via a facade.
> 
> The new service adds **typed failure paths** (e.g., already-running/spawn/window errors), **managed runtime lifecycle** (explicit `disposeRuntime()` on app quit), and **resource-safe process handling** including output streaming with a 1MB truncation cap and abort escalation from `SIGTERM` to `SIGKILL`.
> 
> Adds Vitest coverage for the new semantics (typed `BashAlreadyRunning`, TestClock-driven abort escalation, and truncation/end-event behavior), includes the new test path in `vitest.workspace.ts`, and introduces the `effect` dependency (with lockfile updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8305bdd5993f2199940d50636ba776f47bf958c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->