### PR TITLE
Collapse worktree create script settings by default

### DIFF
--- a/src/renderer/src/components/projects/ProjectSettingsDialog.test.tsx
+++ b/src/renderer/src/components/projects/ProjectSettingsDialog.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentProps } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProjectSettingsDialog } from './ProjectSettingsDialog'
+
+const mocks = vi.hoisted(() => ({
+  updateProject: vi.fn()
+}))
+
+vi.mock('@/stores/useProjectStore', () => ({
+  useProjectStore: () => ({
+    updateProject: mocks.updateProject
+  })
+}))
+
+type Project = ComponentProps<typeof ProjectSettingsDialog>['project']
+
+const baseProject: Project = {
+  id: 'project-1',
+  name: 'Hive',
+  path: '/tmp/hive',
+  language: 'typescript',
+  custom_icon: null,
+  detected_icon: null,
+  setup_script: null,
+  run_script: null,
+  archive_script: null,
+  worktree_create_script: null,
+  custom_commands: null,
+  auto_assign_port: false
+}
+
+function renderDialog(projectOverrides: Partial<Project> = {}) {
+  return render(
+    <ProjectSettingsDialog
+      project={{ ...baseProject, ...projectOverrides }}
+      open={true}
+      onOpenChange={vi.fn()}
+    />
+  )
+}
+
+describe('ProjectSettingsDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.updateProject.mockResolvedValue(true)
+
+    Object.defineProperty(window, 'projectOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        detectSetupSuggestions: vi.fn().mockResolvedValue({ success: true, value: [] }),
+        loadLanguageIcons: vi.fn().mockResolvedValue({ success: true, value: {} }),
+        getProjectIconPath: vi.fn().mockResolvedValue({ success: true, value: null }),
+        getAbsoluteIconDataUrl: vi.fn().mockResolvedValue({ success: true, value: null }),
+        pickProjectIcon: vi.fn(),
+        removeProjectIcon: vi.fn()
+      }
+    })
+  })
+
+  it('collapses the worktree create script section by default when no script is configured', async () => {
+    renderDialog({ worktree_create_script: null })
+
+    await waitFor(() => expect(window.projectOps.detectSetupSuggestions).toHaveBeenCalled())
+
+    expect(
+      screen.getByRole('button', { name: /worktree create script/i })
+    ).toHaveProperty('ariaExpanded', 'false')
+    expect(screen.queryByText(/Advanced\. When set/)).toBeNull()
+    expect(screen.queryByPlaceholderText(/git worktree add --no-checkout/)).toBeNull()
+  })
+
+  it('expands the worktree create script section by default when a script is configured', async () => {
+    renderDialog({ worktree_create_script: 'echo custom-create' })
+
+    await waitFor(() => expect(window.projectOps.detectSetupSuggestions).toHaveBeenCalled())
+
+    expect(
+      screen.getByRole('button', { name: /worktree create script/i })
+    ).toHaveProperty('ariaExpanded', 'true')
+    expect(screen.getByDisplayValue('echo custom-create')).toBeTruthy()
+  })
+
+  it('lets users expand the worktree create script section when it starts collapsed', async () => {
+    const user = userEvent.setup()
+    renderDialog({ worktree_create_script: null })
+
+    await waitFor(() => expect(window.projectOps.detectSetupSuggestions).toHaveBeenCalled())
+
+    await user.click(screen.getByRole('button', { name: /worktree create script/i }))
+
+    expect(
+      screen.getByRole('button', { name: /worktree create script/i })
+    ).toHaveProperty('ariaExpanded', 'true')
+    expect(screen.getByPlaceholderText(/git worktree add --no-checkout/)).toBeTruthy()
+  })
+})

--- a/src/renderer/src/components/projects/ProjectSettingsDialog.tsx
+++ b/src/renderer/src/components/projects/ProjectSettingsDialog.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useId } from 'react'
 import { toast } from '@/lib/toast'
