### PR TITLE
Add ticket-level merge conflict fix flow

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -1,9 +1,10 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { Paperclip, AlertCircle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles, Lock, Link2, Plus, StickyNote, Send, Check, Pause, Play } from 'lucide-react'
+import { Paperclip, AlertCircle, AlertTriangle, Trash2, Archive, ArchiveRestore, GitBranch, ExternalLink, X, FileText, Pin, PinOff, RefreshCw, Link as LinkIcon, GitPullRequest, Loader2, Sparkles, Lock, Link2, Plus, StickyNote, Send, Check, Pause, Play, ChevronDown, Hammer, Map as MapIcon } from 'lucide-react'
 import { CheckeredFlagIcon } from './CheckeredFlagIcon'
 import { UpdateStatusModal } from './UpdateStatusModal'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { Button } from '@/components/ui/button'
 import { NoteEditorModal } from './NoteEditorModal'
 import { cn } from '@/lib/utils'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
@@ -21,6 +22,12 @@ import {
   ContextMenuRadioGroup,
   ContextMenuRadioItem
 } from '@/components/ui/context-menu'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem
+} from '@/components/ui/dropdown-menu'
 import {
   AlertDialog,
   AlertDialogContent,
@@ -52,6 +59,7 @@ import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import { useTelegramStore } from '@/stores/useTelegramStore'
 import { useSessionTimer } from '@/hooks/useSessionTimer'
 import { useSessionTokenDelta } from '@/hooks/useSessionTokenDelta'
+import { useConflictFixFlow } from '@/hooks/useConflictFixFlow'
 import { formatTokenCount } from '@/lib/format-utils'
 import type { KanbanTicket, TicketMark } from '../../../../main/db/types'
 
@@ -171,6 +179,50 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       [ticket.worktree_id]
     )
   )
+
+  const conflictTargetWorktreeId = useWorktreeStatusStore(
+    useCallback(
+      (state) =>
+        ticket.worktree_id
+          ? (state.mergeConflictWorktreeByTicket[ticket.id] ?? ticket.worktree_id)
+          : null,
+      [ticket.id, ticket.worktree_id]
+    )
+  )
+
+  const worktreePath = useWorktreeStore(
+    useCallback(
+      (state) => {
+        if (!conflictTargetWorktreeId) return null
+        for (const worktrees of state.worktreesByProject.values()) {
+          const found = worktrees.find((w) => w.id === conflictTargetWorktreeId)
+          if (found) return found.path
+        }
+        return null
+      },
+      [conflictTargetWorktreeId]
+    )
+  )
+
+  const hasConflicts = useGitStore(
+    useCallback(
+      (state) => (worktreePath ? (state.conflictsByWorktree[worktreePath] ?? false) : false),
+      [worktreePath]
+    )
+  )
+
+  const conflictFlow = useWorktreeStatusStore(
+    useCallback(
+      (state) =>
+        conflictTargetWorktreeId
+          ? state.mergeConflictFlowByWorktree[conflictTargetWorktreeId]
+          : undefined,
+      [conflictTargetWorktreeId]
+    )
+  )
+
+  const mergeConflictMode = useSettingsStore((s) => s.mergeConflictMode)
+  const { startFixFlow, openAttachedSession } = useConflictFixFlow(conflictTargetWorktreeId)
 
   // ── Lookup project name + color for connection board ─────────────
   // Selector returns a primitive (string | null) to avoid Zustand infinite
@@ -310,11 +362,25 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       [ticket.current_session_id]
     )
   )
-  const hasRightAlignedStatus = Boolean(
-    ((isBusy || isAsking) && ticket.mode && !isBlocked) ||
-    (isBeingReviewed && !(isBusy || isAsking)) ||
-    (!isBeingReviewed && !(isBusy || isAsking) && completedReviewSessionId)
-  )
+  const rightAlignedSlot: 'conflicts' | 'busy' | 'reviewing' | 'completed-review' | null =
+    useMemo(() => {
+      if (!isArchived && hasConflicts && ticket.worktree_id) return 'conflicts'
+      if ((isBusy || isAsking) && ticket.mode && !isBlocked) return 'busy'
+      if (isBeingReviewed) return 'reviewing'
+      if (completedReviewSessionId) return 'completed-review'
+      return null
+    }, [
+      completedReviewSessionId,
+      hasConflicts,
+      isArchived,
+      isAsking,
+      isBeingReviewed,
+      isBlocked,
+      isBusy,
+      ticket.mode,
+      ticket.worktree_id
+    ])
+  const hasRightAlignedStatus = rightAlignedSlot !== null
 
   const timerText = useSessionTimer(
     ticket.current_session_id,
@@ -719,7 +785,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || isBusy || isAsking || isBeingReviewed || completedReviewSessionId || isArchived || isBlocked || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode) && (
+            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
@@ -833,46 +899,132 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                   </span>
                 )}
 
