### PR TITLE
Add setup script suggestions for projects

### DIFF
--- a/src/main/ipc/project-handlers.ts
+++ b/src/main/ipc/project-handlers.ts
@@ -11,6 +11,7 @@ import {
   initRepository,
   detectProjectLanguage,
   detectProjectFavicon,
+  detectSetupSuggestions,
   loadLanguageIcons,
   getIconDataUrl,
   getAbsoluteIconDataUrl,
@@ -145,6 +146,17 @@ export function registerProjectHandlers(): void {
         return detectProjectFavicon(projectPath)
       },
       catch: (error) => projectFailed('project:detectFavicon', error)
+    })
+  )
+
+  // Detect suggested setup script commands from project files
+  defineHandler('project:detectSetupSuggestions', nonEmptyString, (projectPath) =>
+    Effect.try({
+      try: () => {
+        log.debug('Detecting setup script suggestions', { projectPath })
+        return detectSetupSuggestions(projectPath)
+      },
+      catch: (error) => projectFailed('project:detectSetupSuggestions', error)
     })
   )
 

--- a/src/main/services/project-ops.ts
+++ b/src/main/services/project-ops.ts
@@ -14,6 +14,7 @@ import { createLogger } from './logger'
 import { getDatabase } from '../db'
 
 export { detectProjectLanguage, detectProjectFavicon } from './language-detector'
+export { detectSetupSuggestions } from './setup-script-suggester'
 
 const log = createLogger({ component: 'ProjectOps' })
 

