### PR TITLE
Track and refresh saved usage accounts

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -46,7 +46,11 @@ import type {
   TicketDependency,
   DiffComment,
   DiffCommentCreate,
-  DiffCommentUpdate
+  DiffCommentUpdate,
+  SavedUsageAccount,
+  SavedUsageAccountUpsert,
+  SavedUsageAccountUsageUpdate,
+  SavedUsageProvider
 } from './types'
 
 export class DatabaseService {
@@ -194,7 +198,14 @@ export class DatabaseService {
 
   private normalizeBatchDrafts(
     drafts: KanbanTicketBatchCreateItem[]
-  ): Array<KanbanTicketBatchCreateItem & { draft_key: string; title: string; project_id: string; depends_on: string[] }> {
+  ): Array<
+    KanbanTicketBatchCreateItem & {
+      draft_key: string
+      title: string
+      project_id: string
+      depends_on: string[]
+    }
+  > {
     if (drafts.length === 0) {
       throw new Error('Batch ticket creation requires at least one draft')
     }
@@ -403,6 +414,25 @@ export class DatabaseService {
       CREATE INDEX IF NOT EXISTS idx_connection_members_worktree ON connection_members(worktree_id);
     `)
 
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS saved_usage_accounts (
+        id TEXT PRIMARY KEY,
+        provider TEXT NOT NULL CHECK (provider IN ('anthropic','openai')),
+        email TEXT NOT NULL,
+        credentials_json TEXT NOT NULL,
+        last_usage_json TEXT DEFAULT NULL,
+        last_fetched_at TEXT DEFAULT NULL,
+        status TEXT NOT NULL DEFAULT 'ok' CHECK (status IN ('ok','stale','error')),
+        last_error TEXT DEFAULT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_usage_accounts_provider_email
+        ON saved_usage_accounts(provider, email);
+      CREATE INDEX IF NOT EXISTS idx_saved_usage_accounts_provider_created
+        ON saved_usage_accounts(provider, created_at);
+    `)
+
     this.safeAddColumn(
       'sessions',
       'connection_id',
@@ -519,6 +549,127 @@ export class DatabaseService {
   getAllSettings(): Setting[] {
     const db = this.getDb()
     return db.prepare('SELECT key, value FROM settings').all() as Setting[]
+  }
+
+  // Saved usage account operations
+  upsertSavedUsageAccount(data: SavedUsageAccountUpsert): SavedUsageAccount {
+    const db = this.getDb()
+    const now = new Date().toISOString()
+    const hasLastUsage = data.last_usage_json !== undefined
+    const hasStatus = data.status !== undefined
+    const hasLastError = data.last_error !== undefined
+
+    db.prepare(
+      `INSERT INTO saved_usage_accounts (
+         id, provider, email, credentials_json, last_usage_json, last_fetched_at,
+         status, last_error, created_at, updated_at
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(provider, email) DO UPDATE SET
+         credentials_json = excluded.credentials_json,
+         last_usage_json = CASE
+           WHEN ? THEN excluded.last_usage_json
+           ELSE saved_usage_accounts.last_usage_json
+         END,
+         last_fetched_at = CASE
+           WHEN ? THEN excluded.last_fetched_at
+           ELSE saved_usage_accounts.last_fetched_at
+         END,
+         status = CASE
+           WHEN ? THEN excluded.status
+           ELSE saved_usage_accounts.status
+         END,
+         last_error = CASE
+           WHEN ? THEN excluded.last_error
+           ELSE saved_usage_accounts.last_error
+         END,
+         updated_at = excluded.updated_at`
+    ).run(
+      randomUUID(),
+      data.provider,
+      data.email,
+      data.credentials_json,
+      data.last_usage_json ?? null,
+      hasLastUsage ? now : null,
+      data.status ?? 'ok',
+      data.last_error ?? null,
+      now,
+      now,
+      hasLastUsage ? 1 : 0,
+      hasLastUsage ? 1 : 0,
+      hasStatus ? 1 : 0,
+      hasLastError ? 1 : 0
+    )
+
+    const saved = this.getSavedUsageAccountByProviderEmail(data.provider, data.email)
+    if (!saved) {
+      throw new Error('Failed to upsert saved usage account')
+    }
+    return saved
+  }
+
+  updateSavedUsageAccountUsage(
+    id: string,
+    data: SavedUsageAccountUsageUpdate
+  ): SavedUsageAccount | null {
+    const db = this.getDb()
+    const now = new Date().toISOString()
+    db.prepare(
+      `UPDATE saved_usage_accounts
+       SET last_usage_json = ?,
+           last_fetched_at = ?,
+           status = ?,
+           last_error = ?,
+           updated_at = ?
+       WHERE id = ?`
+    ).run(data.last_usage_json, now, data.status, data.last_error ?? null, now, id)
+    return this.getSavedUsageAccountById(id)
+  }
+
+  updateSavedUsageAccountCredentials(
+    id: string,
+    credentialsJson: string
+  ): SavedUsageAccount | null {
+    const db = this.getDb()
+    const now = new Date().toISOString()
+    db.prepare(
+      `UPDATE saved_usage_accounts
+       SET credentials_json = ?, updated_at = ?
+       WHERE id = ?`
+    ).run(credentialsJson, now, id)
+    return this.getSavedUsageAccountById(id)
+  }
+
+  getSavedUsageAccountById(id: string): SavedUsageAccount | null {
+    const db = this.getDb()
+    const row = db.prepare('SELECT * FROM saved_usage_accounts WHERE id = ?').get(id) as
+      | SavedUsageAccount
+      | undefined
+    return row ?? null
+  }
+
+  getSavedUsageAccountByProviderEmail(
+    provider: SavedUsageProvider,
+    email: string
+  ): SavedUsageAccount | null {
+    const db = this.getDb()
+    const row = db
+      .prepare('SELECT * FROM saved_usage_accounts WHERE provider = ? AND email = ?')
+      .get(provider, email) as SavedUsageAccount | undefined
+    return row ?? null
+  }
+
+  getSavedUsageAccountsByProvider(provider: SavedUsageProvider): SavedUsageAccount[] {
+    const db = this.getDb()
+    return db
+      .prepare('SELECT * FROM saved_usage_accounts WHERE provider = ? ORDER BY created_at ASC')
+      .all(provider) as SavedUsageAccount[]
+  }
+
+  deleteSavedUsageAccount(id: string): boolean {
+    const db = this.getDb()
+    const result = db.prepare('DELETE FROM saved_usage_accounts WHERE id = ?').run(id)
+    return result.changes > 0
   }
 
   // Project operations
@@ -983,9 +1134,11 @@ export class DatabaseService {
     const db = this.getDb()
     const row = db.prepare('SELECT id FROM worktrees WHERE id = ?').get(worktreeId)
     if (!row) return { success: false, error: 'Worktree not found' }
-    db.prepare(
-      'UPDATE worktrees SET github_pr_number = ?, github_pr_url = ? WHERE id = ?'
-    ).run(prNumber, prUrl, worktreeId)
+    db.prepare('UPDATE worktrees SET github_pr_number = ?, github_pr_url = ? WHERE id = ?').run(
+      prNumber,
+      prUrl,
+      worktreeId
+    )
     return { success: true }
   }
 
@@ -1144,7 +1297,9 @@ export class DatabaseService {
 
   countActiveSessions(): number {
     const db = this.getDb()
-    const row = db.prepare("SELECT COUNT(*) as count FROM sessions WHERE status = 'active'").get() as { count: number } | undefined
+    const row = db
+      .prepare("SELECT COUNT(*) as count FROM sessions WHERE status = 'active'")
+      .get() as { count: number } | undefined
     return row?.count ?? 0
   }
 
@@ -1868,9 +2023,11 @@ export class DatabaseService {
     if (data.sort_order != null) {
       sortOrder = data.sort_order
     } else {
-      const maxRow = db.prepare(
-        'SELECT MAX(sort_order) as max_sort FROM kanban_tickets WHERE project_id = ? AND "column" = ? AND archived_at IS NULL'
-      ).get(data.project_id, column) as { max_sort: number | null } | undefined
+      const maxRow = db
+        .prepare(
+          'SELECT MAX(sort_order) as max_sort FROM kanban_tickets WHERE project_id = ? AND "column" = ? AND archived_at IS NULL'
+        )
+        .get(data.project_id, column) as { max_sort: number | null } | undefined
       sortOrder = (maxRow?.max_sort ?? -1) + 1
     }
     const description = data.description ?? null
@@ -2128,17 +2285,22 @@ export class DatabaseService {
     const existing = this.getKanbanTicket(id)
     if (!existing) return null
     const now = new Date().toISOString()
-    db.prepare('UPDATE kanban_tickets SET archived_at = ?, updated_at = ? WHERE id = ?')
-      .run(now, now, id)
+    db.prepare('UPDATE kanban_tickets SET archived_at = ?, updated_at = ? WHERE id = ?').run(
+      now,
+      now,
+      id
+    )
     return this.getKanbanTicket(id)
   }
 
   archiveAllDoneKanbanTickets(projectId: string): number {
     const db = this.getDb()
     const now = new Date().toISOString()
-    const result = db.prepare(
-      'UPDATE kanban_tickets SET archived_at = ?, updated_at = ? WHERE project_id = ? AND "column" = ? AND archived_at IS NULL'
-    ).run(now, now, projectId, 'done')
+    const result = db
+      .prepare(
+        'UPDATE kanban_tickets SET archived_at = ?, updated_at = ? WHERE project_id = ? AND "column" = ? AND archived_at IS NULL'
+      )
+      .run(now, now, projectId, 'done')
     return result.changes
   }
 
@@ -2147,8 +2309,10 @@ export class DatabaseService {
     const existing = this.getKanbanTicket(id)
     if (!existing) return null
     const now = new Date().toISOString()
-    db.prepare('UPDATE kanban_tickets SET archived_at = NULL, updated_at = ? WHERE id = ?')
-      .run(now, id)
+    db.prepare('UPDATE kanban_tickets SET archived_at = NULL, updated_at = ? WHERE id = ?').run(
+      now,
+      id
+    )
     return this.getKanbanTicket(id)
   }
 
@@ -2186,9 +2350,7 @@ export class DatabaseService {
   getKanbanTicketsBySession(sessionId: string): KanbanTicket[] {
     const db = this.getDb()
     const rows = db
-      .prepare(
-        'SELECT * FROM kanban_tickets WHERE current_session_id = ? ORDER BY sort_order ASC'
-      )
+      .prepare('SELECT * FROM kanban_tickets WHERE current_session_id = ? ORDER BY sort_order ASC')
       .all(sessionId) as Record<string, unknown>[]
     return rows.map((row) => this.mapKanbanTicketRow(row))
   }
@@ -2228,9 +2390,9 @@ export class DatabaseService {
   detachWorktreeFromTickets(worktreeId: string): number {
     const db = this.getDb()
     const now = new Date().toISOString()
-    const result = db.prepare(
-      'UPDATE kanban_tickets SET worktree_id = NULL, updated_at = ? WHERE worktree_id = ?'
-    ).run(now, worktreeId)
+    const result = db
+      .prepare('UPDATE kanban_tickets SET worktree_id = NULL, updated_at = ? WHERE worktree_id = ?')
+      .run(now, worktreeId)
     return result.changes
   }
 
@@ -2270,9 +2432,9 @@ export class DatabaseService {
       }
 
       // Fix 2: Check for existing dependency
-      const existing = db.prepare(
-        'SELECT 1 FROM ticket_dependencies WHERE dependent_id = ? AND blocker_id = ?'
-      ).get(dependentId, blockerId)
+      const existing = db
+        .prepare('SELECT 1 FROM ticket_dependencies WHERE dependent_id = ? AND blocker_id = ?')
+        .get(dependentId, blockerId)
       if (existing) {
         return { success: true } // Idempotent - already exists
       }
@@ -2376,9 +2538,9 @@ export class DatabaseService {
 
   getTicketFollowupMessages(ticketId: string): TicketFollowupMessage[] {
     const db = this.getDb()
-    const rows = db.prepare(
-      'SELECT * FROM ticket_followup_messages WHERE ticket_id = ? ORDER BY created_at ASC'
-    ).all(ticketId) as TicketFollowupMessage[]
+    const rows = db
+      .prepare('SELECT * FROM ticket_followup_messages WHERE ticket_id = ? ORDER BY created_at ASC')
+      .all(ticketId) as TicketFollowupMessage[]
     return rows
   }
 
@@ -2396,7 +2558,19 @@ export class DatabaseService {
     db.prepare(
       `INSERT INTO diff_comments (id, worktree_id, file_path, line_start, line_end, anchor_text, anchor_context_before, anchor_context_after, body, is_outdated, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`
-    ).run(id, data.worktree_id, data.file_path, data.line_start, lineEnd, anchorText, anchorContextBefore, anchorContextAfter, data.body, now, now)
+    ).run(
+      id,
+      data.worktree_id,
+      data.file_path,
+      data.line_start,
+      lineEnd,
+      anchorText,
+      anchorContextBefore,
+      anchorContextAfter,
+      data.body,
+      now,
+      now
+    )
 
     return {
       id,
@@ -2416,16 +2590,18 @@ export class DatabaseService {
 
   getDiffComment(id: string): DiffComment | null {
     const db = this.getDb()
-    const row = db.prepare('SELECT * FROM diff_comments WHERE id = ?').get(id) as Record<string, unknown> | undefined
+    const row = db.prepare('SELECT * FROM diff_comments WHERE id = ?').get(id) as
+      | Record<string, unknown>
+      | undefined
     if (!row) return null
     return this.mapDiffCommentRow(row)
   }
 
   getDiffCommentsByWorktree(worktreeId: string): DiffComment[] {
     const db = this.getDb()
-    const rows = db.prepare(
-      'SELECT * FROM diff_comments WHERE worktree_id = ? ORDER BY file_path, line_start'
-    ).all(worktreeId) as Record<string, unknown>[]
+    const rows = db
+      .prepare('SELECT * FROM diff_comments WHERE worktree_id = ? ORDER BY file_path, line_start')
+      .all(worktreeId) as Record<string, unknown>[]
     return rows.map((row) => this.mapDiffCommentRow(row))
   }
 

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -35,5 +35,10 @@ export type {
   TicketDependency,
   DiffComment,
   DiffCommentCreate,
-  DiffCommentUpdate
+  DiffCommentUpdate,
+  SavedUsageAccount,
+  SavedUsageAccountUpsert,
+  SavedUsageAccountUsageUpdate,
+  SavedUsageProvider,
+  SavedUsageStatus
 } from './types'

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 26
+export const CURRENT_SCHEMA_VERSION = 27
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -487,5 +487,32 @@ DROP TABLE IF EXISTS diff_comments;`
       ALTER TABLE kanban_tickets ADD COLUMN goal_success_criteria TEXT DEFAULT NULL;
     `,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 27,
+    name: 'add_saved_usage_accounts',
+    up: `
+      CREATE TABLE IF NOT EXISTS saved_usage_accounts (
+        id TEXT PRIMARY KEY,
+        provider TEXT NOT NULL CHECK (provider IN ('anthropic','openai')),
+        email TEXT NOT NULL,
+        credentials_json TEXT NOT NULL,
+        last_usage_json TEXT DEFAULT NULL,
+        last_fetched_at TEXT DEFAULT NULL,
+        status TEXT NOT NULL DEFAULT 'ok' CHECK (status IN ('ok','stale','error')),
+        last_error TEXT DEFAULT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_usage_accounts_provider_email
+        ON saved_usage_accounts(provider, email);
+      CREATE INDEX IF NOT EXISTS idx_saved_usage_accounts_provider_created
+        ON saved_usage_accounts(provider, created_at);
+    `,
+    down: `
+      DROP INDEX IF EXISTS idx_saved_usage_accounts_provider_created;
+      DROP INDEX IF EXISTS idx_saved_usage_accounts_provider_email;
+      DROP TABLE IF EXISTS saved_usage_accounts;
+    `
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -266,6 +266,37 @@ export interface ProjectSpaceAssignment {
   space_id: string
 }
 
+export type SavedUsageProvider = 'anthropic' | 'openai'
+export type SavedUsageStatus = 'ok' | 'stale' | 'error'
+
+export interface SavedUsageAccount {
+  id: string
+  provider: SavedUsageProvider
+  email: string
+  credentials_json: string
+  last_usage_json: string | null
+  last_fetched_at: string | null
+  status: SavedUsageStatus
+  last_error: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface SavedUsageAccountUpsert {
+  provider: SavedUsageProvider
+  email: string
+  credentials_json: string
+  last_usage_json?: string | null
+  status?: SavedUsageStatus
+  last_error?: string | null
+}
+
+export interface SavedUsageAccountUsageUpdate {
+  last_usage_json: string | null
+  status: SavedUsageStatus
+  last_error?: string | null
+}
+
 // Connection color quad: [inactiveBg, activeBg, inactiveText, activeText] stored as JSON string
 export type ConnectionColorQuad = [string, string, string, string]
 
@@ -493,9 +524,7 @@ export interface KanbanTicketBatchCreateResult {
 }
 
 export interface PendingLaunchConfig {
-  worktree:
-    | { type: 'new'; sourceBranch: string }
-    | { type: 'existing'; worktreeId: string }
+  worktree: { type: 'new'; sourceBranch: string } | { type: 'existing'; worktreeId: string }
   prompt: string
   mode: 'build' | 'plan' | 'super-plan'
   model: { providerID: string; modelID: string; variant?: string } | null

--- a/src/main/ipc/account-handlers.ts
+++ b/src/main/ipc/account-handlers.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 import { createLogger } from '../services'
 import { getClaudeAccountEmail, getOpenAIAccountEmail } from '../services/account-service'
+import { listSavedAccounts, removeSavedAccount } from '../services/saved-usage-orchestrator'
 import { defineHandler } from './_shared/define-handler'
 
 const log = createLogger({ component: 'AccountHandlers' })
@@ -32,6 +33,27 @@ export function registerAccountHandlers(): void {
     Effect.tryPromise({
       try: () => getOpenAIAccountEmail(),
       catch: (cause) => accountFailed('account:getOpenAIEmail', cause)
+    })
+  )
+
+  defineHandler('account:listSaved', z.enum(['anthropic', 'openai']).optional(), (provider) =>
+    Effect.try({
+      try: () => {
+        const accounts = listSavedAccounts(provider)
+        log.info('Listed saved usage accounts', {
+          provider: provider ?? 'all',
+          count: accounts.length
+        })
+        return accounts
+      },
+      catch: (cause) => accountFailed('account:listSaved', cause)
+    })
+  )
+
+  defineHandler('account:removeSaved', z.string(), (accountId) =>
+    Effect.try({
+      try: () => removeSavedAccount(accountId),
+      catch: (cause) => accountFailed('account:removeSaved', cause)
     })
   )
 }

--- a/src/main/ipc/usage-handlers.ts
+++ b/src/main/ipc/usage-handlers.ts
@@ -4,6 +4,11 @@ import { z } from 'zod'
 import { createLogger } from '../services'
 import { fetchClaudeUsage } from '../services/usage-service'
 import { fetchOpenAIUsage } from '../services/openai-usage-service'
+import {
+  captureLiveAccountFromFetch,
+  fetchForSavedAccount,
+  refreshAllForProvider
+} from '../services/saved-usage-orchestrator'
 import { defineHandler } from './_shared/define-handler'
 
 const log = createLogger({ component: 'UsageHandlers' })
@@ -24,15 +29,53 @@ export function registerUsageHandlers(): void {
 
   defineHandler('usage:fetch', z.tuple([]), () =>
     Effect.tryPromise({
-      try: () => fetchClaudeUsage(),
+      try: async () => {
+        const result = await fetchClaudeUsage()
+        if (result.success && result.data) {
+          try {
+            await captureLiveAccountFromFetch('anthropic', result.data)
+          } catch (error) {
+            log.warn('Failed to capture Claude saved usage account', {
+              error: error instanceof Error ? error.message : String(error)
+            })
+          }
+        }
+        return result
+      },
       catch: (cause) => usageFailed('usage:fetch', cause)
     })
   )
 
   defineHandler('usage:fetchOpenai', z.tuple([]), () =>
     Effect.tryPromise({
-      try: () => fetchOpenAIUsage(),
+      try: async () => {
+        const result = await fetchOpenAIUsage()
+        if (result.success && result.data) {
+          try {
+            await captureLiveAccountFromFetch('openai', result.data)
+          } catch (error) {
+            log.warn('Failed to capture OpenAI saved usage account', {
+              error: error instanceof Error ? error.message : String(error)
+            })
+          }
+        }
+        return result
+      },
       catch: (cause) => usageFailed('usage:fetchOpenai', cause)
+    })
+  )
+
+  defineHandler('usage:fetchForAccount', z.string(), (accountId) =>
+    Effect.tryPromise({
+      try: () => fetchForSavedAccount(accountId),
+      catch: (cause) => usageFailed('usage:fetchForAccount', cause)
+    })
+  )
+
+  defineHandler('usage:refreshAllForProvider', z.enum(['anthropic', 'openai']), (provider) =>
+    Effect.tryPromise({
+      try: () => refreshAllForProvider(provider),
+      catch: (cause) => usageFailed('usage:refreshAllForProvider', cause)
     })
   )
 }

--- a/src/main/services/openai-usage-service.ts
+++ b/src/main/services/openai-usage-service.ts
@@ -23,11 +23,19 @@ interface CodexAuthTokens {
   account_id: string
 }
 
-interface CodexAuth {
+export interface CodexAuth {
   OPENAI_API_KEY?: string | null
   auth_mode?: string | null
   tokens?: CodexAuthTokens
   last_refresh?: string
+}
+
+export interface OpenAIUsageOverride {
+  accessToken: string
+  refreshToken: string
+  accountId: string
+  idToken?: string
+  email?: string
 }
 
 interface RefreshResponse {
@@ -36,8 +44,15 @@ interface RefreshResponse {
   refresh_token?: string
 }
 
+interface RefreshResult {
+  accessToken: string
+  refreshToken: string
+  idToken?: string
+}
+
 /** Module-level promise to deduplicate concurrent refresh requests. */
 let refreshPromise: Promise<string> | null = null
+const inMemoryRefreshPromises = new Map<string, Promise<RefreshResult>>()
 
 /**
  * Read Codex credentials from the auth.json file.
@@ -79,7 +94,7 @@ async function readFromKeychain(): Promise<CodexAuth | null> {
 /**
  * Read Codex credentials. Tries auth.json first, then macOS Keychain as fallback.
  */
-async function readCodexCredentials(): Promise<CodexAuth | null> {
+export async function readCodexCredentials(): Promise<CodexAuth | null> {
   const fromFile = await readFromFile()
   if (fromFile?.tokens?.access_token) return fromFile
 
@@ -116,8 +131,44 @@ function isTokenExpired(accessToken: string): boolean {
 }
 
 /**
- * Refresh the access token using the refresh token.
- * Uses a module-level promise to deduplicate concurrent refresh requests.
+ * Refresh the access token using the given refresh token.
+ */
+async function requestTokenRefresh(refreshToken: string): Promise<RefreshResponse> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+
+  try {
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: CLIENT_ID,
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken
+      }),
+      signal: controller.signal
+    })
+
+    clearTimeout(timeout)
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(`Token refresh failed (${response.status}): ${body}`)
+    }
+
+    return (await response.json()) as RefreshResponse
+  } catch (error) {
+    clearTimeout(timeout)
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Token refresh timed out')
+    }
+    throw error
+  }
+}
+
+/**
+ * Refresh the live access token and persist the updated auth.json.
+ * Uses a module-level promise to deduplicate concurrent live refresh requests.
  */
 async function refreshAccessToken(auth: CodexAuth): Promise<string> {
   if (refreshPromise) return refreshPromise
@@ -127,54 +178,61 @@ async function refreshAccessToken(auth: CodexAuth): Promise<string> {
       throw new Error('No refresh token available')
     }
 
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), 10_000)
+    const data = await requestTokenRefresh(auth.tokens.refresh_token)
+
+    if (data.access_token) auth.tokens.access_token = data.access_token
+    if (data.refresh_token) auth.tokens.refresh_token = data.refresh_token
+    if (data.id_token) auth.tokens.id_token = data.id_token
+    auth.last_refresh = new Date().toISOString()
 
     try {
-      const response = await fetch(TOKEN_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          client_id: CLIENT_ID,
-          grant_type: 'refresh_token',
-          refresh_token: auth.tokens.refresh_token
-        }),
-        signal: controller.signal
-      })
-
-      clearTimeout(timeout)
-
-      if (!response.ok) {
-        const body = await response.text()
-        throw new Error(`Token refresh failed (${response.status}): ${body}`)
-      }
-
-      const data = (await response.json()) as RefreshResponse
-
-      if (data.access_token) auth.tokens.access_token = data.access_token
-      if (data.refresh_token) auth.tokens.refresh_token = data.refresh_token
-      if (data.id_token) auth.tokens.id_token = data.id_token
-      auth.last_refresh = new Date().toISOString()
-
-      try {
-        await writeFile(AUTH_FILE, JSON.stringify(auth, null, 2), { mode: 0o600 })
-      } catch {
-        // persist failed, continue with in-memory token
-      }
-
-      return auth.tokens.access_token
-    } catch (error) {
-      clearTimeout(timeout)
-      if (error instanceof Error && error.name === 'AbortError') {
-        throw new Error('Token refresh timed out')
-      }
-      throw error
+      await writeFile(AUTH_FILE, JSON.stringify(auth, null, 2), { mode: 0o600 })
+    } catch {
+      // persist failed, continue with in-memory token
     }
+
+    return auth.tokens.access_token
   })().finally(() => {
     refreshPromise = null
   })
 
   return refreshPromise
+}
+
+/**
+ * Refresh a saved account in memory only. Concurrent refreshes for the same
+ * account share the same HTTP request; different accounts refresh independently.
+ */
+export async function refreshAccessTokenInMemory(auth: CodexAuth): Promise<RefreshResult> {
+  if (!auth.tokens?.refresh_token) {
+    throw new Error('No refresh token available')
+  }
+  if (!auth.tokens.account_id) {
+    throw new Error('No account id available')
+  }
+
+  const accountId = auth.tokens.account_id
+  const existing = inMemoryRefreshPromises.get(accountId)
+  if (existing) return existing
+
+  const promise = (async () => {
+    const data = await requestTokenRefresh(auth.tokens!.refresh_token)
+    if (data.access_token) auth.tokens!.access_token = data.access_token
+    if (data.refresh_token) auth.tokens!.refresh_token = data.refresh_token
+    if (data.id_token) auth.tokens!.id_token = data.id_token
+    auth.last_refresh = new Date().toISOString()
+
+    return {
+      accessToken: auth.tokens!.access_token,
+      refreshToken: auth.tokens!.refresh_token,
+      idToken: typeof auth.tokens!.id_token === 'string' ? auth.tokens!.id_token : undefined
+    }
+  })().finally(() => {
+    inMemoryRefreshPromises.delete(accountId)
+  })
+
+  inMemoryRefreshPromises.set(accountId, promise)
+  return promise
 }
 
 /**
@@ -220,8 +278,18 @@ async function fetchUsage(
  * Fetch OpenAI usage data. Reads credentials, refreshes the token if expired,
  * calls the usage endpoint, and retries once on 401 after a forced refresh.
  */
-export async function fetchOpenAIUsage(): Promise<OpenAIUsageResult> {
-  const auth = await readCodexCredentials()
+export async function fetchOpenAIUsage(override?: OpenAIUsageOverride): Promise<OpenAIUsageResult> {
+  const auth: CodexAuth | null = override
+    ? {
+        auth_mode: 'chatgpt',
+        tokens: {
+          access_token: override.accessToken,
+          refresh_token: override.refreshToken,
+          account_id: override.accountId,
+          id_token: override.idToken ?? ''
+        }
+      }
+    : await readCodexCredentials()
   if (!auth?.tokens) {
     log.warn('No Codex credentials found (checked auth.json and keychain)')
     return { success: false, error: 'No Codex credentials found' }
@@ -229,11 +297,17 @@ export async function fetchOpenAIUsage(): Promise<OpenAIUsageResult> {
 
   let accessToken = auth.tokens.access_token
   const accountId = auth.tokens.account_id
+  let rotated: RefreshResult | undefined
 
   // Refresh if token is expired
   if (isTokenExpired(accessToken)) {
     try {
-      accessToken = await refreshAccessToken(auth)
+      if (override) {
+        rotated = await refreshAccessTokenInMemory(auth)
+        accessToken = rotated.accessToken
+      } else {
+        accessToken = await refreshAccessToken(auth)
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       log.warn('Failed to refresh OpenAI access token', { error: message })
@@ -247,7 +321,12 @@ export async function fetchOpenAIUsage(): Promise<OpenAIUsageResult> {
     // Retry once on 401 after forcing a refresh
     if (result.status === 401) {
       try {
-        accessToken = await refreshAccessToken(auth)
+        if (override) {
+          rotated = await refreshAccessTokenInMemory(auth)
+          accessToken = rotated.accessToken
+        } else {
+          accessToken = await refreshAccessToken(auth)
+        }
         result = await fetchUsage(accessToken, accountId)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
@@ -263,7 +342,7 @@ export async function fetchOpenAIUsage(): Promise<OpenAIUsageResult> {
     }
 
     const data = result.data as OpenAIUsageData
-    return { success: true, data }
+    return { success: true, data, rotated }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     log.warn('Failed to fetch OpenAI usage', { error: message })

--- a/src/main/services/saved-usage-orchestrator.ts
+++ b/src/main/services/saved-usage-orchestrator.ts
@@ -1,0 +1,262 @@
+import { getDatabase } from '../db'
+import { getClaudeAccountEmail, getOpenAIAccountEmail } from './account-service'
+import { createLogger } from './logger'
+import {
+  fetchOpenAIUsage,
+  readCodexCredentials,
+  type OpenAIUsageOverride
+} from './openai-usage-service'
+import { fetchClaudeUsage, readAccessToken } from './usage-service'
+import type {
+  FetchForAccountResult,
+  OpenAIUsageData,
+  RefreshAllResultItem,
+  SavedAccountDTO,
+  UsageData,
+  UsageProvider
+} from '@shared/types/usage'
+import type { SavedUsageAccount, SavedUsageProvider, SavedUsageStatus } from '../db/types'
+
+const log = createLogger({ component: 'SavedUsageOrchestrator' })
+
+interface ClaudeSavedCredentials {
+  accessToken: string
+  email: string
+}
+
+interface OpenAISavedCredentials extends OpenAIUsageOverride {
+  email: string
+}
+
+function safeParseJson(value: string): unknown {
+  return JSON.parse(value)
+}
+
+function parseLastUsage(row: SavedUsageAccount): UsageData | OpenAIUsageData | null {
+  if (!row.last_usage_json) return null
+  try {
+    return safeParseJson(row.last_usage_json) as UsageData | OpenAIUsageData
+  } catch {
+    return null
+  }
+}
+
+export function toSavedAccountDTO(row: SavedUsageAccount): SavedAccountDTO {
+  return {
+    id: row.id,
+    provider: row.provider,
+    email: row.email,
+    last_usage: parseLastUsage(row),
+    last_fetched_at: row.last_fetched_at,
+    status: row.status,
+    last_error: row.last_error,
+    created_at: row.created_at
+  }
+}
+
+export function listSavedAccounts(provider?: UsageProvider): SavedAccountDTO[] {
+  const db = getDatabase()
+  const providers: SavedUsageProvider[] = provider ? [provider] : ['anthropic', 'openai']
+  return providers.flatMap((p) => db.getSavedUsageAccountsByProvider(p).map(toSavedAccountDTO))
+}
+
+export function removeSavedAccount(accountId: string): boolean {
+  return getDatabase().deleteSavedUsageAccount(accountId)
+}
+
+export async function captureLiveAccountFromFetch(
+  provider: UsageProvider,
+  usage: UsageData | OpenAIUsageData
+): Promise<void> {
+  const db = getDatabase()
+
+  if (provider === 'anthropic') {
+    const [accessToken, email] = await Promise.all([readAccessToken(), getClaudeAccountEmail()])
+    if (!accessToken || !email) {
+      log.warn('Skipping Claude saved usage capture because token or email is unavailable')
+      return
+    }
+
+    const credentials: ClaudeSavedCredentials = { accessToken, email }
+    db.upsertSavedUsageAccount({
+      provider,
+      email,
+      credentials_json: JSON.stringify(credentials),
+      last_usage_json: JSON.stringify(usage),
+      status: 'ok',
+      last_error: null
+    })
+    log.info('Captured Claude saved usage account', { provider })
+    return
+  }
+
+  const [auth, email] = await Promise.all([readCodexCredentials(), getOpenAIAccountEmail()])
+  const tokens = auth?.tokens
+  if (!tokens?.access_token || !tokens.refresh_token || !tokens.account_id || !email) {
+    log.warn('Skipping OpenAI saved usage capture because credentials or email are unavailable')
+    return
+  }
+
+  const credentials: OpenAISavedCredentials = {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    accountId: tokens.account_id,
+    idToken: typeof tokens.id_token === 'string' ? tokens.id_token : undefined,
+    email
+  }
+  db.upsertSavedUsageAccount({
+    provider,
+    email,
+    credentials_json: JSON.stringify(credentials),
+    last_usage_json: JSON.stringify(usage),
+    status: 'ok',
+    last_error: null
+  })
+  log.info('Captured OpenAI saved usage account', { provider })
+}
+
+function isAuthStatusError(message: string): boolean {
+  return /\b(401|403)\b/.test(message)
+}
+
+function isOpenAIStaleError(message: string): boolean {
+  return (
+    isAuthStatusError(message) ||
+    message.includes('Token refresh failed') ||
+    message.includes('No refresh token available')
+  )
+}
+
+function accountError(
+  accountId: string,
+  message: string,
+  status: SavedUsageStatus = 'error',
+  lastUsageJson: string | null = null
+): FetchForAccountResult {
+  const db = getDatabase()
+  db.updateSavedUsageAccountUsage(accountId, {
+    last_usage_json: lastUsageJson,
+    status,
+    last_error: message
+  })
+  return { success: false, error: message, status }
+}
+
+function parseClaudeCredentials(row: SavedUsageAccount): ClaudeSavedCredentials | null {
+  const parsed = safeParseJson(row.credentials_json) as Partial<ClaudeSavedCredentials>
+  if (typeof parsed.accessToken !== 'string' || parsed.accessToken.length === 0) return null
+  return { accessToken: parsed.accessToken, email: row.email }
+}
+
+function parseOpenAICredentials(row: SavedUsageAccount): OpenAISavedCredentials | null {
+  const parsed = safeParseJson(row.credentials_json) as Partial<OpenAISavedCredentials>
+  if (
+    typeof parsed.accessToken !== 'string' ||
+    typeof parsed.refreshToken !== 'string' ||
+    typeof parsed.accountId !== 'string' ||
+    parsed.accessToken.length === 0 ||
+    parsed.refreshToken.length === 0 ||
+    parsed.accountId.length === 0
+  ) {
+    return null
+  }
+
+  return {
+    accessToken: parsed.accessToken,
+    refreshToken: parsed.refreshToken,
+    accountId: parsed.accountId,
+    idToken: typeof parsed.idToken === 'string' ? parsed.idToken : undefined,
+    email: row.email
+  }
+}
+
+export async function fetchForSavedAccount(accountId: string): Promise<FetchForAccountResult> {
+  const db = getDatabase()
+  const row = db.getSavedUsageAccountById(accountId)
+  if (!row) return { success: false, error: 'not found', status: 'error' }
+
+  try {
+    if (row.provider === 'anthropic') {
+      const credentials = parseClaudeCredentials(row)
+      if (!credentials)
+        return accountError(accountId, 'Invalid Claude credentials', 'error', row.last_usage_json)
+
+      const result = await fetchClaudeUsage(credentials.accessToken)
+      if (!result.success || !result.data) {
+        const message = result.error ?? 'Claude usage fetch failed'
+        const status: SavedUsageStatus = isAuthStatusError(message) ? 'stale' : 'error'
+        db.updateSavedUsageAccountUsage(accountId, {
+          last_usage_json: row.last_usage_json,
+          status,
+          last_error: message
+        })
+        return { success: false, error: message, status }
+      }
+
+      db.updateSavedUsageAccountUsage(accountId, {
+        last_usage_json: JSON.stringify(result.data),
+        status: 'ok',
+        last_error: null
+      })
+      return { success: true, data: result.data, status: 'ok' }
+    }
+
+    const credentials = parseOpenAICredentials(row)
+    if (!credentials) {
+      return accountError(accountId, 'Invalid OpenAI credentials', 'stale', row.last_usage_json)
+    }
+
+    const result = await fetchOpenAIUsage(credentials)
+    if (!result.success || !result.data) {
+      const message = result.error ?? 'OpenAI usage fetch failed'
+      const status: SavedUsageStatus = isOpenAIStaleError(message) ? 'stale' : 'error'
+      db.updateSavedUsageAccountUsage(accountId, {
+        last_usage_json: row.last_usage_json,
+        status,
+        last_error: message
+      })
+      return { success: false, error: message, status }
+    }
+
+    if (result.rotated) {
+      const rotatedCredentials: OpenAISavedCredentials = {
+        ...credentials,
+        accessToken: result.rotated.accessToken,
+        refreshToken: result.rotated.refreshToken,
+        idToken: result.rotated.idToken ?? credentials.idToken
+      }
+      db.updateSavedUsageAccountCredentials(accountId, JSON.stringify(rotatedCredentials))
+    }
+
+    db.updateSavedUsageAccountUsage(accountId, {
+      last_usage_json: JSON.stringify(result.data),
+      status: 'ok',
+      last_error: null
+    })
+    return { success: true, data: result.data, status: 'ok' }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return accountError(accountId, message, 'error', row.last_usage_json)
+  }
+}
+
+export async function refreshAllForProvider(
+  provider: UsageProvider
+): Promise<RefreshAllResultItem[]> {
+  const rows = getDatabase().getSavedUsageAccountsByProvider(provider)
+  return Promise.all(
+    rows.map(async (row) => {
+      try {
+        const result = await fetchForSavedAccount(row.id)
+        return {
+          accountId: row.id,
+          success: result.success,
+          error: result.error
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return { accountId: row.id, success: false, error: message }
+      }
+    })
+  )
+}

--- a/src/main/services/usage-service.ts
+++ b/src/main/services/usage-service.ts
@@ -57,14 +57,14 @@ async function readFromFile(): Promise<string | null> {
  * Read the Claude OAuth access token.
  * Tries macOS Keychain first (v2.x), then falls back to credentials file.
  */
-async function readAccessToken(): Promise<string | null> {
+export async function readAccessToken(): Promise<string | null> {
   const token = await readFromKeychain()
   if (token) return token
   return readFromFile()
 }
 
-export async function fetchClaudeUsage(): Promise<UsageResult> {
-  const token = await readAccessToken()
+export async function fetchClaudeUsage(overrideToken?: string): Promise<UsageResult> {
+  const token = overrideToken ?? (await readAccessToken())
   if (!token) {
     log.warn('No Claude OAuth access token found (checked keychain and credentials file)')
     return { success: false, error: 'No access token found' }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1758,10 +1758,20 @@ declare global {
     usageOps: {
       fetch: () => Promise<Envelope<import('../shared/types/usage').UsageResult>>
       fetchOpenai: () => Promise<Envelope<import('../shared/types/usage').OpenAIUsageResult>>
+      fetchForAccount: (
+        accountId: string
+      ) => Promise<Envelope<import('../shared/types/usage').FetchForAccountResult>>
+      refreshAllForProvider: (
+        provider: import('../shared/types/usage').UsageProvider
+      ) => Promise<Envelope<import('../shared/types/usage').RefreshAllResultItem[]>>
     }
     accountOps: {
       getClaudeEmail: () => Promise<Envelope<string | null>>
       getOpenAIEmail: () => Promise<Envelope<string | null>>
+      listSaved: (
+        provider?: import('../shared/types/usage').UsageProvider
+      ) => Promise<Envelope<import('../shared/types/usage').SavedAccountDTO[]>>
+      removeSaved: (accountId: string) => Promise<Envelope<boolean>>
     }
     analyticsOps: {
       track: (event: string, properties?: Record<string, unknown>) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2260,6 +2260,14 @@ const usageOps = {
   fetchOpenai: () =>
     ipcRenderer.invoke('usage:fetchOpenai') as Promise<
       Envelope<import('../shared/types/usage').OpenAIUsageResult>
+    >,
+  fetchForAccount: (accountId: string) =>
+    ipcRenderer.invoke('usage:fetchForAccount', accountId) as Promise<
+      Envelope<import('../shared/types/usage').FetchForAccountResult>
+    >,
+  refreshAllForProvider: (provider: import('../shared/types/usage').UsageProvider) =>
+    ipcRenderer.invoke('usage:refreshAllForProvider', provider) as Promise<
+      Envelope<import('../shared/types/usage').RefreshAllResultItem[]>
     >
 }
 
@@ -2267,7 +2275,13 @@ const accountOps = {
   getClaudeEmail: (): Promise<Envelope<string | null>> =>
     ipcRenderer.invoke('account:getClaudeEmail'),
   getOpenAIEmail: (): Promise<Envelope<string | null>> =>
-    ipcRenderer.invoke('account:getOpenAIEmail')
+    ipcRenderer.invoke('account:getOpenAIEmail'),
+  listSaved: (provider?: import('../shared/types/usage').UsageProvider) =>
+    ipcRenderer.invoke('account:listSaved', provider) as Promise<
+      Envelope<import('../shared/types/usage').SavedAccountDTO[]>
+    >,
+  removeSaved: (accountId: string): Promise<Envelope<boolean>> =>
+    ipcRenderer.invoke('account:removeSaved', accountId)
 }
 
 const perfDiagnosticsOps = {

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -1,11 +1,24 @@
 import React, { useEffect } from 'react'
-import { useUsageStore, useAccountStore, useSessionStore, resolveUsageProvider, resolveDefaultUsageProvider, normalizeUsage } from '@/stores'
+import {
+  useUsageStore,
+  useAccountStore,
+  useSessionStore,
+  resolveUsageProvider,
+  resolveDefaultUsageProvider,
+  normalizeUsage
+} from '@/stores'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { Loader2 } from 'lucide-react'
 import claudeIcon from '@/assets/model-icons/claude.svg'
 import openaiIcon from '@/assets/model-icons/openai.svg'
-import type { UsageProvider } from '@shared/types/usage'
+import type {
+  OpenAIUsageData,
+  SavedAccountDTO,
+  UsageData,
+  UsageProvider
+} from '@shared/types/usage'
 
 function getBarColor(percent: number): string {
   if (percent >= 90) return 'bg-red-500'
@@ -72,9 +85,77 @@ function UsageRow({ label, percent, resetTime }: UsageRowProps): React.JSX.Eleme
   )
 }
 
-function findSessionById(
-  sessionId: string
-): {
+interface TooltipAccountRow {
+  id: string
+  email: string | null
+  usage: UsageData | null
+  status: 'ok' | 'stale' | 'error'
+  lastError: string | null
+  isActive: boolean
+  isRefreshing: boolean
+}
+
+function usageFromSavedAccount(
+  provider: UsageProvider,
+  account: SavedAccountDTO
+): UsageData | null {
+  if (!account.last_usage) return null
+  if (provider === 'anthropic') {
+    return normalizeUsage(provider, account.last_usage as UsageData, null)
+  }
+  return normalizeUsage(provider, null, account.last_usage as OpenAIUsageData)
+}
+
+function UsageTooltipAccountRow({ row }: { row: TooltipAccountRow }): React.JSX.Element {
+  const fiveHourPercent = row.usage ? Math.round(row.usage.five_hour.utilization) : 0
+  const sevenDayPercent = row.usage ? Math.round(row.usage.seven_day.utilization) : 0
+  const fiveHourReset = row.usage
+    ? formatResetTime(row.usage.five_hour.resets_at, 'five_hour')
+    : 'N/A'
+  const sevenDayReset = row.usage
+    ? formatResetTime(row.usage.seven_day.resets_at, 'seven_day')
+    : 'N/A'
+
+  return (
+    <div className="relative rounded-md border border-border/50 bg-background/40 px-2 py-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={cn(
+            'min-w-0 truncate text-[11px] text-foreground',
+            row.isActive && 'font-semibold'
+          )}
+        >
+          {row.email ?? 'Active account'}
+        </div>
+        {row.isActive && (
+          <span className="shrink-0 rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-medium text-primary">
+            Active
+          </span>
+        )}
+      </div>
+
+      {row.status === 'stale' && (
+        <div className="mt-1 text-[10px] text-destructive">expired - sign in again</div>
+      )}
+      {row.status === 'error' && row.lastError && (
+        <div className="mt-1 truncate text-[10px] text-destructive/90">{row.lastError}</div>
+      )}
+
+      <div className={cn('mt-1 space-y-0.5', row.status === 'stale' && 'opacity-50')}>
+        <UsageRow label="5h" percent={fiveHourPercent} resetTime={fiveHourReset} />
+        <UsageRow label="7d" percent={sevenDayPercent} resetTime={sevenDayReset} />
+      </div>
+
+      {row.isRefreshing && (
+        <div className="absolute inset-0 flex items-center justify-center rounded-md bg-background/60">
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function findSessionById(sessionId: string): {
   agent_sdk?: string | null
   model_provider_id?: string | null
   model_id?: string | null
@@ -112,10 +193,18 @@ function ProviderUsageBlock({
   const anthropicUsage = useUsageStore((s) => s.anthropicUsage)
   const openaiUsage = useUsageStore((s) => s.openaiUsage)
   const forceRefreshProvider = useUsageStore((s) => s.forceRefreshProvider)
+  const refreshAllForProvider = useUsageStore((s) => s.refreshAllForProvider)
+  const loadSavedAccounts = useUsageStore((s) => s.loadSavedAccounts)
+  const savedAccounts = useUsageStore((s) => s.savedAccounts[provider])
+  const savedAccountLoadError = useUsageStore((s) => s.savedAccountLoadErrors[provider])
+  const refreshingProvider = useUsageStore((s) => s.refreshingProviders[provider])
+  const refreshingAccountIds = useUsageStore((s) => s.refreshingAccountIds)
   const isLoading = useUsageStore((s) =>
     provider === 'anthropic' ? s.anthropicIsLoading : s.openaiIsLoading
   )
-  const email = useAccountStore((s) => provider === 'anthropic' ? s.anthropicEmail : s.openaiEmail)
+  const email = useAccountStore((s) =>
+    provider === 'anthropic' ? s.anthropicEmail : s.openaiEmail
+  )
   const fetchEmail = useAccountStore((s) => s.fetchEmail)
 
   const usage = normalizeUsage(provider, anthropicUsage, openaiUsage)
@@ -123,6 +212,48 @@ function ProviderUsageBlock({
   const providerIcon = provider === 'anthropic' ? claudeIcon : openaiIcon
   const providerLabel = provider === 'anthropic' ? 'Claude' : 'OpenAI'
   const tooltipTitle = provider === 'anthropic' ? 'Claude API Usage' : 'OpenAI API Usage'
+  const iconIsRefreshing = isLoading || refreshingProvider
+
+  const tooltipRows: TooltipAccountRow[] =
+    savedAccounts.length > 0
+      ? savedAccounts.map((account) => ({
+          id: account.id,
+          email: account.email,
+          usage: usageFromSavedAccount(provider, account),
+          status: account.status,
+          lastError: account.last_error,
+          isActive: email !== null && account.email === email,
+          isRefreshing: refreshingAccountIds.has(account.id)
+        }))
+      : [
+          {
+            id: `${provider}-active`,
+            email,
+            usage,
+            status: 'ok',
+            lastError: null,
+            isActive: !!email,
+            isRefreshing: false
+          }
+        ]
+
+  const handleRefreshActive = (): void => {
+    forceRefreshProvider(provider)
+    fetchEmail(provider)
+  }
+
+  const handleRefreshAll = (event: React.MouseEvent): void => {
+    event.preventDefault()
+    refreshAllForProvider(provider)
+  }
+
+  const handleLoadSavedAccounts = (): void => {
+    loadSavedAccounts(provider).catch(() => {})
+  }
+
+  useEffect(() => {
+    loadSavedAccounts(provider).catch(() => {})
+  }, [loadSavedAccounts, provider])
 
   // No credentials state — show muted N/A bars when explicitly selected
   if (!usage) {
@@ -130,12 +261,17 @@ function ProviderUsageBlock({
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="px-3 py-1.5 space-y-0.5 cursor-default opacity-40">
+          <div
+            className="px-3 py-1.5 space-y-0.5 cursor-default opacity-40"
+            onMouseEnter={handleLoadSavedAccounts}
+            onFocus={handleLoadSavedAccounts}
+          >
             <div className="flex items-center gap-1.5">
               <button
                 type="button"
                 className="shrink-0 cursor-pointer bg-transparent border-none p-0"
-                onClick={() => { forceRefreshProvider(provider); fetchEmail(provider) }}
+                onClick={handleRefreshActive}
+                onContextMenu={handleRefreshAll}
                 aria-label={`Refresh ${providerLabel} usage`}
               >
                 <img
@@ -143,7 +279,7 @@ function ProviderUsageBlock({
                   alt={providerLabel}
                   className={cn(
                     'h-3 w-3 opacity-50 hover:opacity-80 transition-opacity',
-                    isLoading && 'animate-spin'
+                    iconIsRefreshing && 'animate-spin'
                   )}
                 />
               </button>
@@ -154,10 +290,23 @@ function ProviderUsageBlock({
             </div>
           </div>
         </TooltipTrigger>
-        <TooltipContent side="top" sideOffset={8}>
-          <div className="space-y-1">
+        <TooltipContent
+          side="top"
+          sideOffset={8}
+          className="w-72 max-w-[min(18rem,calc(100vw-2rem))]"
+        >
+          <div className="space-y-2">
             <div className="font-medium">{tooltipTitle}</div>
-            <div className="text-[10px]">No credentials configured</div>
+            {savedAccountLoadError && (
+              <div className="rounded-md border border-destructive/30 bg-destructive/10 px-2 py-1 text-[10px] text-destructive">
+                Saved accounts unavailable: {savedAccountLoadError}
+              </div>
+            )}
+            {tooltipRows.some((row) => row.email || row.usage) ? (
+              tooltipRows.map((row) => <UsageTooltipAccountRow key={row.id} row={row} />)
+            ) : (
+              <div className="text-[10px]">No credentials configured</div>
+            )}
           </div>
         </TooltipContent>
       </Tooltip>
@@ -173,12 +322,17 @@ function ProviderUsageBlock({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div className="px-3 py-1.5 space-y-0.5 cursor-default">
+        <div
+          className="px-3 py-1.5 space-y-0.5 cursor-default"
+          onMouseEnter={handleLoadSavedAccounts}
+          onFocus={handleLoadSavedAccounts}
+        >
           <div className="flex items-center gap-1.5">
             <button
               type="button"
               className="shrink-0 cursor-pointer bg-transparent border-none p-0"
-              onClick={() => { forceRefreshProvider(provider); fetchEmail(provider) }}
+              onClick={handleRefreshActive}
+              onContextMenu={handleRefreshAll}
               aria-label={`Refresh ${providerLabel} usage`}
             >
               <img
@@ -186,7 +340,7 @@ function ProviderUsageBlock({
                 alt={providerLabel}
                 className={cn(
                   'h-3 w-3 opacity-50 hover:opacity-80 transition-opacity',
-                  isLoading && 'animate-spin'
+                  iconIsRefreshing && 'animate-spin'
                 )}
               />
             </button>
@@ -197,20 +351,25 @@ function ProviderUsageBlock({
           </div>
         </div>
       </TooltipTrigger>
-      <TooltipContent side="top" sideOffset={8}>
-        <div className="space-y-1">
+      <TooltipContent
+        side="top"
+        sideOffset={8}
+        className="w-72 max-w-[min(18rem,calc(100vw-2rem))]"
+      >
+        <div className="space-y-2">
           <div className="font-medium">{tooltipTitle}</div>
-          {email && <div className="text-[10px] text-muted-foreground">{email}</div>}
-          <div className="text-[10px]">
-            5-hour: {Math.round(fiveHourPercent)}% (resets {fiveHourReset})
-          </div>
-          <div className="text-[10px]">
-            7-day: {Math.round(sevenDayPercent)}% (resets {sevenDayReset})
-          </div>
+          {savedAccountLoadError && (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 px-2 py-1 text-[10px] text-destructive">
+              Saved accounts unavailable: {savedAccountLoadError}
+            </div>
+          )}
+          {tooltipRows.map((row) => (
+            <UsageTooltipAccountRow key={row.id} row={row} />
+          ))}
           {provider === 'anthropic' && extra?.is_enabled && (
             <div className="border-t border-background/20 pt-1 text-[10px]">
-              Extra: ${(extra.used_credits ?? 0).toFixed(2)} / ${(extra.monthly_limit ?? 0).toFixed(2)} used (
-              {Math.round(extra.utilization ?? 0)}%)
+              Extra: ${(extra.used_credits ?? 0).toFixed(2)} / $
+              {(extra.monthly_limit ?? 0).toFixed(2)} used ({Math.round(extra.utilization ?? 0)}%)
             </div>
           )}
         </div>
@@ -225,6 +384,7 @@ export function UsageIndicator(): React.JSX.Element | null {
 
   const activeProvider = useUsageStore((s) => s.activeProvider)
   const fetchUsageForProvider = useUsageStore((s) => s.fetchUsageForProvider)
+  const loadSavedAccounts = useUsageStore((s) => s.loadSavedAccounts)
   const setActiveProvider = useUsageStore((s) => s.setActiveProvider)
   const fetchEmail = useAccountStore((s) => s.fetchEmail)
 
@@ -256,10 +416,11 @@ export function UsageIndicator(): React.JSX.Element | null {
       useSettingsStore.getState()
     const current = useUsageStore.getState().activeProvider
     getVisibleProviders(mode, selected, current).forEach((p) => {
+      loadSavedAccounts(p).catch(() => {})
       fetchUsageForProvider(p)
       fetchEmail(p)
     })
-  }, [activeSessionId, setActiveProvider, fetchUsageForProvider, fetchEmail])
+  }, [activeSessionId, setActiveProvider, fetchUsageForProvider, fetchEmail, loadSavedAccounts])
 
   const visibleProviders = getVisibleProviders(
     usageIndicatorMode,

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -1,15 +1,116 @@
+import { useEffect } from 'react'
 import { useThemeStore } from '@/stores/useThemeStore'
 import { DEFAULT_THEME_ID } from '@/lib/themes'
 import { useSettingsStore } from '@/stores/useSettingsStore'
-import { RotateCcw } from 'lucide-react'
+import { RotateCcw, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { useShortcutStore } from '@/stores/useShortcutStore'
+import { useAccountStore, useUsageStore } from '@/stores'
 import { toast } from '@/lib/toast'
 import type { UsageProvider } from '@shared/types/usage'
 import claudeIcon from '@/assets/model-icons/claude.svg'
 import openaiIcon from '@/assets/model-icons/openai.svg'
 import { isAgentSdkAvailable } from '@/lib/agent-sdk-availability'
+
+const SAVED_ACCOUNT_PROVIDERS: UsageProvider[] = ['anthropic', 'openai']
+
+function SavedAccountsList(): React.JSX.Element {
+  const savedAccounts = useUsageStore((s) => s.savedAccounts)
+  const loadSavedAccounts = useUsageStore((s) => s.loadSavedAccounts)
+  const removeSavedAccount = useUsageStore((s) => s.removeSavedAccount)
+  const anthropicEmail = useAccountStore((s) => s.anthropicEmail)
+  const openaiEmail = useAccountStore((s) => s.openaiEmail)
+  const fetchEmail = useAccountStore((s) => s.fetchEmail)
+
+  useEffect(() => {
+    loadSavedAccounts().catch(() => {})
+    fetchEmail('anthropic')
+    fetchEmail('openai')
+  }, [loadSavedAccounts, fetchEmail])
+
+  const activeEmails: Record<UsageProvider, string | null> = {
+    anthropic: anthropicEmail,
+    openai: openaiEmail
+  }
+
+  return (
+    <div className="mt-4 space-y-3 border-t border-border/60 pt-4">
+      <div>
+        <div className="text-sm font-medium">Saved accounts</div>
+        <p className="text-xs text-muted-foreground">
+          Remove accounts from the usage popup without signing out of provider CLIs.
+        </p>
+      </div>
+
+      {SAVED_ACCOUNT_PROVIDERS.map((provider) => {
+        const providerAccounts = savedAccounts[provider]
+        const icon = provider === 'anthropic' ? claudeIcon : openaiIcon
+        const label = provider === 'anthropic' ? 'Claude' : 'OpenAI'
+
+        return (
+          <div key={provider} className="space-y-2">
+            <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+              <img src={icon} alt={label} className="h-3.5 w-3.5" />
+              {label}
+            </div>
+
+            {providerAccounts.length === 0 ? (
+              <div className="rounded-md border border-border/60 px-3 py-2 text-xs text-muted-foreground">
+                No saved accounts yet. Use Claude or Codex to capture one.
+              </div>
+            ) : (
+              <div className="space-y-1.5">
+                {providerAccounts.map((account) => {
+                  const isActive = activeEmails[provider] === account.email
+                  const isExpired = account.status === 'stale'
+                  return (
+                    <div
+                      key={account.id}
+                      className="flex items-center justify-between gap-3 rounded-md border border-border/60 px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <div className={cn('truncate text-sm', isActive && 'font-semibold')}>
+                          {account.email}
+                        </div>
+                        <div className="mt-1 flex items-center gap-1.5">
+                          {isActive && (
+                            <span className="rounded-full bg-primary/15 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                              Active
+                            </span>
+                          )}
+                          {isExpired && (
+                            <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-medium text-destructive">
+                              Expired
+                            </span>
+                          )}
+                          {account.status === 'error' && (
+                            <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-medium text-destructive">
+                              Error
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                        onClick={() => removeSavedAccount(account.id)}
+                        aria-label={`Remove ${account.email}`}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
 
 export function SettingsGeneral(): React.JSX.Element {
   const { setTheme } = useThemeStore()
@@ -146,9 +247,7 @@ export function SettingsGeneral(): React.JSX.Element {
       {/* Board Mode */}
       <div className="space-y-2">
         <label className="text-sm font-medium">Board Mode</label>
-        <p className="text-xs text-muted-foreground">
-          Choose how the Kanban board is accessed.
-        </p>
+        <p className="text-xs text-muted-foreground">Choose how the Kanban board is accessed.</p>
         <div className="flex gap-2">
           <button
             onClick={() => updateSetting('boardMode', 'toggle')}
@@ -243,7 +342,8 @@ export function SettingsGeneral(): React.JSX.Element {
         <div>
           <label className="text-sm font-medium">Keep computer awake during sessions</label>
           <p className="text-xs text-muted-foreground">
-            Prevent your computer from sleeping while any worktree has an AI session actively running.
+            Prevent your computer from sleeping while any worktree has an AI session actively
+            running.
           </p>
         </div>
         <button
@@ -396,7 +496,8 @@ export function SettingsGeneral(): React.JSX.Element {
       <div className="space-y-2">
         <label className="text-sm font-medium">Usage indicator</label>
         <p className="text-xs text-muted-foreground">
-          Choose how usage is displayed. Current agent auto-detects from the active session. Specific providers lets you pin which usage bars always show.
+          Choose how usage is displayed. Current agent auto-detects from the active session.
+          Specific providers lets you pin which usage bars always show.
         </p>
         <div className="flex gap-2">
           <button
@@ -463,6 +564,7 @@ export function SettingsGeneral(): React.JSX.Element {
             )}
           </div>
         )}
+        <SavedAccountsList />
       </div>
 
       {/* Default Agent SDK */}

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand'
-import type { UsageData, OpenAIUsageData, UsageProvider } from '@shared/types/usage'
+import type {
+  UsageData,
+  OpenAIUsageData,
+  UsageProvider,
+  SavedAccountDTO
+} from '@shared/types/usage'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 
 export type { UsageData, UsageProvider }
@@ -14,7 +19,15 @@ interface UsageState {
   openaiIsLoading: boolean
 
   activeProvider: UsageProvider
+  savedAccounts: Record<UsageProvider, SavedAccountDTO[]>
+  savedAccountLoadErrors: Record<UsageProvider, string | null>
+  refreshingProviders: Record<UsageProvider, boolean>
+  refreshingAccountIds: Set<string>
 
+  loadSavedAccounts: (provider?: UsageProvider) => Promise<void>
+  refreshAllForProvider: (provider: UsageProvider) => Promise<void>
+  refreshSavedAccount: (id: string) => Promise<void>
+  removeSavedAccount: (id: string) => Promise<void>
   fetchUsageForProvider: (provider: UsageProvider) => Promise<void>
   forceRefreshProvider: (provider: UsageProvider) => Promise<void>
   setActiveProvider: (provider: UsageProvider) => void
@@ -33,6 +46,94 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
   openaiIsLoading: false,
 
   activeProvider: 'anthropic',
+  savedAccounts: { anthropic: [], openai: [] },
+  savedAccountLoadErrors: { anthropic: null, openai: null },
+  refreshingProviders: { anthropic: false, openai: false },
+  refreshingAccountIds: new Set<string>(),
+
+  loadSavedAccounts: async (provider?: UsageProvider) => {
+    try {
+      const accounts = unwrapEnvelope(await window.accountOps.listSaved(provider))
+      if (provider) {
+        set((state) => ({
+          savedAccounts: { ...state.savedAccounts, [provider]: accounts },
+          savedAccountLoadErrors: { ...state.savedAccountLoadErrors, [provider]: null }
+        }))
+        return
+      }
+
+      set({
+        savedAccounts: {
+          anthropic: accounts.filter((account) => account.provider === 'anthropic'),
+          openai: accounts.filter((account) => account.provider === 'openai')
+        },
+        savedAccountLoadErrors: { anthropic: null, openai: null }
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (provider) {
+        set((state) => ({
+          savedAccountLoadErrors: { ...state.savedAccountLoadErrors, [provider]: message }
+        }))
+      } else {
+        set({
+          savedAccountLoadErrors: { anthropic: message, openai: message }
+        })
+      }
+      throw error
+    }
+  },
+
+  refreshAllForProvider: async (provider: UsageProvider) => {
+    const state = get()
+    if (state.refreshingProviders[provider]) return
+
+    const accountIds = state.savedAccounts[provider].map((account) => account.id)
+    set((current) => ({
+      refreshingProviders: { ...current.refreshingProviders, [provider]: true },
+      refreshingAccountIds: new Set([...current.refreshingAccountIds, ...accountIds])
+    }))
+
+    try {
+      unwrapEnvelope(await window.usageOps.refreshAllForProvider(provider))
+      await get().loadSavedAccounts(provider)
+    } finally {
+      set((current) => {
+        const nextIds = new Set(current.refreshingAccountIds)
+        accountIds.forEach((id) => nextIds.delete(id))
+        return {
+          refreshingProviders: { ...current.refreshingProviders, [provider]: false },
+          refreshingAccountIds: nextIds
+        }
+      })
+    }
+  },
+
+  refreshSavedAccount: async (id: string) => {
+    const state = get()
+    const provider = (['anthropic', 'openai'] as UsageProvider[]).find((p) =>
+      state.savedAccounts[p].some((account) => account.id === id)
+    )
+
+    set((current) => ({
+      refreshingAccountIds: new Set([...current.refreshingAccountIds, id])
+    }))
+    try {
+      unwrapEnvelope(await window.usageOps.fetchForAccount(id))
+      await get().loadSavedAccounts(provider)
+    } finally {
+      set((current) => {
+        const nextIds = new Set(current.refreshingAccountIds)
+        nextIds.delete(id)
+        return { refreshingAccountIds: nextIds }
+      })
+    }
+  },
+
+  removeSavedAccount: async (id: string) => {
+    unwrapEnvelope(await window.accountOps.removeSaved(id))
+    await get().loadSavedAccounts()
+  },
 
   fetchUsageForProvider: async (provider: UsageProvider) => {
     const state = get()
@@ -47,6 +148,9 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
         const result = unwrapEnvelope(await window.usageOps.fetch())
         if (result.success) {
           set({ anthropicUsage: result.data ?? null })
+          get()
+            .loadSavedAccounts(provider)
+            .catch(() => {})
         }
       } finally {
         set({ anthropicIsLoading: false, anthropicLastFetchedAt: Date.now() })
@@ -60,6 +164,9 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
         const result = unwrapEnvelope(await window.usageOps.fetchOpenai())
         if (result.success) {
           set({ openaiUsage: result.data ?? null })
+          get()
+            .loadSavedAccounts(provider)
+            .catch(() => {})
         }
       } finally {
         set({ openaiIsLoading: false, openaiLastFetchedAt: Date.now() })
@@ -78,6 +185,9 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
         const result = unwrapEnvelope(await window.usageOps.fetch())
         if (result.success) {
           set({ anthropicUsage: result.data ?? null })
+          get()
+            .loadSavedAccounts(provider)
+            .catch(() => {})
         }
       } finally {
         set({ anthropicIsLoading: false, anthropicLastFetchedAt: Date.now() })
@@ -90,6 +200,9 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
         const result = unwrapEnvelope(await window.usageOps.fetchOpenai())
         if (result.success) {
           set({ openaiUsage: result.data ?? null })
+          get()
+            .loadSavedAccounts(provider)
+            .catch(() => {})
         }
       } finally {
         set({ openaiIsLoading: false, openaiLastFetchedAt: Date.now() })

--- a/src/shared/types/usage.ts
+++ b/src/shared/types/usage.ts
@@ -16,6 +16,7 @@ export interface UsageResult {
 }
 
 export type UsageProvider = 'anthropic' | 'openai'
+export type SavedUsageStatus = 'ok' | 'stale' | 'error'
 
 export interface OpenAIUsageData {
   plan_type: string
@@ -39,5 +40,34 @@ export interface OpenAIUsageData {
 export interface OpenAIUsageResult {
   success: boolean
   data?: OpenAIUsageData
+  error?: string
+  rotated?: {
+    accessToken: string
+    refreshToken: string
+    idToken?: string
+  }
+}
+
+export interface SavedAccountDTO {
+  id: string
+  provider: UsageProvider
+  email: string
+  last_usage: UsageData | OpenAIUsageData | null
+  last_fetched_at: string | null
+  status: SavedUsageStatus
+  last_error: string | null
+  created_at: string
+}
+
+export interface FetchForAccountResult {
+  success: boolean
+  data?: UsageData | OpenAIUsageData
+  error?: string
+  status: SavedUsageStatus
+}
+
+export interface RefreshAllResultItem {
+  accountId: string
+  success: boolean
   error?: string
 }


### PR DESCRIPTION
## Summary
- Add persistence for saved usage accounts, including provider, email, credentials, last usage payload, refresh time, and status.
- Capture live Claude and OpenAI usage fetches into the new saved-accounts store and expose IPC handlers to list, remove, fetch, and refresh saved accounts.
- Extend OpenAI usage fetching to support in-memory token rotation for saved accounts without rewriting the on-disk auth file.
- Update the renderer usage indicator and settings UI to surface saved accounts and refresh state.

## Testing
- Not run
- Verify saved Claude and OpenAI accounts appear in Settings and can be refreshed individually.
- Verify the usage indicator updates after a successful fetch and reflects stale/error states when credentials are invalid.
- Verify removing a saved account deletes it from the UI and the local database.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persistence + IPC flows for storing provider credentials/usage snapshots and introduces in-memory OpenAI token rotation, which touches auth-like data handling and DB migrations but is scoped to local storage.
> 
> **Overview**
> Adds a new SQLite-backed `saved_usage_accounts` store (schema v27) plus typed DB APIs to upsert, query, update usage/credentials, and delete saved accounts.
> 
> Introduces a `saved-usage-orchestrator` that captures live usage fetches into the store, fetches/refreshes usage for a specific saved account or all accounts for a provider, and maps stale/error states based on auth failures.
> 
> Extends OpenAI usage fetching to accept per-account credential overrides and return rotated tokens, using a per-account in-memory refresh de-duplication path (avoids rewriting `auth.json` for saved accounts). Adds IPC endpoints and renderer updates so the usage indicator and Settings can show saved accounts, refresh state, and allow removal/refresh-all.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae982ef12321a72a808182a11d44f70f67bcea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->