### PR TITLE
Add Cmd+Q quit confirmation

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -78,6 +78,11 @@ import {
   getPetWindow,
   shouldSuppressMainWindowActivationFromPet
 } from './services/pet-window'
+import {
+  getQuitConfirmationDecision,
+  QUIT_CONFIRM_WINDOW_MS,
+  readWarnBeforeQuitting
+} from './quit-confirmation'
 
 const log = createLogger({ component: 'Main' })
 
@@ -92,6 +97,7 @@ process.on('unhandledRejection', (reason) => {
 })
 
 const appStartTime = Date.now()
+let lastQuitConfirmAt: number | null = null
 
 // Parse CLI flags
 const cliArgs = process.argv.slice(2)
@@ -748,6 +754,39 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit()
   }
+})
+
+app.on('before-quit', (event) => {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+
+  const warnBeforeQuitting = readWarnBeforeQuitting(getDatabase().getSetting(APP_SETTINGS_DB_KEY))
+  const decision = getQuitConfirmationDecision({
+    now: Date.now(),
+    lastQuitConfirmAt,
+    warnBeforeQuitting
+  })
+
+  lastQuitConfirmAt = decision.lastQuitConfirmAt
+
+  if (!decision.shouldPreventQuit) return
+
+  event.preventDefault()
+
+  if (mainWindow.isMinimized()) {
+    mainWindow.restore()
+  }
+  mainWindow.show()
+  mainWindow.focus()
+  mainWindow.webContents.send('shortcut:quit-confirmation-show')
+
+  setTimeout(() => {
+    if (lastQuitConfirmAt && Date.now() - lastQuitConfirmAt >= QUIT_CONFIRM_WINDOW_MS) {
+      lastQuitConfirmAt = null
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('shortcut:quit-confirmation-hide')
+      }
+    }
+  }, QUIT_CONFIRM_WINDOW_MS + 50)
 })
 
 // Cleanup when app is about to quit