-import { Brain, ImageIcon, X } from 'lucide-react'
+import { Brain, ChevronDown, ImageIcon, X } from 'lucide-react'
 import type { SuggestionItem } from '@shared/types/setup-suggestions'
 import {
   Dialog,
@@ -15,7 +15,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { CustomCommandsEditor } from '@/components/custom-commands/CustomCommandsEditor'
-import { useProjectStore } from '@/stores'
+import { useProjectStore } from '@/stores/useProjectStore'
 import { LanguageIcon } from './LanguageIcon'
 import { SetupScriptSuggestionsDialog } from './SetupScriptSuggestionsDialog'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
@@ -49,11 +49,13 @@ export function ProjectSettingsDialog({
   onOpenChange
 }: ProjectSettingsDialogProps): React.JSX.Element {
   const { updateProject } = useProjectStore()
+  const worktreeCreateScriptContentId = useId()
 
   const [setupScript, setSetupScript] = useState('')
   const [runScript, setRunScript] = useState('')
   const [archiveScript, setArchiveScript] = useState('')
   const [worktreeCreateScript, setWorktreeCreateScript] = useState('')
+  const [worktreeCreateScriptExpanded, setWorktreeCreateScriptExpanded] = useState(false)
   const [customIcon, setCustomIcon] = useState<string | null>(null)
   const [customCommands, setCustomCommands] = useState<CustomProjectCommand[]>([])
   const [autoAssignPort, setAutoAssignPort] = useState(false)
@@ -69,6 +71,7 @@ export function ProjectSettingsDialog({
       setRunScript(project.run_script ?? '')
       setArchiveScript(project.archive_script ?? '')
       setWorktreeCreateScript(project.worktree_create_script ?? '')
+      setWorktreeCreateScriptExpanded((project.worktree_create_script ?? '').trim().length > 0)
       setCustomIcon(project.custom_icon ?? null)
       setCustomCommands(project.custom_commands ?? [])
       setAutoAssignPort(project.auto_assign_port ?? false)
@@ -303,48 +306,81 @@ export function ProjectSettingsDialog({
               </div>
 
               {/* Worktree Create Script */}
-              <div className="space-y-1.5">
-                <label className="text-sm font-medium">Worktree Create Script</label>
-                <p className="text-xs text-muted-foreground">
-                  Advanced. When set, this script replaces Hive&apos;s built-in{' '}
-                  <code className="font-mono text-[0.7rem]">git worktree add</code> call. Use for
-                  repos that need special handling (e.g. git-crypt, sparse-checkout). The script
-                  must create a worktree at{' '}
-                  <code className="font-mono text-[0.7rem]">$HIVE_WORKTREE_PATH</code> on branch{' '}
-                  <code className="font-mono text-[0.7rem]">$HIVE_BRANCH_NAME</code>. Available env
-                  vars: <code className="font-mono text-[0.7rem]">HIVE_WORKTREE_PATH</code>,{' '}
-                  <code className="font-mono text-[0.7rem]">HIVE_BRANCH_NAME</code>,{' '}
-                  <code className="font-mono text-[0.7rem]">HIVE_BASE_BRANCH</code> (human-readable
-                  base branch name),{' '}
-                  <code className="font-mono text-[0.7rem]">HIVE_BASE_REF</code> (git ref to use
-                  with <code className="font-mono text-[0.7rem]">git worktree add</code>; equals{' '}
-                  <code className="font-mono text-[0.7rem]">HIVE_BASE_BRANCH</code> in most flows,
-                  but is <code className="font-mono text-[0.7rem]">FETCH_HEAD</code> when checking
-                  out a pull-request ref),{' '}
-                  <code className="font-mono text-[0.7rem]">HIVE_PROJECT_PATH</code>,{' '}
-                  <code className="font-mono text-[0.7rem]">HIVE_WORKTREE_MODE</code> (
-                  <code className="font-mono text-[0.7rem]">new</code> |{' '}
-                  <code className="font-mono text-[0.7rem]">existing</code> |{' '}
-                  <code className="font-mono text-[0.7rem]">duplicate</code>). In{' '}
-                  <code className="font-mono text-[0.7rem]">duplicate</code> mode, also receives{' '}
-                  <code className="font-mono text-[0.7rem]">HIVE_SOURCE_WORKTREE_PATH</code> and{' '}
-                  <code className="font-mono text-[0.7rem]">HIVE_SOURCE_BRANCH</code>. Scripts run
-                  via <code className="font-mono text-[0.7rem]">/bin/sh -c</code> by default; a{' '}
-                  <code className="font-mono text-[0.7rem]">#!/usr/bin/env bash</code> or{' '}
-                  <code className="font-mono text-[0.7rem]">#!/bin/bash</code> shebang on the first
-                  line switches to <code className="font-mono text-[0.7rem]">bash -c</code>. Hive
-                  aborts the script (and its whole process group) after 5 minutes if it does not
-                  exit, and best-effort cleans up any partial worktree/branch on failure.
-                </p>
-                <Textarea
-                  value={worktreeCreateScript}
-                  onChange={(e) => setWorktreeCreateScript(e.target.value)}
-                  placeholder={
-                    'git worktree add --no-checkout "$HIVE_WORKTREE_PATH" -b "$HIVE_BRANCH_NAME" "$HIVE_BASE_REF"\n# ... any tool-specific post-create work, e.g. copying encryption keys ...\ngit -C "$HIVE_WORKTREE_PATH" reset --hard HEAD'
-                  }
-                  rows={5}
-                  className="font-mono text-sm resize-y"
-                />
+              <div className="rounded-md border border-border bg-muted/20">
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/24"
+                  onClick={() => setWorktreeCreateScriptExpanded((expanded) => !expanded)}
+                  aria-expanded={worktreeCreateScriptExpanded}
+                  aria-controls={worktreeCreateScriptContentId}
+                >
+                  <span className="flex min-w-0 items-center gap-2">
+                    <ChevronDown
+                      className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${
+                        worktreeCreateScriptExpanded ? '' : '-rotate-90'
+                      }`}
+                    />
+                    <span className="text-sm font-medium">Worktree Create Script</span>
+                    <span className="rounded border border-border px-1.5 py-0.5 text-[0.65rem] font-medium uppercase leading-none text-muted-foreground">
+                      Advanced
+                    </span>
+                  </span>
+                  {worktreeCreateScript.trim().length > 0 && (
+                    <span className="shrink-0 text-xs text-muted-foreground">Configured</span>
+                  )}
+                </button>
+                {worktreeCreateScriptExpanded && (
+                  <div
+                    id={worktreeCreateScriptContentId}
+                    className="space-y-1.5 border-t border-border px-3 py-3"
+                  >
+                    <p className="text-xs text-muted-foreground">
+                      When set, this script replaces Hive&apos;s built-in{' '}
+                      <code className="font-mono text-[0.7rem]">git worktree add</code> call. Use
+                      for repos that need special handling (e.g. git-crypt, sparse-checkout). The
+                      script must create a worktree at{' '}
+                      <code className="font-mono text-[0.7rem]">$HIVE_WORKTREE_PATH</code> on
+                      branch <code className="font-mono text-[0.7rem]">$HIVE_BRANCH_NAME</code>.
+                      Available env vars:{' '}
+                      <code className="font-mono text-[0.7rem]">HIVE_WORKTREE_PATH</code>,{' '}
+                      <code className="font-mono text-[0.7rem]">HIVE_BRANCH_NAME</code>,{' '}
+                      <code className="font-mono text-[0.7rem]">HIVE_BASE_BRANCH</code>{' '}
+                      (human-readable base branch name),{' '}
+                      <code className="font-mono text-[0.7rem]">HIVE_BASE_REF</code> (git ref to
+                      use with <code className="font-mono text-[0.7rem]">git worktree add</code>;
+                      equals <code className="font-mono text-[0.7rem]">HIVE_BASE_BRANCH</code> in
+                      most flows, but is{' '}
+                      <code className="font-mono text-[0.7rem]">FETCH_HEAD</code> when checking out
+                      a pull-request ref),{' '}
+                      <code className="font-mono text-[0.7rem]">HIVE_PROJECT_PATH</code>,{' '}
+                      <code className="font-mono text-[0.7rem]">HIVE_WORKTREE_MODE</code> (
+                      <code className="font-mono text-[0.7rem]">new</code> |{' '}
+                      <code className="font-mono text-[0.7rem]">existing</code> |{' '}
+                      <code className="font-mono text-[0.7rem]">duplicate</code>). In{' '}
+                      <code className="font-mono text-[0.7rem]">duplicate</code> mode, also
+                      receives{' '}
+                      <code className="font-mono text-[0.7rem]">HIVE_SOURCE_WORKTREE_PATH</code>{' '}
+                      and <code className="font-mono text-[0.7rem]">HIVE_SOURCE_BRANCH</code>.
+                      Scripts run via <code className="font-mono text-[0.7rem]">/bin/sh -c</code>{' '}
+                      by default; a{' '}
+                      <code className="font-mono text-[0.7rem]">#!/usr/bin/env bash</code> or{' '}
+                      <code className="font-mono text-[0.7rem]">#!/bin/bash</code> shebang on the
+                      first line switches to{' '}
+                      <code className="font-mono text-[0.7rem]">bash -c</code>. Hive aborts the
+                      script (and its whole process group) after 5 minutes if it does not exit, and
+                      best-effort cleans up any partial worktree/branch on failure.
+                    </p>
+                    <Textarea
+                      value={worktreeCreateScript}
+                      onChange={(e) => setWorktreeCreateScript(e.target.value)}
+                      placeholder={
+                        'git worktree add --no-checkout "$HIVE_WORKTREE_PATH" -b "$HIVE_BRANCH_NAME" "$HIVE_BASE_REF"\n# ... any tool-specific post-create work, e.g. copying encryption keys ...\ngit -C "$HIVE_WORKTREE_PATH" reset --hard HEAD'
+                      }
+                      rows={5}
+                      className="font-mono text-sm resize-y"
+                    />
+                  </div>
+                )}
               </div>
             </TabsContent>
 

--- a/src/renderer/src/components/ui/GhosttySuppressionBoundary.tsx
+++ b/src/renderer/src/components/ui/GhosttySuppressionBoundary.tsx
@@ -1,5 +1,5 @@
 import { useId, type ReactNode } from 'react'
-import { useGhosttySuppression } from '@/hooks'
+import { useGhosttySuppression } from '@/hooks/useGhosttySuppression'
 
 interface GhosttySuppressionBoundaryProps {
   scope: string

--- a/test/phase-22/worktree-create-script-override/project-settings-dialog.test.tsx
+++ b/test/phase-22/worktree-create-script-override/project-settings-dialog.test.tsx
@@ -1,9 +1,18 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { ProjectSettingsDialog } from '../../../src/renderer/src/components/projects/ProjectSettingsDialog'
-import { useProjectStore } from '../../../src/renderer/src/stores/useProjectStore'
+
+const mocks = vi.hoisted(() => ({
+  updateProject: vi.fn()
+}))
+
+vi.mock('@/stores/useProjectStore', () => ({
+  useProjectStore: () => ({
+    updateProject: mocks.updateProject
+  })
+}))
 
 vi.mock('@/lib/toast', () => ({
   toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() }
@@ -59,18 +68,10 @@ function makeProject(overrides: Partial<ProjectMock> = {}): ProjectMock {
 describe('ProjectSettingsDialog — worktree_create_script field', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    useProjectStore.setState({
-      projects: [],
-      isLoading: false,
-      error: null,
-      selectedProjectId: null,
-      expandedProjectIds: new Set(),
-      editingProjectId: null,
-      settingsProjectId: null
-    })
+    mocks.updateProject.mockResolvedValue(true)
   })
 
-  test('renders the Worktree Create Script textarea', () => {
+  test('renders the collapsed Worktree Create Script trigger', async () => {
     render(
       <ProjectSettingsDialog
         project={makeProject()}
@@ -79,11 +80,14 @@ describe('ProjectSettingsDialog — worktree_create_script field', () => {
       />
     )
 
-    const label = screen.getByText('Worktree Create Script')
-    expect(label).toBeTruthy()
+    await waitFor(() => expect(mockProjectOps.detectSetupSuggestions).toHaveBeenCalled())
+
+    const trigger = screen.getByRole('button', { name: /worktree create script/i })
+    expect(trigger).toBeTruthy()
+    expect(trigger).toHaveProperty('ariaExpanded', 'false')
   })
 
-  test('loads existing worktree_create_script value into the textarea', () => {
+  test('loads existing worktree_create_script value into the textarea', async () => {
     const existingScript = 'git worktree add --no-checkout "$HIVE_WORKTREE_PATH"'
     render(
       <ProjectSettingsDialog
@@ -93,14 +97,13 @@ describe('ProjectSettingsDialog — worktree_create_script field', () => {
       />
     )
 
+    await waitFor(() => expect(mockProjectOps.detectSetupSuggestions).toHaveBeenCalled())
+
     const textarea = screen.getByDisplayValue(existingScript)
     expect(textarea).toBeTruthy()
   })
 
   test('saves the entered script via updateProject', async () => {
-    const updateProject = vi.fn().mockResolvedValue(true)
-    useProjectStore.setState({ updateProject } as Partial<ReturnType<typeof useProjectStore.getState>> as ReturnType<typeof useProjectStore.getState>)
-
     render(
       <ProjectSettingsDialog
         project={makeProject()}
@@ -109,19 +112,22 @@ describe('ProjectSettingsDialog — worktree_create_script field', () => {
       />
     )
 
-    const label = screen.getByText('Worktree Create Script')
-    const wrapper = label.closest('div.space-y-1\\.5') as HTMLElement
-    const textarea = wrapper.querySelector('textarea') as HTMLTextAreaElement
+    const user = userEvent.setup()
+    await waitFor(() => expect(mockProjectOps.detectSetupSuggestions).toHaveBeenCalled())
+    await user.click(screen.getByRole('button', { name: /worktree create script/i }))
+
+    const textarea = screen.getByPlaceholderText(
+      /git worktree add --no-checkout/
+    ) as HTMLTextAreaElement
     expect(textarea).toBeTruthy()
 
-    const user = userEvent.setup()
     await user.click(textarea)
     await user.type(textarea, 'custom-create-script')
 
     const saveButton = screen.getByRole('button', { name: /save/i })
     await user.click(saveButton)
 
-    expect(updateProject).toHaveBeenCalledWith(
+    expect(mocks.updateProject).toHaveBeenCalledWith(
       'test-project-id',
       expect.objectContaining({
         worktree_create_script: 'custom-create-script'
@@ -130,9 +136,6 @@ describe('ProjectSettingsDialog — worktree_create_script field', () => {
   })
 
   test('saves null when the textarea is cleared', async () => {
-    const updateProject = vi.fn().mockResolvedValue(true)
-    useProjectStore.setState({ updateProject } as Partial<ReturnType<typeof useProjectStore.getState>> as ReturnType<typeof useProjectStore.getState>)
-
     render(
       <ProjectSettingsDialog
         project={makeProject({ worktree_create_script: 'old-script' })}
@@ -141,6 +144,8 @@ describe('ProjectSettingsDialog — worktree_create_script field', () => {
       />
     )
 
+    await waitFor(() => expect(mockProjectOps.detectSetupSuggestions).toHaveBeenCalled())
+
     const textarea = screen.getByDisplayValue('old-script') as HTMLTextAreaElement
     const user = userEvent.setup()
     await user.clear(textarea)
@@ -148,7 +153,7 @@ describe('ProjectSettingsDialog — worktree_create_script field', () => {
     const saveButton = screen.getByRole('button', { name: /save/i })
     await user.click(saveButton)
 
-    expect(updateProject).toHaveBeenCalledWith(
+    expect(mocks.updateProject).toHaveBeenCalledWith(
       'test-project-id',
       expect.objectContaining({
         worktree_create_script: null


### PR DESCRIPTION
## Summary
- Converted the Worktree Create Script field in project settings into a collapsible advanced section.
- Auto-expands the section when a script already exists, while keeping it collapsed for unset projects.
- Updated project settings tests to cover the new collapsed/expanded behavior and save flow.
- Cleaned up a couple of imports to use direct module paths.

## Testing
- `Not run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only project settings presentation and test changes; worktree script persistence behavior is unchanged.
> 
> **Overview**
> The **Worktree Create Script** area in project settings is now a collapsible **Advanced** section instead of always showing the long help text and textarea. It starts **collapsed** when no script is set and **opens by default** when a non-empty script is already saved; users can toggle it, and a **Configured** hint appears when there is content.
> 
> Tests were added and updated for collapsed/expanded defaults, manual expand, and unchanged save behavior (including clearing to `null`). A couple of imports were switched from barrel paths to direct module imports (`useProjectStore`, `useGhosttySuppression`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8caac7ac4d74156285fa9318325d9e91407d74d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->