### PR TITLE
Fix session model provider resolution for explicit SDK overrides

### DIFF
--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -107,6 +107,7 @@ function resolveSessionSelection(opts: {
   worktreeId?: string
   agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
   mode?: 'build' | 'plan' | 'super-plan'
+  explicitSdk?: boolean
 }): EffectiveHandoffSelection {
   const settings = useSettingsStore.getState()
   const requestedSdk = normalizeHandoffSdk(opts.agentSdk ?? settings.defaultAgentSdk ?? 'opencode')
@@ -115,10 +116,18 @@ function resolveSessionSelection(opts: {
   let resolvedSdk = requestedSdk
 
   const modeDefault = settings.getModelForMode(getModeDefaultKey(opts.mode))
-  // A mode default with its own agentSdk takes precedence over the requested SDK.
+  // Session creation can pass an explicit SDK; in that case the mode default may only
+  // supply a model that already belongs to the requested SDK.
   if (modeDefault && (modeDefault.agentSdk || requestedSdk === configuredDefaultSdk)) {
-    model = modeDefault
-    resolvedSdk = normalizeHandoffSdk(modeDefault.agentSdk ?? requestedSdk)
+    const modeDefaultSdk = modeDefault.agentSdk ? normalizeHandoffSdk(modeDefault.agentSdk) : null
+    if (opts.explicitSdk) {
+      if (modeDefaultSdk === requestedSdk) {
+        model = modeDefault
+      }
+    } else {
+      model = modeDefault
+      resolvedSdk = modeDefaultSdk ?? requestedSdk
+    }
   }
 
   if (!model) {
@@ -275,7 +284,8 @@ export function resolveSessionCreationSelection(opts: {
   const resolved = resolveSessionSelection({
     worktreeId: opts.worktreeId,
     agentSdk,
-    mode: opts.initialMode
+    mode: opts.initialMode,
+    explicitSdk: opts.agentSdkOverride != null
   })
   return { agentSdk: resolved.agentSdk, model: resolved.model }
 }

--- a/test/kanban/auto-launch-goal-mode.test.ts
+++ b/test/kanban/auto-launch-goal-mode.test.ts
@@ -11,35 +11,40 @@ vi.mock('@/lib/toast', () => ({
 
 const mockKanban = {
   ticket: {
-    update: vi.fn().mockResolvedValue(undefined)
+    update: vi.fn().mockResolvedValue({ success: true, value: undefined })
   }
 }
 
 const mockDbSession = {
   create: vi.fn().mockImplementation(async (input: Record<string, unknown>) => ({
-    id: 'session-1',
-    worktree_id: input.worktree_id,
-    project_id: input.project_id,
-    connection_id: null,
-    name: 'Session 1',
-    status: 'active',
-    opencode_session_id: null,
-    agent_sdk: input.agent_sdk,
-    mode: input.mode,
-    session_type: 'default',
-    model_provider_id: null,
-    model_id: null,
-    model_variant: null,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-    completed_at: null
+    success: true,
+    value: {
+      id: 'session-1',
+      worktree_id: input.worktree_id,
+      project_id: input.project_id,
+      connection_id: null,
+      name: 'Session 1',
+      status: 'active',
+      opencode_session_id: null,
+      agent_sdk: input.agent_sdk,
+      mode: input.mode,
+      session_type: 'default',
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      completed_at: null
+    }
   })),
-  update: vi.fn().mockResolvedValue(undefined)
+  update: vi.fn().mockResolvedValue({ success: true, value: undefined })
 }
 
 const mockOpencodeOps = {
-  connect: vi.fn().mockResolvedValue({ success: true, sessionId: 'oc-session-1' }),
-  prompt: vi.fn().mockResolvedValue({ success: true })
+  connect: vi
+    .fn()
+    .mockResolvedValue({ success: true, value: { success: true, sessionId: 'oc-session-1' } }),
+  prompt: vi.fn().mockResolvedValue({ success: true, value: { success: true } })
 }
 
 Object.defineProperty(window, 'kanban', {
@@ -66,8 +71,8 @@ Object.defineProperty(window, 'usageOps', {
   writable: true,
   configurable: true,
   value: {
-    fetch: vi.fn().mockResolvedValue({ success: true, data: null }),
-    fetchOpenai: vi.fn().mockResolvedValue({ success: true, data: null })
+    fetch: vi.fn().mockResolvedValue({ success: true, value: { success: true, data: null } }),
+    fetchOpenai: vi.fn().mockResolvedValue({ success: true, value: { success: true, data: null } })
   }
 })
 
@@ -209,6 +214,8 @@ describe('autoLaunchTicket goal mode', () => {
       type: string
       text: string
     }>
-    expect(promptParts[0]?.text).toBe('/goal Build auth. Goal success criteria: Auth works end to end')
+    expect(promptParts[0]?.text).toBe(
+      '/goal Build auth. Goal success criteria: Auth works end to end'
+    )
   })
 })

--- a/test/kanban/session-9/worktree-picker-modal.test.tsx
+++ b/test/kanban/session-9/worktree-picker-modal.test.tsx
@@ -20,11 +20,11 @@ const mockKanban = {
   ticket: {
     create: vi.fn(),
     get: vi.fn(),
-    getByProject: vi.fn().mockResolvedValue([]),
-    update: vi.fn().mockResolvedValue(undefined),
+    getByProject: vi.fn().mockResolvedValue({ success: true, value: [] }),
+    update: vi.fn().mockResolvedValue({ success: true, value: undefined }),
     delete: vi.fn(),
-    move: vi.fn().mockResolvedValue(undefined),
-    reorder: vi.fn().mockResolvedValue(undefined),
+    move: vi.fn().mockResolvedValue({ success: true, value: undefined }),
+    reorder: vi.fn().mockResolvedValue({ success: true, value: undefined }),
     getBySession: vi.fn()
   },
   simpleMode: {
@@ -34,73 +34,82 @@ const mockKanban = {
 
 const mockDbSession = {
   create: vi.fn().mockImplementation(async (input: Record<string, unknown>) => ({
-    id: 'new-session-1',
-    worktree_id: (input.worktree_id as string | null) ?? 'wt-1',
-    project_id: (input.project_id as string | null) ?? 'proj-1',
-    connection_id: (input.connection_id as string | null) ?? null,
-    name: (input.name as string | null) ?? 'Session 1',
-    status: 'active',
-    opencode_session_id: null,
-    agent_sdk: (input.agent_sdk as string | null) ?? 'opencode',
-    mode: (input.mode as string | null) ?? 'build',
-    model_provider_id: (input.model_provider_id as string | null) ?? null,
-    model_id: (input.model_id as string | null) ?? null,
-    model_variant: (input.model_variant as string | null) ?? null,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-    completed_at: null
+    success: true,
+    value: {
+      id: 'new-session-1',
+      worktree_id: (input.worktree_id as string | null) ?? 'wt-1',
+      project_id: (input.project_id as string | null) ?? 'proj-1',
+      connection_id: (input.connection_id as string | null) ?? null,
+      name: (input.name as string | null) ?? 'Session 1',
+      status: 'active',
+      opencode_session_id: null,
+      agent_sdk: (input.agent_sdk as string | null) ?? 'opencode',
+      mode: (input.mode as string | null) ?? 'build',
+      model_provider_id: (input.model_provider_id as string | null) ?? null,
+      model_id: (input.model_id as string | null) ?? null,
+      model_variant: (input.model_variant as string | null) ?? null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      completed_at: null
+    }
   })),
-  update: vi.fn().mockResolvedValue(undefined),
-  getActiveByWorktree: vi.fn().mockResolvedValue([])
+  update: vi.fn().mockResolvedValue({ success: true, value: undefined }),
+  getActiveByWorktree: vi.fn().mockResolvedValue({ success: true, value: [] })
 }
 
 const mockDbWorktree = {
-  getActiveByProject: vi.fn().mockResolvedValue([])
+  getActiveByProject: vi.fn().mockResolvedValue({ success: true, value: [] })
 }
 
 const mockWorktreeOps = {
   create: vi.fn().mockResolvedValue({
     success: true,
-    worktree: {
-      id: 'wt-new',
-      project_id: 'proj-1',
-      name: 'new-worktree',
-      branch_name: 'new-worktree',
-      path: '/test/new-worktree',
-      status: 'active',
-      is_default: false,
-      branch_renamed: 0,
-      last_message_at: null,
-      session_titles: '[]',
-      last_model_provider_id: null,
-      last_model_id: null,
-      last_model_variant: null,
-      created_at: '2026-01-01T00:00:00Z',
-      last_accessed_at: '2026-01-01T00:00:00Z',
-      github_pr_number: null,
-      github_pr_url: null
+    value: {
+      success: true,
+      worktree: {
+        id: 'wt-new',
+        project_id: 'proj-1',
+        name: 'new-worktree',
+        branch_name: 'new-worktree',
+        path: '/test/new-worktree',
+        status: 'active',
+        is_default: false,
+        branch_renamed: 0,
+        last_message_at: null,
+        session_titles: '[]',
+        last_model_provider_id: null,
+        last_model_id: null,
+        last_model_variant: null,
+        created_at: '2026-01-01T00:00:00Z',
+        last_accessed_at: '2026-01-01T00:00:00Z',
+        github_pr_number: null,
+        github_pr_url: null
+      }
     }
   }),
   createFromBranch: vi.fn().mockResolvedValue({
     success: true,
-    worktree: {
-      id: 'wt-new',
-      project_id: 'proj-1',
-      name: 'new-worktree',
-      branch_name: 'new-worktree',
-      path: '/test/new-worktree',
-      status: 'active',
-      is_default: false,
-      branch_renamed: 0,
-      last_message_at: null,
-      session_titles: '[]',
-      last_model_provider_id: null,
-      last_model_id: null,
-      last_model_variant: null,
-      created_at: '2026-01-01T00:00:00Z',
-      last_accessed_at: '2026-01-01T00:00:00Z',
-      github_pr_number: null,
-      github_pr_url: null
+    value: {
+      success: true,
+      worktree: {
+        id: 'wt-new',
+        project_id: 'proj-1',
+        name: 'new-worktree',
+        branch_name: 'new-worktree',
+        path: '/test/new-worktree',
+        status: 'active',
+        is_default: false,
+        branch_renamed: 0,
+        last_message_at: null,
+        session_titles: '[]',
+        last_model_provider_id: null,
+        last_model_id: null,
+        last_model_variant: null,
+        created_at: '2026-01-01T00:00:00Z',
+        last_accessed_at: '2026-01-01T00:00:00Z',
+        github_pr_number: null,
+        github_pr_url: null
+      }
     }
   })
 }
@@ -108,30 +117,38 @@ const mockWorktreeOps = {
 const mockGitOps = {
   listBranchesWithStatus: vi.fn().mockResolvedValue({
     success: true,
-    branches: [
-      { name: 'main', isRemote: false, isCheckedOut: true },
-      { name: 'feature-x', isRemote: false, isCheckedOut: false },
-      { name: 'develop', isRemote: true, isCheckedOut: false }
-    ]
+    value: {
+      success: true,
+      branches: [
+        { name: 'main', isRemote: false, isCheckedOut: true },
+        { name: 'feature-x', isRemote: false, isCheckedOut: false },
+        { name: 'develop', isRemote: true, isCheckedOut: false }
+      ]
+    }
   })
 }
 
 const mockOpencodeOps = {
-  connect: vi.fn().mockResolvedValue({ success: true, sessionId: 'oc-session-1' }),
-  prompt: vi.fn().mockResolvedValue({ success: true }),
+  connect: vi
+    .fn()
+    .mockResolvedValue({ success: true, value: { success: true, sessionId: 'oc-session-1' } }),
+  prompt: vi.fn().mockResolvedValue({ success: true, value: { success: true } }),
   listModels: vi.fn().mockResolvedValue({
     success: true,
-    providers: [
-      {
-        id: 'openai',
-        name: 'OpenAI',
-        models: {
-          'gpt-5.5': { id: 'gpt-5.5', name: 'GPT-5.5' },
-          'gpt-5.4': { id: 'gpt-5.4', name: 'GPT-5.4' },
-          'gpt-5.4-mini': { id: 'gpt-5.4-mini', name: 'GPT-5.4 Mini' }
+    value: {
+      success: true,
+      providers: [
+        {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'gpt-5.5': { id: 'gpt-5.5', name: 'GPT-5.5' },
+            'gpt-5.4': { id: 'gpt-5.4', name: 'GPT-5.4' },
+            'gpt-5.4-mini': { id: 'gpt-5.4-mini', name: 'GPT-5.4 Mini' }
+          }
         }
-      }
-    ]
+      ]
+    }
   })
 }
 
@@ -166,8 +183,8 @@ Object.defineProperty(window, 'usageOps', {
   writable: true,
   configurable: true,
   value: {
-    fetch: vi.fn().mockResolvedValue({ success: true, data: null }),
-    fetchOpenai: vi.fn().mockResolvedValue({ success: true, data: null })
+    fetch: vi.fn().mockResolvedValue({ success: true, value: { success: true, data: null } }),
+    fetchOpenai: vi.fn().mockResolvedValue({ success: true, value: { success: true, data: null } })
   }
 })
 
@@ -177,9 +194,12 @@ Object.defineProperty(window, 'connectionOps', {
   value: {
     get: vi.fn().mockResolvedValue({
       success: true,
-      connection: {
-        id: 'conn-1',
-        members: [{ project_id: 'proj-1' }]
+      value: {
+        success: true,
+        connection: {
+          id: 'conn-1',
+          members: [{ project_id: 'proj-1' }]
+        }
       }
     })
   }
@@ -201,7 +221,10 @@ import { useConnectionStore } from '@/stores/useConnectionStore'
 import { getSuperPlanModePrefix } from '@/lib/constants'
 
 // ── Import component under test ─────────────────────────────────────
-import { WorktreePickerModal, _resetLastSourceBranch } from '@/components/kanban/WorktreePickerModal'
+import {
+  WorktreePickerModal,
+  _resetLastSourceBranch
+} from '@/components/kanban/WorktreePickerModal'
 
 import type { KanbanTicket } from '../../../src/main/db/types'
 
@@ -359,7 +382,7 @@ describe('Session 9: Worktree Picker Modal', () => {
             created_at: '2026-01-01T00:00:00Z',
             updated_at: '2026-01-01T00:00:00Z'
           }
-        ],
+        ]
       })
     })
     vi.clearAllMocks()
@@ -637,7 +660,12 @@ describe('Session 9: Worktree Picker Modal', () => {
 
   test('toggling mode swaps prefix but preserves user edits to body', () => {
     render(
-      <WorktreePickerModal ticket={defaultTicket} projectId="proj-1" open={true} onOpenChange={() => {}} />
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
     )
     const textarea = screen.getByTestId('wt-picker-prompt') as HTMLTextAreaElement
     const toggle = screen.getByTestId('wt-picker-mode-toggle')
@@ -648,7 +676,9 @@ describe('Session 9: Worktree Picker Modal', () => {
 
     // Toggle build → plan: prefix should swap, appended text preserved
     fireEvent.click(toggle)
-    expect(textarea.value).toContain('Please review the following ticket and create a detailed implementation plan.')
+    expect(textarea.value).toContain(
+      'Please review the following ticket and create a detailed implementation plan.'
+    )
     expect(textarea.value).toContain('Also add unit tests.')
 
     // Toggle plan → build: prefix swaps back, appended text still there
@@ -659,7 +689,12 @@ describe('Session 9: Worktree Picker Modal', () => {
 
   test('toggling mode does not change text when prefix was edited by user', () => {
     render(
-      <WorktreePickerModal ticket={defaultTicket} projectId="proj-1" open={true} onOpenChange={() => {}} />
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
     )
     const textarea = screen.getByTestId('wt-picker-prompt') as HTMLTextAreaElement
     const toggle = screen.getByTestId('wt-picker-mode-toggle')
@@ -880,7 +915,9 @@ describe('Session 9: Worktree Picker Modal', () => {
       type: string
       text: string
     }>
-    expect(promptParts[0]?.text).toBe('/goal Build auth. Goal success criteria: Login and signup work')
+    expect(promptParts[0]?.text).toBe(
+      '/goal Build auth. Goal success criteria: Login and signup work'
+    )
     expect(mockKanban.ticket.update).toHaveBeenCalledWith(
       'ticket-1',
       expect.objectContaining({
@@ -923,7 +960,9 @@ describe('Session 9: Worktree Picker Modal', () => {
       type: string
       text: string
     }>
-    expect(promptParts[0]?.text).toBe('/goal Build auth. Goal success criteria: Auth works end to end')
+    expect(promptParts[0]?.text).toBe(
+      '/goal Build auth. Goal success criteria: Auth works end to end'
+    )
   })
 
   test('saveConfigOnly persists goalMode and goalSuccessCriteria in pending config JSON', async () => {
@@ -1002,7 +1041,9 @@ describe('Session 9: Worktree Picker Modal', () => {
       type: string
       text: string
     }>
-    expect(promptParts[0]?.text).toBe('/goal Build auth. Goal success criteria: No duplicate goal command')
+    expect(promptParts[0]?.text).toBe(
+      '/goal Build auth. Goal success criteria: No duplicate goal command'
+    )
   })
 
   // ── Submit flow tests ────────────────────────────────────────────

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -3,8 +3,8 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import userEvent from '@testing-library/user-event'
 
 const mockSettingsDb = {
-  get: vi.fn().mockResolvedValue(null),
-  set: vi.fn().mockResolvedValue(undefined)
+  get: vi.fn().mockResolvedValue({ success: true, value: null }),
+  set: vi.fn().mockResolvedValue({ success: true, value: undefined })
 }
 
 const claudeProviders = [
@@ -79,10 +79,10 @@ Object.defineProperty(window, 'opencodeOps', {
   value: {
     listModels: vi.fn().mockImplementation(async ({ agentSdk }: { agentSdk?: string } = {}) => {
       if (agentSdk === 'codex') {
-        return { success: true, providers: codexProviders }
+        return { success: true, value: { success: true, providers: codexProviders } }
       }
 
-      return { success: true, providers: claudeProviders }
+      return { success: true, value: { success: true, providers: claudeProviders } }
     })
   }
 })
@@ -217,6 +217,38 @@ describe('handoff model picker', () => {
         providerID: 'codex',
         modelID: 'gpt-5.5',
         variant: 'xhigh'
+      }
+    })
+  })
+
+  test('resolveSessionCreationSelection keeps an explicit SDK when the mode default uses another SDK', () => {
+    cacheHandoffModelCatalog('codex', codexProviders)
+    useSettingsStore.setState({
+      defaultAgentSdk: 'claude-code',
+      defaultModels: {
+        build: {
+          agentSdk: 'claude-code',
+          providerID: 'anthropic',
+          modelID: 'sonnet-4.6',
+          variant: 'high'
+        },
+        plan: null,
+        ask: null,
+        review: null
+      }
+    })
+
+    const selection = resolveSessionCreationSelection({
+      agentSdkOverride: 'codex',
+      initialMode: 'build'
+    })
+
+    expect(selection).toEqual({
+      agentSdk: 'codex',
+      model: {
+        providerID: 'codex',
+        modelID: 'gpt-5.5',
+        variant: 'high'
       }
     })
   })


### PR DESCRIPTION
## Summary
- Preserve an explicitly requested SDK during session creation when the mode default points at a different SDK.
- Keep mode defaults as the source of truth when no SDK override is provided.
- Update tests to match the new `success`/`value` result shapes across session, worktree, git, connection, and opencode mocks.
- Add coverage for the explicit-SDK case in handoff session creation.

## Testing
- `Not run`
- Added/updated unit coverage in `test/phase-22/session-11/handoff-model-picker.test.tsx` for explicit SDK override handling.
- Updated existing kanban and worktree picker tests to reflect the current async result wrappers used by the app APIs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session creation selection logic for agent SDK/model resolution; mistakes could lead to sessions launching with unintended SDKs/models, but the change is localized and covered by updated tests.
> 
> **Overview**
> Fixes session-creation handoff selection so an *explicit* `agentSdkOverride` is preserved even when a mode default is configured for a different SDK; mode defaults only override the SDK when no explicit override was provided.
> 
> Updates multiple kanban/worktree/handoff tests to match the current IPC `success`/`value` envelope return shapes for mocked window APIs, and adds coverage for the explicit-SDK override case in `resolveSessionCreationSelection`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bbfb32dd89762bb46240750841c40f073a9cbee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->