### PR TITLE
Detect run-script errors and suggest kill actions

### DIFF
--- a/src/main/ipc/__tests__/script-handlers.killPid.test.ts
+++ b/src/main/ipc/__tests__/script-handlers.killPid.test.ts
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handlers = new Map<string, (...args: any[]) => any>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
+      handlers.set(channel, handler)
+    })
+  },
+  BrowserWindow: class {},
+  app: { getPath: vi.fn(() => '/tmp') }
+}))
+
+vi.mock('../../services/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  LoggerService: class {},
+  LogLevel: { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3 }
+}))
+
+vi.mock('../../db', () => ({
+  getDatabase: vi.fn()
+}))
+
+vi.mock('../../services/port-registry', () => ({
+  getAssignedPort: vi.fn(() => null),
+  assignPort: vi.fn(() => 3000)
+}))
+
+vi.mock('../../services/telemetry-service', () => ({
+  telemetryService: { track: vi.fn() }
+}))
+
+import { registerScriptHandlers } from '../script-handlers'
+import { __resetRuntimeRegistryForTests } from '../../effect/_shared/runtime'
+
+const mockEvent = {} as any
+
+describe('script:killPid handler', () => {
+  const originalKill = process.kill
+
+  beforeEach(() => {
+    handlers.clear()
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    __resetRuntimeRegistryForTests()
+    registerScriptHandlers({} as any)
+  })
+
+  afterEach(() => {
+    process.kill = originalKill
+    vi.useRealTimers()
+  })
+
+  it('returns ESRCH when the initial SIGTERM reports no such process', async () => {
+    process.kill = vi.fn(() => {
+      const error = new Error('no such process') as NodeJS.ErrnoException
+      error.code = 'ESRCH'
+      throw error
+    }) as unknown as typeof process.kill
+
+    const result = await handlers.get('script:killPid')!(mockEvent, { pid: 12345 })
+
+    expect(result).toEqual({
+      success: true,
+      value: { killed: false, reason: 'ESRCH' }
+    })
+  })
+
+  it('resolves killed when the PID exits after SIGTERM', async () => {
+    process.kill = vi.fn((_pid: number, signal?: NodeJS.Signals | 0) => {
+      if (signal === 0) {
+        const error = new Error('no such process') as NodeJS.ErrnoException
+        error.code = 'ESRCH'
+        throw error
+      }
+      return true
+    }) as unknown as typeof process.kill
+
+    const pending = handlers.get('script:killPid')!(mockEvent, { pid: 12345 })
+    await vi.advanceTimersByTimeAsync(100)
+
+    await expect(pending).resolves.toEqual({
+      success: true,
+      value: { killed: true }
+    })
+  })
+
+  it('falls back to SIGKILL when the process remains alive after SIGTERM polling', async () => {
+    const kill = vi.fn(() => true)
+    process.kill = kill as unknown as typeof process.kill
+
+    const pending = handlers.get('script:killPid')!(mockEvent, { pid: 12345 })
+    await vi.advanceTimersByTimeAsync(1300)
+    const result = await pending
+
+    expect(kill).toHaveBeenCalledWith(12345, 'SIGTERM')
+    expect(kill).toHaveBeenCalledWith(12345, 'SIGKILL')
+    expect(result).toEqual({
+      success: true,
+      value: { killed: false, reason: 'still alive after SIGKILL' }
+    })
+  })
+
+  it.each([0, 1, process.pid])('rejects invalid PID %s', async (pid) => {
+    const kill = vi.fn(() => true)
+    process.kill = kill as unknown as typeof process.kill
+
+    const result = await handlers.get('script:killPid')!(mockEvent, { pid })
+
+    expect(kill).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      success: true,
+      value: { killed: false, reason: 'EINVAL' }
+    })
+  })
+})

--- a/src/main/ipc/script-handlers.ts
+++ b/src/main/ipc/script-handlers.ts
@@ -133,6 +133,14 @@ export function registerScriptHandlers(mainWindow: BrowserWindow): void {
     })
   })
 
