### PR TITLE
Add Codex transcript refresh from thread file

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -1694,6 +1694,12 @@ export class DatabaseService {
       .all(sessionId) as SessionActivity[]
   }
 
+  deleteSessionActivities(sessionId: string): number {
+    const db = this.getDb()
+    const result = db.prepare('DELETE FROM session_activities WHERE session_id = ?').run(sessionId)
+    return result.changes
+  }
+
   // Connection operations
   createConnection(data: ConnectionCreate): Connection {
     const db = this.getDb()

--- a/src/main/ipc/opencode-handlers.ts
+++ b/src/main/ipc/opencode-handlers.ts
@@ -1026,6 +1026,37 @@ export function registerOpenCodeHandlers(
       })
   )
 
+  defineHandler(
+    'opencode:refresh-from-thread',
+    z.tuple([z.string().min(1), z.string().min(1)]),
+    ([worktreePath, opencodeSessionId]) =>
+      opencodeEffect(async () => {
+        log.info('IPC: opencode:refresh-from-thread', { worktreePath, opencodeSessionId })
+        try {
+          if (!sdkManager || !dbService) {
+            return { success: false, error: 'SDK manager is not available' }
+          }
+
+          const sdkId = dbService.getAgentSdkForSession(opencodeSessionId)
+          if (sdkId !== 'codex') {
+            return {
+              success: false,
+              error: 'Refresh from file is only supported for Codex sessions'
+            }
+          }
+
+          const impl = sdkManager.getImplementer('codex') as CodexImplementer
+          return await impl.refreshMessagesFromThread(worktreePath, opencodeSessionId)
+        } catch (error) {
+          log.error('IPC: opencode:refresh-from-thread failed', toError(error))
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Unknown error'
+          }
+        }
+      })
+  )
+
   // Abort a streaming session
   defineHandler(
     'opencode:abort',

--- a/src/main/services/__tests__/codex-implementer-refresh.test.ts
+++ b/src/main/services/__tests__/codex-implementer-refresh.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('../agent-event-bus', () => ({
+  agentEventBus: { setMainWindow: vi.fn(), publish: vi.fn() }
+}))
+
+vi.mock('../codex-app-server-manager', () => ({
+  CodexAppServerManager: class {
+    on = vi.fn()
+    readThread = vi.fn()
+  }
+}))
+
+vi.mock('../notification-service', () => ({
+  notificationService: {}
+}))
+
+vi.mock('../codex-session-title', () => ({
+  generateCodexSessionTitle: vi.fn()
+}))
+
+vi.mock('../git-service', () => ({
+  autoRenameWorktreeBranch: vi.fn()
+}))
+
+import { CodexImplementer, type CodexSessionState } from '../codex-implementer'
+
+type RefreshResult = { success: boolean; count?: number; error?: string }
+
+function createSession(overrides: Partial<CodexSessionState> = {}): CodexSessionState {
+  return {
+    threadId: 'thread-1',
+    hiveSessionId: 'hive-session-1',
+    worktreePath: '/repo',
+    status: 'ready',
+    messages: [],
+    pendingHitlRequestIds: new Set(),
+    liveAssistantDraft: null,
+    currentTurnId: null,
+    currentAssistantMessageId: null,
+    revertMessageID: null,
+    revertDiff: null,
+    titleGenerated: true,
+    titleGenerationStarted: true,
+    persistDebounceTimer: null,
+    ...overrides
+  }
+}
+
+function installSession(
+  impl: CodexImplementer,
+  session: CodexSessionState,
+  agentSessionId = session.threadId
+): void {
+  ;(impl as unknown as { sessions: Map<string, CodexSessionState> }).sessions.set(
+    `${session.worktreePath}::${agentSessionId}`,
+    session
+  )
+}
+
+function installDb(impl: CodexImplementer) {
+  const db = {
+    replaceSessionMessages: vi.fn(),
+    deleteSessionActivities: vi.fn()
+  }
+  ;(impl as unknown as { dbService: typeof db }).dbService = db
+  return db
+}
+
+function installManager(impl: CodexImplementer, readThread: () => Promise<unknown>): void {
+  ;(impl as unknown as { manager: { readThread: () => Promise<unknown> } }).manager = {
+    readThread
+  }
+}
+
+async function refresh(impl: CodexImplementer): Promise<RefreshResult> {
+  return (
+    impl as unknown as {
+      refreshMessagesFromThread: (
+        worktreePath: string,
+        agentSessionId: string
+      ) => Promise<RefreshResult>
+    }
+  ).refreshMessagesFromThread('/repo', 'thread-1')
+}
+
+const snapshot = {
+  thread: {
+    turns: [
+      {
+        id: 'turn-1',
+        createdAt: '2026-05-15T10:00:00.000Z',
+        items: [
+          {
+            type: 'userMessage',
+            id: 'user-item',
+            content: [{ type: 'text', text: 'hello' }]
+          },
+          {
+            type: 'agentMessage',
+            id: 'agent-item',
+            text: 'hi there'
+          }
+        ]
+      }
+    ]
+  }
+}
+
+describe('CodexImplementer.refreshMessagesFromThread', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('replaces canonical messages and clears durable activities on success', async () => {
+    const impl = new CodexImplementer()
+    const session = createSession()
+    installSession(impl, session)
+    const db = installDb(impl)
+    installManager(impl, vi.fn().mockResolvedValue(snapshot))
+
+    const result = await refresh(impl)
+
+    expect(result).toEqual({ success: true, count: 2 })
+    expect(session.messages).toHaveLength(2)
+    expect(db.replaceSessionMessages).toHaveBeenCalledWith(
+      'hive-session-1',
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'user', content: 'hello' }),
+        expect.objectContaining({ role: 'assistant', content: 'hi there' })
+      ])
+    )
+    expect(db.deleteSessionActivities).toHaveBeenCalledWith('hive-session-1')
+  })
+
+  it('does not overwrite durable state for an empty snapshot', async () => {
+    const impl = new CodexImplementer()
+    installSession(impl, createSession())
+    const db = installDb(impl)
+    installManager(impl, vi.fn().mockResolvedValue({ thread: { turns: [] } }))
+
+    const result = await refresh(impl)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/empty/i)
+    expect(db.replaceSessionMessages).not.toHaveBeenCalled()
+    expect(db.deleteSessionActivities).not.toHaveBeenCalled()
+  })
+
+  it('rejects sessions without a thread id', async () => {
+    const impl = new CodexImplementer()
+    installSession(impl, createSession({ threadId: null as unknown as string }), 'thread-1')
+    const db = installDb(impl)
+    installManager(impl, vi.fn().mockResolvedValue(snapshot))
+
+    const result = await refresh(impl)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/thread/i)
+    expect(db.replaceSessionMessages).not.toHaveBeenCalled()
+    expect(db.deleteSessionActivities).not.toHaveBeenCalled()
+  })
+
+  it('rejects running sessions', async () => {
+    const impl = new CodexImplementer()
+    installSession(impl, createSession({ status: 'running' }))
+    const db = installDb(impl)
+    installManager(impl, vi.fn().mockResolvedValue(snapshot))
+
+    const result = await refresh(impl)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/running/i)
+    expect(db.replaceSessionMessages).not.toHaveBeenCalled()
+    expect(db.deleteSessionActivities).not.toHaveBeenCalled()
+  })
+
+  it('returns failure when thread/read throws', async () => {
+    const impl = new CodexImplementer()
+    installSession(impl, createSession())
+    const db = installDb(impl)
+    installManager(impl, vi.fn().mockRejectedValue(new Error('thread read failed')))
+
+    const result = await refresh(impl)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('thread read failed')
+    expect(db.replaceSessionMessages).not.toHaveBeenCalled()
+    expect(db.deleteSessionActivities).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/services/__tests__/database-session-activities.test.ts
+++ b/src/main/services/__tests__/database-session-activities.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { DatabaseService } from '../../db/database'
+
+describe('DatabaseService session activities', () => {
+  it('deleteSessionActivities deletes rows by target session id and returns changed count', () => {
+    const run = vi.fn().mockReturnValue({ changes: 2 })
+    const prepare = vi.fn().mockReturnValue({ run })
+    const service = Object.create(DatabaseService.prototype) as unknown as {
+      deleteSessionActivities: (sessionId: string) => number
+      db: { prepare: typeof prepare }
+    }
+    service.db = { prepare }
+
+    const deleted = service.deleteSessionActivities('session-target')
+
+    expect(prepare).toHaveBeenCalledWith('DELETE FROM session_activities WHERE session_id = ?')
+    expect(run).toHaveBeenCalledWith('session-target')
+    expect(deleted).toBe(2)
+  })
+})

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -1275,6 +1275,60 @@ export class CodexImplementer implements AgentSdkImplementer {
     return []
   }
 
+  async refreshMessagesFromThread(
+    worktreePath: string,
+    agentSessionId: string
+  ): Promise<{ success: boolean; count?: number; error?: string }> {
+    const key = this.getSessionKey(worktreePath, agentSessionId)
+    let session = this.sessions.get(key)
+    if (!session) {
+      const recoveredSession = await this.recoverSessionForRead(worktreePath, agentSessionId)
+      session = recoveredSession ?? undefined
+    }
+
+    if (!session) {
+      return { success: false, error: 'Codex session not found' }
+    }
+
+    if (session.status === 'running') {
+      return { success: false, error: 'Cannot refresh a running Codex session' }
+    }
+
+    if (!session.threadId) {
+      return { success: false, error: 'Codex session has no thread ID' }
+    }
+
+    try {
+      const threadSnapshot = await this.manager.readThread(session.threadId)
+      const parsed = this.parseThreadSnapshot(threadSnapshot)
+      if (parsed.length === 0) {
+        return { success: false, error: 'thread/read snapshot was empty' }
+      }
+
+      session.messages = parsed
+      this.flushPendingPersist(session)
+      this.persistCanonicalMessages(session)
+      this.dbService?.deleteSessionActivities(session.hiveSessionId)
+
+      log.info('refreshMessagesFromThread: refreshed transcript from thread/read', {
+        agentSessionId,
+        hiveSessionId: session.hiveSessionId,
+        count: parsed.length
+      })
+
+      return { success: true, count: parsed.length }
+    } catch (error) {
+      log.warn('refreshMessagesFromThread: readThread failed', {
+        agentSessionId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to refresh from thread'
+      }
+    }
+  }
+
   // ── Models ───────────────────────────────────────────────────────
 
   async getAvailableModels(): Promise<unknown> {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -811,6 +811,10 @@ declare global {
         worktreePath: string,
         opencodeSessionId: string
       ) => Promise<Envelope<{ success: boolean; messages: unknown[]; error?: string }>>
+      refreshFromThread: (
+        worktreePath: string,
+        opencodeSessionId: string
+      ) => Promise<Envelope<{ success: boolean; count?: number; error?: string }>>
       // List available models from all configured providers
       listModels: (opts?: {
         agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1531,6 +1531,12 @@ const opencodeOps = {
   ): Promise<Envelope<{ success: boolean; messages: unknown[]; error?: string }>> =>
     ipcRenderer.invoke('opencode:messages', worktreePath, opencodeSessionId),
 
+  refreshFromThread: (
+    worktreePath: string,
+    opencodeSessionId: string
+  ): Promise<Envelope<{ success: boolean; count?: number; error?: string }>> =>
+    ipcRenderer.invoke('opencode:refresh-from-thread', worktreePath, opencodeSessionId),
+
   // List available models from all configured providers
   listModels: (opts?: {
     agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -64,6 +64,16 @@ import {
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
@@ -75,6 +85,15 @@ import { useTipStore } from '@/stores/useTipStore'
 import { unwrapEnvelopeApi } from '@/lib/ipc-envelope'
 
 const kanban = unwrapEnvelopeApi(() => window.kanban)
+const TRANSCRIPT_CACHE_KEY_PREFIX = 'hive:session-transcript:'
+
+function clearTranscriptCache(sessionId: string): void {
+  try {
+    window.sessionStorage.removeItem(`${TRANSCRIPT_CACHE_KEY_PREFIX}${sessionId}`)
+  } catch {
+    // Non-fatal cache clear failure
+  }
+}
 
 interface SessionTabProps {
   sessionId: string
@@ -94,6 +113,7 @@ interface SessionTabProps {
   worktreeId: string | null
   onCloseOthers?: () => void
   onCloseToRight?: () => void
+  onRefreshFromFile?: () => void
   hintCode?: string
 }
 
@@ -115,6 +135,7 @@ const SessionTab = memo(function SessionTab({
   worktreeId: _worktreeId,
   onCloseOthers,
   onCloseToRight,
+  onRefreshFromFile,
   hintCode
 }: SessionTabProps): React.JSX.Element {
   const [isEditing, setIsEditing] = useState(false)
@@ -130,6 +151,7 @@ const SessionTab = memo(function SessionTab({
   const sessionStatus = useWorktreeStatusStore(
     (state) => state.sessionStatuses[sessionId]?.status ?? null
   )
+  const isSessionBusy = sessionStatus === 'working' || sessionStatus === 'planning'
 
   // Focus and select input text when entering edit mode
   useEffect(() => {
@@ -271,6 +293,15 @@ const SessionTab = memo(function SessionTab({
         {onCloseOthers && <ContextMenuItem onSelect={onCloseOthers}>Close Others</ContextMenuItem>}
         {onCloseToRight && (
           <ContextMenuItem onSelect={onCloseToRight}>Close Others to the Right</ContextMenuItem>
+        )}
+        {agentSdk === 'codex' && (
+          <>
+            <ContextMenuSeparator />
+            <ContextMenuItem disabled={isSessionBusy} onSelect={() => onRefreshFromFile?.()}>
+              <FileSearch className="h-4 w-4 mr-2" />
+              Refresh from file
+            </ContextMenuItem>
+          </>
         )}
       </ContextMenuContent>
     </ContextMenu>
@@ -534,6 +565,9 @@ export function SessionTabs(): React.JSX.Element | null {
   const [showImport, setShowImport] = useState(false)
   const [showJiraImport, setShowJiraImport] = useState(false)
   const [showHiveImport, setShowHiveImport] = useState(false)
+  const [refreshTarget, setRefreshTarget] = useState<{ sessionId: string; name: string } | null>(
+    null
+  )
   const [hiveImportTickets, setHiveImportTickets] = useState<
     Array<{
       id: string
@@ -913,6 +947,51 @@ export function SessionTabs(): React.JSX.Element | null {
     }
   }
 
+  const handleRefreshFromFile = async (sessionId: string) => {
+    const targetSession = allSessions.find((session) => session.id === sessionId)
+    const opencodeSessionId = targetSession?.opencode_session_id
+    const worktreePath = (() => {
+      if (targetSession?.worktree_id) {
+        for (const worktrees of useWorktreeStore.getState().worktreesByProject.values()) {
+          const worktree = worktrees.find((item) => item.id === targetSession.worktree_id)
+          if (worktree?.path) return worktree.path
+        }
+      }
+      return selectedWorktree?.path ?? null
+    })()
+
+    setRefreshTarget(null)
+
+    if (!worktreePath || !opencodeSessionId) {
+      window.dispatchEvent(
+        new CustomEvent('hive:refresh-codex-from-file', { detail: { sessionId } })
+      )
+      return
+    }
+
+    try {
+      const result = unwrapEnvelopeApi(() => window.opencodeOps).refreshFromThread(
+        worktreePath,
+        opencodeSessionId
+      )
+      const refreshed = await result
+      if (!refreshed.success) {
+        toast.error(refreshed.error || 'Refresh from file failed')
+        return
+      }
+
+      clearTranscriptCache(sessionId)
+      window.dispatchEvent(
+        new CustomEvent('hive:refresh-codex-from-file', {
+          detail: { sessionId, refreshed: true, count: refreshed.count }
+        })
+      )
+      toast.success(`Refreshed transcript from file (${refreshed.count ?? 0} messages)`)
+    } catch {
+      toast.error('Refresh from file failed')
+    }
+  }
+
   // Handle clicking a session tab - deactivate file tab and clear unread status
   const handleSessionTabClick = (sessionId: string) => {
     const isAlreadyPresentedSession =
@@ -1170,6 +1249,9 @@ export function SessionTabs(): React.JSX.Element | null {
                     isConnectionMode
                       ? closeConnectionSessionsToRight(resolvedScopeId, session.id)
                       : closeSessionsToRight(resolvedScopeId, session.id)
+            }
+            onRefreshFromFile={() =>
+              setRefreshTarget({ sessionId: session.id, name: session.name || 'Untitled' })
             }
             hintCode={sessionHints.sessionHintMap.get(session.id)}
           />
@@ -1604,6 +1686,32 @@ export function SessionTabs(): React.JSX.Element | null {
           />
         </>
       )}
+      <AlertDialog
+        open={refreshTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setRefreshTarget(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Refresh from file?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will rebuild the visible Codex transcript from the thread file and replace the
+              stored transcript for {refreshTarget?.name ?? 'this session'}.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setRefreshTarget(null)}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (refreshTarget) handleRefreshFromFile(refreshTarget.sessionId)
+              }}
+            >
+              Refresh
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -476,6 +476,15 @@ function writeTranscriptCache(sessionId: string, messages: OpenCodeMessage[]): v
   }
 }
 
+function clearTranscriptCache(sessionId: string): void {
+  if (isTestRuntime()) return
+  try {
+    window.sessionStorage.removeItem(getTranscriptCacheKey(sessionId))
+  } catch {
+    // Non-fatal cache clear failure
+  }
+}
+
 // Loading state component
 function LoadingState(): React.JSX.Element {
   return (
@@ -3808,6 +3817,12 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     return true
   }, [opencodeSessionId, sessionId, sessionRecord?.agent_sdk, worktreePath])
 
+  const refreshCodexMessagesFromDurableState = useCallback(async (): Promise<boolean> => {
+    const durableState = await loadCodexDurableState(sessionId)
+    setMessages(durableState.messages)
+    return durableState.messages.length > 0
+  }, [sessionId])
+
   const refreshCodexStreamingMessages = useCallback(async (): Promise<void> => {
     if (sessionRecord?.agent_sdk !== 'codex') return
     if (!worktreePath || !opencodeSessionId) return
@@ -5669,6 +5684,53 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       window.removeEventListener('hive:redo-turn', onRedo)
     }
   }, [sessionId, worktreePath, opencodeSessionId, refreshMessagesFromOpenCode])
+
+  useEffect(() => {
+    const onRefreshFromFile = (event: Event): void => {
+      const detail = (
+        event as CustomEvent<{ sessionId?: string; refreshed?: boolean; count?: number }>
+      ).detail
+      if (detail?.sessionId !== sessionId) return
+      if (!worktreePath || !opencodeSessionId) {
+        toast.error('Refresh from file failed: session is not connected')
+        return
+      }
+
+      void (async () => {
+        try {
+          if (detail.refreshed) {
+            clearTranscriptCache(sessionId)
+            await refreshCodexMessagesFromDurableState()
+            return
+          }
+
+          const result = unwrapEnvelope(
+            await window.opencodeOps.refreshFromThread(worktreePath, opencodeSessionId)
+          )
+          if (!result.success) {
+            toast.error(result.error || 'Refresh from file failed')
+            return
+          }
+
+          clearTranscriptCache(sessionId)
+          await refreshCodexMessagesFromDurableState()
+          toast.success(`Refreshed transcript from file (${result.count ?? 0} messages)`)
+        } catch {
+          toast.error('Refresh from file failed')
+        }
+      })()
+    }
+
+    window.addEventListener('hive:refresh-codex-from-file', onRefreshFromFile)
+    return () => {
+      window.removeEventListener('hive:refresh-codex-from-file', onRefreshFromFile)
+    }
+  }, [
+    sessionId,
+    worktreePath,
+    opencodeSessionId,
+    refreshCodexMessagesFromDurableState
+  ])
 
   // Determine if there's streaming content to show
   const visibleMessages = useMemo(() => {

--- a/test/phase-19/session-8/tab-context-ui.test.tsx
+++ b/test/phase-19/session-8/tab-context-ui.test.tsx
@@ -67,11 +67,13 @@ const projectId = 'proj-test'
 function setupStores({
   sessionCount = 3,
   fileTabs = false,
-  diffTabs = false
+  diffTabs = false,
+  agentSdk = 'opencode'
 }: {
   sessionCount?: number
   fileTabs?: boolean
   diffTabs?: boolean
+  agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
 } = {}) {
   const sessions = Array.from({ length: sessionCount }, (_, i) => ({
     id: `s${i + 1}`,
@@ -80,6 +82,7 @@ function setupStores({
     name: `Session ${i + 1}`,
     status: 'active' as const,
     opencode_session_id: null,
+    agent_sdk: agentSdk,
     mode: 'build' as const,
     model_provider_id: null,
     model_id: null,
@@ -219,6 +222,29 @@ describe('Session 8: Tab Context Menus UI', () => {
 
       expect(screen.queryByText('Copy Relative Path')).not.toBeInTheDocument()
       expect(screen.queryByText('Copy Absolute Path')).not.toBeInTheDocument()
+    })
+
+    test('Refresh from file is shown only for codex session tabs', async () => {
+      setupStores({ agentSdk: 'opencode' })
+      render(<SessionTabs />)
+
+      fireEvent.contextMenu(screen.getByTestId('session-tab-s1'))
+
+      await waitFor(() => {
+        expect(screen.getByText('Close')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('Refresh from file')).not.toBeInTheDocument()
+    })
+
+    test('codex Refresh from file item is disabled while working', async () => {
+      setupStores({ agentSdk: 'codex' })
+      useWorktreeStatusStore.getState().setSessionStatus('s1', 'working')
+      render(<SessionTabs />)
+
+      fireEvent.contextMenu(screen.getByTestId('session-tab-s1'))
+
+      const item = await screen.findByText('Refresh from file')
+      expect(item.closest('[role="menuitem"]')).toHaveAttribute('data-disabled')
     })
   })
 

--- a/test/refresh-codex-from-file/session-view-refresh.test.ts
+++ b/test/refresh-codex-from-file/session-view-refresh.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('SessionView refresh from file re-render path', () => {
+  it('reloads refreshed Codex sessions from durable DB state instead of live transcript merge', () => {
+    const source = readFileSync(
+      resolve(__dirname, '../../src/renderer/src/components/sessions/SessionView.tsx'),
+      'utf8'
+    )
+
+    const refreshedBranch = source.match(/if \(detail\.refreshed\) \{([\s\S]*?)return\s*\n\s*\}/)
+
+    expect(refreshedBranch?.[1]).toContain('refreshCodexMessagesFromDurableState')
+    expect(refreshedBranch?.[1]).not.toContain('refreshMessagesFromOpenCode')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a Codex-only "Refresh from file" flow for session tabs, with confirmation UI and cache clearing.
- Introduces a main-process IPC handler and Codex implementer refresh path that rebuilds stored messages from the thread file and clears session activities.
- Updates session view re-rendering to reload refreshed Codex sessions from durable database state instead of merging live transcript data.
- Adds coverage for database cleanup, Codex refresh behavior, and UI visibility/disabled-state cases.

## Testing
- Added unit tests for `DatabaseService.deleteSessionActivities()`.
- Added unit tests for `CodexImplementer.refreshMessagesFromThread()` success and failure paths.
- Added UI tests covering Codex-only context menu exposure and disabled state while a session is busy.
- Added a regression test for the SessionView refresh-from-file re-render path.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Codex-only IPC + persistence path that overwrites stored session transcripts and clears related activity rows, which could affect transcript integrity if mis-invoked or if thread parsing is wrong.
> 
> **Overview**
> Adds a Codex-only **“Refresh from file”** action on session tabs (with confirmation and disabled while the session is busy) that rebuilds the transcript from the Codex thread file, clears client transcript cache, and triggers a UI reload.
> 
> Implements an `opencode:refresh-from-thread` IPC route that dispatches only for `codex` sessions to a new `CodexImplementer.refreshMessagesFromThread`, which reads `thread/read`, replaces canonical stored messages, flushes pending persists, and clears durable `session_activities` via new `DatabaseService.deleteSessionActivities`.
> 
> Updates `SessionView` to handle refresh events by reloading Codex messages from durable DB state (not live transcript merging), and adds unit/UI/regression tests covering the refresh flow, DB cleanup, and menu visibility/disabled-state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b094eca3a79a3e6bf0b5bd8b3a65de6e184813b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->