### PR TITLE
Add goal mode indicator to kanban tickets

### DIFF
--- a/src/renderer/src/components/kanban/CheckeredFlagIcon.tsx
+++ b/src/renderer/src/components/kanban/CheckeredFlagIcon.tsx
@@ -1,0 +1,30 @@
+interface CheckeredFlagIconProps {
+  className?: string
+  size?: number | string
+}
+
+// Simple 4x3 checkered flag with a thin pole. The flag uses explicit
+// black and white cells so it reads differently from the status icons.
+export function CheckeredFlagIcon({ className, size = 24 }: CheckeredFlagIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      width={size}
+      height={size}
+      aria-hidden="true"
+    >
+      <line x1="5" y1="3" x2="5" y2="21" stroke="black" strokeWidth="1.5" strokeLinecap="round" />
+      <rect x="5" y="4" width="15" height="9" fill="white" />
+      <rect x="5" y="4" width="3.75" height="3" fill="black" />
+      <rect x="12.5" y="4" width="3.75" height="3" fill="black" />
+      <rect x="8.75" y="7" width="3.75" height="3" fill="black" />
+      <rect x="16.25" y="7" width="3.75" height="3" fill="black" />
+      <rect x="5" y="10" width="3.75" height="3" fill="black" />
+      <rect x="12.5" y="10" width="3.75" height="3" fill="black" />
+      <rect x="5" y="4" width="15" height="9" stroke="black" strokeWidth="1.25" fill="none" />
+    </svg>
+  )
+}

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles, Lock, Link2, Plus, StickyNote, Send } from 'lucide-react'
+import { CheckeredFlagIcon } from './CheckeredFlagIcon'
 import { UpdateStatusModal } from './UpdateStatusModal'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { NoteEditorModal } from './NoteEditorModal'
@@ -297,6 +298,11 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       },
       [ticket.current_session_id]
     )
+  )
+  const hasRightAlignedStatus = Boolean(
+    ((isBusy || isAsking) && ticket.mode && !isBlocked) ||
+    (isBeingReviewed && !(isBusy || isAsking)) ||
+    (!isBeingReviewed && !(isBusy || isAsking) && completedReviewSessionId)
   )
 
   const timerText = useSessionTimer(
@@ -670,7 +676,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isBeingReviewed || completedReviewSessionId || isArchived || isBlocked || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram) && (
+            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isBeingReviewed || completedReviewSessionId || isArchived || isBlocked || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
@@ -823,6 +829,24 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                   >
                     Go to review
                   </button>
+                )}
+
+                {/* Goal mode badge */}
+                {ticket.goal_mode && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        data-testid="kanban-ticket-goal"
+                        className={cn(
+                          'inline-flex items-center rounded-full border border-black/20 bg-white px-1.5 py-0.5 text-black shadow-sm cursor-help',
+                          !hasRightAlignedStatus && 'ml-auto'
+                        )}
+                      >
+                        <CheckeredFlagIcon className="h-3 w-3" />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>Goal mode</TooltipContent>
+                  </Tooltip>
                 )}
               </div>
             )}

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles, Lock, Link2, Plus, StickyNote, Send } from 'lucide-react'
+import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles, Lock, Link2, Plus, StickyNote, Send, Check, Pause } from 'lucide-react'
 import { CheckeredFlagIcon } from './CheckeredFlagIcon'
 import { UpdateStatusModal } from './UpdateStatusModal'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -250,6 +250,16 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
           if (found) return found.status
         }
         return null
+      },
+      [ticket.current_session_id]
+    )
+  )
+
+  const goalStatus = useSessionStore(
+    useCallback(
+      (state) => {
+        if (!ticket.current_session_id) return null
+        return state.codexGoalsBySession.get(ticket.current_session_id)?.status ?? null
       },
       [ticket.current_session_id]
     )
@@ -832,22 +842,40 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                 )}
 
                 {/* Goal mode badge */}
