### PR TITLE
Reduce redundant git metadata loads during sidebar refreshes

### DIFF
--- a/src/main/effect/git/layers.ts
+++ b/src/main/effect/git/layers.ts
@@ -59,6 +59,8 @@ const parseNumstat = (line: string): GitDiffStatFile | null => {
 const make = Effect.gen(function* () {
   const gitCache = yield* Ref.make<Map<string, SimpleGit>>(new Map())
   const semaphores = yield* Ref.make<Map<string, Effect.Semaphore>>(new Map())
+  const GLOBAL_GIT_CONCURRENCY = 6
+  const globalGitSem = yield* Effect.makeSemaphore(GLOBAL_GIT_CONCURRENCY)
 
   const getGit = (repoPath: string) =>
     Effect.gen(function* () {
@@ -86,11 +88,13 @@ const make = Effect.gen(function* () {
     operation: GitOperation | undefined,
     body: (git: SimpleGit) => Promise<A>
   ): Effect.Effect<A, GitError> =>
-    Effect.flatMap(getGit(repoPath), (git) =>
-      Effect.tryPromise({
-        try: () => body(git),
-        catch: (err) => classifyGitError(err, { worktreePath: repoPath, command, operation })
-      })
+    globalGitSem.withPermits(1)(
+      Effect.flatMap(getGit(repoPath), (git) =>
+        Effect.tryPromise({
+          try: () => body(git),
+          catch: (err) => classifyGitError(err, { worktreePath: repoPath, command, operation })
+        })
+      )
     )
 
   const writeOp = <A>(
@@ -110,16 +114,18 @@ const make = Effect.gen(function* () {
     map: (stdout: string) => A,
     options?: { maxBuffer?: number }
   ): Effect.Effect<A, GitError> =>
-    Effect.tryPromise({
-      try: async () => {
-        const { stdout } = await execFileAsync('git', [...args], {
-          cwd: repoPath,
-          maxBuffer: options?.maxBuffer
-        })
-        return map(stdout)
-      },
-      catch: (err) => classifyGitError(err, { worktreePath: repoPath, command })
-    })
+    globalGitSem.withPermits(1)(
+      Effect.tryPromise({
+        try: async () => {
+          const { stdout } = await execFileAsync('git', [...args], {
+            cwd: repoPath,
+            maxBuffer: options?.maxBuffer
+          })
+          return map(stdout)
+        },
+        catch: (err) => classifyGitError(err, { worktreePath: repoPath, command })
+      })
+    )
 
   const getAllBranches = (repoPath: string) =>
     tryGit(repoPath, 'git branch -a', undefined, async (git) => {
@@ -338,7 +344,9 @@ const make = Effect.gen(function* () {
       if (stashRef) {
         try {
           await simpleGit(worktreePath).raw(['stash', 'apply', stashRef])
-        } catch {}
+        } catch {
+          // Best-effort copy; leave the duplicated worktree even if stash application fails.
+        }
       }
       const untrackedRaw = await sourceGit.raw(['ls-files', '--others', '--exclude-standard'])
       for (const file of untrackedRaw.trim().split('\n').filter(Boolean)) {
@@ -416,7 +424,9 @@ const make = Effect.gen(function* () {
               existingDirs = readdirSync(projectWorktreesDir).map((d) =>
                 d.startsWith(`${projectName}--`) ? d.slice(projectName.length + 2) : d
               )
-            } catch {}
+            } catch {
+              // Missing or unreadable worktree directory only reduces collision hints.
+            }
             const breedName = selectUniqueBreedName(
               new Set([...existingBranches, ...existingWorktreeBranches, ...existingDirs]),
               breedType
@@ -526,7 +536,9 @@ const make = Effect.gen(function* () {
                 existingDirs = readdirSync(projectWorktreesDir).map((d) =>
                   d.startsWith(`${projectName}--`) ? d.slice(projectName.length + 2) : d
                 )
-              } catch {}
+              } catch {
+                // Missing or unreadable worktree directory only reduces collision hints.
+              }
               const existingNames = new Set([...existingBranches, ...existingWorktreeBranches, ...existingDirs])
               let worktreeName = options?.nameHint || selectUniqueBreedName(existingNames, breedType)
               if (options?.nameHint && existingNames.has(worktreeName)) {
@@ -921,7 +933,9 @@ const make = Effect.gen(function* () {
           } finally {
             try {
               rmSync(tempDir, { recursive: true, force: true })
-            } catch {}
+            } catch {
+              // Temporary cleanup failure should not mask the pull request result.
+            }
           }
         }).pipe(
           Effect.mapError((error) =>

--- a/src/renderer/src/hooks/useSidebarBranchWatcher.ts
+++ b/src/renderer/src/hooks/useSidebarBranchWatcher.ts
@@ -64,7 +64,7 @@ export function useSidebarBranchWatcher(worktreePaths: string[]): void {
     const unsubscribe = window.gitOps.onBranchChanged((event) => {
       const currentPaths = previousPathsRef.current
       if (currentPaths.includes(event.worktreePath)) {
-        useGitStore.getState().loadBranchInfo(event.worktreePath)
+        useGitStore.getState().loadBranchInfo(event.worktreePath, { force: true })
       }
     })
 

--- a/src/renderer/src/stores/__tests__/useGitStore.git-loads.test.ts
+++ b/src/renderer/src/stores/__tests__/useGitStore.git-loads.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useGitStore } from '../useGitStore'
+
+const branchInfo = { name: 'main', tracking: null, ahead: 0, behind: 0 }
+
+describe('useGitStore git metadata loading', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+    useGitStore.setState({
+      fileStatusesByWorktree: new Map(),
+      branchInfoByWorktree: new Map(),
+      conflictsByWorktree: {},
+      isLoading: false,
+      error: null
+    })
+
+    Object.defineProperty(window, 'gitOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        ...window.gitOps,
+        getBranchInfo: vi.fn().mockResolvedValue({
+          success: true,
+          value: { success: true, branch: branchInfo }
+        }),
+        getFileStatuses: vi.fn().mockResolvedValue({
+          success: true,
+          value: { success: true, files: [] }
+        })
+      }
+    })
+  })
+
+  it('coalesces concurrent branch info loads for the same worktree', async () => {
+    const worktreePath = '/repo/concurrent'
+    let resolveBranchInfo: (value: {
+      success: true
+      value: { success: true; branch: typeof branchInfo }
+    }) => void
+    const branchInfoPromise = new Promise<{
+      success: true
+      value: { success: true; branch: typeof branchInfo }
+    }>((resolve) => {
+      resolveBranchInfo = resolve
+    })
+
+    vi.mocked(window.gitOps.getBranchInfo).mockReturnValue(branchInfoPromise)
+
+    const firstLoad = useGitStore.getState().loadBranchInfo(worktreePath)
+    const secondLoad = useGitStore.getState().loadBranchInfo(worktreePath)
+
+    expect(window.gitOps.getBranchInfo).toHaveBeenCalledTimes(1)
+
+    resolveBranchInfo!({ success: true, value: { success: true, branch: branchInfo } })
+    await Promise.all([firstLoad, secondLoad])
+
+    expect(useGitStore.getState().getBranchInfo(worktreePath)).toEqual(branchInfo)
+  })
+
+  it('skips a branch info refetch inside the load TTL', async () => {
+    vi.useFakeTimers()
+    const worktreePath = '/repo/ttl'
+    vi.setSystemTime(1_000)
+
+    await useGitStore.getState().loadBranchInfo(worktreePath)
+    await useGitStore.getState().loadBranchInfo(worktreePath)
+
+    expect(window.gitOps.getBranchInfo).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows force branch info loads to bypass the load TTL', async () => {
+    vi.useFakeTimers()
+    const worktreePath = '/repo/force'
+    vi.setSystemTime(1_000)
+
+    await useGitStore.getState().loadBranchInfo(worktreePath)
+    await useGitStore.getState().loadBranchInfo(worktreePath, { force: true })
+
+    expect(window.gitOps.getBranchInfo).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/stores/useGitStore.ts
+++ b/src/renderer/src/stores/useGitStore.ts
@@ -11,6 +11,11 @@ const refreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
 // Pending promise resolvers — accumulated so ALL callers resolve when debounced work completes
 const pendingResolvers = new Map<string, Array<() => void>>()
 const REFRESH_DEBOUNCE_MS = 150
+const inflightFileStatuses = new Map<string, Promise<void>>()
+const inflightBranchInfo = new Map<string, Promise<void>>()
+const lastFileStatusLoad = new Map<string, number>()
+const lastBranchInfoLoad = new Map<string, number>()
+const LOAD_TTL_MS = 2500
 
 // Git status types matching main process
 type GitStatusCode = 'M' | 'A' | 'D' | '?' | 'C' | ''
@@ -79,8 +84,8 @@ interface GitStoreState {
   createPRWorktreePath: string | null
 
   // Actions
-  loadFileStatuses: (worktreePath: string) => Promise<void>
-  loadBranchInfo: (worktreePath: string) => Promise<void>
+  loadFileStatuses: (worktreePath: string, opts?: { force?: boolean }) => Promise<void>
+  loadBranchInfo: (worktreePath: string, opts?: { force?: boolean }) => Promise<void>
   getFileStatuses: (worktreePath: string) => GitFileStatus[]
   getBranchInfo: (worktreePath: string) => GitBranchInfo | undefined
   getFileStatus: (worktreePath: string, relativePath: string) => GitFileStatus | undefined
@@ -178,57 +183,87 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
   createPRWorktreePath: null,
 
   // Load file statuses for a worktree
-  loadFileStatuses: async (worktreePath: string) => {
-    set({ isLoading: true, error: null })
-    try {
-      const result = unwrapEnvelope(await window.gitOps.getFileStatuses(worktreePath))
-      if (!result.success || !result.files) {
+  loadFileStatuses: async (worktreePath: string, opts?: { force?: boolean }) => {
+    const inflight = inflightFileStatuses.get(worktreePath)
+    if (inflight) return inflight
+
+    const lastLoad = lastFileStatusLoad.get(worktreePath)
+    if (!opts?.force && lastLoad !== undefined && Date.now() - lastLoad < LOAD_TTL_MS) {
+      return
+    }
+
+    const promise = (async () => {
+      set({ isLoading: true, error: null })
+      try {
+        const result = unwrapEnvelope(await window.gitOps.getFileStatuses(worktreePath))
+        if (!result.success || !result.files) {
+          set({
+            error: result.error || 'Failed to load file statuses',
+            isLoading: false
+          })
+          return
+        }
+
+        const files = result.files!
+        const hasConflicts = files.some((f) => f.status === 'C')
+
+        set((state) => {
+          const newMap = new Map(state.fileStatusesByWorktree)
+          newMap.set(worktreePath, files)
+          return {
+            fileStatusesByWorktree: newMap,
+            isLoading: false,
+            conflictsByWorktree: {
+              ...state.conflictsByWorktree,
+              [worktreePath]: hasConflicts
+            }
+          }
+        })
+        lastFileStatusLoad.set(worktreePath, Date.now())
+      } catch (error) {
         set({
-          error: result.error || 'Failed to load file statuses',
+          error: error instanceof Error ? error.message : 'Failed to load file statuses',
           isLoading: false
         })
-        return
+      } finally {
+        inflightFileStatuses.delete(worktreePath)
       }
-
-      const files = result.files!
-      const hasConflicts = files.some((f) => f.status === 'C')
-
-      set((state) => {
-        const newMap = new Map(state.fileStatusesByWorktree)
-        newMap.set(worktreePath, files)
-        return {
-          fileStatusesByWorktree: newMap,
-          isLoading: false,
-          conflictsByWorktree: {
-            ...state.conflictsByWorktree,
-            [worktreePath]: hasConflicts
-          }
-        }
-      })
-    } catch (error) {
-      set({
-        error: error instanceof Error ? error.message : 'Failed to load file statuses',
-        isLoading: false
-      })
-    }
+    })()
+    inflightFileStatuses.set(worktreePath, promise)
+    return promise
   },
 
   // Load branch info for a worktree
-  loadBranchInfo: async (worktreePath: string) => {
-    try {
-      const result = unwrapEnvelope(await window.gitOps.getBranchInfo(worktreePath))
-      if (!result.success || !result.branch) {
-        return
-      }
+  loadBranchInfo: async (worktreePath: string, opts?: { force?: boolean }) => {
+    const inflight = inflightBranchInfo.get(worktreePath)
+    if (inflight) return inflight
 
-      set((state) => {
-        const newMap = new Map(state.branchInfoByWorktree)
-        newMap.set(worktreePath, result.branch!)
-        return { branchInfoByWorktree: newMap }
-      })
-    } catch (error) {
-      console.error('Failed to load branch info:', error)
+    const lastLoad = lastBranchInfoLoad.get(worktreePath)
+    if (!opts?.force && lastLoad !== undefined && Date.now() - lastLoad < LOAD_TTL_MS) {
+      return
     }
+
+    const promise = (async () => {
+      try {
+        const result = unwrapEnvelope(await window.gitOps.getBranchInfo(worktreePath))
+        if (!result.success || !result.branch) {
+          return
+        }
+
+        set((state) => {
+          const newMap = new Map(state.branchInfoByWorktree)
+          newMap.set(worktreePath, result.branch!)
+          return { branchInfoByWorktree: newMap }
+        })
+        lastBranchInfoLoad.set(worktreePath, Date.now())
+      } catch (error) {
+        console.error('Failed to load branch info:', error)
+      } finally {
+        inflightBranchInfo.delete(worktreePath)
+      }
+    })()
+    inflightBranchInfo.set(worktreePath, promise)
+    return promise
   },
 
   // Get file statuses for a worktree
@@ -343,8 +378,8 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
           refreshTimers.delete(worktreePath)
           try {
             await Promise.all([
-              get().loadFileStatuses(worktreePath),
-              get().loadBranchInfo(worktreePath)
+              get().loadFileStatuses(worktreePath, { force: true }),
+              get().loadBranchInfo(worktreePath, { force: true })
             ])
           } finally {
             // Resolve ALL pending promises for this worktree
@@ -614,7 +649,7 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
       if (result.success) {
         // Refresh branch info to update ahead/behind counts
         try {
-          await get().loadBranchInfo(worktreePath)
+          await get().loadBranchInfo(worktreePath, { force: true })
         } catch {
           // Non-critical — push already succeeded
         }


### PR DESCRIPTION
## Summary
- Added per-worktree in-flight deduping and a short TTL for git file-status and branch-info loads in `useGitStore` to avoid repeated requests during bursty UI updates.
- Forced refresh paths now bypass the TTL where freshness matters, including sidebar branch-change events, refresh flows, and post-push branch info updates.
- Added tests covering concurrent load coalescing, TTL skipping, and force-bypass behavior.
- Introduced global concurrency limiting for git operations in the main process to reduce pressure from parallel git commands.
- Cleaned up a few best-effort failure paths with clearer comments.

## Testing
- `vitest src/renderer/src/stores/__tests__/useGitStore.git-loads.test.ts`
- Not run: full application test suite
- Not run: manual UI verification in the Electron app

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renderer TTL could briefly show stale branch/status data if a non-force caller wins the race; main-process global semaphore changes timing under heavy parallel git load and could surface latent ordering assumptions.
> 
> **Overview**
> Cuts redundant IPC/git metadata traffic during bursty sidebar and refresh activity by **deduping in-flight loads**, applying a **~2.5s per-worktree TTL** on `loadFileStatuses` / `loadBranchInfo`, and using **`{ force: true }`** where freshness matters (debounced refresh, post-push, branch-change events).
> 
> On the main process, **global git concurrency is capped at 6** for `simple-git` and `execFile` git calls (per-repo write serialization is unchanged). A few best-effort `catch` blocks now have clarifying comments. **Vitest** covers concurrent coalescing, TTL skip, and force bypass for branch info loads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dfadf68e4e5c466560d6b04cb6d21284af5a29b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->