### PR TITLE
Surface Anthropic rate-limit state in usage UI

### DIFF
--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -585,344 +585,357 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         hiveSessionId: session.hiveSessionId,
         queryIterator: queryData as unknown as AsyncIterable<unknown>,
         onMessage: async (sdkMessage) => {
-        // Break if aborted
-        if (session.abortController?.signal.aborted) {
-          log.info('Prompt: aborted, breaking loop')
-          return
-        }
+          // Break if aborted
+          if (session.abortController?.signal.aborted) {
+            log.info('Prompt: aborted, breaking loop')
+            return
+          }
 
-        const msgType = sdkMessage.type as string
+          const msgType = sdkMessage.type as string
 
-        // stream_event messages fire per-token — log at debug to avoid spam
-        if (msgType === 'stream_event') {
-          hasStreamedContent = true
-          this.emitSdkMessage(session.hiveSessionId, sdkMessage, messageIndex, session.toolNames)
-          return // No materialization/accumulation needed for partials
-        }
+          // stream_event messages fire per-token — log at debug to avoid spam
+          if (msgType === 'stream_event') {
+            hasStreamedContent = true
+            this.emitSdkMessage(session.hiveSessionId, sdkMessage, messageIndex, session.toolNames)
+            return // No materialization/accumulation needed for partials
+          }
 
-        if (msgType === 'rate_limit_event') {
-          log.info('Prompt: rate_limit_event received', {
-            fullMessage: sdkMessage
-          })
-        }
-
-        log.info('Prompt: received SDK message', {
-          type: msgType,
-          index: messageIndex,
-          hasSessionId: !!sdkMessage.session_id,
-          hasContent: !!sdkMessage.content,
-          keys: Object.keys(sdkMessage).join(',')
-        })
-
-        // Log init messages (includes MCP server connection status) and cache slash commands
-        // SDK sends init as { type: 'system', subtype: 'init' }
-        const msgSubtype = (sdkMessage as Record<string, unknown>).subtype as string | undefined
-        if (msgType === 'system' && msgSubtype === 'init') {
-          const initMsg = sdkMessage as Record<string, unknown>
-          log.info('Prompt: init message received', {
-            mcpServers: initMsg.mcp_servers,
-            model: initMsg.model,
-            slashCommands: initMsg.slash_commands
-          })
-
-          // Phase 1: Cache command names from init message as minimal entries
-          const initSlashCommandNames = initMsg.slash_commands as string[] | undefined
-          if (initSlashCommandNames && Array.isArray(initSlashCommandNames)) {
-            const minimal = initSlashCommandNames
-              .filter((name): name is string => typeof name === 'string')
-              .map((name) => ({
-                name,
-                description: '',
-                argumentHint: ''
-              }))
-            this.cachedSlashCommands.set(worktreePath, minimal)
-            this.persistCommandsToDb(worktreePath)
-            log.info('Prompt: cached slash command names from init', {
-              count: minimal.length,
-              names: minimal.map((c) => c.name)
+          if (msgType === 'rate_limit_event') {
+            const info = (sdkMessage as Record<string, unknown>).rate_limit_info
+            log.info('Prompt: rate_limit_event received', {
+              fullMessage: sdkMessage
             })
-          }
-
-          // Phase 2: Enrich with full metadata via supportedCommands() (fire-and-forget)
-          if (session.query?.supportedCommands) {
-            session.query
-              .supportedCommands()
-              .then((cmds) => {
-                if (cmds?.length) {
-                  this.cachedSlashCommands.set(worktreePath, cmds)
-                  this.persistCommandsToDb(worktreePath)
-                  log.info('Prompt: cached full slash commands from supportedCommands()', {
-                    count: cmds.length,
-                    names: cmds.map((c) => c.name)
-                  })
-                }
-              })
-              .catch((err) => {
-                log.warn('Prompt: supportedCommands() failed, using init names', {
-                  error: err instanceof Error ? err.message : String(err)
-                })
-              })
-          }
-
-          // Notify renderer that commands are now available for fetching
-          this.sendToRenderer('opencode:stream', {
-            type: 'session.commands_available',
-            sessionId: session.hiveSessionId,
-            data: {}
-          })
-
-          // Send Claude model limits so the renderer can populate contextStore
-          this.sendToRenderer('opencode:stream', {
-            type: 'session.model_limits',
-            sessionId: session.hiveSessionId,
-            data: {
-              models: CLAUDE_MODELS.map((m) => ({
-                modelID: m.id,
-                providerID: 'anthropic',
-                contextLimit: m.limit.context
-              }))
-            }
-          })
-
-          return
-        }
-
-        // Materialize pending:: to real SDK session ID from first message,
-        // or capture a new session ID after a fork (forkSession: true returns a new ID)
-        const sdkSessionId = sdkMessage.session_id as string | undefined
-        if (
-          sdkSessionId &&
-          (session.claudeSessionId.startsWith('pending::') ||
-            sdkSessionId !== session.claudeSessionId)
-        ) {
-          const wasPending = session.claudeSessionId.startsWith('pending::')
-          const oldKey = this.getSessionKey(worktreePath, session.claudeSessionId)
-          session.claudeSessionId = sdkSessionId
-          session.materialized = true
-          this.sessions.delete(oldKey)
-          const newKey = this.getSessionKey(worktreePath, sdkSessionId)
-          this.sessions.set(newKey, session)
-          log.info(wasPending ? 'Materialized session ID' : 'Forked session ID', {
-            oldKey,
-            newKey
-          })
-
-          // When forking (not initial materialization), reset checkpoints
-          // since the new fork starts with its own checkpoint space
-          if (!wasPending) {
-            session.checkpoints = new Map()
-            session.checkpointCounter = 0
-            log.info('Reset checkpoints for forked session', {
-              hiveSessionId: session.hiveSessionId,
-              newSessionId: sdkSessionId
+            this.sendToRenderer('opencode:stream', {
+              type: 'session.rate_limit',
+              sessionId: session.hiveSessionId,
+              data: info
             })
+            return
           }
 
-          // Update DB so future IPC calls with the new ID resolve correctly
-          if (this.dbService) {
-            try {
-              this.dbService.updateSession(session.hiveSessionId, {
-                opencode_session_id: sdkSessionId
-              })
-              log.info('Updated DB opencode_session_id', {
-                hiveSessionId: session.hiveSessionId,
-                newAgentSessionId: sdkSessionId
-              })
-            } catch (err) {
-              const error = err instanceof Error ? err : new Error(String(err))
-              log.error('Failed to update opencode_session_id in DB', error, {
-                hiveSessionId: session.hiveSessionId
+          log.info('Prompt: received SDK message', {
+            type: msgType,
+            index: messageIndex,
+            hasSessionId: !!sdkMessage.session_id,
+            hasContent: !!sdkMessage.content,
+            keys: Object.keys(sdkMessage).join(',')
+          })
+
+          // Log init messages (includes MCP server connection status) and cache slash commands
+          // SDK sends init as { type: 'system', subtype: 'init' }
+          const msgSubtype = (sdkMessage as Record<string, unknown>).subtype as string | undefined
+          if (msgType === 'system' && msgSubtype === 'init') {
+            const initMsg = sdkMessage as Record<string, unknown>
+            log.info('Prompt: init message received', {
+              mcpServers: initMsg.mcp_servers,
+              model: initMsg.model,
+              slashCommands: initMsg.slash_commands
+            })
+
+            // Phase 1: Cache command names from init message as minimal entries
+            const initSlashCommandNames = initMsg.slash_commands as string[] | undefined
+            if (initSlashCommandNames && Array.isArray(initSlashCommandNames)) {
+              const minimal = initSlashCommandNames
+                .filter((name): name is string => typeof name === 'string')
+                .map((name) => ({
+                  name,
+                  description: '',
+                  argumentHint: ''
+                }))
+              this.cachedSlashCommands.set(worktreePath, minimal)
+              this.persistCommandsToDb(worktreePath)
+              log.info('Prompt: cached slash command names from init', {
+                count: minimal.length,
+                names: minimal.map((c) => c.name)
               })
             }
-          }
 
-          // Notify renderer so it updates its opencodeSessionId state
-          // (otherwise loadMessages() after idle will use the stale pending:: ID).
-          // Include wasFork so the renderer knows whether to clear old messages.
-          // wasFork is true ONLY for explicit fork requests (undo+resend), not
-          // for normal SDK session ID changes during resume.
-          this.sendToRenderer('opencode:stream', {
-            type: 'session.materialized',
-            sessionId: session.hiveSessionId,
-            data: { newSessionId: sdkSessionId, wasFork: !wasPending && wasForkRequest }
-          })
-
-          // Fire-and-forget: generate a title for brand-new sessions only.
-          // wasPending is only true on initial materialization, not forks.
-          if (wasPending) {
-            if (prompt.trimStart().startsWith('/using-superpowers')) {
-              session.titleDeferred = true
-              log.info('Prompt: deferring title generation (superpowers hook)', {
-                hiveSessionId: session.hiveSessionId
-              })
-            } else {
-              this.handleTitleGeneration(session, prompt).catch(() => {
-                // Swallowed — handleTitleGeneration already logs internally
-              })
-            }
-          }
-        }
-
-        // Accumulate translated messages in-memory for getMessages()
-        if (msgType === 'user' || msgType === 'assistant') {
-          const sdkMsg = sdkMessage as Record<string, unknown>
-          const msgContent = (
-            sdkMsg.message as { content?: { type: string; [key: string]: unknown }[] } | undefined
-          )?.content
-          const contentBlockTypes = Array.isArray(msgContent) ? msgContent.map((b) => b.type) : []
-          const isToolResultOnly =
-            msgType === 'user' &&
-            contentBlockTypes.length > 0 &&
-            contentBlockTypes.every((t) => t === 'tool_result')
-
-          // Capture checkpoints only from actual user prompts on the
-          // main conversation thread (not subagent messages).
-          // tool_result-only user messages carry UUIDs but do not represent
-          // stable rewind points for file checkpointing.
-          // Subagent messages have parent_tool_use_id set — their UUIDs live
-          // in a separate JSONL file and are not valid fork/resume points.
-          const isSubagentMessage = !!(sdkMessage as Record<string, unknown>).parent_tool_use_id
-          if (msgType === 'user' && sdkMessage.uuid && !isToolResultOnly && !isSubagentMessage) {
-            const checkpointUuid = sdkMessage.uuid as string
-            const isFirstSeenCheckpoint = !session.checkpoints.has(checkpointUuid)
-            if (isFirstSeenCheckpoint) {
-              session.checkpointCounter += 1
-              session.checkpoints.set(checkpointUuid, session.checkpointCounter)
-              log.info('Checkpoint captured', {
-                uuid: checkpointUuid,
-                counter: session.checkpointCounter,
-                totalCheckpoints: session.checkpoints.size
-              })
-            }
-          } else if (msgType === 'user' && sdkMessage.uuid && isSubagentMessage) {
-            log.debug('Skipping subagent user message for checkpoint', {
-              uuid: (sdkMessage.uuid as string).slice(0, 12),
-              parentToolUseId: (sdkMessage as Record<string, unknown>).parent_tool_use_id
-            })
-          }
-
-          log.info('TOOL_LIFECYCLE: accumulate message', {
-            hiveSessionId: session.hiveSessionId,
-            msgType,
-            contentBlockTypes,
-            isToolResultOnly,
-            isSubagentMessage
-          })
-
-          // Skip subagent messages from accumulation — they belong to the child
-          // session's transcript and should not appear in the main conversation.
-          // The renderer routes subagent content into SubtaskCards via childSessionId
-          // on stream events; the in-memory cache must not include them either.
-          if (isSubagentMessage) {
-            log.debug('Skipping subagent message from session.messages accumulation', {
-              msgType,
-              parentToolUseId: (sdkMessage as Record<string, unknown>).parent_tool_use_id
-            })
-          } else if (isToolResultOnly) {
-            // Instead of creating an empty user message, merge tool_result
-            // output/error into the preceding assistant message's tool_use parts.
-            const toolResults = msgContent as {
-              type: string
-              tool_use_id?: string
-              is_error?: boolean
-              content?: string | { type: string; text?: string }[]
-            }[]
-            // Find the last assistant message
-            const lastAssistant = [...session.messages]
-              .reverse()
-              .find((m) => (m as Record<string, unknown>).role === 'assistant') as
-              | Record<string, unknown>
-              | undefined
-            if (lastAssistant) {
-              const parts = lastAssistant.parts as Record<string, unknown>[] | undefined
-              if (Array.isArray(parts)) {
-                for (const tr of toolResults) {
-                  if (tr.type !== 'tool_result' || !tr.tool_use_id) continue
-                  let output: string | undefined
-                  if (typeof tr.content === 'string') {
-                    output = tr.content
-                  } else if (Array.isArray(tr.content)) {
-                    output = tr.content
-                      .filter((c) => c.type === 'text')
-                      .map((c) => c.text ?? '')
-                      .join('\n')
-                  }
-                  const toolPart = parts.find(
-                    (p) =>
-                      p.type === 'tool_use' &&
-                      (p.toolUse as Record<string, unknown> | undefined)?.id === tr.tool_use_id
-                  )
-                  if (toolPart) {
-                    const tu = toolPart.toolUse as Record<string, unknown>
-                    tu.output = output
-                    tu.error = tr.is_error ? output : undefined
-                    tu.status = tr.is_error ? 'error' : 'success'
-                    log.info('TOOL_LIFECYCLE: merged tool_result into assistant tool_use', {
-                      toolId: tr.tool_use_id,
-                      isError: !!tr.is_error,
-                      hasOutput: !!output
+            // Phase 2: Enrich with full metadata via supportedCommands() (fire-and-forget)
+            if (session.query?.supportedCommands) {
+              session.query
+                .supportedCommands()
+                .then((cmds) => {
+                  if (cmds?.length) {
+                    this.cachedSlashCommands.set(worktreePath, cmds)
+                    this.persistCommandsToDb(worktreePath)
+                    log.info('Prompt: cached full slash commands from supportedCommands()', {
+                      count: cmds.length,
+                      names: cmds.map((c) => c.name)
                     })
                   }
-                }
+                })
+                .catch((err) => {
+                  log.warn('Prompt: supportedCommands() failed, using init names', {
+                    error: err instanceof Error ? err.message : String(err)
+                  })
+                })
+            }
+
+            // Notify renderer that commands are now available for fetching
+            this.sendToRenderer('opencode:stream', {
+              type: 'session.commands_available',
+              sessionId: session.hiveSessionId,
+              data: {}
+            })
+
+            // Send Claude model limits so the renderer can populate contextStore
+            this.sendToRenderer('opencode:stream', {
+              type: 'session.model_limits',
+              sessionId: session.hiveSessionId,
+              data: {
+                models: CLAUDE_MODELS.map((m) => ({
+                  modelID: m.id,
+                  providerID: 'anthropic',
+                  contextLimit: m.limit.context
+                }))
+              }
+            })
+
+            return
+          }
+
+          // Materialize pending:: to real SDK session ID from first message,
+          // or capture a new session ID after a fork (forkSession: true returns a new ID)
+          const sdkSessionId = sdkMessage.session_id as string | undefined
+          if (
+            sdkSessionId &&
+            (session.claudeSessionId.startsWith('pending::') ||
+              sdkSessionId !== session.claudeSessionId)
+          ) {
+            const wasPending = session.claudeSessionId.startsWith('pending::')
+            const oldKey = this.getSessionKey(worktreePath, session.claudeSessionId)
+            session.claudeSessionId = sdkSessionId
+            session.materialized = true
+            this.sessions.delete(oldKey)
+            const newKey = this.getSessionKey(worktreePath, sdkSessionId)
+            this.sessions.set(newKey, session)
+            log.info(wasPending ? 'Materialized session ID' : 'Forked session ID', {
+              oldKey,
+              newKey
+            })
+
+            // When forking (not initial materialization), reset checkpoints
+            // since the new fork starts with its own checkpoint space
+            if (!wasPending) {
+              session.checkpoints = new Map()
+              session.checkpointCounter = 0
+              log.info('Reset checkpoints for forked session', {
+                hiveSessionId: session.hiveSessionId,
+                newSessionId: sdkSessionId
+              })
+            }
+
+            // Update DB so future IPC calls with the new ID resolve correctly
+            if (this.dbService) {
+              try {
+                this.dbService.updateSession(session.hiveSessionId, {
+                  opencode_session_id: sdkSessionId
+                })
+                log.info('Updated DB opencode_session_id', {
+                  hiveSessionId: session.hiveSessionId,
+                  newAgentSessionId: sdkSessionId
+                })
+              } catch (err) {
+                const error = err instanceof Error ? err : new Error(String(err))
+                log.error('Failed to update opencode_session_id in DB', error, {
+                  hiveSessionId: session.hiveSessionId
+                })
               }
             }
-          } else {
-            const translated = translateEntry(
-              {
-                type: msgType,
-                uuid: sdkMsg.uuid as string | undefined,
-                timestamp: new Date().toISOString(),
-                message: sdkMsg.message as
-                  | {
-                      role?: string
-                      content?: { type: string; [key: string]: unknown }[] | string
-                    }
-                  | undefined,
-                isSidechain: false
-              },
-              session.messages.length
-            )
-            if (translated) {
-              const isUserMessage = msgType === 'user'
-              const translatedContent = (translated as Record<string, unknown>).content
-              let optimisticIndex = -1
 
-              if (isUserMessage && typeof translatedContent === 'string') {
-                for (let i = session.messages.length - 1; i >= 0; i--) {
-                  const candidate = session.messages[i] as Record<string, unknown>
-                  if (
-                    candidate.role === 'user' &&
-                    typeof candidate.id === 'string' &&
-                    candidate.id.startsWith('user-') &&
-                    typeof candidate.content === 'string' &&
-                    candidate.content === translatedContent
-                  ) {
-                    optimisticIndex = i
-                    break
-                  }
-                }
-              }
+            // Notify renderer so it updates its opencodeSessionId state
+            // (otherwise loadMessages() after idle will use the stale pending:: ID).
+            // Include wasFork so the renderer knows whether to clear old messages.
+            // wasFork is true ONLY for explicit fork requests (undo+resend), not
+            // for normal SDK session ID changes during resume.
+            this.sendToRenderer('opencode:stream', {
+              type: 'session.materialized',
+              sessionId: session.hiveSessionId,
+              data: { newSessionId: sdkSessionId, wasFork: !wasPending && wasForkRequest }
+            })
 
-              if (optimisticIndex >= 0) {
-                session.messages[optimisticIndex] = translated
+            // Fire-and-forget: generate a title for brand-new sessions only.
+            // wasPending is only true on initial materialization, not forks.
+            if (wasPending) {
+              if (prompt.trimStart().startsWith('/using-superpowers')) {
+                session.titleDeferred = true
+                log.info('Prompt: deferring title generation (superpowers hook)', {
+                  hiveSessionId: session.hiveSessionId
+                })
               } else {
-                session.messages.push(translated)
+                this.handleTitleGeneration(session, prompt).catch(() => {
+                  // Swallowed — handleTitleGeneration already logs internally
+                })
               }
             }
           }
-        }
 
-        // Emit normalized event
-        this.emitSdkMessage(session.hiveSessionId, sdkMessage, messageIndex, session.toolNames, hasStreamedContent)
-        messageIndex++
+          // Accumulate translated messages in-memory for getMessages()
+          if (msgType === 'user' || msgType === 'assistant') {
+            const sdkMsg = sdkMessage as Record<string, unknown>
+            const msgContent = (
+              sdkMsg.message as { content?: { type: string; [key: string]: unknown }[] } | undefined
+            )?.content
+            const contentBlockTypes = Array.isArray(msgContent) ? msgContent.map((b) => b.type) : []
+            const isToolResultOnly =
+              msgType === 'user' &&
+              contentBlockTypes.length > 0 &&
+              contentBlockTypes.every((t) => t === 'tool_result')
 
-        // Reset streaming flag after each result so the next message sequence
-        // (e.g. a tool result following a streamed LLM response) gets fresh tracking.
-        // Without this, a single stream_event early in the loop would suppress
-        // result-text emission for all subsequent non-streamed results.
-        if (msgType === 'result') {
-          hasStreamedContent = false
-        }
+            // Capture checkpoints only from actual user prompts on the
+            // main conversation thread (not subagent messages).
+            // tool_result-only user messages carry UUIDs but do not represent
+            // stable rewind points for file checkpointing.
+            // Subagent messages have parent_tool_use_id set — their UUIDs live
+            // in a separate JSONL file and are not valid fork/resume points.
+            const isSubagentMessage = !!(sdkMessage as Record<string, unknown>).parent_tool_use_id
+            if (msgType === 'user' && sdkMessage.uuid && !isToolResultOnly && !isSubagentMessage) {
+              const checkpointUuid = sdkMessage.uuid as string
+              const isFirstSeenCheckpoint = !session.checkpoints.has(checkpointUuid)
+              if (isFirstSeenCheckpoint) {
+                session.checkpointCounter += 1
+                session.checkpoints.set(checkpointUuid, session.checkpointCounter)
+                log.info('Checkpoint captured', {
+                  uuid: checkpointUuid,
+                  counter: session.checkpointCounter,
+                  totalCheckpoints: session.checkpoints.size
+                })
+              }
+            } else if (msgType === 'user' && sdkMessage.uuid && isSubagentMessage) {
+              log.debug('Skipping subagent user message for checkpoint', {
+                uuid: (sdkMessage.uuid as string).slice(0, 12),
+                parentToolUseId: (sdkMessage as Record<string, unknown>).parent_tool_use_id
+              })
+            }
+
+            log.info('TOOL_LIFECYCLE: accumulate message', {
+              hiveSessionId: session.hiveSessionId,
+              msgType,
+              contentBlockTypes,
+              isToolResultOnly,
+              isSubagentMessage
+            })
+
+            // Skip subagent messages from accumulation — they belong to the child
+            // session's transcript and should not appear in the main conversation.
+            // The renderer routes subagent content into SubtaskCards via childSessionId
+            // on stream events; the in-memory cache must not include them either.
+            if (isSubagentMessage) {
+              log.debug('Skipping subagent message from session.messages accumulation', {
+                msgType,
+                parentToolUseId: (sdkMessage as Record<string, unknown>).parent_tool_use_id
+              })
+            } else if (isToolResultOnly) {
+              // Instead of creating an empty user message, merge tool_result
+              // output/error into the preceding assistant message's tool_use parts.
+              const toolResults = msgContent as {
+                type: string
+                tool_use_id?: string
+                is_error?: boolean
+                content?: string | { type: string; text?: string }[]
+              }[]
+              // Find the last assistant message
+              const lastAssistant = [...session.messages]
+                .reverse()
+                .find((m) => (m as Record<string, unknown>).role === 'assistant') as
+                | Record<string, unknown>
+                | undefined
+              if (lastAssistant) {
+                const parts = lastAssistant.parts as Record<string, unknown>[] | undefined
+                if (Array.isArray(parts)) {
+                  for (const tr of toolResults) {
+                    if (tr.type !== 'tool_result' || !tr.tool_use_id) continue
+                    let output: string | undefined
+                    if (typeof tr.content === 'string') {
+                      output = tr.content
+                    } else if (Array.isArray(tr.content)) {
+                      output = tr.content
+                        .filter((c) => c.type === 'text')
+                        .map((c) => c.text ?? '')
+                        .join('\n')
+                    }
+                    const toolPart = parts.find(
+                      (p) =>
+                        p.type === 'tool_use' &&
+                        (p.toolUse as Record<string, unknown> | undefined)?.id === tr.tool_use_id
+                    )
+                    if (toolPart) {
+                      const tu = toolPart.toolUse as Record<string, unknown>
+                      tu.output = output
+                      tu.error = tr.is_error ? output : undefined
+                      tu.status = tr.is_error ? 'error' : 'success'
+                      log.info('TOOL_LIFECYCLE: merged tool_result into assistant tool_use', {
+                        toolId: tr.tool_use_id,
+                        isError: !!tr.is_error,
+                        hasOutput: !!output
+                      })
+                    }
+                  }
+                }
+              }
+            } else {
+              const translated = translateEntry(
+                {
+                  type: msgType,
+                  uuid: sdkMsg.uuid as string | undefined,
+                  timestamp: new Date().toISOString(),
+                  message: sdkMsg.message as
+                    | {
+                        role?: string
+                        content?: { type: string; [key: string]: unknown }[] | string
+                      }
+                    | undefined,
+                  isSidechain: false
+                },
+                session.messages.length
+              )
+              if (translated) {
+                const isUserMessage = msgType === 'user'
+                const translatedContent = (translated as Record<string, unknown>).content
+                let optimisticIndex = -1
+
+                if (isUserMessage && typeof translatedContent === 'string') {
+                  for (let i = session.messages.length - 1; i >= 0; i--) {
+                    const candidate = session.messages[i] as Record<string, unknown>
+                    if (
+                      candidate.role === 'user' &&
+                      typeof candidate.id === 'string' &&
+                      candidate.id.startsWith('user-') &&
+                      typeof candidate.content === 'string' &&
+                      candidate.content === translatedContent
+                    ) {
+                      optimisticIndex = i
+                      break
+                    }
+                  }
+                }
+
+                if (optimisticIndex >= 0) {
+                  session.messages[optimisticIndex] = translated
+                } else {
+                  session.messages.push(translated)
+                }
+              }
+            }
+          }
+
+          // Emit normalized event
+          this.emitSdkMessage(
+            session.hiveSessionId,
+            sdkMessage,
+            messageIndex,
+            session.toolNames,
+            hasStreamedContent
+          )
+          messageIndex++
+
+          // Reset streaming flag after each result so the next message sequence
+          // (e.g. a tool result following a streamed LLM response) gets fresh tracking.
+          // Without this, a single stream_event early in the loop would suppress
+          // result-text emission for all subsequent non-streamed results.
+          if (msgType === 'result') {
+            hasStreamedContent = false
+          }
         }
       })
       session.subscription = subscription
@@ -2100,7 +2113,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     // Git commands need special handling - be very specific
     if (command === 'git') {
       if (!subcommand) {
-        return commandStr  // Just "git" alone - use exact
+        return commandStr // Just "git" alone - use exact
       }
 
       // Safe git subcommands that can have broad patterns
@@ -2112,7 +2125,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       // For git commit, be very specific about the flags
       if (subcommand === 'commit') {
         if (flag === '-m' || flag === '--message') {
-          return `git commit -m *`  // Only allow commit with message flag
+          return `git commit -m *` // Only allow commit with message flag
         }
         // For other commit variations (--amend, --no-verify, etc), use exact command
         // This prevents dangerous operations
@@ -2122,14 +2135,14 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       // For git push/pull, include the operation but not force flags
       if (subcommand === 'push' || subcommand === 'pull') {
         if (flag === '--force' || flag === '-f') {
-          return commandStr  // Don't suggest pattern for force push
+          return commandStr // Don't suggest pattern for force push
         }
         return `git ${subcommand} *`
       }
 
       // For git checkout/reset, be very careful
       if (subcommand === 'checkout' || subcommand === 'reset') {
-        return commandStr  // Always use exact for these dangerous operations
+        return commandStr // Always use exact for these dangerous operations
       }
 
       // For other git subcommands, use subcommand + first flag if present
@@ -2144,13 +2157,13 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     if (dangerousCommands.includes(command)) {
       // For rm, never suggest patterns with -rf
       if (command === 'rm' && (parts.includes('-rf') || parts.includes('-fr'))) {
-        return commandStr  // Use exact command for dangerous rm operations
+        return commandStr // Use exact command for dangerous rm operations
       }
 
       if (subcommand) {
         return `${command} ${subcommand} *`
       }
-      return commandStr  // Use exact if no subcommand
+      return commandStr // Use exact if no subcommand
     }
 
     // For other commands, suggest the exact command
@@ -2199,7 +2212,10 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     }
 
     // Emit command.approval_needed event to renderer
-    log.info('APPROVAL FLOW: Sending event to renderer', { requestId, sessionId: session.hiveSessionId })
+    log.info('APPROVAL FLOW: Sending event to renderer', {
+      requestId,
+      sessionId: session.hiveSessionId
+    })
     this.sendToRenderer('opencode:stream', {
       type: 'command.approval_needed',
       sessionId: session.hiveSessionId,
@@ -2224,7 +2240,10 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     }>((resolve) => {
       this.pendingApprovals.set(requestId, {
         resolve: (response) => {
-          log.info('APPROVAL FLOW: User response received', { requestId, approved: response.approved })
+          log.info('APPROVAL FLOW: User response received', {
+            requestId,
+            approved: response.approved
+          })
           resolve(response)
         },
         toolName,

--- a/src/main/services/usage-service.ts
+++ b/src/main/services/usage-service.ts
@@ -10,6 +10,9 @@ export type { UsageData, UsageResult }
 
 const log = createLogger({ component: 'UsageService' })
 
+const CLAUDE_CLIENT_USER_AGENT = 'claude-code/2.1.5'
+const ANTHROPIC_API_VERSION = '2023-06-01'
+
 type ClaudeTokenSource = 'keychain' | 'file' | 'override'
 
 export interface ClaudeUsageFetchContext {
@@ -140,7 +143,9 @@ export async function fetchClaudeUsage(
       : await readAccessTokenWithSource()
   const token = tokenWithSource?.token
   if (!token) {
-    log.warn('No Claude OAuth access token found (checked keychain and credentials file)', { ...ctx })
+    log.warn('No Claude OAuth access token found (checked keychain and credentials file)', {
+      ...ctx
+    })
     return { success: false, error: 'No access token found' }
   }
 
@@ -165,6 +170,8 @@ export async function fetchClaudeUsage(
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
+        'User-Agent': CLAUDE_CLIENT_USER_AGENT,
+        'anthropic-version': ANTHROPIC_API_VERSION,
         'anthropic-beta': 'oauth-2025-04-20',
         Accept: 'application/json',
         'Content-Type': 'application/json'

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -16,11 +16,15 @@ import openaiIcon from '@/assets/model-icons/openai.svg'
 import type {
   OpenAIUsageData,
   SavedAccountDTO,
+  AnthropicRateLimitState,
+  AnthropicRateLimitWindow,
   UsageData,
   UsageProvider
 } from '@shared/types/usage'
 
-function getBarColor(percent: number): string {
+function getBarColor(percent: number, rateLimitStatus?: string): string {
+  if (rateLimitStatus === 'rejected') return 'bg-red-500'
+  if (rateLimitStatus === 'allowed_warning') return 'bg-orange-500'
   if (percent >= 90) return 'bg-red-500'
   if (percent >= 80) return 'bg-orange-500'
   if (percent >= 60) return 'bg-yellow-500'
@@ -61,26 +65,75 @@ function formatResetTime(isoString: string, type: 'five_hour' | 'seven_day'): st
   return `${month} ${day}, ${timeStr}`
 }
 
+function formatRelativeReset(resetsAt: number): string {
+  const seconds = Math.max(0, Math.ceil(resetsAt - Date.now() / 1000))
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.ceil((seconds % 3600) / 60)
+
+  if (hours > 0) return `${hours}h ${minutes}m`
+  if (minutes > 0) return `${minutes}m`
+  return '<1m'
+}
+
+function getStatusLabel(status?: string): string | null {
+  if (status === 'rejected') return 'blocked'
+  if (status === 'allowed_warning') return 'warning'
+  return null
+}
+
+function getRateLimitWindow(
+  rateLimit: AnthropicRateLimitState | null,
+  type: 'five_hour' | 'seven_day'
+): AnthropicRateLimitWindow | undefined {
+  if (!rateLimit) return undefined
+  return type === 'five_hour' ? rateLimit.fiveHour : rateLimit.sevenDay
+}
+
 interface UsageRowProps {
   label: string
   percent: number
   resetTime: string
+  rateLimit?: AnthropicRateLimitWindow
 }
 
-function UsageRow({ label, percent, resetTime }: UsageRowProps): React.JSX.Element {
+function UsageRow({ label, percent, resetTime, rateLimit }: UsageRowProps): React.JSX.Element {
+  const statusLabel = getStatusLabel(rateLimit?.status)
+  const displayedPercent = rateLimit?.status === 'rejected' ? 100 : percent
+  const percentLabel = rateLimit?.status === 'rejected' ? 'limit' : `${Math.round(percent)}%`
+  const statusTitle =
+    statusLabel && rateLimit
+      ? `${statusLabel} - resets in ${formatRelativeReset(rateLimit.resetsAt)}`
+      : undefined
+
   return (
     <div className="flex items-center gap-1.5">
       <span className="text-[10px] text-muted-foreground w-5 shrink-0">{label}</span>
       <div className="h-1.5 flex-1 rounded-full bg-muted overflow-hidden">
         <div
-          className={cn('h-full rounded-full transition-all duration-300', getBarColor(percent))}
-          style={{ width: `${Math.min(100, Math.max(0, percent))}%`, minWidth: 2 }}
+          className={cn(
+            'h-full rounded-full transition-all duration-300',
+            getBarColor(displayedPercent, rateLimit?.status)
+          )}
+          style={{ width: `${Math.min(100, Math.max(0, displayedPercent))}%`, minWidth: 2 }}
         />
       </div>
       <span className="text-[10px] font-mono text-muted-foreground w-7 text-right shrink-0">
-        {Math.round(percent)}%
+        {percentLabel}
       </span>
       <span className="text-[10px] text-muted-foreground/60 shrink-0">{resetTime}</span>
+      {statusLabel && (
+        <span
+          className={cn(
+            'rounded-sm px-1 py-0.5 text-[9px] leading-none shrink-0',
+            rateLimit?.status === 'rejected'
+              ? 'bg-red-500/15 text-red-400'
+              : 'bg-orange-500/15 text-orange-400'
+          )}
+          title={statusTitle}
+        >
+          {rateLimit?.status === 'rejected' ? 'limit' : 'warn'}
+        </span>
+      )}
     </div>
   )
 }
@@ -191,6 +244,7 @@ function ProviderUsageBlock({
   isExplicitlySelected: boolean
 }): React.JSX.Element | null {
   const anthropicUsage = useUsageStore((s) => s.anthropicUsage)
+  const anthropicRateLimit = useUsageStore((s) => s.anthropicRateLimit)
   const openaiUsage = useUsageStore((s) => s.openaiUsage)
   const forceRefreshProvider = useUsageStore((s) => s.forceRefreshProvider)
   const refreshAllForProvider = useUsageStore((s) => s.refreshAllForProvider)
@@ -331,6 +385,10 @@ function ProviderUsageBlock({
   const fiveHourReset = formatResetTime(usage.five_hour.resets_at, 'five_hour')
   const sevenDayReset = formatResetTime(usage.seven_day.resets_at, 'seven_day')
   const extra = usage.extra_usage
+  const fiveHourRateLimit =
+    provider === 'anthropic' ? getRateLimitWindow(anthropicRateLimit, 'five_hour') : undefined
+  const sevenDayRateLimit =
+    provider === 'anthropic' ? getRateLimitWindow(anthropicRateLimit, 'seven_day') : undefined
 
   return (
     <Tooltip>
@@ -358,8 +416,18 @@ function ProviderUsageBlock({
               />
             </button>
             <div className="flex-1 space-y-0.5">
-              <UsageRow label="5h" percent={fiveHourPercent} resetTime={fiveHourReset} />
-              <UsageRow label="7d" percent={sevenDayPercent} resetTime={sevenDayReset} />
+              <UsageRow
+                label="5h"
+                percent={fiveHourPercent}
+                resetTime={fiveHourReset}
+                rateLimit={fiveHourRateLimit}
+              />
+              <UsageRow
+                label="7d"
+                percent={sevenDayPercent}
+                resetTime={sevenDayReset}
+                rateLimit={sevenDayRateLimit}
+              />
             </div>
           </div>
         </div>
@@ -383,6 +451,22 @@ function ProviderUsageBlock({
             <div className="border-t border-background/20 pt-1 text-[10px]">
               Extra: ${(extra.used_credits ?? 0).toFixed(2)} / $
               {(extra.monthly_limit ?? 0).toFixed(2)} used ({Math.round(extra.utilization ?? 0)}%)
+            </div>
+          )}
+          {provider === 'anthropic' && (fiveHourRateLimit || sevenDayRateLimit) && (
+            <div className="border-t border-background/20 pt-1 text-[10px] text-muted-foreground">
+              {fiveHourRateLimit && (
+                <div>
+                  5h: {fiveHourRateLimit.status} - resets in{' '}
+                  {formatRelativeReset(fiveHourRateLimit.resetsAt)}
+                </div>
+              )}
+              {sevenDayRateLimit && (
+                <div>
+                  7d: {sevenDayRateLimit.status} - resets in{' '}
+                  {formatRelativeReset(sevenDayRateLimit.resetsAt)}
+                </div>
+              )}
             </div>
           )}
           {lastError && (

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -23,6 +23,7 @@ import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { maybeExtractJsonTitle } from '@shared/title-utils'
+import type { AnthropicRateLimitInfo } from '@shared/types/usage'
 
 const db = unwrapEnvelopeApi(() => window.db)
 
@@ -254,6 +255,11 @@ export function useOpenCodeGlobalListener(): void {
                 .setModelLimit(model.modelID, contextWindow, model.providerID)
               useContextStore.getState().setModelLimit(model.modelID, contextWindow)
             }
+            return
+          }
+
+          if (event.type === 'session.rate_limit') {
+            useUsageStore.getState().setAnthropicRateLimit(event.data as AnthropicRateLimitInfo)
             return
           }
 

--- a/src/renderer/src/stores/__tests__/useUsageStore.retry-after.test.ts
+++ b/src/renderer/src/stores/__tests__/useUsageStore.retry-after.test.ts
@@ -8,6 +8,7 @@ const baseState = {
   anthropicIsLoading: false,
   anthropicLastError: null,
   anthropicLastRetryAfter: null,
+  anthropicRateLimit: null,
   openaiUsage: null,
   openaiLastFetchedAt: null,
   openaiIsLoading: false,

--- a/src/renderer/src/stores/index.ts
+++ b/src/renderer/src/stores/index.ts
@@ -1,4 +1,9 @@
-export { useLayoutStore, LAYOUT_CONSTRAINTS, type BottomPanelTab, type CollapsedPanel } from './useLayoutStore'
+export {
+  useLayoutStore,
+  LAYOUT_CONSTRAINTS,
+  type BottomPanelTab,
+  type CollapsedPanel
+} from './useLayoutStore'
 export { useThemeStore } from './useThemeStore'
 export { useProjectStore } from './useProjectStore'
 export { useWorktreeStore } from './useWorktreeStore'
@@ -49,6 +54,8 @@ export {
   useUsageStore,
   type UsageData,
   type UsageProvider,
+  type AnthropicRateLimitInfo,
+  type AnthropicRateLimitState,
   resolveUsageProvider,
   resolveDefaultUsageProvider,
   normalizeUsage

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -1,13 +1,15 @@
 import { create } from 'zustand'
 import type {
   UsageData,
+  AnthropicRateLimitInfo,
+  AnthropicRateLimitState,
   OpenAIUsageData,
   UsageProvider,
   SavedAccountDTO
 } from '@shared/types/usage'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 
-export type { UsageData, UsageProvider }
+export type { UsageData, UsageProvider, AnthropicRateLimitInfo, AnthropicRateLimitState }
 
 interface UsageState {
   anthropicUsage: UsageData | null
@@ -15,6 +17,7 @@ interface UsageState {
   anthropicIsLoading: boolean
   anthropicLastError: string | null
   anthropicLastRetryAfter: number | null
+  anthropicRateLimit: AnthropicRateLimitState | null
 
   openaiUsage: OpenAIUsageData | null
   openaiLastFetchedAt: number | null
@@ -34,6 +37,7 @@ interface UsageState {
   fetchUsageForProvider: (provider: UsageProvider) => Promise<void>
   forceRefreshProvider: (provider: UsageProvider) => Promise<void>
   setActiveProvider: (provider: UsageProvider) => void
+  setAnthropicRateLimit: (info: AnthropicRateLimitInfo) => void
   fetchUsage: () => Promise<void>
 }
 
@@ -54,6 +58,7 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
   anthropicIsLoading: false,
   anthropicLastError: null,
   anthropicLastRetryAfter: null,
+  anthropicRateLimit: null,
 
   openaiUsage: null,
   openaiLastFetchedAt: null,
@@ -302,6 +307,42 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
     if (isStale) {
       state.fetchUsageForProvider(provider).catch(() => {})
     }
+  },
+
+  setAnthropicRateLimit: (info: AnthropicRateLimitInfo) => {
+    set((state) => {
+      const now = Date.now()
+      const nowSeconds = now / 1000
+      const current = state.anthropicRateLimit
+      const next: AnthropicRateLimitState = {
+        ...(current ?? { updatedAt: now }),
+        updatedAt: now
+      }
+
+      const windowKey = info.rateLimitType === 'five_hour' ? 'fiveHour' : 'sevenDay'
+      if (info.resetsAt >= nowSeconds) {
+        next[windowKey] = {
+          status: info.status,
+          resetsAt: info.resetsAt,
+          isUsingOverage: info.isUsingOverage,
+          overageStatus: info.overageStatus
+        }
+      } else {
+        delete next[windowKey]
+      }
+
+      if (next.fiveHour?.resetsAt !== undefined && next.fiveHour.resetsAt < nowSeconds) {
+        delete next.fiveHour
+      }
+      if (next.sevenDay?.resetsAt !== undefined && next.sevenDay.resetsAt < nowSeconds) {
+        delete next.sevenDay
+      }
+
+      return {
+        anthropicRateLimit: next.fiveHour || next.sevenDay ? next : null,
+        anthropicLastFetchedAt: now
+      }
+    })
   },
 
   fetchUsage: async () => {

--- a/src/shared/types/usage.ts
+++ b/src/shared/types/usage.ts
@@ -16,6 +16,29 @@ export interface UsageResult {
   retryAfter?: number
 }
 
+export type AnthropicRateLimitType = 'five_hour' | 'seven_day'
+
+export interface AnthropicRateLimitInfo {
+  status: string
+  resetsAt: number
+  rateLimitType: AnthropicRateLimitType
+  isUsingOverage?: boolean
+  overageStatus?: string
+}
+
+export interface AnthropicRateLimitWindow {
+  status: string
+  resetsAt: number
+  isUsingOverage?: boolean
+  overageStatus?: string
+}
+
+export interface AnthropicRateLimitState {
+  fiveHour?: AnthropicRateLimitWindow
+  sevenDay?: AnthropicRateLimitWindow
+  updatedAt: number
+}
+
 export type UsageProvider = 'anthropic' | 'openai'
 export type SavedUsageStatus = 'ok' | 'stale' | 'error'
 

--- a/test/usage/rate-limit-event-listener.test.tsx
+++ b/test/usage/rate-limit-event-listener.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useUsageStore } from '@/stores/useUsageStore'
+import type { OpenCodeStreamEvent } from '@shared/types/opencode'
+
+describe('useOpenCodeGlobalListener rate-limit events', () => {
+  let streamListener: ((event: OpenCodeStreamEvent) => void) | null
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-19T09:00:00.000Z'))
+    streamListener = null
+
+    Object.defineProperty(window, 'opencodeOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        onStream: vi.fn((listener: (event: OpenCodeStreamEvent) => void) => {
+          streamListener = listener
+          return vi.fn()
+        })
+      }
+    })
+
+    Object.defineProperty(window, 'db', {
+      writable: true,
+      configurable: true,
+      value: {
+        setting: {
+          get: vi.fn().mockResolvedValue({ success: true, value: null }),
+          set: vi.fn().mockResolvedValue({ success: true, value: undefined })
+        }
+      }
+    })
+
+    useUsageStore.setState({
+      anthropicRateLimit: null,
+      anthropicLastFetchedAt: null
+    } as Partial<ReturnType<typeof useUsageStore.getState>>)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stores streamed Claude Code rate-limit events as fresh Anthropic usage state', async () => {
+    const { useOpenCodeGlobalListener } = await import('@/hooks/useOpenCodeGlobalListener')
+    function ListenerHarness(): null {
+      useOpenCodeGlobalListener()
+      return null
+    }
+
+    render(<ListenerHarness />)
+
+    streamListener?.({
+      type: 'session.rate_limit',
+      sessionId: 'session-1',
+      data: {
+        status: 'rejected',
+        resetsAt: Math.floor(Date.now() / 1000) + 1_800,
+        rateLimitType: 'five_hour',
+        isUsingOverage: false,
+        overageStatus: 'rejected'
+      }
+    })
+
+    expect(useUsageStore.getState().anthropicRateLimit).toMatchObject({
+      fiveHour: {
+        status: 'rejected',
+        resetsAt: Math.floor(Date.now() / 1000) + 1_800,
+        isUsingOverage: false,
+        overageStatus: 'rejected'
+      },
+      updatedAt: Date.now()
+    })
+    expect(useUsageStore.getState().anthropicLastFetchedAt).toBe(Date.now())
+  })
+})

--- a/test/usage/usage-service.headers.test.ts
+++ b/test/usage/usage-service.headers.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp'
+  }
+}))
+
+import { fetchClaudeUsage } from '../../src/main/services/usage-service'
+
+describe('fetchClaudeUsage Claude client identification', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('identifies OAuth usage requests as the Claude Code client', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          five_hour: { utilization: 12, resets_at: '2026-05-19T12:00:00.000Z' },
+          seven_day: { utilization: 34, resets_at: '2026-05-20T12:00:00.000Z' }
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchClaudeUsage('oauth-token', { caller: 'usage:fetch' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/api/oauth/usage',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer oauth-token',
+          'User-Agent': 'claude-code/2.1.5',
+          'anthropic-version': '2023-06-01',
+          'anthropic-beta': 'oauth-2025-04-20'
+        })
+      })
+    )
+  })
+})

--- a/test/usage/use-usage-store.test.ts
+++ b/test/usage/use-usage-store.test.ts
@@ -42,6 +42,7 @@ describe('useUsageStore', () => {
       anthropicLastFetchedAt: null,
       anthropicIsLoading: false,
       anthropicLastError: null,
+      anthropicRateLimit: null,
       openaiUsage: null,
       openaiLastFetchedAt: null,
       openaiIsLoading: false,
@@ -80,7 +81,9 @@ describe('useUsageStore', () => {
       error: 'Could not decode usage response'
     })
 
-    await expect(useUsageStore.getState().forceRefreshProvider('anthropic')).resolves.toBeUndefined()
+    await expect(
+      useUsageStore.getState().forceRefreshProvider('anthropic')
+    ).resolves.toBeUndefined()
 
     const state = usageState()
     expect(state.anthropicLastError).toBe('Could not decode usage response')
@@ -118,5 +121,45 @@ describe('useUsageStore', () => {
     expect(state.openaiLastError).toBe('OpenAI auth failed')
     expect(state.openaiLastFetchedAt).toBeNull()
     expect(state.openaiIsLoading).toBe(false)
+  })
+
+  it('merges Anthropic rate-limit windows and drops stale windows', () => {
+    useUsageStore.getState().setAnthropicRateLimit({
+      status: 'allowed_warning',
+      resetsAt: Math.floor(Date.now() / 1000) + 3_600,
+      rateLimitType: 'five_hour',
+      isUsingOverage: false,
+      overageStatus: 'rejected'
+    })
+    useUsageStore.getState().setAnthropicRateLimit({
+      status: 'allowed',
+      resetsAt: Math.floor(Date.now() / 1000) + 86_400,
+      rateLimitType: 'seven_day',
+      isUsingOverage: true,
+      overageStatus: 'allowed'
+    })
+
+    expect(useUsageStore.getState().anthropicRateLimit).toMatchObject({
+      fiveHour: {
+        status: 'allowed_warning',
+        isUsingOverage: false,
+        overageStatus: 'rejected'
+      },
+      sevenDay: {
+        status: 'allowed',
+        isUsingOverage: true,
+        overageStatus: 'allowed'
+      },
+      updatedAt: Date.now()
+    })
+
+    useUsageStore.getState().setAnthropicRateLimit({
+      status: 'rejected',
+      resetsAt: Math.floor(Date.now() / 1000) - 1,
+      rateLimitType: 'five_hour'
+    })
+
+    expect(useUsageStore.getState().anthropicRateLimit?.fiveHour).toBeUndefined()
+    expect(useUsageStore.getState().anthropicRateLimit?.sevenDay?.status).toBe('allowed')
   })
 })


### PR DESCRIPTION
## Summary
- Added Anthropic usage rate-limit tracking and wired renderer events so rate-limit updates flow from the main process into store state.
- Updated the usage indicator to show blocked/warning states, adjusted bar colors, and display reset timing for Anthropic limits.
- Set Claude usage fetch headers to match the expected client/API version so usage requests can succeed more reliably.
- Expanded shared usage types and store logic to carry rate-limit state through the app.
- Added coverage for the rate-limit event listener, usage service headers, and store behavior.

## Testing
- Not run
- Added/updated tests in `test/usage/rate-limit-event-listener.test.tsx`, `test/usage/usage-service.headers.test.ts`, and `test/usage/use-usage-store.test.ts`
- Verified the UI/store path compiles conceptually with the new Anthropic rate-limit types and event payloads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the main→renderer event stream and shared usage state; mistakes could lead to stale/incorrect rate-limit UI or unexpected store updates, but changes are contained to usage/telemetry paths.
> 
> **Overview**
> **Anthropic rate-limit state is now streamed into the UI.** The main process (`claude-code-implementer`) intercepts SDK `rate_limit_event`s and emits a new `session.rate_limit` stream event, which `useOpenCodeGlobalListener` stores in `useUsageStore`.
> 
> **Usage UI now reflects rate-limit status.** `UsageIndicator` uses the stored 5h/7d rate-limit windows to adjust bar color/labels (e.g. blocked/warn) and show relative reset timing in the tooltip.
> 
> **Usage fetching is more explicit about client identity.** `fetchClaudeUsage` now sends `User-Agent` and `anthropic-version` headers, and shared types/tests were expanded to cover rate-limit payloads, store merging/pruning, and header assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b6cb552941323e303d7538e1d6b084d65a7123d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->