-                {(isBusy || isAsking) && ticket.mode && !isBlocked && (
-                  <span data-testid="kanban-ticket-progress" className="ml-auto flex items-center gap-1.5">
-                    {timerText && (
-                      <span className={cn(
-                        'text-[11px] tabular-nums font-semibold',
-                        isAsking
-                          ? 'text-amber-500'
-                          : ticket.mode === 'build'
-                            ? 'text-blue-500'
-                            : 'text-violet-500'
-                      )}>
-                        {timerText}
-                      </span>
-                    )}
-                    <IndeterminateProgressBar mode={ticket.mode} isAsking={isAsking} className="w-20" />
-                    {isAsking && (
-                      <span className="text-[11px] font-semibold text-amber-500">
-                        Question
-                      </span>
-                    )}
-                  </span>
-                )}
+                {(() => {
+                  switch (rightAlignedSlot) {
+                    case 'conflicts': {
+                      const isConflictFlowActive =
+                        conflictFlow?.phase === 'starting' ||
+                        conflictFlow?.phase === 'running' ||
+                        conflictFlow?.phase === 'refreshing'
+                      if (isConflictFlowActive) {
+                        return (
+                          <span
+                            data-testid="kanban-ticket-conflict-progress"
+                            className="ml-auto flex items-center gap-1.5"
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              if (conflictFlow?.phase !== 'starting') openAttachedSession()
+                            }}
+                          >
+                            <IndeterminateProgressBar
+                              mode={ticket.mode || 'build'}
+                              isFixingConflicts
+                              className="w-20"
+                            />
+                          </span>
+                        )
+                      }
 
-                {/* Review active but ticket's own session is NOT busy — show green bar */}
-                {isBeingReviewed && !(isBusy || isAsking) && (
-                  <span data-testid="kanban-ticket-reviewing" className="ml-auto flex items-center gap-1.5">
-                    <IndeterminateProgressBar mode={ticket.mode || 'build'} isReviewing className="w-20" />
-                  </span>
-                )}
+                      if (mergeConflictMode === 'always-ask') {
+                        return (
+                          <span className="ml-auto" onClick={(e) => e.stopPropagation()}>
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  size="sm"
+                                  variant="destructive"
+                                  className="h-6 px-2 text-xs font-semibold"
+                                  data-testid="kanban-ticket-fix-conflicts"
+                                >
+                                  <AlertTriangle className="h-3.5 w-3.5 mr-1" />
+                                  Fix conflicts
+                                  <ChevronDown className="h-3 w-3 ml-1" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                <DropdownMenuItem
+                                  onClick={(e) => {
+                                    e.stopPropagation()
+                                    void startFixFlow('build')
+                                  }}
+                                >
+                                  <Hammer className="h-4 w-4 mr-2" />
+                                  Fix in Build mode
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  onClick={(e) => {
+                                    e.stopPropagation()
+                                    void startFixFlow('plan')
+                                  }}
+                                >
+                                  <MapIcon className="h-4 w-4 mr-2" />
+                                  Fix in Plan mode
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </span>
+                        )
+                      }
 
-                {/* Completed review — show "Go to review" link */}
-                {!isBeingReviewed && !(isBusy || isAsking) && completedReviewSessionId && (
-                  <button
-                    data-testid="kanban-ticket-go-to-review"
-                    onClick={(e) => { e.stopPropagation(); handleGoToReview() }}
-                    className="ml-auto text-green-500 hover:text-green-400 text-xs cursor-pointer"
-                  >
-                    Go to review
-                  </button>
-                )}
+                      return (
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          className="ml-auto h-6 px-2 text-xs font-semibold"
+                          data-testid="kanban-ticket-fix-conflicts"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            void startFixFlow()
+                          }}
+                        >
+                          <AlertTriangle className="h-3.5 w-3.5 mr-1" />
+                          Fix conflicts
+                        </Button>
+                      )
+                    }
+                    case 'busy':
+                      return (
+                        <span data-testid="kanban-ticket-progress" className="ml-auto flex items-center gap-1.5">
+                          {timerText && (
+                            <span className={cn(
+                              'text-[11px] tabular-nums font-semibold',
+                              isAsking
+                                ? 'text-amber-500'
+                                : ticket.mode === 'build'
+                                  ? 'text-blue-500'
+                                  : 'text-violet-500'
+                            )}>
+                              {timerText}
+                            </span>
+                          )}
+                          <IndeterminateProgressBar mode={ticket.mode!} isAsking={isAsking} className="w-20" />
+                          {isAsking && (
+                            <span className="text-[11px] font-semibold text-amber-500">
+                              Question
+                            </span>
+                          )}
+                        </span>
+                      )
+                    case 'reviewing':
+                      return (
+                        <span data-testid="kanban-ticket-reviewing" className="ml-auto flex items-center gap-1.5">
+                          <IndeterminateProgressBar mode={ticket.mode || 'build'} isReviewing className="w-20" />
+                        </span>
+                      )
+                    case 'completed-review':
+                      return (
+                        <button
+                          data-testid="kanban-ticket-go-to-review"
+                          onClick={(e) => { e.stopPropagation(); handleGoToReview() }}
+                          className="ml-auto text-green-500 hover:text-green-400 text-xs cursor-pointer"
+                        >
+                          Go to review
+                        </button>
+                      )
+                    default:
+                      return null
+                  }
+                })()}
 
                 {/* Goal mode badge */}
                 {ticket.goal_mode && (() => {

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -7,6 +7,8 @@ import {
   Trash2,
   ExternalLink,
   Hammer,
+  AlertTriangle,
+  ChevronDown,
   Send,
   Zap,
   AlertCircle,
@@ -19,7 +21,8 @@ import {
   Github,
   Upload,
   Lock,
-  Plus
+  Plus,
+  Map as MapIcon
 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -32,10 +35,17 @@ import {
   DialogDescription
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem
+} from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { MarkdownRenderer } from '../sessions/MarkdownRenderer'
 import { HandoffSplitButton } from '../sessions/HandoffSplitButton'
+import { IndeterminateProgressBar } from '@/components/sessions/IndeterminateProgressBar'
 import { cn } from '@/lib/utils'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useSessionStore } from '@/stores/useSessionStore'
@@ -71,6 +81,7 @@ import { ReviewTicketDiffSummary, type ReviewTicketDiffFile } from './ReviewTick
 import { ProviderIcon, getProviderLabel } from '@/components/ui/provider-icon'
 import { useLifecycleActions } from '@/hooks/useLifecycleActions'
 import { usePinAndActivateSession } from '@/hooks/usePinAndActivateSession'
+import { useConflictFixFlow } from '@/hooks/useConflictFixFlow'
 import { TicketAttachmentEditor } from './TicketAttachmentEditor'
 import { TicketDiscardChangesDialog } from './TicketDiscardChangesDialog'
 import { useImagePaste } from '@/hooks/useImagePaste'
@@ -409,6 +420,131 @@ export function KanbanTicketModal() {
   return <KanbanTicketModalContent ticket={ticket} onForceClose={() => setSelectedTicketId(null)} />
 }
 
+function MergeConflictBanner({ ticket }: { ticket: KanbanTicket }) {
+  const conflictTargetWorktreeId = useWorktreeStatusStore(
+    useCallback(
+      (state) =>
+        ticket.worktree_id
+          ? (state.mergeConflictWorktreeByTicket[ticket.id] ?? ticket.worktree_id)
+          : null,
+      [ticket.id, ticket.worktree_id]
+    )
+  )
+  const worktreePath = useWorktreeStore(
+    useCallback(
+      (state) => {
+        if (!conflictTargetWorktreeId) return null
+        for (const worktrees of state.worktreesByProject.values()) {
+          const found = worktrees.find((w) => w.id === conflictTargetWorktreeId)
+          if (found) return found.path
+        }
+        return null
+      },
+      [conflictTargetWorktreeId]
+    )
+  )
+  const hasConflicts = useGitStore(
+    useCallback(
+      (state) => (worktreePath ? (state.conflictsByWorktree[worktreePath] ?? false) : false),
+      [worktreePath]
+    )
+  )
+  const conflictFlow = useWorktreeStatusStore(
+    useCallback(
+      (state) =>
+        conflictTargetWorktreeId
+          ? state.mergeConflictFlowByWorktree[conflictTargetWorktreeId]
+          : undefined,
+      [conflictTargetWorktreeId]
+    )
+  )
+  const mergeConflictMode = useSettingsStore((s) => s.mergeConflictMode)
+  const { startFixFlow, openAttachedSession } = useConflictFixFlow(conflictTargetWorktreeId)
+
+  if (!ticket.worktree_id || ticket.archived_at || !hasConflicts) return null
+
+  const isConflictFlowActive =
+    conflictFlow?.phase === 'starting' ||
+    conflictFlow?.phase === 'running' ||
+    conflictFlow?.phase === 'refreshing'
+
+  return (
+    <div
+      data-testid="ticket-modal-fix-conflicts-banner"
+      className="flex items-center justify-between gap-3 border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center gap-2 font-medium text-destructive">
+        <AlertTriangle className="h-4 w-4" />
+        Merge conflicts detected
+      </div>
+      {isConflictFlowActive ? (
+        <button
+          type="button"
+          className="flex items-center"
+          onClick={(e) => {
+            e.stopPropagation()
+            if (conflictFlow?.phase !== 'starting') openAttachedSession()
+          }}
+        >
+          <IndeterminateProgressBar
+            mode={ticket.mode || 'build'}
+            isFixingConflicts
+            className="w-24"
+          />
+        </button>
+      ) : mergeConflictMode === 'always-ask' ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              size="sm"
+              variant="destructive"
+              className="h-7 text-xs font-semibold"
+            >
+              <AlertTriangle className="h-3.5 w-3.5 mr-1" />
+              Fix conflicts
+              <ChevronDown className="h-3 w-3 ml-1" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation()
+                void startFixFlow('build')
+              }}
+            >
+              <Hammer className="h-4 w-4 mr-2" />
+              Fix in Build mode
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation()
+                void startFixFlow('plan')
+              }}
+            >
+              <MapIcon className="h-4 w-4 mr-2" />
+              Fix in Plan mode
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <Button
+          size="sm"
+          variant="destructive"
+          className="h-7 text-xs font-semibold"
+          onClick={(e) => {
+            e.stopPropagation()
+            void startFixFlow()
+          }}
+        >
+          <AlertTriangle className="h-3.5 w-3.5 mr-1" />
+          Fix conflicts
+        </Button>
+      )}
+    </div>
+  )
+}
+
 // ── Inner content (only rendered when ticket is non-null) ───────────
 function KanbanTicketModalContent({
   ticket,
@@ -698,6 +834,7 @@ function KanbanTicketModalContent({
     opcSessionId &&
     !opcSessionId.startsWith('pending::')
   )
+  const conflictBanner = <MergeConflictBanner ticket={ticket} />
 
   // Commit to dual-pane layout as soon as we know the ticket has a session,
   // even before the async DB lookups resolve.  This prevents the user from
@@ -853,12 +990,13 @@ function KanbanTicketModalContent({
     dialogBody = (
       <DialogContent
         data-testid="kanban-ticket-modal"
-        className="w-[96vw] max-w-[1920px] h-[90vh] p-0 gap-0 overflow-hidden"
+        className="w-[96vw] max-w-[1920px] h-[90vh] p-0 gap-0 overflow-hidden flex flex-col"
       >
         <DialogHeader className="sr-only">
           <DialogTitle>{ticket.title}</DialogTitle>
         </DialogHeader>
-        <div className="flex h-full overflow-hidden">
+        {conflictBanner}
+        <div className="flex min-h-0 flex-1 overflow-hidden">
           {hasSession && sessionReady ? (
             <SessionStreamPanel
               sessionId={ticket.current_session_id!}
@@ -895,9 +1033,10 @@ function KanbanTicketModalContent({
     dialogBody = (
       <DialogContent
         data-testid="kanban-ticket-modal"
-        className="w-[96vw] max-w-[1920px] h-[90vh] p-0 gap-0 overflow-hidden"
+        className="w-[96vw] max-w-[1920px] h-[90vh] p-0 gap-0 overflow-hidden flex flex-col"
       >
-        <div className="flex h-full overflow-hidden">
+        {conflictBanner}
+        <div className="flex min-h-0 flex-1 overflow-hidden">
           {/* Left: ticket content */}
           <div className="w-[480px] shrink-0 h-full flex flex-col overflow-y-auto p-6 gap-4">
             {/* Shared ticket context header for non-edit modes */}
@@ -935,6 +1074,7 @@ function KanbanTicketModalContent({
     // ── Standard layout (no session) ────────────────────────────────
     dialogBody = (
       <DialogContent data-testid="kanban-ticket-modal" className={MODE_DIALOG_CLASS[modalMode]}>
+        {conflictBanner}
         {modeContent}
       </DialogContent>
     )

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useGitStore } from '@/stores/useGitStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
@@ -23,6 +25,7 @@ interface ResolvedState {
   featureWorktreeId: string
   featureWorktreePath: string
   featureBranch: string
+  baseWorktreeId: string
   baseWorktreePath: string
   baseBranch: string
   ticketTitle: string
@@ -170,6 +173,7 @@ export function MergeOnDoneDialog() {
           featureWorktreeId: featureWorktree.id,
           featureWorktreePath: featureWorktree.path,
           featureBranch: featureWorktree.branch_name,
+          baseWorktreeId: baseWorktree.id,
           baseWorktreePath: baseWorktree.path,
           baseBranch: resolvedBaseBranch,
           ticketTitle: ticket.title,
@@ -318,7 +322,7 @@ export function MergeOnDoneDialog() {
   }, [resolved, baseCommitMessage, completeDoneMove, clearPendingDoneMove])
 
   const handleMerge = useCallback(async () => {
-    if (!resolved) return
+    if (!resolved || !pendingDoneMove) return
     setMerging(true)
     try {
       // Pull latest on base branch first (only if remote exists)
@@ -338,9 +342,13 @@ export function MergeOnDoneDialog() {
       )
 
       if (!mergeResult.success) {
-        // Conflicts or error — abort and let user handle manually
+        // Conflicts or error — keep conflicts on disk so the ticket-level fix flow can act on them.
         if (mergeResult.conflicts && mergeResult.conflicts.length > 0) {
-          unwrapEnvelope(await window.gitOps.mergeAbort(resolved.baseWorktreePath))
+          useGitStore.getState().setHasConflicts(resolved.baseWorktreePath, true)
+          useWorktreeStatusStore
+            .getState()
+            .setMergeConflictWorktreeForTicket(pendingDoneMove.ticketId, resolved.baseWorktreeId)
+          void useGitStore.getState().refreshStatuses(resolved.baseWorktreePath)
           toast.error(
             `Merge conflicts in ${mergeResult.conflicts.length} file${mergeResult.conflicts.length !== 1 ? 's' : ''} — merge manually`
           )
@@ -359,7 +367,7 @@ export function MergeOnDoneDialog() {
     } finally {
       setMerging(false)
     }
-  }, [resolved, clearPendingDoneMove])
+  }, [resolved, pendingDoneMove, clearPendingDoneMove])
 
   const handleArchive = useCallback(async () => {
     if (!resolved) return

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useMemo, useRef } from 'react'
+import { useEffect, useState, useMemo, useRef } from 'react'
 import { isMac } from '@/lib/platform'
 import {
   PanelRightClose,
@@ -45,7 +45,6 @@ import { REVIEW_PROMPT_LABELS, type ReviewPromptType } from '@/constants/reviewP
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
-import { useSessionStore } from '@/stores/useSessionStore'
 import { useGitStore } from '@/stores/useGitStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useVimModeStore } from '@/stores/useVimModeStore'
@@ -57,32 +56,8 @@ import { QuickActions } from './QuickActions'
 import { HeaderTelegramToggle } from './HeaderTelegramToggle'
 import { useLifecycleActions } from '@/hooks/useLifecycleActions'
 import { usePinAndActivateSession } from '@/hooks/usePinAndActivateSession'
+import { useConflictFixFlow } from '@/hooks/useConflictFixFlow'
 import hiveLogo from '@/assets/icon.png'
-
-type ConflictFixFlow =
-  | {
-      phase: 'starting'
-      worktreePath: string
-    }
-  | {
-      phase: 'running'
-      worktreePath: string
-      sessionId: string
-      seenBusy: boolean
-    }
-  | {
-      phase: 'refreshing'
-      worktreePath: string
-    }
-
-function isConflictFixActiveStatus(status: string | null): boolean {
-  return (
-    status === 'working' ||
-    status === 'planning' ||
-    status === 'answering' ||
-    status === 'permission'
-  )
-}
 
 export function Header(): React.JSX.Element {
   const { rightSidebarCollapsed, toggleRightSidebar } = useLayoutStore()
@@ -99,11 +74,6 @@ export function Header(): React.JSX.Element {
     }
     return null
   }, [selectedWorktreeId, worktreesByProject])
-  const createSession = useSessionStore((s) => s.createSession)
-  const updateSessionName = useSessionStore((s) => s.updateSessionName)
-  const setPendingMessage = useSessionStore((s) => s.setPendingMessage)
-  const setActiveSession = useSessionStore((s) => s.setActiveSession)
-
   // Lifecycle actions hook — PR/Review/Merge/Archive logic
   const lifecycle = useLifecycleActions(selectedWorktreeId)
   const { pinAndActivate, lifecycleLoading } = usePinAndActivateSession()
@@ -127,7 +97,11 @@ export function Header(): React.JSX.Element {
   const hatchFirstPetSeen = useTipStore((s) => s.isTipSeen('hatch-first-pet'))
   const nonDefaultProviderChosen = useTipStore((s) => s.nonDefaultProviderChosen)
   const petEnabled = useSettingsStore((s) => s.pet.enabled)
-  const [conflictFixFlow, setConflictFixFlow] = useState<ConflictFixFlow | null>(null)
+  const {
+    isRunning: isFixConflictsRunning,
+    isFinalizing: isFixConflictsFinalizing,
+    startFixFlow
+  } = useConflictFixFlow(selectedWorktreeId)
 
   const showHatchTip = !hatchFirstPetSeen && !petEnabled
   const settingsTipId = showHatchTip ? 'hatch-first-pet' : 'settings-default-provider'
@@ -177,63 +151,6 @@ export function Header(): React.JSX.Element {
     prTargetBranch, reviewTargetBranch, isCleanTree
   } = lifecycle
 
-  const conflictFixSessionStatus = useWorktreeStatusStore((state) =>
-    conflictFixFlow?.phase === 'running'
-      ? (state.sessionStatuses[conflictFixFlow.sessionId]?.status ?? null)
-      : null
-  )
-
-  // Clear conflict fix flow as soon as conflicts are resolved
-  useEffect(() => {
-    if (!hasConflicts && conflictFixFlow) {
-      setConflictFixFlow(null)
-    }
-  }, [hasConflicts, conflictFixFlow])
-
-  useEffect(() => {
-    if (!conflictFixFlow || conflictFixFlow.phase !== 'running') return
-
-    const isBusy = isConflictFixActiveStatus(conflictFixSessionStatus)
-
-    if (isBusy && !conflictFixFlow.seenBusy) {
-      setConflictFixFlow((prev) =>
-        prev && prev.phase === 'running' ? { ...prev, seenBusy: true } : prev
-      )
-      return
-    }
-
-    const shouldFinalize =
-      (conflictFixFlow.seenBusy && !isBusy) ||
-      (!conflictFixFlow.seenBusy && conflictFixSessionStatus === 'completed')
-
-    if (!shouldFinalize) return
-
-    let cancelled = false
-    const finishConflictRun = async (): Promise<void> => {
-      setConflictFixFlow((prev) =>
-        prev && prev.phase === 'running'
-          ? { phase: 'refreshing', worktreePath: prev.worktreePath }
-          : prev
-      )
-
-      try {
-        await useGitStore.getState().refreshStatuses(conflictFixFlow.worktreePath)
-      } finally {
-        if (!cancelled) {
-          setConflictFixFlow((prev) =>
-            prev?.worktreePath === conflictFixFlow.worktreePath ? null : prev
-          )
-        }
-      }
-    }
-
-    void finishConflictRun()
-
-    return () => {
-      cancelled = true
-    }
-  }, [conflictFixFlow, conflictFixSessionStatus])
-
   // PR picker popover state (UI-specific to Header)
   const [prPickerOpen, setPrPickerOpen] = useState(false)
   const [prList, setPrList] = useState<
@@ -268,39 +185,7 @@ export function Header(): React.JSX.Element {
     setPrPickerOpen(false)
   }
 
-  const handleFixConflicts = useCallback(async (modeOverride?: 'build' | 'plan') => {
-    if (!selectedWorktreeId || !selectedProjectId || !selectedWorktree?.path) return
-
-    const resolvedMode = modeOverride ?? (mergeConflictMode === 'always-ask' ? 'build' : mergeConflictMode)
-
-    setConflictFixFlow({
-      phase: 'starting',
-      worktreePath: selectedWorktree.path
-    })
-
-    const { success, session } = await createSession(selectedWorktreeId, selectedProjectId, undefined, resolvedMode)
-    if (!success || !session) {
-      setConflictFixFlow(null)
-      return
-    }
-
-    const branchName = selectedWorktree?.branch_name || 'unknown'
-    await updateSessionName(session.id, `Merge Conflicts — ${branchName}`)
-    setPendingMessage(session.id, 'Fix merge conflicts')
-    setActiveSession(session.id)
-
-    setConflictFixFlow({
-      phase: 'running',
-      worktreePath: selectedWorktree.path,
-      sessionId: session.id,
-      seenBusy: false
-    })
-  }, [mergeConflictMode, selectedWorktreeId, selectedProjectId, selectedWorktree, createSession, updateSessionName, setPendingMessage, setActiveSession])
-
-  const isFixConflictsLoading =
-    !!selectedWorktree?.path &&
-    !!conflictFixFlow &&
-    conflictFixFlow.worktreePath === selectedWorktree.path
+  const isFixConflictsLoading = isFixConflictsRunning || isFixConflictsFinalizing
 
   const showFixConflictsButton = hasConflicts || isFixConflictsLoading
 
@@ -387,11 +272,11 @@ export function Header(): React.JSX.Element {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => handleFixConflicts('build')}>
+                <DropdownMenuItem onClick={() => startFixFlow('build')}>
                   <Hammer className="h-4 w-4 mr-2" />
                   Fix in Build mode
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => handleFixConflicts('plan')}>
+                <DropdownMenuItem onClick={() => startFixFlow('plan')}>
                   <Map className="h-4 w-4 mr-2" />
                   Fix in Plan mode
                 </DropdownMenuItem>
@@ -402,7 +287,7 @@ export function Header(): React.JSX.Element {
               size="sm"
               variant="destructive"
               className="h-7 text-xs font-semibold"
-              onClick={() => handleFixConflicts()}
+              onClick={() => startFixFlow()}
               disabled={isFixConflictsLoading}
               data-testid="fix-conflicts-button"
             >

--- a/src/renderer/src/components/sessions/IndeterminateProgressBar.tsx
+++ b/src/renderer/src/components/sessions/IndeterminateProgressBar.tsx
@@ -7,6 +7,7 @@ interface IndeterminateProgressBarProps {
   isAsking?: boolean
   isCompacting?: boolean
   isReviewing?: boolean
+  isFixingConflicts?: boolean
   className?: string
 }
 
@@ -35,6 +36,7 @@ export function IndeterminateProgressBar({
   isAsking,
   isCompacting,
   isReviewing,
+  isFixingConflicts,
   className
 }: IndeterminateProgressBarProps) {
   const barRef = useRef<HTMLDivElement>(null)
@@ -55,9 +57,12 @@ export function IndeterminateProgressBar({
     } catch {
       // Animation failed — bar stays visible at CSS default position
     }
+    return undefined
   }, [])
 
-  const bgTrack = isCompacting
+  const bgTrack = isFixingConflicts
+    ? 'bg-fuchsia-500/15'
+    : isCompacting
     ? 'bg-red-500/15'
     : isAsking
       ? 'bg-amber-500/15'
@@ -68,7 +73,9 @@ export function IndeterminateProgressBar({
           : mode === 'super-plan'
             ? 'bg-orange-500/15'
             : 'bg-violet-500/15'
-  const bgBar = isCompacting
+  const bgBar = isFixingConflicts
+    ? 'bg-fuchsia-500'
+    : isCompacting
     ? 'bg-red-500'
     : isAsking
       ? 'bg-amber-500'
@@ -89,7 +96,15 @@ export function IndeterminateProgressBar({
       )}
       <div
         role="progressbar"
-        aria-label={isCompacting ? 'Compacting conversation' : isAsking ? 'Waiting for answer' : 'Agent is working'}
+        aria-label={
+          isFixingConflicts
+            ? 'Fixing merge conflicts'
+            : isCompacting
+              ? 'Compacting conversation'
+              : isAsking
+                ? 'Waiting for answer'
+                : 'Agent is working'
+        }
         className={cn('relative w-full h-4 rounded-full overflow-hidden', bgTrack)}
       >
         <div

--- a/src/renderer/src/hooks/useConflictFixFlow.ts
+++ b/src/renderer/src/hooks/useConflictFixFlow.ts
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useMemo } from 'react'
+import { useGitStore } from '@/stores/useGitStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStatusStore, type MergeConflictFlow } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+type ConflictFixMode = 'build' | 'plan'
+
+function isConflictFixActiveStatus(status: string | null): boolean {
+  return (
+    status === 'working' ||
+    status === 'planning' ||
+    status === 'answering' ||
+    status === 'permission'
+  )
+}
+
+function resolveWorktree(worktreeId: string | null): {
+  worktreePath: string | null
+  projectId: string | null
+  branchName: string
+} {
+  if (!worktreeId) {
+    return { worktreePath: null, projectId: null, branchName: 'unknown' }
+  }
+
+  for (const worktrees of useWorktreeStore.getState().worktreesByProject.values()) {
+    const worktree = worktrees.find((wt) => wt.id === worktreeId)
+    if (worktree) {
+      return {
+        worktreePath: worktree.path,
+        projectId: worktree.project_id,
+        branchName: worktree.branch_name || 'unknown'
+      }
+    }
+  }
+
+  return { worktreePath: null, projectId: null, branchName: 'unknown' }
+}
+
+export function useConflictFixFlow(worktreeId: string | null): {
+  phase: MergeConflictFlow['phase'] | null
+  isRunning: boolean
+  isFinalizing: boolean
+  attachedSessionId: string | null
+  startFixFlow: (modeOverride?: ConflictFixMode) => Promise<void>
+  openAttachedSession: () => void
+} {
+  const worktreesByProject = useWorktreeStore((state) => state.worktreesByProject)
+  const worktreeInfo = useMemo(() => {
+    if (!worktreeId) {
+      return { worktreePath: null, projectId: null, branchName: 'unknown' }
+    }
+    for (const worktrees of worktreesByProject.values()) {
+      const worktree = worktrees.find((wt) => wt.id === worktreeId)
+      if (worktree) {
+        return {
+          worktreePath: worktree.path,
+          projectId: worktree.project_id,
+          branchName: worktree.branch_name || 'unknown'
+        }
+      }
+    }
+    return { worktreePath: null, projectId: null, branchName: 'unknown' }
+  }, [worktreeId, worktreesByProject])
+
+  const mergeConflictMode = useSettingsStore((state) => state.mergeConflictMode)
+  const createSession = useSessionStore((state) => state.createSession)
+  const updateSessionName = useSessionStore((state) => state.updateSessionName)
+  const setPendingMessage = useSessionStore((state) => state.setPendingMessage)
+  const setActiveSession = useSessionStore((state) => state.setActiveSession)
+  const flow = useWorktreeStatusStore((state) =>
+    worktreeId ? state.mergeConflictFlowByWorktree[worktreeId] : undefined
+  )
+  const attachedSessionId = useWorktreeStatusStore((state) =>
+    worktreeId ? (state.mergeConflictSessionByWorktree[worktreeId] ?? null) : null
+  )
+  const conflictFixSessionStatus = useWorktreeStatusStore((state) =>
+    flow?.phase === 'running' ? (state.sessionStatuses[flow.sessionId]?.status ?? null) : null
+  )
+  const hasConflicts = useGitStore((state) =>
+    worktreeInfo.worktreePath
+      ? (state.conflictsByWorktree[worktreeInfo.worktreePath] ?? false)
+      : false
+  )
+
+  const clearFlowAndSession = useCallback(() => {
+    if (!worktreeId) return
+    const statusStore = useWorktreeStatusStore.getState()
+    statusStore.setMergeConflictFlow(worktreeId, null)
+    statusStore.clearMergeConflictSession(worktreeId)
+  }, [worktreeId])
+
+  const startFixFlow = useCallback(
+    async (modeOverride?: ConflictFixMode) => {
+      if (!worktreeId) return
+
+      const currentFlow = useWorktreeStatusStore.getState().mergeConflictFlowByWorktree[worktreeId]
+      if (currentFlow?.phase === 'starting' || currentFlow?.phase === 'running') return
+
+      const currentWorktree = resolveWorktree(worktreeId)
+      if (!currentWorktree.worktreePath || !currentWorktree.projectId) return
+
+      const resolvedMode =
+        modeOverride ?? (mergeConflictMode === 'always-ask' ? 'build' : mergeConflictMode)
+      const statusStore = useWorktreeStatusStore.getState()
+      statusStore.setMergeConflictFlow(worktreeId, { phase: 'starting' })
+
+      const { success, session } = await createSession(
+        worktreeId,
+        currentWorktree.projectId,
+        undefined,
+        resolvedMode
+      )
+      if (!success || !session) {
+        statusStore.setMergeConflictFlow(worktreeId, null)
+        return
+      }
+
+      useProjectStore.getState().selectProject(currentWorktree.projectId)
+      useWorktreeStore.getState().selectWorktree(worktreeId)
+      useSessionStore.getState().setActiveWorktree(worktreeId)
+      await updateSessionName(session.id, `Merge Conflicts — ${currentWorktree.branchName}`)
+      setPendingMessage(session.id, 'Fix merge conflicts')
+      setActiveSession(session.id)
+      statusStore.setMergeConflictSession(worktreeId, session.id)
+      statusStore.setMergeConflictFlow(worktreeId, {
+        phase: 'running',
+        sessionId: session.id,
+        seenBusy: false
+      })
+    },
+    [
+      createSession,
+      mergeConflictMode,
+      setActiveSession,
+      setPendingMessage,
+      updateSessionName,
+      worktreeId
+    ]
+  )
+
+  useEffect(() => {
+    if (!worktreeId || !worktreeInfo.worktreePath || !flow || flow.phase !== 'running') return
+
+    const isBusy = isConflictFixActiveStatus(conflictFixSessionStatus)
+
+    if (isBusy && !flow.seenBusy) {
+      useWorktreeStatusStore
+        .getState()
+        .setMergeConflictFlow(worktreeId, { ...flow, seenBusy: true })
+      return
+    }
+
+    const shouldFinalize =
+      (flow.seenBusy && !isBusy) || (!flow.seenBusy && conflictFixSessionStatus === 'completed')
+
+    if (!shouldFinalize) return
+
+    let cancelled = false
+    const finishConflictRun = async (): Promise<void> => {
+      useWorktreeStatusStore.getState().setMergeConflictFlow(worktreeId, { phase: 'refreshing' })
+
+      try {
+        await useGitStore.getState().refreshStatuses(worktreeInfo.worktreePath!)
+      } finally {
+        if (!cancelled) {
+          clearFlowAndSession()
+        }
+      }
+    }
+
+    void finishConflictRun()
+
+    return () => {
+      cancelled = true
+    }
+  }, [clearFlowAndSession, conflictFixSessionStatus, flow, worktreeId, worktreeInfo.worktreePath])
+
+  useEffect(() => {
+    if (!worktreeId || (!flow && !attachedSessionId)) return
+    if (!hasConflicts) {
+      clearFlowAndSession()
+    }
+  }, [attachedSessionId, clearFlowAndSession, flow, hasConflicts, worktreeId])
+
+  const openAttachedSession = useCallback(() => {
+    if (!worktreeId || !attachedSessionId) return
+    const currentWorktree = resolveWorktree(worktreeId)
+    const kanbanStore = useKanbanStore.getState()
+    if (kanbanStore.isBoardViewActive) kanbanStore.toggleBoardView()
+    if (kanbanStore.isPinnedBoardActive) kanbanStore.togglePinnedBoard()
+    if (currentWorktree.projectId) {
+      useProjectStore.getState().selectProject(currentWorktree.projectId)
+    }
+    useWorktreeStore.getState().selectWorktree(worktreeId)
+    useSessionStore.getState().setActiveWorktree(worktreeId)
+    useSessionStore.getState().setActiveSession(attachedSessionId)
+  }, [attachedSessionId, worktreeId])
+
+  return {
+    phase: flow?.phase ?? null,
+    isRunning: flow?.phase === 'starting' || flow?.phase === 'running',
+    isFinalizing: flow?.phase === 'refreshing',
+    attachedSessionId,
+    startFixFlow,
+    openAttachedSession
+  }
+}

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -25,6 +25,11 @@ export interface SessionStatusEntry {
   tokenDelta?: number
 }
 
+export type MergeConflictFlow =
+  | { phase: 'starting' }
+  | { phase: 'running'; sessionId: string; seenBusy: boolean }
+  | { phase: 'refreshing' }
+
 interface WorktreeStatusState {
   // sessionId → status info (null means no status / cleared)
   sessionStatuses: Record<string, SessionStatusEntry | null>
@@ -34,6 +39,12 @@ interface WorktreeStatusState {
   reviewSessionByWorktree: Record<string, string>
   // worktreeId → sessionId for completed review sessions (in-memory only)
   completedReviewSessionByWorktree: Record<string, string>
+  // worktreeId → sessionId for active conflict-fix sessions
+  mergeConflictSessionByWorktree: Record<string, string>
+  // worktreeId → current conflict-fix flow phase
+  mergeConflictFlowByWorktree: Record<string, MergeConflictFlow>
+  // ticketId → worktreeId whose conflicts should be surfaced on that ticket
+  mergeConflictWorktreeByTicket: Record<string, string>
 
   // Actions
   setSessionStatus: (
@@ -51,6 +62,10 @@ interface WorktreeStatusState {
   setReviewSession: (worktreeId: string, sessionId: string) => void
   clearReviewSession: (worktreeId: string) => void
   clearCompletedReviewSession: (worktreeId: string) => void
+  setMergeConflictSession: (worktreeId: string, sessionId: string) => void
+  clearMergeConflictSession: (worktreeId: string) => void
+  setMergeConflictFlow: (worktreeId: string, flow: MergeConflictFlow | null) => void
+  setMergeConflictWorktreeForTicket: (ticketId: string, worktreeId: string | null) => void
   isWorktreeBeingReviewed: (worktreeId: string) => boolean
 }
 
@@ -80,6 +95,9 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
   lastMessageTimeByWorktree: {},
   reviewSessionByWorktree: {},
   completedReviewSessionByWorktree: {},
+  mergeConflictSessionByWorktree: {},
+  mergeConflictFlowByWorktree: {},
+  mergeConflictWorktreeByTicket: {},
 
   setSessionStatus: (
     sessionId: string,
@@ -337,6 +355,52 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
     set((state) => {
       const { [worktreeId]: _, ...rest } = state.completedReviewSessionByWorktree
       return { completedReviewSessionByWorktree: rest }
+    })
+  },
+
+  setMergeConflictSession: (worktreeId: string, sessionId: string) => {
+    set((state) => ({
+      mergeConflictSessionByWorktree: {
+        ...state.mergeConflictSessionByWorktree,
+        [worktreeId]: sessionId
+      }
+    }))
+  },
+
+  clearMergeConflictSession: (worktreeId: string) => {
+    set((state) => {
+      const { [worktreeId]: _, ...rest } = state.mergeConflictSessionByWorktree
+      return { mergeConflictSessionByWorktree: rest }
+    })
+  },
+
+  setMergeConflictFlow: (worktreeId: string, flow: MergeConflictFlow | null) => {
+    set((state) => {
+      if (!flow) {
+        const { [worktreeId]: _, ...rest } = state.mergeConflictFlowByWorktree
+        return { mergeConflictFlowByWorktree: rest }
+      }
+      return {
+        mergeConflictFlowByWorktree: {
+          ...state.mergeConflictFlowByWorktree,
+          [worktreeId]: flow
+        }
+      }
+    })
+  },
+
+  setMergeConflictWorktreeForTicket: (ticketId: string, worktreeId: string | null) => {
+    set((state) => {
+      if (!worktreeId) {
+        const { [ticketId]: _, ...rest } = state.mergeConflictWorktreeByTicket
+        return { mergeConflictWorktreeByTicket: rest }
+      }
+      return {
+        mergeConflictWorktreeByTicket: {
+          ...state.mergeConflictWorktreeByTicket,
+          [ticketId]: worktreeId
+        }
+      }
     })
   },
 

--- a/test/kanban/merge-conflicts-ticket-button.test.tsx
+++ b/test/kanban/merge-conflicts-ticket-button.test.tsx
@@ -1,0 +1,533 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen, waitFor } from '../utils/render'
+import { KanbanTicketCard } from '@/components/kanban/KanbanTicketCard'
+import { KanbanTicketModal } from '@/components/kanban/KanbanTicketModal'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { useConflictFixFlow } from '@/hooks/useConflictFixFlow'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useGitStore } from '@/stores/useGitStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { usePinnedStore } from '@/stores/usePinnedStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useQuestionStore } from '@/stores/useQuestionStore'
+import { useScriptStore } from '@/stores/useScriptStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket } from '../../src/main/db/types'
+
+vi.mock('@/components/kanban/WorktreePickerModal', () => ({
+  WorktreePickerModal: () => null
+}))
+
+vi.mock('@/components/kanban/AttachPRPopover', () => ({
+  AttachPRPopover: () => null
+}))
+
+vi.mock('@/components/kanban/UpdateStatusModal', () => ({
+  UpdateStatusModal: () => null
+}))
+
+vi.mock('@/components/worktrees/PulseAnimation', () => ({
+  PulseAnimation: () => null
+}))
+
+vi.mock('@/components/kanban/TicketRunButton', () => ({
+  TicketRunButton: () => null
+}))
+
+vi.mock('@/hooks/useTicketRunScript', () => ({
+  useTicketRunScript: () => ({
+    isRunning: false,
+    isConfigured: false,
+    run: vi.fn()
+  }),
+  useTicketRunScriptHotkey: vi.fn()
+}))
+
+vi.mock('@/hooks/useSessionTimer', () => ({
+  useSessionTimer: () => null
+}))
+
+vi.mock('@/hooks/useSessionTokenDelta', () => ({
+  useSessionTokenDelta: () => null
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const WORKTREE_PATH = '/tmp/proj-1/feature-auth'
+
+const mockCreateSession = vi.fn()
+const mockUpdateSessionName = vi.fn()
+const mockSetPendingMessage = vi.fn()
+const mockSetActiveSession = vi.fn()
+const mockSetActiveWorktree = vi.fn()
+const mockRefreshStatuses = vi.fn()
+
+const mockDb = {
+  project: {
+    touch: vi.fn().mockResolvedValue(undefined)
+  },
+  worktree: {
+    touch: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockResolvedValue(null)
+  },
+  session: {
+    get: vi.fn().mockResolvedValue(null)
+  }
+}
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'proj-1',
+    title: 'Resolve auth conflicts',
+    description: null,
+    attachments: [],
+    column: 'todo',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: 'wt-1',
+    mode: null,
+    plan_ready: false,
+    created_at: '2026-05-21T00:00:00.000Z',
+    updated_at: '2026-05-21T00:00:00.000Z',
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    ...overrides
+  }
+}
+
+function seedStores(ticket = makeTicket()): void {
+  useKanbanStore.setState({
+    tickets: new Map([['proj-1', [ticket]]]),
+    dependencyMap: new Map(),
+    selectedTicketId: null,
+    isBoardViewActive: true,
+    isPinnedBoardActive: false
+  })
+
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'proj-1',
+        name: 'Project One',
+        path: '/tmp/proj-1',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-05-21T00:00:00.000Z',
+        last_accessed_at: '2026-05-21T00:00:00.000Z'
+      }
+    ],
+    selectedProjectId: 'proj-1'
+  })
+
+  useWorktreeStore.setState({
+    selectedWorktreeId: null,
+    worktreesByProject: new Map([
+      [
+        'proj-1',
+        [
+          {
+            id: 'wt-1',
+            project_id: 'proj-1',
+            name: 'feature-auth',
+            branch_name: 'feature-auth',
+            path: WORKTREE_PATH,
+            status: 'active',
+            is_default: false,
+            branch_renamed: 0,
+            last_message_at: null,
+            session_titles: '[]',
+            last_model_provider_id: null,
+            last_model_id: null,
+            last_model_variant: null,
+            created_at: '2026-05-21T00:00:00.000Z',
+            last_accessed_at: '2026-05-21T00:00:00.000Z',
+            github_pr_number: null,
+            github_pr_url: null
+          },
+          {
+            id: 'base-wt',
+            project_id: 'proj-1',
+            name: 'main',
+            branch_name: 'main',
+            path: '/tmp/proj-1/main',
+            status: 'active',
+            is_default: true,
+            branch_renamed: 0,
+            last_message_at: null,
+            session_titles: '[]',
+            last_model_provider_id: null,
+            last_model_id: null,
+            last_model_variant: null,
+            created_at: '2026-05-21T00:00:00.000Z',
+            last_accessed_at: '2026-05-21T00:00:00.000Z',
+            github_pr_number: null,
+            github_pr_url: null
+          }
+        ]
+      ]
+    ]),
+    worktreeOrderByProject: new Map()
+  })
+
+  useSessionStore.setState({
+    activeSessionId: null,
+    activeWorktreeId: null,
+    sessionsByWorktree: new Map(),
+    sessionsByConnection: new Map(),
+    createSession: mockCreateSession,
+    updateSessionName: mockUpdateSessionName,
+    setPendingMessage: mockSetPendingMessage,
+    setActiveSession: mockSetActiveSession,
+    setActiveWorktree: mockSetActiveWorktree
+  })
+
+  useWorktreeStatusStore.setState({
+    sessionStatuses: {},
+    reviewSessionByWorktree: {},
+    completedReviewSessionByWorktree: {},
+    mergeConflictSessionByWorktree: {},
+    mergeConflictFlowByWorktree: {},
+    mergeConflictWorktreeByTicket: {}
+  })
+
+  useSettingsStore.setState({
+    mergeConflictMode: 'build'
+  })
+
+  useGitStore.setState({
+    conflictsByWorktree: {
+      [WORKTREE_PATH]: true
+    },
+    remoteInfo: new Map(),
+    creatingPRByWorktreeId: new Map(),
+    refreshStatuses: mockRefreshStatuses
+  })
+
+  useConnectionStore.setState({
+    selectedConnectionId: null,
+    connections: []
+  })
+
+  usePinnedStore.setState({
+    loaded: true,
+    pinnedProjectIds: new Set(),
+    pinnedWorktreeIds: new Set(),
+    pinnedConnectionIds: new Set()
+  })
+
+  useScriptStore.setState({
+    scriptStates: {}
+  })
+
+  useQuestionStore.setState({
+    pendingBySession: new Map()
+  })
+}
+
+function renderCard(ticket = makeTicket(), props: { isArchived?: boolean } = {}) {
+  return render(
+    <TooltipProvider>
+      <KanbanTicketCard ticket={ticket} {...props} />
+    </TooltipProvider>
+  )
+}
+
+function ConflictFlowHarness({ worktreeId }: { worktreeId: string | null }) {
+  const { startFixFlow } = useConflictFixFlow(worktreeId)
+  return (
+    <button type="button" data-testid="start-conflict-flow" onClick={() => void startFixFlow()}>
+      Start
+    </button>
+  )
+}
+
+describe('merge conflicts ticket button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateSession.mockResolvedValue({
+      success: true,
+      session: { id: 'conflict-session-1' }
+    })
+    mockUpdateSessionName.mockResolvedValue(true)
+    mockRefreshStatuses.mockResolvedValue(undefined)
+
+    if (!globalThis.ResizeObserver) {
+      class MockResizeObserver {
+        observe = vi.fn()
+        unobserve = vi.fn()
+        disconnect = vi.fn()
+      }
+
+      Object.defineProperty(globalThis, 'ResizeObserver', {
+        writable: true,
+        configurable: true,
+        value: MockResizeObserver
+      })
+    }
+
+    Object.defineProperty(window, 'db', {
+      writable: true,
+      configurable: true,
+      value: mockDb
+    })
+
+    Object.defineProperty(window, 'systemOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        openInChrome: vi.fn()
+      }
+    })
+
+    Object.defineProperty(window, 'gitOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        listBranchesWithStatus: vi.fn().mockResolvedValue({
+          success: true,
+          value: { success: true, branches: [] }
+        }),
+        getChangedFiles: vi.fn().mockResolvedValue({ success: true, files: [] })
+      }
+    })
+
+    seedStores()
+  })
+
+  test('renders Fix conflicts button when the ticket worktree has conflicts', () => {
+    renderCard()
+
+    expect(screen.getByTestId('kanban-ticket-fix-conflicts')).toHaveTextContent('Fix conflicts')
+  })
+
+  test('hides the Fix conflicts button when the ticket has no worktree', () => {
+    renderCard(makeTicket({ worktree_id: null }))
+
+    expect(screen.queryByTestId('kanban-ticket-fix-conflicts')).not.toBeInTheDocument()
+  })
+
+  test('hides the Fix conflicts button when the ticket is archived', () => {
+    renderCard(makeTicket({ archived_at: '2026-05-21T01:00:00.000Z' }), { isArchived: true })
+
+    expect(screen.queryByTestId('kanban-ticket-fix-conflicts')).not.toBeInTheDocument()
+  })
+
+  test('renders conflicts from a merge target worktree linked to the ticket', async () => {
+    const user = userEvent.setup()
+    useGitStore.setState({
+      conflictsByWorktree: {
+        [WORKTREE_PATH]: false,
+        '/tmp/proj-1/main': true
+      }
+    })
+    useWorktreeStatusStore.setState({
+      mergeConflictWorktreeByTicket: { 'ticket-1': 'base-wt' }
+    })
+
+    renderCard()
+
+    await user.click(screen.getByTestId('kanban-ticket-fix-conflicts'))
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith('base-wt', 'proj-1', undefined, 'build')
+    })
+  })
+
+  test('always-ask mode renders Build and Plan choices that start the selected flow', async () => {
+    const user = userEvent.setup()
+    useSettingsStore.setState({ mergeConflictMode: 'always-ask' })
+
+    const { rerender } = render(
+      <TooltipProvider>
+        <KanbanTicketCard ticket={makeTicket()} />
+      </TooltipProvider>
+    )
+
+    await user.click(screen.getByTestId('kanban-ticket-fix-conflicts'))
+    await user.click(await screen.findByText('Fix in Plan mode'))
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith('wt-1', 'proj-1', undefined, 'plan')
+    })
+
+    mockCreateSession.mockClear()
+    useWorktreeStatusStore.setState({
+      mergeConflictSessionByWorktree: {},
+      mergeConflictFlowByWorktree: {}
+    })
+
+    rerender(
+      <TooltipProvider>
+        <KanbanTicketCard ticket={makeTicket()} />
+      </TooltipProvider>
+    )
+
+    await user.click(screen.getByTestId('kanban-ticket-fix-conflicts'))
+    await user.click(await screen.findByText('Fix in Build mode'))
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith('wt-1', 'proj-1', undefined, 'build')
+    })
+  })
+
+  test('build mode renders a single button that starts the default flow', async () => {
+    const user = userEvent.setup()
+
+    renderCard()
+
+    await user.click(screen.getByTestId('kanban-ticket-fix-conflicts'))
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith('wt-1', 'proj-1', undefined, 'build')
+    })
+  })
+
+  test('running conflict flow renders a fuchsia progress bar instead of the button', () => {
+    useWorktreeStatusStore.setState({
+      mergeConflictSessionByWorktree: { 'wt-1': 'conflict-session-1' },
+      mergeConflictFlowByWorktree: {
+        'wt-1': { phase: 'running', sessionId: 'conflict-session-1', seenBusy: true }
+      }
+    })
+
+    renderCard(makeTicket({ mode: 'build' }))
+
+    expect(screen.queryByTestId('kanban-ticket-fix-conflicts')).not.toBeInTheDocument()
+    const progress = screen.getByTestId('kanban-ticket-conflict-progress')
+    expect(progress).toBeInTheDocument()
+    expect(screen.getByRole('progressbar', { name: 'Fixing merge conflicts' })).toHaveClass(
+      'bg-fuchsia-500/15'
+    )
+    expect(progress.querySelector('.bg-fuchsia-500')).toBeInTheDocument()
+  })
+
+  test('clicking the running progress bar opens the attached conflict session', () => {
+    useWorktreeStatusStore.setState({
+      mergeConflictSessionByWorktree: { 'wt-1': 'conflict-session-1' },
+      mergeConflictFlowByWorktree: {
+        'wt-1': { phase: 'running', sessionId: 'conflict-session-1', seenBusy: true }
+      }
+    })
+
+    renderCard(makeTicket({ mode: 'build' }))
+
+    fireEvent.click(screen.getByTestId('kanban-ticket-conflict-progress'))
+
+    expect(useKanbanStore.getState().isBoardViewActive).toBe(false)
+    expect(useWorktreeStore.getState().selectedWorktreeId).toBe('wt-1')
+    expect(mockSetActiveWorktree).toHaveBeenCalledWith('wt-1')
+    expect(mockSetActiveSession).toHaveBeenCalledWith('conflict-session-1')
+  })
+
+  test('conflicts slot wins over busy, reviewing, and completed review indicators', () => {
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([
+        [
+          'wt-1',
+          [
+            {
+              id: 'session-1',
+              worktree_id: 'wt-1',
+              project_id: 'proj-1',
+              connection_id: null,
+              name: 'Session 1',
+              status: 'active',
+              opencode_session_id: null,
+              agent_sdk: 'opencode',
+              mode: 'build',
+              session_type: 'default',
+              model_provider_id: null,
+              model_id: null,
+              model_variant: null,
+              created_at: '2026-05-21T00:00:00.000Z',
+              updated_at: '2026-05-21T00:00:00.000Z',
+              completed_at: null,
+              pinned_to_board: false
+            }
+          ]
+        ]
+      ])
+    })
+    useWorktreeStatusStore.setState({
+      sessionStatuses: {
+        'session-1': { status: 'working', timestamp: Date.now() }
+      },
+      reviewSessionByWorktree: { 'wt-1': 'review-session-1' },
+      completedReviewSessionByWorktree: { 'wt-1': 'review-session-2' }
+    })
+
+    renderCard(
+      makeTicket({
+        column: 'review',
+        current_session_id: 'session-1',
+        mode: 'build'
+      })
+    )
+
+    expect(screen.getByTestId('kanban-ticket-fix-conflicts')).toBeInTheDocument()
+    expect(screen.queryByTestId('kanban-ticket-progress')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('kanban-ticket-reviewing')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('kanban-ticket-go-to-review')).not.toBeInTheDocument()
+  })
+
+  test('startFixFlow bails when a flow is already running', async () => {
+    const user = userEvent.setup()
+    useWorktreeStatusStore.setState({
+      mergeConflictSessionByWorktree: { 'wt-1': 'conflict-session-1' },
+      mergeConflictFlowByWorktree: {
+        'wt-1': { phase: 'running', sessionId: 'conflict-session-1', seenBusy: false }
+      }
+    })
+
+    render(<ConflictFlowHarness worktreeId="wt-1" />)
+
+    await user.click(screen.getByTestId('start-conflict-flow'))
+
+    expect(mockCreateSession).not.toHaveBeenCalled()
+  })
+
+  test('renders a conflict banner at the top of the ticket modal', () => {
+    useKanbanStore.setState({
+      selectedTicketId: 'ticket-1',
+      tickets: new Map([['proj-1', [makeTicket()]]])
+    })
+
+    render(
+      <TooltipProvider>
+        <KanbanTicketModal />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByTestId('ticket-modal-fix-conflicts-banner')).toBeInTheDocument()
+    expect(screen.getByTestId('ticket-modal-fix-conflicts-banner')).toHaveTextContent(
+      'Fix conflicts'
+    )
+  })
+})

