### PR TITLE
Handle Anthropic usage 429s with retry-after throttling

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -474,7 +474,22 @@ function registerLoggingHandlers(): void {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
+const gotLock = app.requestSingleInstanceLock()
+if (!gotLock) {
+  app.quit()
+} else {
+  app.on('second-instance', () => {
+    const win = BrowserWindow.getAllWindows()[0]
+    if (win) {
+      if (win.isMinimized()) win.restore()
+      win.focus()
+    }
+  })
+}
+
 app.whenReady().then(async () => {
+  if (!gotLock) return
+
   // Load full shell environment for macOS when launched from Finder/Dock/Spotlight.
   // Must run before any child process spawning (opencode, scripts, Claude Code SDK).
   loadShellEnv()

--- a/src/main/ipc/usage-handlers.ts
+++ b/src/main/ipc/usage-handlers.ts
@@ -30,7 +30,7 @@ export function registerUsageHandlers(): void {
   defineHandler('usage:fetch', z.tuple([]), () =>
     Effect.tryPromise({
       try: async () => {
-        const result = await fetchClaudeUsage()
+        const result = await fetchClaudeUsage(undefined, { caller: 'usage:fetch' })
         if (result.success && result.data) {
           try {
             await captureLiveAccountFromFetch('anthropic', result.data)
@@ -67,7 +67,7 @@ export function registerUsageHandlers(): void {
 
   defineHandler('usage:fetchForAccount', z.string(), (accountId) =>
     Effect.tryPromise({
-      try: () => fetchForSavedAccount(accountId),
+      try: () => fetchForSavedAccount(accountId, { caller: 'usage:fetchForAccount' }),
       catch: (cause) => usageFailed('usage:fetchForAccount', cause)
     })
   )

--- a/src/main/services/saved-usage-orchestrator.ts
+++ b/src/main/services/saved-usage-orchestrator.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { getDatabase } from '../db'
 import { getClaudeAccountEmail, getOpenAIAccountEmail } from './account-service'
 import { createLogger } from './logger'
@@ -6,7 +7,7 @@ import {
   readCodexCredentials,
   type OpenAIUsageOverride
 } from './openai-usage-service'
-import { fetchClaudeUsage, readAccessToken } from './usage-service'
+import { fetchClaudeUsage, readAccessToken, type ClaudeUsageFetchContext } from './usage-service'
 import type {
   FetchForAccountResult,
   OpenAIUsageData,
@@ -131,7 +132,8 @@ function accountError(
   accountId: string,
   message: string,
   status: SavedUsageStatus = 'error',
-  lastUsageJson: string | null = null
+  lastUsageJson: string | null = null,
+  retryAfter?: number
 ): FetchForAccountResult {
   const db = getDatabase()
   db.updateSavedUsageAccountUsage(accountId, {
@@ -139,7 +141,7 @@ function accountError(
     status,
     last_error: message
   })
-  return { success: false, error: message, status }
+  return { success: false, error: message, status, retryAfter }
 }
 
 function parseClaudeCredentials(row: SavedUsageAccount): ClaudeSavedCredentials | null {
@@ -170,7 +172,15 @@ function parseOpenAICredentials(row: SavedUsageAccount): OpenAISavedCredentials 
   }
 }
 
-export async function fetchForSavedAccount(accountId: string): Promise<FetchForAccountResult> {
+interface FetchForSavedAccountOptions {
+  caller?: ClaudeUsageFetchContext['caller']
+  batchId?: string
+}
+
+export async function fetchForSavedAccount(
+  accountId: string,
+  options: FetchForSavedAccountOptions = {}
+): Promise<FetchForAccountResult> {
   const db = getDatabase()
   const row = db.getSavedUsageAccountById(accountId)
   if (!row) return { success: false, error: 'not found', status: 'error' }
@@ -181,7 +191,11 @@ export async function fetchForSavedAccount(accountId: string): Promise<FetchForA
       if (!credentials)
         return accountError(accountId, 'Invalid Claude credentials', 'error', row.last_usage_json)
 
-      const result = await fetchClaudeUsage(credentials.accessToken)
+      const result = await fetchClaudeUsage(credentials.accessToken, {
+        caller: options.caller ?? 'usage:fetchForAccount',
+        accountId,
+        batchId: options.batchId
+      })
       if (!result.success || !result.data) {
         const message = result.error ?? 'Claude usage fetch failed'
         const status: SavedUsageStatus = isAuthStatusError(message) ? 'stale' : 'error'
@@ -190,7 +204,7 @@ export async function fetchForSavedAccount(accountId: string): Promise<FetchForA
           status,
           last_error: message
         })
-        return { success: false, error: message, status }
+        return { success: false, error: message, status, retryAfter: result.retryAfter }
       }
 
       db.updateSavedUsageAccountUsage(accountId, {
@@ -244,19 +258,77 @@ export async function refreshAllForProvider(
   provider: UsageProvider
 ): Promise<RefreshAllResultItem[]> {
   const rows = getDatabase().getSavedUsageAccountsByProvider(provider)
-  return Promise.all(
-    rows.map(async (row) => {
-      try {
-        const result = await fetchForSavedAccount(row.id)
-        return {
-          accountId: row.id,
-          success: result.success,
-          error: result.error
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        return { accountId: row.id, success: false, error: message }
+  const batchId = randomUUID()
+  const startedAt = Date.now()
+  const results: RefreshAllResultItem[] = []
+
+  log.info('refreshAllForProvider start', {
+    provider,
+    batchId,
+    accountCount: rows.length,
+    accountIds: rows.map((row) => row.id)
+  })
+
+  for (const row of rows) {
+    log.info('refreshAllForProvider account start', { provider, batchId, accountId: row.id })
+    try {
+      const result = await fetchForSavedAccount(row.id, {
+        caller: 'refreshAllForProvider',
+        batchId
+      })
+      const item = {
+        accountId: row.id,
+        success: result.success,
+        error: result.error,
+        retryAfter: result.retryAfter
       }
-    })
+      results.push(item)
+
+      if (result.success) {
+        log.info('refreshAllForProvider account success', { provider, batchId, accountId: row.id })
+      } else {
+        log.warn('refreshAllForProvider account failure', {
+          provider,
+          batchId,
+          accountId: row.id,
+          error: result.error,
+          retryAfter: result.retryAfter
+        })
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      results.push({ accountId: row.id, success: false, error: message })
+      log.warn('refreshAllForProvider account failure', {
+        provider,
+        batchId,
+        accountId: row.id,
+        error: message
+      })
+    }
+  }
+
+  const summary = results.reduce(
+    (counts, result) => {
+      if (result.success) {
+        counts.success += 1
+        return counts
+      }
+
+      const status = result.error?.match(/\b([1-5]\d{2})\b/)?.[1]
+      if (status?.startsWith('4')) counts['4xx'] += 1
+      else if (status?.startsWith('5')) counts['5xx'] += 1
+      else counts.network += 1
+      return counts
+    },
+    { success: 0, '4xx': 0, '5xx': 0, network: 0 }
   )
+
+  log.info('refreshAllForProvider complete', {
+    provider,
+    batchId,
+    elapsedMs: Date.now() - startedAt,
+    ...summary
+  })
+
+  return results
 }

--- a/src/main/services/usage-service.ts
+++ b/src/main/services/usage-service.ts
@@ -10,6 +10,32 @@ export type { UsageData, UsageResult }
 
 const log = createLogger({ component: 'UsageService' })
 
+type ClaudeTokenSource = 'keychain' | 'file' | 'override'
+
+export interface ClaudeUsageFetchContext {
+  caller: 'usage:fetch' | 'usage:fetchForAccount' | 'refreshAllForProvider'
+  accountId?: string
+  batchId?: string
+}
+
+interface AccessTokenWithSource {
+  token: string
+  source: ClaudeTokenSource
+}
+
+const RATE_LIMIT_HEADER_NAMES = [
+  'retry-after',
+  'anthropic-ratelimit-unified-status',
+  'anthropic-ratelimit-unified-5h-remaining',
+  'anthropic-ratelimit-unified-5h-reset',
+  'anthropic-ratelimit-unified-7d-remaining',
+  'anthropic-ratelimit-unified-7d-reset',
+  'request-id',
+  'cf-ray'
+] as const
+
+let inFlight = 0
+
 /**
  * Read the OAuth access token from macOS Keychain.
  * Claude Code v2.x stores credentials in the keychain under
@@ -58,21 +84,82 @@ async function readFromFile(): Promise<string | null> {
  * Tries macOS Keychain first (v2.x), then falls back to credentials file.
  */
 export async function readAccessToken(): Promise<string | null> {
-  const token = await readFromKeychain()
-  if (token) return token
-  return readFromFile()
+  return (await readAccessTokenWithSource())?.token ?? null
 }
 
-export async function fetchClaudeUsage(overrideToken?: string): Promise<UsageResult> {
-  const token = overrideToken ?? (await readAccessToken())
+export async function readAccessTokenWithSource(): Promise<AccessTokenWithSource | null> {
+  const keychainToken = await readFromKeychain()
+  if (keychainToken) return { token: keychainToken, source: 'keychain' }
+
+  const fileToken = await readFromFile()
+  if (fileToken) return { token: fileToken, source: 'file' }
+
+  return null
+}
+
+function tokenSuffix(token: string): string {
+  return token.slice(-6)
+}
+
+function extractUsageResponseHeaders(response: Response): Record<string, string | null> {
+  return Object.fromEntries(
+    RATE_LIMIT_HEADER_NAMES.map((headerName) => [headerName, response.headers.get(headerName)])
+  )
+}
+
+function parseRetryAfter(value: string | null): number | undefined {
+  if (!value) return undefined
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds
+
+  const retryAt = Date.parse(value)
+  if (Number.isFinite(retryAt)) {
+    return Math.max(0, Math.ceil((retryAt - Date.now()) / 1000))
+  }
+
+  return undefined
+}
+
+async function readCappedBody(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 1024)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return `Failed to read response body: ${message}`
+  }
+}
+
+export async function fetchClaudeUsage(
+  overrideToken?: string,
+  ctx?: ClaudeUsageFetchContext
+): Promise<UsageResult> {
+  const tokenWithSource =
+    overrideToken !== undefined
+      ? { token: overrideToken, source: 'override' as const }
+      : await readAccessTokenWithSource()
+  const token = tokenWithSource?.token
   if (!token) {
-    log.warn('No Claude OAuth access token found (checked keychain and credentials file)')
+    log.warn('No Claude OAuth access token found (checked keychain and credentials file)', { ...ctx })
     return { success: false, error: 'No access token found' }
   }
 
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let countedInFlight = false
+
   try {
     const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), 10_000)
+    timeout = setTimeout(() => controller.abort(), 10_000)
+
+    inFlight += 1
+    countedInFlight = true
+    log.info('Fetching Claude usage', {
+      ...ctx,
+      tokenSource: tokenWithSource.source,
+      tokenSuffix: tokenSuffix(token),
+      tokenLength: token.length,
+      inFlight
+    })
 
     const response = await fetch('https://api.anthropic.com/api/oauth/usage', {
       method: 'GET',
@@ -84,15 +171,31 @@ export async function fetchClaudeUsage(overrideToken?: string): Promise<UsageRes
       },
       signal: controller.signal
     })
-
     clearTimeout(timeout)
+    timeout = undefined
 
-    if (!response.ok) {
-      const message = `Usage API returned ${response.status}: ${response.statusText}`
-      log.warn(message)
-      return { success: false, error: message }
+    const retryAfter = parseRetryAfter(response.headers.get('retry-after'))
+    const responseLogData: Record<string, unknown> = {
+      ...ctx,
+      status: response.status,
+      statusText: response.statusText,
+      headers: extractUsageResponseHeaders(response),
+      retryAfter,
+      inFlight
     }
 
+    if (!response.ok) {
+      const responseBody = await readCappedBody(response)
+      log.warn('Claude usage response', { ...responseLogData, responseBody })
+      const message = `Usage API returned ${response.status}: ${response.statusText}`
+      return {
+        success: false,
+        error: message,
+        ...(response.status === 429 && retryAfter !== undefined ? { retryAfter } : {})
+      }
+    }
+
+    log.info('Claude usage response', responseLogData)
     const data = (await response.json()) as UsageData
 
     // API returns extra_usage credits in cents — convert to dollars
@@ -104,7 +207,12 @@ export async function fetchClaudeUsage(overrideToken?: string): Promise<UsageRes
     return { success: true, data }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    log.warn('Failed to fetch Claude usage', { error: message })
+    log.warn('Failed to fetch Claude usage', { ...ctx, error: message, inFlight })
     return { success: false, error: message }
+  } finally {
+    if (timeout) clearTimeout(timeout)
+    if (countedInFlight) {
+      inFlight = Math.max(0, inFlight - 1)
+    }
   }
 }

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -205,6 +205,9 @@ function ProviderUsageBlock({
   const lastError = useUsageStore((s) =>
     provider === 'anthropic' ? s.anthropicLastError : s.openaiLastError
   )
+  const retryAfter = useUsageStore((s) =>
+    provider === 'anthropic' ? s.anthropicLastRetryAfter : null
+  )
   const email = useAccountStore((s) =>
     provider === 'anthropic' ? s.anthropicEmail : s.openaiEmail
   )
@@ -312,7 +315,9 @@ function ProviderUsageBlock({
             )}
             {lastError && (
               <div className="text-[10px] text-red-400 border-t border-background/20 pt-1">
-                Refresh failed: {lastError}
+                {retryAfter !== null
+                  ? `Rate limited - retry in ${retryAfter}s`
+                  : `Refresh failed: ${lastError}`}
               </div>
             )}
           </div>
@@ -382,7 +387,9 @@ function ProviderUsageBlock({
           )}
           {lastError && (
             <div className="text-[10px] text-red-400 border-t border-background/20 pt-1">
-              Refresh failed: {lastError}
+              {retryAfter !== null
+                ? `Rate limited - retry in ${retryAfter}s`
+                : `Refresh failed: ${lastError}`}
             </div>
           )}
         </div>

--- a/src/renderer/src/stores/__tests__/useUsageStore.retry-after.test.ts
+++ b/src/renderer/src/stores/__tests__/useUsageStore.retry-after.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useUsageStore } from '../useUsageStore'
+
+const baseState = {
+  anthropicUsage: null,
+  anthropicLastFetchedAt: null,
+  anthropicIsLoading: false,
+  anthropicLastError: null,
+  anthropicLastRetryAfter: null,
+  openaiUsage: null,
+  openaiLastFetchedAt: null,
+  openaiIsLoading: false,
+  openaiLastError: null,
+  activeProvider: 'anthropic' as const,
+  savedAccounts: { anthropic: [], openai: [] },
+  savedAccountLoadErrors: { anthropic: null, openai: null },
+  refreshingProviders: { anthropic: false, openai: false },
+  refreshingAccountIds: new Set<string>()
+}
+
+describe('useUsageStore Anthropic rate-limit throttling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-18T10:00:00.000Z'))
+    vi.clearAllMocks()
+
+    useUsageStore.setState(baseState)
+
+    Object.defineProperty(window, 'usageOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        fetch: vi.fn(),
+        fetchOpenai: vi.fn(),
+        fetchForAccount: vi.fn(),
+        refreshAllForProvider: vi.fn()
+      }
+    })
+
+    Object.defineProperty(window, 'accountOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        getClaudeEmail: vi.fn(),
+        getOpenAIEmail: vi.fn(),
+        listSaved: vi.fn().mockResolvedValue({ success: true, value: [] }),
+        removeSaved: vi.fn()
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses Retry-After from a failed Anthropic fetch to debounce the next fetch', async () => {
+    vi.mocked(window.usageOps.fetch).mockResolvedValue({
+      success: true,
+      value: { success: false, error: 'Usage API returned 429: Too Many Requests', retryAfter: 30 }
+    })
+
+    await useUsageStore.getState().fetchUsageForProvider('anthropic')
+    await useUsageStore.getState().fetchUsageForProvider('anthropic')
+
+    expect(window.usageOps.fetch).toHaveBeenCalledTimes(1)
+    expect(useUsageStore.getState().anthropicLastFetchedAt).toBe(Date.now() - 180_000 + 30_000)
+  })
+
+  it('does not force refresh Anthropic usage within 5 seconds of a successful attempt', async () => {
+    useUsageStore.setState({
+      anthropicLastFetchedAt: Date.now() - 1_000,
+      anthropicLastError: null
+    })
+
+    await useUsageStore.getState().forceRefreshProvider('anthropic')
+
+    expect(window.usageOps.fetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -14,6 +14,7 @@ interface UsageState {
   anthropicLastFetchedAt: number | null
   anthropicIsLoading: boolean
   anthropicLastError: string | null
+  anthropicLastRetryAfter: number | null
 
   openaiUsage: OpenAIUsageData | null
   openaiLastFetchedAt: number | null
@@ -37,9 +38,14 @@ interface UsageState {
 }
 
 const DEBOUNCE_MS = 180_000 // 3 minutes
+const FORCE_REFRESH_FLOOR_MS = 5_000
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
+}
+
+function retryAfterFetchedAt(retryAfter: number | undefined): number | null {
+  return retryAfter === undefined ? null : Date.now() - DEBOUNCE_MS + retryAfter * 1000
 }
 
 export const useUsageStore = create<UsageState>()((set, get) => ({
@@ -47,6 +53,7 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
   anthropicLastFetchedAt: null,
   anthropicIsLoading: false,
   anthropicLastError: null,
+  anthropicLastRetryAfter: null,
 
   openaiUsage: null,
   openaiLastFetchedAt: null,
@@ -156,16 +163,25 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
       try {
         const result = unwrapEnvelope(await window.usageOps.fetch())
         if (result.success) {
-          set({ anthropicUsage: result.data ?? null, anthropicLastError: null })
+          set({
+            anthropicUsage: result.data ?? null,
+            anthropicLastError: null,
+            anthropicLastRetryAfter: null
+          })
           succeeded = true
           get()
             .loadSavedAccounts(provider)
             .catch(() => {})
         } else {
-          set({ anthropicLastError: result.error ?? 'Unknown error' })
+          const retryFetchedAt = retryAfterFetchedAt(result.retryAfter)
+          set({
+            anthropicLastError: result.error ?? 'Unknown error',
+            anthropicLastRetryAfter: result.retryAfter ?? null,
+            ...(retryFetchedAt !== null ? { anthropicLastFetchedAt: retryFetchedAt } : {})
+          })
         }
       } catch (err) {
-        set({ anthropicLastError: errorMessage(err) })
+        set({ anthropicLastError: errorMessage(err), anthropicLastRetryAfter: null })
       } finally {
         set({
           anthropicIsLoading: false,
@@ -205,22 +221,43 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
 
     if (provider === 'anthropic') {
       if (state.anthropicIsLoading) return
+      if (
+        state.anthropicLastRetryAfter !== null &&
+        state.anthropicLastFetchedAt &&
+        Date.now() - state.anthropicLastFetchedAt < DEBOUNCE_MS
+      )
+        return
+      if (
+        state.anthropicLastFetchedAt &&
+        state.anthropicLastError === null &&
+        Date.now() - state.anthropicLastFetchedAt < FORCE_REFRESH_FLOOR_MS
+      )
+        return
 
       set({ anthropicIsLoading: true, anthropicLastError: null })
       let succeeded = false
       try {
         const result = unwrapEnvelope(await window.usageOps.fetch())
         if (result.success) {
-          set({ anthropicUsage: result.data ?? null, anthropicLastError: null })
+          set({
+            anthropicUsage: result.data ?? null,
+            anthropicLastError: null,
+            anthropicLastRetryAfter: null
+          })
           succeeded = true
           get()
             .loadSavedAccounts(provider)
             .catch(() => {})
         } else {
-          set({ anthropicLastError: result.error ?? 'Unknown error' })
+          const retryFetchedAt = retryAfterFetchedAt(result.retryAfter)
+          set({
+            anthropicLastError: result.error ?? 'Unknown error',
+            anthropicLastRetryAfter: result.retryAfter ?? null,
+            ...(retryFetchedAt !== null ? { anthropicLastFetchedAt: retryFetchedAt } : {})
+          })
         }
       } catch (err) {
-        set({ anthropicLastError: errorMessage(err) })
+        set({ anthropicLastError: errorMessage(err), anthropicLastRetryAfter: null })
       } finally {
         set({
           anthropicIsLoading: false,

--- a/src/shared/types/usage.ts
+++ b/src/shared/types/usage.ts
@@ -13,6 +13,7 @@ export interface UsageResult {
   success: boolean
   data?: UsageData
   error?: string
+  retryAfter?: number
 }
 
 export type UsageProvider = 'anthropic' | 'openai'
@@ -63,6 +64,7 @@ export interface FetchForAccountResult {
   success: boolean
   data?: UsageData | OpenAIUsageData
   error?: string
+  retryAfter?: number
   status: SavedUsageStatus
 }
 
@@ -70,4 +72,5 @@ export interface RefreshAllResultItem {
   accountId: string
   success: boolean
   error?: string
+  retryAfter?: number
 }


### PR DESCRIPTION
## Summary
- Propagates `Retry-After` from Anthropic usage fetch failures through the main process and shared result types.
- Debounces repeated Anthropic refresh attempts in the renderer after a 429, while preserving normal refresh behavior for successful fetches.
- Adds richer usage fetch logging and serializes saved-account refreshes with batch-aware context to make 429s easier to trace.
- Updates the usage indicator to surface rate-limit feedback instead of a generic refresh failure.
- Adds coverage for Anthropic retry-after handling in the usage store.

## Testing
- `Not run`
- Added/updated Vitest coverage in `src/renderer/src/stores/__tests__/useUsageStore.retry-after.test.ts`
- Manual verification not run in this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Anthropic usage-fetch path end-to-end (main process, shared types, renderer store/UI) to propagate and act on `Retry-After`, which could affect refresh timing and error handling. Also adds single-instance locking and refactors saved-account refresh to be sequential, which may alter app startup/window focus behavior and refresh throughput.
> 
> **Overview**
> **Anthropic usage refreshes now honor 429 `Retry-After`.** The main-process `fetchClaudeUsage` parses `Retry-After`, returns `retryAfter` on rate limits, and logs richer request/response context (caller/account/batch + selected headers).
> 
> **Retry-after is propagated through IPC/types and used to throttle the UI.** Shared `UsageResult`/`FetchForAccountResult`/`RefreshAllResultItem` gain `retryAfter`; the renderer `useUsageStore` stores `anthropicLastRetryAfter`, debounces subsequent fetches accordingly, and the `UsageIndicator` shows a rate-limit message instead of a generic error.
> 
> **Saved-account refresh is serialized with batch-aware logging,** and Electron now enforces a single-instance lock (second launch focuses/restores the existing window).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f54bddfa85f60fc20c56f3d2596654551120a00c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->