+  defineHandler('script:killPid', z.object({ pid: z.number().int() }), ({ pid }) => {
+    log.info('IPC: script:killPid', { pid })
+    return Effect.tryPromise({
+      try: () => scriptRunner.killPid(pid),
+      catch: (error) => scriptFailed('script:killPid', error)
+    })
+  })
+
   // Run archive script (non-interactive, captures output)
   defineHandler('script:runArchive', runArchiveSchema, ({ commands, cwd }) => {
     log.info('IPC: script:runArchive', { cwd, commandCount: commands.length })

--- a/src/main/services/script-runner.ts
+++ b/src/main/services/script-runner.ts
@@ -20,6 +20,11 @@ interface RunAndWaitResult {
   error?: string
 }
 
+interface KillPidResult {
+  killed: boolean
+  reason?: string
+}
+
 interface ScriptEvent {
   type: 'command-start' | 'output' | 'error' | 'done' | 'long-running'
   command?: string
@@ -508,6 +513,48 @@ export class ScriptRunner {
     }
 
     return true
+  }
+
+  private isAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0)
+      return true
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException
+      return error.code === 'EPERM'
+    }
+  }
+
+  async killPid(pid: number): Promise<KillPidResult> {
+    if (!Number.isFinite(pid) || pid <= 1 || pid === process.pid) {
+      return { killed: false, reason: 'EINVAL' }
+    }
+
+    try {
+      process.kill(pid, 'SIGTERM')
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException
+      return { killed: false, reason: error.code ?? String(err) }
+    }
+
+    for (let i = 0; i < 8; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      if (!this.isAlive(pid)) return { killed: true }
+    }
+
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException
+      return { killed: false, reason: error.code ?? String(err) }
+    }
+
+    for (let i = 0; i < 5; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      if (!this.isAlive(pid)) return { killed: true }
+    }
+
+    return { killed: false, reason: 'still alive after SIGKILL' }
   }
 
   getStats(): { active: number; totalOpened: number; totalClosed: number } {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1107,6 +1107,7 @@ declare global {
           error?: string
         }>
       >
+      killPid: (pid: number) => Promise<Envelope<{ killed: boolean; reason?: string }>>
       runArchive: (
         commands: string[],
         cwd: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1822,6 +1822,10 @@ const scriptOps = {
   kill: (worktreeId: string): Promise<Envelope<{ success: boolean; error?: string }>> =>
     ipcRenderer.invoke('script:kill', { worktreeId }),
 
+  // Kill a foreign PID suggested by run output guidance
+  killPid: (pid: number): Promise<Envelope<{ killed: boolean; reason?: string }>> =>
+    invokeEnvelope('script:killPid', { pid }),
+
   // Run archive script (non-interactive, captures output)
   runArchive: (
     commands: string[],

--- a/src/renderer/src/components/layout/RunSuggestionBanner.tsx
+++ b/src/renderer/src/components/layout/RunSuggestionBanner.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react'
+import { AlertTriangle, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { unwrapEnvelope } from '@/lib/ipc-envelope'
+import { useScriptStore } from '@/stores/useScriptStore'
+
+interface RunSuggestionBannerProps {
+  worktreeId: string
+}
+
+function humanReason(reason: string | undefined): string {
+  switch (reason) {
+    case 'ESRCH':
+      return 'No such process (already exited)'
+    case 'EPERM':
+      return 'Not permitted to kill this process'
+    default:
+      return reason ?? 'Action failed'
+  }
+}
+
+export function RunSuggestionBanner({
+  worktreeId
+}: RunSuggestionBannerProps): React.JSX.Element | null {
+  const suggestion = useScriptStore((s) => s.scriptStates[worktreeId]?.activeSuggestion ?? null)
+  const runRunning = useScriptStore((s) => s.scriptStates[worktreeId]?.runRunning ?? false)
+  const dismissSuggestion = useScriptStore((s) => s.dismissSuggestion)
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setPending(false)
+    setError(null)
+  }, [suggestion?.signature])
+
+  if (!suggestion) return null
+
+  const handleAction = async (): Promise<void> => {
+    if (suggestion.action.kind !== 'killPid') {
+      setError('Unsupported action')
+      return
+    }
+
+    setPending(true)
+    setError(null)
+    try {
+      const result = unwrapEnvelope(await window.scriptOps.killPid(suggestion.action.pid))
+      if (result.killed) {
+        dismissSuggestion(worktreeId)
+      } else {
+        setError(humanReason(result.reason))
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2 border-b border-destructive/20 bg-destructive/8 px-2 py-1.5 text-xs"
+      data-run-running={runRunning ? 'true' : 'false'}
+      data-testid="run-suggestion-banner"
+    >
+      <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-destructive" />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-foreground">
+          {suggestion.description ?? 'Suggested action available.'}
+        </div>
+        {error && <div className="truncate text-destructive">{error}</div>}
+      </div>
+      <Button
+        variant="destructive"
+        size="sm"
+        className="h-7 font-mono text-xs"
+        onClick={handleAction}
+        disabled={pending || error !== null}
+      >
+        {pending ? 'Running...' : suggestion.label}
+      </Button>
+      <button
+        type="button"
+        className="flex h-7 w-7 items-center justify-center rounded hover:bg-destructive/10"
+        aria-label="Dismiss suggestion"
+        onClick={() => dismissSuggestion(worktreeId)}
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/layout/RunTab.tsx
+++ b/src/renderer/src/components/layout/RunTab.tsx
@@ -11,6 +11,7 @@ import type { SearchHighlight } from './RunOutputLine'
 import { RunOutputSearch } from './RunOutputSearch'
 import type { RunSearchMatch } from './RunOutputSearch'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
+import { RunSuggestionBanner } from './RunSuggestionBanner'
 
 interface RunTabProps {
   worktreeId: string | null
@@ -249,6 +250,8 @@ export function RunTab({ worktreeId }: RunTabProps): React.JSX.Element {
           onClose={handleSearchClose}
         />
       )}
+
+      <RunSuggestionBanner worktreeId={worktreeId} />
 
       {/* Output area */}
       <div

--- a/src/renderer/src/lib/run-suggestions/__tests__/patterns.test.ts
+++ b/src/renderer/src/lib/run-suggestions/__tests__/patterns.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectSuggestion } from '../patterns'
+
+describe('run suggestion patterns', () => {
+  it('detects Next.js kill guidance', () => {
+    const suggestion = detectSuggestion('Run kill 31076 to stop it.')
+
+    expect(suggestion).toMatchObject({
+      signature: 'killPid:31076',
+      label: 'kill 31076',
+      description: 'Another dev server is using the expected port.',
+      action: { kind: 'killPid', pid: 31076 }
+    })
+  })
+
+  it('ignores unrelated lines', () => {
+    expect(detectSuggestion('Some random log line')).toBeNull()
+  })
+
+  it('ignores non-numeric PIDs', () => {
+    expect(detectSuggestion('Run kill foo to stop it.')).toBeNull()
+  })
+
+  it('returns distinct suggestions for distinct PIDs', () => {
+    const first = detectSuggestion('Run kill 31076 to stop it.')
+    const second = detectSuggestion('Run kill 31077 to stop it.')
+
+    expect(first?.signature).toBe('killPid:31076')
+    expect(second?.signature).toBe('killPid:31077')
+  })
+})

--- a/src/renderer/src/lib/run-suggestions/patterns.ts
+++ b/src/renderer/src/lib/run-suggestions/patterns.ts
@@ -1,0 +1,41 @@
+export type SuggestedAction = { kind: 'killPid'; pid: number }
+
+export interface Suggestion {
+  /** Stable signature used for dedup within a run session, e.g. "killPid:31076". */
+  signature: string
+  /** Label shown on the action button. */
+  label: string
+  /** Optional human description shown next to the button. */
+  description?: string
+  action: SuggestedAction
+}
+
+interface Pattern {
+  regex: RegExp
+  build: (match: RegExpExecArray) => Suggestion | null
+}
+
+const PATTERNS: Pattern[] = [
+  {
+    // Matches "Run kill 31076 to stop it" (Next.js dev-server collision).
+    regex: /Run kill (\d+) to stop it/,
+    build: (m) => {
+      const pid = Number(m[1])
+      if (!Number.isFinite(pid)) return null
+      return {
+        signature: `killPid:${pid}`,
+        label: `kill ${pid}`,
+        description: 'Another dev server is using the expected port.',
+        action: { kind: 'killPid', pid }
+      }
+    }
+  }
+]
+
+export function detectSuggestion(line: string): Suggestion | null {
+  for (const p of PATTERNS) {
+    const m = p.regex.exec(line)
+    if (m) return p.build(m)
+  }
+  return null
+}

--- a/src/renderer/src/stores/__tests__/useScriptStore.suggestions.test.ts
+++ b/src/renderer/src/stores/__tests__/useScriptStore.suggestions.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { deleteBuffer } from '@/lib/output-ring-buffer'
+import { fireRunScript, useScriptStore } from '../useScriptStore'
+
+type ScriptOutputEvent = Parameters<typeof window.scriptOps.onOutput>[1] extends (
+  event: infer Event
+) => void
+  ? Event
+  : never
+
+describe('useScriptStore run suggestions', () => {
+  const worktreeId = 'wt-suggestions'
+  let emitOutput: (event: ScriptOutputEvent) => void
+
+  beforeEach(() => {
+    useScriptStore.setState({ scriptStates: {} })
+    deleteBuffer(worktreeId)
+    vi.clearAllMocks()
+
+    Object.defineProperty(window, 'scriptOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        runProject: vi
+          .fn()
+          .mockResolvedValue({ success: true, value: { success: true, pid: 123 } }),
+        kill: vi.fn().mockResolvedValue({ success: true, value: { success: true } }),
+        killPid: vi.fn().mockResolvedValue({ success: true, value: { killed: true } }),
+        getPort: vi.fn().mockResolvedValue({ success: true, value: { port: null } }),
+        onOutput: vi.fn((_channel: string, callback: (event: ScriptOutputEvent) => void) => {
+          emitOutput = callback
+          return vi.fn()
+        }),
+        offOutput: vi.fn()
+      }
+    })
+  })
+
+  function startRun(): void {
+    fireRunScript(worktreeId, ['pnpm dev'], '/tmp/project')
+  }
+
+  it('sets the first detected kill suggestion', () => {
+    startRun()
+
+    emitOutput({ type: 'output', data: 'Run kill 1 to stop it.\n' })
+
+    expect(useScriptStore.getState().getScriptState(worktreeId).activeSuggestion).toMatchObject({
+      signature: 'killPid:1',
+      label: 'kill 1',
+      action: { kind: 'killPid', pid: 1 }
+    })
+  })
+
+  it('does not resurface an identical suggestion after dismissing it in the same run', () => {
+    startRun()
+    emitOutput({ type: 'output', data: 'Run kill 1 to stop it.\n' })
+
+    useScriptStore.getState().dismissSuggestion(worktreeId)
+    emitOutput({ type: 'output', data: 'Run kill 1 to stop it.\n' })
+
+    const state = useScriptStore.getState().getScriptState(worktreeId)
+    expect(state.activeSuggestion).toBeNull()
+    expect(state.seenSignatures.has('killPid:1')).toBe(true)
+  })
+
+  it('replaces the active suggestion with a different PID', () => {
+    startRun()
+
+    emitOutput({ type: 'output', data: 'Run kill 1 to stop it.\n' })
+    emitOutput({ type: 'output', data: 'Run kill 2 to stop it.\n' })
+
+    expect(useScriptStore.getState().getScriptState(worktreeId).activeSuggestion).toMatchObject({
+      signature: 'killPid:2',
+      label: 'kill 2',
+      action: { kind: 'killPid', pid: 2 }
+    })
+  })
+
+  it('clearRunOutput clears active and seen suggestions so the same PID can reappear', () => {
+    startRun()
+    emitOutput({ type: 'output', data: 'Run kill 1 to stop it.\n' })
+
+    useScriptStore.getState().clearRunOutput(worktreeId)
+    emitOutput({ type: 'output', data: 'Run kill 1 to stop it.\n' })
+
+    const state = useScriptStore.getState().getScriptState(worktreeId)
+    expect(state.activeSuggestion).toMatchObject({ signature: 'killPid:1' })
+    expect(state.seenSignatures.has('killPid:1')).toBe(true)
+  })
+
+  it('dismissSuggestion keeps the seen signature for the current run', () => {
+    startRun()
+    emitOutput({ type: 'output', data: 'Run kill 1 to stop it.\n' })
+
+    useScriptStore.getState().dismissSuggestion(worktreeId)
+
+    const state = useScriptStore.getState().getScriptState(worktreeId)
+    expect(state.activeSuggestion).toBeNull()
+    expect(state.seenSignatures.has('killPid:1')).toBe(true)
+  })
+})

--- a/src/renderer/src/stores/useScriptStore.ts
+++ b/src/renderer/src/stores/useScriptStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { getOrCreateBuffer } from '@/lib/output-ring-buffer'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
+import { detectSuggestion, type Suggestion } from '@/lib/run-suggestions/patterns'
 
 // Module-level: active IPC subscriptions for run scripts, keyed by worktreeId.
 // Keeps listeners alive regardless of which worktree the UI is showing.
@@ -20,6 +21,8 @@ interface ScriptState {
   runOutputVersion: number
   runRunning: boolean
   runPid: number | null
+  activeSuggestion: Suggestion | null
+  seenSignatures: Set<string>
 }
 
 function createDefaultScriptState(): ScriptState {
@@ -29,7 +32,9 @@ function createDefaultScriptState(): ScriptState {
     setupError: null,
     runOutputVersion: 0,
     runRunning: false,
-    runPid: null
+    runPid: null,
+    activeSuggestion: null,
+    seenSignatures: new Set()
   }
 }
 
@@ -48,6 +53,10 @@ interface ScriptStore {
   setRunPid: (worktreeId: string, pid: number | null) => void
   clearRunOutput: (worktreeId: string) => void
   getRunOutput: (worktreeId: string) => string[]
+  setActiveSuggestion: (worktreeId: string, suggestion: Suggestion | null) => void
+  markSuggestionSeen: (worktreeId: string, signature: string) => void
+  dismissSuggestion: (worktreeId: string) => void
+  clearSuggestions: (worktreeId: string) => void
 
   // Helpers
   getScriptState: (worktreeId: string) => ScriptState
@@ -203,7 +212,9 @@ export const useScriptStore = create<ScriptStore>((set, get) => ({
           ...state.scriptStates,
           [worktreeId]: {
             ...existing,
-            runOutputVersion: existing.runOutputVersion + 1
+            runOutputVersion: existing.runOutputVersion + 1,
+            activeSuggestion: null,
+            seenSignatures: new Set()
           }
         }
       }
@@ -213,6 +224,53 @@ export const useScriptStore = create<ScriptStore>((set, get) => ({
   getRunOutput: (worktreeId: string): string[] => {
     const buffer = getOrCreateBuffer(worktreeId)
     return buffer.toArray()
+  },
+
+  setActiveSuggestion: (worktreeId, suggestion) => {
+    set((state) => {
+      const existing = state.scriptStates[worktreeId] || createDefaultScriptState()
+      return {
+        scriptStates: {
+          ...state.scriptStates,
+          [worktreeId]: { ...existing, activeSuggestion: suggestion }
+        }
+      }
+    })
+  },
+
+  markSuggestionSeen: (worktreeId, signature) => {
+    set((state) => {
+      const existing = state.scriptStates[worktreeId] || createDefaultScriptState()
+      return {
+        scriptStates: {
+          ...state.scriptStates,
+          [worktreeId]: {
+            ...existing,
+            seenSignatures: new Set([...existing.seenSignatures, signature])
+          }
+        }
+      }
+    })
+  },
+
+  dismissSuggestion: (worktreeId) => {
+    get().setActiveSuggestion(worktreeId, null)
+  },
+
+  clearSuggestions: (worktreeId) => {
+    set((state) => {
+      const existing = state.scriptStates[worktreeId] || createDefaultScriptState()
+      return {
+        scriptStates: {
+          ...state.scriptStates,
+          [worktreeId]: {
+            ...existing,
+            activeSuggestion: null,
+            seenSignatures: new Set()
+          }
+        }
+      }
+    })
   },
 
   getScriptState: (worktreeId) => {
@@ -241,7 +299,16 @@ export function fireRunScript(worktreeId: string, commands: string[], cwd: strin
         if (event.data) {
           const lines = event.data.split('\n')
           for (const line of lines) {
-            if (line !== '') s.appendRunOutput(worktreeId, line)
+            if (line === '') continue
+            s.appendRunOutput(worktreeId, line)
+            const suggestion = detectSuggestion(line)
+            if (
+              suggestion &&
+              !s.getScriptState(worktreeId).seenSignatures.has(suggestion.signature)
+            ) {
+              s.markSuggestionSeen(worktreeId, suggestion.signature)
+              s.setActiveSuggestion(worktreeId, suggestion)
+            }
           }
         }
         break


### PR DESCRIPTION
## Summary
- Detects run output patterns like `Run kill <pid> to stop it` and surfaces them as actionable suggestions.
- Adds a run suggestion banner in the renderer with an inline `killPid` action and dismiss handling.
- Exposes a new IPC path to terminate a suggested PID from the main process with SIGTERM/SIGKILL fallback logic.
- Tracks seen suggestions per run so the same hint does not immediately resurface after dismissal.
- Adds coverage for suggestion detection, store behavior, and PID-kill IPC handling.

## Testing
- `Not run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new IPC endpoint that can terminate arbitrary local PIDs (SIGTERM/SIGKILL), which is inherently safety/security-sensitive and could kill the wrong process if misused. Also changes run-output handling and UI state to auto-detect and act on suggestions, affecting the run workflow.
> 
> **Overview**
> Adds *run-output “suggestions”* that detect lines like `Run kill <pid> to stop it` and surface an actionable banner in the Run tab, with dismiss + per-run deduping.
> 
> Introduces a new `script:killPid` IPC + preload API (`window.scriptOps.killPid`) backed by `scriptRunner.killPid`, which validates PIDs and attempts `SIGTERM` with polling before falling back to `SIGKILL`, returning structured `{ killed, reason }` results.
> 
> Extends `useScriptStore` to track `activeSuggestion`/`seenSignatures`, clears suggestion state on output clear, and adds tests covering pattern detection, store behavior, and the new kill-PID handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96bdf92f03a1b36389f2ce2e5deeba31a90c42f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->