### PR TITLE
Prioritize checked-out branches in worktree picker

### DIFF
--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -267,6 +267,8 @@ export function WorktreePickerModal({
     return branches
       .filter((b) => b.name.toLowerCase().includes(lower))
       .sort((a, b) => {
+        // Active (checked-out by a worktree) branches first
+        if (a.isCheckedOut !== b.isCheckedOut) return a.isCheckedOut ? -1 : 1
         if (a.isRemote !== b.isRemote) return a.isRemote ? 1 : -1
         return a.name.localeCompare(b.name)
       })


### PR DESCRIPTION
## Summary
- Updated the worktree picker branch sort order to surface active, checked-out branches first.
- Kept the existing remote-first and alphabetical ordering as the fallback sort behavior.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that only affects branch ordering in the worktree picker; no changes to git operations, persistence, or session flow.
> 
> **Overview**
> Updates the `WorktreePickerModal` branch dropdown sorting to **surface branches currently checked out by a worktree first** (using `isCheckedOut`).
> 
> Keeps existing ordering as fallbacks: local before remote, then alphabetical by branch name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87fdaf8e75eb603c3f5377c87d3efcad97596f43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->