### PR TITLE
Fix Claude session transcript lookup and logging

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -474,22 +474,7 @@ function registerLoggingHandlers(): void {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-const gotLock = app.requestSingleInstanceLock()
-if (!gotLock) {
-  app.quit()
-} else {
-  app.on('second-instance', () => {
-    const win = BrowserWindow.getAllWindows()[0]
-    if (win) {
-      if (win.isMinimized()) win.restore()
-      win.focus()
-    }
-  })
-}
-
 app.whenReady().then(async () => {
-  if (!gotLock) return
-
   // Load full shell environment for macOS when launched from Finder/Dock/Spotlight.
   // Must run before any child process spawning (opencode, scripts, Claude Code SDK).
   loadShellEnv()

--- a/src/main/services/claude-transcript-reader.ts
+++ b/src/main/services/claude-transcript-reader.ts
@@ -1,16 +1,69 @@
-import { readFile } from 'fs/promises'
+import { createHash } from 'crypto'
+import { readFile, readdir } from 'fs/promises'
 import { join } from 'path'
 import { homedir } from 'os'
 import { createLogger } from './logger'
 
 const log = createLogger({ component: 'ClaudeTranscriptReader' })
+const ENCODED_PATH_MAX_LEN = 200
 
 /**
- * Encode a worktree path the same way Claude CLI does:
- * replace every `/` and `.` with `-`.
+ * Encode a worktree path the same way the Claude Agent SDK stores project transcripts.
  */
 export function encodePath(worktreePath: string): string {
-  return worktreePath.replace(/[/.]/g, '-')
+  const normalizedPath = worktreePath.normalize('NFC')
+  const encoded = normalizedPath.replace(/[^a-zA-Z0-9]/g, '-')
+  if (encoded.length <= ENCODED_PATH_MAX_LEN) return encoded
+
+  const hashSuffix = createHash('sha256').update(normalizedPath).digest('hex').slice(0, 8)
+  return `${encoded.slice(0, ENCODED_PATH_MAX_LEN)}-${hashSuffix}`
+}
+
+function resolveProjectsDir(): string {
+  const configuredDir = process.env.CLAUDE_CONFIG_DIR
+  const configRoot =
+    typeof configuredDir === 'string' && configuredDir.trim().length > 0
+      ? configuredDir
+      : join(homedir(), '.claude')
+
+  return join(configRoot.normalize('NFC'), 'projects')
+}
+
+function isErrnoCode(err: unknown, code: string): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as NodeJS.ErrnoException).code === code
+  )
+}
+
+function logTranscriptReadFailure(
+  err: unknown,
+  fields: {
+    projectsRoot: string
+    encoded: string
+    primaryFilePath: string
+    claudeSessionId: string
+  }
+): void {
+  const errCode = isErrnoCode(err, 'ENOENT') ? 'ENOENT' : (err as NodeJS.ErrnoException)?.code
+  const logFields = { ...fields, errCode }
+
+  if (isErrnoCode(err, 'ENOENT')) {
+    if (fields.claudeSessionId.startsWith('pending::')) {
+      log.debug('Claude transcript file not found', logFields)
+    } else {
+      log.warn('Claude transcript file not found', logFields)
+    }
+    return
+  }
+
+  log.error(
+    'Claude transcript file unreadable',
+    err instanceof Error ? err : new Error(String(err)),
+    logFields
+  )
 }
 
 interface ClaudeContentBlock {
@@ -144,19 +197,53 @@ export async function readClaudeTranscript(
   worktreePath: string,
   claudeSessionId: string
 ): Promise<unknown[]> {
+  const projectsRoot = resolveProjectsDir()
   const encoded = encodePath(worktreePath)
-  const filePath = join(homedir(), '.claude', 'projects', encoded, `${claudeSessionId}.jsonl`)
+  const primaryFilePath = join(projectsRoot, encoded, `${claudeSessionId}.jsonl`)
+  const logFields = { projectsRoot, encoded, primaryFilePath, claudeSessionId }
 
-  let raw: string
+  let raw: string | undefined
+  let filePath = primaryFilePath
+  let matchedProjectDir = encoded
+  let readError: unknown
   try {
-    raw = await readFile(filePath, 'utf-8')
+    raw = await readFile(primaryFilePath, 'utf-8')
   } catch (err) {
-    log.debug('Transcript file not found or unreadable', {
-      filePath,
-      error: err instanceof Error ? err.message : String(err)
-    })
-    return []
+    readError = err
+    if (isErrnoCode(err, 'ENOENT')) {
+      const prefix = encoded.slice(0, ENCODED_PATH_MAX_LEN)
+      let candidates: string[] = []
+      try {
+        candidates = (await readdir(projectsRoot)).filter((entry) => entry.startsWith(prefix))
+      } catch (readdirErr) {
+        if (!isErrnoCode(readdirErr, 'ENOENT')) {
+          readError = readdirErr
+        }
+      }
+
+      for (const candidate of candidates) {
+        const candidateFilePath = join(projectsRoot, candidate, `${claudeSessionId}.jsonl`)
+        try {
+          raw = await readFile(candidateFilePath, 'utf-8')
+          filePath = candidateFilePath
+          matchedProjectDir = candidate
+          readError = undefined
+          break
+        } catch (candidateErr) {
+          readError = candidateErr
+          if (!isErrnoCode(candidateErr, 'ENOENT')) {
+            break
+          }
+        }
+      }
+    }
+
+    if (readError !== undefined) {
+      logTranscriptReadFailure(readError, logFields)
+      return []
+    }
   }
+  if (raw === undefined) return []
 
   const lines = raw.split('\n')
 
@@ -239,6 +326,7 @@ export async function readClaudeTranscript(
 
   log.info('Read Claude transcript', {
     filePath,
+    matchedProjectDir,
     totalLines: lines.length,
     parsedEntries: entries.length,
     messageCount: messages.length

--- a/test/phase-21/session-5/claude-transcript-reader.test.ts
+++ b/test/phase-21/session-5/claude-transcript-reader.test.ts
@@ -1,17 +1,21 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'path'
+import { homedir } from 'os'
 
 vi.mock('fs/promises')
-vi.mock('../../../src/main/services/logger', () => ({
-  createLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn()
-  })
+const mockLog = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn()
 }))
 
-import { readFile } from 'fs/promises'
+vi.mock('../../../src/main/services/logger', () => ({
+  createLogger: () => mockLog
+}))
+
+import { readFile, readdir } from 'fs/promises'
 import {
   readClaudeTranscript,
   encodePath,
@@ -24,6 +28,7 @@ import type {
 } from '../../../src/main/services/claude-transcript-reader'
 
 const mockReadFile = vi.mocked(readFile)
+const mockReaddir = vi.mocked(readdir)
 
 // ── Helpers ────────────────────────────────────────────────────────
 
@@ -59,11 +64,31 @@ function buildJsonl(...entries: object[]): string {
   return entries.map((e) => JSON.stringify(e)).join('\n')
 }
 
+function makeEnoent(path = 'missing.jsonl'): NodeJS.ErrnoException {
+  const err = new Error(`ENOENT: no such file or directory, open '${path}'`) as NodeJS.ErrnoException
+  err.code = 'ENOENT'
+  return err
+}
+
 // ── Tests ──────────────────────────────────────────────────────────
 
 describe('claude-transcript-reader', () => {
+  const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
+  const restoreClaudeConfigDir = () => {
+    if (originalClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
+    }
+  }
+
   beforeEach(() => {
     vi.resetAllMocks()
+    restoreClaudeConfigDir()
+  })
+
+  afterEach(() => {
+    restoreClaudeConfigDir()
   })
 
   // 1. Path encoding
@@ -86,6 +111,123 @@ describe('claude-transcript-reader', () => {
 
     it('replaces dots with dashes (dotfiles like .hive-worktrees)', () => {
       expect(encodePath('/Users/mor/.hive-worktrees/proj')).toBe('-Users-mor--hive-worktrees-proj')
+    })
+
+    it('replaces underscores with dashes', () => {
+      expect(encodePath('/Users/mor/my_project')).toBe('-Users-mor-my-project')
+    })
+
+    it('replaces spaces with dashes', () => {
+      expect(encodePath('/Users/mor/My Project')).toBe('-Users-mor-My-Project')
+    })
+
+    it('replaces Windows drive separators and backslashes with dashes', () => {
+      expect(encodePath('C:\\Users\\mor\\proj')).toBe('C--Users-mor-proj')
+    })
+
+    it('replaces parentheses with dashes', () => {
+      expect(encodePath('/Users/mor/work(1)')).toBe('-Users-mor-work-1-')
+    })
+
+    it('replaces at signs with dashes', () => {
+      expect(encodePath('/Users/mor/proj@v2')).toBe('-Users-mor-proj-v2')
+    })
+
+    it('keeps existing hyphens as hyphens', () => {
+      expect(encodePath('/Users/mor/already-hyphen')).toBe('-Users-mor-already-hyphen')
+    })
+
+    it('normalizes accented paths to NFC before encoding', () => {
+      const decomposed = '/Users/mor/cafe\u0301'
+      const expected = decomposed.normalize('NFC').replace(/[^a-zA-Z0-9]/g, '-')
+
+      expect(encodePath(decomposed)).toBe(expected)
+    })
+
+    it('truncates long encodings to 200 chars plus an 8-char hash suffix', () => {
+      const path = `/tmp/${'a'.repeat(260)}`
+      const naiveEncoding = path.normalize('NFC').replace(/[^a-zA-Z0-9]/g, '-')
+      const result = encodePath(path)
+
+      expect(result).toHaveLength(209)
+      expect(result.slice(0, 200)).toBe(naiveEncoding.slice(0, 200))
+      expect(result.slice(200)).toMatch(/^-[a-f0-9]{8}$/)
+    })
+  })
+
+  describe('resolveProjectsDir / CLAUDE_CONFIG_DIR', () => {
+    it('uses CLAUDE_CONFIG_DIR when it is set', async () => {
+      process.env.CLAUDE_CONFIG_DIR = '/tmp/custom-claude'
+      mockReadFile.mockResolvedValue(buildJsonl(makeAssistantEntry()))
+
+      await readClaudeTranscript('/Users/mor/project', 'session-123')
+
+      expect(mockReadFile).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/tmp\/custom-claude\/projects\//),
+        'utf-8'
+      )
+    })
+
+    it('uses homedir .claude when CLAUDE_CONFIG_DIR is empty', async () => {
+      process.env.CLAUDE_CONFIG_DIR = ''
+      mockReadFile.mockResolvedValue(buildJsonl(makeAssistantEntry()))
+
+      await readClaudeTranscript('/Users/mor/project', 'session-123')
+
+      expect(mockReadFile).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`^${join(homedir(), '.claude', 'projects')}`)),
+        'utf-8'
+      )
+    })
+
+    it('uses homedir .claude when CLAUDE_CONFIG_DIR is unset', async () => {
+      delete process.env.CLAUDE_CONFIG_DIR
+      mockReadFile.mockResolvedValue(buildJsonl(makeAssistantEntry()))
+
+      await readClaudeTranscript('/Users/mor/project', 'session-123')
+
+      expect(mockReadFile).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`^${join(homedir(), '.claude', 'projects')}`)),
+        'utf-8'
+      )
+    })
+  })
+
+  describe('lookup fallback for truncated/aliased directories', () => {
+    it('reads the first matching aliased directory that contains the transcript', async () => {
+      const path = `/tmp/${'a'.repeat(260)}`
+      const encoded = encodePath(path)
+      const prefix = encoded.slice(0, 200)
+      const jsonl = buildJsonl(makeAssistantEntry({ uuid: 'from-fallback' }))
+
+      mockReadFile.mockRejectedValueOnce(makeEnoent())
+      mockReaddir.mockResolvedValue([
+        `${prefix}-aaaaaaaa`,
+        `${prefix}-bbbbbbbb`,
+        'other-dir'
+      ] as any)
+      mockReadFile.mockRejectedValueOnce(makeEnoent())
+      mockReadFile.mockResolvedValueOnce(jsonl)
+
+      const result = await readClaudeTranscript(path, 'session-123')
+
+      expect(result).toHaveLength(1)
+      expect((result[0] as any).id).toBe('from-fallback')
+      expect(mockReadFile).toHaveBeenLastCalledWith(
+        expect.stringContaining(`${prefix}-bbbbbbbb/session-123.jsonl`),
+        'utf-8'
+      )
+    })
+
+    it('returns [] without candidate reads when no directory matches the encoded prefix', async () => {
+      const path = `/tmp/${'a'.repeat(260)}`
+      mockReadFile.mockRejectedValueOnce(makeEnoent())
+      mockReaddir.mockResolvedValue(['other-dir'] as any)
+
+      const result = await readClaudeTranscript(path, 'session-123')
+
+      expect(result).toEqual([])
+      expect(mockReadFile).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -242,10 +384,55 @@ describe('claude-transcript-reader', () => {
   // 7. Missing file returns []
   describe('missing file', () => {
     it('returns empty array when file does not exist', async () => {
-      mockReadFile.mockRejectedValue(new Error('ENOENT: no such file or directory'))
+      mockReadFile.mockRejectedValue(makeEnoent())
+      mockReaddir.mockResolvedValue([] as any)
 
       const result = await readClaudeTranscript('/no/such/path', 'missing-session')
       expect(result).toEqual([])
+    })
+
+    it('logs a warning with transcript lookup fields for missing real sessions', async () => {
+      mockReadFile.mockRejectedValue(makeEnoent())
+      mockReaddir.mockResolvedValue([] as any)
+
+      await readClaudeTranscript('/no/such/path', 'real-uuid-123')
+
+      expect(mockLog.warn).toHaveBeenCalledOnce()
+      expect(mockLog.warn).toHaveBeenCalledWith('Claude transcript file not found', {
+        projectsRoot: join(homedir(), '.claude', 'projects').normalize('NFC'),
+        encoded: '-no-such-path',
+        primaryFilePath: join(
+          homedir(),
+          '.claude',
+          'projects',
+          '-no-such-path',
+          'real-uuid-123.jsonl'
+        ).normalize('NFC'),
+        claudeSessionId: 'real-uuid-123',
+        errCode: 'ENOENT'
+      })
+    })
+
+    it('keeps pending session missing-file logs at debug level', async () => {
+      mockReadFile.mockRejectedValue(makeEnoent())
+      mockReaddir.mockResolvedValue([] as any)
+
+      await readClaudeTranscript('/no/such/path', 'pending::abc')
+
+      expect(mockLog.warn).not.toHaveBeenCalled()
+      expect(mockLog.debug).toHaveBeenCalledWith('Claude transcript file not found', {
+        projectsRoot: join(homedir(), '.claude', 'projects').normalize('NFC'),
+        encoded: '-no-such-path',
+        primaryFilePath: join(
+          homedir(),
+          '.claude',
+          'projects',
+          '-no-such-path',
+          'pending::abc.jsonl'
+        ).normalize('NFC'),
+        claudeSessionId: 'pending::abc',
+        errCode: 'ENOENT'
+      })
     })
   })
 


### PR DESCRIPTION
## Summary
- Remove the early single-instance lock gate from Electron startup so the app can continue initializing sessions reliably.
- Update Claude transcript path encoding to match Agent SDK storage, including NFC normalization, broad character replacement, and hash-suffixed truncation for long paths.
- Add support for `CLAUDE_CONFIG_DIR` and fallback lookup of aliased/truncated project directories when the primary transcript path is missing.
- Improve missing-file logging to distinguish pending sessions from real sessions and add coverage for the new lookup behavior.

## Testing
- Added Vitest coverage for path encoding, config-directory resolution, alias fallback, and missing-file logging behavior.
- Not run locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to changes in Electron startup behavior (removing single-instance lock gating) and new filesystem lookup logic that could affect session initialization and transcript discovery across platforms.
> 
> **Overview**
> Removes the early `requestSingleInstanceLock()` gate in `src/main/index.ts`, allowing the app to complete initialization even when a second instance is launched.
> 
> Updates `claude-transcript-reader` to match Agent SDK transcript storage: NFC-normalized, non-alphanumeric-to-dash path encoding with 200-char truncation + hash suffix, support for `CLAUDE_CONFIG_DIR`, and a fallback search for aliased/truncated project directories when the primary transcript path is missing. Missing/unreadable transcript logging is made more structured, with *pending* sessions logged at `debug` and real sessions at `warn`, and tests expanded to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd81894e6471c1805f5e917250f9400518bdd585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->