### PR TITLE
Propagate goal mode through handoff relinks

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1744,6 +1744,7 @@ function PlanReviewModeContent({
 
       try {
         const sessionId = ticket.current_session_id
+        const handoffGoalMode = override?.goalMode === true && override?.agentSdk === 'codex'
         useSessionStore.getState().clearPendingPlan(sessionId)
         useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
         lastSendMode.delete(sessionId)
@@ -1777,7 +1778,7 @@ function PlanReviewModeContent({
           const newSessionId = result.session.id
           const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
 
-          prepareTicketBuildSession(newSessionId)
+          prepareTicketBuildSession(newSessionId, handoffGoalMode)
 
           // In sticky-tab mode, stay on the board; otherwise navigate to the new session.
           // setActiveConnectionSession requires activeConnectionId to be set — which
@@ -1837,7 +1838,7 @@ function PlanReviewModeContent({
           return
         }
 
-        prepareTicketBuildSession(newSessionId)
+        prepareTicketBuildSession(newSessionId, handoffGoalMode)
 
         // In sticky-tab mode, stay on the board; otherwise navigate to the new session
         const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
@@ -1879,13 +1880,15 @@ function PlanReviewModeContent({
   // Synchronously re-link the ticket to a new build session and (if needed) move it to
   // in_progress so the kanban board reflects the new work before the modal closes.
   const prepareTicketBuildSession = useCallback(
-    (newSessionId: string): void => {
+    (newSessionId: string, goalMode: boolean): void => {
       useKanbanStore
         .getState()
         .updateTicket(ticket.id, ticket.project_id, {
           current_session_id: newSessionId,
           plan_ready: false,
-          mode: 'build'
+          mode: 'build',
+          goal_mode: goalMode,
+          goal_success_criteria: goalMode ? (ticket.goal_success_criteria ?? null) : null
         })
         .catch((err) => {
           console.error('[KanbanTicketModal] failed to relink supercharge session:', err)
@@ -1905,7 +1908,7 @@ function PlanReviewModeContent({
           })
       }
     },
-    [ticket.id, ticket.project_id, ticket.column, ticket.sort_order]
+    [ticket.id, ticket.project_id, ticket.column, ticket.sort_order, ticket.goal_success_criteria]
   )
 
   // ── Shared: eagerly connect, send /using-superpowers, queue follow-up for global listener ──
@@ -2039,7 +2042,7 @@ function PlanReviewModeContent({
         const newSessionId = sessionResult.session.id
         const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
 
-        prepareTicketBuildSession(newSessionId)
+        prepareTicketBuildSession(newSessionId, ticket.goal_mode === true)
         onClose()
 
         // NOTE: On IIFE failure, the ticket is left re-linked to the new session (via
@@ -2122,7 +2125,7 @@ function PlanReviewModeContent({
       const newWorktreeId = dupResult.worktree.id
       const newWorktreePath = dupResult.worktree.path
 
-      prepareTicketBuildSession(newSessionId)
+      prepareTicketBuildSession(newSessionId, ticket.goal_mode === true)
       onClose()
 
       // Finish session configuration and startup in the background so the modal can close
@@ -2193,7 +2196,7 @@ function PlanReviewModeContent({
       const newSessionId = sessionResult.session.id
       const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
 
-      prepareTicketBuildSession(newSessionId)
+      prepareTicketBuildSession(newSessionId, ticket.goal_mode === true)
       onClose()
 
       // Finish session configuration and startup in the background so the modal can close

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -5019,6 +5019,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       useSessionStore.getState().clearPendingPlan(sessionId)
       useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
       lastSendMode.delete(sessionId)
+      const handoffGoalMode = override?.goalMode === true && override?.agentSdk === 'codex'
 
       // Abort the original backend session so it stops spinning
       if (worktreePath && opencodeSessionId) {
@@ -5041,7 +5042,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         }
         const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
         sessionStore.setPendingMessage(result.session.id, handoffPrompt)
-        await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
+        await useKanbanStore
+          .getState()
+          .relinkTicketsForHandoff(sessionId, result.session.id, handoffGoalMode)
         sessionStore.setActiveConnectionSession(result.session.id)
         await setModePromise
         return
@@ -5071,7 +5074,9 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
       const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
       sessionStore.setPendingMessage(result.session.id, handoffPrompt)
-      await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
+      await useKanbanStore
+        .getState()
+        .relinkTicketsForHandoff(sessionId, result.session.id, handoffGoalMode)
       sessionStore.setActiveSession(result.session.id)
       await setModePromise
     },
@@ -5725,12 +5730,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     return () => {
       window.removeEventListener('hive:refresh-codex-from-file', onRefreshFromFile)
     }
-  }, [
-    sessionId,
-    worktreePath,
-    opencodeSessionId,
-    refreshCodexMessagesFromDurableState
-  ])
+  }, [sessionId, worktreePath, opencodeSessionId, refreshCodexMessagesFromDurableState])
 
   // Determine if there's streaming content to show
   const visibleMessages = useMemo(() => {

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -142,7 +142,11 @@ interface KanbanState {
 
   // ── Session coordination ────────────────────────────────────────────
   syncTicketWithSession: (sessionId: string, event: KanbanSessionEvent) => void
-  relinkTicketsForHandoff: (oldSessionId: string, newSessionId: string) => Promise<void>
+  relinkTicketsForHandoff: (
+    oldSessionId: string,
+    newSessionId: string,
+    goalMode?: boolean
+  ) => Promise<void>
 
   // ── Getters ────────────────────────────────────────────────────────
   getTicketsForProject: (projectId: string) => KanbanTicket[]
@@ -755,23 +759,35 @@ export const useKanbanStore = create<KanbanState>()(
         }
       },
 
-      relinkTicketsForHandoff: async (oldSessionId: string, newSessionId: string) => {
+      relinkTicketsForHandoff: async (
+        oldSessionId: string,
+        newSessionId: string,
+        goalMode?: boolean
+      ) => {
         const linkedTickets = await kanban.ticket.getBySession(oldSessionId)
         if (!linkedTickets || linkedTickets.length === 0) return
 
+        const nextGoalMode = goalMode === true
         const relinkedById = new Map<string, KanbanTicket>()
 
         for (const ticket of linkedTickets) {
+          const nextGoalSuccessCriteria = nextGoalMode
+            ? (ticket.goal_success_criteria ?? null)
+            : null
           const alreadyRelinked =
             ticket.current_session_id === newSessionId &&
             ticket.plan_ready === false &&
-            ticket.mode === 'build'
+            ticket.mode === 'build' &&
+            ticket.goal_mode === nextGoalMode &&
+            ticket.goal_success_criteria === nextGoalSuccessCriteria
 
           if (!alreadyRelinked) {
             await kanban.ticket.update(ticket.id, {
               current_session_id: newSessionId,
               plan_ready: false,
-              mode: 'build'
+              mode: 'build',
+              goal_mode: nextGoalMode,
+              goal_success_criteria: nextGoalSuccessCriteria
             })
           }
 
@@ -779,7 +795,9 @@ export const useKanbanStore = create<KanbanState>()(
             ...ticket,
             current_session_id: newSessionId,
             plan_ready: false,
-            mode: 'build'
+            mode: 'build',
+            goal_mode: nextGoalMode,
+            goal_success_criteria: nextGoalSuccessCriteria
           })
         }
 
@@ -805,7 +823,9 @@ export const useKanbanStore = create<KanbanState>()(
                 ...ticket,
                 current_session_id: relinked.current_session_id,
                 plan_ready: relinked.plan_ready,
-                mode: relinked.mode
+                mode: relinked.mode,
+                goal_mode: relinked.goal_mode,
+                goal_success_criteria: relinked.goal_success_criteria
               }
             })
 

--- a/test/kanban/relink-handoff-goal-mode.test.ts
+++ b/test/kanban/relink-handoff-goal-mode.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { KanbanTicket } from '../../src/main/db/types'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+
+const getBySession = vi.fn()
+const updateTicket = vi.fn()
+
+Object.defineProperty(window, 'kanban', {
+  writable: true,
+  configurable: true,
+  value: {
+    ticket: {
+      getBySession,
+      update: updateTicket
+    }
+  }
+})
+
+function makeEnvelope<T>(value: T): { success: true; value: T } {
+  return { success: true, value }
+}
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'proj-1',
+    title: 'Handoff ticket',
+    description: null,
+    attachments: [],
+    column: 'in_progress',
+    sort_order: 0,
+    current_session_id: 'session-old',
+    worktree_id: 'wt-1',
+    mode: 'plan',
+    plan_ready: true,
+    created_at: '2026-05-08T00:00:00.000Z',
+    updated_at: '2026-05-08T00:00:00.000Z',
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
+    ...overrides
+  }
+}
+
+describe('relinkTicketsForHandoff goal mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useKanbanStore.setState({
+      tickets: new Map(),
+      boardTelegramTarget: null
+    })
+    updateTicket.mockResolvedValue(makeEnvelope(undefined))
+  })
+
+  test('writes goal mode true and keeps existing criteria when requested', async () => {
+    const ticket = makeTicket({
+      goal_mode: false,
+      goal_success_criteria: 'Ship without regressions'
+    })
+    useKanbanStore.setState({
+      tickets: new Map([['proj-1', [ticket]]])
+    })
+    getBySession.mockResolvedValue(makeEnvelope([ticket]))
+
+    await useKanbanStore.getState().relinkTicketsForHandoff('session-old', 'session-new', true)
+
+    expect(updateTicket).toHaveBeenCalledWith('ticket-1', {
+      current_session_id: 'session-new',
+      plan_ready: false,
+      mode: 'build',
+      goal_mode: true,
+      goal_success_criteria: 'Ship without regressions'
+    })
+    expect(useKanbanStore.getState().tickets.get('proj-1')?.[0]).toMatchObject({
+      current_session_id: 'session-new',
+      plan_ready: false,
+      mode: 'build',
+      goal_mode: true,
+      goal_success_criteria: 'Ship without regressions'
+    })
+  })
+
+  test('defaults omitted goal mode to false and clears criteria', async () => {
+    const ticket = makeTicket({
+      goal_mode: true,
+      goal_success_criteria: 'Old criteria'
+    })
+    useKanbanStore.setState({
+      tickets: new Map([['proj-1', [ticket]]])
+    })
+    getBySession.mockResolvedValue(makeEnvelope([ticket]))
+
+    await useKanbanStore.getState().relinkTicketsForHandoff('session-old', 'session-new')
+
+    expect(updateTicket).toHaveBeenCalledWith('ticket-1', {
+      current_session_id: 'session-new',
+      plan_ready: false,
+      mode: 'build',
+      goal_mode: false,
+      goal_success_criteria: null
+    })
+    expect(useKanbanStore.getState().tickets.get('proj-1')?.[0]).toMatchObject({
+      current_session_id: 'session-new',
+      plan_ready: false,
+      mode: 'build',
+      goal_mode: false,
+      goal_success_criteria: null
+    })
+  })
+})

--- a/test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx
+++ b/test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx
@@ -85,6 +85,10 @@ import { useSettingsStore } from '../../../src/renderer/src/stores/useSettingsSt
 import { useWorktreeStore } from '../../../src/renderer/src/stores/useWorktreeStore'
 import { useWorktreeStatusStore } from '../../../src/renderer/src/stores/useWorktreeStatusStore'
 
+function envelope<T>(value: T): { success: true; value: T } {
+  return { success: true, value }
+}
+
 function createSessionRecord(
   overrides: Partial<{
     id: string
@@ -260,58 +264,67 @@ describe('SessionView handoff ticket relinking', () => {
       archivingWorktreeIds: new Set()
     })
 
-    mockKanban.ticket.getBySession.mockResolvedValue([
-      {
-        id: 'ticket-1',
-        project_id: 'proj-1',
-        current_session_id: 'session-plan-old',
-        plan_ready: true,
-        mode: 'plan'
-      }
-    ])
-    mockKanban.ticket.update.mockResolvedValue(undefined)
+    mockKanban.ticket.getBySession.mockResolvedValue(
+      envelope([
+        {
+          id: 'ticket-1',
+          project_id: 'proj-1',
+          current_session_id: 'session-plan-old',
+          plan_ready: true,
+          mode: 'plan'
+        }
+      ])
+    )
+    mockKanban.ticket.update.mockResolvedValue(envelope(undefined))
 
-    mockDbSession.get.mockResolvedValue(createSessionRecord())
-    mockDbSession.getDraft.mockResolvedValue(null)
-    mockDbSession.updateDraft.mockResolvedValue(undefined)
-    mockDbSession.update.mockImplementation(async (sessionId: string, data: Record<string, unknown>) => ({
-      ...createSessionRecord({ id: sessionId }),
-      ...data
-    }))
+    mockDbSession.get.mockResolvedValue(envelope(createSessionRecord()))
+    mockDbSession.getDraft.mockResolvedValue(envelope(null))
+    mockDbSession.updateDraft.mockResolvedValue(envelope(undefined))
+    mockDbSession.update.mockImplementation(
+      async (sessionId: string, data: Record<string, unknown>) =>
+        envelope({
+          ...createSessionRecord({ id: sessionId }),
+          ...data
+        })
+    )
     mockDbSession.create.mockResolvedValue(
-      createSessionRecord({
-        id: 'session-build-new',
-        mode: 'build',
-        opencode_session_id: null,
-        name: 'Session 2'
+      envelope(
+        createSessionRecord({
+          id: 'session-build-new',
+          mode: 'build',
+          opencode_session_id: null,
+          name: 'Session 2'
+        })
+      )
+    )
+    mockWorktreeOps.duplicate.mockResolvedValue(
+      envelope({
+        success: true,
+        worktree: {
+          id: 'wt-2',
+          project_id: 'proj-1',
+          name: 'add-user-authentication',
+          branch_name: 'add-user-authentication',
+          path: '/tmp/worktree-supercharged',
+          status: 'active',
+          is_default: false,
+          branch_renamed: 0,
+          last_message_at: null,
+          session_titles: '[]',
+          last_model_provider_id: null,
+          last_model_id: null,
+          last_model_variant: null,
+          attachments: '[]',
+          pinned: 0,
+          context: null,
+          github_pr_number: null,
+          github_pr_url: null,
+          base_branch: null,
+          created_at: new Date().toISOString(),
+          last_accessed_at: new Date().toISOString()
+        }
       })
     )
-    mockWorktreeOps.duplicate.mockResolvedValue({
-      success: true,
-      worktree: {
-        id: 'wt-2',
-        project_id: 'proj-1',
-        name: 'add-user-authentication',
-        branch_name: 'add-user-authentication',
-        path: '/tmp/worktree-supercharged',
-        status: 'active',
-        is_default: false,
-        branch_renamed: 0,
-        last_message_at: null,
-        session_titles: '[]',
-        last_model_provider_id: null,
-        last_model_id: null,
-        last_model_variant: null,
-        attachments: '[]',
-        pinned: 0,
-        context: null,
-        github_pr_number: null,
-        github_pr_url: null,
-        base_branch: null,
-        created_at: new Date().toISOString(),
-        last_accessed_at: new Date().toISOString()
-      }
-    })
 
     Object.defineProperty(window, 'kanban', {
       value: mockKanban,
@@ -323,18 +336,20 @@ describe('SessionView handoff ticket relinking', () => {
       value: {
         session: mockDbSession,
         worktree: {
-          get: vi.fn().mockResolvedValue({
-            id: 'wt-1',
-            project_id: 'proj-1',
-            name: 'WT',
-            branch_name: 'main',
-            path: '/tmp/worktree-handoff',
-            status: 'active',
-            is_default: true,
-            created_at: new Date().toISOString(),
-            last_accessed_at: new Date().toISOString()
-          }),
-          update: vi.fn().mockResolvedValue(null)
+          get: vi.fn().mockResolvedValue(
+            envelope({
+              id: 'wt-1',
+              project_id: 'proj-1',
+              name: 'WT',
+              branch_name: 'main',
+              path: '/tmp/worktree-handoff',
+              status: 'active',
+              is_default: true,
+              created_at: new Date().toISOString(),
+              last_accessed_at: new Date().toISOString()
+            })
+          ),
+          update: vi.fn().mockResolvedValue(envelope(null))
         }
       },
       writable: true,
@@ -343,61 +358,67 @@ describe('SessionView handoff ticket relinking', () => {
 
     Object.defineProperty(window, 'opencodeOps', {
       value: {
-        reconnect: vi.fn().mockResolvedValue({ success: true }),
-        connect: vi.fn().mockResolvedValue({ success: false }),
-        prompt: vi.fn().mockResolvedValue({ success: true }),
-        command: vi.fn().mockResolvedValue({ success: true }),
-        fork: vi.fn().mockResolvedValue({ success: true }),
+        reconnect: vi.fn().mockResolvedValue(envelope({ success: true })),
+        connect: vi.fn().mockResolvedValue(envelope({ success: false })),
+        prompt: vi.fn().mockResolvedValue(envelope({ success: true })),
+        command: vi.fn().mockResolvedValue(envelope({ success: true })),
+        fork: vi.fn().mockResolvedValue(envelope({ success: true })),
         sessionInfo: vi
           .fn()
-          .mockResolvedValue({ success: true, revertMessageID: null, revertDiff: null }),
-        undo: vi.fn().mockResolvedValue({ success: true }),
-        redo: vi.fn().mockResolvedValue({ success: true }),
-        disconnect: vi.fn().mockResolvedValue({ success: true }),
-        abort: vi.fn().mockResolvedValue({ success: true }),
-        getMessages: vi.fn().mockResolvedValue({
-          success: true,
-          messages: [
-            {
-              info: {
-                id: 'turn-1:user',
-                role: 'user',
-                time: { created: Date.now() - 2000 }
+          .mockResolvedValue(envelope({ success: true, revertMessageID: null, revertDiff: null })),
+        undo: vi.fn().mockResolvedValue(envelope({ success: true })),
+        redo: vi.fn().mockResolvedValue(envelope({ success: true })),
+        disconnect: vi.fn().mockResolvedValue(envelope({ success: true })),
+        abort: vi.fn().mockResolvedValue(envelope({ success: true })),
+        getMessages: vi.fn().mockResolvedValue(
+          envelope({
+            success: true,
+            messages: [
+              {
+                info: {
+                  id: 'turn-1:user',
+                  role: 'user',
+                  time: { created: Date.now() - 2000 }
+                },
+                parts: [{ type: 'text', text: 'Please draft a plan' }]
               },
-              parts: [{ type: 'text', text: 'Please draft a plan' }]
-            },
-            {
-              info: {
-                id: 'turn-1:assistant',
-                role: 'assistant',
-                time: { created: Date.now() - 1000 }
-              },
-              parts: [{ type: 'text', text: '1. Add the relink helper\n2. Use it during handoff' }]
+              {
+                info: {
+                  id: 'turn-1:assistant',
+                  role: 'assistant',
+                  time: { created: Date.now() - 1000 }
+                },
+                parts: [
+                  { type: 'text', text: '1. Add the relink helper\n2. Use it during handoff' }
+                ]
+              }
+            ]
+          })
+        ),
+        listModels: vi.fn().mockResolvedValue(envelope({ success: true, providers: [] })),
+        setModel: vi.fn().mockResolvedValue(envelope({ success: true })),
+        modelInfo: vi.fn().mockResolvedValue(envelope({ success: true })),
+        questionReply: vi.fn().mockResolvedValue(envelope({ success: true })),
+        questionReject: vi.fn().mockResolvedValue(envelope({ success: true })),
+        permissionReply: vi.fn().mockResolvedValue(envelope({ success: true })),
+        permissionList: vi.fn().mockResolvedValue(envelope({ success: true, permissions: [] })),
+        commands: vi.fn().mockResolvedValue(envelope({ success: true, commands: [] })),
+        capabilities: vi.fn().mockResolvedValue(
+          envelope({
+            success: true,
+            capabilities: {
+              supportsUndo: true,
+              supportsRedo: true,
+              supportsCommands: true,
+              supportsPermissionRequests: true,
+              supportsQuestionPrompts: true,
+              supportsModelSelection: true,
+              supportsReconnect: true,
+              supportsPartialStreaming: true,
+              supportsSteer: true
             }
-          ]
-        }),
-        listModels: vi.fn().mockResolvedValue({ success: true, providers: [] }),
-        setModel: vi.fn().mockResolvedValue({ success: true }),
-        modelInfo: vi.fn().mockResolvedValue({ success: true }),
-        questionReply: vi.fn().mockResolvedValue({ success: true }),
-        questionReject: vi.fn().mockResolvedValue({ success: true }),
-        permissionReply: vi.fn().mockResolvedValue({ success: true }),
-        permissionList: vi.fn().mockResolvedValue({ success: true, permissions: [] }),
-        commands: vi.fn().mockResolvedValue({ success: true, commands: [] }),
-        capabilities: vi.fn().mockResolvedValue({
-          success: true,
-          capabilities: {
-            supportsUndo: true,
-            supportsRedo: true,
-            supportsCommands: true,
-            supportsPermissionRequests: true,
-            supportsQuestionPrompts: true,
-            supportsModelSelection: true,
-            supportsReconnect: true,
-            supportsPartialStreaming: true,
-            supportsSteer: true
-          }
-        }),
+          })
+        ),
         onStream: vi.fn().mockImplementation(() => () => {})
       },
       writable: true,
@@ -409,7 +430,9 @@ describe('SessionView handoff ticket relinking', () => {
         isLogMode: vi.fn().mockResolvedValue(false),
         getLogDir: vi.fn().mockResolvedValue('/tmp/logs'),
         getAppVersion: vi.fn().mockResolvedValue('1.0.0'),
-        getAppPaths: vi.fn().mockResolvedValue({ userData: '/tmp', home: '/tmp', logs: '/tmp/logs' }),
+        getAppPaths: vi
+          .fn()
+          .mockResolvedValue({ userData: '/tmp', home: '/tmp', logs: '/tmp/logs' }),
         setSessionQueuedState: vi.fn().mockResolvedValue(undefined)
       },
       writable: true,
@@ -427,7 +450,7 @@ describe('SessionView handoff ticket relinking', () => {
 
     Object.defineProperty(window, 'bash', {
       value: {
-        getRun: vi.fn().mockResolvedValue(null),
+        getRun: vi.fn().mockResolvedValue(envelope(null)),
         onStream: vi.fn().mockImplementation(() => () => {})
       },
       writable: true,
@@ -464,7 +487,9 @@ describe('SessionView handoff ticket relinking', () => {
       expect(mockKanban.ticket.update).toHaveBeenCalledWith('ticket-1', {
         current_session_id: 'session-build-new',
         plan_ready: false,
-        mode: 'build'
+        mode: 'build',
+        goal_mode: false,
+        goal_success_criteria: null
       })
     })
 

--- a/test/telegram/telegram-forwarding-target.test.tsx
+++ b/test/telegram/telegram-forwarding-target.test.tsx
@@ -70,6 +70,10 @@ const promptSession = vi.fn()
 const getTicketsBySession = vi.fn()
 const updateTicket = vi.fn()
 
+function envelope<T>(value: T): { success: true; value: T } {
+  return { success: true, value }
+}
+
 function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
   return {
     id: 'ticket-1',
@@ -211,7 +215,11 @@ function seedStores(ticket = makeTicket()): void {
 
   useConnectionStore.setState({ selectedConnectionId: null, connections: [] })
   useGitStore.setState({ remoteInfo: new Map(), creatingPRByWorktreeId: new Map() })
-  usePinnedStore.setState({ loaded: true, pinnedProjectIds: new Set(), pinnedWorktreeIds: new Set() })
+  usePinnedStore.setState({
+    loaded: true,
+    pinnedProjectIds: new Set(),
+    pinnedWorktreeIds: new Set()
+  })
   useQuestionStore.setState({ pendingBySession: new Map() })
   useScriptStore.setState({ scriptStates: {} })
   useWorktreeStatusStore.setState({
@@ -244,22 +252,39 @@ describe('Telegram forwarding board target', () => {
       configurable: true,
       value: {
         startForwarding,
-        stopForwarding: vi.fn(),
-        getConfig: vi.fn().mockResolvedValue({
-          botToken: 'token',
-          chatId: 123,
-          chatName: 'me',
-          contextSize: 3
-        }),
-        getStatus: vi.fn().mockResolvedValue({
-          active: false,
-          sessionId: null,
-          worktreeId: null,
-          connectionId: null,
-          mode: null,
-          health: 'ok',
-          lastError: null
-        }),
+        stopForwarding: vi.fn().mockResolvedValue(
+          envelope({
+            ok: true,
+            status: {
+              active: false,
+              sessionId: null,
+              worktreeId: null,
+              connectionId: null,
+              mode: null,
+              health: 'ok',
+              lastError: null
+            }
+          })
+        ),
+        getConfig: vi.fn().mockResolvedValue(
+          envelope({
+            botToken: 'token',
+            chatId: 123,
+            chatName: 'me',
+            contextSize: 3
+          })
+        ),
+        getStatus: vi.fn().mockResolvedValue(
+          envelope({
+            active: false,
+            sessionId: null,
+            worktreeId: null,
+            connectionId: null,
+            mode: null,
+            health: 'ok',
+            lastError: null
+          })
+        ),
         onStatusChanged: vi.fn(),
         onPlanImplementRequested: vi.fn()
       }
@@ -282,23 +307,27 @@ describe('Telegram forwarding board target', () => {
         prompt: promptSession
       }
     })
-    mockDb.session.update.mockResolvedValue(undefined)
-    connectPromptSession.mockResolvedValue({ success: true, sessionId: 'opc-session-new' })
-    promptSession.mockResolvedValue({ success: true })
-    startForwarding.mockResolvedValue({
-      ok: true,
-      status: {
-        active: true,
-        sessionId: 'session-1',
-        worktreeId: 'wt-1',
-        connectionId: null,
-        mode: 'questions',
-        health: 'ok',
-        lastError: null
-      }
-    })
-    getTicketsBySession.mockResolvedValue([])
-    updateTicket.mockResolvedValue(undefined)
+    mockDb.session.update.mockResolvedValue(envelope(undefined))
+    connectPromptSession.mockResolvedValue(
+      envelope({ success: true, sessionId: 'opc-session-new' })
+    )
+    promptSession.mockResolvedValue(envelope({ success: true }))
+    startForwarding.mockResolvedValue(
+      envelope({
+        ok: true,
+        status: {
+          active: true,
+          sessionId: 'session-1',
+          worktreeId: 'wt-1',
+          connectionId: null,
+          mode: 'questions',
+          health: 'ok',
+          lastError: null
+        }
+      })
+    )
+    getTicketsBySession.mockResolvedValue(envelope([]))
+    updateTicket.mockResolvedValue(envelope(undefined))
   })
 
   it('records the ticket session as board Telegram target on cmd-click', () => {
@@ -377,12 +406,6 @@ describe('Telegram forwarding board target', () => {
         ]
       ])
     })
-
-    render(
-      <TooltipProvider>
-        <HeaderTelegramToggle />
-      </TooltipProvider>
-    )
     act(() => {
       useSettingsStore.getState().setTelegramConfig({
         botToken: 'token',
@@ -391,6 +414,12 @@ describe('Telegram forwarding board target', () => {
         contextSize: 3
       })
     })
+
+    render(
+      <TooltipProvider>
+        <HeaderTelegramToggle />
+      </TooltipProvider>
+    )
     await waitFor(() => {
       expect(screen.getByTestId('telegram-forwarding-toggle')).not.toBeDisabled()
     })
@@ -468,7 +497,7 @@ describe('Telegram forwarding board target', () => {
       worktreeId: 'wt-1',
       sessionId: 'session-old'
     })
-    getTicketsBySession.mockResolvedValue([oldTicket])
+    getTicketsBySession.mockResolvedValue(envelope([oldTicket]))
 
     await useKanbanStore.getState().relinkTicketsForHandoff('session-old', 'session-new')
 


### PR DESCRIPTION
## Summary
- Propagated goal-mode state during session handoff so relinked tickets preserve or clear `goal_mode` and `goal_success_criteria` consistently.
- Updated kanban and session handoff paths to pass the goal-mode flag through when relinking tickets.
- Added coverage for goal-mode relinking and adjusted existing handoff/telegram tests to match the updated async envelope responses.

## Testing
- Added `test/kanban/relink-handoff-goal-mode.test.ts` to verify goal-mode relinking behavior.
- Updated `test/phase-22/session-11/session-view-handoff-ticket-relink.test.tsx` for the new relink payload.
- Updated `test/telegram/telegram-forwarding-target.test.tsx` for the new response shapes.
- Not run locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the ticket/session handoff flow and mutates persisted kanban ticket fields (`goal_mode`, `goal_success_criteria`) during relinks, which could cause incorrect ticket state if the new flag is mis-propagated.
> 
> **Overview**
> **Propagates goal-mode state across session handoffs/supercharge relinks.** When creating a new build session from `KanbanTicketModal` or `SessionView` handoff, the relink now carries a computed `handoffGoalMode` (only when `override.goalMode` is true and `agentSdk` is `codex`).
> 
> `useKanbanStore.relinkTicketsForHandoff` now accepts an optional `goalMode` and updates both DB and in-memory tickets to set `goal_mode` and either preserve existing `goal_success_criteria` (when enabled) or clear it (when disabled/omitted), while keeping existing board Telegram target session rewrites.
> 
> Adds a focused vitest for goal-mode relinking and updates existing handoff/telegram tests to match the new relink payload and the IPC `envelope` response shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eab9fe27005de1fb2841ae1c408ab0aab57030e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->