--- a/test/kanban/merge-on-done-dialog.test.tsx
+++ b/test/kanban/merge-on-done-dialog.test.tsx
@@ -2,7 +2,9 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { KanbanTicket, Project, Worktree } from '../../src/main/db/types'
 import { MergeOnDoneDialog } from '../../src/renderer/src/components/kanban/MergeOnDoneDialog'
+import { useGitStore } from '../../src/renderer/src/stores/useGitStore'
 import { useKanbanStore } from '../../src/renderer/src/stores/useKanbanStore'
+import { useWorktreeStatusStore } from '../../src/renderer/src/stores/useWorktreeStatusStore'
 import { useWorktreeStore } from '../../src/renderer/src/stores/useWorktreeStore'
 
 const toastError = vi.fn()
@@ -21,6 +23,7 @@ const ticketMove = vi.fn()
 const mergeAbort = vi.fn()
 const merge = vi.fn()
 const originalArchiveWorktree = useWorktreeStore.getState().archiveWorktree
+const envelope = <T,>(value: T) => ({ success: true, value })
 
 function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
   return {
@@ -114,7 +117,7 @@ describe('MergeOnDoneDialog', () => {
       configurable: true,
       value: {
         ticket: {
-          move: ticketMove.mockResolvedValue(undefined)
+          move: ticketMove.mockResolvedValue(envelope(undefined))
         }
       }
     })
@@ -124,11 +127,11 @@ describe('MergeOnDoneDialog', () => {
       configurable: true,
       value: {
         worktree: {
-          get: vi.fn().mockResolvedValue(makeWorktree()),
-          getActiveByProject: vi.fn().mockResolvedValue([makeWorktree(), baseWorktree])
+          get: vi.fn().mockResolvedValue(envelope(makeWorktree())),
+          getActiveByProject: vi.fn().mockResolvedValue(envelope([makeWorktree(), baseWorktree]))
         },
         project: {
-          get: vi.fn().mockResolvedValue(project)
+          get: vi.fn().mockResolvedValue(envelope(project))
         }
       }
     })
@@ -137,17 +140,17 @@ describe('MergeOnDoneDialog', () => {
       writable: true,
       configurable: true,
       value: {
-        hasUncommittedChanges: vi.fn().mockResolvedValue(false),
-        branchDiffShortStat: vi.fn().mockResolvedValue({
+        hasUncommittedChanges: vi.fn().mockResolvedValue(envelope(false)),
+        branchDiffShortStat: vi.fn().mockResolvedValue(envelope({
           success: true,
           filesChanged: 2,
           insertions: 4,
           deletions: 1,
           commitsAhead: 1
-        }),
+        })),
         getDiffStat: vi.fn(),
-        getRemoteUrl: vi.fn().mockResolvedValue({ success: true, url: null, remote: null }),
-        pull: vi.fn().mockResolvedValue({ success: true }),
+        getRemoteUrl: vi.fn().mockResolvedValue(envelope({ success: true, url: null, remote: null })),
+        pull: vi.fn().mockResolvedValue(envelope({ success: true })),
         merge,
         mergeAbort
       }
@@ -161,37 +164,43 @@ describe('MergeOnDoneDialog', () => {
         sortOrder: 100
       }
     })
+    useGitStore.setState({ conflictsByWorktree: {} })
+    useWorktreeStatusStore.setState({ mergeConflictWorktreeByTicket: {} })
 
     useWorktreeStore.setState({ archiveWorktree: originalArchiveWorktree })
   })
 
   test('keeps ticket in review when merge returns conflicts', async () => {
-    merge.mockResolvedValue({
+    merge.mockResolvedValue(envelope({
       success: false,
       error: 'Merge conflicts in 1 file(s). Resolve conflicts before continuing.',
       conflicts: ['src/file.ts']
-    })
-    mergeAbort.mockResolvedValue({ success: true })
+    }))
+    mergeAbort.mockResolvedValue(envelope({ success: true }))
 
     render(<MergeOnDoneDialog />)
 
     fireEvent.click(await screen.findByRole('button', { name: /^merge$/i }))
 
     await waitFor(() => {
-      expect(mergeAbort).toHaveBeenCalledWith('/repo/main')
+      expect(toastError).toHaveBeenCalledWith('Merge conflicts in 1 file — merge manually')
     })
 
+    expect(mergeAbort).not.toHaveBeenCalled()
     expect(ticketMove).not.toHaveBeenCalled()
     expect(useKanbanStore.getState().tickets.get('project-1')?.[0]?.column).toBe('review')
     expect(useKanbanStore.getState().pendingDoneMove).toBeNull()
-    expect(toastError).toHaveBeenCalledWith('Merge conflicts in 1 file — merge manually')
+    expect(useGitStore.getState().conflictsByWorktree['/repo/main']).toBe(true)
+    expect(useWorktreeStatusStore.getState().mergeConflictWorktreeByTicket['ticket-1']).toBe(
+      'base-wt'
+    )
   })
 
   test('keeps ticket in review when merge fails without conflicts', async () => {
-    merge.mockResolvedValue({
+    merge.mockResolvedValue(envelope({
       success: false,
       error: 'merge failed'
-    })
+    }))
 
     render(<MergeOnDoneDialog />)
 
@@ -208,7 +217,7 @@ describe('MergeOnDoneDialog', () => {
   })
 
   test('moves ticket to done only after a successful merge reaches the archive step', async () => {
-    merge.mockResolvedValue({ success: true })
+    merge.mockResolvedValue(envelope({ success: true }))
 
     render(<MergeOnDoneDialog />)
 
@@ -228,7 +237,7 @@ describe('MergeOnDoneDialog', () => {
   })
 
   test('moves ticket to done and closes immediately while archive continues in the background', async () => {
-    merge.mockResolvedValue({ success: true })
+    merge.mockResolvedValue(envelope({ success: true }))
     let resolveArchive!: (value: { success: boolean }) => void
     const archiveWorktree = vi.fn(
       () =>
@@ -277,14 +286,12 @@ describe('MergeOnDoneDialog', () => {
       path: '/repo/feature-two'
     })
     ;(window.db.worktree.get as ReturnType<typeof vi.fn>).mockImplementation((id: string) =>
-      Promise.resolve(id === 'feature-wt-2' ? secondWorktree : makeWorktree())
+      Promise.resolve(envelope(id === 'feature-wt-2' ? secondWorktree : makeWorktree()))
     )
-    ;(window.db.worktree.getActiveByProject as ReturnType<typeof vi.fn>).mockResolvedValue([
-      makeWorktree(),
-      secondWorktree,
-      baseWorktree
-    ])
-    merge.mockResolvedValue({ success: true })
+    ;(window.db.worktree.getActiveByProject as ReturnType<typeof vi.fn>).mockResolvedValue(
+      envelope([makeWorktree(), secondWorktree, baseWorktree])
+    )
+    merge.mockResolvedValue(envelope({ success: true }))
     const archiveWorktree = vi.fn(
       () =>
         new Promise<{ success: boolean }>(() => {

--- a/test/kanban/pinned-board-ticket-navigation.test.tsx
+++ b/test/kanban/pinned-board-ticket-navigation.test.tsx
@@ -193,7 +193,9 @@ function seedStores(): void {
       }
     },
     reviewSessionByWorktree: {},
-    completedReviewSessionByWorktree: {}
+    completedReviewSessionByWorktree: {},
+    mergeConflictSessionByWorktree: {},
+    mergeConflictFlowByWorktree: {}
   })
 
   useConnectionStore.setState({

--- a/test/phase-18/session-7/merge-conflict-button.test.tsx
+++ b/test/phase-18/session-7/merge-conflict-button.test.tsx
@@ -66,7 +66,9 @@ describe('Session 7: Merge Conflict Header Button', () => {
       ]
 
       const mockGitOps = window.gitOps as Record<string, ReturnType<typeof vi.fn>>
-      mockGitOps.getFileStatuses = vi.fn().mockResolvedValue({ success: true, files: mockFiles })
+      mockGitOps.getFileStatuses = vi
+        .fn()
+        .mockResolvedValue({ success: true, value: { success: true, files: mockFiles } })
 
       await useGitStore.getState().loadFileStatuses('/wt')
       const state = useGitStore.getState()
@@ -80,7 +82,9 @@ describe('Session 7: Merge Conflict Header Button', () => {
       ]
 
       const mockGitOps = window.gitOps as Record<string, ReturnType<typeof vi.fn>>
-      mockGitOps.getFileStatuses = vi.fn().mockResolvedValue({ success: true, files: mockFiles })
+      mockGitOps.getFileStatuses = vi
+        .fn()
+        .mockResolvedValue({ success: true, value: { success: true, files: mockFiles } })
 
       await useGitStore.getState().loadFileStatuses('/wt')
       const state = useGitStore.getState()
@@ -89,7 +93,9 @@ describe('Session 7: Merge Conflict Header Button', () => {
 
     test('loadFileStatuses sets hasConflicts false for empty file list', async () => {
       const mockGitOps = window.gitOps as Record<string, ReturnType<typeof vi.fn>>
-      mockGitOps.getFileStatuses = vi.fn().mockResolvedValue({ success: true, files: [] })
+      mockGitOps.getFileStatuses = vi
+        .fn()
+        .mockResolvedValue({ success: true, value: { success: true, files: [] } })
 
       await useGitStore.getState().loadFileStatuses('/wt')
       const state = useGitStore.getState()

--- a/test/telegram/telegram-forwarding-target.test.tsx
+++ b/test/telegram/telegram-forwarding-target.test.tsx
@@ -217,7 +217,9 @@ function seedStores(ticket = makeTicket()): void {
   useWorktreeStatusStore.setState({
     sessionStatuses: {},
     reviewSessionByWorktree: {},
-    completedReviewSessionByWorktree: {}
+    completedReviewSessionByWorktree: {},
+    mergeConflictSessionByWorktree: {},
+    mergeConflictFlowByWorktree: {}
   })
 }
 


### PR DESCRIPTION
## Summary
- Adds merge-conflict actions to kanban tickets and the ticket modal, including a banner/button state when conflicts are detected.
- Extracts conflict-fix orchestration into `useConflictFixFlow` so header, ticket cards, and modal share the same session startup and completion flow.
- Preserves conflict state after failed merge-on-done operations so the ticket-level fix flow can take over instead of aborting immediately.
- Updates the indeterminate progress bar to show a dedicated merge-conflict fixing state.
- Expands coverage with new and updated tests for ticket buttons, modal behavior, merge-on-done handling, and related navigation/forwarding cases.

## Testing
- `Not run`
- Added/updated unit tests for merge-conflict ticket actions and modal banner behavior.
- Added/updated tests for merge-on-done conflict handling and related status/button flows.
- Updated regression tests for pinned board navigation, merge-conflict button behavior, and telegram forwarding target handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new merge-conflict state tracking and session-orchestration that affects merge-on-done behavior and multiple UI entry points; mistakes could leave conflicts unsurfaced or start sessions in the wrong context.
> 
> **Overview**
> **Merge conflicts can now be fixed directly from a ticket.** Kanban ticket cards show a new right-aligned *Fix conflicts* action (or a dedicated fuchsia progress bar while a fix session runs), and the ticket modal displays a top banner with the same behavior, including *Build/Plan* choices when `mergeConflictMode` is `always-ask`.
> 
> Conflict-fix orchestration is extracted into a new `useConflictFixFlow` hook and new `useWorktreeStatusStore` state (`mergeConflictFlowByWorktree`, `mergeConflictSessionByWorktree`, `mergeConflictWorktreeByTicket`) so Header, cards, and modal share the same start/finalize/open-session logic.
> 
> `MergeOnDoneDialog` now preserves on-disk merge conflicts instead of aborting the merge, marks the base worktree as conflicted, and links the ticket to the base worktree so the ticket-level fix flow surfaces the right conflicts; `IndeterminateProgressBar` adds an `isFixingConflicts` variant and tests are updated/added to cover the new UI and conflict handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6745513abb2880044e1d596e9fcf6050a3d803a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->