### PR TITLE
Fix stale usage indicator after failed refreshes

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "install:mac": "bash scripts/install.sh"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.138",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.140",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-cpp": "^6.0.3",
     "@codemirror/lang-css": "^6.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.138
-        version: 0.2.138(zod@4.4.3)
+        specifier: ^0.2.140
+        version: 0.2.140(zod@4.4.3)
       '@codemirror/commands':
         specifier: ^6.10.3
         version: 6.10.3
@@ -315,48 +315,48 @@ packages:
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
     hasBin: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.138':
-    resolution: {integrity: sha512-aObxJ/GeJ5UxT9N8XypUHPYQKpwYsRT5THiJl5E2pKEUk/Xt42gT55N5GV0TOjtgxVAnDMWjxTAgGCGoDzjgpg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.140':
+    resolution: {integrity: sha512-zEbDsDKeoDO4DzbyX6wBVlcPhLy/gYiCrKzKnxmkOhyNtJBeshgiOTdr+M7WX1xcuI/M/UhEY+B9U6oo884lAQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.138':
-    resolution: {integrity: sha512-ou3i1/gAf2PEgVl2WYJb7ZdE+KGwoB1I46JRhWHSC3uD6lb9HMZam233T/rlKCVX9e5dzfkujUOnmCkmXjgVGQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.140':
+    resolution: {integrity: sha512-BFJGeZEksvERy7mMJ0mkNAWoMrZOgl6XN/mKPaunGnaC/i+1ykx7xih7e58bRhsrzKzo2mnUrwtjiFyF3MFNRQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.138':
-    resolution: {integrity: sha512-uZaEFND1pl7KD9tdYqj2hd6ktjlYizVmkHRgU2Aj/P1CC6WMDsKG+rqPP7dsVXO77gMXhL4xjjwwqMjxx83HkA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.140':
+    resolution: {integrity: sha512-nG7xLL0nKb4ymFVnX0QhSGLoyhh9fuuDpBR+TYz5O4ZQc2RVUMSMqGusqcCNEIGxAKQSVKWCf0WgpCG/edAO9Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.138':
-    resolution: {integrity: sha512-jp8lmAVe9uI9X5o+IYWFajLbN+Z80XogVX7NeyaenLHdpHkxg29Yf8pb6Os4OvHMjJOAdwDhPpXajf6RtBeEDA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.140':
+    resolution: {integrity: sha512-FauGGg3zikxrjAUnu+Pso6zD9Qv4Z2+QBiTiZqc12U+x4uoikNsplymUnsJ7MYD9VaTGmLJuZ9pCch0IiKrseQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.138':
-    resolution: {integrity: sha512-T16F8Vkikb98E781ZM6Cx84yEBk+loSCqAObjaZ1hzQ1eKcpnxzSTF4rH2bz6N91dhFuCfIjFaBfNYg+oQA+yQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.140':
+    resolution: {integrity: sha512-EZ7VzOGmvft/1ymh2rwts5v3yPnsGGlGrTJlY2Dqnr1ABF43JIhEm1NFYrLnXQWSN74s5Pj8tgkPbYS9x4BhFA==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.138':
-    resolution: {integrity: sha512-SLuUmu/nH1Wh0wnoXj/Bwh0nbDfEn9PgXqMsZHEUk3x1zxeR+6aRqFLjKZ8TawBey7xod7nfYUIjPnQx6IWDzg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.140':
+    resolution: {integrity: sha512-7f627Tq2mIiwFoBYfCKTdEeZSP90r8UOWu/I5DezudTtwtoVl2zRaRCnJ8c4rW+Tzw+xWSfP/pHvR9bTQGXaOw==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.138':
-    resolution: {integrity: sha512-H/sD25fmMyEeJWamYmBKRS3E7jaIrg2S8KWxyR37P+xTZgkLe19sDTp7gYYywMXf1X9CJZJ8jJZ93qxINZoCeA==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.140':
+    resolution: {integrity: sha512-9EOozRF+LTt3UedeJtjJXC8pj9VTAFtPBuB+/YUmcpmDAEH9qcWWknWhf7NDKTapKtBWkNP/387x+18L15MLqg==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.138':
-    resolution: {integrity: sha512-cSOdTH1OfIamVdJit9laWZiXne81ewgdP8MGh5HzLLLci0NGHkME7YxCWd0lYkCNkfiOEcToKU9axaZ+84jGiw==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.140':
+    resolution: {integrity: sha512-puQyWoYiqosjDEYULWAS/lBJse1vzib0NmQj/bYTirWCbtiUcu6ixKMd4NmLbE+Si/DKTB8XNz6hVZ/KckqeoQ==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.2.138':
-    resolution: {integrity: sha512-rH6dFI3DBBsPBPcHTBdTZCHA14OCt2t4+6XYi2MJB/GlFrnZvlWmMIk2z9uxAiZ05Txg8YbftgSuE5A1qpAXwg==}
+  '@anthropic-ai/claude-agent-sdk@0.2.140':
+    resolution: {integrity: sha512-Zq2L7YCoTdbxTUi3/soN1axrTqbG7GoKuc6Im8EpkBRdwaY0D1W9+Ux3vAbV/cX8Qk31Vck7DQLZz1lGEArdoQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -6425,44 +6425,44 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.138(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.2.140(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.81.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.138
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.140
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -115,6 +115,9 @@ function ProviderUsageBlock({
   const isLoading = useUsageStore((s) =>
     provider === 'anthropic' ? s.anthropicIsLoading : s.openaiIsLoading
   )
+  const lastError = useUsageStore((s) =>
+    provider === 'anthropic' ? s.anthropicLastError : s.openaiLastError
+  )
   const email = useAccountStore((s) => provider === 'anthropic' ? s.anthropicEmail : s.openaiEmail)
   const fetchEmail = useAccountStore((s) => s.fetchEmail)
 
@@ -135,7 +138,9 @@ function ProviderUsageBlock({
               <button
                 type="button"
                 className="shrink-0 cursor-pointer bg-transparent border-none p-0"
-                onClick={() => { forceRefreshProvider(provider); fetchEmail(provider) }}
+                onClick={() => {
+                  void Promise.allSettled([forceRefreshProvider(provider), fetchEmail(provider)])
+                }}
                 aria-label={`Refresh ${providerLabel} usage`}
               >
                 <img
@@ -158,6 +163,11 @@ function ProviderUsageBlock({
           <div className="space-y-1">
             <div className="font-medium">{tooltipTitle}</div>
             <div className="text-[10px]">No credentials configured</div>
+            {lastError && (
+              <div className="text-[10px] text-red-400 border-t border-background/20 pt-1">
+                Refresh failed: {lastError}
+              </div>
+            )}
           </div>
         </TooltipContent>
       </Tooltip>
@@ -178,7 +188,9 @@ function ProviderUsageBlock({
             <button
               type="button"
               className="shrink-0 cursor-pointer bg-transparent border-none p-0"
-              onClick={() => { forceRefreshProvider(provider); fetchEmail(provider) }}
+              onClick={() => {
+                void Promise.allSettled([forceRefreshProvider(provider), fetchEmail(provider)])
+              }}
               aria-label={`Refresh ${providerLabel} usage`}
             >
               <img
@@ -211,6 +223,11 @@ function ProviderUsageBlock({
             <div className="border-t border-background/20 pt-1 text-[10px]">
               Extra: ${(extra.used_credits ?? 0).toFixed(2)} / ${(extra.monthly_limit ?? 0).toFixed(2)} used (
               {Math.round(extra.utilization ?? 0)}%)
+            </div>
+          )}
+          {lastError && (
+            <div className="text-[10px] text-red-400 border-t border-background/20 pt-1">
+              Refresh failed: {lastError}
             </div>
           )}
         </div>
@@ -256,8 +273,7 @@ export function UsageIndicator(): React.JSX.Element | null {
       useSettingsStore.getState()
     const current = useUsageStore.getState().activeProvider
     getVisibleProviders(mode, selected, current).forEach((p) => {
-      fetchUsageForProvider(p)
-      fetchEmail(p)
+      void Promise.allSettled([fetchUsageForProvider(p), fetchEmail(p)])
     })
   }, [activeSessionId, setActiveProvider, fetchUsageForProvider, fetchEmail])
 

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -8,10 +8,12 @@ interface UsageState {
   anthropicUsage: UsageData | null
   anthropicLastFetchedAt: number | null
   anthropicIsLoading: boolean
+  anthropicLastError: string | null
 
   openaiUsage: OpenAIUsageData | null
   openaiLastFetchedAt: number | null
   openaiIsLoading: boolean
+  openaiLastError: string | null
 
   activeProvider: UsageProvider
 
@@ -23,14 +25,20 @@ interface UsageState {
 
 const DEBOUNCE_MS = 180_000 // 3 minutes
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
 export const useUsageStore = create<UsageState>()((set, get) => ({
   anthropicUsage: null,
   anthropicLastFetchedAt: null,
   anthropicIsLoading: false,
+  anthropicLastError: null,
 
   openaiUsage: null,
   openaiLastFetchedAt: null,
   openaiIsLoading: false,
+  openaiLastError: null,
 
   activeProvider: 'anthropic',
 
@@ -42,27 +50,45 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
       if (state.anthropicLastFetchedAt && Date.now() - state.anthropicLastFetchedAt < DEBOUNCE_MS)
         return
 
-      set({ anthropicIsLoading: true })
+      set({ anthropicIsLoading: true, anthropicLastError: null })
+      let succeeded = false
       try {
         const result = unwrapEnvelope(await window.usageOps.fetch())
         if (result.success) {
-          set({ anthropicUsage: result.data ?? null })
+          set({ anthropicUsage: result.data ?? null, anthropicLastError: null })
+          succeeded = true
+        } else {
+          set({ anthropicLastError: result.error ?? 'Unknown error' })
         }
+      } catch (err) {
+        set({ anthropicLastError: errorMessage(err) })
       } finally {
-        set({ anthropicIsLoading: false, anthropicLastFetchedAt: Date.now() })
+        set({
+          anthropicIsLoading: false,
+          ...(succeeded ? { anthropicLastFetchedAt: Date.now() } : {})
+        })
       }
     } else {
       if (state.openaiIsLoading) return
       if (state.openaiLastFetchedAt && Date.now() - state.openaiLastFetchedAt < DEBOUNCE_MS) return
 
-      set({ openaiIsLoading: true })
+      set({ openaiIsLoading: true, openaiLastError: null })
+      let succeeded = false
       try {
         const result = unwrapEnvelope(await window.usageOps.fetchOpenai())
         if (result.success) {
-          set({ openaiUsage: result.data ?? null })
+          set({ openaiUsage: result.data ?? null, openaiLastError: null })
+          succeeded = true
+        } else {
+          set({ openaiLastError: result.error ?? 'Unknown error' })
         }
+      } catch (err) {
+        set({ openaiLastError: errorMessage(err) })
       } finally {
-        set({ openaiIsLoading: false, openaiLastFetchedAt: Date.now() })
+        set({
+          openaiIsLoading: false,
+          ...(succeeded ? { openaiLastFetchedAt: Date.now() } : {})
+        })
       }
     }
   },
@@ -73,26 +99,44 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
     if (provider === 'anthropic') {
       if (state.anthropicIsLoading) return
 
-      set({ anthropicIsLoading: true })
+      set({ anthropicIsLoading: true, anthropicLastError: null })
+      let succeeded = false
       try {
         const result = unwrapEnvelope(await window.usageOps.fetch())
         if (result.success) {
-          set({ anthropicUsage: result.data ?? null })
+          set({ anthropicUsage: result.data ?? null, anthropicLastError: null })
+          succeeded = true
+        } else {
+          set({ anthropicLastError: result.error ?? 'Unknown error' })
         }
+      } catch (err) {
+        set({ anthropicLastError: errorMessage(err) })
       } finally {
-        set({ anthropicIsLoading: false, anthropicLastFetchedAt: Date.now() })
+        set({
+          anthropicIsLoading: false,
+          ...(succeeded ? { anthropicLastFetchedAt: Date.now() } : {})
+        })
       }
     } else {
       if (state.openaiIsLoading) return
 
-      set({ openaiIsLoading: true })
+      set({ openaiIsLoading: true, openaiLastError: null })
+      let succeeded = false
       try {
         const result = unwrapEnvelope(await window.usageOps.fetchOpenai())
         if (result.success) {
-          set({ openaiUsage: result.data ?? null })
+          set({ openaiUsage: result.data ?? null, openaiLastError: null })
+          succeeded = true
+        } else {
+          set({ openaiLastError: result.error ?? 'Unknown error' })
         }
+      } catch (err) {
+        set({ openaiLastError: errorMessage(err) })
       } finally {
-        set({ openaiIsLoading: false, openaiLastFetchedAt: Date.now() })
+        set({
+          openaiIsLoading: false,
+          ...(succeeded ? { openaiLastFetchedAt: Date.now() } : {})
+        })
       }
     }
   },

--- a/test/usage/use-usage-store.test.ts
+++ b/test/usage/use-usage-store.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useUsageStore, type UsageData } from '@/stores/useUsageStore'
+
+const sampleUsage: UsageData = {
+  five_hour: {
+    utilization: 42,
+    resets_at: '2026-05-14T12:00:00.000Z'
+  },
+  seven_day: {
+    utilization: 13,
+    resets_at: '2026-05-15T12:00:00.000Z'
+  }
+}
+
+function usageState(): ReturnType<typeof useUsageStore.getState> & {
+  anthropicLastError: string | null
+  openaiLastError: string | null
+} {
+  return useUsageStore.getState() as ReturnType<typeof useUsageStore.getState> & {
+    anthropicLastError: string | null
+    openaiLastError: string | null
+  }
+}
+
+describe('useUsageStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-14T09:00:00.000Z'))
+
+    Object.defineProperty(window, 'usageOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        fetch: vi.fn(),
+        fetchOpenai: vi.fn()
+      }
+    })
+
+    useUsageStore.setState({
+      anthropicUsage: null,
+      anthropicLastFetchedAt: null,
+      anthropicIsLoading: false,
+      anthropicLastError: null,
+      openaiUsage: null,
+      openaiLastFetchedAt: null,
+      openaiIsLoading: false,
+      openaiLastError: null,
+      activeProvider: 'anthropic'
+    } as Partial<ReturnType<typeof useUsageStore.getState>>)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('records inner Anthropic failures without changing stale usage or debounce timestamp', async () => {
+    useUsageStore.setState({
+      anthropicUsage: sampleUsage,
+      anthropicLastFetchedAt: null
+    })
+    vi.mocked(window.usageOps.fetch).mockResolvedValue({
+      success: true,
+      value: { success: false, error: 'No access token found' }
+    })
+
+    await useUsageStore.getState().fetchUsageForProvider('anthropic')
+
+    const state = usageState()
+    expect(state.anthropicUsage).toBe(sampleUsage)
+    expect(state.anthropicLastError).toBe('No access token found')
+    expect(state.anthropicLastFetchedAt).toBeNull()
+    expect(state.anthropicIsLoading).toBe(false)
+  })
+
+  it('records envelope-level Anthropic failures without rejecting or advancing debounce', async () => {
+    vi.mocked(window.usageOps.fetch).mockResolvedValue({
+      success: false,
+      errorCode: 'ZodDecodeError',
+      error: 'Could not decode usage response'
+    })
+
+    await expect(useUsageStore.getState().forceRefreshProvider('anthropic')).resolves.toBeUndefined()
+
+    const state = usageState()
+    expect(state.anthropicLastError).toBe('Could not decode usage response')
+    expect(state.anthropicLastFetchedAt).toBeNull()
+    expect(state.anthropicIsLoading).toBe(false)
+  })
+
+  it('clears Anthropic errors and advances debounce after a successful fetch', async () => {
+    useUsageStore.setState({
+      anthropicLastError: 'No access token found'
+    } as Partial<ReturnType<typeof useUsageStore.getState>>)
+    vi.mocked(window.usageOps.fetch).mockResolvedValue({
+      success: true,
+      value: { success: true, data: sampleUsage }
+    })
+
+    await useUsageStore.getState().fetchUsageForProvider('anthropic')
+
+    const state = usageState()
+    expect(state.anthropicUsage).toBe(sampleUsage)
+    expect(state.anthropicLastError).toBeNull()
+    expect(state.anthropicLastFetchedAt).toBe(Date.now())
+    expect(state.anthropicIsLoading).toBe(false)
+  })
+
+  it('records inner OpenAI failures without advancing debounce', async () => {
+    vi.mocked(window.usageOps.fetchOpenai).mockResolvedValue({
+      success: true,
+      value: { success: false, error: 'OpenAI auth failed' }
+    })
+
+    await useUsageStore.getState().forceRefreshProvider('openai')
+
+    const state = usageState()
+    expect(state.openaiLastError).toBe('OpenAI auth failed')
+    expect(state.openaiLastFetchedAt).toBeNull()
+    expect(state.openaiIsLoading).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Track and surface the last usage fetch error for Anthropic and OpenAI in the usage store.
- Keep stale usage data visible when a refresh fails, while clearing the error on the next successful fetch.
- Refresh usage and email requests together with `Promise.allSettled` so one failure does not block the other.
- Add store tests covering envelope failures, thrown errors, and successful recovery.

## Testing
- `Not run`
- Added unit coverage in `test/usage/use-usage-store.test.ts` for failed refresh handling and error clearing on success.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes usage refresh state handling and UI feedback; low functional surface area but affects user-visible refresh/debounce behavior for both providers.
> 
> **Overview**
> Fixes stale/incorrect usage indicator behavior after failed refreshes by tracking `anthropicLastError`/`openaiLastError` in `useUsageStore`, only advancing `*LastFetchedAt` on successful fetches, and leaving prior usage data intact when refresh fails.
> 
> Updates `UsageIndicator` to refresh usage + email concurrently via `Promise.allSettled` and to surface refresh errors in the tooltip UI for both the no-credentials and normal states. Adds Vitest coverage for envelope/inner failures and successful recovery, and bumps `@anthropic-ai/claude-agent-sdk` to `0.2.140`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef34cee134971a96eb4390b3d4ddb6077b29a5f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->