--- a/src/main/quit-confirmation.ts
+++ b/src/main/quit-confirmation.ts
@@ -1,0 +1,34 @@
+export const QUIT_CONFIRM_WINDOW_MS = 2000
+
+export function readWarnBeforeQuitting(rawSettings: string | null): boolean {
+  if (!rawSettings) return true
+
+  try {
+    const settings = JSON.parse(rawSettings) as { warnBeforeQuitting?: unknown }
+    return settings.warnBeforeQuitting === false ? false : true
+  } catch {
+    return true
+  }
+}
+
+export function getQuitConfirmationDecision({
+  now,
+  lastQuitConfirmAt,
+  warnBeforeQuitting,
+  confirmationWindowMs = QUIT_CONFIRM_WINDOW_MS
+}: {
+  now: number
+  lastQuitConfirmAt: number | null
+  warnBeforeQuitting: boolean
+  confirmationWindowMs?: number
+}): { shouldPreventQuit: boolean; lastQuitConfirmAt: number | null } {
+  if (!warnBeforeQuitting) {
+    return { shouldPreventQuit: false, lastQuitConfirmAt: null }
+  }
+
+  if (lastQuitConfirmAt && now - lastQuitConfirmAt < confirmationWindowMs) {
+    return { shouldPreventQuit: false, lastQuitConfirmAt }
+  }
+
+  return { shouldPreventQuit: true, lastQuitConfirmAt: now }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -707,6 +707,8 @@ declare global {
       onNewSessionShortcut: (callback: () => void) => () => void
       onCloseSessionShortcut: (callback: () => void) => () => void
       onFileSearchShortcut: (callback: () => void) => () => void
+      onQuitConfirmationShow: (callback: () => void) => () => void
+      onQuitConfirmationHide: (callback: () => void) => () => void
       onEditPaste: (callback: (text: string) => void) => () => void
       onNotificationNavigate: (
         callback: (data: { projectId: string; worktreeId: string; sessionId: string }) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -556,6 +556,26 @@ const systemOps = {
     }
   },
 
+  onQuitConfirmationShow: (callback: () => void): (() => void) => {
+    const handler = (): void => {
+      callback()
+    }
+    ipcRenderer.on('shortcut:quit-confirmation-show', handler)
+    return () => {
+      ipcRenderer.removeListener('shortcut:quit-confirmation-show', handler)
+    }
+  },
+
+  onQuitConfirmationHide: (callback: () => void): (() => void) => {
+    const handler = (): void => {
+      callback()
+    }
+    ipcRenderer.on('shortcut:quit-confirmation-hide', handler)
+    return () => {
+      ipcRenderer.removeListener('shortcut:quit-confirmation-hide', handler)
+    }
+  },
+
   // Subscribe to Edit > Paste from the application menu.
   // Used to route paste to the Ghostty terminal when it is the active backend,
   // since the menu accelerator intercepts Cmd+V before it reaches the native NSView.

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -38,6 +38,7 @@ import { toast } from '@/lib/toast'
 import { useDropAttachmentStore } from '@/stores'
 import { MAX_ATTACHMENTS, isImageMime } from '@/lib/file-attachment-utils'
 import type { Attachment } from '@/components/sessions/AttachmentPreview'
+import { QuitConfirmationOverlay } from './QuitConfirmationOverlay'
 
 function GlobalProjectSettings(): React.JSX.Element | null {
   const settingsProjectId = useProjectStore((s) => s.settingsProjectId)
@@ -297,6 +298,7 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
         )}
         <AgentSetupGuard />
         <HelpOverlay />
+        <QuitConfirmationOverlay />
       </div>
       <TerminalManagerPortal />
     </TerminalPortalProvider>

--- a/src/renderer/src/components/layout/QuitConfirmationOverlay.tsx
+++ b/src/renderer/src/components/layout/QuitConfirmationOverlay.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react'
+
+const QUIT_CONFIRMATION_DISPLAY_MS = 2000
+
+export function QuitConfirmationOverlay(): React.JSX.Element | null {
+  const [isVisible, setIsVisible] = useState(false)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const clearHideTimer = (): void => {
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current)
+        hideTimerRef.current = null
+      }
+    }
+
+    const hide = (): void => {
+      clearHideTimer()
+      setIsVisible(false)
+    }
+
+    const show = (): void => {
+      clearHideTimer()
+      setIsVisible(true)
+      hideTimerRef.current = setTimeout(() => {
+        hideTimerRef.current = null
+        setIsVisible(false)
+      }, QUIT_CONFIRMATION_DISPLAY_MS)
+    }
+
+    const unsubscribeShow = window.systemOps.onQuitConfirmationShow(show)
+    const unsubscribeHide = window.systemOps.onQuitConfirmationHide(hide)
+
+    return () => {
+      clearHideTimer()
+      unsubscribeShow()
+      unsubscribeHide()
+    }
+  }, [])
+
+  if (!isVisible) return null
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-[60] flex items-center justify-center">
+      <div className="animate-in fade-in zoom-in-95 duration-150 rounded-xl border bg-background/95 px-6 py-4 text-center shadow-2xl backdrop-blur-md">
+        <div className="text-base font-medium">
+          Press <kbd className="mx-1 rounded bg-muted px-2 py-1 font-mono text-sm">⌘Q</kbd> again
+          to Quit Hive
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -16,6 +16,7 @@ export function SettingsGeneral(): React.JSX.Element {
   const {
     autoStartSession,
     autoPullBeforeWorktree,
+    warnBeforeQuitting,
     boardMode,
     followUpTriggerColumn,
     vimModeEnabled,
@@ -59,6 +60,33 @@ export function SettingsGeneral(): React.JSX.Element {
       <div>
         <h3 className="text-base font-medium mb-1">General</h3>
         <p className="text-sm text-muted-foreground">Basic application settings</p>
+      </div>
+
+      {/* Warn before quitting */}
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <label className="text-sm font-medium">Warn before quitting (⌘Q)</label>
+          <p className="text-xs text-muted-foreground">
+            Show a confirmation when you press ⌘Q. Press ⌘Q a second time within 2 seconds to quit.
+          </p>
+        </div>
+        <button
+          role="switch"
+          aria-checked={warnBeforeQuitting}
+          onClick={() => updateSetting('warnBeforeQuitting', !warnBeforeQuitting)}
+          className={cn(
+            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+            warnBeforeQuitting ? 'bg-primary' : 'bg-muted'
+          )}
+          data-testid="warn-before-quitting-toggle"
+        >
+          <span
+            className={cn(
+              'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+              warnBeforeQuitting ? 'translate-x-4' : 'translate-x-0'
+            )}
+          />
+        </button>
       </div>
 
       {/* Auto-start session */}

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -60,6 +60,7 @@ export interface AppSettings {
   // General
   autoStartSession: boolean
   autoPullBeforeWorktree: boolean
+  warnBeforeQuitting: boolean
   breedType: 'dogs' | 'cats'
   vimModeEnabled: boolean
   keepAwakeEnabled: boolean
@@ -162,6 +163,7 @@ export interface AppSettings {
 const DEFAULT_SETTINGS: AppSettings = {
   autoStartSession: true,
   autoPullBeforeWorktree: true,
+  warnBeforeQuitting: true,
   breedType: 'dogs',
   vimModeEnabled: false,
   keepAwakeEnabled: false,
@@ -335,6 +337,7 @@ function extractSettings(state: SettingsState): AppSettings {
   return {
     autoStartSession: state.autoStartSession,
     autoPullBeforeWorktree: state.autoPullBeforeWorktree,
+    warnBeforeQuitting: state.warnBeforeQuitting,
     breedType: state.breedType,
     vimModeEnabled: state.vimModeEnabled,
     keepAwakeEnabled: state.keepAwakeEnabled,
@@ -651,6 +654,7 @@ export const useSettingsStore = create<SettingsState>()(
       partialize: (state) => ({
         autoStartSession: state.autoStartSession,
         autoPullBeforeWorktree: state.autoPullBeforeWorktree,
+        warnBeforeQuitting: state.warnBeforeQuitting,
         breedType: state.breedType,
         vimModeEnabled: state.vimModeEnabled,
         keepAwakeEnabled: state.keepAwakeEnabled,

--- a/test/layout/quit-confirmation-overlay.test.tsx
+++ b/test/layout/quit-confirmation-overlay.test.tsx
@@ -1,0 +1,89 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('QuitConfirmationOverlay', () => {
+  let showHandler: (() => void) | null
+  let hideHandler: (() => void) | null
+  let unsubscribeShow: ReturnType<typeof vi.fn>
+  let unsubscribeHide: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    showHandler = null
+    hideHandler = null
+    unsubscribeShow = vi.fn()
+    unsubscribeHide = vi.fn()
+
+    Object.defineProperty(window, 'systemOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        ...window.systemOps,
+        onQuitConfirmationShow: vi.fn((callback: () => void) => {
+          showHandler = callback
+          return unsubscribeShow
+        }),
+        onQuitConfirmationHide: vi.fn((callback: () => void) => {
+          hideHandler = callback
+          return unsubscribeHide
+        })
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows on IPC and hides itself after two seconds', async () => {
+    const { QuitConfirmationOverlay } = await import(
+      '@/components/layout/QuitConfirmationOverlay'
+    )
+
+    render(<QuitConfirmationOverlay />)
+    expect(screen.queryByText(/again to Quit Hive/)).not.toBeInTheDocument()
+
+    act(() => {
+      showHandler?.()
+    })
+
+    expect(screen.getByText(/again to Quit Hive/)).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(screen.queryByText(/again to Quit Hive/)).not.toBeInTheDocument()
+  })
+
+  it('hides immediately when the hide IPC event arrives', async () => {
+    const { QuitConfirmationOverlay } = await import(
+      '@/components/layout/QuitConfirmationOverlay'
+    )
+
+    render(<QuitConfirmationOverlay />)
+
+    act(() => {
+      showHandler?.()
+    })
+    expect(screen.getByText(/again to Quit Hive/)).toBeInTheDocument()
+
+    act(() => {
+      hideHandler?.()
+    })
+
+    expect(screen.queryByText(/again to Quit Hive/)).not.toBeInTheDocument()
+  })
+
+  it('unsubscribes from IPC events on unmount', async () => {
+    const { QuitConfirmationOverlay } = await import(
+      '@/components/layout/QuitConfirmationOverlay'
+    )
+
+    const { unmount } = render(<QuitConfirmationOverlay />)
+    unmount()
+
+    expect(unsubscribeShow).toHaveBeenCalled()
+    expect(unsubscribeHide).toHaveBeenCalled()
+  })
+})

--- a/test/main/quit-confirmation.test.ts
+++ b/test/main/quit-confirmation.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getQuitConfirmationDecision,
+  readWarnBeforeQuitting
+} from '../../src/main/quit-confirmation'
+
+describe('quit confirmation decision', () => {
+  it('defaults warnBeforeQuitting to enabled when settings are missing', () => {
+    expect(readWarnBeforeQuitting(null)).toBe(true)
+  })
+
+  it('reads warnBeforeQuitting=false from the app settings JSON blob', () => {
+    expect(readWarnBeforeQuitting(JSON.stringify({ warnBeforeQuitting: false }))).toBe(false)
+  })
+
+  it('falls back to enabled when settings JSON is invalid', () => {
+    expect(readWarnBeforeQuitting('{bad json')).toBe(true)
+  })
+
+  it('prevents the first quit attempt and records its timestamp', () => {
+    expect(
+      getQuitConfirmationDecision({
+        now: 1000,
+        lastQuitConfirmAt: null,
+        warnBeforeQuitting: true,
+        confirmationWindowMs: 2000
+      })
+    ).toEqual({ shouldPreventQuit: true, lastQuitConfirmAt: 1000 })
+  })
+
+  it('allows a second quit attempt inside the confirmation window', () => {
+    expect(
+      getQuitConfirmationDecision({
+        now: 2500,
+        lastQuitConfirmAt: 1000,
+        warnBeforeQuitting: true,
+        confirmationWindowMs: 2000
+      })
+    ).toEqual({ shouldPreventQuit: false, lastQuitConfirmAt: 1000 })
+  })
+
+  it('starts a fresh confirmation window after the previous one expires', () => {
+    expect(
+      getQuitConfirmationDecision({
+        now: 3100,
+        lastQuitConfirmAt: 1000,
+        warnBeforeQuitting: true,
+        confirmationWindowMs: 2000
+      })
+    ).toEqual({ shouldPreventQuit: true, lastQuitConfirmAt: 3100 })
+  })
+
+  it('allows quit immediately when warning is disabled', () => {
+    expect(
+      getQuitConfirmationDecision({
+        now: 1000,
+        lastQuitConfirmAt: null,
+        warnBeforeQuitting: false,
+        confirmationWindowMs: 2000
+      })
+    ).toEqual({ shouldPreventQuit: false, lastQuitConfirmAt: null })
+  })
+})

--- a/test/settings/warn-before-quitting.test.tsx
+++ b/test/settings/warn-before-quitting.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockUpdateSetting = vi.fn()
+let mockSettingsState: Record<string, unknown> = {}
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: Object.assign(
+    (selector?: (s: unknown) => unknown) => {
+      return selector ? selector(mockSettingsState) : mockSettingsState
+    },
+    {
+      getState: () => mockSettingsState
+    }
+  )
+}))
+
+vi.mock('@/stores/useThemeStore', () => ({
+  useThemeStore: () => ({ setTheme: vi.fn() })
+}))
+
+vi.mock('@/stores/useShortcutStore', () => ({
+  useShortcutStore: () => ({ resetToDefaults: vi.fn() })
+}))
+
+vi.mock('@/lib/themes', () => ({
+  DEFAULT_THEME_ID: 'default'
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+describe('SettingsGeneral warn before quitting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSettingsState = {
+      autoStartSession: true,
+      autoPullBeforeWorktree: true,
+      boardMode: 'sticky-tab',
+      followUpTriggerColumn: 'done',
+      vimModeEnabled: false,
+      keepAwakeEnabled: false,
+      mergeConflictMode: 'always-ask',
+      tipsEnabled: true,
+      warnBeforeQuitting: true,
+      breedType: 'dogs',
+      showModelIcons: false,
+      showModelProvider: false,
+      usageIndicatorMode: 'current-agent',
+      usageIndicatorProviders: [],
+      defaultAgentSdk: 'opencode',
+      availableAgentSdks: null,
+      stripAtMentions: true,
+      updateSetting: mockUpdateSetting,
+      resetToDefaults: vi.fn()
+    }
+  })
+
+  it('renders and toggles the warn before quitting setting', async () => {
+    const { SettingsGeneral } = await import('@/components/settings/SettingsGeneral')
+    render(<SettingsGeneral />)
+
+    const toggle = screen.getByTestId('warn-before-quitting-toggle')
+
+    expect(screen.getByText('Warn before quitting (⌘Q)')).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
+
+    await userEvent.click(toggle)
+
+    expect(mockUpdateSetting).toHaveBeenCalledWith('warnBeforeQuitting', false)
+  })
+})


### PR DESCRIPTION
## Summary
- Add a two-step Cmd+Q quit flow that shows a confirmation overlay on the first quit attempt and exits on a second attempt within 2 seconds.
- Add a General settings toggle to enable or disable the warning, with `warnBeforeQuitting` persisted in app settings.
- Wire the main process, preload bridge, and renderer overlay together so the confirmation state can be shown and hidden reliably.
- Add unit and component tests for the quit decision logic, overlay behavior, and settings toggle.

## Testing
- `Not run`
- Added coverage for first-quit prevention, second-quit allowance inside the confirmation window, and disabled-warning behavior in `test/main/quit-confirmation.test.ts`.
- Added coverage for overlay show/hide IPC handling and cleanup on unmount in `test/layout/quit-confirmation-overlay.test.tsx`.
- Added coverage for rendering and toggling the new settings switch in `test/settings/warn-before-quitting.test.tsx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Electron `before-quit` lifecycle to conditionally block app termination and drive a renderer overlay via IPC; mistakes here could make the app harder to quit or cause unexpected window focus/visibility behavior.
> 
> **Overview**
> Adds a two-step quit flow: the first Cmd+Q is intercepted in the main process (`before-quit`) to show a temporary confirmation overlay, and quitting proceeds only if Cmd+Q is pressed again within a 2s window.
> 
> Introduces a persisted `warnBeforeQuitting` setting (default on) exposed in General Settings, and wires new preload IPC subscriptions (`shortcut:quit-confirmation-show/hide`) to a new `QuitConfirmationOverlay` mounted in `AppLayout`.
> 
> Adds unit/component tests covering the quit decision logic, overlay show/hide behavior, and the settings toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1348fd59486b03fc22fe99db7460cbe745d6361a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->