--- a/src/main/services/setup-script-suggester.ts
+++ b/src/main/services/setup-script-suggester.ts
@@ -1,0 +1,156 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs'
+import { join } from 'path'
+
+import type { SuggestionItem } from '@shared/types/setup-suggestions'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'SetupScriptSuggester' })
+
+type JsPackageManager = 'pnpm' | 'yarn' | 'bun' | 'npm'
+
+const ENV_TEMPLATE_FILES = new Set(['.env.example', '.env.sample', '.env.template'])
+
+const makeItem = (
+  id: string,
+  command: string,
+  label: string,
+  category: SuggestionItem['category']
+): SuggestionItem => ({
+  id,
+  command,
+  label,
+  category,
+  defaultChecked: true
+})
+
+const fileExists = (projectPath: string, relativePath: string): boolean => {
+  try {
+    return (
+      existsSync(join(projectPath, relativePath)) &&
+      statSync(join(projectPath, relativePath)).isFile()
+    )
+  } catch {
+    return false
+  }
+}
+
+const detectEnvSuggestions = (projectPath: string): SuggestionItem[] =>
+  readdirSync(projectPath)
+    .filter((name) => {
+      if (!name.startsWith('.env') || ENV_TEMPLATE_FILES.has(name)) return false
+      return fileExists(projectPath, name)
+    })
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) =>
+      makeItem('env:' + name, `cp ${join(projectPath, name)} .`, `Copy ${name}`, 'env')
+    )
+
+const detectInstallSuggestion = (
+  projectPath: string
+): { item: SuggestionItem | null; detectedPm: JsPackageManager | null } => {
+  if (fileExists(projectPath, 'pnpm-lock.yaml')) {
+    return {
+      item: makeItem('install:pnpm', 'pnpm i', 'Install with pnpm', 'install'),
+      detectedPm: 'pnpm'
+    }
+  }
+  if (fileExists(projectPath, 'yarn.lock')) {
+    return {
+      item: makeItem('install:yarn', 'yarn install', 'Install with yarn', 'install'),
+      detectedPm: 'yarn'
+    }
+  }
+  if (fileExists(projectPath, 'bun.lockb') || fileExists(projectPath, 'bun.lock')) {
+    return {
+      item: makeItem('install:bun', 'bun install', 'Install with bun', 'install'),
+      detectedPm: 'bun'
+    }
+  }
+  if (fileExists(projectPath, 'package-lock.json')) {
+    return {
+      item: makeItem('install:npm', 'npm install', 'Install with npm', 'install'),
+      detectedPm: 'npm'
+    }
+  }
+  if (fileExists(projectPath, 'pyproject.toml') && fileExists(projectPath, 'uv.lock')) {
+    return {
+      item: makeItem('install:uv', 'uv sync', 'Sync uv environment', 'install'),
+      detectedPm: null
+    }
+  }
+
+  return { item: null, detectedPm: null }
+}
+
+const packageJsonHasPostinstall = (projectPath: string): boolean => {
+  try {
+    const packageJson = JSON.parse(readFileSync(join(projectPath, 'package.json'), 'utf-8')) as {
+      scripts?: { postinstall?: unknown }
+    }
+    return typeof packageJson.scripts?.postinstall === 'string'
+  } catch {
+    return false
+  }
+}
+
+const makefileHasSetupTarget = (projectPath: string): boolean => {
+  try {
+    return /^setup\s*:/m.test(readFileSync(join(projectPath, 'Makefile'), 'utf-8'))
+  } catch {
+    return false
+  }
+}
+
+const detectPostInstallSuggestions = (
+  projectPath: string,
+  detectedPm: JsPackageManager | null
+): SuggestionItem[] => {
+  const items: SuggestionItem[] = []
+
+  if (detectedPm && fileExists(projectPath, 'prisma/schema.prisma')) {
+    items.push(
+      makeItem(
+        'postinstall:prisma',
+        `${detectedPm} exec prisma generate`,
+        'Generate Prisma client',
+        'postinstall'
+      )
+    )
+  }
+
+  if (detectedPm && packageJsonHasPostinstall(projectPath)) {
+    items.push(
+      makeItem(
+        'postinstall:package-json',
+        `${detectedPm} run postinstall`,
+        'Run package postinstall',
+        'postinstall'
+      )
+    )
+  }
+
+  if (fileExists(projectPath, 'Makefile') && makefileHasSetupTarget(projectPath)) {
+    items.push(makeItem('postinstall:make-setup', 'make setup', 'Run make setup', 'postinstall'))
+  }
+
+  return items
+}
+
+export function detectSetupSuggestions(projectPath: string): SuggestionItem[] {
+  try {
+    const items: SuggestionItem[] = [...detectEnvSuggestions(projectPath)]
+    const { item: installItem, detectedPm } = detectInstallSuggestion(projectPath)
+    if (installItem) {
+      items.push(installItem)
+    }
+    items.push(...detectPostInstallSuggestions(projectPath, detectedPm))
+    return items
+  } catch (error) {
+    log.error(
+      'Failed to detect setup script suggestions',
+      error instanceof Error ? error : new Error(String(error)),
+      { projectPath }
+    )
+    return []
+  }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -6,6 +6,7 @@ import type {
   TelegramMode
 } from '../shared/types/telegram'
 import type { Envelope } from '@shared/types/ipc-envelope'
+import type { SuggestionItem } from '../shared/types/setup-suggestions'
 
 type Enveloped<T> = {
   [K in keyof T]: T[K] extends (...args: infer Args) => Promise<infer Result>
@@ -560,6 +561,7 @@ declare global {
       copyToClipboard: (text: string) => Promise<Envelope<void>>
       readFromClipboard: () => Promise<Envelope<string>>
       detectLanguage: (projectPath: string) => Promise<Envelope<string | null>>
+      detectSetupSuggestions: (projectPath: string) => Promise<Envelope<SuggestionItem[]>>
       findXcworkspace: (projectPath: string) => Promise<Envelope<string | null>>
       isAndroidProject: (projectPath: string) => Promise<Envelope<boolean>>
       loadLanguageIcons: () => Promise<Envelope<Record<string, string>>>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,7 @@ import type {
   TelegramMode
 } from '../shared/types/telegram'
 import type { Envelope } from '@shared/types/ipc-envelope'
+import type { SuggestionItem } from '../shared/types/setup-suggestions'
 import type { ConnectionWithMembers } from '../main/db/types'
 import type { BashRunSnapshot, BashStreamEvent } from '../main/effect/bash/types'
 
@@ -264,6 +265,10 @@ const projectOps = {
   // Detect the primary programming language of a project
   detectLanguage: (projectPath: string): Promise<Envelope<string | null>> =>
     ipcRenderer.invoke('project:detectLanguage', projectPath),
+
+  // Detect suggested setup script commands from project files
+  detectSetupSuggestions: (projectPath: string): Promise<Envelope<SuggestionItem[]>> =>
+    ipcRenderer.invoke('project:detectSetupSuggestions', projectPath),
 
   // Find .xcworkspace file for Swift projects
   findXcworkspace: (projectPath: string): Promise<Envelope<string | null>> =>

--- a/src/renderer/src/components/projects/ProjectSettingsDialog.tsx
+++ b/src/renderer/src/components/projects/ProjectSettingsDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { toast } from '@/lib/toast'
-import { ImageIcon, X } from 'lucide-react'
+import { Brain, ImageIcon, X } from 'lucide-react'
+import type { SuggestionItem } from '@shared/types/setup-suggestions'
 import {
   Dialog,
   DialogContent,
@@ -14,6 +15,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
 import { useProjectStore } from '@/stores'
 import { LanguageIcon } from './LanguageIcon'
+import { SetupScriptSuggestionsDialog } from './SetupScriptSuggestionsDialog'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 
 interface Project {
@@ -27,6 +29,7 @@ interface Project {
   run_script: string | null
   archive_script: string | null
   auto_assign_port: boolean
+  is_remote?: boolean
 }
 
 interface ProjectSettingsDialogProps {
@@ -49,6 +52,8 @@ export function ProjectSettingsDialog({
   const [autoAssignPort, setAutoAssignPort] = useState(false)
   const [saving, setSaving] = useState(false)
   const [pickingIcon, setPickingIcon] = useState(false)
+  const [suggestions, setSuggestions] = useState<SuggestionItem[]>([])
+  const [suggestionsOpen, setSuggestionsOpen] = useState(false)
 
   // Load current values when dialog opens
   useEffect(() => {
@@ -58,9 +63,38 @@ export function ProjectSettingsDialog({
       setArchiveScript(project.archive_script ?? '')
       setCustomIcon(project.custom_icon ?? null)
       setAutoAssignPort(project.auto_assign_port ?? false)
+      setSuggestionsOpen(false)
+
+      if (project.is_remote === true) {
+        setSuggestions([])
+        return
+      }
+
+      let cancelled = false
+      window.projectOps
+        .detectSetupSuggestions(project.path)
+        .then((envelope) => {
+          if (!cancelled) {
+            setSuggestions(unwrapEnvelope(envelope))
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setSuggestions([])
+          }
+        })
+
+      return () => {
+        cancelled = true
+      }
     }
+    setSuggestions([])
+    setSuggestionsOpen(false)
+    return undefined
   }, [
     open,
+    project.path,
+    project.is_remote,
     project.setup_script,
     project.run_script,
     project.archive_script,
@@ -114,124 +148,156 @@ export function ProjectSettingsDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-xl max-h-[85vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>Project Settings</DialogTitle>
-          <DialogDescription className="text-xs truncate">{project.path}</DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) {
+            setSuggestionsOpen(false)
+          }
+          onOpenChange(nextOpen)
+        }}
+      >
+        <DialogContent className="max-w-xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Project Settings</DialogTitle>
+            <DialogDescription className="text-xs truncate">{project.path}</DialogDescription>
+          </DialogHeader>
 
-        <div className="space-y-5">
-          {/* Project Icon */}
-          <div className="space-y-1.5">
-            <label className="text-sm font-medium">Project Icon</label>
-            <p className="text-xs text-muted-foreground">
-              Custom icon displayed in the sidebar. Supports SVG, PNG, JPG, and WebP.
-            </p>
-            <div className="flex items-center gap-3">
-              <div className="h-8 w-8 flex items-center justify-center rounded-md border border-border bg-muted/30">
-                <LanguageIcon
-                  language={project.language}
-                  customIcon={customIcon}
-                  detectedIcon={project.detected_icon}
-                  className="h-5 w-5 text-muted-foreground shrink-0"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-7 text-xs"
-                  onClick={handlePickIcon}
-                  disabled={pickingIcon}
-                >
-                  <ImageIcon className="h-3 w-3 mr-1.5" />
-                  {pickingIcon ? 'Picking...' : 'Change'}
-                </Button>
-                {customIcon && (
+          <div className="space-y-5">
+            {/* Project Icon */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Project Icon</label>
+              <p className="text-xs text-muted-foreground">
+                Custom icon displayed in the sidebar. Supports SVG, PNG, JPG, and WebP.
+              </p>
+              <div className="flex items-center gap-3">
+                <div className="h-8 w-8 flex items-center justify-center rounded-md border border-border bg-muted/30">
+                  <LanguageIcon
+                    language={project.language}
+                    customIcon={customIcon}
+                    detectedIcon={project.detected_icon}
+                    className="h-5 w-5 text-muted-foreground shrink-0"
+                  />
+                </div>
+                <div className="flex gap-2">
                   <Button
                     variant="outline"
                     size="sm"
                     className="h-7 text-xs"
-                    onClick={handleClearIcon}
+                    onClick={handlePickIcon}
+                    disabled={pickingIcon}
                   >
-                    <X className="h-3 w-3 mr-1.5" />
-                    Clear
+                    <ImageIcon className="h-3 w-3 mr-1.5" />
+                    {pickingIcon ? 'Picking...' : 'Change'}
+                  </Button>
+                  {customIcon && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 text-xs"
+                      onClick={handleClearIcon}
+                    >
+                      <X className="h-3 w-3 mr-1.5" />
+                      Clear
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Auto Port Assignment */}
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <div>
+                  <label className="text-sm font-medium">Auto-assign Port</label>
+                  <p className="text-xs text-muted-foreground">
+                    Assign a unique port to each worktree and inject PORT into run/setup scripts.
+                    Ports start at 3011.
+                  </p>
+                </div>
+                <Switch checked={autoAssignPort} onCheckedChange={setAutoAssignPort} />
+              </div>
+            </div>
+
+            {/* Setup Script */}
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <label className="text-sm font-medium">Setup Script</label>
+                {suggestions.length > 0 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+                    onClick={() => setSuggestionsOpen(true)}
+                    aria-label="Suggest setup script commands"
+                    title="Suggest setup script commands"
+                  >
+                    <Brain className="h-3.5 w-3.5" />
                   </Button>
                 )}
               </div>
+              <p className="text-xs text-muted-foreground">
+                Commands to run when a new worktree is initialized. Each line is a separate command.
+              </p>
+              <Textarea
+                value={setupScript}
+                onChange={(e) => setSetupScript(e.target.value)}
+                placeholder={'pnpm install\npnpm run build'}
+                rows={4}
+                className="font-mono text-sm resize-y"
+              />
+            </div>
+
+            {/* Run Script */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Run Script</label>
+              <p className="text-xs text-muted-foreground">
+                Commands triggered by {'\u2318'}R. Press {'\u2318'}R again while running to stop.
+              </p>
+              <Textarea
+                value={runScript}
+                onChange={(e) => setRunScript(e.target.value)}
+                placeholder={'pnpm run dev'}
+                rows={4}
+                className="font-mono text-sm resize-y"
+              />
+            </div>
+
+            {/* Archive Script */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Archive Script</label>
+              <p className="text-xs text-muted-foreground">
+                Commands to run before worktree archival. Failures won't block archival.
+              </p>
+              <Textarea
+                value={archiveScript}
+                onChange={(e) => setArchiveScript(e.target.value)}
+                placeholder={'pnpm run clean'}
+                rows={4}
+                className="font-mono text-sm resize-y"
+              />
             </div>
           </div>
 
-          {/* Auto Port Assignment */}
-          <div className="space-y-1.5">
-            <div className="flex items-center justify-between">
-              <div>
-                <label className="text-sm font-medium">Auto-assign Port</label>
-                <p className="text-xs text-muted-foreground">
-                  Assign a unique port to each worktree and inject PORT into run/setup scripts.
-                  Ports start at 3011.
-                </p>
-              </div>
-              <Switch checked={autoAssignPort} onCheckedChange={setAutoAssignPort} />
-            </div>
-          </div>
-
-          {/* Setup Script */}
-          <div className="space-y-1.5">
-            <label className="text-sm font-medium">Setup Script</label>
-            <p className="text-xs text-muted-foreground">
-              Commands to run when a new worktree is initialized. Each line is a separate command.
-            </p>
-            <Textarea
-              value={setupScript}
-              onChange={(e) => setSetupScript(e.target.value)}
-              placeholder={'pnpm install\npnpm run build'}
-              rows={4}
-              className="font-mono text-sm resize-y"
-            />
-          </div>
-
-          {/* Run Script */}
-          <div className="space-y-1.5">
-            <label className="text-sm font-medium">Run Script</label>
-            <p className="text-xs text-muted-foreground">
-              Commands triggered by {'\u2318'}R. Press {'\u2318'}R again while running to stop.
-            </p>
-            <Textarea
-              value={runScript}
-              onChange={(e) => setRunScript(e.target.value)}
-              placeholder={'pnpm run dev'}
-              rows={4}
-              className="font-mono text-sm resize-y"
-            />
-          </div>
-
-          {/* Archive Script */}
-          <div className="space-y-1.5">
-            <label className="text-sm font-medium">Archive Script</label>
-            <p className="text-xs text-muted-foreground">
-              Commands to run before worktree archival. Failures won't block archival.
-            </p>
-            <Textarea
-              value={archiveScript}
-              onChange={(e) => setArchiveScript(e.target.value)}
-              placeholder={'pnpm run clean'}
-              rows={4}
-              className="font-mono text-sm resize-y"
-            />
-          </div>
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button onClick={handleSave} disabled={saving}>
-            {saving ? 'Saving...' : 'Save'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving...' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <SetupScriptSuggestionsDialog
+        open={suggestionsOpen}
+        onOpenChange={setSuggestionsOpen}
+        items={suggestions}
+        currentValue={setupScript}
+        onApply={setSetupScript}
+      />
+    </>
   )
 }

--- a/src/renderer/src/components/projects/SetupScriptSuggestionsDialog.tsx
+++ b/src/renderer/src/components/projects/SetupScriptSuggestionsDialog.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { SuggestionItem } from '@shared/types/setup-suggestions'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+
+interface SetupScriptSuggestionsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  items: SuggestionItem[]
+  currentValue: string
+  onApply: (next: string) => void
+}
+
+export function SetupScriptSuggestionsDialog({
+  open,
+  onOpenChange,
+  items,
+  currentValue,
+  onApply
+}: SetupScriptSuggestionsDialogProps): React.JSX.Element {
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    if (!open) return
+    setCheckedIds(new Set(items.filter((item) => item.defaultChecked).map((item) => item.id)))
+  }, [items, open])
+
+  const selectedCommands = useMemo(
+    () => items.filter((item) => checkedIds.has(item.id)).map((item) => item.command),
+    [checkedIds, items]
+  )
+
+  const selectedText = selectedCommands.join('\n')
+  const hasSelection = selectedCommands.length > 0
+  const isEmpty = currentValue.trim() === ''
+
+  const toggleItem = (id: string): void => {
+    setCheckedIds((previous) => {
+      const next = new Set(previous)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  const apply = (mode: 'replace' | 'append'): void => {
+    if (!hasSelection) return
+    const next =
+      mode === 'append' && currentValue.trim() !== ''
+        ? `${currentValue.trimEnd()}\n${selectedText}`
+        : selectedText
+    onApply(next)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Suggested setup commands</DialogTitle>
+          <DialogDescription>
+            Choose the command lines to use for this project setup script.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          {items.map((item) => (
+            <div
+              key={item.id}
+              className="flex items-start gap-3 rounded-md border border-border bg-muted/20 p-3"
+            >
+              <Checkbox
+                checked={checkedIds.has(item.id)}
+                onCheckedChange={() => toggleItem(item.id)}
+                className="mt-0.5"
+                aria-label={item.label}
+              />
+              <div className="min-w-0 flex-1 space-y-1">
+                <div className="text-xs text-muted-foreground">{item.label}</div>
+                <code className="block whitespace-pre-wrap break-words font-mono text-sm">
+                  {item.command}
+                </code>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          {isEmpty ? (
+            <Button onClick={() => apply('replace')} disabled={!hasSelection}>
+              Apply
+            </Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={() => apply('append')} disabled={!hasSelection}>
+                Append
+              </Button>
+              <Button onClick={() => apply('replace')} disabled={!hasSelection}>
+                Replace
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/shared/types/setup-suggestions.ts
+++ b/src/shared/types/setup-suggestions.ts
@@ -1,0 +1,9 @@
+export type SuggestionCategory = 'env' | 'install' | 'postinstall'
+
+export type SuggestionItem = {
+  id: string
+  command: string
+  label: string
+  category: SuggestionCategory
+  defaultChecked: boolean
+}

--- a/test/setup-script-suggester.test.ts
+++ b/test/setup-script-suggester.test.ts
@@ -1,0 +1,154 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => process.env.TMPDIR ?? '/tmp'
+  }
+}))
+
+import { detectSetupSuggestions } from '../src/main/services/setup-script-suggester'
+
+const roots: string[] = []
+
+function createProject(): string {
+  const root = mkdtempSync(join(tmpdir(), 'hive-setup-suggestions-'))
+  roots.push(root)
+  return root
+}
+
+function writeFixture(root: string, relativePath: string, contents = ''): void {
+  const fullPath = join(root, relativePath)
+  mkdirSync(join(fullPath, '..'), { recursive: true })
+  writeFileSync(fullPath, contents)
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('detectSetupSuggestions', () => {
+  test('suggests env copy, pnpm install, and prisma generate for pnpm prisma projects', () => {
+    const root = createProject()
+    writeFixture(root, '.env.local', 'DATABASE_URL=postgres://example')
+    writeFixture(root, 'pnpm-lock.yaml')
+    writeFixture(root, 'prisma/schema.prisma')
+
+    expect(detectSetupSuggestions(root)).toEqual([
+      {
+        id: 'env:.env.local',
+        command: `cp ${join(root, '.env.local')} .`,
+        label: 'Copy .env.local',
+        category: 'env',
+        defaultChecked: true
+      },
+      {
+        id: 'install:pnpm',
+        command: 'pnpm i',
+        label: 'Install with pnpm',
+        category: 'install',
+        defaultChecked: true
+      },
+      {
+        id: 'postinstall:prisma',
+        command: 'pnpm exec prisma generate',
+        label: 'Generate Prisma client',
+        category: 'postinstall',
+        defaultChecked: true
+      }
+    ])
+  })
+
+  test('suggests yarn install and package postinstall for yarn projects', () => {
+    const root = createProject()
+    writeFixture(root, 'yarn.lock')
+    writeFixture(
+      root,
+      'package.json',
+      JSON.stringify({ scripts: { postinstall: 'node setup.js' } })
+    )
+
+    expect(detectSetupSuggestions(root).map((item) => item.command)).toEqual([
+      'yarn install',
+      'yarn run postinstall'
+    ])
+  })
+
+  test('uses lockfile precedence winner when multiple JavaScript lockfiles exist', () => {
+    const root = createProject()
+    writeFixture(root, 'pnpm-lock.yaml')
+    writeFixture(root, 'yarn.lock')
+
+    expect(detectSetupSuggestions(root).map((item) => item.command)).toEqual(['pnpm i'])
+  })
+
+  test('suggests uv sync for uv Python projects', () => {
+    const root = createProject()
+    writeFixture(root, 'pyproject.toml')
+    writeFixture(root, 'uv.lock')
+
+    expect(detectSetupSuggestions(root).map((item) => item.command)).toEqual(['uv sync'])
+  })
+
+  test('suggests only env copy for Rust projects without install rules', () => {
+    const root = createProject()
+    writeFixture(root, '.env', 'RUST_LOG=debug')
+    writeFixture(root, 'Cargo.toml')
+
+    expect(detectSetupSuggestions(root).map((item) => item.command)).toEqual([
+      `cp ${join(root, '.env')} .`
+    ])
+  })
+
+  test('suggests env copy and make setup when Makefile has setup target', () => {
+    const root = createProject()
+    writeFixture(root, '.env', 'APP_ENV=local')
+    writeFixture(root, 'Makefile', 'setup:\n\tbin/setup\n')
+
+    expect(detectSetupSuggestions(root).map((item) => item.command)).toEqual([
+      `cp ${join(root, '.env')} .`,
+      'make setup'
+    ])
+  })
+
+  test('filters env template files', () => {
+    const root = createProject()
+    writeFixture(root, '.env.example', 'TOKEN=')
+
+    expect(detectSetupSuggestions(root)).toEqual([])
+  })
+
+  test('returns empty array for unsupported projects', () => {
+    const root = createProject()
+    writeFixture(root, 'README.md', '# Project')
+
+    expect(detectSetupSuggestions(root)).toEqual([])
+  })
+
+  test('sorts multiple env files and checks both by default', () => {
+    const root = createProject()
+    writeFixture(root, '.env.local', 'LOCAL=1')
+    writeFixture(root, '.env', 'BASE=1')
+
+    expect(detectSetupSuggestions(root)).toEqual([
+      {
+        id: 'env:.env',
+        command: `cp ${join(root, '.env')} .`,
+        label: 'Copy .env',
+        category: 'env',
+        defaultChecked: true
+      },
+      {
+        id: 'env:.env.local',
+        command: `cp ${join(root, '.env.local')} .`,
+        label: 'Copy .env.local',
+        category: 'env',
+        defaultChecked: true
+      }
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Added backend detection for suggested setup commands based on project files, lockfiles, Prisma schema, `package.json` postinstall scripts, `Makefile` setup targets, and `.env` templates.
- Exposed the new IPC API through preload and project handlers so the renderer can request suggestions for local projects.
- Updated the Project Settings dialog to show a suggestion button for setup scripts and added a dedicated dialog for selecting, appending, or replacing commands.
- Added shared suggestion types and unit coverage for the detection logic across common project layouts.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new IPC surface and filesystem-based heuristics to generate shell command suggestions, which could affect UX correctness and needs care around path/command formatting and remote-project gating.
> 
> **Overview**
> Adds a new setup-suggestion pipeline that detects recommended setup command lines from project files (env files, lockfiles/package managers, Prisma schema, `package.json` postinstall, `Makefile setup`, and `uv` locks) and exposes it via a new `project:detectSetupSuggestions` IPC API.
> 
> Updates Project Settings so local projects can fetch these suggestions and open a new `SetupScriptSuggestionsDialog` to apply the selected commands (append/replace) into the setup script field, backed by new shared `SuggestionItem` types and unit tests covering common project layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc8cbd9aa6624b78671f7ca3eedcf30f8900946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->