### PR TITLE
Restrict Cmd+Q guard to keyboard shortcuts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -79,6 +79,7 @@ import {
   shouldSuppressMainWindowActivationFromPet
 } from './services/pet-window'
 import {
+  consumeQuitViaShortcut,
   getQuitConfirmationDecision,
   QUIT_CONFIRM_WINDOW_MS,
   readWarnBeforeQuitting
@@ -757,6 +758,9 @@ app.on('window-all-closed', () => {
 })
 
 app.on('before-quit', (event) => {
+  const viaShortcut = consumeQuitViaShortcut()
+  if (!viaShortcut) return
+
   if (!mainWindow || mainWindow.isDestroyed()) return
 
   const warnBeforeQuitting = readWarnBeforeQuitting(getDatabase().getSetting(APP_SETTINGS_DB_KEY))

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, Menu, app, clipboard, shell } from 'electron'
 import { createLogger, getLogDir } from './services/logger'
 import { ghosttyService } from './services/ghostty-service'
 import { updaterService } from './services/updater'
+import { markQuitViaShortcut } from './quit-confirmation'
 
 const log = createLogger({ component: 'Menu' })
 
@@ -48,10 +49,37 @@ export function buildMenu(mainWindow: BrowserWindow, isDev: boolean): Menu {
   _mainWindow = mainWindow
 
   const isMac = process.platform === 'darwin'
+  const quitMenuItem: Electron.MenuItemConstructorOptions = {
+    label: `Quit ${app.name}`,
+    accelerator: 'CmdOrCtrl+Q',
+    click: (_item, _window, event) => {
+      // Only the keystroke arms the double-tap guard; a mouse click on the
+      // menu item is a deliberate action and quits immediately.
+      if (event?.triggeredByAccelerator) markQuitViaShortcut()
+      app.quit()
+    }
+  }
 
   const template: Electron.MenuItemConstructorOptions[] = [
-    // Hive (appMenu) — macOS only
-    ...(isMac ? [{ role: 'appMenu' as const }] : []),
+    // Hive — macOS only
+    ...(isMac
+      ? [
+          {
+            label: app.name,
+            submenu: [
+              { role: 'about' as const },
+              { type: 'separator' as const },
+              { role: 'services' as const },
+              { type: 'separator' as const },
+              { role: 'hide' as const },
+              { role: 'hideOthers' as const },
+              { role: 'unhide' as const },
+              { type: 'separator' as const },
+              quitMenuItem
+            ]
+          }
+        ]
+      : []),
 
     // File
     {
@@ -79,7 +107,7 @@ export function buildMenu(mainWindow: BrowserWindow, isDev: boolean): Menu {
           click: () => send('menu:add-project')
         },
         { type: 'separator' },
-        ...(!isMac ? [{ role: 'quit' as const }] : [])
+        ...(!isMac ? [quitMenuItem] : [])
       ]
     },
 

--- a/src/main/quit-confirmation.ts
+++ b/src/main/quit-confirmation.ts
@@ -1,5 +1,19 @@
 export const QUIT_CONFIRM_WINDOW_MS = 2000
 
+let quitViaShortcut = false
+
+/** Mark that the next quit was initiated by the Cmd+Q accelerator. */
+export function markQuitViaShortcut(): void {
+  quitViaShortcut = true
+}
+
+/** Read and reset the flag. Returns true only once per mark. */
+export function consumeQuitViaShortcut(): boolean {
+  const value = quitViaShortcut
+  quitViaShortcut = false
+  return value
+}
+
 export function readWarnBeforeQuitting(rawSettings: string | null): boolean {
   if (!rawSettings) return true
 

--- a/test/main/quit-confirmation.test.ts
+++ b/test/main/quit-confirmation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  consumeQuitViaShortcut,
   getQuitConfirmationDecision,
+  markQuitViaShortcut,
   readWarnBeforeQuitting
 } from '../../src/main/quit-confirmation'
 
@@ -59,5 +61,16 @@ describe('quit confirmation decision', () => {
         confirmationWindowMs: 2000
       })
     ).toEqual({ shouldPreventQuit: false, lastQuitConfirmAt: null })
+  })
+})
+
+describe('quit shortcut marker', () => {
+  it('returns true exactly once after being marked', () => {
+    expect(consumeQuitViaShortcut()).toBe(false)
+
+    markQuitViaShortcut()
+
+    expect(consumeQuitViaShortcut()).toBe(true)
+    expect(consumeQuitViaShortcut()).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- Scope the quit-confirmation guard to quit attempts initiated via the Cmd+Q/Ctrl+Q accelerator.
- Preserve immediate quitting when the Quit menu item is clicked directly with the mouse.
- Add a small one-shot flag helper and unit coverage for the shortcut marker behavior.

## Testing
- Added unit test coverage for `markQuitViaShortcut()` / `consumeQuitViaShortcut()` one-shot behavior.
- Not run: full test suite.
- Not run: manual Electron quit flow verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the Electron quit flow and menu wiring; mistakes could cause the app to quit without confirmation (or block quitting) in some paths, especially across platforms.
> 
> **Overview**
> Scopes the quit-confirmation “double-tap to quit” guard to quits initiated via the `CmdOrCtrl+Q` accelerator, while allowing immediate quits from direct menu clicks.
> 
> Adds a one-shot shortcut marker (`markQuitViaShortcut`/`consumeQuitViaShortcut`) in `quit-confirmation`, wires it into the custom Quit menu item, and gates the `app.on('before-quit')` confirmation logic on that flag. Includes unit coverage for the marker’s one-time behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5297d4e0d1e3d4ad40c0a95f6656c3f60004887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->