-                {ticket.goal_mode && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span
-                        data-testid="kanban-ticket-goal"
-                        className={cn(
-                          'inline-flex items-center rounded-full border border-black/20 bg-white px-1.5 py-0.5 text-black shadow-sm cursor-help',
-                          !hasRightAlignedStatus && 'ml-auto'
-                        )}
-                      >
-                        <CheckeredFlagIcon className="h-3 w-3" />
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>Goal mode</TooltipContent>
-                  </Tooltip>
-                )}
+                {ticket.goal_mode && (() => {
+                  const isComplete = goalStatus === 'complete'
+                  const isPaused = goalStatus === 'paused' || goalStatus === 'budgetLimited'
+                  const tooltipText = isComplete ? 'Goal complete' : isPaused ? 'Goal paused' : 'Goal mode'
+
+                  return (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          data-testid="kanban-ticket-goal"
+                          className={cn(
+                            'inline-flex items-center rounded-full border border-black/20 bg-white px-1.5 py-0.5 text-black shadow-sm cursor-help',
+                            !hasRightAlignedStatus && 'ml-auto'
+                          )}
+                        >
+                          <span className="relative inline-flex h-3 w-3 items-center justify-center">
+                            <CheckeredFlagIcon className="h-3 w-3" />
+                            {isComplete && (
+                              <span className="absolute -right-1 -top-1 inline-flex h-2.5 w-2.5 items-center justify-center rounded-full bg-emerald-500 text-white ring-1 ring-white">
+                                <Check className="h-2 w-2 stroke-[3]" />
+                              </span>
+                            )}
+                            {isPaused && (
+                              <span className="absolute -right-1 -top-1 inline-flex h-2.5 w-2.5 items-center justify-center rounded-full bg-amber-500 text-white ring-1 ring-white">
+                                <Pause className="h-1.5 w-1.5 fill-current stroke-[3]" />
+                              </span>
+                            )}
+                          </span>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>{tooltipText}</TooltipContent>
+                    </Tooltip>
+                  )
+                })()}
               </div>
             )}
               </div>

--- a/test/kanban/pinned-board-ticket-navigation.test.tsx
+++ b/test/kanban/pinned-board-ticket-navigation.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { fireEvent, render, screen } from '../utils/render'
 import { KanbanTicketCard } from '@/components/kanban/KanbanTicketCard'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useGitStore } from '@/stores/useGitStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
@@ -81,6 +82,8 @@ function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
     mark: null,
     total_tokens: 0,
     pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
     ...overrides
   }
 }
@@ -218,6 +221,20 @@ describe('pinned board ticket navigation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
+    if (!globalThis.ResizeObserver) {
+      class MockResizeObserver {
+        observe = vi.fn()
+        unobserve = vi.fn()
+        disconnect = vi.fn()
+      }
+
+      Object.defineProperty(globalThis, 'ResizeObserver', {
+        writable: true,
+        configurable: true,
+        value: MockResizeObserver
+      })
+    }
+
     Object.defineProperty(window, 'db', {
       writable: true,
       configurable: true,
@@ -258,5 +275,38 @@ describe('pinned board ticket navigation', () => {
     expect(useWorktreeStore.getState().selectedWorktreeId).toBe('wt-1')
     expect(useProjectStore.getState().selectedProjectId).toBe('proj-1')
     expect(useWorktreeStatusStore.getState().sessionStatuses['session-1']).toBeNull()
+  })
+
+  test('renders a goal mode badge and tooltip when the ticket is configured for goal mode', async () => {
+    render(
+      <TooltipProvider>
+        <KanbanTicketCard
+          ticket={makeTicket({
+            worktree_id: null,
+            goal_mode: true,
+            goal_success_criteria: 'Acceptance criteria are met'
+          })}
+        />
+      </TooltipProvider>
+    )
+
+    const badge = screen.getByTestId('kanban-ticket-goal')
+    const icon = badge.querySelector('svg')
+
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveClass('ml-auto')
+    expect(icon).toBeInTheDocument()
+    expect(icon?.querySelector('[fill="black"]')).toBeInTheDocument()
+    expect(icon?.querySelector('[fill="white"]')).toBeInTheDocument()
+
+    fireEvent.pointerMove(badge)
+
+    expect(await screen.findAllByText('Goal mode')).not.toHaveLength(0)
+  })
+
+  test('does not render a goal mode badge for non-goal tickets', () => {
+    render(<KanbanTicketCard ticket={makeTicket({ worktree_id: null })} />)
+
+    expect(screen.queryByTestId('kanban-ticket-goal')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Added a new checkered flag icon to represent goal mode on ticket cards.
- Render goal mode badges on kanban tickets, with completion and paused overlays driven by goal status.
- Adjusted badge alignment so the goal indicator stays visually correct alongside existing status badges.
- Added tests covering goal-mode rendering, tooltip behavior, and non-goal tickets.

## Testing
- Added Vitest coverage in `test/kanban/pinned-board-ticket-navigation.test.tsx` for goal-mode badge rendering.
- Added tooltip interaction assertions for the goal-mode badge.
- Added a regression test ensuring non-goal tickets do not render the badge.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that reads existing session goal state to render a new badge; main risk is minor layout/tooltip regressions on ticket cards.
> 
> **Overview**
> Adds a new `CheckeredFlagIcon` and renders a *Goal mode* badge on `KanbanTicketCard` when `ticket.goal_mode` is set, with tooltip text and small overlay indicators for *complete* (`Check`) and *paused/budget-limited* (`Pause`) driven by `useSessionStore.codexGoalsBySession`.
> 
> Adjusts badge-row alignment logic so the goal badge right-aligns only when no other right-aligned status is present, and extends Vitest coverage to assert badge rendering, tooltip behavior (via `TooltipProvider`), and absence for non-goal tickets (including a `ResizeObserver` test mock).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80e0de7d2c46f17c2f767d2713e6c7c6ec6603a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->