### PR TITLE
Add resume action for paused goal badges

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -1,11 +1,12 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles, Lock, Link2, Plus, StickyNote, Send } from 'lucide-react'
+import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles, Lock, Link2, Plus, StickyNote, Send, Check, Pause, Play } from 'lucide-react'
 import { CheckeredFlagIcon } from './CheckeredFlagIcon'
 import { UpdateStatusModal } from './UpdateStatusModal'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { NoteEditorModal } from './NoteEditorModal'
 import { cn } from '@/lib/utils'
+import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { ProviderIcon, getProviderLabel } from '@/components/ui/provider-icon'
 import { toast } from '@/lib/toast'
 import {
@@ -250,6 +251,16 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
           if (found) return found.status
         }
         return null
+      },
+      [ticket.current_session_id]
+    )
+  )
+
+  const goalStatus = useSessionStore(
+    useCallback(
+      (state) => {
+        if (!ticket.current_session_id) return null
+        return state.codexGoalsBySession.get(ticket.current_session_id)?.status ?? null
       },
       [ticket.current_session_id]
     )
@@ -597,6 +608,38 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     useFileViewerStore.getState().openContextEditor(ticket.worktree_id)
   }, [ticket.worktree_id])
 
+  const handleResumeGoal = useCallback(async () => {
+    if (!ticket.current_session_id) return
+    if (!ticket.worktree_id) {
+      toast.error('No worktree assigned to this ticket')
+      return
+    }
+
+    const worktrees = Array.from(useWorktreeStore.getState().worktreesByProject.values()).flat()
+    const worktree = worktrees.find((w) => w.id === ticket.worktree_id)
+    if (!worktree) {
+      toast.error('Worktree not found')
+      return
+    }
+
+    try {
+      const result = unwrapEnvelope(
+        await window.opencodeOps.command(
+          worktree.path,
+          ticket.current_session_id,
+          'goal',
+          'resume'
+        )
+      )
+      if (!result.success) {
+        toast.error(result.error ?? 'Failed to resume goal')
+      }
+    } catch (err) {
+      console.error('Failed to resume goal:', err)
+      toast.error('Failed to resume goal')
+    }
+  }, [ticket.current_session_id, ticket.worktree_id])
+
   const handleMarkChange = useCallback(async (value: string) => {
     try {
       await useKanbanStore.getState().updateTicket(ticket.id, ticket.project_id, {
@@ -832,22 +875,68 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                 )}
 
                 {/* Goal mode badge */}
-                {ticket.goal_mode && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span
-                        data-testid="kanban-ticket-goal"
-                        className={cn(
-                          'inline-flex items-center rounded-full border border-black/20 bg-white px-1.5 py-0.5 text-black shadow-sm cursor-help',
-                          !hasRightAlignedStatus && 'ml-auto'
-                        )}
-                      >
+                {ticket.goal_mode && (() => {
+                  const isComplete = goalStatus === 'complete'
+                  const isPaused = goalStatus === 'paused' || goalStatus === 'budgetLimited'
+                  const tooltipText = isComplete ? 'Goal complete' : isPaused ? 'Goal paused' : 'Goal mode'
+
+                  const badge = (
+                    <span
+                      data-testid="kanban-ticket-goal"
+                      onContextMenu={isPaused ? (e) => e.stopPropagation() : undefined}
+                      className={cn(
+                        'inline-flex items-center rounded-full border border-black/20 bg-white px-1.5 py-0.5 text-black shadow-sm',
+                        isPaused ? 'cursor-context-menu' : 'cursor-help',
+                        !hasRightAlignedStatus && 'ml-auto'
+                      )}
+                    >
+                      <span className="relative inline-flex h-3 w-3 items-center justify-center">
                         <CheckeredFlagIcon className="h-3 w-3" />
+                        {isComplete && (
+                          <span className="absolute -right-1 -top-1 inline-flex h-2.5 w-2.5 items-center justify-center rounded-full bg-emerald-500 text-white ring-1 ring-white">
+                            <Check className="h-2 w-2 stroke-[3]" />
+                          </span>
+                        )}
+                        {isPaused && (
+                          <span className="absolute -right-1 -top-1 inline-flex h-2.5 w-2.5 items-center justify-center rounded-full bg-amber-500 text-white ring-1 ring-white">
+                            <Pause className="h-1.5 w-1.5 fill-current stroke-[3]" />
+                          </span>
+                        )}
                       </span>
-                    </TooltipTrigger>
-                    <TooltipContent>Goal mode</TooltipContent>
-                  </Tooltip>
-                )}
+                    </span>
+                  )
+
+                  return isPaused ? (
+                    <ContextMenu>
+                      <Tooltip>
+                        <ContextMenuTrigger asChild>
+                          <TooltipTrigger asChild>{badge}</TooltipTrigger>
+                        </ContextMenuTrigger>
+                        <TooltipContent>{tooltipText}</TooltipContent>
+                      </Tooltip>
+                      <ContextMenuContent>
+                        <ContextMenuItem
+                          data-testid="ctx-resume-goal"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            void handleResumeGoal()
+                          }}
+                          className="gap-2"
+                        >
+                          <Play className="h-3.5 w-3.5" />
+                          Resume goal
+                        </ContextMenuItem>
+                      </ContextMenuContent>
+                    </ContextMenu>
+                  ) : (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        {badge}
+                      </TooltipTrigger>
+                      <TooltipContent>{tooltipText}</TooltipContent>
+                    </Tooltip>
+                  )
+                })()}
               </div>
             )}
               </div>

