### PR TITLE
Fix Codex CLI binary resolution for app-server startup

### DIFF
--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -7,7 +7,7 @@ import { Effect } from 'effect'
 
 import { createLogger } from './logger'
 import { logCodexMessage, logCodexLifecycleEvent, resetSession } from './codex-debug-logger'
-import { supportsCodexAppServer } from './codex-binary-resolver'
+import { resolveCodexBinaryPath, supportsCodexAppServer } from './codex-binary-resolver'
 import { getCodexCliEnv } from './codex-cli-env'
 import { asObject, asString } from './codex-utils'
 import { CODEX_DEFAULT_MODEL } from './codex-models'
@@ -445,7 +445,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         updatedAt: now
       }
 
-      const codexBinaryPath = options.codexBinaryPath ?? 'codex'
+      const codexBinaryPath = options.codexBinaryPath ?? resolveCodexBinaryPath() ?? 'codex'
       if (!supportsCodexAppServer(codexBinaryPath)) {
         throw new Error(
           `Installed Codex CLI does not support app-server: ${codexBinaryPath}. Upgrade @openai/codex to 0.118.0 or newer.`

--- a/src/main/services/codex-binary-resolver.ts
+++ b/src/main/services/codex-binary-resolver.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'child_process'
 import { existsSync } from 'fs'
+import { homedir } from 'os'
 import { extname } from 'path'
 import { createLogger } from './logger'
 
@@ -36,6 +37,72 @@ function usesShellForCodexBinary(binaryPath: string): boolean {
   )
 }
 
+function isBareCommand(binaryPath: string): boolean {
+  return !binaryPath.includes('/') && !binaryPath.includes('\\')
+}
+
+function stringifyProbeOutput(output: unknown): string {
+  if (Buffer.isBuffer(output)) {
+    return output.toString('utf-8')
+  }
+  if (typeof output === 'string') {
+    return output
+  }
+  return ''
+}
+
+function hasCodexAppServerUsage(output: string): boolean {
+  return /Usage:\s*codex\s+app-server\b/i.test(output)
+}
+
+function firstExistingPath(paths: string[]): string | null {
+  return paths.find((candidate) => existsSync(candidate)) ?? null
+}
+
+function orderResolvedPaths(paths: string[]): string[] {
+  return process.platform === 'win32'
+    ? [...paths].sort(compareWindowsCodexCandidates)
+    : paths
+}
+
+function readCodexFromPath(): string | null {
+  const command = process.platform === 'win32' ? 'where' : 'which'
+  const result = execFileSync(command, ['codex'], {
+    encoding: 'utf-8',
+    timeout: 5000,
+    env: process.env
+  }).trim()
+
+  return firstExistingPath(orderResolvedPaths(splitResolvedPaths(result)))
+}
+
+function readCodexFromLoginShell(): string | null {
+  if (process.platform === 'win32') return null
+
+  const shell = process.env.SHELL || (process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash')
+  const result = execFileSync(shell, ['-ilc', 'command -v codex'], {
+    encoding: 'utf-8',
+    timeout: 5000,
+    env: process.env
+  }).trim()
+
+  return firstExistingPath(splitResolvedPaths(result))
+}
+
+function readKnownCodexLocations(): string | null {
+  if (process.platform === 'win32') return null
+
+  const home = homedir()
+  return firstExistingPath([
+    `${home}/Applications/Codex.app/Contents/Resources/codex`,
+    '/Applications/Codex.app/Contents/Resources/codex',
+    `${home}/.local/share/mise/shims/codex`,
+    `${home}/.local/bin/codex`,
+    '/opt/homebrew/bin/codex',
+    '/usr/local/bin/codex'
+  ])
+}
+
 /**
  * Resolve the system-wide Codex CLI binary path.
  *
@@ -44,34 +111,29 @@ function usesShellForCodexBinary(binaryPath: string): boolean {
  * binary once and inject it into every child-process spawn site.
  */
 export function resolveCodexBinaryPath(): string | null {
-  const command = process.platform === 'win32' ? 'where' : 'which'
-  const binary = 'codex'
+  const attempts: Array<[source: string, read: () => string | null]> = [
+    ['PATH', readCodexFromPath],
+    ['login shell', readCodexFromLoginShell],
+    ['known locations', readKnownCodexLocations]
+  ]
 
-  try {
-    const result = execFileSync(command, [binary], {
-      encoding: 'utf-8',
-      timeout: 5000,
-      env: process.env
-    }).trim()
-
-    const resolvedPaths = splitResolvedPaths(result)
-    const orderedPaths =
-      process.platform === 'win32'
-        ? [...resolvedPaths].sort(compareWindowsCodexCandidates)
-        : resolvedPaths
-    const resolvedPath = orderedPaths.find((candidate) => existsSync(candidate)) ?? null
-
-    if (!resolvedPath) {
-      log.warn('Codex binary not found on PATH')
-      return null
+  for (const [source, read] of attempts) {
+    try {
+      const resolvedPath = read()
+      if (resolvedPath) {
+        log.info('Resolved Codex binary', { path: resolvedPath, source })
+        return resolvedPath
+      }
+    } catch (error) {
+      log.debug('Codex binary lookup failed', {
+        source,
+        error: error instanceof Error ? error.message : String(error)
+      })
     }
-
-    log.info('Resolved Codex binary', { path: resolvedPath })
-    return resolvedPath
-  } catch {
-    log.warn('Could not resolve Codex binary (not installed or not on PATH)')
-    return null
   }
+
+  log.warn('Could not resolve Codex binary (not installed or not on PATH)')
+  return null
 }
 
 export function supportsCodexAppServer(binaryPath: string): boolean {
@@ -87,11 +149,21 @@ export function supportsCodexAppServer(binaryPath: string): boolean {
       env: process.env,
       shell: usesShellForCodexBinary(binaryPath)
     })
-    const supported = output.includes('Usage: codex app-server')
-    codexAppServerSupportCache.set(binaryPath, supported)
+    const supported = hasCodexAppServerUsage(output)
+    if (supported || !isBareCommand(binaryPath)) {
+      codexAppServerSupportCache.set(binaryPath, supported)
+    }
     return supported
-  } catch {
-    codexAppServerSupportCache.set(binaryPath, false)
+  } catch (error) {
+    const output = [
+      stringifyProbeOutput((error as { stdout?: unknown }).stdout),
+      stringifyProbeOutput((error as { stderr?: unknown }).stderr)
+    ].join('\n')
+    const supported = hasCodexAppServerUsage(output)
+    if (supported) {
+      codexAppServerSupportCache.set(binaryPath, true)
+      return true
+    }
     return false
   }
 }

--- a/src/main/services/codex-binary-resolver.ts
+++ b/src/main/services/codex-binary-resolver.ts
@@ -80,7 +80,7 @@ function readCodexFromLoginShell(): string | null {
   if (process.platform === 'win32') return null
 
   const shell = process.env.SHELL || (process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash')
-  const result = execFileSync(shell, ['-ilc', 'command -v codex'], {
+  const result = execFileSync(shell, ['-lc', 'command -v codex'], {
     encoding: 'utf-8',
     timeout: 5000,
     env: process.env
@@ -163,6 +163,9 @@ export function supportsCodexAppServer(binaryPath: string): boolean {
     if (supported) {
       codexAppServerSupportCache.set(binaryPath, true)
       return true
+    }
+    if (!isBareCommand(binaryPath)) {
+      codexAppServerSupportCache.set(binaryPath, false)
     }
     return false
   }

--- a/test/phase-22/session-3/codex-binary-resolver.test.ts
+++ b/test/phase-22/session-3/codex-binary-resolver.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockExecFileSync, mockExistsSync } = vi.hoisted(() => ({
+const { mockExecFileSync, mockExistsSync, mockHomedir } = vi.hoisted(() => ({
   mockExecFileSync: vi.fn(),
-  mockExistsSync: vi.fn()
+  mockExistsSync: vi.fn(),
+  mockHomedir: vi.fn()
 }))
 
 vi.mock('../../../src/main/services/logger', () => ({
@@ -24,12 +25,18 @@ vi.mock('fs', () => ({
   existsSync: (...args: unknown[]) => mockExistsSync(...args)
 }))
 
+vi.mock('os', () => ({
+  default: { homedir: () => mockHomedir() },
+  homedir: () => mockHomedir()
+}))
+
 describe('resolveCodexBinaryPath', () => {
   const originalPlatform = process.platform
 
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    mockHomedir.mockReturnValue('/Users/test')
     mockExistsSync.mockReturnValue(true)
   })
 
@@ -58,10 +65,40 @@ describe('resolveCodexBinaryPath', () => {
     expect(resolveCodexBinaryPath()).toBeNull()
   })
 
-  it('returns null when the lookup command fails', async () => {
+  it('uses the login shell when the app process PATH lookup fails', async () => {
     mockExecFileSync.mockImplementation(() => {
       throw new Error('not found')
     })
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw new Error('not found')
+      })
+      .mockReturnValueOnce('/Users/test/Applications/Codex.app/Contents/Resources/codex\n')
+
+    const { resolveCodexBinaryPath } = await import('../../../src/main/services/codex-binary-resolver')
+
+    expect(resolveCodexBinaryPath()).toBe('/Users/test/Applications/Codex.app/Contents/Resources/codex')
+  })
+
+  it('checks known Codex locations when PATH and login shell lookups fail', async () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('not found')
+    })
+    mockExistsSync.mockImplementation(
+      (candidate: unknown) =>
+        candidate === '/Users/test/Applications/Codex.app/Contents/Resources/codex'
+    )
+
+    const { resolveCodexBinaryPath } = await import('../../../src/main/services/codex-binary-resolver')
+
+    expect(resolveCodexBinaryPath()).toBe('/Users/test/Applications/Codex.app/Contents/Resources/codex')
+  })
+
+  it('returns null when all lookup strategies fail', async () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('not found')
+    })
+    mockExistsSync.mockReturnValue(false)
 
     const { resolveCodexBinaryPath } = await import('../../../src/main/services/codex-binary-resolver')
 
@@ -122,11 +159,48 @@ describe('resolveCodexBinaryPath', () => {
     )
   })
 
+  it('recognizes app-server support when warnings surround the usage output', async () => {
+    mockExecFileSync.mockReturnValue(
+      'Warning: falling back to default config\nUsage: codex app-server [OPTIONS] [COMMAND]\n'
+    )
+
+    const { supportsCodexAppServer } = await import('../../../src/main/services/codex-binary-resolver')
+
+    expect(supportsCodexAppServer('/usr/local/bin/codex')).toBe(true)
+  })
+
+  it('recognizes app-server support from captured stderr when the help probe exits non-zero', async () => {
+    const error = new Error('help failed') as Error & { stdout: string; stderr: string }
+    error.stdout = ''
+    error.stderr = 'Warning: config issue\nUsage: codex app-server [OPTIONS] [COMMAND]\n'
+    mockExecFileSync.mockImplementation(() => {
+      throw error
+    })
+
+    const { supportsCodexAppServer } = await import('../../../src/main/services/codex-binary-resolver')
+
+    expect(supportsCodexAppServer('/usr/local/bin/codex')).toBe(true)
+  })
+
   it('reports no app-server support when help falls back to the top-level CLI usage', async () => {
     mockExecFileSync.mockReturnValue('Usage: codex [OPTIONS] [PROMPT]\n')
 
     const { supportsCodexAppServer } = await import('../../../src/main/services/codex-binary-resolver')
 
     expect(supportsCodexAppServer('/usr/local/bin/codex')).toBe(false)
+  })
+
+  it('does not cache transient probe failures for the bare codex command', async () => {
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw new Error('temporary PATH failure')
+      })
+      .mockReturnValueOnce('Usage: codex app-server [OPTIONS] [COMMAND]\n')
+
+    const { supportsCodexAppServer } = await import('../../../src/main/services/codex-binary-resolver')
+
+    expect(supportsCodexAppServer('codex')).toBe(false)
+    expect(supportsCodexAppServer('codex')).toBe(true)
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2)
   })
 })

--- a/test/phase-22/session-3/codex-binary-resolver.test.ts
+++ b/test/phase-22/session-3/codex-binary-resolver.test.ts
@@ -66,9 +66,6 @@ describe('resolveCodexBinaryPath', () => {
   })
 
   it('uses the login shell when the app process PATH lookup fails', async () => {
-    mockExecFileSync.mockImplementation(() => {
-      throw new Error('not found')
-    })
     mockExecFileSync
       .mockImplementationOnce(() => {
         throw new Error('not found')
@@ -188,6 +185,18 @@ describe('resolveCodexBinaryPath', () => {
     const { supportsCodexAppServer } = await import('../../../src/main/services/codex-binary-resolver')
 
     expect(supportsCodexAppServer('/usr/local/bin/codex')).toBe(false)
+  })
+
+  it('caches non-zero negative app-server probes for resolved paths', async () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('unsupported')
+    })
+
+    const { supportsCodexAppServer } = await import('../../../src/main/services/codex-binary-resolver')
+
+    expect(supportsCodexAppServer('/usr/local/bin/codex')).toBe(false)
+    expect(supportsCodexAppServer('/usr/local/bin/codex')).toBe(false)
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1)
   })
 
   it('does not cache transient probe failures for the bare codex command', async () => {

--- a/test/phase-22/session-5/codex-app-server-manager.test.ts
+++ b/test/phase-22/session-5/codex-app-server-manager.test.ts
@@ -11,11 +11,13 @@ vi.mock('../../../src/main/services/logger', () => ({
   })
 }))
 
-const { mockSupportsCodexAppServer } = vi.hoisted(() => ({
+const { mockResolveCodexBinaryPath, mockSupportsCodexAppServer } = vi.hoisted(() => ({
+  mockResolveCodexBinaryPath: vi.fn(() => null as string | null),
   mockSupportsCodexAppServer: vi.fn(() => true)
 }))
 
 vi.mock('../../../src/main/services/codex-binary-resolver', () => ({
+  resolveCodexBinaryPath: (...args: unknown[]) => mockResolveCodexBinaryPath(...args),
   supportsCodexAppServer: (...args: unknown[]) => mockSupportsCodexAppServer(...args)
 }))
 
@@ -94,6 +96,7 @@ describe('CodexAppServerManager — collaborationMode in sendTurn', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockResolveCodexBinaryPath.mockReturnValue(null)
     mockSupportsCodexAppServer.mockReturnValue(true)
     manager = new CodexAppServerManager()
   })
@@ -128,6 +131,23 @@ describe('CodexAppServerManager — collaborationMode in sendTurn', () => {
     ).rejects.toThrow(
       'Installed Codex CLI does not support app-server: /usr/local/bin/codex. Upgrade @openai/codex to 0.118.0 or newer.'
     )
+  })
+
+  it('re-resolves the Codex binary before probing support when no path was injected', async () => {
+    mockResolveCodexBinaryPath.mockReturnValue('/resolved/bin/codex')
+    mockSupportsCodexAppServer.mockReturnValue(false)
+
+    await expect(
+      manager.startSession({
+        cwd: '/test/project'
+      })
+    ).rejects.toThrow(
+      'Installed Codex CLI does not support app-server: /resolved/bin/codex. Upgrade @openai/codex to 0.118.0 or newer.'
+    )
+
+    expect(mockResolveCodexBinaryPath).toHaveBeenCalledTimes(1)
+    expect(mockSupportsCodexAppServer).toHaveBeenCalledWith('/resolved/bin/codex')
+    expect(mockSupportsCodexAppServer).not.toHaveBeenCalledWith('codex')
   })
 
   it('includes collaborationMode with mode: plan and plan developer instructions when interactionMode is plan', async () => {


### PR DESCRIPTION
## Description
Fixes Codex session startup when the Electron main process cannot find the installed Codex CLI on `PATH`, causing Hive to incorrectly report that the installed CLI does not support `app-server`.

The resolver now retries Codex binary discovery at session startup, checks the user login shell and known Codex install locations, and makes the app-server support probe more tolerant of warning output and stderr help text.

## Related Issue
N/A

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] ♻️ Code refactoring
- [x] 🧪 Test improvement
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Changes Made
- Resolve the Codex CLI binary at Codex session startup when no explicit binary path was injected.
- Add fallback lookup through the user login shell and known Codex install locations.
- Improve the `app-server` support probe to handle warning output, stderr usage output, and transient failures for the bare `codex` command.
- Add focused tests for binary resolution and app-server startup probing.
- Add a fix report for PR/reviewer context.

## Screenshots
<details>
<summary>Screenshots (if applicable)</summary>

<img width="1468" height="1061" alt="Screenshot 2026-05-27 at 22 14 34" src="https://github.com/user-attachments/assets/1c6fdfdc-ab96-4429-bfd3-e5109f7e9609" />


</details>

## Testing

### Test Configuration
- **OS**: macOS 26.5
- **Node Version**: v24.15.0
- **Test Type**: Unit / Typecheck / Build / Manual

### Test Steps
1. Verified the installed Codex CLI is discoverable and supports `app-server`.
2. Ran focused Vitest coverage for the Codex binary resolver and app-server manager.
3. Ran TypeScript typechecking.
4. Ran the production build.
5. Manually verified Hive can open a Codex session successfully.

### Test Results
- [ ] All existing tests pass
- [x] New tests added (if applicable)
- [x] Manual testing completed

Focused commands run:

```text
pnpm exec vitest run test/phase-22/session-3/codex-binary-resolver.test.ts test/phase-22/session-5/codex-app-server-manager.test.ts
pnpm exec tsc --noEmit
pnpm run build