--- a/test/kanban/pinned-board-ticket-navigation.test.tsx
+++ b/test/kanban/pinned-board-ticket-navigation.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { fireEvent, render, screen } from '../utils/render'
+import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen, waitFor } from '../utils/render'
 import { KanbanTicketCard } from '@/components/kanban/KanbanTicketCard'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -56,6 +57,10 @@ const mockDb = {
   worktree: {
     touch: vi.fn().mockResolvedValue(undefined)
   }
+}
+
+const mockOpencodeOps = {
+  command: vi.fn().mockResolvedValue({ success: true, value: { success: true } })
 }
 
 function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
@@ -241,6 +246,12 @@ describe('pinned board ticket navigation', () => {
       value: mockDb
     })
 
+    Object.defineProperty(window, 'opencodeOps', {
+      writable: true,
+      configurable: true,
+      value: mockOpencodeOps
+    })
+
     seedStores()
   })
 
@@ -302,6 +313,57 @@ describe('pinned board ticket navigation', () => {
     fireEvent.pointerMove(badge)
 
     expect(await screen.findAllByText('Goal mode')).not.toHaveLength(0)
+  })
+
+  test('resumes a paused goal from the goal badge context menu', async () => {
+    const user = userEvent.setup()
+    useSessionStore.setState({
+      codexGoalsBySession: new Map([
+        [
+          'session-1',
+          {
+            threadId: 'thread-1',
+            objective: 'Ship auth',
+            status: 'paused',
+            tokenBudget: null,
+            tokensUsed: 0,
+            timeUsedSeconds: 0,
+            createdAt: 0,
+            updatedAt: 0
+          }
+        ]
+      ])
+    })
+
+    render(
+      <TooltipProvider>
+        <KanbanTicketCard
+          ticket={makeTicket({
+            current_session_id: 'session-1',
+            goal_mode: true,
+            goal_success_criteria: 'Acceptance criteria are met'
+          })}
+        />
+      </TooltipProvider>
+    )
+
+    fireEvent.contextMenu(screen.getByTestId('kanban-ticket-goal'))
+
+    const resumeItem = await screen.findByTestId('ctx-resume-goal')
+    expect(resumeItem).toHaveTextContent('Resume goal')
+    expect(screen.queryByTestId('ctx-edit-context')).not.toBeInTheDocument()
+
+    await user.click(resumeItem)
+
+    await waitFor(() => {
+      expect(mockOpencodeOps.command).toHaveBeenCalledWith(
+        '/tmp/proj-1/feature-auth',
+        'session-1',
+        'goal',
+        'resume'
+      )
+    })
+    expect(useKanbanStore.getState().selectedTicketId).toBeNull()
   })
 
   test('does not render a goal mode badge for non-goal tickets', () => {


### PR DESCRIPTION
## Summary
- Adds paused and complete state indicators to the Kanban goal badge.
- Turns the paused goal badge into a context menu entry with a `Resume goal` action.
- Resumes the linked goal by calling `window.opencodeOps.command(..., 'goal', 'resume')` for the ticket’s session and worktree.
- Extends coverage with a test that verifies the paused goal context menu and resume command wiring.

## Testing
- Added a unit test for right-clicking the paused goal badge and selecting `Resume goal`.
- Verified the resume action calls `window.opencodeOps.command` with the expected worktree path, session id, and `goal resume` arguments.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds a new IPC command invocation (`window.opencodeOps.command`) from the UI and changes goal badge interactions; failures could impact goal state handling and user workflows.
> 
> **Overview**
> Adds goal status awareness to the Kanban ticket goal badge, including **paused** and **complete** visual indicators and updated tooltip text.
> 
> When a goal is paused (or budget-limited), the badge becomes a context menu trigger exposing a **Resume goal** action that looks up the ticket’s worktree path and calls `window.opencodeOps.command(path, sessionId, 'goal', 'resume')` (with IPC envelope handling and error toasts).
> 
> Extends tests to cover right-clicking the paused badge and asserting the resume command wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311e0e91dbe0230d1ab9fd35c80c1f293ac995f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->