### PR TITLE
Add Claude CLI terminal and ticket handoff flow

### DIFF
--- a/PLAN_MIGRATE_IPC_TO_HTTP.md
+++ b/PLAN_MIGRATE_IPC_TO_HTTP.md
@@ -1,0 +1,661 @@
+# IPC to HTTP/WS Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate Hive from Electron IPC-backed application APIs to a T3Code-style local HTTP/WebSocket backend, leaving Electron as a desktop shell only.
+
+**Architecture:** Hive will gain a `src/server` runtime that owns database, git, filesystem, terminal, script, agent, settings, telemetry, and streaming services. The renderer will connect over authenticated HTTP/WS through a typed client. Electron IPC will shrink to a small `desktopBridge` for native shell functions only.
+
+**Tech Stack:** Electron, React/Vite, TypeScript, Node HTTP/WebSocket runtime, Zod schemas, Vitest, Playwright, existing Hive service modules.
+
+---
+
+## Desired End State
+
+Hive should run in two equivalent UI hosts:
+
+- Electron desktop app: Electron starts and supervises a local backend server, then loads the renderer.
+- Chrome/browser app: a browser loads the same renderer and connects to an already-running Hive backend.
+
+The backend server owns all high-privilege app behavior:
+
+- SQLite database access
+- project/worktree operations
+- git operations and watchers
+- file tree scanning and file reads/writes
+- attachment storage
+- terminal PTYs
+- script execution
+- bash execution
+- OpenCode, Claude Code, Claude CLI, and Codex session management
+- agent streaming events, approvals, questions, plan approvals, and command approvals
+- usage/account/settings/telemetry operations
+- ticket import and kanban operations
+
+Electron IPC remains only for native desktop shell capabilities:
+
+- native folder/file picker
+- native context menu
+- app/window/menu actions
+- updater
+- open external URL/path
+- app quit/restart
+- secure desktop bootstrap
+- desktop-only overlays and native UI integrations
+
+## Non-Goals
+
+- Do not rewrite the renderer UI.
+- Do not replace Electron packaging.
+- Do not expose the server publicly by default.
+- Do not make Ghostty native surfaces browser-compatible.
+- Do not delete the current IPC bridge until HTTP/WS parity exists.
+- Do not move every renderer call site in one commit.
+
+## Migration Strategy
+
+Use a strangler migration.
+
+1. Introduce a server and renderer HTTP/WS client.
+2. Add a compatibility shim that exposes the existing `window.db`, `window.gitOps`, `window.opencodeOps`, and related APIs over HTTP/WS.
+3. Migrate one domain at a time from IPC to RPC.
+4. Keep old IPC handlers calling the same extracted services until each domain has parity.
+5. Move renderer call sites from globals to explicit imported clients after the system works.
+6. Delete old IPC surfaces only after all direct callers are gone.
+
+This avoids a risky one-shot rewrite of the renderer, preload, and main process.
+
+## Canonical Transport Shape
+
+Define a shared request/response/event model in `src/shared/rpc`.
+
+```ts
+export interface RpcRequest {
+  id: string
+  method: string
+  params: unknown
+}
+
+export type RpcResponse =
+  | { id: string; ok: true; value: unknown }
+  | {
+      id: string
+      ok: false
+      error: {
+        code: string
+        message: string
+        details?: unknown
+      }
+    }
+
+export interface ServerEvent {
+  channel: string
+  payload: unknown
+}
+```
+
+During the compatibility phase, convert RPC responses back into the existing `Envelope<T>` shape at the renderer compatibility boundary. That keeps current stores/components stable while transport changes underneath.
+
+## Proposed File Structure
+
+Create these new areas:
+
+```text
+src/server/
+  bin.ts
+  config.ts
+  server.ts
+  auth/
+    bootstrap.ts
+    session.ts
+  events/
+    event-bus.ts
+  routes/
+    environment.ts
+    auth.ts
+    static.ts
+    attachments.ts
+  rpc/
+    protocol.ts
+    router.ts
+    ws-server.ts
+    domains/
+      db.ts
+      project.ts
+      worktree.ts
+      git.ts
+      file-tree.ts
+      file.ts
+      attachment.ts
+      agent.ts
+      terminal.ts
+      script.ts
+      bash.ts
+      settings.ts
+      connection.ts
+      kanban.ts
+      ticket-import.ts
+      usage.ts
+      account.ts
+      telemetry.ts
+      diagnostics.ts
+
+src/shared/rpc/
+  envelope.ts
+  methods.ts
+  events.ts
+  errors.ts
+
+src/renderer/src/api/
+  environment.ts
+  auth-bootstrap.ts
+  hive-client.ts
+  ws-transport.ts
+  legacy-window-api.ts
+  desktop-bridge.ts
+
+src/main/desktop/
+  backend-config.ts
+  backend-manager.ts
+  desktop-bridge-handlers.ts
+```
+
+Existing IPC handlers should be retained temporarily, then deleted domain by domain.
+
+---
+
+## Phase 1: Server Skeleton
+
+**Goal:** Create a standalone Hive backend process with a health route and minimal WebSocket RPC.
+
+**Files:**
+
+- Create: `src/server/config.ts`
+- Create: `src/server/bin.ts`
+- Create: `src/server/server.ts`
+- Create: `src/server/events/event-bus.ts`
+- Create: `src/server/rpc/protocol.ts`
+- Create: `src/server/rpc/router.ts`
+- Create: `src/server/rpc/ws-server.ts`
+- Create: `src/shared/rpc/envelope.ts`
+- Create: `src/shared/rpc/errors.ts`
+- Test: `src/server/__tests__/server-config.test.ts`
+- Test: `src/server/__tests__/server-smoke.test.ts`
+- Test: `src/server/__tests__/rpc-router.test.ts`
+
+- [ ] Add `ServerConfig` with `mode`, `host`, `port`, `baseDir`, `devUrl`, `staticDir`, `desktopBootstrapToken`, `logLevel`, and path derivation.
+- [ ] Add a server entrypoint that can run without Electron.
+- [ ] Add `GET /.well-known/hive/environment`.
+- [ ] Add `/ws` WebSocket endpoint.
+- [ ] Add `system.ping` RPC returning `{ ok: true }`.
+- [ ] Add typed RPC error conversion for validation errors, domain errors, and unexpected defects.
+- [ ] Add server event bus with `publish`, `subscribe`, and `unsubscribe`.
+- [ ] Verify that `pnpm test -- src/server/__tests__/server-smoke.test.ts` passes.
+
+**Acceptance criteria:**
+
+- The server can start without creating an Electron window.
+- A client can hit the health route.
+- A client can call `system.ping` over WebSocket.
+
+---
+
+## Phase 2: Desktop Backend Manager
+
+**Goal:** Make Electron start and supervise the backend server before opening the renderer.
+
+**Files:**
+
+- Create: `src/main/desktop/backend-config.ts`
+- Create: `src/main/desktop/backend-manager.ts`
+- Create: `src/main/desktop/backend-manager.test.ts`
+- Modify: `src/main/index.ts`
+- Modify: `src/preload/index.ts`
+
+- [ ] Add backend port selection, defaulting to `3773` and scanning upward when unavailable.
+- [ ] Generate a one-time desktop bootstrap token per Electron run.
+- [ ] Spawn the backend with `ELECTRON_RUN_AS_NODE=1`.
+- [ ] Pass bootstrap config to the child process through a file descriptor or a scoped environment variable.
+- [ ] Capture backend stdout/stderr to Hive logs.
+- [ ] Poll `/.well-known/hive/environment` until ready.
+- [ ] Open the renderer only after backend readiness.
+- [ ] Add bounded restart on unexpected backend exit.
+- [ ] Stop backend on app shutdown.
+
+**Acceptance criteria:**
+
+- `pnpm dev` starts a backend process first.
+- The Electron window opens only after backend readiness.
+- Backend crash logs are visible.
+- The backend shuts down when Electron quits.
+
+---
+
+## Phase 3: Desktop Bridge
+
+**Goal:** Shrink Electron preload toward native shell features while keeping the old IPC namespaces temporarily.
+
+**Files:**
+
+- Create: `src/main/desktop/desktop-bridge-handlers.ts`
+- Create: `src/renderer/src/api/desktop-bridge.ts`
+- Modify: `src/preload/index.ts`
+- Modify: `src/preload/index.d.ts`
+
+Expose this future stable shape:
+
+```ts
+export interface DesktopBridge {
+  getLocalEnvironmentBootstrap(): {
+    httpBaseUrl: string
+    wsBaseUrl: string
+    bootstrapToken: string
+  } | null
+  pickFolder(options?: { defaultPath?: string }): Promise<string | null>
+  confirm(message: string): Promise<boolean>
+  showContextMenu<T extends string>(
+    items: readonly { id: T; label: string; destructive?: boolean; disabled?: boolean }[],
+    position?: { x: number; y: number }
+  ): Promise<T | null>
+  openExternal(url: string): Promise<boolean>
+  onMenuAction(listener: (action: string) => void): () => void
+  getUpdateState(): Promise<unknown>
+  checkForUpdate(): Promise<unknown>
+  downloadUpdate(): Promise<unknown>
+  installUpdate(): Promise<unknown>
+}
+```
+
+- [ ] Add `window.desktopBridge`.
+- [ ] Keep existing `window.db`, `window.gitOps`, and similar namespaces for compatibility.
+- [ ] Route native dialog/menu/updater methods through `desktopBridge`.
+- [ ] Move desktop-only types away from core server/shared RPC types.
+
+**Acceptance criteria:**
+
+- Native menu, folder picker, updater, and external URL actions still work.
+- Renderer can read backend bootstrap information from `desktopBridge`.
+
+---
+
+## Phase 4: Renderer HTTP/WS Client
+
+**Goal:** Add a browser-capable renderer client and a compatibility shim for the existing global APIs.
+
+**Files:**
+
+- Create: `src/renderer/src/api/environment.ts`
+- Create: `src/renderer/src/api/auth-bootstrap.ts`
+- Create: `src/renderer/src/api/ws-transport.ts`
+- Create: `src/renderer/src/api/hive-client.ts`
+- Create: `src/renderer/src/api/legacy-window-api.ts`
+- Test: `src/renderer/src/api/__tests__/environment.test.ts`
+- Test: `src/renderer/src/api/__tests__/hive-client.test.ts`
+- Test: `src/renderer/src/api/__tests__/legacy-window-api.test.ts`
+
+- [ ] Resolve backend target from `desktopBridge.getLocalEnvironmentBootstrap()`.
+- [ ] Resolve backend target from Vite env for browser dev mode.
+- [ ] Resolve backend target from `window.location.origin` for production browser mode.
+- [ ] Exchange desktop bootstrap token for an authenticated session.
+- [ ] Create reconnecting WebSocket transport.
+- [ ] Implement `HiveClient.request(method, params)`.
+- [ ] Implement `HiveClient.subscribe(channel, params, callback)`.
+- [ ] Implement `installLegacyWindowApi(client)` that recreates the existing preload global namespaces.
+
+**Acceptance criteria:**
+
+- Renderer code can call `window.db.setting.get` through the compatibility shim.
+- A browser tab can connect to a local backend in dev mode.
+
+---
+
+## Phase 5: Authentication
+
+**Goal:** Protect the local backend even before remote access exists.
+
+**Files:**
+
+- Create: `src/server/auth/bootstrap.ts`
+- Create: `src/server/auth/session.ts`
+- Create: `src/server/routes/auth.ts`
+- Modify: `src/server/rpc/ws-server.ts`
+- Test: `src/server/__tests__/auth-bootstrap.test.ts`
+- Test: `src/server/__tests__/auth-ws.test.ts`
+
+- [ ] Add `POST /api/auth/bootstrap` to exchange a desktop bootstrap token.
+- [ ] Add `GET /api/auth/session` to check auth state.
+- [ ] Add `POST /api/auth/ws-token` to issue a short-lived WS token.
+- [ ] Require auth for WebSocket upgrade.
+- [ ] Require auth for high-privilege HTTP routes.
+- [ ] Allow unauthenticated access only to health/environment and bootstrap endpoints.
+
+**Acceptance criteria:**
+
+- Unauthenticated WS connection is rejected.
+- Desktop bootstrap token creates an authenticated session.
+- Browser mode can authenticate when given valid pairing/bootstrap credentials.
+
+---
+
+## Phase 6: Low-Risk RPC Domains
+
+**Goal:** Prove the migration pattern with stateful but lower-risk domains.
+
+**Domains:**
+
+- `db`
+- `settingsOps`
+- `projectOps`
+- `worktreeOps`
+- `connectionOps`
+- `kanban`
+- `fileOps`
+- `attachmentOps`
+
+**Files:**
+
+- Create RPC files under `src/server/rpc/domains/`
+- Extract service modules as needed under `src/main/services/` or `src/server/services/`
+- Modify matching files under `src/main/ipc/`
+- Test parity per domain under `src/server/__tests__/`
+
+- [ ] Extract domain logic from IPC handler into Electron-free service functions.
+- [ ] Keep old IPC handler as an adapter over the extracted function.
+- [ ] Add RPC handler as another adapter over the same function.
+- [ ] Add tests that verify RPC output matches current IPC envelope behavior.
+- [ ] Switch the compatibility shim method by method from IPC to RPC.
+- [ ] Leave old IPC in place until direct renderer callers are gone.
+
+**Acceptance criteria:**
+
+- Settings, project list, worktree list, kanban tickets, files, and attachments work through HTTP/WS.
+- IPC and RPC parity tests pass during migration.
+
+---
+
+## Phase 7: Event Subscriptions
+
+**Goal:** Replace `BrowserWindow.webContents.send` and `ipcRenderer.on` with server-published WebSocket subscriptions.
+
+**Events to migrate:**
+
+- `git:statusChanged`
+- `git:branchChanged`
+- `worktree:branchRenamed`
+- `file-tree:change`
+- `opencode:stream`
+- `telegram:statusChanged`
+- `telegram:planImplementRequested`
+- `script:*`
+- `terminal:data:*`
+- `terminal:exit:*`
+- `terminal:claude-session-id:*`
+- `claude-cli:status`
+- `bash:stream`
+
+**Files:**
+
+- Modify: `src/server/events/event-bus.ts`
+- Modify: `src/server/rpc/ws-server.ts`
+- Modify affected services that currently call `webContents.send`
+- Test: `src/server/__tests__/subscriptions.test.ts`
+
+- [ ] Add subscription request shape: `{ channel: string; filter?: unknown }`.
+- [ ] Add filtered event streams over WS.
+- [ ] Add unsubscribe support.
+- [ ] Batch terminal/script output chunks.
+- [ ] Replace service-level `BrowserWindow` dependencies with event bus publishing.
+- [ ] Keep menu/shortcut events on `desktopBridge`, not server event bus.
+
+**Acceptance criteria:**
+
+- Renderer can subscribe/unsubscribe to server events.
+- High-volume output does not flood the renderer with one WS frame per byte chunk.
+- Reconnect can resubscribe.
+
+---
+
+## Phase 8: Git and File Tree
+
+**Goal:** Move git/file watching fully into the server runtime.
+
+**Files:**
+
+- Refactor: `src/main/ipc/git-file-handlers.ts`
+- Refactor: `src/main/ipc/file-tree-handlers.ts`
+- Refactor: `src/main/services/git-service.ts`
+- Refactor: `src/main/services/worktree-watcher.ts`
+- Refactor: `src/main/services/branch-watcher.ts`
+- Create: `src/server/rpc/domains/git.ts`
+- Create: `src/server/rpc/domains/file-tree.ts`
+- Test: `src/server/__tests__/git-rpc.test.ts`
+- Test: `src/server/__tests__/file-tree-rpc.test.ts`
+
+- [ ] Move git operations into server-safe services with no Electron imports.
+- [ ] Move watcher ownership into server lifecycle.
+- [ ] Publish watcher updates through server event bus.
+- [ ] Add RPC methods for status, branch info, diffs, staging, commits, push/pull, PR helpers, and file content.
+- [ ] Add temp-git-repository integration tests.
+
+**Acceptance criteria:**
+
+- Git sidebar, diff UI, staging, commit, push, pull, and PR helpers work without Electron IPC.
+- File tree scan/watch works without Electron IPC.
+
+---
+
+## Phase 9: Terminal and Script Streaming
+
+**Goal:** Make xterm/node-pty and scripts work over WebSocket.
+
+**Files:**
+
+- Refactor: `src/main/services/pty-service.ts`
+- Refactor: `src/main/services/script-runner.ts`
+- Create: `src/server/rpc/domains/terminal.ts`
+- Create: `src/server/rpc/domains/script.ts`
+- Test: `src/server/__tests__/terminal-rpc.test.ts`
+- Test: `src/server/__tests__/script-rpc.test.ts`
+
+- [ ] Add `terminal.create`.
+- [ ] Add `terminal.write`.
+- [ ] Add `terminal.resize`.
+- [ ] Add `terminal.destroy`.
+- [ ] Add `terminal.data` subscription.
+- [ ] Add `terminal.exit` subscription.
+- [ ] Add script setup/run/archive/kill RPC methods.
+- [ ] Add script output subscription.
+- [ ] Keep Ghostty native integration desktop-only behind Electron.
+
+**Acceptance criteria:**
+
+- xterm terminal works in Electron and Chrome.
+- Script output streams over WS.
+- Ghostty absence does not break browser mode.
+
+---
+
+## Phase 10: Agent APIs
+
+**Goal:** Move OpenCode, Claude Code, Claude CLI, and Codex session APIs to server RPC.
+
+**Files:**
+
+- Refactor: `src/main/ipc/opencode-handlers.ts`
+- Refactor: `src/main/services/opencode-service.ts`
+- Refactor: `src/main/services/agent-sdk-manager.ts`
+- Refactor: `src/main/services/claude-code-implementer.ts`
+- Refactor: `src/main/services/codex-implementer.ts`
+- Refactor: `src/main/services/agent-event-bus.ts`
+- Create: `src/server/rpc/domains/agent.ts`
+- Test: `src/server/__tests__/agent-rpc.mock-provider.test.ts`
+- Test: `src/server/__tests__/agent-stream-subscription.test.ts`
+
+- [ ] Remove `BrowserWindow` from core agent service dependencies.
+- [ ] Publish agent streams through server event bus.
+- [ ] Add RPC methods for connect, reconnect, prompt, abort, steer, disconnect, messages, models, set model, model info, session info, undo, redo, commands, command execution, capabilities, fork, rename, refresh from thread.
+- [ ] Add RPC methods for question reply/reject.
+- [ ] Add RPC methods for plan approve/reject.
+- [ ] Add RPC methods for permission and command approval replies.
+- [ ] Add mocked-provider tests before real provider smoke tests.
+
+**Acceptance criteria:**
+
+- Agent sessions work through HTTP/WS.
+- Approval/question/plan flows route correctly.
+- Stream event ordering matches current renderer expectations.
+
+---
+
+## Phase 11: Browser Mode Scripts and Dev Workflow
+
+**Goal:** Make Chrome a supported development target.
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `electron.vite.config.ts`
+- Add or modify Vite config if a separate web config is needed.
+- Test: Playwright browser smoke tests.
+
+- [ ] Add `dev:server`.
+- [ ] Add `dev:web`.
+- [ ] Add `dev:desktop`.
+- [ ] Add loopback CORS rules for Vite dev origins.
+- [ ] Add browser smoke test that loads app in Chrome, authenticates, reads settings, and lists projects.
+- [ ] Add Electron smoke test that verifies desktop starts backend and opens renderer.
+
+**Acceptance criteria:**
+
+- `pnpm dev:web` can run the renderer in Chrome against a local backend.
+- `pnpm dev:desktop` still runs the Electron app.
+- Browser and Electron share the same renderer client path.
+
+---
+
+## Phase 12: Renderer API Cleanup
+
+**Goal:** Stop relying on `window.*Ops` globals in app code.
+
+**Files:**
+
+- Modify renderer stores and hooks under `src/renderer/src/stores/`
+- Modify renderer components under `src/renderer/src/components/`
+- Delete: `src/renderer/src/api/legacy-window-api.ts` after migration
+- Modify: `src/preload/index.ts`
+- Modify: `src/preload/index.d.ts`
+
+- [ ] Introduce explicit API access hooks or modules for each domain.
+- [ ] Replace `window.db` calls.
+- [ ] Replace `window.gitOps` calls.
+- [ ] Replace `window.opencodeOps` calls.
+- [ ] Replace `window.terminalOps` calls.
+- [ ] Replace remaining business API globals.
+- [ ] Keep `window.desktopBridge` for native shell actions.
+- [ ] Delete compatibility shim when unused.
+
+**Acceptance criteria:**
+
+- Core renderer code has no direct dependency on Electron IPC globals.
+- Only `desktopBridge` remains as a window global.
+
+---
+
+## Phase 13: IPC Deletion
+
+**Goal:** Remove old business IPC handlers and preload namespaces.
+
+**Files:**
+
+- Delete migrated files under `src/main/ipc/` where no longer needed.
+- Shrink: `src/preload/index.ts`
+- Shrink: `src/preload/index.d.ts`
+- Update: `README.md`
+- Update architecture docs.
+
+- [ ] Delete migrated IPC handlers.
+- [ ] Delete old preload namespace exposure for business APIs.
+- [ ] Delete old IPC-specific tests or convert them to RPC tests.
+- [ ] Update README architecture diagram from IPC to HTTP/WS.
+- [ ] Run full build/test/lint suite.
+
+**Acceptance criteria:**
+
+- No core application operation uses Electron IPC.
+- Electron IPC is desktop-shell-only.
+- Server can run headlessly.
+- Chrome can run Hive against the backend.
+
+---
+
+## Testing Strategy
+
+Required test categories:
+
+- Server config tests.
+- Auth bootstrap tests.
+- RPC router tests.
+- WebSocket transport tests.
+- Domain parity tests while IPC and RPC coexist.
+- Subscription tests.
+- Temp git repository integration tests.
+- Terminal PTY integration tests.
+- Script streaming tests.
+- Mocked agent provider tests.
+- Electron smoke test.
+- Browser Playwright smoke test.
+
+Recommended verification commands during implementation:
+
+```bash
+pnpm test
+pnpm build
+pnpm lint
+pnpm test:e2e
+```
+
+Run narrower tests at each phase before running the full suite.
+
+---
+
+## First Milestone
+
+Build the smallest useful vertical slice:
+
+- Desktop starts backend.
+- Backend exposes health route and `/ws`.
+- Renderer authenticates using desktop bootstrap.
+- RPC supports:
+  - `db.setting.get`
+  - `db.setting.set`
+  - `db.setting.getAll`
+- Compatibility shim exposes existing `window.db.setting`.
+- Existing settings flow works through WS.
+- Chrome can open the Vite app and connect to the backend.
+
+This proves the architecture before migrating the full IPC surface.
+
+---
+
+## Migration Risks
+
+- The current preload exposes a very large API surface, so compatibility shim behavior must be precise.
+- Agent streams and approval flows are the highest-risk migration area.
+- Terminal streaming needs batching and reconnect behavior.
+- Browser file uploads cannot rely on Electron `webUtils.getPathForFile`.
+- Ghostty native surfaces cannot work in Chrome and must remain optional.
+- A local backend has filesystem/git/terminal privileges, so auth cannot be deferred.
+
+---
+
+## Completion Definition
+
+The migration is complete when:
+
+- Electron app works as before.
+- Chrome can run Hive against the backend.
+- Server owns all business logic.
+- Renderer uses HTTP/WS client APIs.
+- `src/preload/index.ts` exposes only desktop shell functionality.
+- Old business IPC handlers are removed.
+- Full verification suite passes.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "install:mac": "bash scripts/install.sh"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.140",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.150",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-cpp": "^6.0.3",
     "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "install:mac": "bash scripts/install.sh"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.138",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.140",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-cpp": "^6.0.3",
     "@codemirror/lang-css": "^6.3.1",

--- a/plans/claude-ui-v2.md
+++ b/plans/claude-ui-v2.md
@@ -1,0 +1,121 @@
+# Claude UI V2 — Run claude CLI in a terminal
+
+## Context
+
+Today, sessions with `agent_sdk = 'claude-code'` are driven by `@anthropic-ai/claude-agent-sdk` through `src/main/services/claude-code-implementer.ts` and rendered as structured messages + tool cards inside `SessionView`. We want to move away from the SDK and instead spawn `claude --dangerously-skip-permissions` as a child process attached to a PTY, rendered as a full-bleed xterm terminal inside `SessionView`. Handoffs/ticket prompts should be passed to claude as the positional first-message argument, and the session's mode (plan/build) should be passed via `--permission-mode`.
+
+We keep the SDK path alive as a **legacy** backend so existing sessions and users who prefer it can still use it.
+
+## Goals
+
+- Add a new agent backend `claude-code-cli` that spawns the `claude` CLI inside a PTY.
+- Render the PTY full-bleed inside `SessionView` when `agent_sdk === 'claude-code-cli'`.
+- Pass initial handoff/ticket prompt as the CLI positional arg so it auto-sends.
+- Apply session mode at spawn via `--permission-mode plan` (build mode = no flag).
+- Toggle mode mid-session by sending Shift+Tab (`\x1b[Z`) to the PTY (claude's built-in shortcut).
+- Track claude's session UUID and resume with `--resume <id>` after app restart.
+
+## Non-goals
+
+- Removing the existing SDK code (`claude-code-implementer.ts`, Effect facade, etc.) — that becomes the **legacy** `claude-code` backend, untouched.
+- Migrating existing `claude-code` DB rows — they stay on the legacy SDK renderer forever.
+- Parsing claude's terminal output back into hive-style bubbles/tool cards.
+
+## Key Decisions
+
+| # | Decision | Notes |
+|---|---|---|
+| 1 | New `agent_sdk` value: `'claude-code-cli'` | Existing `'claude-code'` rows stay on legacy SDK path. No DB migration. |
+| 2 | Renders **full-bleed terminal** in `SessionView` main canvas | No textarea, no Stop button, no message list, no tool cards. PTY handles all input/output/interrupt. |
+| 3 | Initial prompt → positional argv | `claude --dangerously-skip-permissions [...] "<prompt>"` auto-sends on launch. |
+| 4 | Plan mode → `--permission-mode plan` at spawn | Build mode = flag omitted. |
+| 5 | Mid-session mode toggle → `pty.write('\x1b[Z')` | Shift+Tab escape. Still call `setSessionMode()` to keep hive UI in sync. |
+| 6 | Super-plan with handoff → prefix `SUPER_PLAN_MODE_PREFIX` into positional arg | Same constant already used by SDK path. Super-plan toggle is **disabled when no handoff prompt is pending**. |
+| 7 | Model dropdown stays | Translate to `--model <name>` + `--effort <level>` at spawn. Mid-session model changes happen via `/model` slash command typed by the user. |
+| 8 | Resume on reconnect | Watch `~/.claude/projects/<encoded-worktree-path>/` for the newest `.jsonl` after first spawn; persist UUID basename as `sessions.claude_session_id`. On reconnect spawn `claude --resume <id> ...`. |
+| 9 | PTY exit handling | Terminal stays mounted with final frame; overlay "Session ended — click to restart". Restart respawns with `--resume <id>` if known. |
+| 10 | Reuse `pty-service.ts` | Extend `PtyCreateOpts` with optional `command` + `args` (defaults to shell). |
+
+## CLI argv builder
+
+```
+claude
+  --dangerously-skip-permissions
+  [--permission-mode plan]            // when session.mode is plan or super-plan
+  [--model <opus|sonnet|haiku>]       // from model dropdown
+  [--effort <low|medium|high|xhigh|max>]
+  [--resume <claudeSessionId>]        // when we have one from a prior run
+  [<initialPrompt>]                   // positional; prefixed with SUPER_PLAN_MODE_PREFIX if mode=super-plan
+```
+
+`initialPrompt` is sourced from `pendingMessages.dequeue(sessionId)` at spawn time. Absent if user manually creates a session.
+
+## Critical files to modify
+
+### Main process
+
+- **`src/main/services/pty-service.ts`** — Extend `PtyCreateOpts` with optional `command?: string` and `args?: string[]`. Default behavior (shell spawn) unchanged. The ghostty backend path needs the same parameterization or to be skipped for `claude-code-cli`.
+- **`src/main/services/claude-cli-spawner.ts`** *(NEW)* — Pure function: given `{ session, worktreePath, pendingPrompt, claudeBinary, claudeSessionId }`, return `{ command, args, cwd, env }` for `pty-service.create()`. Encapsulates flag-building logic.
+- **`src/main/services/claude-session-watcher.ts`** *(NEW)* — Wraps `fs.watch` on `~/.claude/projects/<encodePath(worktreePath)>/`. After spawn, the first new `.jsonl` filename is the session UUID. Emits the UUID to the renderer via IPC; main persists `sessions.claude_session_id = <uuid>`. Reuses `encodePath()` from existing `src/main/services/claude-transcript-reader.ts`.
+- **`src/main/ipc/terminal-handlers.ts`** — Add a small IPC channel (or extend existing terminal create handler) so the renderer can request a "claude" PTY by session id; main calls `claude-cli-spawner` then `pty-service.create()`.
+- **`src/main/db/database.ts`** + new numbered migration — Add `claude_session_id TEXT NULL` column on `sessions` (additive; safe with no row migration).
+- **`src/main/services/claude-binary-resolver.ts`** — Already exists; reuse for binary discovery. Surface availability via existing `availableAgentSdks` plumbing.
+
+### Renderer
+
+- **`src/shared/types/session.ts`** — Extend `agent_sdk` union with `'claude-code-cli'`.
+- **`src/renderer/src/lib/agent-sdk-availability.ts`** — Register `'claude-code-cli'` and gate it on claude binary presence (same check as existing `claude-session-title.ts` uses).
+- **`src/renderer/src/stores/useSettingsStore.ts`** — Add `'claude-code-cli'` to known SDK list.
+- **`src/renderer/src/components/settings/SettingsGeneral.tsx`** — New radio option labelled "Claude Code (CLI)" plus rename existing "Claude Code" → "Claude Code (legacy SDK)".
+- **`src/renderer/src/stores/useSessionStore.ts`** —
+  - `createSession()`: when `agent_sdk='claude-code-cli'`, do *not* call the SDK implementer's `connect()`; instead trigger the new terminal-spawn IPC. The pending message stays in `pendingMessages` until the main process asks for it during spawn.
+  - `setSessionMode()` / `toggleSessionMode()`: when target session is `claude-code-cli` AND currently running, also send `\x1b[Z` to the PTY via terminal IPC. DB write still happens.
+- **`src/renderer/src/components/sessions/SessionView.tsx`** — Early branch: if `session.agent_sdk === 'claude-code-cli'`, render `<ClaudeCliSessionView>` instead of the existing messages/textarea tree. Keep the header (title, mode toggle, model selector, super toggle, handoff button) above it.
+- **`src/renderer/src/components/sessions/ClaudeCliSessionView.tsx`** *(NEW)* — Hosts an `<XtermBackend>` bound to the session's PTY. Full height. Renders `<ClaudeCliEndedOverlay>` when PTY has exited.
+- **`src/renderer/src/components/sessions/ClaudeCliEndedOverlay.tsx`** *(NEW)* — Semi-transparent overlay: "Session ended — click to restart". On click, dispatch the spawn IPC again (with `--resume <claude_session_id>` if present).
+- **`src/renderer/src/components/sessions/ModelSelector.tsx`** — When session is `claude-code-cli`, show only the model + effort dimensions that map to CLI flags. No structural change beyond conditional options.
+- **`src/renderer/src/components/sessions/SuperToggle.tsx`** — Disable / hide the super-plan toggle for `claude-code-cli` sessions when there is no pending handoff prompt.
+- **`src/renderer/src/lib/handoffSelection.ts`** — `resolveSessionCreationSelection()` and `buildHandoffPrompt()` accept `claude-code-cli` as a target sdk. For super-plan + claude-code-cli, prepend `SUPER_PLAN_MODE_PREFIX` from `src/renderer/src/lib/constants.ts` to the handoff prompt.
+
+## Reused existing pieces
+
+- `src/main/services/pty-service.ts` — PTY lifecycle (node-pty + ghostty fallbacks).
+- `src/renderer/src/components/terminal/backends/XtermBackend.ts` — xterm.js renderer.
+- `src/renderer/src/components/terminal/TerminalManager.tsx` — mount/unmount lifecycle. We adapt this (or a thin wrapper) for the in-SessionView mount instead of `MainPaneTerminalPanel`.
+- `src/main/services/claude-binary-resolver.ts` — `which claude` discovery.
+- `src/main/services/claude-transcript-reader.ts::encodePath()` — re-export the function for the session watcher.
+- `src/main/services/claude-session-title.ts` — title generation continues to shell out to `claude -p`; unaffected by this work.
+- `src/renderer/src/lib/constants.ts::SUPER_PLAN_MODE_PREFIX` — reused for super-plan handoff prefix injection.
+
+## Out-of-scope / known limitations to document
+
+- Mid-session messages typed into the terminal do NOT receive plan-mode or super-plan-mode prefixes (no interception point). Only the initial positional-arg prompt does.
+- Mid-session model changes must be done via `/model` slash command typed in the terminal; the UI dropdown only takes effect at spawn time (or on a manual restart).
+- Hive's "abort current message" UI is not shown — users press Ctrl+C in the terminal.
+- Hive's structured plan-content overlay (from `ExitPlanMode` SDK tool) is not triggered; claude shows plan output inline in the terminal.
+
+## Verification
+
+1. **Smoke — new session, build mode, no prompt:**
+   - Settings → pick "Claude Code (CLI)" as default.
+   - Create a new session. Confirm SessionView renders a terminal with claude's REPL prompt. Type "hello" → response renders.
+2. **Plan mode at spawn:**
+   - Toggle mode to plan before sending. Confirm spawn argv contains `--permission-mode plan` (log inspection). Confirm claude shows plan-mode indicator in its TUI.
+3. **Handoff with prompt:**
+   - From a plan, use Handoff → claude-code-cli. New session opens. Confirm the prompt appears as the first user message inside the terminal and was auto-sent.
+4. **Super-plan handoff:**
+   - From a plan, set super-plan armed + handoff. Confirm the spawned argv's positional arg starts with the `SUPER_PLAN_MODE_PREFIX` text.
+5. **Mid-session mode toggle:**
+   - Press Tab in SessionView. Confirm claude's permission-mode indicator flips (Shift+Tab effect) and `sessions.mode` updates in DB.
+6. **Resume after app restart:**
+   - Send a few messages, quit hive, relaunch. Open the same session. Confirm spawn argv includes `--resume <uuid>` and claude reloads the prior transcript.
+7. **PTY exit:**
+   - Inside the terminal type `/quit`. Confirm the "Session ended — click to restart" overlay appears. Click → claude respawns with `--resume <uuid>`.
+8. **Legacy backend untouched:**
+   - Existing session rows with `agent_sdk='claude-code'` still open with the message-list/tool-card UI; SDK still drives them.
+9. **Availability:**
+   - Temporarily rename the `claude` binary on PATH. Confirm "Claude Code (CLI)" option is disabled in settings with the standard unavailable-sdk treatment.
+
+## Rollout
+
+- One Electron release. No phased flag — the legacy `claude-code` path remains selectable indefinitely as "Claude Code (legacy SDK)" so users can fall back.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.138
-        version: 0.2.138(zod@4.4.3)
+        specifier: ^0.2.140
+        version: 0.2.140(zod@4.4.3)
       '@codemirror/commands':
         specifier: ^6.10.3
         version: 6.10.3
@@ -315,48 +315,48 @@ packages:
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
     hasBin: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.138':
-    resolution: {integrity: sha512-aObxJ/GeJ5UxT9N8XypUHPYQKpwYsRT5THiJl5E2pKEUk/Xt42gT55N5GV0TOjtgxVAnDMWjxTAgGCGoDzjgpg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.140':
+    resolution: {integrity: sha512-zEbDsDKeoDO4DzbyX6wBVlcPhLy/gYiCrKzKnxmkOhyNtJBeshgiOTdr+M7WX1xcuI/M/UhEY+B9U6oo884lAQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.138':
-    resolution: {integrity: sha512-ou3i1/gAf2PEgVl2WYJb7ZdE+KGwoB1I46JRhWHSC3uD6lb9HMZam233T/rlKCVX9e5dzfkujUOnmCkmXjgVGQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.140':
+    resolution: {integrity: sha512-BFJGeZEksvERy7mMJ0mkNAWoMrZOgl6XN/mKPaunGnaC/i+1ykx7xih7e58bRhsrzKzo2mnUrwtjiFyF3MFNRQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.138':
-    resolution: {integrity: sha512-uZaEFND1pl7KD9tdYqj2hd6ktjlYizVmkHRgU2Aj/P1CC6WMDsKG+rqPP7dsVXO77gMXhL4xjjwwqMjxx83HkA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.140':
+    resolution: {integrity: sha512-nG7xLL0nKb4ymFVnX0QhSGLoyhh9fuuDpBR+TYz5O4ZQc2RVUMSMqGusqcCNEIGxAKQSVKWCf0WgpCG/edAO9Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.138':
-    resolution: {integrity: sha512-jp8lmAVe9uI9X5o+IYWFajLbN+Z80XogVX7NeyaenLHdpHkxg29Yf8pb6Os4OvHMjJOAdwDhPpXajf6RtBeEDA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.140':
+    resolution: {integrity: sha512-FauGGg3zikxrjAUnu+Pso6zD9Qv4Z2+QBiTiZqc12U+x4uoikNsplymUnsJ7MYD9VaTGmLJuZ9pCch0IiKrseQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.138':
-    resolution: {integrity: sha512-T16F8Vkikb98E781ZM6Cx84yEBk+loSCqAObjaZ1hzQ1eKcpnxzSTF4rH2bz6N91dhFuCfIjFaBfNYg+oQA+yQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.140':
+    resolution: {integrity: sha512-EZ7VzOGmvft/1ymh2rwts5v3yPnsGGlGrTJlY2Dqnr1ABF43JIhEm1NFYrLnXQWSN74s5Pj8tgkPbYS9x4BhFA==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.138':
-    resolution: {integrity: sha512-SLuUmu/nH1Wh0wnoXj/Bwh0nbDfEn9PgXqMsZHEUk3x1zxeR+6aRqFLjKZ8TawBey7xod7nfYUIjPnQx6IWDzg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.140':
+    resolution: {integrity: sha512-7f627Tq2mIiwFoBYfCKTdEeZSP90r8UOWu/I5DezudTtwtoVl2zRaRCnJ8c4rW+Tzw+xWSfP/pHvR9bTQGXaOw==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.138':
-    resolution: {integrity: sha512-H/sD25fmMyEeJWamYmBKRS3E7jaIrg2S8KWxyR37P+xTZgkLe19sDTp7gYYywMXf1X9CJZJ8jJZ93qxINZoCeA==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.140':
+    resolution: {integrity: sha512-9EOozRF+LTt3UedeJtjJXC8pj9VTAFtPBuB+/YUmcpmDAEH9qcWWknWhf7NDKTapKtBWkNP/387x+18L15MLqg==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.138':
-    resolution: {integrity: sha512-cSOdTH1OfIamVdJit9laWZiXne81ewgdP8MGh5HzLLLci0NGHkME7YxCWd0lYkCNkfiOEcToKU9axaZ+84jGiw==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.140':
+    resolution: {integrity: sha512-puQyWoYiqosjDEYULWAS/lBJse1vzib0NmQj/bYTirWCbtiUcu6ixKMd4NmLbE+Si/DKTB8XNz6hVZ/KckqeoQ==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.2.138':
-    resolution: {integrity: sha512-rH6dFI3DBBsPBPcHTBdTZCHA14OCt2t4+6XYi2MJB/GlFrnZvlWmMIk2z9uxAiZ05Txg8YbftgSuE5A1qpAXwg==}
+  '@anthropic-ai/claude-agent-sdk@0.2.140':
+    resolution: {integrity: sha512-Zq2L7YCoTdbxTUi3/soN1axrTqbG7GoKuc6Im8EpkBRdwaY0D1W9+Ux3vAbV/cX8Qk31Vck7DQLZz1lGEArdoQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -6425,44 +6425,44 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.138':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.140':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.138(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.2.140(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.81.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.138
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.138
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.140
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.140
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.140
-        version: 0.2.140(zod@4.4.3)
+        specifier: ^0.3.150
+        version: 0.3.150(@anthropic-ai/sdk@0.81.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@codemirror/commands':
         specifier: ^6.10.3
         version: 6.10.3
@@ -315,50 +315,52 @@ packages:
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
     hasBin: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.140':
-    resolution: {integrity: sha512-zEbDsDKeoDO4DzbyX6wBVlcPhLy/gYiCrKzKnxmkOhyNtJBeshgiOTdr+M7WX1xcuI/M/UhEY+B9U6oo884lAQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.150':
+    resolution: {integrity: sha512-YVWJ0MHdSy0tobHO2G5/+vd9iRGyosg3wM6sY4pirezsnwZJBkJv/9IeVIaKqdLv83OA6HUcxxOLGzKSBawq2Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.140':
-    resolution: {integrity: sha512-BFJGeZEksvERy7mMJ0mkNAWoMrZOgl6XN/mKPaunGnaC/i+1ykx7xih7e58bRhsrzKzo2mnUrwtjiFyF3MFNRQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.150':
+    resolution: {integrity: sha512-72M8mKCa7Tfy66G5hr5z9TirKynQa9sFj+4qDxkAp5LAYnyViUzHOqO6mEjVtwDr2aXnjqkhTdBtc5Hmn1m/nA==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.140':
-    resolution: {integrity: sha512-nG7xLL0nKb4ymFVnX0QhSGLoyhh9fuuDpBR+TYz5O4ZQc2RVUMSMqGusqcCNEIGxAKQSVKWCf0WgpCG/edAO9Q==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.150':
+    resolution: {integrity: sha512-KxkrUkGRhVcj4/2LkLrhVcEPl+6McDvtpZlgikHwAczVIf7aCvh01w2meEvuNjvex3dCv0d8CT+WYWxKJUhsbw==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.140':
-    resolution: {integrity: sha512-FauGGg3zikxrjAUnu+Pso6zD9Qv4Z2+QBiTiZqc12U+x4uoikNsplymUnsJ7MYD9VaTGmLJuZ9pCch0IiKrseQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.150':
+    resolution: {integrity: sha512-1nhCXjfbxwhQPTgx2+q8lFYHx8DGJEOdaSd4wLvhGJifd/9QJwtnxaill1q+qdggZDroXHDJOTugttP0be6diA==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.140':
-    resolution: {integrity: sha512-EZ7VzOGmvft/1ymh2rwts5v3yPnsGGlGrTJlY2Dqnr1ABF43JIhEm1NFYrLnXQWSN74s5Pj8tgkPbYS9x4BhFA==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.150':
+    resolution: {integrity: sha512-cm+kWR077H4+ZaMPtqrHosjsVba9hjfn31gtK7D96ziz9Mzn/XhkAz68oObDOTBDqj4j+JbmAHSl5JvyGMHcAg==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.140':
-    resolution: {integrity: sha512-7f627Tq2mIiwFoBYfCKTdEeZSP90r8UOWu/I5DezudTtwtoVl2zRaRCnJ8c4rW+Tzw+xWSfP/pHvR9bTQGXaOw==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.150':
+    resolution: {integrity: sha512-G7yOB9O6twOhQH3SvZWIvOcjehfA0HD5f/j49Z/yxZK5U72hOxtnbx7GCbcH/8AyB7JFyHjHpR9hxOxFoJNIhQ==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.140':
-    resolution: {integrity: sha512-9EOozRF+LTt3UedeJtjJXC8pj9VTAFtPBuB+/YUmcpmDAEH9qcWWknWhf7NDKTapKtBWkNP/387x+18L15MLqg==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.150':
+    resolution: {integrity: sha512-z9vlm3JdOQ1Vqj9sG8kW+r9miunv4UFQOn0AqoI++J9AgoCBjKGCH2WWmZYhGOvezZqogunXaTciJvhtDhJiWQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.140':
-    resolution: {integrity: sha512-puQyWoYiqosjDEYULWAS/lBJse1vzib0NmQj/bYTirWCbtiUcu6ixKMd4NmLbE+Si/DKTB8XNz6hVZ/KckqeoQ==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.150':
+    resolution: {integrity: sha512-lpAVi7tZdHi3BXRWmCVmOE2O8q7nzbvuMneYKS9rkpIbcjMjOBk6ud/rlp8Cuiqmp4LzZ8ylbbI7vFEiylK6Hg==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.2.140':
-    resolution: {integrity: sha512-Zq2L7YCoTdbxTUi3/soN1axrTqbG7GoKuc6Im8EpkBRdwaY0D1W9+Ux3vAbV/cX8Qk31Vck7DQLZz1lGEArdoQ==}
+  '@anthropic-ai/claude-agent-sdk@0.3.150':
+    resolution: {integrity: sha512-/RgkK5eTgIbzw5VRvH+T/hWeC5P7dCoYEO5ZWlwTSqvjfdVFOZhkiUKf4gz0ONpeLORAetqWU4rIfcVjQAH5fg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
 
   '@anthropic-ai/sdk@0.81.0':
@@ -6425,47 +6427,44 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.140':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.150':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.140':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.150':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.140':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.150':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.140':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.150':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.140':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.150':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.140':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.150':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.140':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.150':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.140':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.150':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.140(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.150(@anthropic-ai/sdk@0.81.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.81.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.140
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.140
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.140
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.140
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.140
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.140
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.140
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.140
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.150
 
   '@anthropic-ai/sdk@0.81.0(zod@4.4.3)':
     dependencies:

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -129,6 +129,7 @@ export class DatabaseService {
   private mapSessionRow(row: Record<string, unknown>): Session {
     return {
       ...row,
+      claude_session_id: (row.claude_session_id as string) ?? null,
       pinned_to_board: !!(row.pinned_to_board as number),
       session_type: (row.session_type as string) ?? 'default'
     } as Session
@@ -409,6 +410,7 @@ export class DatabaseService {
       'TEXT DEFAULT NULL REFERENCES connections(id) ON DELETE SET NULL'
     )
     this.safeAddColumn('sessions', 'agent_sdk', "TEXT NOT NULL DEFAULT 'opencode'")
+    this.safeAddColumn('sessions', 'claude_session_id', 'TEXT DEFAULT NULL')
     this.safeAddColumn('connections', 'color', 'TEXT DEFAULT NULL')
     this.safeAddColumn('connections', 'custom_name', 'TEXT DEFAULT NULL')
     this.safeAddColumn('worktrees', 'attachments', "TEXT DEFAULT '[]'")
@@ -1040,6 +1042,7 @@ export class DatabaseService {
       name: data.name ?? null,
       status: 'active',
       opencode_session_id: data.opencode_session_id ?? null,
+      claude_session_id: data.claude_session_id ?? null,
       agent_sdk: data.agent_sdk ?? 'opencode',
       mode: data.mode ?? 'build',
       session_type: data.session_type ?? 'default',
@@ -1053,8 +1056,8 @@ export class DatabaseService {
     }
 
     db.prepare(
-      `INSERT INTO sessions (id, worktree_id, project_id, connection_id, name, status, opencode_session_id, agent_sdk, mode, session_type, model_provider_id, model_id, model_variant, created_at, updated_at, completed_at, pinned_to_board)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO sessions (id, worktree_id, project_id, connection_id, name, status, opencode_session_id, claude_session_id, agent_sdk, mode, session_type, model_provider_id, model_id, model_variant, created_at, updated_at, completed_at, pinned_to_board)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       session.id,
       session.worktree_id,
@@ -1063,6 +1066,7 @@ export class DatabaseService {
       session.name,
       session.status,
       session.opencode_session_id,
+      session.claude_session_id,
       session.agent_sdk,
       session.mode,
       session.session_type,
@@ -1096,12 +1100,12 @@ export class DatabaseService {
 
   getAgentSdkForSession(
     agentSessionId: string
-  ): 'opencode' | 'claude-code' | 'codex' | 'terminal' | null {
+  ): 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal' | null {
     const db = this.getDb()
     const row = db
       .prepare('SELECT agent_sdk FROM sessions WHERE opencode_session_id = ? LIMIT 1')
       .get(agentSessionId) as
-      | { agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal' }
+      | { agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal' }
       | undefined
     return row?.agent_sdk ?? null
   }
@@ -1167,6 +1171,10 @@ export class DatabaseService {
     if (data.opencode_session_id !== undefined) {
       updates.push('opencode_session_id = ?')
       values.push(data.opencode_session_id)
+    }
+    if (data.claude_session_id !== undefined) {
+      updates.push('claude_session_id = ?')
+      values.push(data.claude_session_id)
     }
     if (data.agent_sdk !== undefined) {
       updates.push('agent_sdk = ?')

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -1,4 +1,5 @@
 import { deleteAttachment } from '../services/attachment-storage'
+import type { AgentSdk } from '@shared/types/agent-sdk'
 import Database from 'better-sqlite3'
 import { app } from 'electron'
 import { join } from 'path'
@@ -1280,12 +1281,12 @@ export class DatabaseService {
 
   getAgentSdkForSession(
     agentSessionId: string
-  ): 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal' | null {
+  ): AgentSdk | null {
     const db = this.getDb()
     const row = db
       .prepare('SELECT agent_sdk FROM sessions WHERE opencode_session_id = ? LIMIT 1')
       .get(agentSessionId) as
-      | { agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal' }
+      | { agent_sdk: AgentSdk }
       | undefined
     return row?.agent_sdk ?? null
   }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 29
+export const CURRENT_SCHEMA_VERSION = 31
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -492,13 +492,29 @@ DROP TABLE IF EXISTS diff_comments;`
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   },
   {
-    version: 27,
+    version: 28,
+    name: 'add_project_custom_commands',
+    up: `ALTER TABLE projects ADD COLUMN custom_commands TEXT DEFAULT NULL`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 29,
+    name: 'add_project_worktree_create_script',
+    up: `ALTER TABLE projects ADD COLUMN worktree_create_script TEXT DEFAULT NULL`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  // Migrations added on the claude-ui-terminal branch. Appended at the end
+  // (v30+) rather than inserted mid-sequence so they never collide with or
+  // renumber migrations that already shipped on main. (v27 is intentionally
+  // skipped — it briefly held add_claude_session_id before this reordering.)
+  {
+    version: 30,
     name: 'add_claude_session_id',
     up: `ALTER TABLE sessions ADD COLUMN claude_session_id TEXT DEFAULT NULL`,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   },
   {
-    version: 28,
+    version: 31,
     name: 'add_saved_usage_accounts',
     up: `
       CREATE TABLE IF NOT EXISTS saved_usage_accounts (
@@ -523,17 +539,5 @@ DROP TABLE IF EXISTS diff_comments;`
       DROP INDEX IF EXISTS idx_saved_usage_accounts_provider_email;
       DROP TABLE IF EXISTS saved_usage_accounts;
     `
-  },
-  {
-    version: 28,
-    name: 'add_project_custom_commands',
-    up: `ALTER TABLE projects ADD COLUMN custom_commands TEXT DEFAULT NULL`,
-    down: `-- SQLite cannot drop columns; this is a no-op for safety`
-  },
-  {
-    version: 29,
-    name: 'add_project_worktree_create_script',
-    up: `ALTER TABLE projects ADD COLUMN worktree_create_script TEXT DEFAULT NULL`,
-    down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 26
+export const CURRENT_SCHEMA_VERSION = 27
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   name TEXT,
   status TEXT NOT NULL DEFAULT 'active',
   opencode_session_id TEXT,
+  claude_session_id TEXT,
   mode TEXT NOT NULL DEFAULT 'build',
   draft_input TEXT DEFAULT NULL,
   pinned_to_board INTEGER NOT NULL DEFAULT 0,
@@ -486,6 +487,12 @@ DROP TABLE IF EXISTS diff_comments;`
       ALTER TABLE kanban_tickets ADD COLUMN goal_mode INTEGER NOT NULL DEFAULT 0;
       ALTER TABLE kanban_tickets ADD COLUMN goal_success_criteria TEXT DEFAULT NULL;
     `,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 27,
+    name: 'add_claude_session_id',
+    up: `ALTER TABLE sessions ADD COLUMN claude_session_id TEXT DEFAULT NULL`,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -99,7 +99,8 @@ export interface Session {
   name: string | null
   status: 'active' | 'completed' | 'error'
   opencode_session_id: string | null
-  agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  claude_session_id: string | null
+  agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   mode: SessionMode
   session_type: SessionType
   model_provider_id: string | null
@@ -117,7 +118,8 @@ export interface SessionCreate {
   connection_id?: string | null
   name?: string | null
   opencode_session_id?: string | null
-  agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  claude_session_id?: string | null
+  agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   mode?: SessionMode
   session_type?: SessionType
   model_provider_id?: string | null
@@ -130,7 +132,8 @@ export interface SessionUpdate {
   name?: string | null
   status?: 'active' | 'completed' | 'error'
   opencode_session_id?: string | null
-  agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  claude_session_id?: string | null
+  agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   mode?: SessionMode
   session_type?: SessionType
   model_provider_id?: string | null

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -1,4 +1,5 @@
 import type { CustomProjectCommand } from '@shared/lib/custom-commands'
+import type { AgentSdk } from '@shared/types/agent-sdk'
 
 export interface Project {
   id: string
@@ -107,7 +108,7 @@ export interface Session {
   status: 'active' | 'completed' | 'error'
   opencode_session_id: string | null
   claude_session_id: string | null
-  agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agent_sdk: AgentSdk
   mode: SessionMode
   session_type: SessionType
   model_provider_id: string | null
@@ -126,7 +127,7 @@ export interface SessionCreate {
   name?: string | null
   opencode_session_id?: string | null
   claude_session_id?: string | null
-  agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agent_sdk?: AgentSdk
   mode?: SessionMode
   session_type?: SessionType
   model_provider_id?: string | null
@@ -140,7 +141,7 @@ export interface SessionUpdate {
   status?: 'active' | 'completed' | 'error'
   opencode_session_id?: string | null
   claude_session_id?: string | null
-  agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agent_sdk?: AgentSdk
   mode?: SessionMode
   session_type?: SessionType
   model_provider_id?: string | null

--- a/src/main/effect/git/layers.ts
+++ b/src/main/effect/git/layers.ts
@@ -338,7 +338,9 @@ const make = Effect.gen(function* () {
       if (stashRef) {
         try {
           await simpleGit(worktreePath).raw(['stash', 'apply', stashRef])
-        } catch {}
+        } catch {
+          // Best-effort carryover of uncommitted source changes.
+        }
       }
       const untrackedRaw = await sourceGit.raw(['ls-files', '--others', '--exclude-standard'])
       for (const file of untrackedRaw.trim().split('\n').filter(Boolean)) {
@@ -416,7 +418,9 @@ const make = Effect.gen(function* () {
               existingDirs = readdirSync(projectWorktreesDir).map((d) =>
                 d.startsWith(`${projectName}--`) ? d.slice(projectName.length + 2) : d
               )
-            } catch {}
+            } catch {
+              // Directory may not exist yet; branch/worktree names still provide collision coverage.
+            }
             const breedName = selectUniqueBreedName(
               new Set([...existingBranches, ...existingWorktreeBranches, ...existingDirs]),
               breedType
@@ -526,7 +530,9 @@ const make = Effect.gen(function* () {
                 existingDirs = readdirSync(projectWorktreesDir).map((d) =>
                   d.startsWith(`${projectName}--`) ? d.slice(projectName.length + 2) : d
                 )
-              } catch {}
+              } catch {
+                // Directory may not exist yet; branch/worktree names still provide collision coverage.
+              }
               const existingNames = new Set([...existingBranches, ...existingWorktreeBranches, ...existingDirs])
               let worktreeName = options?.nameHint || selectUniqueBreedName(existingNames, breedType)
               if (options?.nameHint && existingNames.has(worktreeName)) {
@@ -921,7 +927,9 @@ const make = Effect.gen(function* () {
           } finally {
             try {
               rmSync(tempDir, { recursive: true, force: true })
-            } catch {}
+            } catch {
+              // Temporary directory cleanup is best-effort.
+            }
           }
         }).pipe(
           Effect.mapError((error) =>

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -60,6 +60,7 @@ import { telemetryService } from './services/telemetry-service'
 import { perfDiagnostics } from './services/perf-diagnostics'
 import { configure as configureCodexDebugLogger } from './services/codex-debug-logger'
 import { ptyService } from './services/pty-service'
+import { closeClaudeHookServer } from './services/claude-hook-server'
 import { scriptRunner } from './services/script-runner'
 import { bashService } from './effect/bash/facade'
 import { disposeAllRuntimes } from './effect/_shared/runtime'
@@ -801,6 +802,8 @@ app.on('will-quit', async () => {
   updaterService.cleanup()
   // Cleanup terminal PTYs
   cleanupTerminals()
+  // Cleanup Claude CLI hook server
+  await closeClaudeHookServer()
   // Cleanup running scripts
   cleanupScripts()
   // Cleanup running bash runs (best-effort, no await)

--- a/src/main/ipc/__tests__/terminal-handlers.claude-cli.test.ts
+++ b/src/main/ipc/__tests__/terminal-handlers.claude-cli.test.ts
@@ -5,6 +5,13 @@ const mocks = vi.hoisted(() => {
   const handlers = new Map<string, (...args: any[]) => any>()
   const exitCallbacks = new Map<string, (code: number | null) => void>()
   const dataCallbacks = new Map<string, (data: string) => void>()
+  const statusCallbacks: Array<
+    (payload: {
+      sessionId: string
+      status: string
+      metadata?: { hookEventName?: string; toolName?: string }
+    }) => void
+  > = []
 
   return {
     handlers,
@@ -15,7 +22,19 @@ const mocks = vi.hoisted(() => {
     getDatabase: vi.fn(),
     getClaudeHookServer: vi.fn(),
     buildClaudeCliHookSettings: vi.fn(),
+    subscribeClaudeCliStatus: vi.fn(
+      (callback: (payload: {
+        sessionId: string
+        status: string
+        metadata?: { hookEventName?: string; toolName?: string }
+      }) => void) => {
+        statusCallbacks.push(callback)
+        return vi.fn()
+      }
+    ),
+    statusCallbacks,
     publishClaudeCliStatus: vi.fn(),
+    watchForClaudePlanFollowup: vi.fn(() => ({ close: vi.fn() })),
     ptyService: {
       has: vi.fn(() => false),
       create: vi.fn(() => ({ cols: 120, rows: 40 })),
@@ -94,9 +113,14 @@ vi.mock('../../services/claude-session-watcher', () => ({
   watchForClaudeSessionId: vi.fn(() => ({ close: vi.fn() }))
 }))
 
+vi.mock('../../services/claude-plan-followup-watcher', () => ({
+  watchForClaudePlanFollowup: mocks.watchForClaudePlanFollowup
+}))
+
 vi.mock('../../services/claude-hook-server', () => ({
   getClaudeHookServer: mocks.getClaudeHookServer,
   buildClaudeCliHookSettings: mocks.buildClaudeCliHookSettings,
+  subscribeClaudeCliStatus: mocks.subscribeClaudeCliStatus,
   publishClaudeCliStatus: mocks.publishClaudeCliStatus
 }))
 
@@ -156,6 +180,7 @@ describe('terminal:createClaudeCli hook status wiring', () => {
     mocks.handlers.clear()
     mocks.exitCallbacks.clear()
     mocks.dataCallbacks.clear()
+    mocks.statusCallbacks.length = 0
     vi.clearAllMocks()
     __resetRuntimeRegistryForTests()
 
@@ -185,7 +210,10 @@ describe('terminal:createClaudeCli hook status wiring', () => {
     expect(mocks.getClaudeHookServer).toHaveBeenCalledWith(mainWindow)
     expect(mocks.buildClaudeCliHookSettings).toHaveBeenCalledWith(45678, 'hive-session-1')
 
-    const [, options] = mocks.ptyService.create.mock.calls.at(-1)!
+    const [, options] = mocks.ptyService.create.mock.calls.at(-1)! as unknown as [
+      string,
+      { cwd: string; command: string; args: string[] }
+    ]
     expect(options).toMatchObject({
       cwd: '/repo/worktree',
       command: '/usr/local/bin/claude'
@@ -225,6 +253,45 @@ describe('terminal:createClaudeCli hook status wiring', () => {
       sessionId: 'hive-session-1',
       status: 'completed',
       metadata: { reason: 'pty_start' }
+    })
+  })
+
+  it('arms transcript polling on plan_ready and publishes a dedicated plan followup IPC event', async () => {
+    await mocks.handlers.get('terminal:createClaudeCli')!(mockEvent, 'hive-session-1', {})
+
+    expect(mocks.subscribeClaudeCliStatus).toHaveBeenCalledTimes(1)
+    mocks.statusCallbacks[0]?.({ sessionId: 'hive-session-1', status: 'plan_ready' })
+
+    expect(mocks.watchForClaudePlanFollowup).toHaveBeenCalledWith(
+      '/repo/worktree',
+      'claude-session-1',
+      expect.any(Function)
+    )
+
+    const onPlanFollowup = (
+      mocks.watchForClaudePlanFollowup.mock.calls[0] as unknown as [string, string, () => void]
+    )[2]
+    onPlanFollowup()
+
+    expect(mocks.webContentsSend).toHaveBeenCalledWith('claude-cli:plan-followup', {
+      sessionId: 'hive-session-1'
+    })
+  })
+
+  it('publishes a dedicated plan followup IPC event from the ExitPlanMode failure hook', async () => {
+    await mocks.handlers.get('terminal:createClaudeCli')!(mockEvent, 'hive-session-1', {})
+
+    mocks.statusCallbacks[0]?.({
+      sessionId: 'hive-session-1',
+      status: 'planning',
+      metadata: {
+        hookEventName: 'PostToolUseFailure',
+        toolName: 'ExitPlanMode'
+      }
+    })
+
+    expect(mocks.webContentsSend).toHaveBeenCalledWith('claude-cli:plan-followup', {
+      sessionId: 'hive-session-1'
     })
   })
 

--- a/src/main/ipc/__tests__/terminal-handlers.claude-cli.test.ts
+++ b/src/main/ipc/__tests__/terminal-handlers.claude-cli.test.ts
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => {
     ),
     statusCallbacks,
     publishClaudeCliStatus: vi.fn(),
+    clearClaudeCliStatus: vi.fn(),
     watchForClaudePlanFollowup: vi.fn(() => ({ close: vi.fn() })),
     ptyService: {
       has: vi.fn(() => false),
@@ -121,7 +122,8 @@ vi.mock('../../services/claude-hook-server', () => ({
   getClaudeHookServer: mocks.getClaudeHookServer,
   buildClaudeCliHookSettings: mocks.buildClaudeCliHookSettings,
   subscribeClaudeCliStatus: mocks.subscribeClaudeCliStatus,
-  publishClaudeCliStatus: mocks.publishClaudeCliStatus
+  publishClaudeCliStatus: mocks.publishClaudeCliStatus,
+  clearClaudeCliStatus: mocks.clearClaudeCliStatus
 }))
 
 import type { Session } from '../../db/types'
@@ -244,6 +246,9 @@ describe('terminal:createClaudeCli hook status wiring', () => {
       status: 'completed',
       metadata: { reason: 'pty_exit' }
     })
+    // Evicts the hook-server dedup entry so the map doesn't leak and a
+    // re-created session with the same id starts with fresh dedup state.
+    expect(mocks.clearClaudeCliStatus).toHaveBeenCalledWith('hive-session-1')
   })
 
   it('publishes an initial completed status after starting an idle Claude CLI PTY', async () => {
@@ -303,9 +308,39 @@ describe('terminal:createClaudeCli hook status wiring', () => {
     const destroyResult = await mocks.handlers.get('terminal:destroy')!(mockEvent, 'hive-session-1')
     expect(destroyResult).toEqual({ success: true, value: undefined })
     expect(mocks.ptyService.destroy).toHaveBeenCalledWith('hive-session-1')
+    expect(mocks.clearClaudeCliStatus).toHaveBeenCalledWith('hive-session-1')
 
     exitCallback?.(0)
 
     expect(mocks.publishClaudeCliStatus).not.toHaveBeenCalled()
+  })
+
+  it('delivers a follow-up prompt to a live Claude CLI PTY via bracketed paste', async () => {
+    await mocks.handlers.get('terminal:createClaudeCli')!(mockEvent, 'hive-session-1', {})
+    mocks.ptyService.write.mockClear()
+    mocks.ptyService.has.mockReturnValueOnce(true)
+
+    const result = await mocks.handlers.get('terminal:sendClaudeCliPrompt')!(
+      mockEvent,
+      'hive-session-1',
+      'follow-up question'
+    )
+
+    expect(result).toEqual({ success: true, value: { delivered: true } })
+    expect(mocks.ptyService.write).toHaveBeenCalledWith(
+      'hive-session-1',
+      '\u001b[200~follow-up question\u001b[201~\r'
+    )
+  })
+
+  it('reports not delivered (so the caller queues it) when no live Claude CLI PTY exists', async () => {
+    const result = await mocks.handlers.get('terminal:sendClaudeCliPrompt')!(
+      mockEvent,
+      'hive-session-not-running',
+      'hello'
+    )
+
+    expect(result).toEqual({ success: true, value: { delivered: false } })
+    expect(mocks.ptyService.write).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/__tests__/terminal-handlers.claude-cli.test.ts
+++ b/src/main/ipc/__tests__/terminal-handlers.claude-cli.test.ts
@@ -1,0 +1,244 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: any[]) => any>()
+  const exitCallbacks = new Map<string, (code: number | null) => void>()
+  const dataCallbacks = new Map<string, (data: string) => void>()
+
+  return {
+    handlers,
+    exitCallbacks,
+    dataCallbacks,
+    webContentsSend: vi.fn(),
+    ipcMainOn: vi.fn(),
+    getDatabase: vi.fn(),
+    getClaudeHookServer: vi.fn(),
+    buildClaudeCliHookSettings: vi.fn(),
+    publishClaudeCliStatus: vi.fn(),
+    ptyService: {
+      has: vi.fn(() => false),
+      create: vi.fn(() => ({ cols: 120, rows: 40 })),
+      onData: vi.fn((terminalId: string, callback: (data: string) => void) => {
+        dataCallbacks.set(terminalId, callback)
+        return vi.fn(() => dataCallbacks.delete(terminalId))
+      }),
+      onExit: vi.fn((terminalId: string, callback: (code: number | null) => void) => {
+        exitCallbacks.set(terminalId, callback)
+        return vi.fn(() => exitCallbacks.delete(terminalId))
+      }),
+      write: vi.fn(),
+      resize: vi.fn(),
+      destroy: vi.fn(),
+      destroyAll: vi.fn()
+    }
+  }
+})
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
+      mocks.handlers.set(channel, handler)
+    }),
+    on: mocks.ipcMainOn
+  },
+  BrowserWindow: class {},
+  app: { getPath: vi.fn(() => '/tmp') }
+}))
+
+vi.mock('../../services/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  LoggerService: class {},
+  LogLevel: { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3 }
+}))
+
+vi.mock('../../services/pty-service', () => ({
+  ptyService: mocks.ptyService
+}))
+
+vi.mock('../../services/ghostty-service', () => ({
+  ghosttyService: {
+    setMainWindow: vi.fn(),
+    init: vi.fn(),
+    loadAddon: vi.fn(),
+    isAvailable: vi.fn(() => false),
+    isInitialized: vi.fn(() => false),
+    createSurface: vi.fn(),
+    setFrame: vi.fn(),
+    setSize: vi.fn(),
+    keyEvent: vi.fn(),
+    mouseButton: vi.fn(),
+    mousePos: vi.fn(),
+    mouseScroll: vi.fn(),
+    setFocus: vi.fn(),
+    pasteText: vi.fn(),
+    focusDiagnostics: vi.fn(),
+    destroySurface: vi.fn(),
+    shutdown: vi.fn()
+  }
+}))
+
+vi.mock('../../services/ghostty-config', () => ({
+  parseGhosttyConfig: vi.fn(() => ({}))
+}))
+
+vi.mock('../../db', () => ({
+  getDatabase: mocks.getDatabase
+}))
+
+vi.mock('../../services/claude-binary-resolver', () => ({
+  resolveClaudeBinaryPath: vi.fn(() => '/usr/local/bin/claude')
+}))
+
+vi.mock('../../services/claude-session-watcher', () => ({
+  watchForClaudeSessionId: vi.fn(() => ({ close: vi.fn() }))
+}))
+
+vi.mock('../../services/claude-hook-server', () => ({
+  getClaudeHookServer: mocks.getClaudeHookServer,
+  buildClaudeCliHookSettings: mocks.buildClaudeCliHookSettings,
+  publishClaudeCliStatus: mocks.publishClaudeCliStatus
+}))
+
+import type { Session } from '../../db/types'
+import { registerTerminalHandlers, cleanupTerminals } from '../terminal-handlers'
+import { __resetRuntimeRegistryForTests } from '../../effect/_shared/runtime'
+
+const mockEvent = {} as any
+
+function makeMainWindow(): any {
+  return {
+    isDestroyed: vi.fn(() => false),
+    webContents: {
+      send: mocks.webContentsSend
+    }
+  }
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'hive-session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: 'claude-session-1',
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: 'anthropic',
+    model_id: 'sonnet',
+    model_variant: 'high',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    pinned_to_board: false,
+    ...overrides
+  }
+}
+
+function setupDb(session: Session = makeSession()): void {
+  mocks.getDatabase.mockReturnValue({
+    getSession: vi.fn(() => session),
+    getWorktree: vi.fn(() => ({ path: '/repo/worktree' })),
+    getConnection: vi.fn(() => ({ path: '/repo/connection' })),
+    getSetting: vi.fn(() => null),
+    updateSession: vi.fn()
+  })
+}
+
+describe('terminal:createClaudeCli hook status wiring', () => {
+  let mainWindow: any
+
+  beforeEach(() => {
+    mocks.handlers.clear()
+    mocks.exitCallbacks.clear()
+    mocks.dataCallbacks.clear()
+    vi.clearAllMocks()
+    __resetRuntimeRegistryForTests()
+
+    mainWindow = makeMainWindow()
+    setupDb()
+    mocks.getClaudeHookServer.mockResolvedValue({ port: 45678 })
+    mocks.buildClaudeCliHookSettings.mockReturnValue('{"hooks":{"mock":true}}')
+
+    registerTerminalHandlers(mainWindow)
+  })
+
+  afterEach(() => {
+    cleanupTerminals()
+  })
+
+  it('starts the hook server and passes inline settings into the Claude PTY argv before the prompt', async () => {
+    const result = await mocks.handlers.get('terminal:createClaudeCli')!(
+      mockEvent,
+      'hive-session-1',
+      { pendingPrompt: 'Implement the plan' }
+    )
+
+    expect(result).toEqual({
+      success: true,
+      value: { success: true, cols: 120, rows: 40 }
+    })
+    expect(mocks.getClaudeHookServer).toHaveBeenCalledWith(mainWindow)
+    expect(mocks.buildClaudeCliHookSettings).toHaveBeenCalledWith(45678, 'hive-session-1')
+
+    const [, options] = mocks.ptyService.create.mock.calls.at(-1)!
+    expect(options).toMatchObject({
+      cwd: '/repo/worktree',
+      command: '/usr/local/bin/claude'
+    })
+    expect(options.args).toEqual([
+      '--dangerously-skip-permissions',
+      '--model',
+      'sonnet',
+      '--effort',
+      'high',
+      '--resume',
+      'claude-session-1',
+      '--settings',
+      '{"hooks":{"mock":true}}',
+      'Implement the plan'
+    ])
+    expect(mocks.publishClaudeCliStatus).not.toHaveBeenCalled()
+  })
+
+  it('publishes completed with pty_exit metadata when a tracked Claude CLI PTY exits', async () => {
+    await mocks.handlers.get('terminal:createClaudeCli')!(mockEvent, 'hive-session-1', {})
+
+    mocks.exitCallbacks.get('hive-session-1')?.(9)
+
+    expect(mocks.webContentsSend).toHaveBeenCalledWith('terminal:exit:hive-session-1', 9)
+    expect(mocks.publishClaudeCliStatus).toHaveBeenCalledWith(mainWindow, {
+      sessionId: 'hive-session-1',
+      status: 'completed',
+      metadata: { reason: 'pty_exit' }
+    })
+  })
+
+  it('publishes an initial completed status after starting an idle Claude CLI PTY', async () => {
+    await mocks.handlers.get('terminal:createClaudeCli')!(mockEvent, 'hive-session-1', {})
+
+    expect(mocks.publishClaudeCliStatus).toHaveBeenCalledWith(mainWindow, {
+      sessionId: 'hive-session-1',
+      status: 'completed',
+      metadata: { reason: 'pty_start' }
+    })
+  })
+
+  it('removes the Claude CLI PTY-exit safety net when the terminal is destroyed', async () => {
+    await mocks.handlers.get('terminal:createClaudeCli')!(mockEvent, 'hive-session-1', {})
+    const exitCallback = mocks.exitCallbacks.get('hive-session-1')
+    mocks.publishClaudeCliStatus.mockClear()
+
+    const destroyResult = await mocks.handlers.get('terminal:destroy')!(mockEvent, 'hive-session-1')
+    expect(destroyResult).toEqual({ success: true, value: undefined })
+    expect(mocks.ptyService.destroy).toHaveBeenCalledWith('hive-session-1')
+
+    exitCallback?.(0)
+
+    expect(mocks.publishClaudeCliStatus).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/database-handlers.ts
+++ b/src/main/ipc/database-handlers.ts
@@ -1,5 +1,6 @@
 import { Data, Effect } from 'effect'
 import { z } from 'zod'
+import { AGENT_SDK_VALUES } from '@shared/types/agent-sdk'
 
 import { getDatabase } from '../db'
 import { createLogger } from '../services/logger'
@@ -45,7 +46,7 @@ const stringBooleanPairSchema = z.tuple([z.string(), z.boolean()])
 const stringArraySchema = z.array(z.string())
 const sessionModeSchema = z.enum(['build', 'plan', 'super-plan'])
 const sessionTypeSchema = z.enum(['default', 'board-assistant'])
-const agentSdkSchema = z.enum(['opencode', 'claude-code', 'claude-code-cli', 'codex', 'terminal'])
+const agentSdkSchema = z.enum(AGENT_SDK_VALUES)
 const customProjectCommandSchema = z.object({
   id: z.string(),
   name: z.string(),

--- a/src/main/ipc/database-handlers.ts
+++ b/src/main/ipc/database-handlers.ts
@@ -45,7 +45,7 @@ const stringBooleanPairSchema = z.tuple([z.string(), z.boolean()])
 const stringArraySchema = z.array(z.string())
 const sessionModeSchema = z.enum(['build', 'plan', 'super-plan'])
 const sessionTypeSchema = z.enum(['default', 'board-assistant'])
-const agentSdkSchema = z.enum(['opencode', 'claude-code', 'codex', 'terminal'])
+const agentSdkSchema = z.enum(['opencode', 'claude-code', 'claude-code-cli', 'codex', 'terminal'])
 
 const projectCreateSchema = z.object({
   name: z.string(),
@@ -101,6 +101,7 @@ const sessionCreateSchema = z.object({
   connection_id: z.string().nullable().optional(),
   name: z.string().nullable().optional(),
   opencode_session_id: z.string().nullable().optional(),
+  claude_session_id: z.string().nullable().optional(),
   agent_sdk: agentSdkSchema.optional(),
   mode: sessionModeSchema.optional(),
   session_type: sessionTypeSchema.optional(),
@@ -114,6 +115,7 @@ const sessionUpdateSchema = z.object({
   name: z.string().nullable().optional(),
   status: z.enum(['active', 'completed', 'error']).optional(),
   opencode_session_id: z.string().nullable().optional(),
+  claude_session_id: z.string().nullable().optional(),
   agent_sdk: agentSdkSchema.optional(),
   mode: sessionModeSchema.optional(),
   session_type: sessionTypeSchema.optional(),

--- a/src/main/ipc/opencode-handlers.ts
+++ b/src/main/ipc/opencode-handlers.ts
@@ -15,7 +15,7 @@ import { defineHandler } from './_shared/define-handler'
 const log = createLogger({ component: 'OpenCodeHandlers' })
 const opencodeEffect = <A>(operation: () => Promise<A>): Effect.Effect<A> =>
   Effect.promise(operation)
-const agentSdkSchema = z.enum(['opencode', 'claude-code', 'codex', 'terminal'])
+const agentSdkSchema = z.enum(['opencode', 'claude-code', 'claude-code-cli', 'codex', 'terminal'])
 const modelSchema = z
   .object({
     providerID: z.string(),
@@ -46,7 +46,7 @@ const injectedWorktrees = new Set<string>()
 function resolveSdkId(
   dbService: DatabaseService,
   sessionId: string
-): 'opencode' | 'claude-code' | 'codex' | 'terminal' | null {
+): 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal' | null {
   return (
     dbService.getAgentSdkForSession(sessionId) ?? dbService.getSession(sessionId)?.agent_sdk ?? null
   )
@@ -327,8 +327,9 @@ export function registerOpenCodeHandlers(
       opencodeEffect(async () => {
         log.info('IPC: opencode:models', { agentSdk: opts?.agentSdk })
         try {
-          if (opts?.agentSdk && opts.agentSdk !== 'opencode' && sdkManager) {
-            const impl = sdkManager.getImplementer(opts.agentSdk)
+          const requestedSdk = opts?.agentSdk === 'claude-code-cli' ? 'claude-code' : opts?.agentSdk
+          if (requestedSdk && requestedSdk !== 'opencode' && requestedSdk !== 'terminal' && sdkManager) {
+            const impl = sdkManager.getImplementer(requestedSdk)
             if (impl) {
               const providers = await impl.getAvailableModels()
               return { success: true, providers }
@@ -395,8 +396,9 @@ export function registerOpenCodeHandlers(
       opencodeEffect(async () => {
         log.info('IPC: opencode:modelInfo', { worktreePath, modelId, agentSdk })
         try {
-          if (agentSdk && agentSdk !== 'opencode' && sdkManager) {
-            const impl = sdkManager.getImplementer(agentSdk)
+          const requestedSdk = agentSdk === 'claude-code-cli' ? 'claude-code' : agentSdk
+          if (requestedSdk && requestedSdk !== 'opencode' && requestedSdk !== 'terminal' && sdkManager) {
+            const impl = sdkManager.getImplementer(requestedSdk)
             if (impl) {
               const model = await impl.getModelInfo(worktreePath, modelId)
               if (!model) {

--- a/src/main/ipc/opencode-handlers.ts
+++ b/src/main/ipc/opencode-handlers.ts
@@ -15,6 +15,7 @@ import {
 } from '@shared/types/agent-sdk'
 import { ClaudeCodeImplementer } from '../services/claude-code-implementer'
 import { CodexImplementer } from '../services/codex-implementer'
+import { claudeCliTelegramBridge } from '../services/claude-cli-telegram-bridge'
 import { toError } from '../services/error-utils'
 import { defineHandler } from './_shared/define-handler'
 
@@ -690,6 +691,11 @@ export function registerOpenCodeHandlers(
       opencodeEffect(async () => {
         log.info('IPC: opencode:question:reply', { requestId })
         try {
+          // Claude CLI (terminal-backed) question held open by the Telegram bridge.
+          if (claudeCliTelegramBridge.hasPendingQuestion(requestId)) {
+            claudeCliTelegramBridge.resolveQuestion(requestId, answers)
+            return { success: true }
+          }
           // Route to Claude Code implementer if this is a Claude Code question
           if (sdkManager) {
             const claudeImpl = sdkManager.getImplementer('claude-code') as ClaudeCodeImplementer
@@ -730,6 +736,11 @@ export function registerOpenCodeHandlers(
       opencodeEffect(async () => {
         log.info('IPC: opencode:question:reject', { requestId })
         try {
+          // Claude CLI (terminal-backed) question held open by the Telegram bridge.
+          if (claudeCliTelegramBridge.hasPendingQuestion(requestId)) {
+            claudeCliTelegramBridge.rejectQuestion(requestId)
+            return { success: true }
+          }
           // Route to Claude Code implementer if this is a Claude Code question
           if (sdkManager) {
             const claudeImpl = sdkManager.getImplementer('claude-code') as ClaudeCodeImplementer

--- a/src/main/ipc/opencode-handlers.ts
+++ b/src/main/ipc/opencode-handlers.ts
@@ -7,6 +7,12 @@ import { telemetryService } from '../services/telemetry-service'
 import type { DatabaseService } from '../db/database'
 import type { AgentSdkManager } from '../services/agent-sdk-manager'
 import type { PromptOptions } from '../services/agent-sdk-types'
+import {
+  isTerminalBacked,
+  toModelCatalogSdk,
+  type AgentSdk,
+  AGENT_SDK_VALUES
+} from '@shared/types/agent-sdk'
 import { ClaudeCodeImplementer } from '../services/claude-code-implementer'
 import { CodexImplementer } from '../services/codex-implementer'
 import { toError } from '../services/error-utils'
@@ -15,7 +21,7 @@ import { defineHandler } from './_shared/define-handler'
 const log = createLogger({ component: 'OpenCodeHandlers' })
 const opencodeEffect = <A>(operation: () => Promise<A>): Effect.Effect<A> =>
   Effect.promise(operation)
-const agentSdkSchema = z.enum(['opencode', 'claude-code', 'claude-code-cli', 'codex', 'terminal'])
+const agentSdkSchema = z.enum(AGENT_SDK_VALUES)
 const modelSchema = z
   .object({
     providerID: z.string(),
@@ -46,7 +52,7 @@ const injectedWorktrees = new Set<string>()
 function resolveSdkId(
   dbService: DatabaseService,
   sessionId: string
-): 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal' | null {
+): AgentSdk | null {
   return (
     dbService.getAgentSdkForSession(sessionId) ?? dbService.getSession(sessionId)?.agent_sdk ?? null
   )
@@ -77,8 +83,11 @@ export function registerOpenCodeHandlers(
           // SDK-aware dispatch: route non-OpenCode sessions to their implementer
           if (sdkManager && dbService) {
             const session = dbService.getSession(hiveSessionId)
-            // Terminal sessions have no AI backend — short-circuit
-            if (session?.agent_sdk === 'terminal') {
+            // Terminal and Claude CLI sessions have no Agent-SDK backend reachable
+            // here (Claude CLI is PTY-backed and has no registered implementer) —
+            // short-circuit instead of falling through to getImplementer (throws)
+            // or the OpenCode connect path (would start an unwanted server).
+            if (isTerminalBacked(session?.agent_sdk)) {
               return { success: true, sessionId: hiveSessionId }
             }
             if (session?.agent_sdk && session.agent_sdk !== 'opencode') {
@@ -113,8 +122,8 @@ export function registerOpenCodeHandlers(
           // SDK-aware dispatch: route non-OpenCode sessions to their implementer
           if (sdkManager && dbService) {
             const sdkId = dbService.getAgentSdkForSession(opencodeSessionId)
-            // Terminal sessions have no AI backend — short-circuit
-            if (sdkId === 'terminal') {
+            // Terminal and Claude CLI sessions have no Agent-SDK backend — short-circuit
+            if (isTerminalBacked(sdkId)) {
               return { success: true, sessionStatus: 'idle' as const }
             }
             if (sdkId && sdkId !== 'opencode') {
@@ -265,9 +274,9 @@ export function registerOpenCodeHandlers(
             worktreePath,
             requestedSessionId: opencodeSessionId,
             sdkId,
-            route: sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' ? 'sdk' : 'opencode'
+            route: sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli' ? 'sdk' : 'opencode'
           })
-          if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
+          if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli') {
             const impl = sdkManager.getImplementer(sdkId)
             await impl.prompt(worktreePath, opencodeSessionId, messageOrParts, model, options)
             telemetryService.track('prompt_sent', { agent_sdk: sdkId })
@@ -300,7 +309,7 @@ export function registerOpenCodeHandlers(
           // SDK-aware dispatch: route non-OpenCode sessions to their implementer
           if (sdkManager && dbService) {
             const sdkId = dbService.getAgentSdkForSession(opencodeSessionId)
-            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
+            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli') {
               const impl = sdkManager.getImplementer(sdkId)
               await impl.disconnect(worktreePath, opencodeSessionId)
               return { success: true }
@@ -327,7 +336,7 @@ export function registerOpenCodeHandlers(
       opencodeEffect(async () => {
         log.info('IPC: opencode:models', { agentSdk: opts?.agentSdk })
         try {
-          const requestedSdk = opts?.agentSdk === 'claude-code-cli' ? 'claude-code' : opts?.agentSdk
+          const requestedSdk = toModelCatalogSdk(opts?.agentSdk)
           if (requestedSdk && requestedSdk !== 'opencode' && requestedSdk !== 'terminal' && sdkManager) {
             const impl = sdkManager.getImplementer(requestedSdk)
             if (impl) {
@@ -396,7 +405,7 @@ export function registerOpenCodeHandlers(
       opencodeEffect(async () => {
         log.info('IPC: opencode:modelInfo', { worktreePath, modelId, agentSdk })
         try {
-          const requestedSdk = agentSdk === 'claude-code-cli' ? 'claude-code' : agentSdk
+          const requestedSdk = toModelCatalogSdk(agentSdk)
           if (requestedSdk && requestedSdk !== 'opencode' && requestedSdk !== 'terminal' && sdkManager) {
             const impl = sdkManager.getImplementer(requestedSdk)
             if (impl) {
@@ -434,7 +443,7 @@ export function registerOpenCodeHandlers(
           // SDK-aware dispatch: route non-OpenCode sessions to their implementer
           if (sdkManager && dbService) {
             const sdkId = dbService.getAgentSdkForSession(sessionId)
-            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
+            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli') {
               const impl = sdkManager.getImplementer(sdkId)
               const result = await impl.getSessionInfo(worktreePath, sessionId)
               return { success: true, ...result }
@@ -464,7 +473,7 @@ export function registerOpenCodeHandlers(
           // SDK-aware dispatch: route non-OpenCode sessions to their implementer
           if (sdkManager && dbService && sessionId) {
             const sdkId = resolveSdkId(dbService, sessionId)
-            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
+            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli') {
               const impl = sdkManager.getImplementer(sdkId)
               const commands = await impl.listCommands(worktreePath)
               return { success: true, commands }
@@ -513,7 +522,7 @@ export function registerOpenCodeHandlers(
           if (sdkManager && dbService) {
             const sdkId = resolveSdkId(dbService, sessionId)
             const resolvedAgentSessionId =
-              sdkId && sdkId !== 'opencode' && sdkId !== 'terminal'
+              sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli'
                 ? resolveAgentSessionId(dbService, sessionId)
                 : sessionId
             log.info('[CODEX_STREAM_DEBUG] IPC command route resolved', {
@@ -522,9 +531,9 @@ export function registerOpenCodeHandlers(
               resolvedAgentSessionId,
               sdkId,
               command,
-              route: sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' ? 'sdk' : 'opencode'
+              route: sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli' ? 'sdk' : 'opencode'
             })
-            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
+            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli') {
               const impl = sdkManager.getImplementer(sdkId)
               await impl.sendCommand(worktreePath, resolvedAgentSessionId, command, args)
               return { success: true }
@@ -554,7 +563,7 @@ export function registerOpenCodeHandlers(
           // SDK-aware dispatch: route non-OpenCode sessions to their implementer
           if (sdkManager && dbService) {
             const sdkId = dbService.getAgentSdkForSession(sessionId)
-            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
+            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli') {
               const impl = sdkManager.getImplementer(sdkId)
               const result = await impl.undo(worktreePath, sessionId, '')
               return { success: true, ...(result as Record<string, unknown>) }
@@ -585,7 +594,7 @@ export function registerOpenCodeHandlers(
           // SDK-aware dispatch: route non-OpenCode sessions to their implementer
           if (sdkManager && dbService) {
             const sdkId = dbService.getAgentSdkForSession(sessionId)
-            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
+            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli') {
               const impl = sdkManager.getImplementer(sdkId)
               const result = await impl.redo(worktreePath, sessionId, '')
               return { success: true, ...(result as Record<string, unknown>) }
@@ -954,7 +963,7 @@ export function registerOpenCodeHandlers(
           // SDK-aware dispatch: route non-OpenCode sessions to their implementer
           if (sdkManager && dbService) {
             const sdkId = dbService.getAgentSdkForSession(opencodeSessionId)
-            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
+            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli') {
               const impl = sdkManager.getImplementer(sdkId)
               await impl.renameSession(worktreePath ?? '', opencodeSessionId, title)
               return { success: true }
@@ -1008,7 +1017,7 @@ export function registerOpenCodeHandlers(
           // SDK-aware dispatch: route non-OpenCode sessions to their implementer
           if (sdkManager && dbService) {
             const sdkId = dbService.getAgentSdkForSession(opencodeSessionId)
-            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
+            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli') {
               const impl = sdkManager.getImplementer(sdkId)
               const messages = await impl.getMessages(worktreePath, opencodeSessionId)
               return { success: true, messages }
@@ -1070,7 +1079,7 @@ export function registerOpenCodeHandlers(
           // SDK-aware dispatch: route non-OpenCode sessions to their implementer
           if (sdkManager && dbService) {
             const sdkId = dbService.getAgentSdkForSession(opencodeSessionId)
-            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
+            if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' && sdkId !== 'claude-code-cli') {
               const impl = sdkManager.getImplementer(sdkId)
               const result = await impl.abort(worktreePath, opencodeSessionId)
               return { success: result }

--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -17,8 +17,14 @@ import {
 import {
   buildClaudeCliHookSettings,
   getClaudeHookServer,
-  publishClaudeCliStatus
+  publishClaudeCliStatus,
+  subscribeClaudeCliStatus,
+  type ClaudeCliStatusPayload
 } from '../services/claude-hook-server'
+import {
+  watchForClaudePlanFollowup,
+  type ClaudePlanFollowupWatchHandle
+} from '../services/claude-plan-followup-watcher'
 import {
   applyClaudeCliTitle,
   processClaudeCliPtyData,
@@ -76,8 +82,75 @@ const listenerCleanups = new Map<string, { removeData: () => void; removeExit: (
 const dataBuffers = new Map<string, string>()
 const flushScheduled = new Set<string>()
 const claudeWatchers = new Map<string, ClaudeSessionWatchHandle>()
+const claudePlanFollowupWatchers = new Map<string, ClaudePlanFollowupWatchHandle>()
 const claudeCliSessions = new Set<string>()
 const claudeCliWorktreeBasenames = new Map<string, string>()
+const claudeCliTranscriptSources = new Map<
+  string,
+  { worktreePath: string; claudeSessionId: string | null }
+>()
+const claudeCliLastStatus = new Map<string, ClaudeCliStatusPayload>()
+let unsubscribeClaudeCliStatus: (() => void) | null = null
+
+function closeClaudePlanFollowupWatcher(sessionId: string): void {
+  claudePlanFollowupWatchers.get(sessionId)?.close()
+  claudePlanFollowupWatchers.delete(sessionId)
+}
+
+function armClaudePlanFollowupWatcher(mainWindow: BrowserWindow, sessionId: string): void {
+  const source = claudeCliTranscriptSources.get(sessionId)
+  if (!source?.claudeSessionId) return
+
+  closeClaudePlanFollowupWatcher(sessionId)
+  claudePlanFollowupWatchers.set(
+    sessionId,
+    watchForClaudePlanFollowup(source.worktreePath, source.claudeSessionId, () => {
+      closeClaudePlanFollowupWatcher(sessionId)
+      publishClaudeCliStatus(mainWindow, {
+        sessionId,
+        status: 'planning',
+        metadata: { reason: 'claude_cli_plan_followup' }
+      })
+      if (!mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('claude-cli:plan-followup', { sessionId })
+      }
+    })
+  )
+}
+
+function ensureClaudeCliStatusSubscription(mainWindow: BrowserWindow): void {
+  if (unsubscribeClaudeCliStatus) return
+
+  unsubscribeClaudeCliStatus = subscribeClaudeCliStatus((payload) => {
+    if (!claudeCliSessions.has(payload.sessionId)) return
+
+    claudeCliLastStatus.set(payload.sessionId, payload)
+    if (payload.status === 'plan_ready') {
+      armClaudePlanFollowupWatcher(mainWindow, payload.sessionId)
+      return
+    }
+
+    if (
+      payload.status === 'working' &&
+      payload.metadata?.hookEventName === 'PostToolUse' &&
+      payload.metadata.toolName === 'ExitPlanMode'
+    ) {
+      closeClaudePlanFollowupWatcher(payload.sessionId)
+      return
+    }
+
+    if (
+      payload.status === 'planning' &&
+      payload.metadata?.hookEventName === 'PostToolUseFailure' &&
+      payload.metadata.toolName === 'ExitPlanMode'
+    ) {
+      closeClaudePlanFollowupWatcher(payload.sessionId)
+      if (!mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('claude-cli:plan-followup', { sessionId: payload.sessionId })
+      }
+    }
+  })
+}
 
 function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): void {
   // Clean up any stale listeners for this terminalId (shouldn't happen, but defensive)
@@ -132,6 +205,7 @@ function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): 
     flushScheduled.delete(terminalId)
     claudeWatchers.get(terminalId)?.close()
     claudeWatchers.delete(terminalId)
+    closeClaudePlanFollowupWatcher(terminalId)
     if (claudeCliSessions.has(terminalId)) {
       publishClaudeCliStatus(mainWindow, {
         sessionId: terminalId,
@@ -141,6 +215,8 @@ function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): 
       claudeCliSessions.delete(terminalId)
     }
     claudeCliWorktreeBasenames.delete(terminalId)
+    claudeCliTranscriptSources.delete(terminalId)
+    claudeCliLastStatus.delete(terminalId)
     resetClaudeCliTitleState(terminalId)
   })
 
@@ -150,6 +226,7 @@ function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): 
 export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
   // Set main window reference on the Ghostty service
   ghosttyService.setMainWindow(mainWindow)
+  ensureClaudeCliStatusSubscription(mainWindow)
 
   // -----------------------------------------------------------------------
   // node-pty (xterm.js backend) handlers
@@ -264,10 +341,18 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
                     claudeSessionId
                   )
                 }
+                claudeCliTranscriptSources.set(sessionId, { worktreePath, claudeSessionId })
+                if (claudeCliLastStatus.get(sessionId)?.status === 'plan_ready') {
+                  armClaudePlanFollowupWatcher(mainWindow, sessionId)
+                }
                 claudeWatchers.delete(sessionId)
               })
             )
           }
+          claudeCliTranscriptSources.set(sessionId, {
+            worktreePath,
+            claudeSessionId: session.claude_session_id
+          })
 
           const { cols, rows } = ptyService.create(sessionId, {
             cwd: spawn.cwd,
@@ -332,8 +417,11 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
       flushScheduled.delete(terminalId)
       claudeWatchers.get(terminalId)?.close()
       claudeWatchers.delete(terminalId)
+      closeClaudePlanFollowupWatcher(terminalId)
       claudeCliSessions.delete(terminalId)
       claudeCliWorktreeBasenames.delete(terminalId)
+      claudeCliTranscriptSources.delete(terminalId)
+      claudeCliLastStatus.delete(terminalId)
       resetClaudeCliTitleState(terminalId)
       ptyService.destroy(terminalId)
     })
@@ -485,8 +573,20 @@ export function cleanupTerminals(): void {
   // Discard all pending buffered data
   dataBuffers.clear()
   flushScheduled.clear()
+  for (const [, watcher] of claudeWatchers) {
+    watcher.close()
+  }
+  claudeWatchers.clear()
+  for (const [, watcher] of claudePlanFollowupWatchers) {
+    watcher.close()
+  }
+  claudePlanFollowupWatchers.clear()
   claudeCliSessions.clear()
   claudeCliWorktreeBasenames.clear()
+  claudeCliTranscriptSources.clear()
+  claudeCliLastStatus.clear()
+  unsubscribeClaudeCliStatus?.()
+  unsubscribeClaudeCliStatus = null
   resetAllClaudeCliTitleState()
   ptyService.destroyAll()
   ghosttyService.shutdown()

--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -9,7 +9,15 @@ import { defineHandler } from './_shared/define-handler'
 import { getDatabase } from '../db'
 import { resolveClaudeBinaryPath } from '../services/claude-binary-resolver'
 import { buildClaudeCliPtySpawn } from '../services/claude-cli-spawner'
-import { watchForClaudeSessionId, type ClaudeSessionWatchHandle } from '../services/claude-session-watcher'
+import {
+  watchForClaudeSessionId,
+  type ClaudeSessionWatchHandle
+} from '../services/claude-session-watcher'
+import {
+  buildClaudeCliHookSettings,
+  getClaudeHookServer,
+  publishClaudeCliStatus
+} from '../services/claude-hook-server'
 
 const log = createLogger({ component: 'TerminalHandlers' })
 
@@ -60,6 +68,7 @@ const listenerCleanups = new Map<string, { removeData: () => void; removeExit: (
 const dataBuffers = new Map<string, string>()
 const flushScheduled = new Set<string>()
 const claudeWatchers = new Map<string, ClaudeSessionWatchHandle>()
+const claudeCliSessions = new Set<string>()
 
 function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): void {
   // Clean up any stale listeners for this terminalId (shouldn't happen, but defensive)
@@ -98,6 +107,14 @@ function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): 
     flushScheduled.delete(terminalId)
     claudeWatchers.get(terminalId)?.close()
     claudeWatchers.delete(terminalId)
+    if (claudeCliSessions.has(terminalId)) {
+      publishClaudeCliStatus(mainWindow, {
+        sessionId: terminalId,
+        status: 'completed',
+        metadata: { reason: 'pty_exit' }
+      })
+      claudeCliSessions.delete(terminalId)
+    }
   })
 
   listenerCleanups.set(terminalId, { removeData, removeExit })
@@ -154,7 +171,8 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
     ]),
     ([sessionId, opts]) =>
       asyncEffect(async () => {
-        log.info('IPC: terminal:createClaudeCli', { sessionId, hasPrompt: !!opts?.pendingPrompt })
+        const pendingPrompt = opts?.pendingPrompt ?? null
+        log.info('IPC: terminal:createClaudeCli', { sessionId, hasPrompt: !!pendingPrompt })
         try {
           const db = getDatabase()
           const session = db.getSession(sessionId)
@@ -181,11 +199,14 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
           }
 
           const alreadyExists = ptyService.has(sessionId)
+          const { port } = await getClaudeHookServer(mainWindow)
+          const hookSettingsJson = buildClaudeCliHookSettings(port, sessionId)
           const spawn = buildClaudeCliPtySpawn({
             session,
             worktreePath,
-            pendingPrompt: opts?.pendingPrompt ?? null,
+            pendingPrompt,
             claudeBinary,
+            hookSettingsJson,
             db
           })
 
@@ -193,7 +214,7 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
             sessionId,
             command: spawn.command,
             args: spawn.args.map((arg, index) =>
-              index === spawn.args.length - 1 && opts?.pendingPrompt ? '<prompt>' : arg
+              index === spawn.args.length - 1 && pendingPrompt ? '<prompt>' : arg
             )
           })
 
@@ -227,6 +248,14 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
             args: spawn.args,
             env: spawn.env
           })
+          claudeCliSessions.add(sessionId)
+          if (!pendingPrompt) {
+            publishClaudeCliStatus(mainWindow, {
+              sessionId,
+              status: 'completed',
+              metadata: { reason: 'pty_start' }
+            })
+          }
 
           if (!alreadyExists) {
             attachNodePtyListeners(mainWindow, sessionId)
@@ -275,6 +304,7 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
       flushScheduled.delete(terminalId)
       claudeWatchers.get(terminalId)?.close()
       claudeWatchers.delete(terminalId)
+      claudeCliSessions.delete(terminalId)
       ptyService.destroy(terminalId)
     })
   )
@@ -425,6 +455,7 @@ export function cleanupTerminals(): void {
   // Discard all pending buffered data
   dataBuffers.clear()
   flushScheduled.clear()
+  claudeCliSessions.clear()
   ptyService.destroyAll()
   ghosttyService.shutdown()
 }

--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -32,6 +32,8 @@ import {
   resetAllClaudeCliTitleState,
   resetClaudeCliTitleState
 } from '../services/claude-cli-title-handler'
+import { claudeCliTelegramBridge } from '../services/claude-cli-telegram-bridge'
+import { writeClaudeCliPrompt } from '../services/claude-cli-pty-prompt'
 
 const log = createLogger({ component: 'TerminalHandlers' })
 
@@ -266,6 +268,8 @@ function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): 
         metadata: { reason: 'pty_exit' }
       })
     }
+    // Unblock any Telegram-held hook for this now-dead session.
+    claudeCliTelegramBridge.cancelSession(terminalId)
     disposeClaudeCliSession(terminalId)
     clearClaudeCliStatus(terminalId)
     resetClaudeCliTitleState(terminalId)
@@ -457,13 +461,12 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
     z.tuple([z.string().min(1), z.string()]),
     ([sessionId, prompt]) =>
       syncEffect(() => {
-        if (!ptyService.has(sessionId) || !isActiveClaudeCliSession(sessionId)) {
+        // The bracketed-paste write lives in writeClaudeCliPrompt (shared with
+        // the Telegram forwarding service). Guard on the live CLI PTY here.
+        if (!isActiveClaudeCliSession(sessionId)) {
           return { delivered: false }
         }
-        // Bracketed paste keeps a multi-line prompt from being submitted
-        // line-by-line; the trailing CR submits the turn (as pressing Enter).
-        ptyService.write(sessionId, `\u001b[200~${prompt}\u001b[201~\r`)
-        return { delivered: true }
+        return writeClaudeCliPrompt(sessionId, prompt)
       })
   )
 
@@ -493,6 +496,7 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
       // Discard any pending buffered data
       dataBuffers.delete(terminalId)
       flushScheduled.delete(terminalId)
+      claudeCliTelegramBridge.cancelSession(terminalId)
       disposeClaudeCliSession(terminalId)
       clearClaudeCliStatus(terminalId)
       resetClaudeCliTitleState(terminalId)
@@ -651,6 +655,7 @@ export function cleanupTerminals(): void {
     state.planFollowupWatcher?.close()
   }
   claudeCliSessionsState.clear()
+  claudeCliTelegramBridge.cancelAll()
   unsubscribeClaudeCliStatus?.()
   unsubscribeClaudeCliStatus = null
   resetAllClaudeCliTitleState()

--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -6,6 +6,10 @@ import { ghosttyService } from '../services/ghostty-service'
 import { parseGhosttyConfig } from '../services/ghostty-config'
 import { createLogger } from '../services/logger'
 import { defineHandler } from './_shared/define-handler'
+import { getDatabase } from '../db'
+import { resolveClaudeBinaryPath } from '../services/claude-binary-resolver'
+import { buildClaudeCliPtySpawn } from '../services/claude-cli-spawner'
+import { watchForClaudeSessionId, type ClaudeSessionWatchHandle } from '../services/claude-session-watcher'
 
 const log = createLogger({ component: 'TerminalHandlers' })
 
@@ -55,6 +59,49 @@ const listenerCleanups = new Map<string, { removeData: () => void; removeExit: (
 // Batching with setImmediate collects all data from the current I/O phase into one IPC message.
 const dataBuffers = new Map<string, string>()
 const flushScheduled = new Set<string>()
+const claudeWatchers = new Map<string, ClaudeSessionWatchHandle>()
+
+function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): void {
+  // Clean up any stale listeners for this terminalId (shouldn't happen, but defensive)
+  const existing = listenerCleanups.get(terminalId)
+  if (existing) {
+    existing.removeData()
+    existing.removeExit()
+    listenerCleanups.delete(terminalId)
+  }
+
+  const removeData = ptyService.onData(terminalId, (data) => {
+    if (mainWindow.isDestroyed()) return
+
+    const existing = dataBuffers.get(terminalId)
+    dataBuffers.set(terminalId, existing ? existing + data : data)
+
+    if (!flushScheduled.has(terminalId)) {
+      flushScheduled.add(terminalId)
+      setImmediate(() => {
+        flushScheduled.delete(terminalId)
+        const buffered = dataBuffers.get(terminalId)
+        dataBuffers.delete(terminalId)
+        if (buffered && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send(`terminal:data:${terminalId}`, buffered)
+        }
+      })
+    }
+  })
+
+  const removeExit = ptyService.onExit(terminalId, (code) => {
+    if (!mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(`terminal:exit:${terminalId}`, code)
+    }
+    listenerCleanups.delete(terminalId)
+    dataBuffers.delete(terminalId)
+    flushScheduled.delete(terminalId)
+    claudeWatchers.get(terminalId)?.close()
+    claudeWatchers.delete(terminalId)
+  })
+
+  listenerCleanups.set(terminalId, { removeData, removeExit })
+}
 
 export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
   // Set main window reference on the Ghostty service
@@ -72,7 +119,6 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
       asyncEffect(async () => {
         log.info('IPC: terminal:create', { terminalId, cwd, shell })
         try {
-          // Check if PTY already exists before creating — if it does, skip listener registration
           const alreadyExists = ptyService.has(terminalId)
           const { cols, rows } = ptyService.create(terminalId, { cwd, shell: shell || undefined })
 
@@ -81,46 +127,7 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
             return { success: true, cols, rows }
           }
 
-          // Clean up any stale listeners for this terminalId (shouldn't happen, but defensive)
-          const existing = listenerCleanups.get(terminalId)
-          if (existing) {
-            existing.removeData()
-            existing.removeExit()
-            listenerCleanups.delete(terminalId)
-          }
-
-          // Wire PTY output to renderer (batched via setImmediate)
-          const removeData = ptyService.onData(terminalId, (data) => {
-            if (mainWindow.isDestroyed()) return
-
-            // Accumulate into buffer
-            const existing = dataBuffers.get(terminalId)
-            dataBuffers.set(terminalId, existing ? existing + data : data)
-
-            // Schedule a flush if one isn't already pending
-            if (!flushScheduled.has(terminalId)) {
-              flushScheduled.add(terminalId)
-              setImmediate(() => {
-                flushScheduled.delete(terminalId)
-                const buffered = dataBuffers.get(terminalId)
-                dataBuffers.delete(terminalId)
-                if (buffered && !mainWindow.isDestroyed()) {
-                  mainWindow.webContents.send(`terminal:data:${terminalId}`, buffered)
-                }
-              })
-            }
-          })
-
-          // Wire PTY exit to renderer
-          const removeExit = ptyService.onExit(terminalId, (code) => {
-            if (!mainWindow.isDestroyed()) {
-              mainWindow.webContents.send(`terminal:exit:${terminalId}`, code)
-            }
-            // Clean up listener tracking on exit
-            listenerCleanups.delete(terminalId)
-          })
-
-          listenerCleanups.set(terminalId, { removeData, removeExit })
+          attachNodePtyListeners(mainWindow, terminalId)
 
           return { success: true, cols, rows }
         } catch (error) {
@@ -128,6 +135,109 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
             'IPC: terminal:create failed',
             error instanceof Error ? error : new Error(String(error)),
             { terminalId }
+          )
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Unknown error'
+          }
+        }
+      })
+  )
+
+  defineHandler(
+    'terminal:createClaudeCli',
+    z.tuple([
+      z.string().min(1),
+      z.object({
+        pendingPrompt: z.string().nullable().optional()
+      }).optional()
+    ]),
+    ([sessionId, opts]) =>
+      asyncEffect(async () => {
+        log.info('IPC: terminal:createClaudeCli', { sessionId, hasPrompt: !!opts?.pendingPrompt })
+        try {
+          const db = getDatabase()
+          const session = db.getSession(sessionId)
+          if (!session) {
+            return { success: false, error: 'Session not found' }
+          }
+          if (session.agent_sdk !== 'claude-code-cli') {
+            return { success: false, error: 'Session is not a Claude Code CLI session' }
+          }
+
+          let worktreePath: string | null = null
+          if (session.worktree_id) {
+            worktreePath = db.getWorktree(session.worktree_id)?.path ?? null
+          } else if (session.connection_id) {
+            worktreePath = db.getConnection(session.connection_id)?.path ?? null
+          }
+          if (!worktreePath) {
+            return { success: false, error: 'Could not resolve session working directory' }
+          }
+
+          const claudeBinary = resolveClaudeBinaryPath()
+          if (!claudeBinary) {
+            return { success: false, error: 'Claude binary not found on PATH' }
+          }
+
+          const alreadyExists = ptyService.has(sessionId)
+          const spawn = buildClaudeCliPtySpawn({
+            session,
+            worktreePath,
+            pendingPrompt: opts?.pendingPrompt ?? null,
+            claudeBinary,
+            db
+          })
+
+          log.info('Creating Claude CLI PTY', {
+            sessionId,
+            command: spawn.command,
+            args: spawn.args.map((arg, index) =>
+              index === spawn.args.length - 1 && opts?.pendingPrompt ? '<prompt>' : arg
+            )
+          })
+
+          if (!session.claude_session_id) {
+            claudeWatchers.get(sessionId)?.close()
+            claudeWatchers.set(
+              sessionId,
+              watchForClaudeSessionId(worktreePath, (claudeSessionId) => {
+                try {
+                  db.updateSession(sessionId, { claude_session_id: claudeSessionId })
+                } catch (error) {
+                  log.warn('Failed to persist Claude CLI session id', {
+                    sessionId,
+                    error: error instanceof Error ? error.message : String(error)
+                  })
+                }
+                if (!mainWindow.isDestroyed()) {
+                  mainWindow.webContents.send(
+                    `terminal:claude-session-id:${sessionId}`,
+                    claudeSessionId
+                  )
+                }
+                claudeWatchers.delete(sessionId)
+              })
+            )
+          }
+
+          const { cols, rows } = ptyService.create(sessionId, {
+            cwd: spawn.cwd,
+            command: spawn.command,
+            args: spawn.args,
+            env: spawn.env
+          })
+
+          if (!alreadyExists) {
+            attachNodePtyListeners(mainWindow, sessionId)
+          }
+
+          return { success: true, cols, rows }
+        } catch (error) {
+          log.error(
+            'IPC: terminal:createClaudeCli failed',
+            error instanceof Error ? error : new Error(String(error)),
+            { sessionId }
           )
           return {
             success: false,
@@ -163,6 +273,8 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
       // Discard any pending buffered data
       dataBuffers.delete(terminalId)
       flushScheduled.delete(terminalId)
+      claudeWatchers.get(terminalId)?.close()
+      claudeWatchers.delete(terminalId)
       ptyService.destroy(terminalId)
     })
   )

--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { ipcMain, BrowserWindow } from 'electron'
 import { Data, Effect } from 'effect'
 import { z } from 'zod'
@@ -18,6 +19,12 @@ import {
   getClaudeHookServer,
   publishClaudeCliStatus
 } from '../services/claude-hook-server'
+import {
+  applyClaudeCliTitle,
+  processClaudeCliPtyData,
+  resetAllClaudeCliTitleState,
+  resetClaudeCliTitleState
+} from '../services/claude-cli-title-handler'
 
 const log = createLogger({ component: 'TerminalHandlers' })
 
@@ -69,6 +76,7 @@ const dataBuffers = new Map<string, string>()
 const flushScheduled = new Set<string>()
 const claudeWatchers = new Map<string, ClaudeSessionWatchHandle>()
 const claudeCliSessions = new Set<string>()
+const claudeCliWorktreeBasenames = new Map<string, string>()
 
 function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): void {
   // Clean up any stale listeners for this terminalId (shouldn't happen, but defensive)
@@ -84,6 +92,22 @@ function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): 
 
     const existing = dataBuffers.get(terminalId)
     dataBuffers.set(terminalId, existing ? existing + data : data)
+
+    if (claudeCliSessions.has(terminalId)) {
+      const title = processClaudeCliPtyData(terminalId, data, {
+        worktreeBasename: claudeCliWorktreeBasenames.get(terminalId)
+      })
+      if (title) {
+        applyClaudeCliTitle({
+          sessionId: terminalId,
+          title,
+          db: getDatabase(),
+          mainWindow
+        }).catch(() => {
+          // applyClaudeCliTitle already logs and swallows internally
+        })
+      }
+    }
 
     if (!flushScheduled.has(terminalId)) {
       flushScheduled.add(terminalId)
@@ -115,6 +139,8 @@ function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): 
       })
       claudeCliSessions.delete(terminalId)
     }
+    claudeCliWorktreeBasenames.delete(terminalId)
+    resetClaudeCliTitleState(terminalId)
   })
 
   listenerCleanups.set(terminalId, { removeData, removeExit })
@@ -249,6 +275,7 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
             env: spawn.env
           })
           claudeCliSessions.add(sessionId)
+          claudeCliWorktreeBasenames.set(sessionId, path.basename(worktreePath))
           if (!pendingPrompt) {
             publishClaudeCliStatus(mainWindow, {
               sessionId,
@@ -305,6 +332,8 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
       claudeWatchers.get(terminalId)?.close()
       claudeWatchers.delete(terminalId)
       claudeCliSessions.delete(terminalId)
+      claudeCliWorktreeBasenames.delete(terminalId)
+      resetClaudeCliTitleState(terminalId)
       ptyService.destroy(terminalId)
     })
   )
@@ -456,6 +485,8 @@ export function cleanupTerminals(): void {
   dataBuffers.clear()
   flushScheduled.clear()
   claudeCliSessions.clear()
+  claudeCliWorktreeBasenames.clear()
+  resetAllClaudeCliTitleState()
   ptyService.destroyAll()
   ghosttyService.shutdown()
 }

--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -16,6 +16,7 @@ import {
 } from '../services/claude-session-watcher'
 import {
   buildClaudeCliHookSettings,
+  clearClaudeCliStatus,
   getClaudeHookServer,
   publishClaudeCliStatus,
   subscribeClaudeCliStatus,
@@ -81,50 +82,102 @@ const listenerCleanups = new Map<string, { removeData: () => void; removeExit: (
 // Batching with setImmediate collects all data from the current I/O phase into one IPC message.
 const dataBuffers = new Map<string, string>()
 const flushScheduled = new Set<string>()
-const claudeWatchers = new Map<string, ClaudeSessionWatchHandle>()
-const claudePlanFollowupWatchers = new Map<string, ClaudePlanFollowupWatchHandle>()
-const claudeCliSessions = new Set<string>()
-const claudeCliWorktreeBasenames = new Map<string, string>()
-const claudeCliTranscriptSources = new Map<
-  string,
-  { worktreePath: string; claudeSessionId: string | null }
->()
-const claudeCliLastStatus = new Map<string, ClaudeCliStatusPayload>()
+
+/**
+ * All per-session Claude CLI state, consolidated into one record per session so
+ * teardown is atomic (see {@link disposeClaudeCliSession}). This previously lived
+ * across six parallel maps/sets — session-id watcher, plan-followup watcher, a
+ * membership Set, worktree basename, transcript source, last status — cleaned up
+ * in three separate places (onExit, terminal:destroy, cleanupTerminals) that had
+ * already begun to drift. Owning the state in one object means a new field is
+ * disposed in exactly one place and `has`-style checks can't miss a session.
+ */
+interface ClaudeCliSessionState {
+  /** True once the PTY is created — the live-session flag the rest of the file gates on. */
+  active: boolean
+  /** Basename of the worktree, used to clean up the CLI-reported terminal title. */
+  worktreeBasename?: string
+  /** fs watcher detecting the freshly-created `claude_session_id`; nulled once found. */
+  sessionIdWatcher: ClaudeSessionWatchHandle | null
+  /** Watcher armed after a plan is ready to detect the follow-up that resumes work. */
+  planFollowupWatcher: ClaudePlanFollowupWatchHandle | null
+  /** Where the transcript lives, used to arm the plan-followup watcher. */
+  transcriptSource: { worktreePath: string; claudeSessionId: string | null } | null
+  /** Last status published for this session (drives plan-followup arming on session-id detection). */
+  lastStatus: ClaudeCliStatusPayload | null
+}
+
+const claudeCliSessionsState = new Map<string, ClaudeCliSessionState>()
 let unsubscribeClaudeCliStatus: (() => void) | null = null
 
+function getClaudeCliSession(sessionId: string): ClaudeCliSessionState | undefined {
+  return claudeCliSessionsState.get(sessionId)
+}
+
+function getOrCreateClaudeCliSession(sessionId: string): ClaudeCliSessionState {
+  let state = claudeCliSessionsState.get(sessionId)
+  if (!state) {
+    state = {
+      active: false,
+      worktreeBasename: undefined,
+      sessionIdWatcher: null,
+      planFollowupWatcher: null,
+      transcriptSource: null,
+      lastStatus: null
+    }
+    claudeCliSessionsState.set(sessionId, state)
+  }
+  return state
+}
+
+/** Membership check mirroring the old `claudeCliSessions.has()` — true only for a live CLI PTY. */
+function isActiveClaudeCliSession(sessionId: string): boolean {
+  return claudeCliSessionsState.get(sessionId)?.active === true
+}
+
+/** Atomic teardown: close both watchers and drop the session record. Idempotent. */
+function disposeClaudeCliSession(sessionId: string): void {
+  const state = claudeCliSessionsState.get(sessionId)
+  if (!state) return
+  state.sessionIdWatcher?.close()
+  state.planFollowupWatcher?.close()
+  claudeCliSessionsState.delete(sessionId)
+}
+
 function closeClaudePlanFollowupWatcher(sessionId: string): void {
-  claudePlanFollowupWatchers.get(sessionId)?.close()
-  claudePlanFollowupWatchers.delete(sessionId)
+  const state = claudeCliSessionsState.get(sessionId)
+  if (!state?.planFollowupWatcher) return
+  state.planFollowupWatcher.close()
+  state.planFollowupWatcher = null
 }
 
 function armClaudePlanFollowupWatcher(mainWindow: BrowserWindow, sessionId: string): void {
-  const source = claudeCliTranscriptSources.get(sessionId)
-  if (!source?.claudeSessionId) return
+  const state = claudeCliSessionsState.get(sessionId)
+  if (!state?.transcriptSource?.claudeSessionId) return
+  const { worktreePath, claudeSessionId } = state.transcriptSource
 
   closeClaudePlanFollowupWatcher(sessionId)
-  claudePlanFollowupWatchers.set(
-    sessionId,
-    watchForClaudePlanFollowup(source.worktreePath, source.claudeSessionId, () => {
-      closeClaudePlanFollowupWatcher(sessionId)
-      publishClaudeCliStatus(mainWindow, {
-        sessionId,
-        status: 'planning',
-        metadata: { reason: 'claude_cli_plan_followup' }
-      })
-      if (!mainWindow.isDestroyed()) {
-        mainWindow.webContents.send('claude-cli:plan-followup', { sessionId })
-      }
+  state.planFollowupWatcher = watchForClaudePlanFollowup(worktreePath, claudeSessionId, () => {
+    closeClaudePlanFollowupWatcher(sessionId)
+    publishClaudeCliStatus(mainWindow, {
+      sessionId,
+      status: 'planning',
+      metadata: { reason: 'claude_cli_plan_followup' }
     })
-  )
+    if (!mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('claude-cli:plan-followup', { sessionId })
+    }
+  })
 }
 
 function ensureClaudeCliStatusSubscription(mainWindow: BrowserWindow): void {
   if (unsubscribeClaudeCliStatus) return
 
   unsubscribeClaudeCliStatus = subscribeClaudeCliStatus((payload) => {
-    if (!claudeCliSessions.has(payload.sessionId)) return
+    const state = claudeCliSessionsState.get(payload.sessionId)
+    if (!state?.active) return
 
-    claudeCliLastStatus.set(payload.sessionId, payload)
+    state.lastStatus = payload
     if (payload.status === 'plan_ready') {
       armClaudePlanFollowupWatcher(mainWindow, payload.sessionId)
       return
@@ -167,9 +220,10 @@ function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): 
     const existing = dataBuffers.get(terminalId)
     dataBuffers.set(terminalId, existing ? existing + data : data)
 
-    if (claudeCliSessions.has(terminalId)) {
+    const cliState = getClaudeCliSession(terminalId)
+    if (cliState?.active) {
       const title = processClaudeCliPtyData(terminalId, data, {
-        worktreeBasename: claudeCliWorktreeBasenames.get(terminalId)
+        worktreeBasename: cliState.worktreeBasename
       })
       if (title) {
         applyClaudeCliTitle({
@@ -203,20 +257,17 @@ function attachNodePtyListeners(mainWindow: BrowserWindow, terminalId: string): 
     listenerCleanups.delete(terminalId)
     dataBuffers.delete(terminalId)
     flushScheduled.delete(terminalId)
-    claudeWatchers.get(terminalId)?.close()
-    claudeWatchers.delete(terminalId)
-    closeClaudePlanFollowupWatcher(terminalId)
-    if (claudeCliSessions.has(terminalId)) {
+    // Publish the terminal `completed` status while the record is still present
+    // (so `active` is readable), then dispose every per-session resource at once.
+    if (isActiveClaudeCliSession(terminalId)) {
       publishClaudeCliStatus(mainWindow, {
         sessionId: terminalId,
         status: 'completed',
         metadata: { reason: 'pty_exit' }
       })
-      claudeCliSessions.delete(terminalId)
     }
-    claudeCliWorktreeBasenames.delete(terminalId)
-    claudeCliTranscriptSources.delete(terminalId)
-    claudeCliLastStatus.delete(terminalId)
+    disposeClaudeCliSession(terminalId)
+    clearClaudeCliStatus(terminalId)
     resetClaudeCliTitleState(terminalId)
   })
 
@@ -322,37 +373,40 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
             )
           })
 
+          const cliState = getOrCreateClaudeCliSession(sessionId)
           if (!session.claude_session_id) {
-            claudeWatchers.get(sessionId)?.close()
-            claudeWatchers.set(
-              sessionId,
-              watchForClaudeSessionId(worktreePath, (claudeSessionId) => {
-                try {
-                  db.updateSession(sessionId, { claude_session_id: claudeSessionId })
-                } catch (error) {
-                  log.warn('Failed to persist Claude CLI session id', {
-                    sessionId,
-                    error: error instanceof Error ? error.message : String(error)
-                  })
-                }
-                if (!mainWindow.isDestroyed()) {
-                  mainWindow.webContents.send(
-                    `terminal:claude-session-id:${sessionId}`,
-                    claudeSessionId
-                  )
-                }
-                claudeCliTranscriptSources.set(sessionId, { worktreePath, claudeSessionId })
-                if (claudeCliLastStatus.get(sessionId)?.status === 'plan_ready') {
+            cliState.sessionIdWatcher?.close()
+            cliState.sessionIdWatcher = watchForClaudeSessionId(worktreePath, (claudeSessionId) => {
+              try {
+                db.updateSession(sessionId, { claude_session_id: claudeSessionId })
+              } catch (error) {
+                log.warn('Failed to persist Claude CLI session id', {
+                  sessionId,
+                  error: error instanceof Error ? error.message : String(error)
+                })
+              }
+              if (!mainWindow.isDestroyed()) {
+                mainWindow.webContents.send(
+                  `terminal:claude-session-id:${sessionId}`,
+                  claudeSessionId
+                )
+              }
+              // The watcher closes itself once it finds the id; if the session
+              // was torn down first its record is gone, so skip resurrecting it.
+              const found = getClaudeCliSession(sessionId)
+              if (found) {
+                found.transcriptSource = { worktreePath, claudeSessionId }
+                if (found.lastStatus?.status === 'plan_ready') {
                   armClaudePlanFollowupWatcher(mainWindow, sessionId)
                 }
-                claudeWatchers.delete(sessionId)
-              })
-            )
+                found.sessionIdWatcher = null
+              }
+            })
           }
-          claudeCliTranscriptSources.set(sessionId, {
+          cliState.transcriptSource = {
             worktreePath,
             claudeSessionId: session.claude_session_id
-          })
+          }
 
           const { cols, rows } = ptyService.create(sessionId, {
             cwd: spawn.cwd,
@@ -360,8 +414,8 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
             args: spawn.args,
             env: spawn.env
           })
-          claudeCliSessions.add(sessionId)
-          claudeCliWorktreeBasenames.set(sessionId, path.basename(worktreePath))
+          cliState.active = true
+          cliState.worktreeBasename = path.basename(worktreePath)
           if (!pendingPrompt) {
             publishClaudeCliStatus(mainWindow, {
               sessionId,
@@ -376,6 +430,12 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
 
           return { success: true, cols, rows }
         } catch (error) {
+          // Tear down any per-session state armed before the failure. The
+          // session-id fs watcher (and its interval) is set up before
+          // ptyService.create, so if the spawn throws it would otherwise leak
+          // until app quit — no terminal:destroy is issued for a session that
+          // never started. Disposing the whole record is atomic and idempotent.
+          disposeClaudeCliSession(sessionId)
           log.error(
             'IPC: terminal:createClaudeCli failed',
             error instanceof Error ? error : new Error(String(error)),
@@ -386,6 +446,24 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
             error: error instanceof Error ? error.message : 'Unknown error'
           }
         }
+      })
+  )
+
+  // Inject a prompt into a running Claude CLI session as if the user typed it.
+  // Returns delivered:false when the session has no live PTY so the caller can
+  // queue the prompt for delivery as the next spawn argument instead.
+  defineHandler(
+    'terminal:sendClaudeCliPrompt',
+    z.tuple([z.string().min(1), z.string()]),
+    ([sessionId, prompt]) =>
+      syncEffect(() => {
+        if (!ptyService.has(sessionId) || !isActiveClaudeCliSession(sessionId)) {
+          return { delivered: false }
+        }
+        // Bracketed paste keeps a multi-line prompt from being submitted
+        // line-by-line; the trailing CR submits the turn (as pressing Enter).
+        ptyService.write(sessionId, `\u001b[200~${prompt}\u001b[201~\r`)
+        return { delivered: true }
       })
   )
 
@@ -415,13 +493,8 @@ export function registerTerminalHandlers(mainWindow: BrowserWindow): void {
       // Discard any pending buffered data
       dataBuffers.delete(terminalId)
       flushScheduled.delete(terminalId)
-      claudeWatchers.get(terminalId)?.close()
-      claudeWatchers.delete(terminalId)
-      closeClaudePlanFollowupWatcher(terminalId)
-      claudeCliSessions.delete(terminalId)
-      claudeCliWorktreeBasenames.delete(terminalId)
-      claudeCliTranscriptSources.delete(terminalId)
-      claudeCliLastStatus.delete(terminalId)
+      disposeClaudeCliSession(terminalId)
+      clearClaudeCliStatus(terminalId)
       resetClaudeCliTitleState(terminalId)
       ptyService.destroy(terminalId)
     })
@@ -573,18 +646,11 @@ export function cleanupTerminals(): void {
   // Discard all pending buffered data
   dataBuffers.clear()
   flushScheduled.clear()
-  for (const [, watcher] of claudeWatchers) {
-    watcher.close()
+  for (const state of claudeCliSessionsState.values()) {
+    state.sessionIdWatcher?.close()
+    state.planFollowupWatcher?.close()
   }
-  claudeWatchers.clear()
-  for (const [, watcher] of claudePlanFollowupWatchers) {
-    watcher.close()
-  }
-  claudePlanFollowupWatchers.clear()
-  claudeCliSessions.clear()
-  claudeCliWorktreeBasenames.clear()
-  claudeCliTranscriptSources.clear()
-  claudeCliLastStatus.clear()
+  claudeCliSessionsState.clear()
   unsubscribeClaudeCliStatus?.()
   unsubscribeClaudeCliStatus = null
   resetAllClaudeCliTitleState()

--- a/src/main/ipc/terminal-handlers.ts
+++ b/src/main/ipc/terminal-handlers.ts
@@ -43,7 +43,8 @@ const ghosttyOptsSchema = z
     cwd: z.string().optional(),
     shell: z.string().optional(),
     scaleFactor: z.number().optional(),
-    fontSize: z.number().optional()
+    fontSize: z.number().optional(),
+    shiftEnterAsNewline: z.boolean().optional()
   })
   .optional()
 const ghosttyKeyEventSchema = z.object({

--- a/src/main/services/__tests__/claude-cli-spawner.test.ts
+++ b/src/main/services/__tests__/claude-cli-spawner.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import type { Session } from '../../db/types'
+import { buildClaudeCliPtySpawn } from '../claude-cli-spawner'
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'hive-session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: 'anthropic',
+    model_id: 'sonnet',
+    model_variant: 'high',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    pinned_to_board: false,
+    ...overrides
+  }
+}
+
+describe('buildClaudeCliPtySpawn', () => {
+  it('builds build-mode argv with model, effort, resume id, and positional prompt', () => {
+    const spawn = buildClaudeCliPtySpawn({
+      session: makeSession({ claude_session_id: 'claude-uuid-1' }),
+      worktreePath: '/repo/worktree',
+      pendingPrompt: 'Implement this plan',
+      claudeBinary: '/usr/local/bin/claude'
+    })
+
+    expect(spawn.command).toBe('/usr/local/bin/claude')
+    expect(spawn.cwd).toBe('/repo/worktree')
+    expect(spawn.args).toEqual([
+      '--dangerously-skip-permissions',
+      '--model',
+      'sonnet',
+      '--effort',
+      'high',
+      '--resume',
+      'claude-uuid-1',
+      'Implement this plan'
+    ])
+  })
+
+  it('adds permission-mode plan for plan-like sessions and normalizes model ids', () => {
+    const spawn = buildClaudeCliPtySpawn({
+      session: makeSession({
+        mode: 'super-plan',
+        model_id: 'claude-opus-4-5-20251101',
+        model_variant: 'max'
+      }),
+      worktreePath: '/repo/worktree',
+      pendingPrompt: null,
+      claudeBinary: 'claude'
+    })
+
+    expect(spawn.args).toEqual([
+      '--dangerously-skip-permissions',
+      '--permission-mode',
+      'plan',
+      '--model',
+      'opus',
+      '--effort',
+      'max'
+    ])
+  })
+
+  it('omits invalid optional model and effort flags', () => {
+    const spawn = buildClaudeCliPtySpawn({
+      session: makeSession({
+        model_id: 'not-a-claude-cli-model',
+        model_variant: 'turbo'
+      }),
+      worktreePath: '/repo/worktree',
+      pendingPrompt: '',
+      claudeBinary: 'claude',
+      claudeSessionId: null
+    })
+
+    expect(spawn.args).toEqual(['--dangerously-skip-permissions'])
+  })
+})

--- a/src/main/services/__tests__/claude-cli-spawner.test.ts
+++ b/src/main/services/__tests__/claude-cli-spawner.test.ts
@@ -49,10 +49,10 @@ describe('buildClaudeCliPtySpawn', () => {
     ])
   })
 
-  it('adds permission-mode plan for plan-like sessions and normalizes model ids', () => {
+  it('adds the Claude CLI plan bypass flags for plan sessions and normalizes model ids', () => {
     const spawn = buildClaudeCliPtySpawn({
       session: makeSession({
-        mode: 'super-plan',
+        mode: 'plan',
         model_id: 'claude-opus-4-5-20251101',
         model_variant: 'max'
       }),
@@ -62,13 +62,32 @@ describe('buildClaudeCliPtySpawn', () => {
     })
 
     expect(spawn.args).toEqual([
-      '--dangerously-skip-permissions',
+      '--allow-dangerously-skip-permissions',
       '--permission-mode',
       'plan',
       '--model',
       'opus',
       '--effort',
       'max'
+    ])
+  })
+
+  it('adds the Claude CLI plan bypass flags for super-plan sessions', () => {
+    const spawn = buildClaudeCliPtySpawn({
+      session: makeSession({
+        mode: 'super-plan',
+        model_id: 'opus',
+        model_variant: 'max'
+      }),
+      worktreePath: '/repo/worktree',
+      pendingPrompt: null,
+      claudeBinary: 'claude'
+    })
+
+    expect(spawn.args.slice(0, 3)).toEqual([
+      '--allow-dangerously-skip-permissions',
+      '--permission-mode',
+      'plan'
     ])
   })
 

--- a/src/main/services/__tests__/claude-cli-spawner.test.ts
+++ b/src/main/services/__tests__/claude-cli-spawner.test.ts
@@ -86,4 +86,40 @@ describe('buildClaudeCliPtySpawn', () => {
 
     expect(spawn.args).toEqual(['--dangerously-skip-permissions'])
   })
+
+  it('places hook settings immediately before the trailing prompt argument', () => {
+    const hookSettingsJson = '{"hooks":{}}'
+    const spawn = buildClaudeCliPtySpawn({
+      session: makeSession({ claude_session_id: 'claude-uuid-1' }),
+      worktreePath: '/repo/worktree',
+      pendingPrompt: 'Implement this plan',
+      claudeBinary: 'claude',
+      hookSettingsJson
+    })
+
+    expect(spawn.args).toEqual([
+      '--dangerously-skip-permissions',
+      '--model',
+      'sonnet',
+      '--effort',
+      'high',
+      '--resume',
+      'claude-uuid-1',
+      '--settings',
+      hookSettingsJson,
+      'Implement this plan'
+    ])
+  })
+
+  it('omits the settings flag when hook settings are absent', () => {
+    const spawn = buildClaudeCliPtySpawn({
+      session: makeSession(),
+      worktreePath: '/repo/worktree',
+      pendingPrompt: 'Say hi',
+      claudeBinary: 'claude'
+    })
+
+    expect(spawn.args).not.toContain('--settings')
+    expect(spawn.args.at(-1)).toBe('Say hi')
+  })
 })

--- a/src/main/services/__tests__/claude-cli-telegram-bridge.test.ts
+++ b/src/main/services/__tests__/claude-cli-telegram-bridge.test.ts
@@ -1,0 +1,235 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ServerResponse } from 'node:http'
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+// Question events flow through agentEventBus (renderer + telegram); capture them.
+const { publishedEvents } = vi.hoisted(() => ({ publishedEvents: [] as Array<{ type: string; sessionId: string; data: unknown }> }))
+vi.mock('../agent-event-bus', () => ({
+  agentEventBus: { publish: (event: { type: string; sessionId: string; data: unknown }) => publishedEvents.push(event) }
+}))
+
+import { claudeCliTelegramBridge, type ClaudeHookBody } from '../claude-cli-telegram-bridge'
+import type { OpenCodeStreamEvent } from '@shared/types/opencode'
+
+/** Minimal fake ServerResponse capturing what the bridge writes. */
+function makeRes(): ServerResponse & { body: string | null } {
+  const res = {
+    writableEnded: false,
+    body: null as string | null,
+    setTimeout: vi.fn(),
+    writeHead: vi.fn(function (this: unknown) {
+      return this
+    }),
+    end: vi.fn(function (this: { writableEnded: boolean; body: string | null }, body?: string) {
+      this.writableEnded = true
+      this.body = body ?? ''
+    }),
+    on: vi.fn(),
+    removeListener: vi.fn()
+  }
+  return res as unknown as ServerResponse & { body: string | null }
+}
+
+const SESSION = 'cli-session-1'
+
+afterEach(() => {
+  claudeCliTelegramBridge.cancelAll()
+  publishedEvents.length = 0
+  vi.clearAllMocks()
+  vi.useRealTimers()
+})
+
+describe('claudeCliTelegramBridge.onHook (registration gating)', () => {
+  it('does not take ownership for an unregistered session', () => {
+    const res = makeRes()
+    const owned = claudeCliTelegramBridge.onHook(
+      SESSION,
+      { hook_event_name: 'PreToolUse', tool_name: 'AskUserQuestion', tool_input: { questions: [{ question: 'Q?' }] } },
+      res
+    )
+    expect(owned).toBe(false)
+    expect(res.end).not.toHaveBeenCalled()
+    expect(publishedEvents).toHaveLength(0)
+  })
+
+  it('does not hold when forwarding-registered but the tool is not a question/plan', () => {
+    claudeCliTelegramBridge.register(SESSION)
+    const res = makeRes()
+    const owned = claudeCliTelegramBridge.onHook(
+      SESSION,
+      { hook_event_name: 'PostToolUse', tool_name: 'Bash' },
+      res
+    )
+    expect(owned).toBe(false)
+  })
+})
+
+describe('claudeCliTelegramBridge questions (renderer + telegram via agentEventBus)', () => {
+  beforeEach(() => claudeCliTelegramBridge.register(SESSION))
+
+  it('holds the response, publishes question.asked, and resolves with an allow + answers map', () => {
+    const res = makeRes()
+    const body: ClaudeHookBody = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [
+          { question: 'Pick a language', header: 'Lang', options: [{ label: 'TypeScript' }, { label: 'Rust' }] }
+        ]
+      }
+    }
+
+    const owned = claudeCliTelegramBridge.onHook(SESSION, body, res)
+    expect(owned).toBe(true)
+    expect(res.end).not.toHaveBeenCalled() // held open
+
+    const asked = publishedEvents.find((e) => e.type === 'question.asked')
+    expect(asked).toBeTruthy()
+    const requestId = (asked!.data as { requestId: string }).requestId
+    expect(claudeCliTelegramBridge.hasPendingQuestion(requestId)).toBe(true)
+
+    claudeCliTelegramBridge.resolveQuestion(requestId, [['TypeScript']])
+
+    expect(res.end).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(res.body!)
+    expect(written.hookSpecificOutput.permissionDecision).toBe('allow')
+    expect(written.hookSpecificOutput.hookEventName).toBe('PreToolUse')
+    // answers keyed by question TEXT, value = the selected option label
+    expect(written.hookSpecificOutput.updatedInput.answers).toEqual({ 'Pick a language': 'TypeScript' })
+    expect(written.hookSpecificOutput.updatedInput.questions).toEqual(body.tool_input!.questions)
+    // a question.replied is published so the in-app UI + telegram message clear
+    expect(publishedEvents.some((e) => e.type === 'question.replied')).toBe(true)
+    expect(claudeCliTelegramBridge.hasPendingQuestion(requestId)).toBe(false)
+  })
+
+  it('rejectQuestion resolves with {} and publishes question.rejected', () => {
+    const res = makeRes()
+    claudeCliTelegramBridge.onHook(
+      SESSION,
+      { hook_event_name: 'PreToolUse', tool_name: 'AskUserQuestion', tool_input: { questions: [{ question: 'Q?' }] } },
+      res
+    )
+    const requestId = (publishedEvents.find((e) => e.type === 'question.asked')!.data as { requestId: string })
+      .requestId
+    claudeCliTelegramBridge.rejectQuestion(requestId)
+    expect(res.end).toHaveBeenCalledWith('{}')
+    expect(publishedEvents.some((e) => e.type === 'question.rejected')).toBe(true)
+  })
+
+  it('falls back (returns false) when AskUserQuestion has no questions', () => {
+    const res = makeRes()
+    const owned = claudeCliTelegramBridge.onHook(
+      SESSION,
+      { hook_event_name: 'PreToolUse', tool_name: 'AskUserQuestion', tool_input: { questions: [] } },
+      res
+    )
+    expect(owned).toBe(false)
+    expect(publishedEvents).toHaveLength(0)
+  })
+})
+
+describe('claudeCliTelegramBridge plans (telegram-only private channel)', () => {
+  let events: OpenCodeStreamEvent[]
+  let unsub: () => void
+  beforeEach(() => {
+    events = []
+    unsub = claudeCliTelegramBridge.subscribe((e) => events.push(e))
+    claudeCliTelegramBridge.register(SESSION)
+  })
+  afterEach(() => unsub())
+
+  it('emits plan.ready on the private channel, NOT to the renderer', () => {
+    const res = makeRes()
+    const owned = claudeCliTelegramBridge.onHook(
+      SESSION,
+      { hook_event_name: 'PreToolUse', tool_name: 'ExitPlanMode', tool_input: { plan: '# Plan\n1. Do it' } },
+      res
+    )
+    expect(owned).toBe(true)
+    const ready = events.find((e) => e.type === 'plan.ready')!
+    expect((ready.data as { plan: string }).plan).toContain('# Plan')
+    // plan events must NOT reach the renderer (would collide with the CLI plan card)
+    expect(publishedEvents.some((e) => e.type === 'plan.ready')).toBe(false)
+
+    const requestId = (ready.data as { requestId: string }).requestId
+    claudeCliTelegramBridge.resolvePlan(requestId, true)
+    expect(JSON.parse(res.body!).hookSpecificOutput.permissionDecision).toBe('allow')
+  })
+
+  it('rejects a held plan with deny + feedback as the reason', () => {
+    const res = makeRes()
+    claudeCliTelegramBridge.onHook(
+      SESSION,
+      { hook_event_name: 'PreToolUse', tool_name: 'ExitPlanMode', tool_input: { plan: 'plan' } },
+      res
+    )
+    const requestId = (events.find((e) => e.type === 'plan.ready')!.data as { requestId: string }).requestId
+    claudeCliTelegramBridge.resolvePlan(requestId, false, 'Please add tests')
+    const written = JSON.parse(res.body!)
+    expect(written.hookSpecificOutput.permissionDecision).toBe('deny')
+    expect(written.hookSpecificOutput.permissionDecisionReason).toBe('Please add tests')
+  })
+})
+
+describe('claudeCliTelegramBridge Stop + busy bridging (private channel)', () => {
+  it('emits assistant text + idle on Stop (both message field spellings)', () => {
+    const events: OpenCodeStreamEvent[] = []
+    const unsub = claudeCliTelegramBridge.subscribe((e) => events.push(e))
+    claudeCliTelegramBridge.register(SESSION)
+
+    const owned = claudeCliTelegramBridge.onHook(
+      SESSION,
+      { hook_event_name: 'Stop', last_assistant_message: 'All done.' },
+      makeRes()
+    )
+    expect(owned).toBe(false)
+    const msg = events.find((e) => e.type === 'message.updated')
+    expect((msg!.data as { content: string }).content).toBe('All done.')
+    expect(events.some((e) => e.type === 'session.idle')).toBe(true)
+    expect(publishedEvents).toHaveLength(0) // never reaches the renderer
+    unsub()
+  })
+
+  it('emits session.busy on UserPromptSubmit / PostToolUse', () => {
+    const events: OpenCodeStreamEvent[] = []
+    const unsub = claudeCliTelegramBridge.subscribe((e) => events.push(e))
+    claudeCliTelegramBridge.register(SESSION)
+    claudeCliTelegramBridge.onHook(SESSION, { hook_event_name: 'UserPromptSubmit' }, makeRes())
+    expect(events.some((e) => e.type === 'session.busy')).toBe(true)
+    unsub()
+  })
+})
+
+describe('claudeCliTelegramBridge teardown', () => {
+  it('cancelSession unblocks a held question with {}, clears the in-app UI, and stops intercepting', () => {
+    claudeCliTelegramBridge.register(SESSION)
+    const res = makeRes()
+    claudeCliTelegramBridge.onHook(
+      SESSION,
+      { hook_event_name: 'PreToolUse', tool_name: 'AskUserQuestion', tool_input: { questions: [{ question: 'Q?' }] } },
+      res
+    )
+    claudeCliTelegramBridge.cancelSession(SESSION)
+    expect(res.end).toHaveBeenCalledWith('{}')
+    expect(publishedEvents.some((e) => e.type === 'question.rejected')).toBe(true)
+    expect(claudeCliTelegramBridge.isRegistered(SESSION)).toBe(false)
+  })
+
+  it('the safety timeout resolves a held question with {} and clears the in-app UI', () => {
+    vi.useFakeTimers()
+    claudeCliTelegramBridge.register(SESSION)
+    const res = makeRes()
+    claudeCliTelegramBridge.onHook(
+      SESSION,
+      { hook_event_name: 'PreToolUse', tool_name: 'AskUserQuestion', tool_input: { questions: [{ question: 'Q?' }] } },
+      res
+    )
+    vi.advanceTimersByTime(9 * 60 * 1000 + 1000)
+    expect(res.end).toHaveBeenCalledWith('{}')
+    expect(publishedEvents.some((e) => e.type === 'question.rejected')).toBe(true)
+  })
+})

--- a/src/main/services/__tests__/claude-cli-title-handler.test.ts
+++ b/src/main/services/__tests__/claude-cli-title-handler.test.ts
@@ -1,0 +1,282 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  autoRenameWorktreeBranch: vi.fn()
+}))
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('../git-service', () => ({
+  autoRenameWorktreeBranch: mocks.autoRenameWorktreeBranch
+}))
+
+import {
+  applyClaudeCliTitle,
+  processClaudeCliPtyData,
+  resetAllClaudeCliTitleState,
+  resetClaudeCliTitleState
+} from '../claude-cli-title-handler'
+
+const BEL = '\x07'
+const ESC = '\x1b'
+const ST = `${ESC}\\`
+
+function osc(code: 0 | 1 | 2, title: string, terminator: string = BEL): string {
+  return `${ESC}]${code};${title}${terminator}`
+}
+
+describe('processClaudeCliPtyData — OSC parsing', () => {
+  beforeEach(() => {
+    resetAllClaudeCliTitleState()
+  })
+
+  it('extracts an OSC 0 title terminated by BEL', () => {
+    expect(processClaudeCliPtyData('s1', osc(0, 'Fix the README'))).toBe('Fix the README')
+  })
+
+  it('extracts an OSC 2 title terminated by BEL', () => {
+    expect(processClaudeCliPtyData('s1', osc(2, 'Refactor auth flow'))).toBe('Refactor auth flow')
+  })
+
+  it('extracts an OSC 0 title terminated by ST', () => {
+    expect(processClaudeCliPtyData('s1', osc(0, 'Add tests', ST))).toBe('Add tests')
+  })
+
+  it('ignores OSC 1 (icon name only)', () => {
+    expect(processClaudeCliPtyData('s1', osc(1, 'Should be ignored'))).toBeNull()
+  })
+
+  it('returns null when no OSC is present', () => {
+    expect(processClaudeCliPtyData('s1', 'plain shell output with \x1b[31mansi color\x1b[0m')).toBeNull()
+  })
+
+  it('handles OSC split across two chunks', () => {
+    expect(processClaudeCliPtyData('s1', `${ESC}]2;ho`)).toBeNull()
+    expect(processClaudeCliPtyData('s1', `me-page${BEL}`)).toBe('home-page')
+  })
+
+  it('does not lose the title when an unterminated tail precedes it', () => {
+    expect(processClaudeCliPtyData('s1', `prefix ${ESC}]2;par`)).toBeNull()
+    expect(processClaudeCliPtyData('s1', `tial${BEL}`)).toBe('partial')
+  })
+})
+
+describe('processClaudeCliPtyData — noise filter', () => {
+  beforeEach(() => {
+    resetAllClaudeCliTitleState()
+  })
+
+  it('rejects the literal "claude" (case-insensitive)', () => {
+    expect(processClaudeCliPtyData('s1', osc(2, 'claude'))).toBeNull()
+    expect(processClaudeCliPtyData('s2', osc(2, 'Claude'))).toBeNull()
+  })
+
+  it('rejects "Claude Code" boilerplate even when prefixed by a spinner glyph', () => {
+    expect(processClaudeCliPtyData('s1', osc(0, '⠐ Claude Code'))).toBeNull()
+    expect(processClaudeCliPtyData('s2', osc(0, '⠋ Claude Code'))).toBeNull()
+  })
+
+  it('rejects empty / whitespace titles', () => {
+    expect(processClaudeCliPtyData('s1', osc(2, ''))).toBeNull()
+    expect(processClaudeCliPtyData('s2', osc(2, '   '))).toBeNull()
+    expect(processClaudeCliPtyData('s3', osc(2, '⠐  '))).toBeNull()
+  })
+
+  it('strips leading spinner glyph + whitespace and accepts the remainder', () => {
+    expect(processClaudeCliPtyData('s1', osc(0, '⠐ Explore project structure'))).toBe(
+      'Explore project structure'
+    )
+    expect(processClaudeCliPtyData('s2', osc(2, '✻ Build the parser'))).toBe('Build the parser')
+    expect(processClaudeCliPtyData('s3', osc(2, '⠋ Refactor auth'))).toBe('Refactor auth')
+  })
+
+  it('treats the entire Braille Patterns block (U+2800–U+28FF) as a spinner', () => {
+    // sample a glyph not in any obvious spinner cycle
+    expect(processClaudeCliPtyData('s1', osc(2, '⣿ Some title'))).toBe('Some title')
+  })
+
+  it('rejects absolute path titles', () => {
+    expect(processClaudeCliPtyData('s1', osc(2, '/Users/mor/repo'))).toBeNull()
+    expect(processClaudeCliPtyData('s2', osc(2, '~/repo/worktree'))).toBeNull()
+  })
+
+  it('rejects the worktree basename when provided (also after spinner strip)', () => {
+    expect(
+      processClaudeCliPtyData('s1', osc(2, 'my-worktree'), { worktreeBasename: 'my-worktree' })
+    ).toBeNull()
+    expect(
+      processClaudeCliPtyData('s2', osc(2, '⠐ my-worktree'), { worktreeBasename: 'my-worktree' })
+    ).toBeNull()
+  })
+
+  it('walks past noise to the first acceptable title in the same chunk', () => {
+    const combined =
+      osc(0, '⠐ Claude Code') + osc(0, '⠋ Claude Code') + osc(0, '⠐ Explore project structure')
+    expect(processClaudeCliPtyData('s1', combined)).toBe('Explore project structure')
+  })
+})
+
+describe('processClaudeCliPtyData — one-shot guard', () => {
+  beforeEach(() => {
+    resetAllClaudeCliTitleState()
+  })
+
+  it('returns null on subsequent OSC titles after the first is accepted', () => {
+    expect(processClaudeCliPtyData('s1', osc(2, 'first title'))).toBe('first title')
+    expect(processClaudeCliPtyData('s1', osc(2, 'second title'))).toBeNull()
+  })
+
+  it('keeps each session independent', () => {
+    expect(processClaudeCliPtyData('s1', osc(2, 'session one title'))).toBe('session one title')
+    expect(processClaudeCliPtyData('s2', osc(2, 'session two title'))).toBe('session two title')
+  })
+
+  it('resetClaudeCliTitleState clears the one-shot for that session only', () => {
+    expect(processClaudeCliPtyData('s1', osc(2, 'first'))).toBe('first')
+    expect(processClaudeCliPtyData('s2', osc(2, 'other'))).toBe('other')
+    resetClaudeCliTitleState('s1')
+    expect(processClaudeCliPtyData('s1', osc(2, 'second'))).toBe('second')
+    // s2 still in applied state
+    expect(processClaudeCliPtyData('s2', osc(2, 'another'))).toBeNull()
+  })
+})
+
+describe('applyClaudeCliTitle', () => {
+  let db: any
+  let mainWindow: any
+  let webContentsSend: any
+
+  beforeEach(() => {
+    resetAllClaudeCliTitleState()
+    mocks.autoRenameWorktreeBranch.mockReset()
+    webContentsSend = vi.fn()
+    mainWindow = {
+      isDestroyed: vi.fn(() => false),
+      webContents: { send: webContentsSend }
+    }
+    db = {
+      getSession: vi.fn(),
+      updateSession: vi.fn(),
+      updateWorktree: vi.fn(),
+      getWorktreeBySessionId: vi.fn(() => null),
+      getWorktree: vi.fn(() => null),
+      getConnection: vi.fn(() => null)
+    }
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function makeSession(overrides: any = {}): any {
+    return {
+      id: 'hive-1',
+      agent_sdk: 'claude-code-cli',
+      worktree_id: 'wt-1',
+      connection_id: null,
+      name: null,
+      ...overrides
+    }
+  }
+
+  function makeWorktree(overrides: any = {}): any {
+    return {
+      id: 'wt-1',
+      path: '/repo/wt',
+      branch_name: 'running-zebra',
+      branch_renamed: 0,
+      ...overrides
+    }
+  }
+
+  it('bails when the session is missing', async () => {
+    db.getSession.mockReturnValue(null)
+    await applyClaudeCliTitle({ sessionId: 'hive-1', title: 'Title', db, mainWindow })
+    expect(db.updateSession).not.toHaveBeenCalled()
+    expect(webContentsSend).not.toHaveBeenCalled()
+  })
+
+  it('bails when the session is not a claude-code-cli session', async () => {
+    db.getSession.mockReturnValue(makeSession({ agent_sdk: 'codex' }))
+    await applyClaudeCliTitle({ sessionId: 'hive-1', title: 'Title', db, mainWindow })
+    expect(db.updateSession).not.toHaveBeenCalled()
+  })
+
+  it('updates the session name and emits opencode:stream session.updated', async () => {
+    db.getSession.mockReturnValue(makeSession())
+    db.getWorktreeBySessionId.mockReturnValue(null)
+    await applyClaudeCliTitle({ sessionId: 'hive-1', title: 'New title', db, mainWindow })
+    expect(db.updateSession).toHaveBeenCalledWith('hive-1', { name: 'New title' })
+    expect(webContentsSend).toHaveBeenCalledWith('opencode:stream', {
+      type: 'session.updated',
+      sessionId: 'hive-1',
+      data: { title: 'New title', info: { title: 'New title' } }
+    })
+  })
+
+  it('calls autoRenameWorktreeBranch for the direct worktree when branch_renamed=0', async () => {
+    db.getSession.mockReturnValue(makeSession())
+    db.getWorktreeBySessionId.mockReturnValue(makeWorktree())
+    mocks.autoRenameWorktreeBranch.mockResolvedValue({ renamed: true, newBranch: 'new-title' })
+
+    await applyClaudeCliTitle({ sessionId: 'hive-1', title: 'New title', db, mainWindow })
+
+    expect(mocks.autoRenameWorktreeBranch).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo/wt',
+      currentBranchName: 'running-zebra',
+      sessionTitle: 'New title',
+      db
+    })
+    expect(webContentsSend).toHaveBeenCalledWith('worktree:branchRenamed', {
+      worktreeId: 'wt-1',
+      newBranch: 'new-title'
+    })
+  })
+
+  it('skips branch rename when branch_renamed=1', async () => {
+    db.getSession.mockReturnValue(makeSession())
+    db.getWorktreeBySessionId.mockReturnValue(makeWorktree({ branch_renamed: 1 }))
+    await applyClaudeCliTitle({ sessionId: 'hive-1', title: 'New title', db, mainWindow })
+    expect(mocks.autoRenameWorktreeBranch).not.toHaveBeenCalled()
+  })
+
+  it('renames branches for all eligible connection members', async () => {
+    db.getSession.mockReturnValue(makeSession({ connection_id: 'conn-1' }))
+    const directWt = makeWorktree()
+    db.getWorktreeBySessionId.mockReturnValue(directWt)
+    db.getConnection.mockReturnValue({
+      members: [
+        { worktree_id: 'wt-1' },
+        { worktree_id: 'wt-2' },
+        { worktree_id: 'wt-3' }
+      ]
+    })
+    db.getWorktree.mockImplementation((id: string) => {
+      if (id === 'wt-2') return makeWorktree({ id: 'wt-2', path: '/repo/wt2', branch_name: 'happy-cat' })
+      if (id === 'wt-3') return makeWorktree({ id: 'wt-3', path: '/repo/wt3', branch_name: 'lazy-dog', branch_renamed: 1 })
+      return null
+    })
+    mocks.autoRenameWorktreeBranch.mockResolvedValue({ renamed: true, newBranch: 'new-title' })
+
+    await applyClaudeCliTitle({ sessionId: 'hive-1', title: 'New title', db, mainWindow })
+
+    const calls = mocks.autoRenameWorktreeBranch.mock.calls
+    const worktreeIds = calls.map((c) => c[0].worktreeId)
+    expect(worktreeIds).toEqual(['wt-1', 'wt-2'])
+  })
+
+  it('swallows errors and flips branch_renamed on autoRename throwing', async () => {
+    db.getSession.mockReturnValue(makeSession())
+    db.getWorktreeBySessionId.mockReturnValue(makeWorktree())
+    mocks.autoRenameWorktreeBranch.mockRejectedValue(new Error('git boom'))
+
+    await expect(
+      applyClaudeCliTitle({ sessionId: 'hive-1', title: 'New title', db, mainWindow })
+    ).resolves.toBeUndefined()
+    expect(db.updateWorktree).toHaveBeenCalledWith('wt-1', { branch_renamed: 1 })
+  })
+})

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -101,6 +101,11 @@ describe('mapHookEventToStatus', () => {
       { hook_event_name: 'PermissionRequest' },
       'permission'
     ],
+    [
+      'PermissionRequest for ExitPlanMode maps to plan_ready',
+      { hook_event_name: 'PermissionRequest', tool_name: 'ExitPlanMode' },
+      'plan_ready'
+    ],
     ['unknown events are ignored', { hook_event_name: 'BogusEvent' }, null],
     [
       'unmatched PreToolUse events are ignored',
@@ -221,6 +226,30 @@ describe('ClaudeHookServer HTTP round-trip', () => {
       sessionId: 'hive-session-1',
       status: 'completed',
       metadata: { hookEventName: 'SessionStart', hookPath: 'session' }
+    })
+  })
+
+  it('forwards ExitPlanMode raw plan text to the renderer', async () => {
+    const mockWindow = makeWindow()
+    const { port } = await getClaudeHookServer(mockWindow as never)
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'ExitPlanMode',
+      tool_input: {
+        plan: '# Plan\n\n1. Add CLI card.'
+      }
+    })
+
+    expect(mockWindow.webContents.send).toHaveBeenCalledWith('claude-cli:status', {
+      sessionId: 'hive-session-1',
+      status: 'plan_ready',
+      metadata: {
+        hookEventName: 'PreToolUse',
+        hookPath: 'tool',
+        toolName: 'ExitPlanMode',
+        plan: '# Plan\n\n1. Add CLI card.'
+      }
     })
   })
 

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -95,6 +95,11 @@ describe('mapHookEventToStatus', () => {
       { hook_event_name: 'PostToolUse', tool_name: 'Read' },
       'working'
     ],
+    [
+      'PostToolUseFailure ExitPlanMode maps to planning',
+      { hook_event_name: 'PostToolUseFailure', tool_name: 'ExitPlanMode' },
+      'planning'
+    ],
     ['PostToolUseFailure maps to working', { hook_event_name: 'PostToolUseFailure' }, 'working'],
     [
       'PermissionRequest maps to permission',
@@ -254,6 +259,29 @@ describe('ClaudeHookServer HTTP round-trip', () => {
         hookPath: 'tool',
         toolName: 'ExitPlanMode',
         plan: '# Plan\n\n1. Add CLI card.'
+      }
+    })
+  })
+
+  it('forwards ExitPlanMode rejection as planning so plan followups can resume review', async () => {
+    const mockWindow = makeWindow()
+    const { port } = await getClaudeHookServer(mockWindow as never)
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'ExitPlanMode',
+      tool_response: {
+        content: 'Please revise the plan before implementing.'
+      }
+    })
+
+    expect(mockWindow.webContents.send).toHaveBeenCalledWith('claude-cli:status', {
+      sessionId: 'hive-session-1',
+      status: 'planning',
+      metadata: {
+        hookEventName: 'PostToolUseFailure',
+        hookPath: 'tool',
+        toolName: 'ExitPlanMode'
       }
     })
   })

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -1,0 +1,319 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+import {
+  buildClaudeCliHookSettings,
+  closeClaudeHookServer,
+  getClaudeHookServer,
+  mapHookEventToStatus,
+  publishClaudeCliStatus,
+  type ParsedClaudeHook
+} from '../claude-hook-server'
+
+function makeWindow() {
+  return {
+    isDestroyed: vi.fn(() => false),
+    webContents: {
+      send: vi.fn()
+    }
+  }
+}
+
+async function postHook(
+  port: number,
+  sessionId: string,
+  path: 'session' | 'start' | 'stop' | 'tool' | 'permission',
+  body: Record<string, unknown> | string
+): Promise<{ status: number; text: string }> {
+  const response = await fetch(`http://127.0.0.1:${port}/hook/${sessionId}/${path}`, {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+    headers: {
+      'content-type': 'application/json'
+    }
+  })
+
+  return { status: response.status, text: await response.text() }
+}
+
+async function getHook(
+  port: number,
+  sessionId: string,
+  path: 'session' | 'start' | 'stop' | 'tool' | 'permission'
+): Promise<{ status: number; text: string }> {
+  const response = await fetch(`http://127.0.0.1:${port}/hook/${sessionId}/${path}`)
+
+  return { status: response.status, text: await response.text() }
+}
+
+afterEach(async () => {
+  await closeClaudeHookServer()
+  vi.clearAllMocks()
+})
+
+describe('mapHookEventToStatus', () => {
+  it.each<[string, ParsedClaudeHook, string | null]>([
+    ['SessionStart maps to completed', { hook_event_name: 'SessionStart' }, 'completed'],
+    ['SessionEnd maps to completed', { hook_event_name: 'SessionEnd' }, 'completed'],
+    [
+      'UserPromptSubmit in plan mode maps to planning',
+      { hook_event_name: 'UserPromptSubmit', permission_mode: 'plan' },
+      'planning'
+    ],
+    [
+      'UserPromptSubmit in default mode maps to working',
+      { hook_event_name: 'UserPromptSubmit', permission_mode: 'default' },
+      'working'
+    ],
+    ['Stop maps to completed', { hook_event_name: 'Stop' }, 'completed'],
+    [
+      'PreToolUse ExitPlanMode maps to plan_ready',
+      { hook_event_name: 'PreToolUse', tool_name: 'ExitPlanMode' },
+      'plan_ready'
+    ],
+    [
+      'PreToolUse AskUserQuestion maps to answering',
+      { hook_event_name: 'PreToolUse', tool_name: 'AskUserQuestion' },
+      'answering'
+    ],
+    [
+      'PostToolUse ExitPlanMode maps to working',
+      { hook_event_name: 'PostToolUse', tool_name: 'ExitPlanMode' },
+      'working'
+    ],
+    [
+      'PostToolUse other tool maps to working',
+      { hook_event_name: 'PostToolUse', tool_name: 'Read' },
+      'working'
+    ],
+    ['PostToolUseFailure maps to working', { hook_event_name: 'PostToolUseFailure' }, 'working'],
+    [
+      'PermissionRequest maps to permission',
+      { hook_event_name: 'PermissionRequest' },
+      'permission'
+    ],
+    ['unknown events are ignored', { hook_event_name: 'BogusEvent' }, null],
+    [
+      'unmatched PreToolUse events are ignored',
+      { hook_event_name: 'PreToolUse', tool_name: 'Read' },
+      null
+    ]
+  ])('%s', (_name, hook, expected) => {
+    expect(mapHookEventToStatus(hook)).toBe(expected)
+  })
+})
+
+describe('buildClaudeCliHookSettings', () => {
+  it('builds Claude hook settings with session-scoped localhost URLs and exact matchers', () => {
+    const settings = JSON.parse(buildClaudeCliHookSettings(34819, 'hive-session-1'))
+
+    expect(settings).toEqual({
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              {
+                type: 'http',
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/session'
+              }
+            ]
+          }
+        ],
+        SessionEnd: [
+          {
+            hooks: [
+              {
+                type: 'http',
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/session'
+              }
+            ]
+          }
+        ],
+        UserPromptSubmit: [
+          {
+            hooks: [
+              {
+                type: 'http',
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/start'
+              }
+            ]
+          }
+        ],
+        Stop: [
+          {
+            hooks: [
+              {
+                type: 'http',
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/stop'
+              }
+            ]
+          }
+        ],
+        PreToolUse: [
+          {
+            matcher: 'ExitPlanMode|AskUserQuestion',
+            hooks: [
+              {
+                type: 'http',
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/tool'
+              }
+            ]
+          }
+        ],
+        PostToolUse: [
+          {
+            matcher: '*',
+            hooks: [
+              {
+                type: 'http',
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/tool'
+              }
+            ]
+          }
+        ],
+        PostToolUseFailure: [
+          {
+            matcher: '*',
+            hooks: [
+              {
+                type: 'http',
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/tool'
+              }
+            ]
+          }
+        ],
+        PermissionRequest: [
+          {
+            matcher: '*',
+            hooks: [
+              {
+                type: 'http',
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/permission'
+              }
+            ]
+          }
+        ]
+      }
+    })
+  })
+})
+
+describe('ClaudeHookServer HTTP round-trip', () => {
+  it('forwards mapped hook status to the renderer', async () => {
+    const mockWindow = makeWindow()
+    const { port } = await getClaudeHookServer(mockWindow as never)
+
+    const response = await postHook(port, 'hive-session-1', 'session', {
+      hook_event_name: 'SessionStart'
+    })
+
+    expect(response).toEqual({ status: 200, text: '{}' })
+    expect(mockWindow.webContents.send).toHaveBeenCalledWith('claude-cli:status', {
+      sessionId: 'hive-session-1',
+      status: 'completed',
+      metadata: { hookEventName: 'SessionStart', hookPath: 'session' }
+    })
+  })
+
+  it('does not send duplicate sequential statuses for the same session', async () => {
+    const mockWindow = makeWindow()
+    const { port } = await getClaudeHookServer(mockWindow as never)
+
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default'
+    })
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default'
+    })
+
+    expect(mockWindow.webContents.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends again after the session status changes', async () => {
+    const mockWindow = makeWindow()
+    const { port } = await getClaudeHookServer(mockWindow as never)
+
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default'
+    })
+    await postHook(port, 'hive-session-1', 'permission', {
+      hook_event_name: 'PermissionRequest'
+    })
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default'
+    })
+
+    expect(mockWindow.webContents.send).toHaveBeenCalledTimes(3)
+    expect(mockWindow.webContents.send).toHaveBeenNthCalledWith(3, 'claude-cli:status', {
+      sessionId: 'hive-session-1',
+      status: 'working',
+      metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start' }
+    })
+  })
+
+  it('dedupes direct PTY-exit fallback after an equivalent hook status', async () => {
+    const mockWindow = makeWindow()
+    const { port } = await getClaudeHookServer(mockWindow as never)
+
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'Stop'
+    })
+    publishClaudeCliStatus(mockWindow as never, {
+      sessionId: 'hive-session-1',
+      status: 'completed',
+      metadata: { reason: 'pty_exit' }
+    })
+
+    expect(mockWindow.webContents.send).toHaveBeenCalledTimes(1)
+    expect(mockWindow.webContents.send).toHaveBeenCalledWith('claude-cli:status', {
+      sessionId: 'hive-session-1',
+      status: 'completed',
+      metadata: { hookEventName: 'Stop', hookPath: 'stop' }
+    })
+  })
+
+  it('ignores unknown event names without sending IPC', async () => {
+    const mockWindow = makeWindow()
+    const { port } = await getClaudeHookServer(mockWindow as never)
+
+    const response = await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'BogusEvent'
+    })
+
+    expect(response).toEqual({ status: 200, text: '{}' })
+    expect(mockWindow.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('handles malformed JSON without sending IPC', async () => {
+    const mockWindow = makeWindow()
+    const { port } = await getClaudeHookServer(mockWindow as never)
+
+    const response = await postHook(port, 'hive-session-1', 'start', 'not json')
+
+    expect(response).toEqual({ status: 200, text: '{}' })
+    expect(mockWindow.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-POST requests without sending IPC', async () => {
+    const mockWindow = makeWindow()
+    const { port } = await getClaudeHookServer(mockWindow as never)
+
+    const response = await getHook(port, 'hive-session-1', 'start')
+
+    expect(response).toEqual({ status: 405, text: '{}' })
+    expect(mockWindow.webContents.send).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -179,7 +179,8 @@ describe('buildClaudeCliHookSettings', () => {
             hooks: [
               {
                 type: 'http',
-                url: 'http://127.0.0.1:34819/hook/hive-session-1/tool'
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/tool',
+                timeout: 600
               }
             ]
           }

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -106,6 +106,11 @@ describe('mapHookEventToStatus', () => {
       { hook_event_name: 'PermissionRequest', tool_name: 'ExitPlanMode' },
       'plan_ready'
     ],
+    [
+      'PermissionRequest for AskUserQuestion maps to answering',
+      { hook_event_name: 'PermissionRequest', tool_name: 'AskUserQuestion' },
+      'answering'
+    ],
     ['unknown events are ignored', { hook_event_name: 'BogusEvent' }, null],
     [
       'unmatched PreToolUse events are ignored',

--- a/src/main/services/__tests__/claude-plan-followup-watcher.test.ts
+++ b/src/main/services/__tests__/claude-plan-followup-watcher.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { findClaudePlanFollowupAfterLine } from '../claude-plan-followup-watcher'
+
+function line(entry: Record<string, unknown>): string {
+  return JSON.stringify(entry)
+}
+
+describe('claude-plan-followup-watcher', () => {
+  it('detects ExitPlanMode error tool results appended after the baseline', () => {
+    const raw = [
+      line({ type: 'user', message: { role: 'user', content: 'Initial prompt' } }),
+      line({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 'toolu_plan', name: 'ExitPlanMode', input: { plan: 'Plan' } }
+          ]
+        }
+      }),
+      line({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_plan',
+              is_error: true,
+              content: 'Please adjust the plan before implementing.'
+            }
+          ]
+        }
+      })
+    ].join('\n')
+
+    expect(findClaudePlanFollowupAfterLine(raw, 2)).toEqual({
+      found: true,
+      nextLine: 3
+    })
+  })
+
+  it('ignores unrelated tool results and sidechain user entries after the baseline', () => {
+    const raw = [
+      line({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'toolu_read', name: 'Read', input: {} }]
+        }
+      }),
+      line({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'toolu_read', is_error: true, content: 'ok' }]
+        }
+      }),
+      line({
+        type: 'user',
+        isSidechain: true,
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'subtask prompt' }]
+        }
+      })
+    ].join('\n')
+
+    expect(findClaudePlanFollowupAfterLine(raw, 0)).toEqual({
+      found: false,
+      nextLine: 3
+    })
+  })
+})

--- a/src/main/services/__tests__/claude-plan-followup-watcher.test.ts
+++ b/src/main/services/__tests__/claude-plan-followup-watcher.test.ts
@@ -1,10 +1,36 @@
 import { describe, expect, it } from 'vitest'
 
-import { findClaudePlanFollowupAfterLine } from '../claude-plan-followup-watcher'
+import {
+  findClaudePlanFollowupAfterLine,
+  scanPlanFollowupLines
+} from '../claude-plan-followup-watcher'
 
 function line(entry: Record<string, unknown>): string {
   return JSON.stringify(entry)
 }
+
+const planToolUse = line({
+  type: 'assistant',
+  message: {
+    role: 'assistant',
+    content: [{ type: 'tool_use', id: 'toolu_plan', name: 'ExitPlanMode', input: { plan: 'Plan' } }]
+  }
+})
+
+const planFollowup = line({
+  type: 'user',
+  message: {
+    role: 'user',
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_plan',
+        is_error: true,
+        content: 'Please adjust the plan before implementing.'
+      }
+    ]
+  }
+})
 
 describe('claude-plan-followup-watcher', () => {
   it('detects ExitPlanMode error tool results appended after the baseline', () => {
@@ -71,5 +97,25 @@ describe('claude-plan-followup-watcher', () => {
       found: false,
       nextLine: 3
     })
+  })
+
+  it('scanPlanFollowupLines accumulates ExitPlanMode tool ids across incremental calls', () => {
+    const exitPlanToolIds = new Set<string>()
+
+    // First poll sees only the plan tool_use (id captured), no follow-up yet.
+    expect(scanPlanFollowupLines([planToolUse], 0, 1, exitPlanToolIds)).toBe(false)
+    expect(exitPlanToolIds.has('toolu_plan')).toBe(true)
+
+    // Second poll scans ONLY the newly-appended line, yet still detects the
+    // follow-up because the tool id was carried over from the previous call —
+    // i.e. it does not need to re-parse the earlier plan tool_use line.
+    expect(scanPlanFollowupLines([planToolUse, planFollowup], 1, 1, exitPlanToolIds)).toBe(true)
+  })
+
+  it('scanPlanFollowupLines respects the baseline (ignores follow-ups before it)', () => {
+    const exitPlanToolIds = new Set<string>()
+    // Both lines present, but baseline is past them → no detection.
+    expect(scanPlanFollowupLines([planToolUse, planFollowup], 0, 2, exitPlanToolIds)).toBe(false)
+    expect(exitPlanToolIds.has('toolu_plan')).toBe(true)
   })
 })

--- a/src/main/services/agent-sdk-types.ts
+++ b/src/main/services/agent-sdk-types.ts
@@ -1,6 +1,6 @@
 import type { BrowserWindow } from 'electron'
 
-export type AgentSdkId = 'opencode' | 'claude-code' | 'codex' | 'terminal'
+export type AgentSdkId = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
 
 export interface AgentSdkCapabilities {
   supportsUndo: boolean

--- a/src/main/services/agent-sdk-types.ts
+++ b/src/main/services/agent-sdk-types.ts
@@ -1,6 +1,8 @@
 import type { BrowserWindow } from 'electron'
+import type { AgentSdk } from '@shared/types/agent-sdk'
 
-export type AgentSdkId = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+/** Alias of the shared {@link AgentSdk} union, kept for the main-process implementer registry's naming. */
+export type AgentSdkId = AgentSdk
 
 export interface AgentSdkCapabilities {
   supportsUndo: boolean

--- a/src/main/services/claude-cli-pty-prompt.ts
+++ b/src/main/services/claude-cli-pty-prompt.ts
@@ -1,0 +1,24 @@
+import { ptyService } from './pty-service'
+
+/**
+ * Inject a prompt into a running Claude CLI session as if the user typed it.
+ *
+ * Bracketed paste (`ESC[200~ … ESC[201~`) keeps a multi-line prompt from being
+ * submitted line-by-line; the trailing CR submits the turn (as pressing Enter).
+ *
+ * Returns `delivered: false` when the session has no live PTY so the caller can
+ * queue the prompt for later delivery (e.g. as the next spawn argument, or until
+ * the session is idle) instead of silently dropping it.
+ *
+ * Shared by the `terminal:sendClaudeCliPrompt` IPC handler and the Telegram
+ * forwarding service (which has no SDK implementer to route a CLI prompt to).
+ * Lives in the service layer and imports only `pty-service` so callers don't
+ * have to reach into the IPC layer (which would create import cycles).
+ */
+export function writeClaudeCliPrompt(sessionId: string, prompt: string): { delivered: boolean } {
+  if (!ptyService.has(sessionId)) {
+    return { delivered: false }
+  }
+  ptyService.write(sessionId, `[200~${prompt}[201~\r`)
+  return { delivered: true }
+}

--- a/src/main/services/claude-cli-spawner.ts
+++ b/src/main/services/claude-cli-spawner.ts
@@ -11,6 +11,7 @@ export interface ClaudeCliPtySpawnInput {
   pendingPrompt?: string | null
   claudeBinary?: string | null
   claudeSessionId?: string | null
+  hookSettingsJson?: string | null
   db?: DatabaseService | null
 }
 
@@ -61,6 +62,10 @@ export function buildClaudeCliPtySpawn(input: ClaudeCliPtySpawnInput): ClaudeCli
   const resumeId = input.claudeSessionId ?? input.session.claude_session_id
   if (resumeId) {
     args.push('--resume', resumeId)
+  }
+
+  if (input.hookSettingsJson) {
+    args.push('--settings', input.hookSettingsJson)
   }
 
   const prompt = input.pendingPrompt?.trim()

--- a/src/main/services/claude-cli-spawner.ts
+++ b/src/main/services/claude-cli-spawner.ts
@@ -42,12 +42,11 @@ function normalizeClaudeCliEffort(effort: string | null | undefined): string | n
 }
 
 export function buildClaudeCliPtySpawn(input: ClaudeCliPtySpawnInput): ClaudeCliPtySpawn {
-  const args = ['--dangerously-skip-permissions']
   const mode = input.session.mode
-
-  if (mode === 'plan' || mode === 'super-plan') {
-    args.push('--permission-mode', 'plan')
-  }
+  const args =
+    mode === 'plan' || mode === 'super-plan'
+      ? ['--allow-dangerously-skip-permissions', '--permission-mode', 'plan']
+      : ['--dangerously-skip-permissions']
 
   const model = normalizeClaudeCliModel(input.session.model_id)
   if (model) {

--- a/src/main/services/claude-cli-spawner.ts
+++ b/src/main/services/claude-cli-spawner.ts
@@ -1,0 +1,77 @@
+import type { Session } from '../db/types'
+import { getUserEnvironmentVariables } from './env-vars'
+import type { DatabaseService } from '../db/database'
+
+export interface ClaudeCliPtySpawnInput {
+  session: Pick<
+    Session,
+    'mode' | 'model_id' | 'model_variant' | 'claude_session_id'
+  >
+  worktreePath: string
+  pendingPrompt?: string | null
+  claudeBinary?: string | null
+  claudeSessionId?: string | null
+  db?: DatabaseService | null
+}
+
+export interface ClaudeCliPtySpawn {
+  command: string
+  args: string[]
+  cwd: string
+  env: Record<string, string>
+}
+
+const VALID_MODELS = new Set(['opus', 'sonnet', 'haiku'])
+const VALID_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh', 'max'])
+
+export function normalizeClaudeCliModel(modelId: string | null | undefined): string | null {
+  if (!modelId) return null
+  const lower = modelId.toLowerCase()
+  if (VALID_MODELS.has(lower)) return lower
+  if (lower.includes('opus')) return 'opus'
+  if (lower.includes('sonnet')) return 'sonnet'
+  if (lower.includes('haiku')) return 'haiku'
+  return null
+}
+
+function normalizeClaudeCliEffort(effort: string | null | undefined): string | null {
+  if (!effort) return null
+  const lower = effort.toLowerCase()
+  return VALID_EFFORTS.has(lower) ? lower : null
+}
+
+export function buildClaudeCliPtySpawn(input: ClaudeCliPtySpawnInput): ClaudeCliPtySpawn {
+  const args = ['--dangerously-skip-permissions']
+  const mode = input.session.mode
+
+  if (mode === 'plan' || mode === 'super-plan') {
+    args.push('--permission-mode', 'plan')
+  }
+
+  const model = normalizeClaudeCliModel(input.session.model_id)
+  if (model) {
+    args.push('--model', model)
+  }
+
+  const effort = normalizeClaudeCliEffort(input.session.model_variant)
+  if (effort) {
+    args.push('--effort', effort)
+  }
+
+  const resumeId = input.claudeSessionId ?? input.session.claude_session_id
+  if (resumeId) {
+    args.push('--resume', resumeId)
+  }
+
+  const prompt = input.pendingPrompt?.trim()
+  if (prompt) {
+    args.push(prompt)
+  }
+
+  return {
+    command: input.claudeBinary || 'claude',
+    args,
+    cwd: input.worktreePath,
+    env: getUserEnvironmentVariables(input.db ?? null)
+  }
+}

--- a/src/main/services/claude-cli-telegram-bridge.ts
+++ b/src/main/services/claude-cli-telegram-bridge.ts
@@ -1,0 +1,355 @@
+import { EventEmitter } from 'node:events'
+import { randomUUID } from 'node:crypto'
+import type { ServerResponse } from 'node:http'
+import type { OpenCodeStreamEvent } from '@shared/types/opencode'
+import { createLogger } from './logger'
+import { agentEventBus } from './agent-event-bus'
+
+const log = createLogger({ component: 'ClaudeCliTelegramBridge' })
+
+/**
+ * Resolve a held hook a little before the Claude HTTP-hook `timeout` (600s) so we
+ * proactively unblock the CLI (falling back to its terminal prompt) rather than
+ * letting Claude's own timeout fire with undocumented behavior.
+ */
+const SAFETY_TIMEOUT_MS = 9 * 60 * 1000
+
+/** Minimal shape of the Claude hook POST body the bridge inspects. */
+export interface ClaudeHookBody {
+  hook_event_name?: string
+  tool_name?: string
+  tool_input?: { plan?: unknown; questions?: unknown }
+  /** The turn's final assistant message. Docs call it `assistant_message`; */
+  assistant_message?: string
+  /** real Claude CLI payloads have shown `last_assistant_message` — read both. */
+  last_assistant_message?: string
+}
+
+type InteractionKind = 'question' | 'plan'
+
+interface PendingInteraction {
+  res: ServerResponse
+  sessionId: string
+  kind: InteractionKind
+  toolInput: Record<string, unknown>
+  /** Raw `AskUserQuestion` questions (each `{ question, header, options:[{label}] }`). */
+  questions: Array<Record<string, unknown>>
+  timer: NodeJS.Timeout
+  onClose: () => void
+}
+
+function asArray(value: unknown): unknown[] | null {
+  return Array.isArray(value) ? value : null
+}
+
+function questionText(question: Record<string, unknown>): string {
+  return typeof question.question === 'string' ? question.question : ''
+}
+
+/**
+ * Bridges Claude CLI hook events to the Telegram forwarding service — but ONLY
+ * for sessions the user has enabled Telegram forwarding on.
+ *
+ * The Claude CLI answers questions/plans in its terminal; there is no SDK
+ * implementer to route a Telegram answer to. This bridge holds the blocking
+ * `PreToolUse` HTTP hook response open, forwards the question/plan to Telegram
+ * via the existing event pipeline, and resolves the held response with the
+ * answer (so Claude proceeds without ever prompting in the terminal).
+ *
+ * Delivery uses two channels:
+ *  - QUESTION events (`question.asked` / `question.replied` / `question.rejected`)
+ *    go through `agentEventBus` so they reach BOTH the Telegram service AND the
+ *    renderer — the renderer renders the same in-app question UI the SDK
+ *    providers use (since the question never shows in the CLI's terminal while
+ *    intercepted). The store only fills while forwarding, so the in-app UI is
+ *    implicitly gated on forwarding.
+ *  - PLAN / status / assistant-text events go through this object's OWN private
+ *    EventEmitter (Telegram only). Pushing those to the renderer would collide
+ *    with the CLI's existing in-app plan card / status pipeline.
+ */
+class ClaudeCliTelegramBridge {
+  private registered = new Set<string>()
+  private pending = new Map<string, PendingInteraction>()
+  private emitter = new EventEmitter()
+
+  /** Mark a CLI session as Telegram-forwarded so its hooks get intercepted. */
+  register(sessionId: string): void {
+    this.registered.add(sessionId)
+  }
+
+  isRegistered(sessionId: string): boolean {
+    return this.registered.has(sessionId)
+  }
+
+  /** The Telegram service subscribes here and routes events to handleAgentEvent. */
+  subscribe(listener: (event: OpenCodeStreamEvent) => void): () => void {
+    this.emitter.on('event', listener)
+    return () => this.emitter.off('event', listener)
+  }
+
+  /**
+   * Called by the hook server for every Claude CLI hook. Returns true when the
+   * bridge has taken ownership of `res` (held open, to be resolved later); the
+   * caller must then NOT write to `res`. Returns false for unregistered sessions
+   * and non-intercepted events, preserving the hook server's default behavior.
+   */
+  onHook(sessionId: string, body: ClaudeHookBody, res: ServerResponse): boolean {
+    if (!this.registered.has(sessionId)) return false
+
+    const event = body.hook_event_name
+    if (event === 'PreToolUse' && body.tool_name === 'AskUserQuestion') {
+      return this.holdQuestion(sessionId, body, res)
+    }
+    if (event === 'PreToolUse' && body.tool_name === 'ExitPlanMode') {
+      return this.holdPlan(sessionId, body, res)
+    }
+    if (event === 'Stop') {
+      this.emitIdle(sessionId, body)
+      return false
+    }
+    if (
+      event === 'UserPromptSubmit' ||
+      event === 'PostToolUse' ||
+      event === 'PostToolUseFailure'
+    ) {
+      this.emitTelegram({ type: 'session.busy', sessionId, data: {} })
+      return false
+    }
+    return false
+  }
+
+  hasPendingQuestion(requestId: string): boolean {
+    return this.pending.get(requestId)?.kind === 'question'
+  }
+
+  hasPendingPlan(requestId: string): boolean {
+    return this.pending.get(requestId)?.kind === 'plan'
+  }
+
+  hasPendingPlanForSession(sessionId: string): boolean {
+    for (const entry of this.pending.values()) {
+      if (entry.kind === 'plan' && entry.sessionId === sessionId) return true
+    }
+    return false
+  }
+
+  /**
+   * Resolve a held `AskUserQuestion` hook with the Telegram answers, auto-answering
+   * the tool so Claude proceeds without a terminal prompt. `answers` is the
+   * Telegram batch shape (one inner array of selected labels per question); the
+   * hook contract wants `updatedInput.answers` keyed by each question's text.
+   */
+  resolveQuestion(requestId: string, answers: string[][]): void {
+    const entry = this.pending.get(requestId)
+    if (!entry || entry.kind !== 'question') return
+
+    const answerMap: Record<string, string> = {}
+    entry.questions.forEach((question, index) => {
+      const text = questionText(question)
+      const selected = (answers[index] ?? []).filter((value) => typeof value === 'string')
+      if (text && selected.length > 0) answerMap[text] = selected.join(', ')
+    })
+
+    const sessionId = entry.sessionId
+    this.finalize(requestId, {
+      responseBody: JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          permissionDecisionReason: 'Answered via Telegram',
+          updatedInput: { ...entry.toolInput, answers: answerMap }
+        }
+      })
+    })
+    // Clear the in-app question UI (renderer) and any tracked Telegram message.
+    this.emitShared({ type: 'question.replied', sessionId, data: { requestId, id: requestId } })
+  }
+
+  /**
+   * Dismiss a held question (in-app "Dismiss"): unblock the hook with `{}` so the
+   * CLI falls back to its terminal prompt, and clear the in-app/Telegram UI.
+   */
+  rejectQuestion(requestId: string): void {
+    const entry = this.pending.get(requestId)
+    if (!entry || entry.kind !== 'question') return
+    this.finalize(requestId, { responseBody: '{}', emitCleanup: true })
+  }
+
+  /**
+   * Resolve a held `ExitPlanMode` hook: `allow` to exit plan mode and implement,
+   * or `deny` with the feedback as the reason (Claude revises the plan).
+   */
+  resolvePlan(requestId: string, approve: boolean, feedback?: string): void {
+    const entry = this.pending.get(requestId)
+    if (!entry || entry.kind !== 'plan') return
+
+    const hookSpecificOutput = approve
+      ? {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          permissionDecisionReason: 'Approved via Telegram'
+        }
+      : {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: feedback?.trim() || 'Rejected via Telegram'
+        }
+
+    this.finalize(requestId, { responseBody: JSON.stringify({ hookSpecificOutput }) })
+  }
+
+  /**
+   * Stop intercepting a session and unblock any held hook with `{}` so the CLI
+   * falls back to its terminal prompt. Called when forwarding stops/moves and on
+   * PTY teardown — guarantees turning Telegram off never freezes the CLI.
+   */
+  cancelSession(sessionId: string): void {
+    const requestIds = [...this.pending.entries()]
+      .filter(([, entry]) => entry.sessionId === sessionId)
+      .map(([requestId]) => requestId)
+    for (const requestId of requestIds) {
+      // emitCleanup clears the in-app question UI when forwarding stops/moves.
+      this.finalize(requestId, { emitCleanup: true })
+    }
+    this.registered.delete(sessionId)
+  }
+
+  /** Unblock every held hook (app shutdown / hook-server close). */
+  cancelAll(): void {
+    for (const requestId of [...this.pending.keys()]) {
+      this.finalize(requestId, {})
+    }
+    this.registered.clear()
+  }
+
+  private holdQuestion(sessionId: string, body: ClaudeHookBody, res: ServerResponse): boolean {
+    const rawQuestions = asArray(body.tool_input?.questions)
+    const questions = (rawQuestions ?? []).filter(
+      (item): item is Record<string, unknown> =>
+        typeof item === 'object' && item !== null && !Array.isArray(item)
+    )
+    if (questions.length === 0) return false
+
+    const requestId = this.hold(sessionId, body, res, 'question', questions)
+    this.emitShared({
+      type: 'question.asked',
+      sessionId,
+      data: { requestId, id: requestId, sessionID: sessionId, questions }
+    })
+    return true
+  }
+
+  private holdPlan(sessionId: string, body: ClaudeHookBody, res: ServerResponse): boolean {
+    const plan = typeof body.tool_input?.plan === 'string' ? body.tool_input.plan : ''
+    if (!plan) return false
+
+    const requestId = this.hold(sessionId, body, res, 'plan', [])
+    this.emitTelegram({ type: 'plan.ready', sessionId, data: { requestId, id: requestId, plan } })
+    return true
+  }
+
+  private hold(
+    sessionId: string,
+    body: ClaudeHookBody,
+    res: ServerResponse,
+    kind: InteractionKind,
+    questions: Array<Record<string, unknown>>
+  ): string {
+    const requestId = randomUUID()
+    // Disable Node's per-socket inactivity timeout so a long-held response isn't
+    // dropped while a human answers on Telegram.
+    res.setTimeout(0)
+    const onClose = (): void => this.finalize(requestId, { emitCleanup: true, skipWrite: true })
+    res.on('close', onClose)
+    const timer = setTimeout(() => {
+      log.warn('Held Claude CLI hook expired; falling back to terminal', { sessionId, kind })
+      this.finalize(requestId, { emitCleanup: true })
+    }, SAFETY_TIMEOUT_MS)
+
+    this.pending.set(requestId, {
+      res,
+      sessionId,
+      kind,
+      toolInput:
+        typeof body.tool_input === 'object' && body.tool_input !== null
+          ? (body.tool_input as Record<string, unknown>)
+          : {},
+      questions,
+      timer,
+      onClose
+    })
+    return requestId
+  }
+
+  private emitIdle(sessionId: string, body: ClaudeHookBody): void {
+    const text = body.last_assistant_message ?? body.assistant_message
+    if (typeof text === 'string' && text.trim().length > 0) {
+      this.emitTelegram({
+        type: 'message.updated',
+        sessionId,
+        data: { role: 'assistant', content: text }
+      })
+    }
+    this.emitTelegram({ type: 'session.idle', sessionId, data: {} })
+  }
+
+  /**
+   * Single exit path for a held interaction: drop it, clear the timer/listener,
+   * write the response (unless the socket is already gone), and optionally emit a
+   * cleanup event so the Telegram service clears its tracked message.
+   */
+  private finalize(
+    requestId: string,
+    opts: { responseBody?: string; emitCleanup?: boolean; skipWrite?: boolean }
+  ): void {
+    const entry = this.pending.get(requestId)
+    if (!entry) return
+    this.pending.delete(requestId)
+    clearTimeout(entry.timer)
+    entry.res.removeListener('close', entry.onClose)
+
+    if (!opts.skipWrite) {
+      try {
+        if (!entry.res.writableEnded) {
+          entry.res.writeHead(200, { 'content-type': 'application/json' })
+          entry.res.end(opts.responseBody ?? '{}')
+        }
+      } catch (error) {
+        log.warn('Failed to write held Claude CLI hook response', {
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+
+    if (opts.emitCleanup) {
+      if (entry.kind === 'question') {
+        this.emitShared({
+          type: 'question.rejected',
+          sessionId: entry.sessionId,
+          data: { requestId, id: requestId }
+        })
+      } else {
+        this.emitTelegram({
+          type: 'plan.resolved',
+          sessionId: entry.sessionId,
+          data: { requestId, id: requestId, approved: false }
+        })
+      }
+    }
+  }
+
+  /** Telegram-only delivery (plan/status/assistant-text — kept off the renderer). */
+  private emitTelegram(event: OpenCodeStreamEvent): void {
+    this.emitter.emit('event', event)
+  }
+
+  /**
+   * Renderer + Telegram delivery for QUESTION events. agentEventBus reaches the
+   * renderer (in-app question UI) and the Telegram service (its own subscription).
+   */
+  private emitShared(event: OpenCodeStreamEvent): void {
+    agentEventBus.publish(event)
+  }
+}
+
+export const claudeCliTelegramBridge = new ClaudeCliTelegramBridge()

--- a/src/main/services/claude-cli-title-handler.ts
+++ b/src/main/services/claude-cli-title-handler.ts
@@ -1,0 +1,233 @@
+import type { BrowserWindow } from 'electron'
+import type { DatabaseService } from '../db/database'
+import { autoRenameWorktreeBranch } from './git-service'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'ClaudeCliTitle' })
+
+// Matches OSC 0 or OSC 2 with BEL or ST terminator.
+// Body excludes BEL (\x07) and ESC (\x1b) so partial sequences stay unmatched.
+const OSC_TITLE_RE = /\x1b\][02];([^\x07\x1b]*)(?:\x07|\x1b\\)/g
+
+// Tail buffer cap — a partial OSC sequence should never exceed this in practice.
+// Anything larger means we lost a terminator; drop the buffer to avoid unbounded growth.
+const MAX_TAIL_LENGTH = 4096
+
+// Non-braille spinner / status glyphs claude-cli (and friends) may prefix titles with.
+const NON_BRAILLE_SPINNERS = new Set(['✻', '✶', '✳', '✺', '·', '⏺', '◐', '◓', '◑', '◒'])
+
+function isSpinnerGlyph(ch: string): boolean {
+  if (!ch) return false
+  const code = ch.codePointAt(0)
+  if (code === undefined) return false
+  // Full Braille Patterns block — claude-cli cycles through these.
+  if (code >= 0x2800 && code <= 0x28ff) return true
+  return NON_BRAILLE_SPINNERS.has(ch)
+}
+
+function stripSpinnerPrefix(title: string): string {
+  let i = 0
+  while (i < title.length) {
+    const ch = title[i]
+    if (ch === ' ' || ch === '\t' || isSpinnerGlyph(ch)) {
+      i += 1
+    } else {
+      break
+    }
+  }
+  return title.slice(i)
+}
+
+// Boilerplate titles claude-cli emits before the meaningful one (case-insensitive,
+// compared after the spinner prefix is stripped).
+const BOILERPLATE_TITLES = new Set(['claude', 'claude code'])
+
+const tailBuffers = new Map<string, string>()
+const appliedSessions = new Set<string>()
+
+interface ProcessOptions {
+  worktreeBasename?: string
+}
+
+type TitleVerdict =
+  | { kind: 'accepted'; cleaned: string }
+  | { kind: 'noise'; reason: string }
+
+function classifyTitle(raw: string, options: ProcessOptions): TitleVerdict {
+  const cleaned = stripSpinnerPrefix(raw).trim()
+  if (!cleaned) return { kind: 'noise', reason: 'empty' }
+  if (BOILERPLATE_TITLES.has(cleaned.toLowerCase()))
+    return { kind: 'noise', reason: 'boilerplate' }
+  if (cleaned.startsWith('/') || cleaned.startsWith('~'))
+    return { kind: 'noise', reason: 'absolute-path' }
+  if (options.worktreeBasename && cleaned === options.worktreeBasename)
+    return { kind: 'noise', reason: 'worktree-basename' }
+  return { kind: 'accepted', cleaned }
+}
+
+/**
+ * Scan a PTY chunk for the first acceptable OSC 0/2 title.
+ * Returns the title string on a hit (and marks the session as applied so
+ * subsequent chunks short-circuit). Returns null when no title is found, or
+ * when the session has already had a title applied.
+ *
+ * Maintains a per-session tail buffer so that an OSC sequence split across
+ * two chunks is still matched on the second chunk.
+ */
+export function processClaudeCliPtyData(
+  sessionId: string,
+  chunk: string,
+  options: ProcessOptions = {}
+): string | null {
+  if (appliedSessions.has(sessionId)) return null
+
+  const prev = tailBuffers.get(sessionId) ?? ''
+  const buffer = prev + chunk
+
+  let foundTitle: string | null = null
+  let lastConsumedIndex = 0
+  OSC_TITLE_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = OSC_TITLE_RE.exec(buffer)) !== null) {
+    lastConsumedIndex = OSC_TITLE_RE.lastIndex
+    const verdict = classifyTitle(m[1], options)
+    if (verdict.kind === 'accepted') {
+      foundTitle = verdict.cleaned
+      break
+    }
+  }
+
+  // Preserve any partial OSC suffix after the last consumed match for the next chunk.
+  const remainder = buffer.slice(lastConsumedIndex)
+  const lastEsc = remainder.lastIndexOf('\x1b]')
+  let newTail = ''
+  if (lastEsc !== -1) {
+    const suffix = remainder.slice(lastEsc)
+    if (!suffix.includes('\x07') && !suffix.includes('\x1b\\')) {
+      newTail = suffix
+    }
+  }
+  if (newTail.length > MAX_TAIL_LENGTH) newTail = ''
+  if (newTail) {
+    tailBuffers.set(sessionId, newTail)
+  } else {
+    tailBuffers.delete(sessionId)
+  }
+
+  if (foundTitle !== null) {
+    appliedSessions.add(sessionId)
+    tailBuffers.delete(sessionId)
+    return foundTitle
+  }
+  return null
+}
+
+export function resetClaudeCliTitleState(sessionId: string): void {
+  tailBuffers.delete(sessionId)
+  appliedSessions.delete(sessionId)
+}
+
+export function resetAllClaudeCliTitleState(): void {
+  tailBuffers.clear()
+  appliedSessions.clear()
+}
+
+export interface ApplyClaudeCliTitleParams {
+  sessionId: string
+  title: string
+  db: DatabaseService
+  mainWindow: BrowserWindow
+}
+
+/**
+ * Mirrors the post-title-generation flow in claude-code-implementer.ts /
+ * codex-implementer.ts: write the title to the DB, push an opencode:stream
+ * session.updated event to the renderer, then auto-rename the worktree
+ * branch (and any connection-member branches) when still eligible.
+ *
+ * Fire-and-forget — errors are logged and swallowed.
+ */
+export async function applyClaudeCliTitle({
+  sessionId,
+  title,
+  db,
+  mainWindow
+}: ApplyClaudeCliTitleParams): Promise<void> {
+  try {
+    const session = db.getSession(sessionId)
+    if (!session || session.agent_sdk !== 'claude-code-cli') return
+
+    db.updateSession(sessionId, { name: title })
+    log.info('applied claude-cli title', { sessionId, title })
+
+    if (!mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('opencode:stream', {
+        type: 'session.updated',
+        sessionId,
+        data: { title, info: { title } }
+      })
+    }
+
+    const worktree = db.getWorktreeBySessionId(sessionId)
+    if (worktree && !worktree.branch_renamed) {
+      try {
+        const result = await autoRenameWorktreeBranch({
+          worktreeId: worktree.id,
+          worktreePath: worktree.path,
+          currentBranchName: worktree.branch_name,
+          sessionTitle: title,
+          db
+        })
+        if (result.renamed && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send('worktree:branchRenamed', {
+            worktreeId: worktree.id,
+            newBranch: result.newBranch
+          })
+        } else if (result.error) {
+          log.warn('branch rename failed', { sessionId, error: result.error })
+        }
+      } catch (err) {
+        db.updateWorktree(worktree.id, { branch_renamed: 1 })
+        log.warn('branch rename threw', {
+          sessionId,
+          error: err instanceof Error ? err.message : String(err)
+        })
+      }
+    }
+
+    if (!session.connection_id) return
+    const connection = db.getConnection(session.connection_id)
+    if (!connection) return
+
+    for (const member of connection.members) {
+      if (worktree && member.worktree_id === worktree.id) continue
+      try {
+        const memberWt = db.getWorktree(member.worktree_id)
+        if (!memberWt || memberWt.branch_renamed) continue
+        const result = await autoRenameWorktreeBranch({
+          worktreeId: memberWt.id,
+          worktreePath: memberWt.path,
+          currentBranchName: memberWt.branch_name,
+          sessionTitle: title,
+          db
+        })
+        if (result.renamed && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send('worktree:branchRenamed', {
+            worktreeId: memberWt.id,
+            newBranch: result.newBranch
+          })
+        }
+      } catch (err) {
+        log.warn('connection member branch rename threw', {
+          worktreeId: member.worktree_id,
+          error: err instanceof Error ? err.message : String(err)
+        })
+      }
+    }
+  } catch (err) {
+    log.warn('applyClaudeCliTitle unexpected error', {
+      sessionId,
+      error: err instanceof Error ? err.message : String(err)
+    })
+  }
+}

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -2,6 +2,7 @@ import type { BrowserWindow } from 'electron'
 import http from 'http'
 import type { SessionStatusType } from '@shared/types/session-status'
 import { createLogger } from './logger'
+import { claudeCliTelegramBridge } from './claude-cli-telegram-bridge'
 
 export interface ParsedClaudeHook {
   hook_event_name?: string
@@ -9,7 +10,11 @@ export interface ParsedClaudeHook {
   permission_mode?: string
   tool_input?: {
     plan?: unknown
+    questions?: unknown
   }
+  /** Final assistant message of the turn (Stop hook). Read both spellings: */
+  assistant_message?: string
+  last_assistant_message?: string
 }
 
 export interface ClaudeCliStatusPayload {
@@ -63,7 +68,10 @@ export function buildClaudeCliHookSettings(port: number, hiveSessionId: string):
       PreToolUse: [
         {
           matcher: 'ExitPlanMode|AskUserQuestion',
-          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'tool') }]
+          // A generous timeout (default is 600s) so a question/plan held open
+          // while a human answers via Telegram isn't cancelled early. Harmless
+          // when not held — it's a ceiling, not a delay.
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'tool'), timeout: 600 }]
         }
       ],
       PostToolUse: [
@@ -219,31 +227,36 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
     return
   }
 
-  res.writeHead(200, { 'content-type': 'application/json' })
-  res.end('{}')
-
+  // Read+parse the body before responding so the Telegram bridge can decide
+  // whether to hold the response open (to answer a question/plan remotely). The
+  // status publish below is unchanged and still drives the in-app badge.
   const route = parseHookPath(req.url)
-  if (!route) {
-    return
-  }
-
+  let owned = false
   try {
     const rawBody = await readRequestBody(req)
     const body = JSON.parse(rawBody || '{}') as ParsedClaudeHook
-    const status = mapHookEventToStatus(body)
-    if (!status || !rendererWindow) {
-      return
+    if (route) {
+      const status = mapHookEventToStatus(body)
+      if (status && rendererWindow) {
+        publishClaudeCliStatus(rendererWindow, {
+          sessionId: route.sessionId,
+          status,
+          metadata: buildStatusMetadata(body, route.hookPath)
+        })
+      }
+      // For Telegram-forwarded CLI sessions the bridge may take ownership of the
+      // response (held open until answered). Otherwise behavior is unchanged.
+      owned = claudeCliTelegramBridge.onHook(route.sessionId, body, res)
     }
-
-    publishClaudeCliStatus(rendererWindow, {
-      sessionId: route.sessionId,
-      status,
-      metadata: buildStatusMetadata(body, route.hookPath)
-    })
   } catch (error) {
     log.warn('Failed to parse Claude hook payload', {
       error: error instanceof Error ? error.message : String(error)
     })
+  }
+
+  if (!owned && !res.writableEnded) {
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end('{}')
   }
 }
 
@@ -261,6 +274,14 @@ export async function getClaudeHookServer(mainWindow: BrowserWindow): Promise<{ 
   server = http.createServer((req, res) => {
     void handleHook(req, res)
   })
+
+  // Held hook responses (a question/plan awaiting a Telegram answer) can stay
+  // open for minutes; disable Node's own request/socket timeouts so they aren't
+  // dropped mid-wait. The per-hook `timeout` in the injected settings is the
+  // real upper bound, with the bridge's safety timer just under it.
+  server.requestTimeout = 0
+  server.headersTimeout = 0
+  server.timeout = 0
 
   startingPromise = (async () => {
     await new Promise<void>((resolve, reject) => {
@@ -300,6 +321,10 @@ export async function getClaudeHookServer(mainWindow: BrowserWindow): Promise<{ 
 }
 
 export async function closeClaudeHookServer(): Promise<void> {
+  // Unblock any held hook responses first, otherwise their open sockets keep the
+  // server alive and `close()` hangs at shutdown.
+  claudeCliTelegramBridge.cancelAll()
+
   if (!server) {
     rendererWindow = null
     boundPort = null

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -1,0 +1,281 @@
+import type { BrowserWindow } from 'electron'
+import http from 'http'
+import { createLogger } from './logger'
+
+export type ClaudeCliSessionStatusType =
+  | 'working'
+  | 'planning'
+  | 'answering'
+  | 'permission'
+  | 'command_approval'
+  | 'unread'
+  | 'completed'
+  | 'plan_ready'
+
+export interface ParsedClaudeHook {
+  hook_event_name?: string
+  tool_name?: string
+  permission_mode?: string
+}
+
+export interface ClaudeCliStatusPayload {
+  sessionId: string
+  status: ClaudeCliSessionStatusType
+  metadata?: {
+    reason?: string
+    hookEventName?: string
+    hookPath?: string
+  }
+}
+
+const log = createLogger({ component: 'ClaudeHookServer' })
+const host = '127.0.0.1'
+let server: http.Server | null = null
+let boundPort: number | null = null
+let startingPromise: Promise<{ port: number }> | null = null
+let rendererWindow: BrowserWindow | null = null
+const lastStatusBySession = new Map<string, ClaudeCliSessionStatusType>()
+
+function hookUrl(port: number, hiveSessionId: string, path: string): string {
+  return `http://${host}:${port}/hook/${encodeURIComponent(hiveSessionId)}/${path}`
+}
+
+export function buildClaudeCliHookSettings(port: number, hiveSessionId: string): string {
+  return JSON.stringify({
+    hooks: {
+      SessionStart: [
+        {
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'session') }]
+        }
+      ],
+      SessionEnd: [
+        {
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'session') }]
+        }
+      ],
+      UserPromptSubmit: [
+        {
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'start') }]
+        }
+      ],
+      Stop: [
+        {
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'stop') }]
+        }
+      ],
+      PreToolUse: [
+        {
+          matcher: 'ExitPlanMode|AskUserQuestion',
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'tool') }]
+        }
+      ],
+      PostToolUse: [
+        {
+          matcher: '*',
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'tool') }]
+        }
+      ],
+      PostToolUseFailure: [
+        {
+          matcher: '*',
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'tool') }]
+        }
+      ],
+      PermissionRequest: [
+        {
+          matcher: '*',
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'permission') }]
+        }
+      ]
+    }
+  })
+}
+
+export function mapHookEventToStatus(hook: ParsedClaudeHook): ClaudeCliSessionStatusType | null {
+  switch (hook.hook_event_name) {
+    case 'SessionStart':
+    case 'SessionEnd':
+    case 'Stop':
+      return 'completed'
+    case 'UserPromptSubmit':
+      return hook.permission_mode === 'plan' ? 'planning' : 'working'
+    case 'PreToolUse':
+      if (hook.tool_name === 'ExitPlanMode') return 'plan_ready'
+      if (hook.tool_name === 'AskUserQuestion') return 'answering'
+      return null
+    case 'PostToolUse':
+    case 'PostToolUseFailure':
+      return 'working'
+    case 'PermissionRequest':
+      return 'permission'
+    default:
+      return null
+  }
+}
+
+export function publishClaudeCliStatus(
+  mainWindow: BrowserWindow,
+  payload: ClaudeCliStatusPayload
+): void {
+  if (lastStatusBySession.get(payload.sessionId) === payload.status) {
+    return
+  }
+
+  lastStatusBySession.set(payload.sessionId, payload.status)
+  if (!mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('claude-cli:status', payload)
+  }
+}
+
+function parseHookPath(url: string | undefined): { sessionId: string; hookPath: string } | null {
+  if (!url) return null
+
+  try {
+    const parsed = new URL(url, `http://${host}`)
+    const segments = parsed.pathname.split('/').filter(Boolean)
+    if (segments.length !== 3 || segments[0] !== 'hook') return null
+
+    return {
+      sessionId: decodeURIComponent(segments[1]),
+      hookPath: segments[2]
+    }
+  } catch {
+    return null
+  }
+}
+
+function readRequestBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = ''
+
+    req.setEncoding('utf8')
+    req.on('data', (chunk) => {
+      body += chunk
+    })
+    req.on('end', () => resolve(body))
+    req.on('error', reject)
+  })
+}
+
+async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const remoteAddress = req.socket.remoteAddress
+  if (remoteAddress !== host) {
+    res.writeHead(403, { 'content-type': 'application/json' })
+    res.end('{}')
+    return
+  }
+
+  if (req.method !== 'POST') {
+    res.writeHead(405, { 'content-type': 'application/json' })
+    res.end('{}')
+    return
+  }
+
+  res.writeHead(200, { 'content-type': 'application/json' })
+  res.end('{}')
+
+  const route = parseHookPath(req.url)
+  if (!route) {
+    return
+  }
+
+  try {
+    const rawBody = await readRequestBody(req)
+    const body = JSON.parse(rawBody || '{}') as ParsedClaudeHook
+    const status = mapHookEventToStatus(body)
+    if (!status || !rendererWindow) {
+      return
+    }
+
+    publishClaudeCliStatus(rendererWindow, {
+      sessionId: route.sessionId,
+      status,
+      metadata: {
+        hookEventName: body.hook_event_name,
+        hookPath: route.hookPath
+      }
+    })
+  } catch (error) {
+    log.warn('Failed to parse Claude hook payload', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+export async function getClaudeHookServer(mainWindow: BrowserWindow): Promise<{ port: number }> {
+  rendererWindow = mainWindow
+
+  if (server && boundPort !== null) {
+    return { port: boundPort }
+  }
+
+  if (startingPromise) {
+    return startingPromise
+  }
+
+  server = http.createServer((req, res) => {
+    void handleHook(req, res)
+  })
+
+  startingPromise = (async () => {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error): void => {
+        server?.off('listening', onListening)
+        reject(error)
+      }
+      const onListening = (): void => {
+        server?.off('error', onError)
+        resolve()
+      }
+
+      server?.once('error', onError)
+      server?.once('listening', onListening)
+      server?.listen(0, host)
+    })
+
+    const address = server?.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Claude hook server failed to bind a TCP port')
+    }
+
+    boundPort = address.port
+    log.info(`ClaudeHookServer listening on http://${host}:${boundPort}`)
+    return { port: boundPort }
+  })()
+
+  try {
+    return await startingPromise
+  } catch (error) {
+    server = null
+    boundPort = null
+    throw error
+  } finally {
+    startingPromise = null
+  }
+}
+
+export async function closeClaudeHookServer(): Promise<void> {
+  if (!server) {
+    rendererWindow = null
+    boundPort = null
+    startingPromise = null
+    lastStatusBySession.clear()
+    return
+  }
+
+  const closingServer = server
+  server = null
+
+  await new Promise<void>((resolve, reject) => {
+    closingServer.close((error) => {
+      if (error) reject(error)
+      else resolve()
+    })
+  })
+
+  log.info('ClaudeHookServer closed')
+  rendererWindow = null
+  boundPort = null
+  startingPromise = null
+  lastStatusBySession.clear()
+}

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -16,6 +16,9 @@ export interface ParsedClaudeHook {
   hook_event_name?: string
   tool_name?: string
   permission_mode?: string
+  tool_input?: {
+    plan?: unknown
+  }
 }
 
 export interface ClaudeCliStatusPayload {
@@ -25,6 +28,8 @@ export interface ClaudeCliStatusPayload {
     reason?: string
     hookEventName?: string
     hookPath?: string
+    toolName?: string
+    plan?: string
   }
 }
 
@@ -107,10 +112,36 @@ export function mapHookEventToStatus(hook: ParsedClaudeHook): ClaudeCliSessionSt
     case 'PostToolUseFailure':
       return 'working'
     case 'PermissionRequest':
+      if (hook.tool_name === 'ExitPlanMode') return 'plan_ready'
       return 'permission'
     default:
       return null
   }
+}
+
+function extractPlanText(hook: ParsedClaudeHook): string | undefined {
+  return typeof hook.tool_input?.plan === 'string' ? hook.tool_input.plan : undefined
+}
+
+function buildStatusMetadata(
+  hook: ParsedClaudeHook,
+  hookPath: string
+): NonNullable<ClaudeCliStatusPayload['metadata']> {
+  const metadata: NonNullable<ClaudeCliStatusPayload['metadata']> = {
+    hookEventName: hook.hook_event_name,
+    hookPath
+  }
+
+  if (hook.tool_name) {
+    metadata.toolName = hook.tool_name
+  }
+
+  const plan = extractPlanText(hook)
+  if (plan !== undefined) {
+    metadata.plan = plan
+  }
+
+  return metadata
 }
 
 export function publishClaudeCliStatus(
@@ -190,10 +221,7 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
     publishClaudeCliStatus(rendererWindow, {
       sessionId: route.sessionId,
       status,
-      metadata: {
-        hookEventName: body.hook_event_name,
-        hookPath: route.hookPath
-      }
+      metadata: buildStatusMetadata(body, route.hookPath)
     })
   } catch (error) {
     log.warn('Failed to parse Claude hook payload', {

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -1,16 +1,7 @@
 import type { BrowserWindow } from 'electron'
 import http from 'http'
+import type { SessionStatusType } from '@shared/types/session-status'
 import { createLogger } from './logger'
-
-export type ClaudeCliSessionStatusType =
-  | 'working'
-  | 'planning'
-  | 'answering'
-  | 'permission'
-  | 'command_approval'
-  | 'unread'
-  | 'completed'
-  | 'plan_ready'
 
 export interface ParsedClaudeHook {
   hook_event_name?: string
@@ -23,7 +14,7 @@ export interface ParsedClaudeHook {
 
 export interface ClaudeCliStatusPayload {
   sessionId: string
-  status: ClaudeCliSessionStatusType
+  status: SessionStatusType
   metadata?: {
     reason?: string
     hookEventName?: string
@@ -39,7 +30,7 @@ let server: http.Server | null = null
 let boundPort: number | null = null
 let startingPromise: Promise<{ port: number }> | null = null
 let rendererWindow: BrowserWindow | null = null
-const lastStatusBySession = new Map<string, ClaudeCliSessionStatusType>()
+const lastStatusBySession = new Map<string, SessionStatusType>()
 const statusSubscribers = new Set<(payload: ClaudeCliStatusPayload) => void>()
 
 function hookUrl(port: number, hiveSessionId: string, path: string): string {
@@ -97,7 +88,7 @@ export function buildClaudeCliHookSettings(port: number, hiveSessionId: string):
   })
 }
 
-export function mapHookEventToStatus(hook: ParsedClaudeHook): ClaudeCliSessionStatusType | null {
+export function mapHookEventToStatus(hook: ParsedClaudeHook): SessionStatusType | null {
   switch (hook.hook_event_name) {
     case 'SessionStart':
     case 'SessionEnd':
@@ -163,6 +154,16 @@ export function publishClaudeCliStatus(
   if (!mainWindow.isDestroyed()) {
     mainWindow.webContents.send('claude-cli:status', payload)
   }
+}
+
+/**
+ * Drop a session's last-published status. Call from the PTY exit / destroy
+ * teardown paths so the dedup map does not grow for the lifetime of the app and
+ * a session re-created with the same id starts with fresh dedup state (otherwise
+ * a stale 'completed' would swallow the restarted session's first status).
+ */
+export function clearClaudeCliStatus(sessionId: string): void {
+  lastStatusBySession.delete(sessionId)
 }
 
 export function subscribeClaudeCliStatus(

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -40,6 +40,7 @@ let boundPort: number | null = null
 let startingPromise: Promise<{ port: number }> | null = null
 let rendererWindow: BrowserWindow | null = null
 const lastStatusBySession = new Map<string, ClaudeCliSessionStatusType>()
+const statusSubscribers = new Set<(payload: ClaudeCliStatusPayload) => void>()
 
 function hookUrl(port: number, hiveSessionId: string, path: string): string {
   return `http://${host}:${port}/hook/${encodeURIComponent(hiveSessionId)}/${path}`
@@ -108,8 +109,10 @@ export function mapHookEventToStatus(hook: ParsedClaudeHook): ClaudeCliSessionSt
       if (hook.tool_name === 'ExitPlanMode') return 'plan_ready'
       if (hook.tool_name === 'AskUserQuestion') return 'answering'
       return null
-    case 'PostToolUse':
     case 'PostToolUseFailure':
+      if (hook.tool_name === 'ExitPlanMode') return 'planning'
+      return 'working'
+    case 'PostToolUse':
       return 'working'
     case 'PermissionRequest':
       if (hook.tool_name === 'ExitPlanMode') return 'plan_ready'
@@ -154,8 +157,20 @@ export function publishClaudeCliStatus(
   }
 
   lastStatusBySession.set(payload.sessionId, payload.status)
+  for (const subscriber of statusSubscribers) {
+    subscriber(payload)
+  }
   if (!mainWindow.isDestroyed()) {
     mainWindow.webContents.send('claude-cli:status', payload)
+  }
+}
+
+export function subscribeClaudeCliStatus(
+  subscriber: (payload: ClaudeCliStatusPayload) => void
+): () => void {
+  statusSubscribers.add(subscriber)
+  return () => {
+    statusSubscribers.delete(subscriber)
   }
 }
 
@@ -289,6 +304,7 @@ export async function closeClaudeHookServer(): Promise<void> {
     boundPort = null
     startingPromise = null
     lastStatusBySession.clear()
+    statusSubscribers.clear()
     return
   }
 
@@ -307,4 +323,5 @@ export async function closeClaudeHookServer(): Promise<void> {
   boundPort = null
   startingPromise = null
   lastStatusBySession.clear()
+  statusSubscribers.clear()
 }

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -113,6 +113,7 @@ export function mapHookEventToStatus(hook: ParsedClaudeHook): ClaudeCliSessionSt
       return 'working'
     case 'PermissionRequest':
       if (hook.tool_name === 'ExitPlanMode') return 'plan_ready'
+      if (hook.tool_name === 'AskUserQuestion') return 'answering'
       return 'permission'
     default:
       return null

--- a/src/main/services/claude-plan-followup-watcher.ts
+++ b/src/main/services/claude-plan-followup-watcher.ts
@@ -1,0 +1,150 @@
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+import { homedir } from 'os'
+import { encodePath } from './claude-transcript-reader'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'ClaudePlanFollowupWatcher' })
+
+export interface ClaudePlanFollowupWatchHandle {
+  close(): void
+}
+
+function resolveProjectsDir(): string {
+  const configuredDir = process.env.CLAUDE_CONFIG_DIR
+  const configRoot =
+    typeof configuredDir === 'string' && configuredDir.trim().length > 0
+      ? configuredDir
+      : join(homedir(), '.claude')
+
+  return join(configRoot.normalize('NFC'), 'projects')
+}
+
+function messageContentBlocks(entry: Record<string, unknown>): Record<string, unknown>[] {
+  const message = entry.message
+  if (!message || typeof message !== 'object') return []
+  const content = (message as { content?: unknown }).content
+  return Array.isArray(content)
+    ? content.filter((block): block is Record<string, unknown> => {
+        return block !== null && typeof block === 'object'
+      })
+    : []
+}
+
+function collectExitPlanToolIds(entry: Record<string, unknown>, toolIds: Set<string>): void {
+  for (const block of messageContentBlocks(entry)) {
+    if (block.type !== 'tool_use' || block.name !== 'ExitPlanMode') continue
+    if (typeof block.id === 'string' && block.id.length > 0) {
+      toolIds.add(block.id)
+    }
+  }
+}
+
+function toolResultContentText(block: Record<string, unknown>): string | null {
+  const content = block.content
+  if (typeof content === 'string') return content
+
+  if (!Array.isArray(content)) return null
+  const text = content
+    .map((item) => {
+      if (!item || typeof item !== 'object') return ''
+      const typed = item as { type?: unknown; text?: unknown }
+      return typed.type === 'text' && typeof typed.text === 'string' ? typed.text : ''
+    })
+    .join('')
+
+  return text.length > 0 ? text : null
+}
+
+function hasExitPlanFollowup(
+  entry: Record<string, unknown>,
+  exitPlanToolIds: Set<string>
+): boolean {
+  for (const block of messageContentBlocks(entry)) {
+    if (block.type !== 'tool_result') continue
+    if (block.is_error !== true) continue
+    if (typeof block.tool_use_id !== 'string') continue
+    if (!exitPlanToolIds.has(block.tool_use_id)) continue
+    if (toolResultContentText(block) !== null) return true
+  }
+  return false
+}
+
+export function findClaudePlanFollowupAfterLine(
+  raw: string,
+  startLine: number
+): { found: boolean; nextLine: number } {
+  const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0)
+  const exitPlanToolIds = new Set<string>()
+
+  for (let index = 0; index < lines.length; index++) {
+    try {
+      const entry = JSON.parse(lines[index]) as Record<string, unknown>
+      collectExitPlanToolIds(entry, exitPlanToolIds)
+      if (index >= Math.max(0, startLine) && hasExitPlanFollowup(entry, exitPlanToolIds)) {
+        return { found: true, nextLine: lines.length }
+      }
+    } catch {
+      // Ignore malformed transcript lines but keep advancing the baseline.
+    }
+  }
+
+  return { found: false, nextLine: lines.length }
+}
+
+export function watchForClaudePlanFollowup(
+  worktreePath: string,
+  claudeSessionId: string,
+  onPlanFollowup: () => void,
+  intervalMs = 1000
+): ClaudePlanFollowupWatchHandle {
+  const filePath = join(resolveProjectsDir(), encodePath(worktreePath), `${claudeSessionId}.jsonl`)
+  let closed = false
+  let baselineLine: number | null = null
+  let interval: NodeJS.Timeout | null = null
+  let polling = false
+
+  const close = (): void => {
+    if (closed) return
+    closed = true
+    if (interval) clearInterval(interval)
+    interval = null
+  }
+
+  const poll = async (): Promise<void> => {
+    if (closed || polling) return
+    polling = true
+    try {
+      const raw = await readFile(filePath, 'utf-8')
+      if (baselineLine === null) {
+        baselineLine = findClaudePlanFollowupAfterLine(raw, Number.MAX_SAFE_INTEGER).nextLine
+        return
+      }
+
+      const result = findClaudePlanFollowupAfterLine(raw, baselineLine)
+      baselineLine = result.nextLine
+      if (result.found) {
+        log.info('Detected Claude CLI plan follow-up in transcript', {
+          worktreePath,
+          claudeSessionId
+        })
+        close()
+        onPlanFollowup()
+      }
+    } catch (error) {
+      log.debug('Claude CLI plan follow-up transcript poll skipped', {
+        filePath,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    } finally {
+      polling = false
+    }
+  }
+
+  void poll()
+  interval = setInterval(() => {
+    void poll()
+  }, intervalMs)
+
+  return { close }
+}

--- a/src/main/services/claude-plan-followup-watcher.ts
+++ b/src/main/services/claude-plan-followup-watcher.ts
@@ -1,23 +1,12 @@
 import { readFile } from 'fs/promises'
 import { join } from 'path'
-import { homedir } from 'os'
-import { encodePath } from './claude-transcript-reader'
+import { encodePath, resolveProjectsDir } from './claude-transcript-reader'
 import { createLogger } from './logger'
 
 const log = createLogger({ component: 'ClaudePlanFollowupWatcher' })
 
 export interface ClaudePlanFollowupWatchHandle {
   close(): void
-}
-
-function resolveProjectsDir(): string {
-  const configuredDir = process.env.CLAUDE_CONFIG_DIR
-  const configRoot =
-    typeof configuredDir === 'string' && configuredDir.trim().length > 0
-      ? configuredDir
-      : join(homedir(), '.claude')
-
-  return join(configRoot.normalize('NFC'), 'projects')
 }
 
 function messageContentBlocks(entry: Record<string, unknown>): Record<string, unknown>[] {
@@ -70,26 +59,41 @@ function hasExitPlanFollowup(
   return false
 }
 
+function splitTranscriptLines(raw: string): string[] {
+  return raw.split(/\r?\n/).filter((line) => line.trim().length > 0)
+}
+
+// Scan lines[fromIndex..], accumulating every ExitPlanMode tool_use id into the
+// caller-owned `exitPlanToolIds` set, and report the first error tool_result (a
+// plan follow-up) at or after `baselineLine`. The set is passed in so a caller
+// can keep it across incremental calls instead of re-parsing the whole file.
+export function scanPlanFollowupLines(
+  lines: string[],
+  fromIndex: number,
+  baselineLine: number,
+  exitPlanToolIds: Set<string>
+): boolean {
+  for (let index = Math.max(0, fromIndex); index < lines.length; index++) {
+    try {
+      const entry = JSON.parse(lines[index]) as Record<string, unknown>
+      collectExitPlanToolIds(entry, exitPlanToolIds)
+      if (index >= Math.max(0, baselineLine) && hasExitPlanFollowup(entry, exitPlanToolIds)) {
+        return true
+      }
+    } catch {
+      // Ignore malformed / partially-written transcript lines.
+    }
+  }
+  return false
+}
+
 export function findClaudePlanFollowupAfterLine(
   raw: string,
   startLine: number
 ): { found: boolean; nextLine: number } {
-  const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0)
-  const exitPlanToolIds = new Set<string>()
-
-  for (let index = 0; index < lines.length; index++) {
-    try {
-      const entry = JSON.parse(lines[index]) as Record<string, unknown>
-      collectExitPlanToolIds(entry, exitPlanToolIds)
-      if (index >= Math.max(0, startLine) && hasExitPlanFollowup(entry, exitPlanToolIds)) {
-        return { found: true, nextLine: lines.length }
-      }
-    } catch {
-      // Ignore malformed transcript lines but keep advancing the baseline.
-    }
-  }
-
-  return { found: false, nextLine: lines.length }
+  const lines = splitTranscriptLines(raw)
+  const found = scanPlanFollowupLines(lines, 0, startLine, new Set<string>())
+  return { found, nextLine: lines.length }
 }
 
 export function watchForClaudePlanFollowup(
@@ -104,6 +108,14 @@ export function watchForClaudePlanFollowup(
   let interval: NodeJS.Timeout | null = null
   let polling = false
 
+  // Persist parse progress across polls so we don't re-JSON.parse the whole
+  // transcript every tick (it can grow to many MB during a plan review). The
+  // ExitPlanMode tool ids accumulate across polls; `scannedThrough` leaves the
+  // last line volatile so a partially-written final line is re-read once it
+  // settles rather than skipped.
+  const exitPlanToolIds = new Set<string>()
+  let scannedThrough = 0
+
   const close = (): void => {
     if (closed) return
     closed = true
@@ -116,14 +128,21 @@ export function watchForClaudePlanFollowup(
     polling = true
     try {
       const raw = await readFile(filePath, 'utf-8')
+      const lines = splitTranscriptLines(raw)
+
       if (baselineLine === null) {
-        baselineLine = findClaudePlanFollowupAfterLine(raw, Number.MAX_SAFE_INTEGER).nextLine
+        // First read: parse everything once to capture ExitPlanMode tool ids that
+        // predate the watcher, but only treat lines appended after now as
+        // candidates (a follow-up must come after the plan was proposed).
+        scanPlanFollowupLines(lines, 0, Number.MAX_SAFE_INTEGER, exitPlanToolIds)
+        baselineLine = lines.length
+        scannedThrough = Math.max(0, lines.length - 1)
         return
       }
 
-      const result = findClaudePlanFollowupAfterLine(raw, baselineLine)
-      baselineLine = result.nextLine
-      if (result.found) {
+      const found = scanPlanFollowupLines(lines, scannedThrough, baselineLine, exitPlanToolIds)
+      scannedThrough = Math.max(0, lines.length - 1)
+      if (found) {
         log.info('Detected Claude CLI plan follow-up in transcript', {
           worktreePath,
           claudeSessionId

--- a/src/main/services/claude-session-watcher.ts
+++ b/src/main/services/claude-session-watcher.ts
@@ -1,7 +1,6 @@
 import { watch, existsSync, readdirSync, statSync, type FSWatcher } from 'fs'
 import { join, basename } from 'path'
-import { homedir } from 'os'
-import { encodePath } from './claude-transcript-reader'
+import { encodePath, resolveProjectsDir } from './claude-transcript-reader'
 import { createLogger } from './logger'
 
 const log = createLogger({ component: 'ClaudeSessionWatcher' })
@@ -39,17 +38,25 @@ export function watchForClaudeSessionId(
   worktreePath: string,
   onSessionId: (sessionId: string) => void
 ): ClaudeSessionWatchHandle {
-  const dir = join(homedir(), '.claude', 'projects', encodePath(worktreePath))
+  const dir = join(resolveProjectsDir(), encodePath(worktreePath))
   const existing = listJsonlFiles(dir)
   const startedAtMs = Date.now()
   let closed = false
   let watcher: FSWatcher | null = null
   let interval: NodeJS.Timeout | null = null
+  let scanScheduled: NodeJS.Timeout | null = null
+
+  const stopTimers = (): void => {
+    if (interval) clearInterval(interval)
+    interval = null
+    if (scanScheduled) clearTimeout(scanScheduled)
+    scanScheduled = null
+  }
 
   const complete = (sessionId: string): void => {
     if (closed) return
     closed = true
-    if (interval) clearInterval(interval)
+    stopTimers()
     watcher?.close()
     log.info('Detected Claude CLI session id', { worktreePath, sessionId })
     onSessionId(sessionId)
@@ -60,11 +67,21 @@ export function watchForClaudeSessionId(
     if (sessionId) complete(sessionId)
   }
 
+  // Coalesce bursts of fs events (the CLI appends many lines while a transcript
+  // is created) into a single directory scan.
+  const requestScan = (): void => {
+    if (closed || scanScheduled) return
+    scanScheduled = setTimeout(() => {
+      scanScheduled = null
+      if (!closed) scan()
+    }, 50)
+  }
+
   try {
     if (existsSync(dir)) {
       watcher = watch(dir, (_eventType, filename) => {
         if (typeof filename === 'string' && filename.endsWith('.jsonl')) {
-          scan()
+          requestScan()
         }
       })
     } else {
@@ -77,14 +94,19 @@ export function watchForClaudeSessionId(
     })
   }
 
-  interval = setInterval(scan, 1000)
+  // Poll only as a fallback when fs.watch could not be attached (most commonly
+  // because the transcript directory does not exist yet). When the watcher is
+  // active its events drive detection, so the periodic full scan is redundant.
+  if (!watcher) {
+    interval = setInterval(scan, 1000)
+  }
   scan()
 
   return {
     close: () => {
       if (closed) return
       closed = true
-      if (interval) clearInterval(interval)
+      stopTimers()
       watcher?.close()
     }
   }

--- a/src/main/services/claude-session-watcher.ts
+++ b/src/main/services/claude-session-watcher.ts
@@ -1,0 +1,91 @@
+import { watch, existsSync, readdirSync, statSync, type FSWatcher } from 'fs'
+import { join, basename } from 'path'
+import { homedir } from 'os'
+import { encodePath } from './claude-transcript-reader'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'ClaudeSessionWatcher' })
+
+function listJsonlFiles(dir: string): Set<string> {
+  try {
+    return new Set(readdirSync(dir).filter((name) => name.endsWith('.jsonl')))
+  } catch {
+    return new Set()
+  }
+}
+
+function newestJsonlCreatedAfter(dir: string, existing: Set<string>, startedAtMs: number): string | null {
+  let newest: { name: string; mtimeMs: number } | null = null
+  for (const name of listJsonlFiles(dir)) {
+    if (existing.has(name)) continue
+    try {
+      const stat = statSync(join(dir, name))
+      if (stat.mtimeMs + 1000 < startedAtMs) continue
+      if (!newest || stat.mtimeMs > newest.mtimeMs) {
+        newest = { name, mtimeMs: stat.mtimeMs }
+      }
+    } catch {
+      // File can disappear between readdir and stat; ignore this scan tick.
+    }
+  }
+  return newest ? basename(newest.name, '.jsonl') : null
+}
+
+export interface ClaudeSessionWatchHandle {
+  close(): void
+}
+
+export function watchForClaudeSessionId(
+  worktreePath: string,
+  onSessionId: (sessionId: string) => void
+): ClaudeSessionWatchHandle {
+  const dir = join(homedir(), '.claude', 'projects', encodePath(worktreePath))
+  const existing = listJsonlFiles(dir)
+  const startedAtMs = Date.now()
+  let closed = false
+  let watcher: FSWatcher | null = null
+  let interval: NodeJS.Timeout | null = null
+
+  const complete = (sessionId: string): void => {
+    if (closed) return
+    closed = true
+    if (interval) clearInterval(interval)
+    watcher?.close()
+    log.info('Detected Claude CLI session id', { worktreePath, sessionId })
+    onSessionId(sessionId)
+  }
+
+  const scan = (): void => {
+    const sessionId = newestJsonlCreatedAfter(dir, existing, startedAtMs)
+    if (sessionId) complete(sessionId)
+  }
+
+  try {
+    if (existsSync(dir)) {
+      watcher = watch(dir, (_eventType, filename) => {
+        if (typeof filename === 'string' && filename.endsWith('.jsonl')) {
+          scan()
+        }
+      })
+    } else {
+      log.info('Claude project transcript directory does not exist yet', { dir })
+    }
+  } catch (error) {
+    log.warn('Unable to watch Claude transcript directory', {
+      dir,
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+
+  interval = setInterval(scan, 1000)
+  scan()
+
+  return {
+    close: () => {
+      if (closed) return
+      closed = true
+      if (interval) clearInterval(interval)
+      watcher?.close()
+    }
+  }
+}

--- a/src/main/services/claude-transcript-reader.ts
+++ b/src/main/services/claude-transcript-reader.ts
@@ -19,7 +19,7 @@ export function encodePath(worktreePath: string): string {
   return `${encoded.slice(0, ENCODED_PATH_MAX_LEN)}-${hashSuffix}`
 }
 
-function resolveProjectsDir(): string {
+export function resolveProjectsDir(): string {
   const configuredDir = process.env.CLAUDE_CONFIG_DIR
   const configRoot =
     typeof configuredDir === 'string' && configuredDir.trim().length > 0

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -76,16 +76,22 @@ export interface CodexSessionState {
   persistDebounceTimer: ReturnType<typeof setTimeout> | null
 }
 
+interface CodexLiveToolState {
+  status: 'running' | 'completed' | 'error'
+  input?: unknown
+  output?: unknown
+  error?: unknown
+}
+
+interface CodexLiveToolStateUpdate extends CodexLiveToolState {
+  outputDelta?: unknown
+}
+
 interface CodexLiveToolPart {
   type: 'tool'
   callID: string
   tool: string
-  state: {
-    status: 'running' | 'completed' | 'error'
-    input?: unknown
-    output?: unknown
-    error?: unknown
-  }
+  state: CodexLiveToolState
 }
 
 type CodexLiveDraftPart =
@@ -139,6 +145,12 @@ interface CodexSteerResult {
 function previewText(value: string, maxLength: number = 120): string {
   if (value.length <= maxLength) return value
   return value.slice(0, maxLength) + '...'
+}
+
+function withoutOutputDelta(state: CodexLiveToolStateUpdate): CodexLiveToolState {
+  const next = { ...state }
+  delete next.outputDelta
+  return next
 }
 
 /**
@@ -2398,12 +2410,7 @@ export class CodexImplementer implements AgentSdkImplementer {
     tool: {
       callID: string
       tool: string
-      state: {
-        status: 'running' | 'completed' | 'error'
-        input?: unknown
-        output?: unknown
-        error?: unknown
-      }
+      state: CodexLiveToolStateUpdate
     },
     turnId?: string
   ): void {
@@ -2437,14 +2444,11 @@ export class CodexImplementer implements AgentSdkImplementer {
       ...(tool.state.error !== undefined ? { error: tool.state.error } : {}),
       ...(tool.state.status !== 'running' ? { endTime: Date.now() } : {})
     }
-    // Remove outputDelta from nextToolUse — it's transient
-    delete (nextToolUse as any).outputDelta
-
     if (existingIndex >= 0) {
       const existingToolUse = asObject(asObject(parts[existingIndex])?.toolUse)
       // Handle outputDelta accumulation
       const prevOutput = existingToolUse?.output
-      const outputDelta = (tool.state as any).outputDelta
+      const outputDelta = tool.state.outputDelta
       const accumulatedOutput = outputDelta
         ? ((prevOutput as string) ?? '') + outputDelta
         : undefined
@@ -2575,13 +2579,7 @@ export class CodexImplementer implements AgentSdkImplementer {
     tool: {
       callID: string
       tool: string
-      state: {
-        status: 'running' | 'completed' | 'error'
-        input?: unknown
-        output?: unknown
-        error?: unknown
-        outputDelta?: unknown
-      }
+        state: CodexLiveToolStateUpdate
     }
   ): void {
     if (!tool.callID) return
@@ -2609,7 +2607,7 @@ export class CodexImplementer implements AgentSdkImplementer {
         existing.tool !== 'Bash'
           ? existing.tool
           : tool.tool || existing.tool
-      existing.state = {
+      existing.state = withoutOutputDelta({
         ...existing.state,
         ...tool.state,
         ...(tool.state.input === undefined ? { input: existing.state.input } : {}),
@@ -2619,8 +2617,7 @@ export class CodexImplementer implements AgentSdkImplementer {
             ? { output: existing.state.output }
             : {}),
         ...(tool.state.error === undefined ? { error: existing.state.error } : {})
-      }
-      delete (existing.state as any).outputDelta
+      })
       return
     }
 
@@ -2628,9 +2625,8 @@ export class CodexImplementer implements AgentSdkImplementer {
       type: 'tool',
       callID: tool.callID,
       tool: tool.tool,
-      state: { ...tool.state }
+      state: withoutOutputDelta(tool.state)
     })
-    delete ((subtask.parts[subtask.parts.length - 1] as CodexLiveToolPart).state as any).outputDelta
   }
 
   private getOrCreateCanonicalAssistantSubtask(
@@ -2724,13 +2720,7 @@ export class CodexImplementer implements AgentSdkImplementer {
     tool: {
       callID: string
       tool: string
-      state: {
-        status: 'running' | 'completed' | 'error'
-        input?: unknown
-        output?: unknown
-        error?: unknown
-        outputDelta?: unknown
-      }
+        state: CodexLiveToolStateUpdate
     },
     turnId?: string
   ): void {
@@ -2753,8 +2743,7 @@ export class CodexImplementer implements AgentSdkImplementer {
     const existingIndex = parts.findIndex(
       (part) => asString(part.type) === 'tool' && asString(part.callID) === tool.callID
     )
-    const nextState = { ...tool.state }
-    delete (nextState as any).outputDelta
+    const nextState = withoutOutputDelta(tool.state)
 
     if (existingIndex >= 0) {
       const existing = parts[existingIndex]
@@ -2838,7 +2827,7 @@ export class CodexImplementer implements AgentSdkImplementer {
               ...(state?.output !== undefined ? { output: state.output } : {}),
               ...(state?.error !== undefined ? { error: state.error } : {}),
               ...(state?.outputDelta !== undefined ? { outputDelta: state.outputDelta } : {})
-            } as any
+            }
           },
           targetTurnId
         )
@@ -2884,7 +2873,7 @@ export class CodexImplementer implements AgentSdkImplementer {
             ...(state?.output !== undefined ? { output: state.output } : {}),
             ...(state?.error !== undefined ? { error: state.error } : {}),
             ...(state?.outputDelta !== undefined ? { outputDelta: state.outputDelta } : {})
-          } as any
+            }
         },
         targetTurnId
       )
@@ -2927,12 +2916,7 @@ export class CodexImplementer implements AgentSdkImplementer {
     tool: {
       callID: string
       tool: string
-      state: {
-        status: 'running' | 'completed' | 'error'
-        input?: unknown
-        output?: unknown
-        error?: unknown
-      }
+      state: CodexLiveToolStateUpdate
     }
   ): void {
     if (!tool.callID) return
@@ -2941,19 +2925,19 @@ export class CodexImplementer implements AgentSdkImplementer {
     const existingIndex = draft.toolIndexById.get(tool.callID)
 
     if (existingIndex !== undefined) {
-      const existing = draft.parts[existingIndex]
-      if (existing && existing.type === 'tool') {
-        existing.tool =
-          (tool.state as any).outputDelta !== undefined &&
+        const existing = draft.parts[existingIndex]
+        if (existing && existing.type === 'tool') {
+          existing.tool =
+          tool.state.outputDelta !== undefined &&
           tool.tool === 'Bash' &&
           existing.tool &&
           existing.tool !== 'Bash'
             ? existing.tool
             : tool.tool || existing.tool
-        const appendedOutput = (tool.state as any).outputDelta
-          ? ((existing.state.output as string) ?? '') + (tool.state as any).outputDelta
+        const appendedOutput = tool.state.outputDelta
+          ? ((existing.state.output as string) ?? '') + String(tool.state.outputDelta)
           : undefined
-        existing.state = {
+        existing.state = withoutOutputDelta({
           ...existing.state,
           ...tool.state,
           ...(tool.state.input === undefined ? { input: existing.state.input } : {}),
@@ -2963,9 +2947,7 @@ export class CodexImplementer implements AgentSdkImplementer {
               ? { output: existing.state.output }
               : {}),
           ...(tool.state.error === undefined ? { error: existing.state.error } : {})
-        }
-        // Remove outputDelta from persisted state — it's transient
-        delete (existing.state as any).outputDelta
+        })
       }
       return
     }
@@ -2975,10 +2957,8 @@ export class CodexImplementer implements AgentSdkImplementer {
       type: 'tool',
       callID: tool.callID,
       tool: tool.tool,
-      state: tool.state
+      state: withoutOutputDelta(tool.state)
     })
-    // Remove outputDelta from persisted state — it's transient (new-tool path)
-    delete ((draft.parts[draft.parts.length - 1] as CodexLiveToolPart).state as any).outputDelta
   }
 
   private updateLiveAssistantDraftFromStreamEvent(
@@ -3014,7 +2994,7 @@ export class CodexImplementer implements AgentSdkImplementer {
             ...(state?.output !== undefined ? { output: state.output } : {}),
             ...(state?.error !== undefined ? { error: state.error } : {}),
             ...(state?.outputDelta !== undefined ? { outputDelta: state.outputDelta } : {})
-          } as any
+          }
         })
         return
       }
@@ -3055,7 +3035,7 @@ export class CodexImplementer implements AgentSdkImplementer {
           ...(state?.output !== undefined ? { output: state.output } : {}),
           ...(state?.error !== undefined ? { error: state.error } : {}),
           ...(state?.outputDelta !== undefined ? { outputDelta: state.outputDelta } : {})
-        } as any
+        }
       })
       return
     }

--- a/src/main/services/ghostty-service.ts
+++ b/src/main/services/ghostty-service.ts
@@ -11,7 +11,13 @@ interface GhosttyAddon {
   ghosttyCreateSurface(
     windowHandle: Buffer,
     rect: { x: number; y: number; w: number; h: number },
-    opts: { cwd?: string; shell?: string; scaleFactor: number; fontSize?: number }
+    opts: {
+      cwd?: string
+      shell?: string
+      scaleFactor: number
+      fontSize?: number
+      shiftEnterAsNewline?: boolean
+    }
   ): number
   ghosttySetFrame(surfaceId: number, rect: { x: number; y: number; w: number; h: number }): void
   ghosttySetSize(surfaceId: number, width: number, height: number): void
@@ -67,6 +73,7 @@ export interface GhosttyCreateSurfaceOpts {
   shell?: string
   scaleFactor?: number
   fontSize?: number
+  shiftEnterAsNewline?: boolean
 }
 
 // Surface tracking for worktree association
@@ -232,7 +239,8 @@ class GhosttyService {
         cwd: opts.cwd,
         shell: opts.shell,
         scaleFactor,
-        fontSize: opts.fontSize
+        fontSize: opts.fontSize,
+        shiftEnterAsNewline: opts.shiftEnterAsNewline
       })
 
       if (surfaceId === 0) {

--- a/src/main/services/pty-service.ts
+++ b/src/main/services/pty-service.ts
@@ -24,6 +24,8 @@ interface PtyInstance {
 
 export interface PtyCreateOpts {
   cwd: string
+  command?: string
+  args?: string[]
   shell?: string
   env?: Record<string, string>
   cols?: number
@@ -52,7 +54,8 @@ class PtyService {
       }
     }
 
-    const shell =
+    const command =
+      opts.command ||
       opts.shell ||
       process.env.SHELL ||
       (process.platform === 'win32'
@@ -60,6 +63,7 @@ class PtyService {
         : process.platform === 'darwin'
           ? '/bin/zsh'
           : '/bin/bash')
+    const args = opts.command ? (opts.args ?? []) : []
     const cols = opts.cols || 80
     const rows = opts.rows || 24
 
@@ -70,9 +74,16 @@ class PtyService {
       ...opts.env
     } as Record<string, string>
 
-    log.info('Creating PTY', { id, shell, cwd: opts.cwd, cols, rows })
+    log.info('Creating PTY', {
+      id,
+      command,
+      args: args.length,
+      cwd: opts.cwd,
+      cols,
+      rows
+    })
 
-    const ptyProcess = pty.spawn(shell, [], {
+    const ptyProcess = pty.spawn(command, args, {
       name: 'xterm-256color',
       cols,
       rows,

--- a/src/main/services/telegram-forwarding-service.ts
+++ b/src/main/services/telegram-forwarding-service.ts
@@ -6,12 +6,15 @@ import type {
   TelegramForwardingStatus,
   TelegramMode
 } from '@shared/types/telegram'
+import { isClaudeCli } from '@shared/types/agent-sdk'
 import { openCodeService } from './opencode-service'
 import { ClaudeCodeImplementer } from './claude-code-implementer'
 import { CodexImplementer } from './codex-implementer'
 import type { AgentSdkManager } from './agent-sdk-manager'
 import type { DatabaseService } from '../db/database'
 import { agentEventBus } from './agent-event-bus'
+import { claudeCliTelegramBridge } from './claude-cli-telegram-bridge'
+import { writeClaudeCliPrompt } from './claude-cli-pty-prompt'
 
 const TELEGRAM_CONFIG_KEY = 'telegram_config'
 const MAX_TELEGRAM_TEXT = 4096
@@ -205,6 +208,7 @@ export class TelegramForwardingService {
   private questionBatches = new Map<string, QuestionBatch>()
   private callbackRequestIds = new Map<string, string>()
   private unsubscribeBus: (() => void) | null = null
+  private unsubscribeBridge: (() => void) | null = null
 
   initialize(opts: {
     mainWindow: BrowserWindow
@@ -219,6 +223,13 @@ export class TelegramForwardingService {
         void this.handleAgentEvent(event)
       })
     }
+    // Claude CLI hook events arrive on the bridge's private channel (not the
+    // renderer-visible agentEventBus), routed through the same handler.
+    if (!this.unsubscribeBridge) {
+      this.unsubscribeBridge = claudeCliTelegramBridge.subscribe((event) => {
+        void this.handleAgentEvent(event)
+      })
+    }
   }
 
   dispose(): void {
@@ -226,6 +237,8 @@ export class TelegramForwardingService {
     this.cancelAssistantFlush()
     this.unsubscribeBus?.()
     this.unsubscribeBus = null
+    this.unsubscribeBridge?.()
+    this.unsubscribeBridge = null
   }
 
   getConfig(): TelegramConfig | null {
@@ -335,6 +348,13 @@ export class TelegramForwardingService {
       firstFailureSurfaced: false
     }
 
+    // Claude CLI sessions have no SDK implementer to route answers to; the bridge
+    // intercepts their hooks instead. Only intercept while forwarding is enabled.
+    const session = this.db?.getSession(params.sessionId)
+    if (session && isClaudeCli(session.agent_sdk)) {
+      claudeCliTelegramBridge.register(params.sessionId)
+    }
+
     const label = this.getSessionLabel(params.sessionId)
     const verb = previous && previous.sessionId !== params.sessionId ? 'Forwarding moved to' : 'Forwarding started'
     this.state.lastUpdateId = await this.discardPendingUpdates(cfg)
@@ -348,6 +368,11 @@ export class TelegramForwardingService {
     const cfg = this.getConfig()
     const state = this.state
     if (!state) return this.getStatus()
+
+    // Unblock any held CLI hook (resolves with `{}` → CLI falls back to its
+    // terminal prompt) and stop intercepting this session. Covers manual stop,
+    // move (handoff), replace, and session-ended.
+    claudeCliTelegramBridge.cancelSession(state.sessionId)
 
     this.stopPolling()
     this.cancelAssistantFlush()
@@ -713,6 +738,10 @@ export class TelegramForwardingService {
   }
 
   private async replyQuestion(requestId: string, answers: string[][], worktreePath?: string): Promise<void> {
+    if (claudeCliTelegramBridge.hasPendingQuestion(requestId)) {
+      claudeCliTelegramBridge.resolveQuestion(requestId, answers)
+      return
+    }
     if (this.sdkManager) {
       const claudeImpl = this.sdkManager.getImplementer('claude-code') as ClaudeCodeImplementer
       if (claudeImpl.hasPendingQuestion(requestId)) {
@@ -836,6 +865,15 @@ export class TelegramForwardingService {
 
   private async requestPlanHandoff(interaction: TrackedInteraction): Promise<void> {
     if (!this.mainWindow || !this.state) return
+    // For a CLI session the ExitPlanMode hook is held open; resolve it (deny) so
+    // the original session parks while the handoff spawns a new session below.
+    if (claudeCliTelegramBridge.hasPendingPlan(interaction.requestId)) {
+      claudeCliTelegramBridge.resolvePlan(
+        interaction.requestId,
+        false,
+        'Plan handed off to a new session'
+      )
+    }
     this.mainWindow.webContents.send('telegram:planImplementRequested', {
       sessionId: this.state.sessionId,
       worktreeId: this.state.worktreeId ?? null,
@@ -846,6 +884,10 @@ export class TelegramForwardingService {
   }
 
   private async rejectPlan(interaction: TrackedInteraction, feedback: string): Promise<void> {
+    if (claudeCliTelegramBridge.hasPendingPlan(interaction.requestId)) {
+      claudeCliTelegramBridge.resolvePlan(interaction.requestId, false, feedback)
+      return
+    }
     const state = this.state
     const impl = this.sdkManager?.getImplementer('claude-code')
     if (
@@ -862,6 +904,10 @@ export class TelegramForwardingService {
   private async approvePlan(interaction: TrackedInteraction): Promise<void> {
     const state = this.state
     if (!state) return
+    if (claudeCliTelegramBridge.hasPendingPlan(interaction.requestId)) {
+      claudeCliTelegramBridge.resolvePlan(interaction.requestId, true)
+      return
+    }
     const impl = this.sdkManager?.getImplementer('claude-code')
     if (
       impl instanceof ClaudeCodeImplementer &&
@@ -928,8 +974,18 @@ export class TelegramForwardingService {
     const state = this.state
     if (!state) return
     const session = this.db?.getSession(state.sessionId)
+    if (!session) throw new Error('Active session not found')
+
+    // CLI sessions have no implementer; inject the prompt straight into the PTY.
+    if (isClaudeCli(session.agent_sdk)) {
+      const { delivered } = writeClaudeCliPrompt(state.sessionId, text)
+      // No live PTY yet — keep it queued for the next idle flush (best-effort).
+      if (!delivered) state.pendingQueuedPrompt = text
+      return
+    }
+
     const workspacePath = this.getSessionWorkspacePath()
-    if (!session || !workspacePath) throw new Error('Active session not found')
+    if (!workspacePath) throw new Error('Active session not found')
     const agentSessionId = session.opencode_session_id ?? state.sessionId
     const parts = [{ type: 'text' as const, text }]
 

--- a/src/native/src/addon.mm
+++ b/src/native/src/addon.mm
@@ -108,6 +108,11 @@ Napi::Value GhosttyCreateSurface(const Napi::CallbackInfo& info) {
     fontSize = static_cast<float>(opts.Get("fontSize").As<Napi::Number>().DoubleValue());
   }
 
+  bool shiftEnterAsNewline = false;
+  if (opts.Has("shiftEnterAsNewline") && opts.Get("shiftEnterAsNewline").IsBoolean()) {
+    shiftEnterAsNewline = opts.Get("shiftEnterAsNewline").As<Napi::Boolean>().Value();
+  }
+
   // Create the host NSView
   NSView* hostView = createHostView(window, rect);
   if (!hostView) {
@@ -129,6 +134,7 @@ Napi::Value GhosttyCreateSurface(const Napi::CallbackInfo& info) {
   }
 
   setHostViewSurfaceId(hostView, surfaceId);
+  setHostViewShiftEnterAsNewline(hostView, shiftEnterAsNewline);
 
   return Napi::Number::New(env, surfaceId);
 }

--- a/src/native/src/nsview_host.h
+++ b/src/native/src/nsview_host.h
@@ -46,6 +46,10 @@ void setHostViewFrame(NSView* view, ViewRect rect);
 // host view to forward input events directly to the correct surface.
 void setHostViewSurfaceId(NSView* view, uint32_t surfaceId);
 
+// Configure whether this host view should preserve Shift for bare
+// Shift+Enter so Ghostty's default `shift+enter=text:\n` binding can match.
+void setHostViewShiftEnterAsNewline(NSView* view, bool enabled);
+
 // Make the given host view the window's first responder.
 void focusHostView(NSView* view);
 

--- a/src/native/src/nsview_host.mm
+++ b/src/native/src/nsview_host.mm
@@ -4,6 +4,7 @@
 // BrowserWindow using the native window handle.
 
 #import <Cocoa/Cocoa.h>
+#import <Carbon/Carbon.h>
 #include <IOKit/hidsystem/ev_keymap.h>
 #include <string>
 #include "nsview_host.h"
@@ -64,6 +65,16 @@ ghostty_input_mods_e ghosttyConsumedModsFromFlags(NSEventModifierFlags flags) {
   return ghosttyModsFromFlags(filtered);
 }
 
+bool isBareShiftEnterEvent(NSEvent* event) {
+  const NSEventModifierFlags flags = event.modifierFlags;
+  const NSEventModifierFlags disallowed =
+    NSEventModifierFlagControl | NSEventModifierFlagOption | NSEventModifierFlagCommand;
+  const bool onlyShift = (flags & NSEventModifierFlagShift) && !(flags & disallowed);
+  const unsigned short keyCode = event.keyCode;
+
+  return onlyShift && (keyCode == kVK_Return || keyCode == kVK_ANSI_KeypadEnter);
+}
+
 uint32_t unshiftedCodepointForEvent(NSEvent* event) {
   NSString* chars = [event charactersByApplyingModifiers:0];
   if (!chars || chars.length == 0) return 0;
@@ -110,6 +121,7 @@ uint8_t momentumFromEventPhase(NSEventPhase phase) {
 
 @interface GhosttyHostView : NSView
 @property(nonatomic, assign) uint32_t surfaceId;
+@property(nonatomic, assign) BOOL shiftEnterAsNewline;
 @end
 
 @implementation GhosttyHostView
@@ -276,6 +288,11 @@ uint8_t momentumFromEventPhase(NSEventPhase phase) {
     return;
   }
 
+  if (self.shiftEnterAsNewline && isBareShiftEnterEvent(event)) {
+    ghostty::GhosttyBridge::instance().pasteText(self.surfaceId, "\x1b\r");
+    return;
+  }
+
   const auto action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS;
   const auto mods = ghosttyModsFromFlags(event.modifierFlags);
   const auto consumedMods = ghosttyConsumedModsFromFlags(event.modifierFlags);
@@ -296,6 +313,10 @@ uint8_t momentumFromEventPhase(NSEventPhase phase) {
 - (void)keyUp:(NSEvent*)event {
   if (self.surfaceId == 0) {
     [super keyUp:event];
+    return;
+  }
+
+  if (self.shiftEnterAsNewline && isBareShiftEnterEvent(event)) {
     return;
   }
 
@@ -354,6 +375,7 @@ NSView* createHostView(NSWindow* window, ViewRect rect) {
 
   GhosttyHostView* hostView = [[GhosttyHostView alloc] initWithFrame:frame];
   hostView.surfaceId = 0;
+  hostView.shiftEnterAsNewline = NO;
   hostView.autoresizingMask = 0; // JS layer controls frame exclusively via setHostViewFrame()
   hostView.wantsLayer = YES;
 
@@ -389,6 +411,15 @@ void setHostViewSurfaceId(NSView* view, uint32_t surfaceId) {
 
   GhosttyHostView* hostView = (GhosttyHostView*)view;
   hostView.surfaceId = surfaceId;
+}
+
+void setHostViewShiftEnterAsNewline(NSView* view, bool enabled) {
+  if (!view || ![view isKindOfClass:[GhosttyHostView class]]) {
+    return;
+  }
+
+  GhosttyHostView* hostView = (GhosttyHostView*)view;
+  hostView.shiftEnterAsNewline = enabled ? YES : NO;
 }
 
 void focusHostView(NSView* view) {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1192,7 +1192,13 @@ declare global {
       ghosttyCreateSurface: (
         terminalId: string,
         rect: { x: number; y: number; w: number; h: number },
-        opts?: { cwd?: string; shell?: string; scaleFactor?: number; fontSize?: number }
+        opts?: {
+          cwd?: string
+          shell?: string
+          scaleFactor?: number
+          fontSize?: number
+          shiftEnterAsNewline?: boolean
+        }
       ) => Promise<Envelope<{ success: boolean; surfaceId?: number; error?: string }>>
       ghosttySetFrame: (
         terminalId: string,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1180,6 +1180,7 @@ declare global {
         callback: (claudeSessionId: string) => void
       ) => () => void
       onClaudeCliStatus: (callback: (payload: ClaudeCliStatusPayload) => void) => () => void
+      onClaudeCliPlanFollowup: (callback: (payload: { sessionId: string }) => void) => () => void
       getConfig: () => Promise<Envelope<GhosttyTerminalConfig>>
 
       // Native Ghostty backend methods

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -336,6 +336,26 @@ declare global {
         exitCode?: number
       }
 
+  type SessionStatusType =
+    | 'working'
+    | 'planning'
+    | 'answering'
+    | 'permission'
+    | 'command_approval'
+    | 'unread'
+    | 'completed'
+    | 'plan_ready'
+
+  interface ClaudeCliStatusPayload {
+    sessionId: string
+    status: SessionStatusType
+    metadata?: {
+      reason?: string
+      hookEventName?: string
+      hookPath?: string
+    }
+  }
+
   interface DiffComment {
     id: string
     worktree_id: string
@@ -1148,6 +1168,7 @@ declare global {
         sessionId: string,
         callback: (claudeSessionId: string) => void
       ) => () => void
+      onClaudeCliStatus: (callback: (payload: ClaudeCliStatusPayload) => void) => () => void
       getConfig: () => Promise<Envelope<GhosttyTerminalConfig>>
 
       // Native Ghostty backend methods

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -353,6 +353,8 @@ declare global {
       reason?: string
       hookEventName?: string
       hookPath?: string
+      toolName?: string
+      plan?: string
     }
   }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -97,7 +97,8 @@ interface Session {
   name: string | null
   status: 'active' | 'completed' | 'error'
   opencode_session_id: string | null
-  agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  claude_session_id: string | null
+  agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   mode: 'build' | 'plan' | 'super-plan'
   session_type: 'default' | 'board-assistant'
   model_provider_id: string | null
@@ -449,7 +450,8 @@ declare global {
           connection_id?: string | null
           name?: string | null
           opencode_session_id?: string | null
-          agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+          claude_session_id?: string | null
+          agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
           mode?: 'build' | 'plan' | 'super-plan'
           session_type?: 'default' | 'board-assistant'
           model_provider_id?: string | null
@@ -467,7 +469,8 @@ declare global {
             name?: string | null
             status?: 'active' | 'completed' | 'error'
             opencode_session_id?: string | null
-            agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+            claude_session_id?: string | null
+            agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
             mode?: 'build' | 'plan' | 'super-plan'
             session_type?: 'default' | 'board-assistant'
             model_provider_id?: string | null
@@ -813,7 +816,7 @@ declare global {
       ) => Promise<Envelope<{ success: boolean; messages: unknown[]; error?: string }>>
       // List available models from all configured providers
       listModels: (opts?: {
-        agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+        agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
       }) => Promise<
         Envelope<{
           success: boolean
@@ -827,14 +830,14 @@ declare global {
           providerID: string
           modelID: string
           variant?: string
-          agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+          agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
         } | null
       ) => Promise<Envelope<{ success: boolean; error?: string }>>
       // Get model info (name, context limit)
       modelInfo: (
         worktreePath: string,
         modelId: string,
-        agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+        agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
       ) => Promise<
         Envelope<{
           success: boolean
@@ -1132,11 +1135,19 @@ declare global {
         cwd: string,
         shell?: string
       ) => Promise<Envelope<{ success: boolean; cols?: number; rows?: number; error?: string }>>
+      createClaudeCli: (
+        sessionId: string,
+        opts?: { pendingPrompt?: string | null }
+      ) => Promise<Envelope<{ success: boolean; cols?: number; rows?: number; error?: string }>>
       write: (terminalId: string, data: string) => void
       resize: (terminalId: string, cols: number, rows: number) => Promise<Envelope<void>>
       destroy: (terminalId: string) => Promise<Envelope<void>>
       onData: (terminalId: string, callback: (data: string) => void) => () => void
       onExit: (terminalId: string, callback: (code: number) => void) => () => void
+      onClaudeSessionId: (
+        sessionId: string,
+        callback: (claudeSessionId: string) => void
+      ) => () => void
       getConfig: () => Promise<Envelope<GhosttyTerminalConfig>>
 
       // Native Ghostty backend methods

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -6,6 +6,8 @@ import type {
   TelegramMode
 } from '../shared/types/telegram'
 import type { Envelope } from '@shared/types/ipc-envelope'
+import type { SessionStatusType } from '@shared/types/session-status'
+import type { AgentSdk } from '@shared/types/agent-sdk'
 import type { CustomProjectCommand } from '@shared/lib/custom-commands'
 import type { SuggestionItem } from '../shared/types/setup-suggestions'
 
@@ -101,7 +103,7 @@ interface Session {
   status: 'active' | 'completed' | 'error'
   opencode_session_id: string | null
   claude_session_id: string | null
-  agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agent_sdk: AgentSdk
   mode: 'build' | 'plan' | 'super-plan'
   session_type: 'default' | 'board-assistant'
   model_provider_id: string | null
@@ -339,16 +341,6 @@ declare global {
         exitCode?: number
       }
 
-  type SessionStatusType =
-    | 'working'
-    | 'planning'
-    | 'answering'
-    | 'permission'
-    | 'command_approval'
-    | 'unread'
-    | 'completed'
-    | 'plan_ready'
-
   interface ClaudeCliStatusPayload {
     sessionId: string
     status: SessionStatusType
@@ -478,7 +470,7 @@ declare global {
           name?: string | null
           opencode_session_id?: string | null
           claude_session_id?: string | null
-          agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+          agent_sdk?: AgentSdk
           mode?: 'build' | 'plan' | 'super-plan'
           session_type?: 'default' | 'board-assistant'
           model_provider_id?: string | null
@@ -497,7 +489,7 @@ declare global {
             status?: 'active' | 'completed' | 'error'
             opencode_session_id?: string | null
             claude_session_id?: string | null
-            agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+            agent_sdk?: AgentSdk
             mode?: 'build' | 'plan' | 'super-plan'
             session_type?: 'default' | 'board-assistant'
             model_provider_id?: string | null
@@ -847,7 +839,7 @@ declare global {
       ) => Promise<Envelope<{ success: boolean; count?: number; error?: string }>>
       // List available models from all configured providers
       listModels: (opts?: {
-        agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+        agentSdk?: AgentSdk
       }) => Promise<
         Envelope<{
           success: boolean
@@ -861,14 +853,14 @@ declare global {
           providerID: string
           modelID: string
           variant?: string
-          agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+          agentSdk?: AgentSdk
         } | null
       ) => Promise<Envelope<{ success: boolean; error?: string }>>
       // Get model info (name, context limit)
       modelInfo: (
         worktreePath: string,
         modelId: string,
-        agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+        agentSdk?: AgentSdk
       ) => Promise<
         Envelope<{
           success: boolean
@@ -1170,6 +1162,10 @@ declare global {
         sessionId: string,
         opts?: { pendingPrompt?: string | null }
       ) => Promise<Envelope<{ success: boolean; cols?: number; rows?: number; error?: string }>>
+      sendClaudeCliPrompt: (
+        sessionId: string,
+        prompt: string
+      ) => Promise<Envelope<{ delivered: boolean }>>
       write: (terminalId: string, data: string) => void
       resize: (terminalId: string, cols: number, rows: number) => Promise<Envelope<void>>
       destroy: (terminalId: string) => Promise<Envelope<void>>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2067,6 +2067,19 @@ const terminalOps = {
     }
   },
 
+  onClaudeCliPlanFollowup: (callback: (payload: { sessionId: string }) => void): (() => void) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      payload: { sessionId: string }
+    ): void => {
+      callback(payload)
+    }
+    ipcRenderer.on('claude-cli:plan-followup', handler)
+    return () => {
+      ipcRenderer.off('claude-cli:plan-followup', handler)
+    }
+  },
+
   getConfig: (): Promise<
     Envelope<{
       fontFamily?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,7 @@ import type {
   TelegramMode
 } from '../shared/types/telegram'
 import type { Envelope } from '@shared/types/ipc-envelope'
+import type { AgentSdk } from '@shared/types/agent-sdk'
 import type { CustomProjectCommand } from '@shared/lib/custom-commands'
 import type { SuggestionItem } from '../shared/types/setup-suggestions'
 import type { ConnectionWithMembers } from '../main/db/types'
@@ -114,7 +115,7 @@ const db = {
       name?: string | null
       opencode_session_id?: string | null
       claude_session_id?: string | null
-      agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+      agent_sdk?: AgentSdk
       mode?: 'build' | 'plan' | 'super-plan'
       session_type?: 'default' | 'board-assistant'
       model_provider_id?: string | null
@@ -134,7 +135,7 @@ const db = {
         status?: 'active' | 'completed' | 'error'
         opencode_session_id?: string | null
         claude_session_id?: string | null
-        agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+        agent_sdk?: AgentSdk
         mode?: 'build' | 'plan' | 'super-plan'
         session_type?: 'default' | 'board-assistant'
         model_provider_id?: string | null
@@ -1544,7 +1545,7 @@ const opencodeOps = {
 
   // List available models from all configured providers
   listModels: (opts?: {
-    agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+    agentSdk?: AgentSdk
   }): Promise<
     Envelope<{
       success: boolean
@@ -1559,7 +1560,7 @@ const opencodeOps = {
       providerID: string
       modelID: string
       variant?: string
-      agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+      agentSdk?: AgentSdk
     } | null
   ): Promise<Envelope<{ success: boolean; error?: string }>> =>
     ipcRenderer.invoke('opencode:setModel', model),
@@ -1568,7 +1569,7 @@ const opencodeOps = {
   modelInfo: (
     worktreePath: string,
     modelId: string,
-    agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+    agentSdk?: AgentSdk
   ): Promise<
     Envelope<{
       success: boolean
@@ -1973,6 +1974,12 @@ const terminalOps = {
     opts?: { pendingPrompt?: string | null }
   ): Promise<Envelope<{ success: boolean; cols?: number; rows?: number; error?: string }>> =>
     ipcRenderer.invoke('terminal:createClaudeCli', sessionId, opts),
+
+  sendClaudeCliPrompt: (
+    sessionId: string,
+    prompt: string
+  ): Promise<Envelope<{ delivered: boolean }>> =>
+    ipcRenderer.invoke('terminal:sendClaudeCliPrompt', sessionId, prompt),
 
   write: (terminalId: string, data: string): void =>
     ipcRenderer.send('terminal:write', terminalId, data),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2007,6 +2007,45 @@ const terminalOps = {
     }
   },
 
+  onClaudeCliStatus: (
+    callback: (payload: {
+      sessionId: string
+      status:
+        | 'working'
+        | 'planning'
+        | 'answering'
+        | 'permission'
+        | 'command_approval'
+        | 'unread'
+        | 'completed'
+        | 'plan_ready'
+      metadata?: { reason?: string; hookEventName?: string; hookPath?: string }
+    }) => void
+  ): (() => void) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      payload: {
+        sessionId: string
+        status:
+          | 'working'
+          | 'planning'
+          | 'answering'
+          | 'permission'
+          | 'command_approval'
+          | 'unread'
+          | 'completed'
+          | 'plan_ready'
+        metadata?: { reason?: string; hookEventName?: string; hookPath?: string }
+      }
+    ): void => {
+      callback(payload)
+    }
+    ipcRenderer.on('claude-cli:status', handler)
+    return () => {
+      ipcRenderer.off('claude-cli:status', handler)
+    }
+  },
+
   getConfig: (): Promise<
     Envelope<{
       fontFamily?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2098,7 +2098,13 @@ const terminalOps = {
   ghosttyCreateSurface: (
     terminalId: string,
     rect: { x: number; y: number; w: number; h: number },
-    opts?: { cwd?: string; shell?: string; scaleFactor?: number; fontSize?: number }
+    opts?: {
+      cwd?: string
+      shell?: string
+      scaleFactor?: number
+      fontSize?: number
+      shiftEnterAsNewline?: boolean
+    }
   ): Promise<Envelope<{ success: boolean; surfaceId?: number; error?: string }>> =>
     ipcRenderer.invoke('terminal:ghostty:createSurface', terminalId, rect, opts),
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2019,7 +2019,13 @@ const terminalOps = {
         | 'unread'
         | 'completed'
         | 'plan_ready'
-      metadata?: { reason?: string; hookEventName?: string; hookPath?: string }
+      metadata?: {
+        reason?: string
+        hookEventName?: string
+        hookPath?: string
+        toolName?: string
+        plan?: string
+      }
     }) => void
   ): (() => void) => {
     const handler = (
@@ -2035,7 +2041,13 @@ const terminalOps = {
           | 'unread'
           | 'completed'
           | 'plan_ready'
-        metadata?: { reason?: string; hookEventName?: string; hookPath?: string }
+        metadata?: {
+          reason?: string
+          hookEventName?: string
+          hookPath?: string
+          toolName?: string
+          plan?: string
+        }
       }
     ): void => {
       callback(payload)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -110,7 +110,8 @@ const db = {
       connection_id?: string | null
       name?: string | null
       opencode_session_id?: string | null
-      agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+      claude_session_id?: string | null
+      agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
       mode?: 'build' | 'plan' | 'super-plan'
       session_type?: 'default' | 'board-assistant'
       model_provider_id?: string | null
@@ -129,7 +130,8 @@ const db = {
         name?: string | null
         status?: 'active' | 'completed' | 'error'
         opencode_session_id?: string | null
-        agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+        claude_session_id?: string | null
+        agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
         mode?: 'build' | 'plan' | 'super-plan'
         session_type?: 'default' | 'board-assistant'
         model_provider_id?: string | null
@@ -1533,7 +1535,7 @@ const opencodeOps = {
 
   // List available models from all configured providers
   listModels: (opts?: {
-    agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+    agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   }): Promise<
     Envelope<{
       success: boolean
@@ -1548,7 +1550,7 @@ const opencodeOps = {
       providerID: string
       modelID: string
       variant?: string
-      agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+      agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
     } | null
   ): Promise<Envelope<{ success: boolean; error?: string }>> =>
     ipcRenderer.invoke('opencode:setModel', model),
@@ -1557,7 +1559,7 @@ const opencodeOps = {
   modelInfo: (
     worktreePath: string,
     modelId: string,
-    agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+    agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   ): Promise<
     Envelope<{
       success: boolean
@@ -1957,6 +1959,12 @@ const terminalOps = {
   ): Promise<Envelope<{ success: boolean; cols?: number; rows?: number; error?: string }>> =>
     ipcRenderer.invoke('terminal:create', terminalId, cwd, shell),
 
+  createClaudeCli: (
+    sessionId: string,
+    opts?: { pendingPrompt?: string | null }
+  ): Promise<Envelope<{ success: boolean; cols?: number; rows?: number; error?: string }>> =>
+    ipcRenderer.invoke('terminal:createClaudeCli', sessionId, opts),
+
   write: (terminalId: string, data: string): void =>
     ipcRenderer.send('terminal:write', terminalId, data),
 
@@ -1981,6 +1989,17 @@ const terminalOps = {
     const channel = `terminal:exit:${terminalId}`
     const handler = (_event: Electron.IpcRendererEvent, code: number): void => {
       callback(code)
+    }
+    ipcRenderer.on(channel, handler)
+    return () => {
+      ipcRenderer.removeListener(channel, handler)
+    }
+  },
+
+  onClaudeSessionId: (sessionId: string, callback: (claudeSessionId: string) => void): (() => void) => {
+    const channel = `terminal:claude-session-id:${sessionId}`
+    const handler = (_event: Electron.IpcRendererEvent, claudeSessionId: string): void => {
+      callback(claudeSessionId)
     }
     ipcRenderer.on(channel, handler)
     return () => {

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -352,7 +352,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
   )
 
   // ── Detect pending questions for this ticket's session ─────────
-  const isAsking = useQuestionStore(
+  const isAskingFromQuestionStore = useQuestionStore(
     useCallback(
       (state) => {
         if (!ticket.current_session_id) return false
@@ -362,6 +362,17 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       [ticket.current_session_id]
     )
   )
+  const isAskingFromStatus = useWorktreeStatusStore(
+    useCallback(
+      (state) => {
+        if (!ticket.current_session_id) return false
+        return state.sessionStatuses[ticket.current_session_id]?.status === 'answering'
+      },
+      [ticket.current_session_id]
+    )
+  )
+  const isAsking = isAskingFromQuestionStore || isAskingFromStatus
+
   const rightAlignedSlot: 'conflicts' | 'busy' | 'reviewing' | 'completed-review' | null =
     useMemo(() => {
       if (!isArchived && hasConflicts && ticket.worktree_id) return 'conflicts'

--- a/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
@@ -342,6 +342,22 @@ describe('KanbanTicketModal handoff from Claude CLI plan review', () => {
     expect(useKanbanStore.getState().isBoardViewActive).toBe(true)
   })
 
+  it('hides left-side followup and implement controls for Claude CLI plan review', async () => {
+    setupStores()
+
+    render(
+      <ClaudeCliSessionPortalProvider>
+        <KanbanTicketModal />
+      </ClaudeCliSessionPortalProvider>
+    )
+
+    expect(screen.queryByTestId('followup-input')).toBeNull()
+    expect(screen.queryByTestId('plan-review-implement-btn')).toBeNull()
+    expect(screen.queryByTestId('plan-review-supercharge-btn')).toBeNull()
+    expect(screen.queryByTestId('plan-review-supercharge-local-btn')).toBeNull()
+    expect(screen.queryByTestId('plan-review-handoff-btn')).not.toBeNull()
+  })
+
   it('keeps board focus when the portaled Claude CLI plan card handoff is clicked', async () => {
     const { createSession, setActiveSession } = setupStores()
     const user = userEvent.setup()

--- a/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
@@ -1,0 +1,371 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { KanbanTicketModal } from './KanbanTicketModal'
+import { ClaudeCliSessionView } from '../sessions/ClaudeCliSessionView'
+import {
+  ClaudeCliSessionPortalProvider,
+  useClaudeCliSessionPortal
+} from '@/contexts/ClaudeCliSessionPortalContext'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket, Session, Worktree } from '../../../../main/db/types'
+
+vi.mock('../sessions/HandoffSplitButton', () => ({
+  HandoffSplitButton: ({
+    onHandoff,
+    testIdPrefix = 'plan-ready',
+    disabled = false
+  }: {
+    onHandoff: (override: { agentSdk: 'claude-code-cli'; model?: undefined }) => void
+    testIdPrefix?: string
+    disabled?: boolean
+  }) => (
+    <button
+      type="button"
+      data-testid={`${testIdPrefix}-handoff-btn`}
+      disabled={disabled}
+      onClick={() => onHandoff({ agentSdk: 'claude-code-cli' })}
+    >
+      Handoff
+    </button>
+  )
+}))
+
+vi.mock('@/components/terminal/TerminalView', () => ({
+  TerminalView: ({
+    createTerminal
+  }: {
+    createTerminal?: () => Promise<unknown>
+  }) => {
+    useEffect(() => {
+      void createTerminal?.()
+    }, [createTerminal])
+    return <div data-testid="mock-terminal-view" />
+  }
+}))
+
+vi.mock('../sessions/MarkdownRenderer', () => ({
+  MarkdownRenderer: ({ content }: { content: string }) => <div>{content}</div>
+}))
+
+vi.mock('./FollowupInput', () => ({
+  FollowupInput: () => <div data-testid="followup-input" />
+}))
+
+vi.mock('./TicketRunButton', () => ({
+  TicketRunButton: () => null
+}))
+
+vi.mock('@/hooks/useTicketRunScript', () => ({
+  useTicketRunScript: () => ({ hasRunScript: false }),
+  useTicketRunScriptHotkey: vi.fn()
+}))
+
+vi.mock('@/hooks/useDropZone', () => ({
+  useDropZone: () => ({ isDragging: false })
+}))
+
+vi.mock('@/hooks/useConflictFixFlow', () => ({
+  useConflictFixFlow: () => ({ startFixFlow: vi.fn(), openAttachedSession: vi.fn() })
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn()
+  }
+}))
+
+const initialSettingsState = useSettingsStore.getState()
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
+
+const now = '2026-01-01T00:00:00.000Z'
+
+const sourceSession: Session = {
+  id: 'source-session',
+  worktree_id: 'worktree-1',
+  project_id: 'project-1',
+  connection_id: null,
+  name: 'Source Claude CLI',
+  status: 'active',
+  opencode_session_id: null,
+  claude_session_id: null,
+  agent_sdk: 'claude-code-cli',
+  mode: 'plan',
+  session_type: 'default',
+  model_provider_id: 'anthropic',
+  model_id: 'opus',
+  model_variant: 'high',
+  created_at: now,
+  updated_at: now,
+  completed_at: null,
+  pinned_to_board: false
+}
+
+const handoffSession: Session = {
+  ...sourceSession,
+  id: 'handoff-session',
+  name: 'Handoff Claude CLI',
+  mode: 'build'
+}
+
+const ticket: KanbanTicket = {
+  id: 'ticket-1',
+  project_id: 'project-1',
+  title: 'Plan ticket',
+  description: 'Ticket description',
+  attachments: [],
+  column: 'review',
+  sort_order: 0,
+  current_session_id: sourceSession.id,
+  worktree_id: 'worktree-1',
+  mode: 'plan',
+  plan_ready: true,
+  created_at: now,
+  updated_at: now,
+  archived_at: null,
+  external_provider: null,
+  external_id: null,
+  external_url: null,
+  github_pr_number: null,
+  github_pr_url: null,
+  mark: null,
+  total_tokens: 0,
+  pending_launch_config: null,
+  goal_mode: false,
+  goal_success_criteria: null,
+  note: null
+}
+
+const worktree: Worktree = {
+  id: 'worktree-1',
+  project_id: 'project-1',
+  name: 'Feature',
+  branch_name: 'feature',
+  path: '/repo/feature',
+  status: 'active',
+  is_default: false,
+  branch_renamed: 0,
+  last_message_at: null,
+  session_titles: '[]',
+  last_model_provider_id: null,
+  last_model_id: null,
+  last_model_variant: null,
+  attachments: '[]',
+  pinned: 0,
+  context: null,
+  github_pr_number: null,
+  github_pr_url: null,
+  base_branch: null,
+  created_at: now,
+  last_accessed_at: now
+}
+
+function setupWindowApis(): void {
+  Object.defineProperty(window, 'terminalOps', {
+    configurable: true,
+    writable: true,
+    value: {
+      createClaudeCli: vi.fn().mockResolvedValue({ success: true, value: { success: true } }),
+      onClaudeSessionId: vi.fn().mockReturnValue(() => {})
+    }
+  })
+
+  Object.defineProperty(window, 'opencodeOps', {
+    configurable: true,
+    writable: true,
+    value: {
+      abort: vi.fn().mockResolvedValue({ success: true, value: { success: true } }),
+      commands: vi.fn().mockResolvedValue({ success: true, value: { success: true, commands: [] } }),
+      listModels: vi.fn().mockResolvedValue({ success: true, value: { success: true, providers: [] } })
+    }
+  })
+
+  Object.defineProperty(window, 'db', {
+    configurable: true,
+    writable: true,
+    value: {
+      session: {
+        get: vi.fn().mockResolvedValue(null),
+        update: vi.fn().mockResolvedValue({ success: true, value: undefined })
+      },
+      worktree: {
+        get: vi.fn().mockResolvedValue(worktree)
+      }
+    }
+  })
+}
+
+function setupStores(): {
+  createSession: ReturnType<typeof vi.fn>
+  setActiveSession: ReturnType<typeof vi.fn>
+} {
+  const createSession = vi.fn(async () => ({ success: true, session: handoffSession }))
+  const setActiveSession = vi.fn()
+
+  useSettingsStore.setState({
+    availableAgentSdks: { opencode: true, claude: true, codex: true },
+    defaultAgentSdk: 'opencode',
+    selectedModel: null,
+    selectedModelByProvider: {},
+    defaultModels: null,
+    boardMode: 'toggle'
+  })
+  useProjectStore.setState({
+    selectedProjectId: 'project-1',
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '/repo',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: now,
+        last_accessed_at: now
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    selectedWorktreeId: 'worktree-1',
+    worktreesByProject: new Map([['project-1', [worktree]]]),
+    selectWorktree: vi.fn(),
+  })
+  useKanbanStore.setState({
+    selectedTicketId: ticket.id,
+    isBoardViewActive: true,
+    tickets: new Map([['project-1', [ticket]]]),
+    updateTicket: vi.fn(async () => undefined),
+    moveTicket: vi.fn(async () => undefined),
+    relinkTicketsForHandoff: vi.fn(async () => undefined)
+  })
+  useSessionStore.setState({
+    activeSessionId: sourceSession.id,
+    activeWorktreeId: 'worktree-1',
+    sessionsByWorktree: new Map([['worktree-1', [sourceSession]]]),
+    sessionsByConnection: new Map(),
+    pendingPlans: new Map([
+      [
+        sourceSession.id,
+        { requestId: 'request-1', toolUseID: 'tool-1', planContent: 'Implement the plan.' }
+      ]
+    ]),
+    createSession,
+    setSessionMode: vi.fn(async () => undefined),
+    setPendingMessage: vi.fn(),
+    dequeuePendingMessage: vi.fn(),
+    clearPendingPlan: vi.fn(),
+    requestSessionMount: vi.fn(),
+    releaseSessionMount: vi.fn(),
+    setActiveSession,
+    setActiveWorktree: vi.fn()
+  })
+  useWorktreeStatusStore.setState({
+    sessionStatuses: { [sourceSession.id]: { status: 'plan_ready', timestamp: 0 } },
+    clearSessionStatus: vi.fn()
+  })
+
+  return { createSession, setActiveSession }
+}
+
+function RegisterClaudeCliPortalTarget({ sessionId }: { sessionId: string }): React.JSX.Element {
+  const { registerTarget } = useClaudeCliSessionPortal()
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    registerTarget(sessionId, ref.current)
+    return () => registerTarget(sessionId, null)
+  }, [registerTarget, sessionId])
+
+  return <div ref={ref} data-testid="registered-claude-cli-target" />
+}
+
+describe('KanbanTicketModal handoff from Claude CLI plan review', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupWindowApis()
+  })
+
+  afterEach(() => {
+    cleanup()
+    useSettingsStore.setState(initialSettingsState, true)
+    useSessionStore.setState(initialSessionState, true)
+    useWorktreeStore.setState(initialWorktreeState, true)
+    useKanbanStore.setState(initialKanbanState, true)
+    useProjectStore.setState(initialProjectState, true)
+    useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
+    delete (window as { terminalOps?: unknown }).terminalOps
+    delete (window as { opencodeOps?: unknown }).opencodeOps
+    delete (window as { db?: unknown }).db
+  })
+
+  it('starts the Claude CLI handoff without focusing the new session', async () => {
+    const { createSession, setActiveSession } = setupStores()
+    const user = userEvent.setup()
+
+    render(
+      <ClaudeCliSessionPortalProvider>
+        <KanbanTicketModal />
+      </ClaudeCliSessionPortalProvider>
+    )
+
+    await user.click(screen.getByTestId('plan-review-handoff-btn'))
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledTimes(1))
+    expect(createSession).toHaveBeenCalledWith('worktree-1', 'project-1', 'claude-code-cli', undefined, {
+      autoFocus: false,
+      modelOverride: undefined
+    })
+    await waitFor(() => expect(window.terminalOps.createClaudeCli).toHaveBeenCalledTimes(1))
+    expect(window.terminalOps.createClaudeCli).toHaveBeenCalledWith('handoff-session', {
+      pendingPrompt: expect.stringContaining('Implement the plan.')
+    })
+    expect(setActiveSession).not.toHaveBeenCalledWith('handoff-session')
+    expect(useKanbanStore.getState().isBoardViewActive).toBe(true)
+  })
+
+  it('keeps board focus when the portaled Claude CLI plan card handoff is clicked', async () => {
+    const { createSession, setActiveSession } = setupStores()
+    const user = userEvent.setup()
+
+    render(
+      <ClaudeCliSessionPortalProvider>
+        <RegisterClaudeCliPortalTarget sessionId={sourceSession.id} />
+        <ClaudeCliSessionView sessionId={sourceSession.id} />
+      </ClaudeCliSessionPortalProvider>
+    )
+
+    await user.click(screen.getByTestId('claude-cli-plan-ready-handoff-btn'))
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledTimes(1))
+    expect(createSession).toHaveBeenCalledWith('worktree-1', 'project-1', 'claude-code-cli', undefined, {
+      autoFocus: false,
+      modelOverride: undefined
+    })
+    await waitFor(() => expect(window.terminalOps.createClaudeCli).toHaveBeenCalledWith(
+      'handoff-session',
+      { pendingPrompt: expect.stringContaining('Implement the plan.') }
+    ))
+    expect(setActiveSession).not.toHaveBeenCalledWith('handoff-session')
+    expect(useKanbanStore.getState().isBoardViewActive).toBe(true)
+    expect(useKanbanStore.getState().selectedTicketId).toBeNull()
+  })
+})

--- a/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -22,19 +22,41 @@ vi.mock('../sessions/HandoffSplitButton', () => ({
     testIdPrefix = 'plan-ready',
     disabled = false
   }: {
-    onHandoff: (override: { agentSdk: 'claude-code-cli'; model?: undefined }) => void
+    onHandoff: (override: {
+      agentSdk: 'claude-code-cli' | 'codex'
+      model?: { providerID: string; modelID: string }
+      goalMode?: boolean
+    }) => void
     testIdPrefix?: string
     disabled?: boolean
-  }) => (
-    <button
-      type="button"
-      data-testid={`${testIdPrefix}-handoff-btn`}
-      disabled={disabled}
-      onClick={() => onHandoff({ agentSdk: 'claude-code-cli' })}
-    >
-      Handoff
-    </button>
-  )
+  }) => {
+    let goalMode = false
+
+    return (
+      <button
+        type="button"
+        data-testid={`${testIdPrefix}-handoff-btn`}
+        disabled={disabled}
+        onContextMenu={(event) => {
+          event.preventDefault()
+          goalMode = true
+        }}
+        onClick={() =>
+          onHandoff(
+            goalMode
+              ? {
+                  agentSdk: 'codex',
+                  model: { providerID: 'codex', modelID: 'gpt-5.5' },
+                  goalMode: true
+                }
+              : { agentSdk: 'claude-code-cli' }
+          )
+        }
+      >
+        Handoff
+      </button>
+    )
+  }
 }))
 
 vi.mock('@/components/terminal/TerminalView', () => ({
@@ -210,9 +232,29 @@ function setupWindowApis(): void {
 function setupStores(): {
   createSession: ReturnType<typeof vi.fn>
   setActiveSession: ReturnType<typeof vi.fn>
+  relinkTicketsForHandoff: ReturnType<typeof vi.fn>
+  setPendingMessage: ReturnType<typeof vi.fn>
 } {
-  const createSession = vi.fn(async () => ({ success: true, session: handoffSession }))
+  const createSession = vi.fn(
+    async (
+      _worktreeId: string,
+      _projectId: string,
+      agentSdk: Session['agent_sdk'] = 'claude-code-cli',
+      mode?: Session['mode']
+    ) => ({
+      success: true,
+      session: {
+        ...handoffSession,
+        agent_sdk: agentSdk,
+        mode: mode ?? 'build',
+        model_provider_id: agentSdk === 'codex' ? 'codex' : 'anthropic',
+        model_id: agentSdk === 'codex' ? 'gpt-5.5' : 'opus'
+      }
+    })
+  )
   const setActiveSession = vi.fn()
+  const relinkTicketsForHandoff = vi.fn(async () => undefined)
+  const setPendingMessage = vi.fn()
 
   useSettingsStore.setState({
     availableAgentSdks: { opencode: true, claude: true, codex: true },
@@ -255,7 +297,7 @@ function setupStores(): {
     tickets: new Map([['project-1', [ticket]]]),
     updateTicket: vi.fn(async () => undefined),
     moveTicket: vi.fn(async () => undefined),
-    relinkTicketsForHandoff: vi.fn(async () => undefined)
+    relinkTicketsForHandoff
   })
   useSessionStore.setState({
     activeSessionId: sourceSession.id,
@@ -270,7 +312,7 @@ function setupStores(): {
     ]),
     createSession,
     setSessionMode: vi.fn(async () => undefined),
-    setPendingMessage: vi.fn(),
+    setPendingMessage,
     dequeuePendingMessage: vi.fn(),
     clearPendingPlan: vi.fn(),
     requestSessionMount: vi.fn(),
@@ -283,7 +325,7 @@ function setupStores(): {
     clearSessionStatus: vi.fn()
   })
 
-  return { createSession, setActiveSession }
+  return { createSession, setActiveSession, relinkTicketsForHandoff, setPendingMessage }
 }
 
 function RegisterClaudeCliPortalTarget({ sessionId }: { sessionId: string }): React.JSX.Element {
@@ -383,6 +425,32 @@ describe('KanbanTicketModal handoff from Claude CLI plan review', () => {
     expect(setActiveSession).not.toHaveBeenCalledWith('handoff-session')
     expect(useKanbanStore.getState().isBoardViewActive).toBe(true)
     expect(useKanbanStore.getState().selectedTicketId).toBeNull()
+  })
+
+  it('marks the relinked ticket as goal mode when the Claude CLI plan card hands off to Codex goal mode', async () => {
+    const { createSession, relinkTicketsForHandoff, setPendingMessage } = setupStores()
+    const user = userEvent.setup()
+
+    render(
+      <ClaudeCliSessionPortalProvider>
+        <ClaudeCliSessionView sessionId={sourceSession.id} />
+      </ClaudeCliSessionPortalProvider>
+    )
+
+    const handoffButton = screen.getByTestId('claude-cli-plan-ready-handoff-btn')
+    fireEvent.contextMenu(handoffButton)
+    await user.click(handoffButton)
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledTimes(1))
+    expect(createSession).toHaveBeenCalledWith('worktree-1', 'project-1', 'codex', undefined, {
+      autoFocus: true,
+      modelOverride: { providerID: 'codex', modelID: 'gpt-5.5' }
+    })
+    expect(setPendingMessage).toHaveBeenCalledWith(
+      'handoff-session',
+      '/goal Implement the following plan\nImplement the plan.'
+    )
+    expect(relinkTicketsForHandoff).toHaveBeenCalledWith(sourceSession.id, 'handoff-session', true)
   })
 
   it('auto-closes when an open Claude CLI question ticket returns to working', async () => {

--- a/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -367,5 +367,29 @@ describe('KanbanTicketModal handoff from Claude CLI plan review', () => {
     expect(setActiveSession).not.toHaveBeenCalledWith('handoff-session')
     expect(useKanbanStore.getState().isBoardViewActive).toBe(true)
     expect(useKanbanStore.getState().selectedTicketId).toBeNull()
+  })
+
+  it('auto-closes when an open Claude CLI question ticket returns to working', async () => {
+    setupStores()
+    useKanbanStore.setState({
+      tickets: new Map([['project-1', [{ ...ticket, column: 'in_progress', plan_ready: false }]]])
+    })
+    useWorktreeStatusStore.getState().setSessionStatus(sourceSession.id, 'answering')
+
+    render(
+      <ClaudeCliSessionPortalProvider>
+        <KanbanTicketModal />
+      </ClaudeCliSessionPortalProvider>
+    )
+
+    expect(screen.getByTestId('kanban-ticket-modal')).toBeInTheDocument()
+
+    act(() => {
+      useWorktreeStatusStore.getState().setSessionStatus(sourceSession.id, 'working')
+    })
+
+    await waitFor(() => {
+      expect(useKanbanStore.getState().selectedTicketId).toBeNull()
+    })
   })
 })

--- a/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
@@ -476,4 +476,67 @@ describe('KanbanTicketModal handoff from Claude CLI plan review', () => {
       expect(useKanbanStore.getState().selectedTicketId).toBeNull()
     })
   })
+
+  it('auto-closes a DB-loaded CLI question ticket even when working arrives before isClaudeCli resolves', async () => {
+    setupStores()
+    // Race setup: the session is NOT in the in-memory store, so `isClaudeCli`
+    // only becomes known after the async DB fallback (findSessionById) resolves.
+    // We hold that lookup open, flip answering→working while it's pending
+    // (isClaudeCli still false), then resolve it — the modal must still close.
+    useSessionStore.setState({
+      sessionsByWorktree: new Map(),
+      sessionsByConnection: new Map(),
+      hydrateSession: vi.fn(),
+      loadSessions: vi.fn(async () => undefined)
+    })
+    useKanbanStore.setState({
+      tickets: new Map([['project-1', [{ ...ticket, column: 'in_progress', plan_ready: false }]]])
+    })
+    useWorktreeStatusStore.getState().setSessionStatus(sourceSession.id, 'answering')
+
+    let resolveDbSession: (value: Session | null) => void = () => {}
+    const dbSessionPromise = new Promise<Session | null>((resolve) => {
+      resolveDbSession = resolve
+    })
+    const dbSessionGet = vi.fn().mockReturnValue(dbSessionPromise)
+    Object.defineProperty(window, 'db', {
+      configurable: true,
+      writable: true,
+      value: {
+        session: {
+          get: dbSessionGet,
+          update: vi.fn().mockResolvedValue({ success: true, value: undefined })
+        },
+        worktree: { get: vi.fn().mockResolvedValue(worktree) }
+      }
+    })
+
+    render(
+      <ClaudeCliSessionPortalProvider>
+        <KanbanTicketModal />
+      </ClaudeCliSessionPortalProvider>
+    )
+
+    expect(screen.getByTestId('kanban-ticket-modal')).toBeInTheDocument()
+
+    // Flip to working while the DB lookup (and thus isClaudeCli) is still pending.
+    act(() => {
+      useWorktreeStatusStore.getState().setSessionStatus(sourceSession.id, 'working')
+    })
+
+    // Still open: isClaudeCli hasn't resolved, so the close action is gated off —
+    // but the latch must have remembered the earlier `answering`.
+    expect(useKanbanStore.getState().selectedTicketId).toBe(ticket.id)
+
+    // Resolve the DB lookup → isClaudeCli flips true → the latched answering→working
+    // transition is honored on the re-run and the modal closes.
+    await act(async () => {
+      resolveDbSession(sourceSession)
+      await dbSessionPromise
+    })
+
+    await waitFor(() => {
+      expect(useKanbanStore.getState().selectedTicketId).toBeNull()
+    })
+  })
 })

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -48,7 +48,7 @@ import { HandoffSplitButton } from '../sessions/HandoffSplitButton'
 import { IndeterminateProgressBar } from '@/components/sessions/IndeterminateProgressBar'
 import { cn } from '@/lib/utils'
 import { useKanbanStore } from '@/stores/useKanbanStore'
-import { useSessionStore } from '@/stores/useSessionStore'
+import { BOARD_TAB_ID, useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalContext'
@@ -2002,22 +2002,30 @@ function PlanReviewModeContent({
             sessionStore.setPendingMessage(newSessionId, handoffPrompt)
           }
 
-          // In sticky-tab mode, stay on the board; otherwise navigate to the new session.
-          // setActiveConnectionSession requires activeConnectionId to be set — which
-          // it isn't when the modal is opened from the kanban board — so we switch
-          // the active connection first, then nail down the session within it.
-          const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
+          // Handoff from the ticket modal starts work in the background and keeps
+          // the board in focus. Sticky-tab mode represents the board as a tab, so
+          // explicitly preserve that tab; toggle mode is already on the board.
           if (useSettingsStore.getState().boardMode === 'sticky-tab') {
             sessionStore.setActiveSession(BOARD_TAB_ID)
-          } else {
-            sessionStore.setActiveConnection(sessionRecord.connection_id)
-            sessionStore.setActiveConnectionSession(newSessionId)
           }
 
           onClose()
           void (async () => {
             await setModePromise
-            if (newSession.agent_sdk !== 'claude-code-cli') {
+            if (newSession.agent_sdk === 'claude-code-cli') {
+              bumpWorktreeLastMessage({ connectionId: sessionRecord.connection_id })
+              const cliResult = unwrapEnvelope(
+                await window.terminalOps.createClaudeCli(newSessionId, {
+                  pendingPrompt: handoffPrompt
+                })
+              )
+              if (!cliResult.success) {
+                throw new Error(cliResult.error ?? 'Failed to start Claude CLI handoff')
+              }
+              if (handoffPrompt) {
+                sessionStore.dequeuePendingMessage(newSessionId)
+              }
+            } else {
               await eagerHandoffStart(connectionPath, newSessionId, handoffPrompt, {
                 connectionId: sessionRecord.connection_id
               })
@@ -2081,20 +2089,30 @@ function PlanReviewModeContent({
           sessionStore.setPendingMessage(newSessionId, handoffPrompt)
         }
 
-        // In sticky-tab mode, stay on the board; otherwise navigate to the new session
-        const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
+        // Handoff from the ticket modal starts work in the background and keeps
+        // the board in focus. Sticky-tab mode represents the board as a tab, so
+        // explicitly preserve that tab; toggle mode is already on the board.
         if (useSettingsStore.getState().boardMode === 'sticky-tab') {
           sessionStore.setActiveSession(BOARD_TAB_ID)
-        } else {
-          useWorktreeStore.getState().selectWorktree(worktreeId)
-          sessionStore.setActiveWorktree(worktreeId)
-          sessionStore.setActiveSession(newSessionId)
         }
 
         onClose()
         void (async () => {
           await setModePromise
-          if (newSession.agent_sdk !== 'claude-code-cli') {
+          if (newSession.agent_sdk === 'claude-code-cli') {
+            bumpWorktreeLastMessage({ worktreeId })
+            const cliResult = unwrapEnvelope(
+              await window.terminalOps.createClaudeCli(newSessionId, {
+                pendingPrompt: handoffPrompt
+              })
+            )
+            if (!cliResult.success) {
+              throw new Error(cliResult.error ?? 'Failed to start Claude CLI handoff')
+            }
+            if (handoffPrompt) {
+              sessionStore.dequeuePendingMessage(newSessionId)
+            }
+          } else {
             await eagerHandoffStart(localWorktreePath, newSessionId, handoffPrompt, { worktreeId })
           }
           toast.success('Handoff session started')

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -805,26 +805,47 @@ function KanbanTicketModalContent({
     onForceClose()
   }, [onForceClose])
 
-  const previousWorktreeSessionStatus = useRef<{ sessionId: string | null; status: string | null }>(
-    { sessionId: null, status: null }
-  )
+  // Auto-close the modal when an answered CLI question resumes work
+  // (answering → working). `isClaudeCli` derives from the DB-loaded session and
+  // can resolve a render or two after the modal opens, so we must NOT gate the
+  // status tracking on it — otherwise a flip that lands before it resolves slides
+  // the baseline forward under the early-return branch and the transition is lost
+  // forever. Instead we latch `sawAnswering` unconditionally and gate only the
+  // close *action* on `isClaudeCli`; the effect re-runs when `isClaudeCli`
+  // resolves (it's a dep), so a flip seen while it was still false is honored as
+  // soon as it becomes true.
+  const autoCloseLatchRef = useRef<{ sessionId: string | null; sawAnswering: boolean }>({
+    sessionId: null,
+    sawAnswering: false
+  })
   useEffect(() => {
     const sessionId = ticket.current_session_id
-    const previous = previousWorktreeSessionStatus.current
+    const latch = autoCloseLatchRef.current
 
-    if (!sessionId || previous.sessionId !== sessionId || !isClaudeCli) {
-      previousWorktreeSessionStatus.current = { sessionId, status: currentWorktreeSessionStatus }
+    if (!sessionId) {
+      autoCloseLatchRef.current = { sessionId: null, sawAnswering: false }
       return
     }
 
-    if (
-      previous.status === 'answering' &&
-      currentWorktreeSessionStatus === 'working'
-    ) {
-      forceClose()
+    // First observation of this session — seed the latch from the current status
+    // so a modal opened on a session already in `answering` still arms.
+    if (latch.sessionId !== sessionId) {
+      autoCloseLatchRef.current = {
+        sessionId,
+        sawAnswering: currentWorktreeSessionStatus === 'answering'
+      }
+      return
     }
 
-    previousWorktreeSessionStatus.current = { sessionId, status: currentWorktreeSessionStatus }
+    if (currentWorktreeSessionStatus === 'answering') {
+      latch.sawAnswering = true
+      return
+    }
+
+    if (isClaudeCli && latch.sawAnswering && currentWorktreeSessionStatus === 'working') {
+      latch.sawAnswering = false
+      forceClose()
+    }
   }, [currentWorktreeSessionStatus, forceClose, isClaudeCli, ticket.current_session_id])
 
   const requestClose = useCallback(() => {

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -780,6 +780,15 @@ function KanbanTicketModalContent({
 
   const effectiveSession = sessionRecord ?? dbSessionInfo?.session ?? null
   const isClaudeCli = effectiveSession?.agent_sdk === 'claude-code-cli'
+  const currentWorktreeSessionStatus = useWorktreeStatusStore(
+    useCallback(
+      (state) =>
+        ticket.current_session_id
+          ? (state.sessionStatuses[ticket.current_session_id]?.status ?? null)
+          : null,
+      [ticket.current_session_id]
+    )
+  )
 
   const baseModalMode = resolveModalMode(ticket, sessionStatus)
   // Question mode takes highest priority — an unanswered question blocks
@@ -795,6 +804,28 @@ function KanbanTicketModalContent({
     setShowDiscardConfirm(false)
     onForceClose()
   }, [onForceClose])
+
+  const previousWorktreeSessionStatus = useRef<{ sessionId: string | null; status: string | null }>(
+    { sessionId: null, status: null }
+  )
+  useEffect(() => {
+    const sessionId = ticket.current_session_id
+    const previous = previousWorktreeSessionStatus.current
+
+    if (!sessionId || previous.sessionId !== sessionId || !isClaudeCli) {
+      previousWorktreeSessionStatus.current = { sessionId, status: currentWorktreeSessionStatus }
+      return
+    }
+
+    if (
+      previous.status === 'answering' &&
+      currentWorktreeSessionStatus === 'working'
+    ) {
+      forceClose()
+    }
+
+    previousWorktreeSessionStatus.current = { sessionId, status: currentWorktreeSessionStatus }
+  }, [currentWorktreeSessionStatus, forceClose, isClaudeCli, ticket.current_session_id])
 
   const requestClose = useCallback(() => {
     if (modalMode === 'edit' && editDraftDirty) {

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1765,7 +1765,9 @@ function PlanReviewModeContent({
           const result = await sessionStore.createConnectionSession(
             sessionRecord.connection_id,
             override?.agentSdk,
-            undefined,
+            override?.agentSdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
+              ? 'super-plan'
+              : undefined,
             { autoFocus: false, modelOverride: override?.model }
           )
           if (!result.success || !result.session) {
@@ -1773,11 +1775,20 @@ function PlanReviewModeContent({
             return
           }
 
-          const handoffPrompt = buildHandoffPrompt(planContent, override)
+          const handoffPrompt = buildHandoffPrompt(planContent, {
+            ...override,
+            superPlan: sessionRecord?.mode === 'super-plan'
+          })
           const newSessionId = result.session.id
-          const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
+          const setModePromise =
+            result.session.agent_sdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
+              ? Promise.resolve()
+              : sessionStore.setSessionMode(newSessionId, 'build')
 
           prepareTicketBuildSession(newSessionId)
+          if (result.session.agent_sdk === 'claude-code-cli') {
+            sessionStore.setPendingMessage(newSessionId, handoffPrompt)
+          }
 
           // In sticky-tab mode, stay on the board; otherwise navigate to the new session.
           // setActiveConnectionSession requires activeConnectionId to be set — which
@@ -1794,9 +1805,11 @@ function PlanReviewModeContent({
           onClose()
           void (async () => {
             await setModePromise
-            await eagerHandoffStart(connectionPath, newSessionId, handoffPrompt, {
-              connectionId: sessionRecord.connection_id
-            })
+            if (result.session.agent_sdk !== 'claude-code-cli') {
+              await eagerHandoffStart(connectionPath, newSessionId, handoffPrompt, {
+                connectionId: sessionRecord.connection_id
+              })
+            }
             toast.success('Handoff session started')
           })().catch((error) => {
             console.error(
@@ -1820,7 +1833,9 @@ function PlanReviewModeContent({
           worktreeId,
           ticket.project_id,
           override?.agentSdk,
-          undefined,
+          override?.agentSdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
+            ? 'super-plan'
+            : undefined,
           { autoFocus: false, modelOverride: override?.model }
         )
         if (!result.success || !result.session) {
@@ -1828,9 +1843,15 @@ function PlanReviewModeContent({
           return
         }
 
-        const handoffPrompt = buildHandoffPrompt(planContent, override)
+        const handoffPrompt = buildHandoffPrompt(planContent, {
+          ...override,
+          superPlan: sessionRecord?.mode === 'super-plan'
+        })
         const newSessionId = result.session.id
-        const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
+        const setModePromise =
+          result.session.agent_sdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
+            ? Promise.resolve()
+            : sessionStore.setSessionMode(newSessionId, 'build')
         const localWorktreePath = findWorktreePathById(worktreeId)
         if (!localWorktreePath) {
           toast.error('Could not find worktree path')
@@ -1838,6 +1859,9 @@ function PlanReviewModeContent({
         }
 
         prepareTicketBuildSession(newSessionId)
+        if (result.session.agent_sdk === 'claude-code-cli') {
+          sessionStore.setPendingMessage(newSessionId, handoffPrompt)
+        }
 
         // In sticky-tab mode, stay on the board; otherwise navigate to the new session
         const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
@@ -1852,7 +1876,9 @@ function PlanReviewModeContent({
         onClose()
         void (async () => {
           await setModePromise
-          await eagerHandoffStart(localWorktreePath, newSessionId, handoffPrompt, { worktreeId })
+          if (result.session.agent_sdk !== 'claude-code-cli') {
+            await eagerHandoffStart(localWorktreePath, newSessionId, handoffPrompt, { worktreeId })
+          }
           toast.success('Handoff session started')
         })().catch((error) => {
           console.error('[KanbanTicketModal] handoff background start failed:', error)

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -51,6 +51,7 @@ import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalContext'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useCommandApprovalStore } from '@/stores/useCommandApprovalStore'
 import { useProjectStore } from '@/stores/useProjectStore'
@@ -108,6 +109,41 @@ const MODE_DIALOG_CLASS: Record<ModalMode, string> = {
 // TicketAttachment is now imported from TicketAttachmentEditor
 type TicketAttachment = import('./TicketAttachmentEditor').TicketAttachment
 
+function ClaudeCliPortalSlot({ sessionId }: { sessionId: string }): React.JSX.Element {
+  const { registerTarget } = useClaudeCliSessionPortal()
+  const requestSessionMount = useSessionStore((s) => s.requestSessionMount)
+  const releaseSessionMount = useSessionStore((s) => s.releaseSessionMount)
+  const targetRef = useRef<HTMLDivElement | null>(null)
+
+  const setTargetRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      targetRef.current = el
+      registerTarget(sessionId, el)
+    },
+    [registerTarget, sessionId]
+  )
+
+  useEffect(() => {
+    requestSessionMount(sessionId)
+    if (targetRef.current) {
+      registerTarget(sessionId, targetRef.current)
+    }
+
+    return () => {
+      registerTarget(sessionId, null)
+      releaseSessionMount(sessionId)
+    }
+  }, [registerTarget, releaseSessionMount, requestSessionMount, sessionId])
+
+  return (
+    <div
+      ref={setTargetRef}
+      className="flex-1 flex flex-col min-h-0"
+      data-testid="claude-cli-modal-slot"
+    />
+  )
+}
+
 function normalizeDraftText(value: string | null | undefined): string | null {
   const trimmed = value?.trim() ?? ''
   return trimmed.length > 0 ? trimmed : null
@@ -150,12 +186,12 @@ async function findSessionById(sessionId: string): Promise<{
     id: string
     worktree_id: string | null
     connection_id: string | null
-	    opencode_session_id: string | null
-	    agent_sdk: string
-	    mode: FollowUpMode
-	    model_provider_id: string | null
-	    model_id: string | null
-	    model_variant: string | null
+    opencode_session_id: string | null
+    agent_sdk: string
+    mode: FollowUpMode
+    model_provider_id: string | null
+    model_id: string | null
+    model_variant: string | null
   }
   worktreePath: string | null
   connectionId: string | null
@@ -208,12 +244,12 @@ async function findSessionById(sessionId: string): Promise<{
       id: dbSession.id,
       worktree_id: dbSession.worktree_id,
       connection_id: dbSession.connection_id,
-	      opencode_session_id: dbSession.opencode_session_id,
-	      agent_sdk: dbSession.agent_sdk,
-	      mode: dbSession.mode,
-	      model_provider_id: dbSession.model_provider_id,
-	      model_id: dbSession.model_id,
-	      model_variant: dbSession.model_variant
+      opencode_session_id: dbSession.opencode_session_id,
+      agent_sdk: dbSession.agent_sdk,
+      mode: dbSession.mode,
+      model_provider_id: dbSession.model_provider_id,
+      model_id: dbSession.model_id,
+      model_variant: dbSession.model_variant
     },
     worktreePath,
     connectionId: dbSession.connection_id,
@@ -613,12 +649,12 @@ function KanbanTicketModalContent({
       id: string
       worktree_id: string | null
       connection_id: string | null
-	      opencode_session_id: string | null
-	      agent_sdk: string
-	      mode: FollowUpMode
-	      model_provider_id: string | null
-	      model_id: string | null
-	      model_variant: string | null
+      opencode_session_id: string | null
+      agent_sdk: string
+      mode: FollowUpMode
+      model_provider_id: string | null
+      model_id: string | null
+      model_variant: string | null
     }
     worktreePath: string | null
   } | null>(null)
@@ -743,6 +779,7 @@ function KanbanTicketModalContent({
   }, [sessionRecord?.worktree_id])
 
   const effectiveSession = sessionRecord ?? dbSessionInfo?.session ?? null
+  const isClaudeCli = effectiveSession?.agent_sdk === 'claude-code-cli'
 
   const baseModalMode = resolveModalMode(ticket, sessionStatus)
   // Question mode takes highest priority — an unanswered question blocks
@@ -860,7 +897,7 @@ function KanbanTicketModalContent({
   )
 
   useEffect(() => {
-    if (!worktreePath || !opcSessionId || !ticket.current_session_id) {
+    if (isClaudeCli || !worktreePath || !opcSessionId || !ticket.current_session_id) {
       setSessionReady(false)
       return
     }
@@ -918,7 +955,7 @@ function KanbanTicketModalContent({
     return () => {
       cancelled = true
     }
-  }, [worktreePath, opcSessionId, ticket.current_session_id])
+  }, [isClaudeCli, worktreePath, opcSessionId, ticket.current_session_id])
 
   // Render the mode-specific inner content (without DialogContent wrapper)
   let modeContent: React.ReactNode
@@ -1000,7 +1037,27 @@ function KanbanTicketModalContent({
         </DialogHeader>
         {conflictBanner}
         <div className="flex min-h-0 flex-1 overflow-hidden">
-          {hasSession && sessionReady ? (
+          {isClaudeCli && ticket.current_session_id ? (
+            <div className="flex flex-col h-full bg-background flex-1 min-w-0">
+              <div className="shrink-0 px-4 py-3 border-b border-border/60 flex items-center gap-2">
+                <span className="text-sm font-medium text-foreground truncate">{ticket.title}</span>
+                <div className="ml-auto shrink-0 flex items-center gap-2">
+                  <TicketRunButton
+                    state={runScriptState}
+                    testId="full-width-run-btn"
+                    className="h-7 px-2 text-xs"
+                  />
+                  <JumpToSessionButton
+                    ticket={ticket}
+                    onClose={forceClose}
+                    label="Go to session"
+                    testId="go-to-session-btn"
+                  />
+                </div>
+              </div>
+              <ClaudeCliPortalSlot sessionId={ticket.current_session_id} />
+            </div>
+          ) : hasSession && sessionReady ? (
             <SessionStreamPanel
               sessionId={ticket.current_session_id!}
               worktreePath={worktreePath!}
@@ -1059,7 +1116,11 @@ function KanbanTicketModalContent({
             {modeContent}
           </div>
           {/* Right: session stream (or loading spinner while DB lookup resolves) */}
-          {hasSession && sessionReady ? (
+          {isClaudeCli && ticket.current_session_id ? (
+            <div className="flex flex-col h-full bg-background flex-1 min-w-0 border-l border-border/60">
+              <ClaudeCliPortalSlot sessionId={ticket.current_session_id} />
+            </div>
+          ) : hasSession && sessionReady ? (
             <SessionStreamPanel
               sessionId={ticket.current_session_id!}
               worktreePath={worktreePath!}
@@ -1547,12 +1608,12 @@ function PlanReviewModeContent({
   ticket: KanbanTicket
   onClose: () => void
   pendingPlan: { requestId: string; planContent: string; toolUseID: string } | null
-	  sessionRecord: {
-	    worktree_id: string | null
-	    connection_id: string | null
-	    agent_sdk: string
-	    mode: FollowUpMode
-	  } | null
+  sessionRecord: {
+    worktree_id: string | null
+    connection_id: string | null
+    agent_sdk: string
+    mode: FollowUpMode
+  } | null
   updateTicket: (ticketId: string, projectId: string, data: KanbanTicketUpdate) => Promise<void>
   dualPane?: boolean
   worktreePath: string | null
@@ -1920,26 +1981,26 @@ function PlanReviewModeContent({
             return
           }
 
-	          const handoffPrompt = buildHandoffPrompt(
-	            planContent,
-	            override
-	              ? {
-	                  ...override,
-	                  superPlan: sessionRecord?.mode === 'super-plan'
-	                }
-	              : undefined
-	          )
-	          const newSession = result.session
-	          const newSessionId = newSession.id
-	          const setModePromise =
-	            newSession.agent_sdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
-	              ? Promise.resolve()
-	              : sessionStore.setSessionMode(newSessionId, 'build')
+          const handoffPrompt = buildHandoffPrompt(
+            planContent,
+            override
+              ? {
+                  ...override,
+                  superPlan: sessionRecord?.mode === 'super-plan'
+                }
+              : undefined
+          )
+          const newSession = result.session
+          const newSessionId = newSession.id
+          const setModePromise =
+            newSession.agent_sdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
+              ? Promise.resolve()
+              : sessionStore.setSessionMode(newSessionId, 'build')
 
-	          prepareTicketBuildSession(newSessionId, handoffGoalMode)
-	          if (newSession.agent_sdk === 'claude-code-cli') {
-	            sessionStore.setPendingMessage(newSessionId, handoffPrompt)
-	          }
+          prepareTicketBuildSession(newSessionId, handoffGoalMode)
+          if (newSession.agent_sdk === 'claude-code-cli') {
+            sessionStore.setPendingMessage(newSessionId, handoffPrompt)
+          }
 
           // In sticky-tab mode, stay on the board; otherwise navigate to the new session.
           // setActiveConnectionSession requires activeConnectionId to be set — which
@@ -1953,13 +2014,13 @@ function PlanReviewModeContent({
             sessionStore.setActiveConnectionSession(newSessionId)
           }
 
-	          onClose()
-	          void (async () => {
-	            await setModePromise
-	            if (newSession.agent_sdk !== 'claude-code-cli') {
-	              await eagerHandoffStart(connectionPath, newSessionId, handoffPrompt, {
-	                connectionId: sessionRecord.connection_id
-	              })
+          onClose()
+          void (async () => {
+            await setModePromise
+            if (newSession.agent_sdk !== 'claude-code-cli') {
+              await eagerHandoffStart(connectionPath, newSessionId, handoffPrompt, {
+                connectionId: sessionRecord.connection_id
+              })
             }
             toast.success('Handoff session started')
           })().catch((error) => {
@@ -1994,31 +2055,31 @@ function PlanReviewModeContent({
           return
         }
 
-	        const handoffPrompt = buildHandoffPrompt(
-	          planContent,
-	          override
-	            ? {
-	                ...override,
-	                superPlan: sessionRecord?.mode === 'super-plan'
-	              }
-	            : undefined
-	        )
-	        const newSession = result.session
-	        const newSessionId = newSession.id
-	        const setModePromise =
-	          newSession.agent_sdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
-	            ? Promise.resolve()
-	            : sessionStore.setSessionMode(newSessionId, 'build')
+        const handoffPrompt = buildHandoffPrompt(
+          planContent,
+          override
+            ? {
+                ...override,
+                superPlan: sessionRecord?.mode === 'super-plan'
+              }
+            : undefined
+        )
+        const newSession = result.session
+        const newSessionId = newSession.id
+        const setModePromise =
+          newSession.agent_sdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
+            ? Promise.resolve()
+            : sessionStore.setSessionMode(newSessionId, 'build')
         const localWorktreePath = findWorktreePathById(worktreeId)
         if (!localWorktreePath) {
           toast.error('Could not find worktree path')
           return
         }
 
-	        prepareTicketBuildSession(newSessionId, handoffGoalMode)
-	        if (newSession.agent_sdk === 'claude-code-cli') {
-	          sessionStore.setPendingMessage(newSessionId, handoffPrompt)
-	        }
+        prepareTicketBuildSession(newSessionId, handoffGoalMode)
+        if (newSession.agent_sdk === 'claude-code-cli') {
+          sessionStore.setPendingMessage(newSessionId, handoffPrompt)
+        }
 
         // In sticky-tab mode, stay on the board; otherwise navigate to the new session
         const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
@@ -2030,12 +2091,12 @@ function PlanReviewModeContent({
           sessionStore.setActiveSession(newSessionId)
         }
 
-	        onClose()
-	        void (async () => {
-	          await setModePromise
-	          if (newSession.agent_sdk !== 'claude-code-cli') {
-	            await eagerHandoffStart(localWorktreePath, newSessionId, handoffPrompt, { worktreeId })
-	          }
+        onClose()
+        void (async () => {
+          await setModePromise
+          if (newSession.agent_sdk !== 'claude-code-cli') {
+            await eagerHandoffStart(localWorktreePath, newSessionId, handoffPrompt, { worktreeId })
+          }
           toast.success('Handoff session started')
         })().catch((error) => {
           console.error('[KanbanTicketModal] handoff background start failed:', error)

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1660,6 +1660,7 @@ function PlanReviewModeContent({
   const dropZoneRef = useRef<HTMLDivElement>(null)
 
   const isConnectionSession = !!sessionRecord?.connection_id
+  const isClaudeCliPlanSession = sessionRecord?.agent_sdk === 'claude-code-cli'
   const hasWorkingContext = !!(sessionRecord?.worktree_id || sessionRecord?.connection_id)
 
   const [slashCommands, setSlashCommands] = useState<{ name: string }[]>([])
@@ -1669,7 +1670,7 @@ function PlanReviewModeContent({
   )
 
   useEffect(() => {
-    if (!worktreePath || !opcSessionId) return
+    if (isClaudeCliPlanSession || !worktreePath || !opcSessionId) return
     let cancelled = false
     window.opencodeOps
       .commands(worktreePath, opcSessionId)
@@ -1685,7 +1686,7 @@ function PlanReviewModeContent({
     return () => {
       cancelled = true
     }
-  }, [worktreePath, opcSessionId])
+  }, [isClaudeCliPlanSession, worktreePath, opcSessionId])
 
   const planContent = pendingPlan?.planContent ?? ticket.description ?? ''
 
@@ -1705,6 +1706,7 @@ function PlanReviewModeContent({
 
   const handleDropFiles = useCallback(
     (files: FileList) => {
+      if (isClaudeCliPlanSession) return
       for (const file of Array.from(files)) {
         if (attachments.length >= MAX_ATTACHMENTS) {
           toast.warning(`Maximum ${MAX_ATTACHMENTS} attachments reached`)
@@ -1731,7 +1733,7 @@ function PlanReviewModeContent({
         }
       }
     },
-    [handleAttach, attachments.length]
+    [handleAttach, attachments.length, isClaudeCliPlanSession]
   )
 
   const { isDragging } = useDropZone({ onDrop: handleDropFiles, containerRef: dropZoneRef })
@@ -1746,6 +1748,7 @@ function PlanReviewModeContent({
 
   // Tab key toggles mode, Shift+Tab toggles super-plan
   useEffect(() => {
+    if (isClaudeCliPlanSession) return
     const handler = (e: KeyboardEvent): void => {
       if (e.key === 'Tab' && !e.ctrlKey && !e.metaKey && !e.altKey) {
         const modal = document.querySelector('[data-testid="kanban-ticket-modal"]')
@@ -1762,7 +1765,7 @@ function PlanReviewModeContent({
     }
     window.addEventListener('keydown', handler, true)
     return () => window.removeEventListener('keydown', handler, true)
-  }, [toggleMode, toggleSuperMode])
+  }, [isClaudeCliPlanSession, toggleMode, toggleSuperMode])
 
   // ── Send followup (reject pending plan + iterate) ────────────────
   const handleSendFollowup = useCallback(async () => {
@@ -2544,24 +2547,26 @@ function PlanReviewModeContent({
       <TicketGoalSection ticket={ticket} />
 
       {/* Followup input — iterate on the plan */}
-      <FollowupInput
-        text={followUpText}
-        onTextChange={setFollowUpText}
-        attachments={attachments}
-        onAttach={handleAttach}
-        onRemoveAttachment={handleRemoveAttachment}
-        followUpMode={followUpMode}
-        onToggleMode={toggleMode}
-        onSend={handleSendFollowup}
-        isSending={isSending}
-        placeholder="Iterate on the plan... (Enter to send)"
-        testIdPrefix="plan-review"
-        showInlineSendButton
-        textareaRef={textareaRef}
-      />
+      {!isClaudeCliPlanSession && (
+        <FollowupInput
+          text={followUpText}
+          onTextChange={setFollowUpText}
+          attachments={attachments}
+          onAttach={handleAttach}
+          onRemoveAttachment={handleRemoveAttachment}
+          followUpMode={followUpMode}
+          onToggleMode={toggleMode}
+          onSend={handleSendFollowup}
+          isSending={isSending}
+          placeholder="Iterate on the plan... (Enter to send)"
+          testIdPrefix="plan-review"
+          showInlineSendButton
+          textareaRef={textareaRef}
+        />
+      )}
 
       {/* Drag-and-drop overlay */}
-      {isDragging && (
+      {!isClaudeCliPlanSession && isDragging && (
         <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm rounded-lg border-2 border-dashed border-primary/50">
           <div className="flex flex-col items-center gap-2 text-primary">
             <Upload className="h-8 w-8" />
@@ -2588,7 +2593,7 @@ function PlanReviewModeContent({
             testIdPrefix="plan-review"
             disabled={isActioning || !hasWorkingContext}
           />
-          {!isConnectionSession && hasSuperpowers && (
+          {!isClaudeCliPlanSession && !isConnectionSession && hasSuperpowers && (
             <Button
               type="button"
               data-testid="plan-review-supercharge-local-btn"
@@ -2601,7 +2606,7 @@ function PlanReviewModeContent({
               Supercharge locally
             </Button>
           )}
-          {hasSuperpowers && (
+          {!isClaudeCliPlanSession && hasSuperpowers && (
             <Button
               type="button"
               data-testid="plan-review-supercharge-btn"
@@ -2613,16 +2618,18 @@ function PlanReviewModeContent({
               Supercharge
             </Button>
           )}
-          <Button
-            type="button"
-            data-testid="plan-review-implement-btn"
-            disabled={isActioning}
-            onClick={handleImplement}
-            className="gap-1.5 bg-blue-600 hover:bg-blue-700 text-white"
-          >
-            <Hammer className="h-3.5 w-3.5" />
-            Implement
-          </Button>
+          {!isClaudeCliPlanSession && (
+            <Button
+              type="button"
+              data-testid="plan-review-implement-btn"
+              disabled={isActioning}
+              onClick={handleImplement}
+              className="gap-1.5 bg-blue-600 hover:bg-blue-700 text-white"
+            >
+              <Hammer className="h-3.5 w-3.5" />
+              Implement
+            </Button>
+          )}
         </DialogFooter>
       )}
     </div>

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -1,0 +1,372 @@
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorktreePickerModal, _resetLastSourceBranch } from './WorktreePickerModal'
+import { PLAN_MODE_PREFIX, getSuperPlanModePrefix } from '@/lib/constants'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useUsageStore } from '@/stores/useUsageStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket, Session } from '../../../../main/db/types'
+
+vi.mock('@/components/sessions/ModelSelector', () => ({
+  ModelSelector: ({
+    onChange
+  }: {
+    onChange?: (model: {
+      agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex'
+      providerID: string
+      modelID: string
+      variant?: string
+    }) => void
+  }) => (
+    <button
+      type="button"
+      data-testid="model-selector-pick-opus"
+      onClick={() =>
+        onChange?.({
+          agentSdk: 'claude-code-cli',
+          providerID: 'anthropic',
+          modelID: 'opus',
+          variant: 'high'
+        })
+      }
+    >
+      Opus high
+    </button>
+  )
+}))
+
+vi.mock('@/components/sessions/CodexFastToggle', () => ({
+  CodexFastToggle: () => <div data-testid="codex-fast-toggle" />
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const initialSettingsState = useSettingsStore.getState()
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialUsageState = useUsageStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
+
+const baseTicket: KanbanTicket = {
+  id: 'ticket-1',
+  project_id: 'project-1',
+  title: 'Launch Claude CLI',
+  description: 'Make ticket launch use Claude CLI',
+  column: 'todo',
+  sort_order: 0,
+  worktree_id: null,
+  current_session_id: null,
+  mode: 'build',
+  plan_ready: false,
+  goal_mode: false,
+  goal_success_criteria: null,
+  pending_launch_config: null,
+  attachments: [],
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z'
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: 'anthropic',
+    model_id: 'opus',
+    model_variant: 'high',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    pinned_to_board: false,
+    ...overrides
+  }
+}
+
+function setupStores(): {
+  createSession: ReturnType<typeof vi.fn>
+  setSessionModel: ReturnType<typeof vi.fn>
+  setSessionMode: ReturnType<typeof vi.fn>
+  updateTicket: ReturnType<typeof vi.fn>
+} {
+  const createSession = vi.fn(async (worktreeId: string, projectId: string, sdk: Session['agent_sdk'], mode: Session['mode']) => ({
+    success: true,
+    session: makeSession({ worktree_id: worktreeId, project_id: projectId, agent_sdk: sdk, mode })
+  }))
+  const setSessionModel = vi.fn(async () => undefined)
+  const setSessionMode = vi.fn(async () => undefined)
+  const updateTicket = vi.fn(async () => undefined)
+
+  useSettingsStore.setState({
+    availableAgentSdks: { opencode: true, claude: true, codex: true },
+    defaultAgentSdk: 'opencode',
+    selectedModel: null,
+    selectedModelByProvider: {},
+    defaultModels: null,
+    codexFastMode: false,
+    codexFastModeAccepted: true,
+    boardMode: 'toggle'
+  })
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        last_accessed_at: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([
+      [
+        'project-1',
+        [
+          {
+            id: 'worktree-1',
+            project_id: 'project-1',
+            name: 'Feature',
+            branch_name: 'feature',
+            path: '/repo/feature',
+            status: 'active',
+            is_default: false,
+            branch_renamed: 0,
+            last_message_at: null,
+            session_titles: '[]',
+            last_model_provider_id: null,
+            last_model_id: null,
+            last_model_variant: null,
+            attachments: '[]',
+            created_at: '2026-01-01T00:00:00.000Z',
+            last_accessed_at: '2026-01-01T00:00:00.000Z',
+            github_pr_number: null,
+            github_pr_url: null
+          }
+        ]
+      ]
+    ]),
+    worktreeOrderByProject: new Map(),
+    syncWorktrees: vi.fn(),
+    createWorktreeFromBranch: vi.fn()
+  })
+  useKanbanStore.setState({
+    tickets: new Map([['project-1', [baseTicket]]]),
+    updateTicket,
+    computeSortOrder: vi.fn(() => 1),
+    getTicketsByColumn: vi.fn(() => []),
+    getTicketsByColumnForConnection: vi.fn(() => [])
+  })
+  useSessionStore.setState({
+    sessionsByWorktree: new Map(),
+    sessionsByConnection: new Map(),
+    modeBySession: new Map(),
+    createSession,
+    setSessionModel,
+    setSessionMode,
+    setOpenCodeSessionId: vi.fn(),
+    setActiveSession: vi.fn()
+  })
+  useWorktreeStatusStore.setState({
+    setSessionStatus: vi.fn(),
+    setLastMessageTime: vi.fn()
+  })
+  useUsageStore.setState({
+    fetchUsageForProvider: vi.fn()
+  })
+
+  return { createSession, setSessionModel, setSessionMode, updateTicket }
+}
+
+function setupWindowApis(): void {
+  Object.defineProperty(window, 'terminalOps', {
+    configurable: true,
+    writable: true,
+    value: {
+      createClaudeCli: vi.fn().mockResolvedValue({ success: true, value: { success: true } })
+    }
+  })
+  Object.defineProperty(window, 'opencodeOps', {
+    configurable: true,
+    writable: true,
+    value: {
+      connect: vi.fn().mockResolvedValue({ success: true, value: { success: true, sessionId: 'opc-1' } }),
+      prompt: vi.fn().mockResolvedValue({ success: true, value: { success: true } }),
+      listModels: vi.fn().mockResolvedValue({ success: true, value: { success: true, providers: [] } })
+    }
+  })
+  Object.defineProperty(window, 'db', {
+    configurable: true,
+    writable: true,
+    value: {
+      session: {
+        update: vi.fn().mockResolvedValue({ success: true, value: undefined })
+      }
+    }
+  })
+  Object.defineProperty(window, 'gitOps', {
+    configurable: true,
+    writable: true,
+    value: {
+      ...window.gitOps,
+      listBranchesWithStatus: vi.fn().mockResolvedValue({ success: true, value: { success: true, branches: [] } })
+    }
+  })
+}
+
+async function renderAndSelectClaudeCli(ticket: KanbanTicket = baseTicket): Promise<void> {
+  render(
+    <WorktreePickerModal
+      ticket={ticket}
+      projectId="project-1"
+      open
+      onOpenChange={vi.fn()}
+      onSendComplete={vi.fn()}
+    />
+  )
+
+  const toggle = screen.getByTestId('sdk-toggle')
+  expect(within(toggle).getAllByRole('button').map((button) => button.textContent)).toEqual([
+    'OpenCode',
+    'Claude CLI',
+    'Codex',
+    'Claude Code (SDK)'
+  ])
+  await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+}
+
+describe('WorktreePickerModal Claude CLI launch', () => {
+  beforeEach(() => {
+    _resetLastSourceBranch()
+    vi.clearAllMocks()
+    setupWindowApis()
+    setupStores()
+  })
+
+  afterEach(() => {
+    cleanup()
+    useSettingsStore.setState(initialSettingsState, true)
+    useSessionStore.setState(initialSessionState, true)
+    useWorktreeStore.setState(initialWorktreeState, true)
+    useKanbanStore.setState(initialKanbanState, true)
+    useProjectStore.setState(initialProjectState, true)
+    useUsageStore.setState(initialUsageState, true)
+    useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
+    delete (window as { terminalOps?: unknown }).terminalOps
+    delete (window as { opencodeOps?: unknown }).opencodeOps
+    delete (window as { db?: unknown }).db
+  })
+
+  it('starts a worktree ticket with Claude CLI and does not call OpenCode connect or prompt', async () => {
+    const { createSession, setSessionModel } = setupStores()
+    await renderAndSelectClaudeCli()
+
+    await userEvent.click(screen.getByTestId('model-selector-pick-opus'))
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(window.terminalOps.createClaudeCli).toHaveBeenCalledTimes(1))
+    expect(createSession).toHaveBeenCalledWith('worktree-1', 'project-1', 'claude-code-cli', 'build', {
+      modelOverride: {
+        agentSdk: 'claude-code-cli',
+        providerID: 'anthropic',
+        modelID: 'opus',
+        variant: 'high'
+      },
+      pendingMessage: expect.stringContaining('Please implement the following ticket.')
+    })
+    expect(setSessionModel).toHaveBeenCalledWith('session-1', {
+      agentSdk: 'claude-code-cli',
+      providerID: 'anthropic',
+      modelID: 'opus',
+      variant: 'high'
+    })
+    expect(window.terminalOps.createClaudeCli).toHaveBeenCalledWith('session-1', {
+      pendingPrompt: expect.stringContaining('Please implement the following ticket.')
+    })
+    expect(window.opencodeOps.connect).not.toHaveBeenCalled()
+    expect(window.opencodeOps.prompt).not.toHaveBeenCalled()
+  })
+
+  it('omits the synthetic plan prefix for Claude CLI plan launches', async () => {
+    await renderAndSelectClaudeCli()
+
+    await userEvent.click(screen.getByTestId('wt-picker-mode-toggle'))
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(window.terminalOps.createClaudeCli).toHaveBeenCalledTimes(1))
+    const pendingPrompt = vi.mocked(window.terminalOps.createClaudeCli).mock.calls[0][1]?.pendingPrompt
+    expect(pendingPrompt).toContain('Please review the following ticket')
+    expect(pendingPrompt).not.toContain(PLAN_MODE_PREFIX)
+  })
+
+  it('keeps the super-plan instruction prefix for Claude CLI super-plan launches', async () => {
+    const { setSessionMode } = setupStores()
+    await renderAndSelectClaudeCli()
+
+    await userEvent.click(screen.getByTestId('wt-picker-mode-toggle'))
+    await userEvent.click(screen.getByTestId('wt-picker-super-toggle'))
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(window.terminalOps.createClaudeCli).toHaveBeenCalledTimes(1))
+    const pendingPrompt = vi.mocked(window.terminalOps.createClaudeCli).mock.calls[0][1]?.pendingPrompt
+    expect(pendingPrompt?.startsWith(getSuperPlanModePrefix('claude-code-cli'))).toBe(true)
+    expect(setSessionMode).toHaveBeenCalledWith('session-1', 'plan')
+  })
+
+  it('serializes Claude CLI SDK in save-config-only mode', async () => {
+    const { updateTicket } = setupStores()
+    render(
+      <WorktreePickerModal
+        ticket={baseTicket}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+        saveConfigOnly
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(updateTicket).toHaveBeenCalledTimes(1))
+    const update = updateTicket.mock.calls[0][2] as { pending_launch_config: string }
+    expect(JSON.parse(update.pending_launch_config)).toMatchObject({
+      sdk: 'claude-code-cli'
+    })
+    expect(window.terminalOps.createClaudeCli).not.toHaveBeenCalled()
+    expect(window.opencodeOps.connect).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -257,9 +257,9 @@ async function renderAndSelectClaudeCli(ticket: KanbanTicket = baseTicket): Prom
   const toggle = screen.getByTestId('sdk-toggle')
   expect(within(toggle).getAllByRole('button').map((button) => button.textContent)).toEqual([
     'OpenCode',
-    'Claude CLI',
+    'Claude Code',
     'Codex',
-    'Claude Code (SDK)'
+    'Claude CLI'
   ])
   await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
 }

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -516,7 +516,9 @@ export function WorktreePickerModal({
             })
 
           if (mode === 'super-plan') {
-            useSessionStore.getState().setSessionMode(sessionId, 'plan')
+            // Await so the persisted mode is committed before the main process
+            // reads it in buildClaudeCliPtySpawn (createClaudeCli).
+            await useSessionStore.getState().setSessionMode(sessionId, 'plan')
           }
 
           bumpWorktreeLastMessage({ connectionId })
@@ -774,7 +776,9 @@ export function WorktreePickerModal({
           })
 
         if (mode === 'super-plan') {
-          useSessionStore.getState().setSessionMode(sessionId, 'plan')
+          // Await so the persisted mode is committed before the main process
+          // reads it in buildClaudeCliPtySpawn (createClaudeCli).
+          await useSessionStore.getState().setSessionMode(sessionId, 'plan')
         }
 
         bumpWorktreeLastMessage({ worktreeId })

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -40,6 +40,7 @@ const EMPTY_ARRAY: readonly never[] = []
 
 // ── Types ───────────────────────────────────────────────────────────
 type PickerMode = 'build' | 'plan' | 'super-plan'
+type PickerAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex'
 
 interface BranchInfo {
   name: string
@@ -120,6 +121,35 @@ function wrapGoalPrompt(prompt: string, criteria: string): string {
   return `/goal ${stripped}. Goal success criteria: ${criteria}`
 }
 
+function composePromptForSdk(
+  mode: PickerMode,
+  sessionAgentSdk: string | null | undefined,
+  prompt: string,
+  goalMode: boolean,
+  goalCriteria: string,
+  options: { claudeCli: boolean }
+): string | null {
+  const trimmedPrompt = prompt.trim()
+  if (!trimmedPrompt) return null
+
+  const skipPrefix =
+    options.claudeCli ||
+    sessionAgentSdk === 'claude-code' ||
+    sessionAgentSdk === 'codex' ||
+    sessionAgentSdk === 'claude-code-cli'
+  const modePrefix =
+    mode === 'super-plan'
+      ? getSuperPlanModePrefix(sessionAgentSdk)
+      : mode === 'plan' && !skipPrefix
+        ? PLAN_MODE_PREFIX
+        : ''
+  const fullPrompt = modePrefix + trimmedPrompt
+
+  return goalMode && goalCriteria.trim()
+    ? wrapGoalPrompt(fullPrompt, goalCriteria.trim())
+    : fullPrompt
+}
+
 // ── Component ───────────────────────────────────────────────────────
 export function WorktreePickerModal({
   ticket,
@@ -147,12 +177,12 @@ export function WorktreePickerModal({
   const [branchFilter, setBranchFilter] = useState('')
   const [branchesLoading, setBranchesLoading] = useState(false)
   const [selectedModel, setSelectedModel] = useState<{
-    agentSdk?: 'opencode' | 'claude-code' | 'codex'
+    agentSdk?: PickerAgentSdk
     providerID: string
     modelID: string
     variant?: string
   } | null>(null)
-  const [selectedSdk, setSelectedSdk] = useState<'opencode' | 'claude-code' | 'codex' | null>(null)
+  const [selectedSdk, setSelectedSdk] = useState<PickerAgentSdk | null>(null)
 
   // ── Store access ────────────────────────────────────────────────
   const worktrees = useWorktreeStore(
@@ -201,6 +231,14 @@ export function WorktreePickerModal({
 
   const agentSdk = selectedSdk ?? autoResolvedModel?.agentSdk ?? baseAgentSdk
   const goalAvailable = agentSdk === 'codex' && mode === 'build' && !preAssignOnly
+  const availableSdkButtonCount = availableAgentSdks
+    ? [
+        availableAgentSdks.opencode,
+        availableAgentSdks.claude,
+        availableAgentSdks.codex,
+        availableAgentSdks.claude
+      ].filter(Boolean).length
+    : 0
 
   // ── Count in-progress tickets per worktree ──────────────────────
   const ticketCountByWorktree = useMemo(() => {
@@ -273,7 +311,7 @@ export function WorktreePickerModal({
   }, [branches, branchFilter])
 
   // ── Handle SDK change ───────────────────────────────────────────
-  const handleSdkChange = useCallback((sdk: 'opencode' | 'claude-code' | 'codex') => {
+  const handleSdkChange = useCallback((sdk: PickerAgentSdk) => {
     setSelectedSdk(sdk)
     setSelectedModel(null) // reset model — new SDK has different models
     if (sdk !== 'codex') {
@@ -396,7 +434,21 @@ export function WorktreePickerModal({
       try {
         // Create connection session
         const createConnectionSession = useSessionStore.getState().createConnectionSession
-        const sessionResult = await createConnectionSession(connectionId, agentSdk, mode)
+        const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
+        const modelOverride = effectiveModel ? { ...effectiveModel, agentSdk } : undefined
+        const cliPendingPrompt =
+          agentSdk === 'claude-code-cli'
+            ? composePromptForSdk(mode, agentSdk, promptText, goalMode, goalCriteria, {
+                claudeCli: true
+              })
+            : null
+        const createOptions = {
+          ...(modelOverride ? { modelOverride } : {}),
+          ...(cliPendingPrompt ? { pendingMessage: cliPendingPrompt } : {})
+        }
+        const sessionResult = await createConnectionSession(connectionId, agentSdk, mode, {
+          ...createOptions
+        })
 
         if (!sessionResult.success || !sessionResult.session) {
           toast.error(sessionResult.error || 'Failed to create session')
@@ -417,7 +469,6 @@ export function WorktreePickerModal({
           .setSessionStatus(sessionId, isPlanLike(mode) ? 'planning' : 'working')
 
         // Apply model override
-        const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
         if (selectedModel) {
           await useSessionStore.getState().setSessionModel(sessionId, selectedModel)
         }
@@ -455,6 +506,29 @@ export function WorktreePickerModal({
         onOpenChange(false)
         toast.success('Session started')
 
+        if (sessionAgentSdk === 'claude-code-cli') {
+          const outboundPrompt =
+            cliPendingPrompt ??
+            composePromptForSdk(mode, sessionAgentSdk, promptText, goalMode, goalCriteria, {
+              claudeCli: true
+            })
+
+          if (mode === 'super-plan') {
+            useSessionStore.getState().setSessionMode(sessionId, 'plan')
+          }
+
+          bumpWorktreeLastMessage({ connectionId })
+          const result = unwrapEnvelope(
+            await window.terminalOps.createClaudeCli(sessionId, {
+              pendingPrompt: outboundPrompt
+            })
+          )
+          if (result.success && outboundPrompt) {
+            useSessionStore.getState().dequeuePendingMessage(sessionId)
+          }
+          return
+        }
+
         // Connect to opencode using connection path
         const connectionPath = useConnectionStore
           .getState()
@@ -471,18 +545,14 @@ export function WorktreePickerModal({
 
         // Send prompt
         if (promptText.trim()) {
-          const skipPrefix = sessionAgentSdk === 'claude-code' || sessionAgentSdk === 'codex'
-          const modePrefix =
-            mode === 'super-plan'
-              ? getSuperPlanModePrefix(sessionAgentSdk)
-              : mode === 'plan' && !skipPrefix
-                ? PLAN_MODE_PREFIX
-                : ''
-          const fullPrompt = modePrefix + promptText.trim()
-          const outboundPrompt =
-            goalMode && goalCriteria.trim()
-              ? wrapGoalPrompt(fullPrompt, goalCriteria.trim())
-              : fullPrompt
+          const outboundPrompt = composePromptForSdk(
+            mode,
+            sessionAgentSdk,
+            promptText,
+            goalMode,
+            goalCriteria,
+            { claudeCli: false }
+          )
           const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
 
           if (mode === 'super-plan') {
@@ -624,7 +694,19 @@ export function WorktreePickerModal({
       }
 
       // Create session in the selected worktree
-      const sessionResult = await createSession(worktreeId, projectId, agentSdk, mode)
+      const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
+      const modelOverride = effectiveModel ? { ...effectiveModel, agentSdk } : undefined
+      const cliPendingPrompt =
+        agentSdk === 'claude-code-cli'
+          ? composePromptForSdk(mode, agentSdk, promptText, goalMode, goalCriteria, {
+              claudeCli: true
+            })
+          : null
+      const createOptions = {
+        ...(modelOverride ? { modelOverride } : {}),
+        ...(cliPendingPrompt ? { pendingMessage: cliPendingPrompt } : {})
+      }
+      const sessionResult = await createSession(worktreeId, projectId, agentSdk, mode, createOptions)
 
       if (!sessionResult.success || !sessionResult.session) {
         toast.error(sessionResult.error || 'Failed to create session')
@@ -648,7 +730,6 @@ export function WorktreePickerModal({
         .setSessionStatus(sessionId, isPlanLike(mode) ? 'planning' : 'working')
 
       // Apply user's model override to the session if they explicitly picked one
-      const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
       if (selectedModel) {
         await useSessionStore.getState().setSessionModel(sessionId, selectedModel)
       }
@@ -683,6 +764,29 @@ export function WorktreePickerModal({
       onOpenChange(false)
       toast.success('Session started')
 
+      if (sessionAgentSdk === 'claude-code-cli') {
+        const outboundPrompt =
+          cliPendingPrompt ??
+          composePromptForSdk(mode, sessionAgentSdk, promptText, goalMode, goalCriteria, {
+            claudeCli: true
+          })
+
+        if (mode === 'super-plan') {
+          useSessionStore.getState().setSessionMode(sessionId, 'plan')
+        }
+
+        bumpWorktreeLastMessage({ worktreeId })
+        const result = unwrapEnvelope(
+          await window.terminalOps.createClaudeCli(sessionId, {
+            pendingPrompt: outboundPrompt
+          })
+        )
+        if (result.success && outboundPrompt) {
+          useSessionStore.getState().dequeuePendingMessage(sessionId)
+        }
+        return
+      }
+
       // ── Start the OpenCode session in the background ──────────
       // Resolve worktree path from the store
       const allWorktrees = Array.from(
@@ -705,18 +809,14 @@ export function WorktreePickerModal({
 
       // Send the prompt — apply plan mode prefix for opencode SDK
       if (promptText.trim()) {
-        const skipPrefix = sessionAgentSdk === 'claude-code' || sessionAgentSdk === 'codex'
-        const modePrefix =
-          mode === 'super-plan'
-            ? getSuperPlanModePrefix(sessionAgentSdk)
-            : mode === 'plan' && !skipPrefix
-              ? PLAN_MODE_PREFIX
-              : ''
-        const fullPrompt = modePrefix + promptText.trim()
-        const outboundPrompt =
-          goalMode && goalCriteria.trim()
-            ? wrapGoalPrompt(fullPrompt, goalCriteria.trim())
-            : fullPrompt
+        const outboundPrompt = composePromptForSdk(
+          mode,
+          sessionAgentSdk,
+          promptText,
+          goalMode,
+          goalCriteria,
+          { claudeCli: false }
+        )
         const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
 
         // Auto-revert super-plan → plan immediately (one-shot mode).
@@ -1003,12 +1103,7 @@ export function WorktreePickerModal({
                 Provider & Model
               </label>
               {/* SDK toggle — only when 2+ SDKs are available */}
-              {availableAgentSdks &&
-                [
-                  availableAgentSdks.opencode,
-                  availableAgentSdks.claude,
-                  availableAgentSdks.codex
-                ].filter(Boolean).length >= 2 && (
+              {availableAgentSdks && availableSdkButtonCount >= 2 && (
                   <div className="flex gap-1.5" data-testid="sdk-toggle">
                     {availableAgentSdks.opencode && (
                       <button
@@ -1028,16 +1123,16 @@ export function WorktreePickerModal({
                     {availableAgentSdks.claude && (
                       <button
                         type="button"
-                        data-testid="sdk-toggle-claude-code"
-                        onClick={() => handleSdkChange('claude-code')}
+                        data-testid="sdk-toggle-claude-code-cli"
+                        onClick={() => handleSdkChange('claude-code-cli')}
                         className={cn(
                           'px-2.5 py-1 rounded-md text-xs border transition-colors',
-                          agentSdk === 'claude-code'
+                          agentSdk === 'claude-code-cli'
                             ? 'bg-primary text-primary-foreground border-primary'
                             : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
                         )}
                       >
-                        Claude Code
+                        Claude CLI
                       </button>
                     )}
                     {availableAgentSdks.codex && (
@@ -1053,6 +1148,21 @@ export function WorktreePickerModal({
                         )}
                       >
                         Codex
+                      </button>
+                    )}
+                    {availableAgentSdks.claude && (
+                      <button
+                        type="button"
+                        data-testid="sdk-toggle-claude-code"
+                        onClick={() => handleSdkChange('claude-code')}
+                        className={cn(
+                          'px-2.5 py-1 rounded-md text-xs border transition-colors',
+                          agentSdk === 'claude-code'
+                            ? 'bg-primary text-primary-foreground border-primary'
+                            : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+                        )}
+                      >
+                        Claude Code (SDK)
                       </button>
                     )}
                   </div>

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -1125,16 +1125,16 @@ export function WorktreePickerModal({
                     {availableAgentSdks.claude && (
                       <button
                         type="button"
-                        data-testid="sdk-toggle-claude-code-cli"
-                        onClick={() => handleSdkChange('claude-code-cli')}
+                        data-testid="sdk-toggle-claude-code"
+                        onClick={() => handleSdkChange('claude-code')}
                         className={cn(
                           'px-2.5 py-1 rounded-md text-xs border transition-colors',
-                          agentSdk === 'claude-code-cli'
+                          agentSdk === 'claude-code'
                             ? 'bg-primary text-primary-foreground border-primary'
                             : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
                         )}
                       >
-                        Claude CLI
+                        Claude Code
                       </button>
                     )}
                     {availableAgentSdks.codex && (
@@ -1155,16 +1155,16 @@ export function WorktreePickerModal({
                     {availableAgentSdks.claude && (
                       <button
                         type="button"
-                        data-testid="sdk-toggle-claude-code"
-                        onClick={() => handleSdkChange('claude-code')}
+                        data-testid="sdk-toggle-claude-code-cli"
+                        onClick={() => handleSdkChange('claude-code-cli')}
                         className={cn(
                           'px-2.5 py-1 rounded-md text-xs border transition-colors',
-                          agentSdk === 'claude-code'
+                          agentSdk === 'claude-code-cli'
                             ? 'bg-primary text-primary-foreground border-primary'
                             : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
                         )}
                       >
-                        Claude Code (SDK)
+                        Claude CLI
                       </button>
                     )}
                   </div>

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -14,6 +14,7 @@ import { FileSearchDialog } from '@/components/file-search'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useVimNavigation } from '@/hooks/useVimNavigation'
 import { useOpenCodeGlobalListener } from '@/hooks/useOpenCodeGlobalListener'
+import { useClaudeCliStatusListener } from '@/hooks/useClaudeCliStatusListener'
 import { useNotificationNavigation } from '@/hooks/useNotificationNavigation'
 import { useWindowFocusRefresh } from '@/hooks/useWindowFocusRefresh'
 import { useWorktreeWatcher } from '@/hooks/useWorktreeWatcher'
@@ -126,6 +127,7 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
   useVimNavigation()
   // Global listener for background session events (AI finishes while viewing another project)
   useOpenCodeGlobalListener()
+  useClaudeCliStatusListener()
   // Navigate to session when native notification is clicked
   useNotificationNavigation()
   // Refresh git statuses when window regains focus

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -25,6 +25,7 @@ import { ErrorBoundary, ErrorFallback } from '@/components/error'
 import { CreatePRModal } from '@/components/pr/CreatePRModal'
 import { ProjectSettingsDialog } from '@/components/projects/ProjectSettingsDialog'
 import { TerminalPortalProvider, useTerminalPortal } from '@/contexts/TerminalPortalContext'
+import { ClaudeCliSessionPortalProvider } from '@/contexts/ClaudeCliSessionPortalContext'
 import { TerminalManager } from '@/components/terminal/TerminalManager'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
@@ -61,6 +62,7 @@ function GlobalProjectSettings(): React.JSX.Element | null {
 
 function TerminalManagerPortal(): React.JSX.Element {
   const { getTarget, revision } = useTerminalPortal()
+  void revision
   const terminalPosition = useSettingsStore((s) => s.terminalPosition)
 
   // Read layout state for visibility computation
@@ -250,59 +252,61 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
 
   return (
     <TerminalPortalProvider>
-      <div className="h-screen flex flex-col bg-background text-foreground" data-testid="app-layout">
-        <ErrorBoundary componentName="Header" fallback={<div className="h-12 bg-muted" />}>
-          <Header />
-        </ErrorBoundary>
-        <div className="flex-1 flex min-h-0" data-testid="layout-content">
-          <ErrorBoundary
-            componentName="LeftSidebar"
-            fallback={
-              <div className="w-60 border-r bg-muted/50 flex items-center justify-center">
-                <ErrorFallback compact title="Sidebar Error" />
-              </div>
-            }
-          >
-            <LeftSidebar />
+      <ClaudeCliSessionPortalProvider>
+        <div
+          className="h-screen flex flex-col bg-background text-foreground"
+          data-testid="app-layout"
+        >
+          <ErrorBoundary componentName="Header" fallback={<div className="h-12 bg-muted" />}>
+            <Header />
           </ErrorBoundary>
-          <ErrorBoundary componentName="MainPane">
-            <MainPane>{children}</MainPane>
+          <div className="flex-1 flex min-h-0" data-testid="layout-content">
+            <ErrorBoundary
+              componentName="LeftSidebar"
+              fallback={
+                <div className="w-60 border-r bg-muted/50 flex items-center justify-center">
+                  <ErrorFallback compact title="Sidebar Error" />
+                </div>
+              }
+            >
+              <LeftSidebar />
+            </ErrorBoundary>
+            <ErrorBoundary componentName="MainPane">
+              <MainPane>{children}</MainPane>
+            </ErrorBoundary>
+            <ErrorBoundary
+              componentName="RightSidebar"
+              fallback={<div className="border-l bg-muted/50" />}
+            >
+              <RightSidebar />
+            </ErrorBoundary>
+          </div>
+          <Toaster />
+          {isDragging && <DropOverlay variant={activeSessionId ? 'normal' : 'warning'} />}
+          <ErrorBoundary componentName="SessionHistory" fallback={null}>
+            <SessionHistory />
           </ErrorBoundary>
-          <ErrorBoundary
-            componentName="RightSidebar"
-            fallback={<div className="border-l bg-muted/50" />}
-          >
-            <RightSidebar />
+          <ErrorBoundary componentName="CommandPalette" fallback={null}>
+            <CommandPalette />
           </ErrorBoundary>
+          <ErrorBoundary componentName="SettingsModal" fallback={null}>
+            <SettingsModal />
+          </ErrorBoundary>
+          <ErrorBoundary componentName="FileSearchDialog" fallback={null}>
+            <FileSearchDialog />
+          </ErrorBoundary>
+          <GlobalProjectSettings />
+          {createPRWorktreeId && createPRWorktreePath && (
+            <ErrorBoundary componentName="CreatePRModal" fallback={null}>
+              <CreatePRModal worktreeId={createPRWorktreeId} worktreePath={createPRWorktreePath} />
+            </ErrorBoundary>
+          )}
+          <AgentSetupGuard />
+          <HelpOverlay />
+          <QuitConfirmationOverlay />
         </div>
-        <Toaster />
-        {isDragging && <DropOverlay variant={activeSessionId ? 'normal' : 'warning'} />}
-        <ErrorBoundary componentName="SessionHistory" fallback={null}>
-          <SessionHistory />
-        </ErrorBoundary>
-        <ErrorBoundary componentName="CommandPalette" fallback={null}>
-          <CommandPalette />
-        </ErrorBoundary>
-        <ErrorBoundary componentName="SettingsModal" fallback={null}>
-          <SettingsModal />
-        </ErrorBoundary>
-        <ErrorBoundary componentName="FileSearchDialog" fallback={null}>
-          <FileSearchDialog />
-        </ErrorBoundary>
-        <GlobalProjectSettings />
-        {createPRWorktreeId && createPRWorktreePath && (
-          <ErrorBoundary componentName="CreatePRModal" fallback={null}>
-            <CreatePRModal
-              worktreeId={createPRWorktreeId}
-              worktreePath={createPRWorktreePath}
-            />
-          </ErrorBoundary>
-        )}
-        <AgentSetupGuard />
-        <HelpOverlay />
-        <QuitConfirmationOverlay />
-      </div>
-      <TerminalManagerPortal />
+        <TerminalManagerPortal />
+      </ClaudeCliSessionPortalProvider>
     </TerminalPortalProvider>
   )
 }

--- a/src/renderer/src/components/layout/MainPane.test.tsx
+++ b/src/renderer/src/components/layout/MainPane.test.tsx
@@ -1,0 +1,231 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MainPane } from './MainPane'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useFileViewerStore } from '@/stores/useFileViewerStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useLayoutStore } from '@/stores/useLayoutStore'
+import { usePinnedStore } from '@/stores/usePinnedStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+vi.mock('@/components/sessions', () => ({
+  SessionTabs: () => <div data-testid="session-tabs" />,
+  SessionView: ({
+    sessionId,
+    isVisible
+  }: {
+    sessionId: string
+    isVisible?: boolean
+  }) => (
+    <div data-testid={`session-view-${sessionId}`} data-visible={String(isVisible)}>
+      session {sessionId}
+    </div>
+  )
+}))
+
+vi.mock('@/components/sessions/SessionTerminalView', () => ({
+  SessionTerminalView: ({
+    sessionId,
+    isVisible
+  }: {
+    sessionId: string
+    isVisible?: boolean
+  }) => (
+    <div data-testid={`terminal-view-${sessionId}`} data-visible={String(isVisible)}>
+      terminal {sessionId}
+    </div>
+  )
+}))
+
+vi.mock('@/components/kanban/KanbanBoard', () => ({
+  KanbanBoard: () => <div data-testid="kanban-board" />
+}))
+
+vi.mock('@/components/kanban/KanbanIcon', () => ({
+  KanbanIcon: () => <span data-testid="kanban-icon" />
+}))
+
+vi.mock('@/components/kanban/BoardAssistantView', () => ({
+  BoardAssistantView: ({ projectId }: { projectId: string }) => (
+    <div data-testid="board-assistant-view">{projectId}</div>
+  )
+}))
+
+vi.mock('@/components/pr/PRNotificationStack', () => ({
+  PRNotificationStack: () => null
+}))
+
+vi.mock('./MainPaneTerminalPanel', () => ({
+  MainPaneTerminalPanel: () => null
+}))
+
+const initialConnectionState = useConnectionStore.getState()
+const initialFileViewerState = useFileViewerStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialLayoutState = useLayoutStore.getState()
+const initialPinnedState = usePinnedStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialSessionState = useSessionStore.getState()
+const initialSettingsState = useSettingsStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+
+type MainPaneSession = {
+  id: string
+  worktree_id: string | null
+  project_id: string
+  connection_id: string | null
+  name: string | null
+  status: 'active' | 'completed' | 'error'
+  opencode_session_id: string | null
+  claude_session_id: string | null
+  agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  mode: 'build' | 'plan' | 'super-plan'
+  session_type: 'default' | 'board-assistant'
+  model_provider_id: string | null
+  model_id: string | null
+  model_variant: string | null
+  created_at: string
+  updated_at: string
+  completed_at: string | null
+}
+
+function makeSession(overrides: Partial<MainPaneSession> = {}): MainPaneSession {
+  return {
+    id: 'session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Claude CLI',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: 'anthropic',
+    model_id: 'opus',
+    model_variant: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    ...overrides
+  }
+}
+
+function setupMainPaneState(session: MainPaneSession = makeSession()): void {
+  useConnectionStore.setState({
+    selectedConnectionId: null,
+    loaded: true
+  })
+  useFileViewerStore.setState({
+    activeFilePath: null,
+    activeDiff: null,
+    contextEditorWorktreeId: null
+  })
+  useKanbanStore.setState({
+    isBoardViewActive: false,
+    isPinnedBoardActive: false
+  })
+  useLayoutStore.setState({
+    ghosttyOverlaySuppressed: false
+  })
+  usePinnedStore.setState({
+    loaded: true
+  })
+  useProjectStore.setState({
+    selectedProjectId: 'project-1',
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '/repo',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        last_accessed_at: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  useSessionStore.setState({
+    activeSessionId: session.id,
+    activePinnedSessionId: null,
+    activeBoardAssistantProjectId: null,
+    inlineConnectionSessionId: null,
+    isLoading: false,
+    closedTerminalSessionIds: new Set(),
+    sessionsByWorktree: new Map([['worktree-1', [session]]]),
+    sessionsByConnection: new Map()
+  })
+  useSettingsStore.setState({
+    boardMode: 'toggle',
+    terminalPosition: 'sidebar'
+  })
+  useWorktreeStore.setState({
+    selectedWorktreeId: 'worktree-1'
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  useConnectionStore.setState(initialConnectionState, true)
+  useFileViewerStore.setState(initialFileViewerState, true)
+  useKanbanStore.setState(initialKanbanState, true)
+  useLayoutStore.setState(initialLayoutState, true)
+  usePinnedStore.setState(initialPinnedState, true)
+  useProjectStore.setState(initialProjectState, true)
+  useSessionStore.setState(initialSessionState, true)
+  useSettingsStore.setState(initialSettingsState, true)
+  useWorktreeStore.setState(initialWorktreeState, true)
+})
+
+describe('MainPane terminal visibility', () => {
+  it('shows a stateful terminal session when it is the active main content', () => {
+    setupMainPaneState()
+
+    render(<MainPane />)
+
+    const terminal = screen.getByTestId('session-view-session-1')
+    expect(terminal.getAttribute('data-visible')).toBe('true')
+    expect(terminal.parentElement?.classList.contains('flex-1')).toBe(true)
+  })
+
+  it.each([
+    ['board view', () => useKanbanStore.setState({ isBoardViewActive: true })],
+    ['pinned board', () => useKanbanStore.setState({ isPinnedBoardActive: true })],
+    [
+      'board assistant',
+      () => useSessionStore.setState({ activeBoardAssistantProjectId: 'project-1' })
+    ]
+  ])('keeps the stateful terminal mounted but hidden during %s', (_label, activateView) => {
+    setupMainPaneState()
+    activateView()
+
+    render(<MainPane />)
+
+    const terminal = screen.getByTestId('session-view-session-1')
+    expect(terminal.getAttribute('data-visible')).toBe('false')
+    expect(terminal.parentElement?.classList.contains('hidden')).toBe(true)
+  })
+
+  it('keeps a plain terminal session mounted but hidden during board view', () => {
+    setupMainPaneState(makeSession({ id: 'terminal-1', agent_sdk: 'terminal' }))
+    useKanbanStore.setState({ isBoardViewActive: true })
+
+    render(<MainPane />)
+
+    const terminal = screen.getByTestId('terminal-view-terminal-1')
+    expect(terminal.getAttribute('data-visible')).toBe('false')
+    expect(terminal.parentElement?.classList.contains('hidden')).toBe(true)
+  })
+})

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -149,6 +149,13 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
       return null
     }
 
+    // When the board, pinned board, or board assistant is occupying the main
+    // pane, hide all stateful terminal sessions — otherwise the always-mounted
+    // terminal would render as flex-1 alongside the board and split the pane.
+    if (isBoardViewActive || isPinnedBoardActive || activeBoardAssistantProjectId) {
+      return null
+    }
+
     // Inline connection terminal takes priority
     if (
       inlineConnectionSessionId &&
@@ -175,7 +182,10 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     activeDiff,
     activeFilePath,
     getAgentSdk,
-    ghosttyOverlaySuppressed
+    ghosttyOverlaySuppressed,
+    isBoardViewActive,
+    isPinnedBoardActive,
+    activeBoardAssistantProjectId
   ])
 
   const handleCloseDiff = useCallback(() => {

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -1,4 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  lazy,
+  Suspense
+} from 'react'
+import { createPortal } from 'react-dom'
 import { Loader2 } from 'lucide-react'
 import { SessionTabs, SessionView } from '@/components/sessions'
 import { SessionTerminalView } from '@/components/sessions/SessionTerminalView'
@@ -14,6 +24,7 @@ import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { usePinnedStore } from '@/stores/usePinnedStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalContext'
 import { KanbanBoard } from '@/components/kanban/KanbanBoard'
 import { KanbanIcon } from '@/components/kanban/KanbanIcon'
 import { BoardAssistantView } from '@/components/kanban/BoardAssistantView'
@@ -32,6 +43,55 @@ interface MainPaneProps {
 
 function isStatefulTerminalSession(agentSdk: string | null): boolean {
   return agentSdk === 'terminal' || agentSdk === 'claude-code-cli'
+}
+
+function ClaudeCliSessionPortal({
+  sessionId,
+  isActive
+}: {
+  sessionId: string
+  isActive: boolean
+}): React.JSX.Element {
+  const { getTarget, revision } = useClaudeCliSessionPortal()
+  void revision
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  if (!hostRef.current && typeof document !== 'undefined') {
+    const host = document.createElement('div')
+    host.className = 'flex-1 flex flex-col min-h-0'
+    hostRef.current = host
+  }
+
+  const [localTarget, setLocalTarget] = useState<HTMLDivElement | null>(null)
+  const modalTarget = getTarget(sessionId)
+  const targetParent = modalTarget ?? localTarget
+
+  useLayoutEffect(() => {
+    const host = hostRef.current
+    if (!host || !targetParent) return
+    if (host.parentElement !== targetParent) {
+      targetParent.appendChild(host)
+    }
+  }, [targetParent])
+
+  useEffect(() => {
+    const host = hostRef.current
+    return () => {
+      host?.remove()
+    }
+  }, [])
+
+  const sessionView = (
+    <SessionView sessionId={sessionId} isVisible={modalTarget ? true : isActive} />
+  )
+
+  return (
+    <>
+      <div ref={setLocalTarget} className="flex-1 flex flex-col min-h-0" />
+      {hostRef.current && targetParent
+        ? createPortal(sessionView, hostRef.current, sessionId)
+        : null}
+    </>
+  )
 }
 
 export function MainPane({ children }: MainPaneProps): React.JSX.Element {
@@ -61,42 +121,47 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   // Subscribe to session maps so terminal list stays reactive
   const sessionsByWorktree = useSessionStore((state) => state.sessionsByWorktree)
   const sessionsByConnection = useSessionStore((state) => state.sessionsByConnection)
+  const sessionMountRequests = useSessionStore((state) => state.sessionMountRequests)
 
   // Look up the agent_sdk for a given session ID
   const getAgentSdk = useCallback((sid: string | null): string | null => {
     if (!sid) return null
-    const state = useSessionStore.getState()
-    for (const sessions of state.sessionsByWorktree.values()) {
-      const found = sessions.find((s) => s.id === sid)
-      if (found) return found.agent_sdk
-    }
-    for (const sessions of state.sessionsByConnection.values()) {
-      const found = sessions.find((s) => s.id === sid)
-      if (found) return found.agent_sdk
-    }
-    return null
+    return useSessionStore.getState().getSessionById(sid)?.agent_sdk ?? null
   }, [])
 
   // Collect all terminal-type sessions in the current scope.
   const terminalSessions = useMemo(() => {
-    const terminals: string[] = []
+    const terminals = new Set<string>()
 
     if (selectedWorktreeId) {
       const sessions = sessionsByWorktree.get(selectedWorktreeId) || []
       for (const s of sessions) {
-        if (isStatefulTerminalSession(s.agent_sdk)) terminals.push(s.id)
+        if (isStatefulTerminalSession(s.agent_sdk)) terminals.add(s.id)
       }
     }
 
     if (selectedConnectionId) {
       const sessions = sessionsByConnection.get(selectedConnectionId) || []
       for (const s of sessions) {
-        if (isStatefulTerminalSession(s.agent_sdk)) terminals.push(s.id)
+        if (isStatefulTerminalSession(s.agent_sdk)) terminals.add(s.id)
       }
     }
 
-    return terminals
-  }, [selectedWorktreeId, selectedConnectionId, sessionsByWorktree, sessionsByConnection])
+    for (const [sessionId, count] of sessionMountRequests.entries()) {
+      if (count > 0 && getAgentSdk(sessionId) === 'claude-code-cli') {
+        terminals.add(sessionId)
+      }
+    }
+
+    return Array.from(terminals)
+  }, [
+    selectedWorktreeId,
+    selectedConnectionId,
+    sessionsByWorktree,
+    sessionsByConnection,
+    sessionMountRequests,
+    getAgentSdk
+  ])
 
   // Keep terminal views mounted once discovered so transient session-map churn
   // does not reset terminal UI state.
@@ -393,6 +458,8 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
             <div key={sessionId} className={isActive ? 'flex-1 flex flex-col min-h-0' : 'hidden'}>
               {agentSdk === 'terminal' ? (
                 <SessionTerminalView sessionId={sessionId} isVisible={isActive} />
+              ) : agentSdk === 'claude-code-cli' ? (
+                <ClaudeCliSessionPortal sessionId={sessionId} isActive={isActive} />
               ) : (
                 <SessionView sessionId={sessionId} isVisible={isActive} />
               )}

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -30,6 +30,10 @@ interface MainPaneProps {
   children?: React.ReactNode
 }
 
+function isStatefulTerminalSession(agentSdk: string | null): boolean {
+  return agentSdk === 'terminal' || agentSdk === 'claude-code-cli'
+}
+
 export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const selectedWorktreeId = useWorktreeStore((state) => state.selectedWorktreeId)
   const selectedConnectionId = useConnectionStore((state) => state.selectedConnectionId)
@@ -80,14 +84,14 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     if (selectedWorktreeId) {
       const sessions = sessionsByWorktree.get(selectedWorktreeId) || []
       for (const s of sessions) {
-        if (s.agent_sdk === 'terminal') terminals.push(s.id)
+        if (isStatefulTerminalSession(s.agent_sdk)) terminals.push(s.id)
       }
     }
 
     if (selectedConnectionId) {
       const sessions = sessionsByConnection.get(selectedConnectionId) || []
       for (const s of sessions) {
-        if (s.agent_sdk === 'terminal') terminals.push(s.id)
+        if (isStatefulTerminalSession(s.agent_sdk)) terminals.push(s.id)
       }
     }
 
@@ -138,14 +142,17 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     }
 
     // Inline connection terminal takes priority
-    if (inlineConnectionSessionId && getAgentSdk(inlineConnectionSessionId) === 'terminal') {
+    if (
+      inlineConnectionSessionId &&
+      isStatefulTerminalSession(getAgentSdk(inlineConnectionSessionId))
+    ) {
       if (!activeDiff && !(activeFilePath && !activeFilePath.startsWith('diff:'))) {
         return inlineConnectionSessionId
       }
     }
 
     // Regular active session
-    if (activeSessionId && getAgentSdk(activeSessionId) === 'terminal') {
+    if (activeSessionId && isStatefulTerminalSession(getAgentSdk(activeSessionId))) {
       if (!activeDiff && !(activeFilePath && !activeFilePath.startsWith('diff:'))) {
         if (!inlineConnectionSessionId) {
           return activeSessionId
@@ -334,7 +341,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     // Inline connection session view (sticky tab clicked in worktree mode)
     if (inlineConnectionSessionId) {
       // Terminal sessions are handled by the always-mounted section below
-      if (getAgentSdk(inlineConnectionSessionId) === 'terminal') {
+      if (isStatefulTerminalSession(getAgentSdk(inlineConnectionSessionId))) {
         return null
       }
       return <SessionView key={inlineConnectionSessionId} sessionId={inlineConnectionSessionId} />
@@ -354,7 +361,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
 
     // Session is active - dispatch based on agent SDK
     // Terminal sessions are handled by the always-mounted section below
-    if (getAgentSdk(activeSessionId) === 'terminal') {
+    if (isStatefulTerminalSession(getAgentSdk(activeSessionId))) {
       return null
     }
     return <SessionView key={activeSessionId} sessionId={activeSessionId} />
@@ -372,9 +379,14 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
         {/* Always-mounted terminal sessions — kept alive to preserve PTY state across tab switches */}
         {mountedTerminalSessionIds.map((sessionId) => {
           const isActive = visibleTerminalId === sessionId
+          const agentSdk = getAgentSdk(sessionId)
           return (
             <div key={sessionId} className={isActive ? 'flex-1 flex flex-col min-h-0' : 'hidden'}>
-              <SessionTerminalView sessionId={sessionId} isVisible={isActive} />
+              {agentSdk === 'terminal' ? (
+                <SessionTerminalView sessionId={sessionId} isVisible={isActive} />
+              ) : (
+                <SessionView sessionId={sessionId} isVisible={isActive} />
+              )}
             </div>
           )
         })}

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -15,6 +15,7 @@ import { SessionTerminalView } from '@/components/sessions/SessionTerminalView'
 import { FileViewer } from '@/components/file-viewer'
 import { ImageDiffView } from '@/components/diff'
 import { isImageFile } from '@shared/types/file-utils'
+import { isTerminalBacked } from '@shared/types/agent-sdk'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useSessionStore, BOARD_TAB_ID } from '@/stores/useSessionStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -42,7 +43,7 @@ interface MainPaneProps {
 }
 
 function isStatefulTerminalSession(agentSdk: string | null): boolean {
-  return agentSdk === 'terminal' || agentSdk === 'claude-code-cli'
+  return isTerminalBacked(agentSdk)
 }
 
 function ClaudeCliSessionPortal({

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, lazy, Suspense } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense } from 'react'
 import { Loader2 } from 'lucide-react'
 import { SessionTabs, SessionView } from '@/components/sessions'
 import { SessionTerminalView } from '@/components/sessions/SessionTerminalView'
@@ -103,6 +103,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const [mountedTerminalSessionIds, setMountedTerminalSessionIds] = useState<string[]>(() =>
     Array.from(new Set(terminalSessions))
   )
+  const mountedTerminalAgentSdkBySessionId = useRef(new Map<string, string>())
 
   useEffect(() => {
     setMountedTerminalSessionIds((current) => {
@@ -110,6 +111,10 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
       let changed = false
 
       for (const sessionId of terminalSessions) {
+        const agentSdk = getAgentSdk(sessionId)
+        if (agentSdk) {
+          mountedTerminalAgentSdkBySessionId.current.set(sessionId, agentSdk)
+        }
         if (!merged.includes(sessionId)) {
           merged.push(sessionId)
           changed = true
@@ -118,7 +123,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
 
       return changed ? merged : current
     })
-  }, [terminalSessions])
+  }, [terminalSessions, getAgentSdk])
 
   // Prune terminals that were explicitly closed (tab close).
   // This is the ONLY path that removes from mountedTerminalSessionIds.
@@ -127,6 +132,9 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
 
     setMountedTerminalSessionIds((current) => {
       const filtered = current.filter((id) => !closedTerminalSessionIds.has(id))
+      for (const id of closedTerminalSessionIds) {
+        mountedTerminalAgentSdkBySessionId.current.delete(id)
+      }
       return filtered.length === current.length ? current : filtered
     })
 
@@ -379,7 +387,8 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
         {/* Always-mounted terminal sessions — kept alive to preserve PTY state across tab switches */}
         {mountedTerminalSessionIds.map((sessionId) => {
           const isActive = visibleTerminalId === sessionId
-          const agentSdk = getAgentSdk(sessionId)
+          const agentSdk =
+            getAgentSdk(sessionId) ?? mountedTerminalAgentSdkBySessionId.current.get(sessionId)
           return (
             <div key={sessionId} className={isActive ? 'flex-1 flex flex-col min-h-0' : 'hidden'}>
               {agentSdk === 'terminal' ? (

--- a/src/renderer/src/components/sessions/ClaudeCliEndedOverlay.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliEndedOverlay.tsx
@@ -1,0 +1,18 @@
+interface ClaudeCliEndedOverlayProps {
+  onRestart: () => void
+}
+
+export function ClaudeCliEndedOverlay({
+  onRestart
+}: ClaudeCliEndedOverlayProps): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onRestart}
+      className="absolute inset-0 z-10 flex items-center justify-center bg-background/55 text-sm font-medium text-foreground backdrop-blur-[1px]"
+      data-testid="claude-cli-ended-overlay"
+    >
+      Session ended - click to restart
+    </button>
+  )
+}

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -1,9 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { TerminalView, type TerminalViewHandle } from '@/components/terminal/TerminalView'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
-import { useSessionStore } from '@/stores/useSessionStore'
+import { useSessionStore, BOARD_TAB_ID } from '@/stores/useSessionStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalContext'
 import { ModeToggle } from './ModeToggle'
 import { SuperToggle } from './SuperToggle'
 import { ModelSelector } from './ModelSelector'
@@ -11,6 +15,8 @@ import { ClaudeCliEndedOverlay } from './ClaudeCliEndedOverlay'
 import { HandoffSplitButton } from './HandoffSplitButton'
 import { buildHandoffPrompt, type HandoffSelectionOverride } from '@/lib/handoffSelection'
 import { lastSendMode } from '@/lib/message-send-times'
+import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
+import { startBackgroundSessionPrompt } from '@/lib/backgroundSessionStart'
 import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 import { extractPlanTitle } from '@shared/types/branch-utils'
@@ -40,6 +46,63 @@ function loadPlanCardPosition(): PlanCardPosition | null {
 
 function savePlanCardPosition(position: PlanCardPosition): void {
   localStorage.setItem(PLAN_CARD_POSITION_KEY, JSON.stringify(position))
+}
+
+function findWorktreePathById(worktreeId: string): string | null {
+  for (const worktrees of useWorktreeStore.getState().worktreesByProject.values()) {
+    const found = worktrees.find((worktree) => worktree.id === worktreeId)
+    if (found) return found.path
+  }
+  return null
+}
+
+function findConnectionPathById(connectionId: string): string | null {
+  return (
+    useConnectionStore.getState().connections.find((connection) => connection.id === connectionId)
+      ?.path ?? null
+  )
+}
+
+async function startTicketModalHandoffSession(opts: {
+  sessionId: string
+  agentSdk: string
+  handoffPrompt: string
+  worktreeId?: string | null
+  connectionId?: string | null
+  worktreePath?: string | null
+}): Promise<void> {
+  if (opts.agentSdk === 'claude-code-cli') {
+    bumpWorktreeLastMessage({
+      worktreeId: opts.worktreeId,
+      connectionId: opts.connectionId
+    })
+    const result = unwrapEnvelope(
+      await window.terminalOps.createClaudeCli(opts.sessionId, {
+        pendingPrompt: opts.handoffPrompt
+      })
+    )
+    if (!result.success) {
+      throw new Error(result.error ?? 'Failed to start Claude CLI handoff')
+    }
+    if (opts.handoffPrompt) {
+      useSessionStore.getState().dequeuePendingMessage(opts.sessionId)
+    }
+    return
+  }
+
+  if (!opts.worktreePath) {
+    throw new Error('Could not find handoff working path')
+  }
+
+  await startBackgroundSessionPrompt({
+    worktreePath: opts.worktreePath,
+    sessionId: opts.sessionId,
+    prompt: opts.handoffPrompt,
+    bumpTarget: {
+      worktreeId: opts.worktreeId,
+      connectionId: opts.connectionId
+    }
+  })
 }
 
 function clampPlanCardPosition(
@@ -201,6 +264,9 @@ export function ClaudeCliSessionView({
   const pendingMessage = useSessionStore((state) => state.pendingMessages.get(sessionId) ?? null)
   const pendingPlan = useSessionStore((state) => state.pendingPlans.get(sessionId) ?? null)
   const mode = useSessionStore((state) => state.modeBySession.get(sessionId) ?? 'build')
+  const { getTarget, revision: portalRevision } = useClaudeCliSessionPortal()
+  void portalRevision
+  const isMountedInTicketModal = !!getTarget(sessionId)
   const sessionRecord = useSessionStore((state) => {
     for (const sessions of state.sessionsByWorktree.values()) {
       const found = sessions.find((session) => session.id === sessionId)
@@ -293,7 +359,7 @@ export function ClaudeCliSessionView({
           override.agentSdk === 'claude-code-cli' && mode === 'super-plan'
             ? 'super-plan'
             : undefined,
-          { modelOverride: override.model }
+          { autoFocus: !isMountedInTicketModal, modelOverride: override.model }
         )
         if (!result.success || !result.session) {
           toast.error(result.error ?? 'Failed to create handoff session')
@@ -306,6 +372,23 @@ export function ClaudeCliSessionView({
             : sessionStore.setSessionMode(result.session.id, 'build')
         sessionStore.setPendingMessage(result.session.id, handoffPrompt)
         await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
+        if (isMountedInTicketModal) {
+          if (useSettingsStore.getState().boardMode === 'sticky-tab') {
+            sessionStore.setActiveSession(BOARD_TAB_ID)
+          }
+          useKanbanStore.getState().setSelectedTicketId(null)
+          const connectionPath = findConnectionPathById(sessionRecord.connection_id)
+          await setModePromise
+          await startTicketModalHandoffSession({
+            sessionId: result.session.id,
+            agentSdk: result.session.agent_sdk,
+            handoffPrompt,
+            connectionId: sessionRecord.connection_id,
+            worktreePath: connectionPath
+          })
+          toast.success('Handoff session started')
+          return
+        }
         sessionStore.setActiveConnectionSession(result.session.id)
         await setModePromise
         return
@@ -323,7 +406,7 @@ export function ClaudeCliSessionView({
         override.agentSdk === 'claude-code-cli' && mode === 'super-plan'
           ? 'super-plan'
           : undefined,
-        { modelOverride: override.model }
+        { autoFocus: !isMountedInTicketModal, modelOverride: override.model }
       )
       if (!result.success || !result.session) {
         toast.error(result.error ?? 'Failed to create handoff session')
@@ -336,10 +419,27 @@ export function ClaudeCliSessionView({
           : sessionStore.setSessionMode(result.session.id, 'build')
       sessionStore.setPendingMessage(result.session.id, handoffPrompt)
       await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
+      if (isMountedInTicketModal) {
+        if (useSettingsStore.getState().boardMode === 'sticky-tab') {
+          sessionStore.setActiveSession(BOARD_TAB_ID)
+        }
+        useKanbanStore.getState().setSelectedTicketId(null)
+        const worktreePath = findWorktreePathById(sessionRecord.worktree_id)
+        await setModePromise
+        await startTicketModalHandoffSession({
+          sessionId: result.session.id,
+          agentSdk: result.session.agent_sdk,
+          handoffPrompt,
+          worktreeId: sessionRecord.worktree_id,
+          worktreePath
+        })
+        toast.success('Handoff session started')
+        return
+      }
       sessionStore.setActiveSession(result.session.id)
       await setModePromise
     },
-    [mode, pendingPlan?.planContent, sessionId, sessionRecord]
+    [isMountedInTicketModal, mode, pendingPlan?.planContent, sessionId, sessionRecord]
   )
 
   const handlePlanReadySaveAsTicket = useCallback(async () => {

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -345,6 +345,7 @@ export function ClaudeCliSessionView({
       useSessionStore.getState().clearPendingPlan(sessionId)
       useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
       lastSendMode.delete(sessionId)
+      const handoffGoalMode = override.goalMode === true && override.agentSdk === 'codex'
 
       const handoffPrompt = buildHandoffPrompt(planContent, {
         ...override,
@@ -371,7 +372,9 @@ export function ClaudeCliSessionView({
             ? Promise.resolve()
             : sessionStore.setSessionMode(result.session.id, 'build')
         sessionStore.setPendingMessage(result.session.id, handoffPrompt)
-        await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
+        await useKanbanStore
+          .getState()
+          .relinkTicketsForHandoff(sessionId, result.session.id, handoffGoalMode)
         if (isMountedInTicketModal) {
           if (useSettingsStore.getState().boardMode === 'sticky-tab') {
             sessionStore.setActiveSession(BOARD_TAB_ID)
@@ -418,7 +421,9 @@ export function ClaudeCliSessionView({
           ? Promise.resolve()
           : sessionStore.setSessionMode(result.session.id, 'build')
       sessionStore.setPendingMessage(result.session.id, handoffPrompt)
-      await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
+      await useKanbanStore
+        .getState()
+        .relinkTicketsForHandoff(sessionId, result.session.id, handoffGoalMode)
       if (isMountedInTicketModal) {
         if (useSettingsStore.getState().boardMode === 'sticky-tab') {
           sessionStore.setActiveSession(BOARD_TAB_ID)

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -1,11 +1,19 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { TerminalView } from '@/components/terminal/TerminalView'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { TerminalView, type TerminalViewHandle } from '@/components/terminal/TerminalView'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
 import { ModeToggle } from './ModeToggle'
 import { SuperToggle } from './SuperToggle'
 import { ModelSelector } from './ModelSelector'
 import { ClaudeCliEndedOverlay } from './ClaudeCliEndedOverlay'
+import { HandoffSplitButton } from './HandoffSplitButton'
+import { buildHandoffPrompt, type HandoffSelectionOverride } from '@/lib/handoffSelection'
+import { lastSendMode } from '@/lib/message-send-times'
+import { toast } from '@/lib/toast'
+import { cn } from '@/lib/utils'
+import { extractPlanTitle } from '@shared/types/branch-utils'
 import '@xterm/xterm/css/xterm.css'
 import '@/styles/xterm.css'
 
@@ -14,13 +22,208 @@ interface ClaudeCliSessionViewProps {
   isVisible?: boolean
 }
 
+type PlanCardPosition = { left: number; top: number }
+
+const PLAN_CARD_POSITION_KEY = 'hive.claudeCliPlanReadyCard.position'
+
+function loadPlanCardPosition(): PlanCardPosition | null {
+  try {
+    const raw = localStorage.getItem(PLAN_CARD_POSITION_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<PlanCardPosition>
+    if (typeof parsed.left !== 'number' || typeof parsed.top !== 'number') return null
+    return parsed as PlanCardPosition
+  } catch {
+    return null
+  }
+}
+
+function savePlanCardPosition(position: PlanCardPosition): void {
+  localStorage.setItem(PLAN_CARD_POSITION_KEY, JSON.stringify(position))
+}
+
+function clampPlanCardPosition(
+  position: PlanCardPosition,
+  container: DOMRect,
+  card: DOMRect
+): PlanCardPosition {
+  return {
+    left: Math.max(8, Math.min(position.left, container.width - card.width - 8)),
+    top: Math.max(8, Math.min(position.top, container.height - card.height - 8))
+  }
+}
+
+interface ClaudeCliPlanReadyCardProps {
+  planContent: string
+  worktreeId?: string
+  onHandoff: (override: HandoffSelectionOverride) => void
+  onSaveAsTicket: () => void
+  savedAsTicket: boolean
+}
+
+function ClaudeCliPlanReadyCard({
+  planContent,
+  worktreeId,
+  onHandoff,
+  onSaveAsTicket,
+  savedAsTicket
+}: ClaudeCliPlanReadyCardProps): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const cardRef = useRef<HTMLDivElement | null>(null)
+  const dragRef = useRef<{
+    pointerId: number
+    offsetX: number
+    offsetY: number
+  } | null>(null)
+  const [position, setPosition] = useState<PlanCardPosition | null>(() => loadPlanCardPosition())
+
+  const preview = planContent.trim().split('\n').find(Boolean) ?? 'Plan ready'
+
+  const moveToPointer = useCallback((clientX: number, clientY: number): void => {
+    const container = containerRef.current?.getBoundingClientRect()
+    const card = cardRef.current?.getBoundingClientRect()
+    const drag = dragRef.current
+    if (!container || !card || !drag) return
+
+    setPosition(
+      clampPlanCardPosition(
+        {
+          left: clientX - container.left - drag.offsetX,
+          top: clientY - container.top - drag.offsetY
+        },
+        container,
+        card
+      )
+    )
+  }, [])
+
+  return (
+    <div ref={containerRef} className="pointer-events-none absolute inset-0 z-20">
+      <div
+        ref={cardRef}
+        data-testid="claude-cli-plan-ready-card"
+        className={cn(
+          'pointer-events-auto absolute w-[min(520px,calc(100%-32px))]',
+          'rounded-lg border border-border bg-background/95 p-3 shadow-xl backdrop-blur',
+          position ? '' : 'bottom-4 right-4'
+        )}
+        style={position ? { left: position.left, top: position.top } : undefined}
+      >
+        <div
+          className="mb-3 cursor-grab select-none active:cursor-grabbing"
+          onPointerDown={(event) => {
+            if (event.button !== 0) return
+            const container = containerRef.current?.getBoundingClientRect()
+            const card = cardRef.current?.getBoundingClientRect()
+            if (!container || !card) return
+
+            const current = clampPlanCardPosition(
+              {
+                left: card.left - container.left,
+                top: card.top - container.top
+              },
+              container,
+              card
+            )
+            setPosition(current)
+            dragRef.current = {
+              pointerId: event.pointerId,
+              offsetX: event.clientX - card.left,
+              offsetY: event.clientY - card.top
+            }
+            event.currentTarget.setPointerCapture(event.pointerId)
+          }}
+          onPointerMove={(event) => {
+            if (dragRef.current?.pointerId !== event.pointerId) return
+            moveToPointer(event.clientX, event.clientY)
+          }}
+          onPointerUp={(event) => {
+            if (dragRef.current?.pointerId !== event.pointerId) return
+            dragRef.current = null
+            const card = cardRef.current?.getBoundingClientRect()
+            const container = containerRef.current?.getBoundingClientRect()
+            if (card && container) {
+              savePlanCardPosition(
+                clampPlanCardPosition(
+                  {
+                    left: card.left - container.left,
+                    top: card.top - container.top
+                  },
+                  container,
+                  card
+                )
+              )
+            }
+            event.currentTarget.releasePointerCapture(event.pointerId)
+          }}
+          onPointerCancel={(event) => {
+            if (dragRef.current?.pointerId !== event.pointerId) return
+            dragRef.current = null
+          }}
+        >
+          <div className="text-sm font-semibold text-foreground">Plan ready</div>
+          <div className="mt-1 truncate text-xs text-muted-foreground">{preview}</div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <HandoffSplitButton
+            worktreeId={worktreeId}
+            onHandoff={onHandoff}
+            testIdPrefix="claude-cli-plan-ready"
+          />
+          <button
+            type="button"
+            onClick={onSaveAsTicket}
+            disabled={savedAsTicket}
+            className={cn(
+              'h-8 rounded-full border border-border bg-muted/80 px-3 text-xs font-medium',
+              'text-foreground shadow-md transition-colors hover:bg-muted',
+              'disabled:pointer-events-none disabled:opacity-60'
+            )}
+            data-testid="claude-cli-plan-ready-save-ticket"
+          >
+            {savedAsTicket ? 'Saved as ticket' : 'Save as ticket'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function ClaudeCliSessionView({
   sessionId,
   isVisible = true
 }: ClaudeCliSessionViewProps): React.JSX.Element {
+  const terminalRef = useRef<TerminalViewHandle>(null)
   const [terminalKey, setTerminalKey] = useState(0)
   const [ended, setEnded] = useState(false)
+  const [planSavedAsTicket, setPlanSavedAsTicket] = useState(false)
   const pendingMessage = useSessionStore((state) => state.pendingMessages.get(sessionId) ?? null)
+  const pendingPlan = useSessionStore((state) => state.pendingPlans.get(sessionId) ?? null)
+  const mode = useSessionStore((state) => state.modeBySession.get(sessionId) ?? 'build')
+  const sessionRecord = useSessionStore((state) => {
+    for (const sessions of state.sessionsByWorktree.values()) {
+      const found = sessions.find((session) => session.id === sessionId)
+      if (found) return found
+    }
+    for (const sessions of state.sessionsByConnection.values()) {
+      const found = sessions.find((session) => session.id === sessionId)
+      if (found) return found
+    }
+    return state.orphanedSessions.get(sessionId) ?? null
+  })
+
+  useEffect(() => {
+    setPlanSavedAsTicket(false)
+  }, [pendingPlan?.planContent])
+
+  useEffect(() => {
+    if (!isVisible) return
+    const timer = window.setTimeout(() => {
+      terminalRef.current?.focus()
+    }, 75)
+    return () => window.clearTimeout(timer)
+  }, [isVisible, sessionId, terminalKey])
 
   const createClaudeTerminal = useCallback(async () => {
     const pendingPrompt = useSessionStore.getState().dequeuePendingMessage(sessionId)
@@ -65,6 +268,109 @@ export function ClaudeCliSessionView({
 
   const terminalId = useMemo(() => `${sessionId}:${terminalKey}`, [sessionId, terminalKey])
 
+  const handlePlanReadyHandoff = useCallback(
+    async (override: HandoffSelectionOverride) => {
+      const planContent = pendingPlan?.planContent
+      if (!planContent) {
+        toast.error('No plan content found to hand off')
+        return
+      }
+
+      useSessionStore.getState().clearPendingPlan(sessionId)
+      useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+      lastSendMode.delete(sessionId)
+
+      const handoffPrompt = buildHandoffPrompt(planContent, {
+        ...override,
+        superPlan: mode === 'super-plan'
+      })
+      const sessionStore = useSessionStore.getState()
+
+      if (sessionRecord?.connection_id) {
+        const result = await sessionStore.createConnectionSession(
+          sessionRecord.connection_id,
+          override.agentSdk,
+          override.agentSdk === 'claude-code-cli' && mode === 'super-plan'
+            ? 'super-plan'
+            : undefined,
+          { modelOverride: override.model }
+        )
+        if (!result.success || !result.session) {
+          toast.error(result.error ?? 'Failed to create handoff session')
+          return
+        }
+
+        const setModePromise =
+          result.session.agent_sdk === 'claude-code-cli' && mode === 'super-plan'
+            ? Promise.resolve()
+            : sessionStore.setSessionMode(result.session.id, 'build')
+        sessionStore.setPendingMessage(result.session.id, handoffPrompt)
+        await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
+        sessionStore.setActiveConnectionSession(result.session.id)
+        await setModePromise
+        return
+      }
+
+      if (!sessionRecord?.worktree_id || !sessionRecord.project_id) {
+        toast.error('Could not start handoff session')
+        return
+      }
+
+      const result = await sessionStore.createSession(
+        sessionRecord.worktree_id,
+        sessionRecord.project_id,
+        override.agentSdk,
+        override.agentSdk === 'claude-code-cli' && mode === 'super-plan'
+          ? 'super-plan'
+          : undefined,
+        { modelOverride: override.model }
+      )
+      if (!result.success || !result.session) {
+        toast.error(result.error ?? 'Failed to create handoff session')
+        return
+      }
+
+      const setModePromise =
+        result.session.agent_sdk === 'claude-code-cli' && mode === 'super-plan'
+          ? Promise.resolve()
+          : sessionStore.setSessionMode(result.session.id, 'build')
+      sessionStore.setPendingMessage(result.session.id, handoffPrompt)
+      await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
+      sessionStore.setActiveSession(result.session.id)
+      await setModePromise
+    },
+    [mode, pendingPlan?.planContent, sessionId, sessionRecord]
+  )
+
+  const handlePlanReadySaveAsTicket = useCallback(async () => {
+    const projectId = sessionRecord?.project_id
+    const planContent = pendingPlan?.planContent
+    if (!projectId) {
+      toast.error('No project associated with this session')
+      return
+    }
+    if (!planContent) {
+      toast.error('No plan content found')
+      return
+    }
+
+    const extracted = extractPlanTitle(planContent)
+    const title = extracted ? extracted.slice(0, 100) : 'Plan ticket'
+
+    try {
+      await useKanbanStore.getState().createTicket(projectId, {
+        project_id: projectId,
+        title,
+        description: planContent,
+        column: 'todo'
+      })
+      setPlanSavedAsTicket(true)
+      toast.success('Saved as ticket')
+    } catch {
+      toast.error('Failed to save as ticket')
+    }
+  }, [pendingPlan?.planContent, sessionRecord?.project_id])
+
   return (
     <div
       className="flex-1 flex flex-col min-h-0 bg-background"
@@ -84,6 +390,7 @@ export function ClaudeCliSessionView({
 
       <div className="relative min-h-0 flex-1">
         <TerminalView
+          ref={terminalRef}
           key={terminalId}
           terminalId={sessionId}
           cwd="/"
@@ -93,6 +400,15 @@ export function ClaudeCliSessionView({
           createTerminal={createClaudeTerminal}
           onStatusChange={handleStatusChange}
         />
+        {pendingPlan?.planContent && (
+          <ClaudeCliPlanReadyCard
+            planContent={pendingPlan.planContent}
+            worktreeId={sessionRecord?.worktree_id ?? undefined}
+            onHandoff={handlePlanReadyHandoff}
+            onSaveAsTicket={handlePlanReadySaveAsTicket}
+            savedAsTicket={planSavedAsTicket}
+          />
+        )}
         {ended && <ClaudeCliEndedOverlay onRestart={handleRestart} />}
       </div>
     </div>

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -7,10 +7,13 @@ import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useQuestionStore } from '@/stores/useQuestionStore'
+import { useTelegramStore } from '@/stores/useTelegramStore'
 import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalContext'
 import { ModeToggle } from './ModeToggle'
 import { SuperToggle } from './SuperToggle'
 import { ModelSelector } from './ModelSelector'
+import { QuestionPrompt } from './QuestionPrompt'
 import { ClaudeCliEndedOverlay } from './ClaudeCliEndedOverlay'
 import { HandoffSplitButton } from './HandoffSplitButton'
 import { buildHandoffPrompt, type HandoffSelectionOverride } from '@/lib/handoffSelection'
@@ -286,6 +289,13 @@ export function ClaudeCliSessionView({
   const isMountedInTicketModal = !!getTarget(sessionId)
   const sessionRecord = useSessionStore((state) => state.getSessionById(sessionId))
 
+  // While Telegram forwarding is active, AskUserQuestion is intercepted by the
+  // hook bridge (so it never renders in the terminal) and surfaced through the
+  // shared question store. Render the same in-app QuestionPrompt the SDK
+  // providers use; when forwarding is off the question shows natively in the CLI.
+  const activeQuestion = useQuestionStore((state) => state.getActiveQuestion(sessionId))
+  const isForwarding = useTelegramStore((state) => state.activeForwardingSessionId === sessionId)
+
   useEffect(() => {
     setPlanSavedAsTicket(false)
   }, [pendingPlan?.planContent])
@@ -483,6 +493,40 @@ export function ClaudeCliSessionView({
     }
   }, [pendingPlan?.planContent, sessionRecord?.project_id])
 
+  const resolveQuestionPath = useCallback((): string | undefined => {
+    if (sessionRecord?.worktree_id) {
+      return findWorktreePathById(sessionRecord.worktree_id) ?? undefined
+    }
+    if (sessionRecord?.connection_id) {
+      return findConnectionPathById(sessionRecord.connection_id) ?? undefined
+    }
+    return undefined
+  }, [sessionRecord?.worktree_id, sessionRecord?.connection_id])
+
+  const handleQuestionReply = useCallback(
+    async (requestId: string, answers: string[][]) => {
+      try {
+        unwrapEnvelope(await window.opencodeOps.questionReply(requestId, answers, resolveQuestionPath()))
+      } catch (err) {
+        console.error('Failed to reply to question:', err)
+        toast.error('Failed to send answer')
+      }
+    },
+    [resolveQuestionPath]
+  )
+
+  const handleQuestionReject = useCallback(
+    async (requestId: string) => {
+      try {
+        unwrapEnvelope(await window.opencodeOps.questionReject(requestId, resolveQuestionPath()))
+      } catch (err) {
+        console.error('Failed to dismiss question:', err)
+        toast.error('Failed to dismiss question')
+      }
+    },
+    [resolveQuestionPath]
+  )
+
   return (
     <div
       className="flex-1 flex flex-col min-h-0 bg-background"
@@ -521,6 +565,20 @@ export function ClaudeCliSessionView({
             onSaveAsTicket={handlePlanReadySaveAsTicket}
             savedAsTicket={planSavedAsTicket}
           />
+        )}
+        {/* In the ticket modal the modal renders its own question sidebar, so only
+            show the session-embedded prompt for the standalone session view. */}
+        {activeQuestion && isForwarding && !isMountedInTicketModal && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 p-4">
+            <div className="pointer-events-auto mx-auto max-w-2xl">
+              <QuestionPrompt
+                key={activeQuestion.id}
+                request={activeQuestion}
+                onReply={handleQuestionReply}
+                onReject={handleQuestionReject}
+              />
+            </div>
+          </div>
         )}
         {ended && <ClaudeCliEndedOverlay onRestart={handleRestart} />}
       </div>

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { TerminalView } from '@/components/terminal/TerminalView'
+import { unwrapEnvelope } from '@/lib/ipc-envelope'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { ModeToggle } from './ModeToggle'
+import { SuperToggle } from './SuperToggle'
+import { ModelSelector } from './ModelSelector'
+import { ClaudeCliEndedOverlay } from './ClaudeCliEndedOverlay'
+import '@xterm/xterm/css/xterm.css'
+import '@/styles/xterm.css'
+
+interface ClaudeCliSessionViewProps {
+  sessionId: string
+  isVisible?: boolean
+}
+
+export function ClaudeCliSessionView({
+  sessionId,
+  isVisible = true
+}: ClaudeCliSessionViewProps): React.JSX.Element {
+  const [terminalKey, setTerminalKey] = useState(0)
+  const [ended, setEnded] = useState(false)
+  const pendingMessage = useSessionStore((state) => state.pendingMessages.get(sessionId) ?? null)
+
+  const createClaudeTerminal = useCallback(async () => {
+    const pendingPrompt = useSessionStore.getState().dequeuePendingMessage(sessionId)
+    try {
+      const envelope = await window.terminalOps.createClaudeCli(sessionId, {
+        pendingPrompt
+      })
+      const result = unwrapEnvelope(envelope)
+      if (!result.success && pendingPrompt) {
+        useSessionStore.getState().requeuePendingMessage(sessionId, pendingPrompt)
+      }
+      return envelope
+    } catch (error) {
+      if (pendingPrompt) {
+        useSessionStore.getState().requeuePendingMessage(sessionId, pendingPrompt)
+      }
+      throw error
+    }
+  }, [sessionId])
+
+  useEffect(() => {
+    return window.terminalOps.onClaudeSessionId(sessionId, (claudeSessionId) => {
+      useSessionStore.getState().setClaudeSessionId(sessionId, claudeSessionId)
+    })
+  }, [sessionId])
+
+  const handleStatusChange = useCallback(
+    (status: 'creating' | 'running' | 'exited') => {
+      if (status === 'running') {
+        setEnded(false)
+      } else if (status === 'exited') {
+        setEnded(true)
+      }
+    },
+    []
+  )
+
+  const handleRestart = useCallback(() => {
+    setEnded(false)
+    setTerminalKey((current) => current + 1)
+  }, [])
+
+  const terminalId = useMemo(() => `${sessionId}:${terminalKey}`, [sessionId, terminalKey])
+
+  return (
+    <div
+      className="flex-1 flex flex-col min-h-0 bg-background"
+      data-testid="claude-cli-session-view"
+      data-session-id={sessionId}
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-border bg-background px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <ModeToggle sessionId={sessionId} />
+          <SuperToggle sessionId={sessionId} />
+          {pendingMessage && (
+            <span className="truncate text-xs text-muted-foreground">handoff prompt pending</span>
+          )}
+        </div>
+        <ModelSelector sessionId={sessionId} />
+      </div>
+
+      <div className="relative min-h-0 flex-1">
+        <TerminalView
+          key={terminalId}
+          terminalId={sessionId}
+          cwd="/"
+          isVisible={isVisible}
+          showToolbar={false}
+          backendTypeOverride="xterm"
+          createTerminal={createClaudeTerminal}
+          onStatusChange={handleStatusChange}
+        />
+        {ended && <ClaudeCliEndedOverlay onRestart={handleRestart} />}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { TerminalView, type TerminalViewHandle } from '@/components/terminal/TerminalView'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { useSessionStore, BOARD_TAB_ID } from '@/stores/useSessionStore'
@@ -142,6 +142,23 @@ function ClaudeCliPlanReadyCard({
 
   const preview = planContent.trim().split('\n').find(Boolean) ?? 'Plan ready'
 
+  // Clamp a persisted position against the current container on mount. A
+  // position saved while the window was larger could otherwise place the card
+  // (and its Handoff / Save-as-ticket buttons) off-screen until the user
+  // happens to drag it back. Runs once on mount (before paint to avoid a flash);
+  // re-clamping on every position change would fight an in-progress drag.
+  useLayoutEffect(() => {
+    if (!position) return
+    const container = containerRef.current?.getBoundingClientRect()
+    const card = cardRef.current?.getBoundingClientRect()
+    if (!container || !card) return
+    const clamped = clampPlanCardPosition(position, container, card)
+    if (clamped.left !== position.left || clamped.top !== position.top) {
+      setPosition(clamped)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const moveToPointer = useCallback((clientX: number, clientY: number): void => {
     const container = containerRef.current?.getBoundingClientRect()
     const card = cardRef.current?.getBoundingClientRect()
@@ -267,17 +284,7 @@ export function ClaudeCliSessionView({
   const { getTarget, revision: portalRevision } = useClaudeCliSessionPortal()
   void portalRevision
   const isMountedInTicketModal = !!getTarget(sessionId)
-  const sessionRecord = useSessionStore((state) => {
-    for (const sessions of state.sessionsByWorktree.values()) {
-      const found = sessions.find((session) => session.id === sessionId)
-      if (found) return found
-    }
-    for (const sessions of state.sessionsByConnection.values()) {
-      const found = sessions.find((session) => session.id === sessionId)
-      if (found) return found
-    }
-    return state.orphanedSessions.get(sessionId) ?? null
-  })
+  const sessionRecord = useSessionStore((state) => state.getSessionById(sessionId))
 
   useEffect(() => {
     setPlanSavedAsTicket(false)

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -497,6 +497,7 @@ export function ClaudeCliSessionView({
           isVisible={isVisible}
           showToolbar={false}
           backendTypeOverride="xterm"
+          shiftEnterAsNewline
           createTerminal={createClaudeTerminal}
           onStatusChange={handleStatusChange}
         />

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -38,7 +38,7 @@ interface ModelSelectorProps {
   value?: SelectedModel | null
   onChange?: (model: SelectedModel) => void
   // Override the SDK used for model listing (e.g. force 'opencode' in settings when defaultAgentSdk is 'terminal')
-  agentSdkOverride?: 'opencode' | 'claude-code' | 'codex'
+  agentSdkOverride?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex'
   disableTitleTooltip?: boolean
   hideProviderPrefix?: boolean
   allowAgentSdkSelection?: boolean
@@ -122,7 +122,10 @@ export const ModelSelector = memo(function ModelSelector({
         setIsLoading(true)
         const catalogs = await Promise.all(
           catalogAgentSdks.map(async (sdk) => {
-            const result = unwrapEnvelope(await window.opencodeOps.listModels({ agentSdk: sdk }))
+            const listModelsSdk = sdk === 'claude-code-cli' ? 'claude-code' : sdk
+            const result = unwrapEnvelope(
+              await window.opencodeOps.listModels({ agentSdk: listModelsSdk })
+            )
             if (!result.success || !result.providers) return []
             const parsed = parseProviders(result.providers)
             cacheHandoffModelCatalog(sdk, result.providers)

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -21,6 +21,7 @@ import {
   type HandoffAgentSdk
 } from '@/stores/useSettingsStore'
 import { useSessionStore } from '@/stores/useSessionStore'
+import { toModelCatalogSdk } from '@shared/types/agent-sdk'
 import { toast } from '@/lib/toast'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import {
@@ -122,7 +123,7 @@ export const ModelSelector = memo(function ModelSelector({
         setIsLoading(true)
         const catalogs = await Promise.all(
           catalogAgentSdks.map(async (sdk) => {
-            const listModelsSdk = sdk === 'claude-code-cli' ? 'claude-code' : sdk
+            const listModelsSdk = toModelCatalogSdk(sdk)
             const result = unwrapEnvelope(
               await window.opencodeOps.listModels({ agentSdk: listModelsSdk })
             )

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -337,13 +337,14 @@ export const ModelSelector = memo(function ModelSelector({
 
   const sdkFilterOptions = useMemo((): SdkFilterOption[] => {
     const availableSdks = new Set(providers.map((provider) => provider.agentSdk))
+    const controlledSdk = allowAgentSdkSelection ? value?.agentSdk : null
     return catalogAgentSdks
-      .filter((sdk) => availableSdks.has(sdk))
+      .filter((sdk) => availableSdks.has(sdk) || sdk === controlledSdk)
       .map((sdk) => ({
         agentSdk: sdk,
         label: getHandoffSdkDisplayName(sdk)
       }))
-  }, [providers, catalogAgentSdks])
+  }, [providers, catalogAgentSdks, allowAgentSdkSelection, value?.agentSdk])
 
   useEffect(() => {
     if (!allowAgentSdkSelection) return
@@ -358,14 +359,17 @@ export const ModelSelector = memo(function ModelSelector({
     }
   }, [agentSdkFilter, sdkFilterOptions])
 
+  const effectiveAgentSdkFilter =
+    agentSdkFilter ?? (allowAgentSdkSelection ? (value?.agentSdk ?? null) : null)
   const selectedProviderFilterLabel =
-    sdkFilterOptions.find((option) => option.agentSdk === agentSdkFilter)?.label ?? 'All providers'
+    sdkFilterOptions.find((option) => option.agentSdk === effectiveAgentSdkFilter)?.label ??
+    'All providers'
   const showProviderFilter = sdkFilterOptions.length > 1
 
   const providerScopedProviders = useMemo(() => {
-    if (!agentSdkFilter) return providers
-    return providers.filter((provider) => provider.agentSdk === agentSdkFilter)
-  }, [providers, agentSdkFilter])
+    if (!effectiveAgentSdkFilter) return providers
+    return providers.filter((provider) => provider.agentSdk === effectiveAgentSdkFilter)
+  }, [providers, effectiveAgentSdkFilter])
 
   const filteredProviders = useMemo(() => {
     if (!filter.trim()) return providerScopedProviders

--- a/src/renderer/src/components/sessions/QuestionPrompt.tsx
+++ b/src/renderer/src/components/sessions/QuestionPrompt.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useLayoutEffect } from 'react'
+import { useState, useCallback, useRef, useLayoutEffect, useEffect } from 'react'
 import { MessageCircleQuestion, Check, X, ChevronRight, Pencil } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -18,6 +18,7 @@ export function QuestionPrompt({ request, onReply, onReject }: QuestionPromptPro
   const [sending, setSending] = useState(false)
 
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const autoAdvanceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const isMultiQuestion = request.questions.length > 1
   const currentQuestion = request.questions[currentTab]
@@ -33,6 +34,15 @@ export function QuestionPrompt({ request, onReply, onReject }: QuestionPromptPro
       textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`
     }
   }, [customInputs, currentTab])
+
+  useEffect(() => {
+    return () => {
+      if (autoAdvanceTimeoutRef.current !== null) {
+        clearTimeout(autoAdvanceTimeoutRef.current)
+        autoAdvanceTimeoutRef.current = null
+      }
+    }
+  }, [])
 
   const handleSubmit = useCallback(
     (finalAnswers?: QuestionAnswer[]) => {
@@ -71,7 +81,11 @@ export function QuestionPrompt({ request, onReply, onReject }: QuestionPromptPro
 
       // Multi-question: auto-advance to next tab
       if (isMultiQuestion && !isLastTab) {
-        setTimeout(() => {
+        if (autoAdvanceTimeoutRef.current !== null) {
+          clearTimeout(autoAdvanceTimeoutRef.current)
+        }
+        autoAdvanceTimeoutRef.current = setTimeout(() => {
+          autoAdvanceTimeoutRef.current = null
           setCurrentTab((t) => t + 1)
           setEditingCustom(false)
         }, 150)

--- a/src/renderer/src/components/sessions/SessionHistory.tsx
+++ b/src/renderer/src/components/sessions/SessionHistory.tsx
@@ -408,7 +408,7 @@ export function SessionHistory(): React.JSX.Element | null {
           return
         } else {
           // Connection was deleted - open in read-only mode
-          openOrphanedSession(session as any)
+          openOrphanedSession(session)
           closePanel()
           toast.info('Opened in read-only mode: connection no longer exists.')
           return
@@ -433,7 +433,7 @@ export function SessionHistory(): React.JSX.Element | null {
           }
         } else {
           // Worktree was deleted/archived - open in read-only mode
-          openOrphanedSession(session as any)
+          openOrphanedSession(session)
           closePanel()
           toast.info(
             `Opened in read-only mode: worktree "${session.worktree_name}" no longer exists.`
@@ -441,7 +441,7 @@ export function SessionHistory(): React.JSX.Element | null {
         }
       } else {
         // Session is orphaned (no worktree_id or connection_id) - open in read-only mode
-        openOrphanedSession(session as any)
+        openOrphanedSession(session)
         closePanel()
         toast.info('Opened in read-only mode: session is from an archived worktree.')
       }

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -80,7 +80,7 @@ interface SessionTabProps {
   sessionId: string
   name: string
   isActive: boolean
-  agentSdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  agentSdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   onClick: () => void
   onClose: (e: React.MouseEvent) => void
   onMiddleClick: (e: React.MouseEvent) => void
@@ -840,7 +840,7 @@ export function SessionTabs(): React.JSX.Element | null {
 
   // Handle creating a new session with a specific agent SDK (from context menu)
   const handleCreateSessionWithSdk = async (
-    sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+    sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   ) => {
     if (isConnectionMode && selectedConnectionId) {
       const result = await createConnectionSession(selectedConnectionId, sdk)
@@ -1241,8 +1241,13 @@ export function SessionTabs(): React.JSX.Element | null {
                   </ContextMenuItem>
                 )}
                 {availableAgentSdks?.claude && (
+                  <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('claude-code-cli')}>
+                    New Claude Code CLI Session
+                  </ContextMenuItem>
+                )}
+                {availableAgentSdks?.claude && (
                   <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('claude-code')}>
-                    New Claude Code Session
+                    New Claude Code Legacy Session
                   </ContextMenuItem>
                 )}
                 {availableAgentSdks?.codex && (

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -1329,13 +1329,13 @@ export function SessionTabs(): React.JSX.Element | null {
                   </ContextMenuItem>
                 )}
                 {availableAgentSdks?.claude && (
-                  <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('claude-code-cli')}>
-                    New Claude Code CLI Session
+                  <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('claude-code')}>
+                    New Claude Code Session
                   </ContextMenuItem>
                 )}
                 {availableAgentSdks?.claude && (
-                  <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('claude-code')}>
-                    New Claude Code Legacy Session
+                  <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('claude-code-cli')}>
+                    New Claude Code CLI Session
                   </ContextMenuItem>
                 )}
                 {availableAgentSdks?.codex && (

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   type KeyboardEvent
 } from 'react'
+import type { AgentSdk } from '@shared/types/agent-sdk'
 import {
   Plus,
   X,
@@ -99,7 +100,7 @@ interface SessionTabProps {
   sessionId: string
   name: string
   isActive: boolean
-  agentSdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agentSdk: AgentSdk
   onClick: () => void
   onClose: (e: React.MouseEvent) => void
   onMiddleClick: (e: React.MouseEvent) => void
@@ -874,7 +875,7 @@ export function SessionTabs(): React.JSX.Element | null {
 
   // Handle creating a new session with a specific agent SDK (from context menu)
   const handleCreateSessionWithSdk = async (
-    sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+    sdk: AgentSdk
   ) => {
     if (isConnectionMode && selectedConnectionId) {
       const result = await createConnectionSession(selectedConnectionId, sdk)

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -992,7 +992,7 @@ export function SessionTabs(): React.JSX.Element | null {
     }
   }
 
-  // Handle clicking a session tab - deactivate file tab and clear unread status
+  // Handle clicking a session tab - deactivate file tab and clear only unread status
   const handleSessionTabClick = (sessionId: string) => {
     const isAlreadyPresentedSession =
       activeSessionId === sessionId && activeFilePath === null && !inlineConnectionSessionId
@@ -1008,7 +1008,10 @@ export function SessionTabs(): React.JSX.Element | null {
     } else {
       setActiveSession(sessionId)
     }
-    useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+    const statusStore = useWorktreeStatusStore.getState()
+    if (statusStore.sessionStatuses[sessionId]?.status === 'unread') {
+      statusStore.clearSessionStatus(sessionId)
+    }
   }
 
   // Handle clicking a sticky connection session tab (inline viewing in worktree mode)
@@ -1022,7 +1025,10 @@ export function SessionTabs(): React.JSX.Element | null {
 
     setActiveFile(null)
     setInlineConnectionSession(sessionId)
-    useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+    const statusStore = useWorktreeStatusStore.getState()
+    if (statusStore.sessionStatuses[sessionId]?.status === 'unread') {
+      statusStore.clearSessionStatus(sessionId)
+    }
   }
 
   // Handle clicking a file tab - keep session but activate file view

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -6441,9 +6441,11 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
 }
 
 export function SessionView({ sessionId, isVisible = true }: SessionViewProps): React.JSX.Element {
-  const session = useSessionStore((state) => state.getSessionById(sessionId))
+  // Subscribe to just the agent_sdk: routing only needs that, so unrelated
+  // session updates no longer re-render this wrapper with a new object identity.
+  const agentSdk = useSessionStore((state) => state.getSessionById(sessionId)?.agent_sdk ?? null)
 
-  if (session?.agent_sdk === 'claude-code-cli') {
+  if (agentSdk === 'claude-code-cli') {
     return <ClaudeCliSessionView sessionId={sessionId} isVisible={isVisible} />
   }
 

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -46,6 +46,7 @@ import { PlanReadyImplementFab } from './PlanReadyImplementFab'
 import { IndeterminateProgressBar } from './IndeterminateProgressBar'
 import { TaskListWidget } from './TaskListWidget'
 import { GoalStatusWidget } from './GoalStatusWidget'
+import { ClaudeCliSessionView } from './ClaudeCliSessionView'
 import { useLatestTodoList } from './useLatestTodoList'
 import { usePRStackTopOffset } from './usePRStackTopOffset'
 import { useFileMentions } from '@/hooks/useFileMentions'
@@ -270,6 +271,7 @@ function delay(ms: number): Promise<void> {
 
 interface SessionViewProps {
   sessionId: string
+  isVisible?: boolean
 }
 
 interface SessionRetryState {
@@ -563,7 +565,7 @@ const PrCommentAttachments = memo(function PrCommentAttachments(): React.JSX.Ele
 })
 
 // Main SessionView component
-export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element {
+function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
   // State
   const [messages, setMessagesState] = useState<OpenCodeMessage[]>([])
   const [inputValue, setInputValue] = useState('')
@@ -5012,19 +5014,27 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       }
 
       if (connectionId) {
-        const handoffPrompt = buildHandoffPrompt(planContent, override)
+        const handoffPrompt = buildHandoffPrompt(planContent, {
+          ...override,
+          superPlan: mode === 'super-plan'
+        })
         const sessionStore = useSessionStore.getState()
         const result = await sessionStore.createConnectionSession(
           connectionId,
           override?.agentSdk,
-          undefined,
+          override?.agentSdk === 'claude-code-cli' && mode === 'super-plan'
+            ? 'super-plan'
+            : undefined,
           { modelOverride: override?.model }
         )
         if (!result.success || !result.session) {
           toast.error(result.error ?? 'Failed to create handoff session')
           return
         }
-        const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
+        const setModePromise =
+          result.session.agent_sdk === 'claude-code-cli' && mode === 'super-plan'
+            ? Promise.resolve()
+            : sessionStore.setSessionMode(result.session.id, 'build')
         sessionStore.setPendingMessage(result.session.id, handoffPrompt)
         await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
         sessionStore.setActiveConnectionSession(result.session.id)
@@ -5039,14 +5049,19 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         return
       }
 
-      const handoffPrompt = buildHandoffPrompt(planContent, override)
+      const handoffPrompt = buildHandoffPrompt(planContent, {
+        ...override,
+        superPlan: mode === 'super-plan'
+      })
 
       const sessionStore = useSessionStore.getState()
       const result = await sessionStore.createSession(
         currentWorktreeId,
         currentProjectId,
         override?.agentSdk,
-        undefined,
+        override?.agentSdk === 'claude-code-cli' && mode === 'super-plan'
+          ? 'super-plan'
+          : undefined,
         { modelOverride: override?.model }
       )
       if (!result.success || !result.session) {
@@ -5054,7 +5069,10 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         return
       }
 
-      const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
+      const setModePromise =
+        result.session.agent_sdk === 'claude-code-cli' && mode === 'super-plan'
+          ? Promise.resolve()
+          : sessionStore.setSessionMode(result.session.id, 'build')
       sessionStore.setPendingMessage(result.session.id, handoffPrompt)
       await useKanbanStore.getState().relinkTicketsForHandoff(sessionId, result.session.id)
       sessionStore.setActiveSession(result.session.id)
@@ -5068,7 +5086,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       sessionId,
       worktreePath,
       opencodeSessionId,
-      pendingPlan
+      pendingPlan,
+      mode
     ]
   )
 
@@ -6316,4 +6335,14 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       )}
     </div>
   )
+}
+
+export function SessionView({ sessionId, isVisible = true }: SessionViewProps): React.JSX.Element {
+  const session = useSessionStore((state) => state.getSessionById(sessionId))
+
+  if (session?.agent_sdk === 'claude-code-cli') {
+    return <ClaudeCliSessionView sessionId={sessionId} isVisible={isVisible} />
+  }
+
+  return <LegacySessionView sessionId={sessionId} />
 }

--- a/src/renderer/src/components/sessions/SuperToggle.tsx
+++ b/src/renderer/src/components/sessions/SuperToggle.tsx
@@ -12,8 +12,11 @@ export const SuperToggle = memo(function SuperToggle({
 }: SuperToggleProps): React.JSX.Element {
   const mode = useSessionStore((state) => state.modeBySession.get(sessionId)) ?? 'build'
   const toggleSuperMode = useSessionStore((state) => state.toggleSuperMode)
+  const session = useSessionStore((state) => state.getSessionById(sessionId))
+  const hasPendingPrompt = useSessionStore((state) => state.pendingMessages.has(sessionId))
 
   const visible = mode === 'plan' || mode === 'super-plan'
+  const disabled = session?.agent_sdk === 'claude-code-cli' && !hasPendingPrompt
   const isOn = mode === 'super-plan'
 
   return (
@@ -29,13 +32,14 @@ export const SuperToggle = memo(function SuperToggle({
         <button
           type="button"
           onClick={() => toggleSuperMode(sessionId)}
+          disabled={disabled}
           aria-pressed={isOn}
           aria-label={`Super mode ${isOn ? 'enabled' : 'disabled'} (Shift+Tab to toggle)`}
           title="Toggle super-plan mode (Shift+Tab)"
           data-testid="super-toggle"
           className={cn(
             'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
-            'border select-none whitespace-nowrap',
+            'border select-none whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed',
             isOn
               ? 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20 super-sparkle'
               : 'bg-muted/50 border-border text-muted-foreground hover:bg-muted hover:text-foreground'

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -591,20 +591,6 @@ export function SettingsGeneral(): React.JSX.Element {
             OpenCode
           </button>
           <button
-            onClick={() => updateSetting('defaultAgentSdk', 'claude-code-cli')}
-            disabled={!claudeCliAvailable}
-            className={cn(
-              'px-3 py-1.5 rounded-md text-sm border transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
-              defaultAgentSdk === 'claude-code-cli'
-                ? 'bg-primary text-primary-foreground border-primary'
-                : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
-            )}
-            data-testid="agent-sdk-claude-code-cli"
-            title={!claudeCliAvailable ? 'Claude Code CLI is not currently available' : undefined}
-          >
-            Claude Code (CLI)
-          </button>
-          <button
             onClick={() => updateSetting('defaultAgentSdk', 'claude-code')}
             disabled={!claudeAvailable}
             className={cn(
@@ -616,7 +602,7 @@ export function SettingsGeneral(): React.JSX.Element {
             data-testid="agent-sdk-claude-code"
             title={!claudeAvailable ? 'Claude Code is not currently available' : undefined}
           >
-            Claude Code (legacy SDK)
+            Claude Code
           </button>
           <button
             onClick={() => updateSetting('defaultAgentSdk', 'codex')}
@@ -643,6 +629,20 @@ export function SettingsGeneral(): React.JSX.Element {
             data-testid="agent-sdk-terminal"
           >
             Terminal
+          </button>
+          <button
+            onClick={() => updateSetting('defaultAgentSdk', 'claude-code-cli')}
+            disabled={!claudeCliAvailable}
+            className={cn(
+              'px-3 py-1.5 rounded-md text-sm border transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+              defaultAgentSdk === 'claude-code-cli'
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+            )}
+            data-testid="agent-sdk-claude-code-cli"
+            title={!claudeCliAvailable ? 'Claude Code CLI is not currently available' : undefined}
+          >
+            Claude Code (CLI)
           </button>
         </div>
         {availableAgentSdks &&

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -53,6 +53,7 @@ export function SettingsGeneral(): React.JSX.Element {
 
   const opencodeAvailable = isAgentSdkAvailable('opencode', availableAgentSdks)
   const claudeAvailable = isAgentSdkAvailable('claude-code', availableAgentSdks)
+  const claudeCliAvailable = isAgentSdkAvailable('claude-code-cli', availableAgentSdks)
   const codexAvailable = isAgentSdkAvailable('codex', availableAgentSdks)
 
   return (
@@ -488,6 +489,20 @@ export function SettingsGeneral(): React.JSX.Element {
             OpenCode
           </button>
           <button
+            onClick={() => updateSetting('defaultAgentSdk', 'claude-code-cli')}
+            disabled={!claudeCliAvailable}
+            className={cn(
+              'px-3 py-1.5 rounded-md text-sm border transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+              defaultAgentSdk === 'claude-code-cli'
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+            )}
+            data-testid="agent-sdk-claude-code-cli"
+            title={!claudeCliAvailable ? 'Claude Code CLI is not currently available' : undefined}
+          >
+            Claude Code (CLI)
+          </button>
+          <button
             onClick={() => updateSetting('defaultAgentSdk', 'claude-code')}
             disabled={!claudeAvailable}
             className={cn(
@@ -499,7 +514,7 @@ export function SettingsGeneral(): React.JSX.Element {
             data-testid="agent-sdk-claude-code"
             title={!claudeAvailable ? 'Claude Code is not currently available' : undefined}
           >
-            Claude Code
+            Claude Code (legacy SDK)
           </button>
           <button
             onClick={() => updateSetting('defaultAgentSdk', 'codex')}
@@ -528,7 +543,8 @@ export function SettingsGeneral(): React.JSX.Element {
             Terminal
           </button>
         </div>
-        {availableAgentSdks && (!opencodeAvailable || !claudeAvailable || !codexAvailable) && (
+        {availableAgentSdks &&
+          (!opencodeAvailable || !claudeAvailable || !claudeCliAvailable || !codexAvailable) && (
           <p className="text-xs text-muted-foreground/70 italic">
             Unavailable providers are disabled until their CLI is installed and launchable from
             Hive.

--- a/src/renderer/src/components/settings/SettingsIntegrations.tsx
+++ b/src/renderer/src/components/settings/SettingsIntegrations.tsx
@@ -44,7 +44,7 @@ export function SettingsIntegrations() {
         setSchemas(schemaMap)
 
         // Load saved values from dedicated provider-settings key (fast initial read)
-        let saved: Record<string, string> = {}
+        const saved: Record<string, string> = {}
         try {
           const raw = localStorage.getItem('hive-provider-settings')
           if (raw) {

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -17,6 +17,10 @@ interface TerminalViewProps {
   terminalId: string
   cwd: string
   isVisible?: boolean
+  showToolbar?: boolean
+  backendTypeOverride?: TerminalBackendType
+  createTerminal?: Parameters<ITerminalBackend['mount']>[1]['createTerminal']
+  onStatusChange?: (status: 'creating' | 'running' | 'exited', exitCode?: number) => void
 }
 
 /** Imperative handle exposed to parent (TerminalManager) */
@@ -37,7 +41,15 @@ function createBackend(type: TerminalBackendType): ITerminalBackend {
 }
 
 export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(function TerminalView(
-  { terminalId, cwd, isVisible = true },
+  {
+    terminalId,
+    cwd,
+    isVisible = true,
+    showToolbar = true,
+    backendTypeOverride,
+    createTerminal,
+    onStatusChange
+  },
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -73,6 +85,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   const embeddedTerminalBackend = useSettingsStore(
     (s) => s.embeddedTerminalBackend
   ) as EmbeddedTerminalBackend
+  const effectiveBackendType = backendTypeOverride ?? embeddedTerminalBackend
   const ghosttyFontSize = useSettingsStore((s) => s.ghosttyFontSize)
   const ghosttyOverlaySuppressed = useLayoutStore((s) => s.ghosttyOverlaySuppressed)
 
@@ -170,7 +183,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     return cleanup
     // embeddedTerminalBackend in deps ensures re-evaluation when the user switches backends,
     // since activeBackendTypeRef is a ref and doesn't trigger re-renders on its own.
-  }, [effectiveVisible, terminalId, embeddedTerminalBackend])
+  }, [effectiveVisible, terminalId, effectiveBackendType])
 
   // Search helpers (only for xterm backend)
   const handleSearch = useCallback((query: string) => {
@@ -276,6 +289,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
           cursorStyle: config.cursorStyle,
           scrollback: config.scrollbackLimit,
           shell: config.shell,
+          createTerminal,
           // Seed visibility from the current UI state. Critical when the
           // backend is recreated (e.g. fontSize change, cwd change, StrictMode
           // double-mount) while the bottom panel is collapsed: defaulting to
@@ -289,13 +303,14 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
             setTerminalStatus(status)
             if (code !== undefined) setExitCode(code)
             useTerminalTabStore.getState().setTabStatus(terminalId, status, code)
+            onStatusChange?.(status, code)
           }
         }
       )
 
       backendRef.current = backend
     },
-    [terminalId, cwd, destroyTerminal]
+    [terminalId, cwd, destroyTerminal, createTerminal, onStatusChange]
   )
 
   // Handle restart — destroy old PTY and re-create terminal
@@ -319,12 +334,12 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     }
 
     await restartTerminal(terminalId, cwd, shell)
-    setupTerminal(embeddedTerminalBackend || 'xterm')
-  }, [terminalId, cwd, restartTerminal, setupTerminal, embeddedTerminalBackend])
+    setupTerminal(effectiveBackendType || 'xterm')
+  }, [terminalId, cwd, restartTerminal, setupTerminal, effectiveBackendType])
 
   // Initialize terminal on mount, and re-create when backend setting changes
   useEffect(() => {
-    setupTerminal(embeddedTerminalBackend || 'xterm')
+    setupTerminal(effectiveBackendType || 'xterm')
 
     return () => {
       // Invalidate the in-flight setupTerminal so its post-await continuation
@@ -341,7 +356,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       initializedRef.current = null
       activeBackendTypeRef.current = null
     }
-  }, [setupTerminal, embeddedTerminalBackend])
+  }, [setupTerminal, effectiveBackendType])
 
   // Restart the Ghostty terminal when font size changes so the new size takes effect.
   // We track the previous value so the effect only fires on actual changes, not on mount.
@@ -379,20 +394,22 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
 
   return (
     <div className="flex flex-col h-full w-full" data-testid="terminal-view">
-      <TerminalToolbar
-        status={terminalStatus}
-        exitCode={exitCode}
-        searchVisible={searchVisible && !isGhostty}
-        searchQuery={searchQuery}
-        onToggleSearch={handleToggleSearch}
-        onSearchChange={handleSearch}
-        onSearchNext={handleSearchNext}
-        onSearchPrev={handleSearchPrev}
-        onSearchClose={handleSearchClose}
-        onRestart={handleRestart}
-        onClear={() => backendRef.current?.clear()}
-        backendType={activeBackendTypeRef.current || 'xterm'}
-      />
+      {showToolbar && (
+        <TerminalToolbar
+          status={terminalStatus}
+          exitCode={exitCode}
+          searchVisible={searchVisible && !isGhostty}
+          searchQuery={searchQuery}
+          onToggleSearch={handleToggleSearch}
+          onSearchChange={handleSearch}
+          onSearchNext={handleSearchNext}
+          onSearchPrev={handleSearchPrev}
+          onSearchClose={handleSearchClose}
+          onRestart={handleRestart}
+          onClear={() => backendRef.current?.clear()}
+          backendType={activeBackendTypeRef.current || 'xterm'}
+        />
+      )}
       <div
         ref={containerRef}
         className="terminal-view-container flex-1 min-h-0"

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -135,6 +135,10 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     return () => clearTimeout(timer)
   }, [themeId])
 
+  // xterm can update the Shift+Enter behavior live — it's just an internal flag
+  // the keydown handler reads. Ghostty bakes the keybinding into the native
+  // surface at creation time (ghosttyCreateSurface) and has no in-place setter,
+  // so its runtime-update path is a surface remount handled by the effect below.
   useEffect(() => {
     const backend = backendRef.current
     if (backend instanceof XtermBackend) {
@@ -397,6 +401,37 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     }
     restart()
   }, [ghosttyFontSize, terminalId, cwd, destroyTerminal, restartTerminal, setupTerminal])
+
+  // Ghostty bakes `shiftEnterAsNewline` into the surface at creation, so a
+  // runtime change requires recreating it — mirror the font-size remount above.
+  // The xterm backend updates this flag in place (see the effect near the top),
+  // so this only acts when the live backend is Ghostty. We track the previous
+  // value so it fires on an actual change, not on mount (mount already seeds the
+  // flag via backend.mount's opts).
+  const prevShiftEnterAsNewlineRef = useRef(shiftEnterAsNewline ?? false)
+  useEffect(() => {
+    const next = shiftEnterAsNewline ?? false
+    if (prevShiftEnterAsNewlineRef.current === next) return
+    prevShiftEnterAsNewlineRef.current = next
+
+    if (activeBackendTypeRef.current !== 'ghostty') return
+
+    const restart = async (): Promise<void> => {
+      if (backendRef.current) {
+        backendRef.current.dispose()
+        backendRef.current = null
+      }
+      initializedRef.current = null
+      activeBackendTypeRef.current = null
+      setTerminalStatus('creating')
+      setExitCode(undefined)
+
+      await destroyTerminal(terminalId)
+      await restartTerminal(terminalId, cwd)
+      setupTerminal('ghostty')
+    }
+    restart()
+  }, [shiftEnterAsNewline, terminalId, cwd, destroyTerminal, restartTerminal, setupTerminal])
 
   // Focus terminal on click
   const handleClick = useCallback(() => {

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -19,6 +19,7 @@ interface TerminalViewProps {
   isVisible?: boolean
   showToolbar?: boolean
   backendTypeOverride?: TerminalBackendType
+  shiftEnterAsNewline?: boolean
   createTerminal?: Parameters<ITerminalBackend['mount']>[1]['createTerminal']
   onStatusChange?: (status: 'creating' | 'running' | 'exited', exitCode?: number) => void
 }
@@ -47,6 +48,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     isVisible = true,
     showToolbar = true,
     backendTypeOverride,
+    shiftEnterAsNewline,
     createTerminal,
     onStatusChange
   },
@@ -100,6 +102,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   const effectiveVisibleRef = useRef(effectiveVisible)
   effectiveVisibleRef.current = effectiveVisible
 
+  const shiftEnterAsNewlineRef = useRef(shiftEnterAsNewline ?? false)
+  shiftEnterAsNewlineRef.current = shiftEnterAsNewline ?? false
+
   // Expose imperative methods to parent via ref
   useImperativeHandle(
     ref,
@@ -129,6 +134,13 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     }, 50)
     return () => clearTimeout(timer)
   }, [themeId])
+
+  useEffect(() => {
+    const backend = backendRef.current
+    if (backend instanceof XtermBackend) {
+      backend.setShiftEnterAsNewline(shiftEnterAsNewline ?? false)
+    }
+  }, [shiftEnterAsNewline])
 
   // Re-fit and focus when becoming visible.
   // Note: GhosttyBackend.setVisible(true) already restores macOS first responder
@@ -290,6 +302,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
           scrollback: config.scrollbackLimit,
           shell: config.shell,
           createTerminal,
+          shiftEnterAsNewline: shiftEnterAsNewlineRef.current,
           // Seed visibility from the current UI state. Critical when the
           // backend is recreated (e.g. fontSize change, cwd change, StrictMode
           // double-mount) while the bottom panel is collapsed: defaulting to

--- a/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/renderer/src/components/terminal/backends/GhosttyBackend.ts
@@ -159,7 +159,8 @@ export class GhosttyBackend implements TerminalBackend {
             shell: this.opts.shell,
             scaleFactor: window.devicePixelRatio || 2.0,
             fontSize:
-              useSettingsStore.getState().ghosttyFontSize || GhosttyBackend.FALLBACK_FONT_SIZE
+              useSettingsStore.getState().ghosttyFontSize || GhosttyBackend.FALLBACK_FONT_SIZE,
+            shiftEnterAsNewline: this.opts.shiftEnterAsNewline ?? false
           })
         )
 

--- a/src/renderer/src/components/terminal/backends/XtermBackend.ts
+++ b/src/renderer/src/components/terminal/backends/XtermBackend.ts
@@ -268,8 +268,8 @@ export class XtermBackend implements TerminalBackend {
 
     // Create the PTY
     callbacks.onStatusChange('creating')
-    window.terminalOps
-      .create(this.terminalId, opts.cwd, opts.shell)
+    const createTerminal = opts.createTerminal ?? window.terminalOps.create
+    createTerminal(this.terminalId, opts.cwd, opts.shell)
       .then(unwrapEnvelope)
       .then((result) => {
         if (result.success) {

--- a/src/renderer/src/components/terminal/backends/XtermBackend.ts
+++ b/src/renderer/src/components/terminal/backends/XtermBackend.ts
@@ -136,6 +136,7 @@ export class XtermBackend implements TerminalBackend {
   private removeExitListener: (() => void) | null = null
   private inputDisposable: { dispose: () => void } | null = null
   private terminalId: string = ''
+  private shiftEnterAsNewline = false
   private ghosttyConfig: GhosttyTerminalConfig = {}
 
   /** Callback for the host to wire Cmd+F search toggling */
@@ -145,6 +146,7 @@ export class XtermBackend implements TerminalBackend {
 
   mount(container: HTMLDivElement, opts: TerminalOpts, callbacks: TerminalBackendCallbacks): void {
     this.terminalId = opts.terminalId
+    this.shiftEnterAsNewline = opts.shiftEnterAsNewline ?? false
     container.innerHTML = ''
 
     // Store config for theme rebuilding
@@ -169,6 +171,20 @@ export class XtermBackend implements TerminalBackend {
 
     // Custom key event handler
     terminal.attachCustomKeyEventHandler((e) => {
+      if (
+        this.shiftEnterAsNewline &&
+        e.type === 'keydown' &&
+        (e.key === 'Enter' || e.code === 'Enter' || e.code === 'NumpadEnter') &&
+        e.shiftKey &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey
+      ) {
+        e.preventDefault()
+        terminal.input('\x1b\r', true)
+        return false
+      }
+
       if (isAppShortcut(e)) return false
 
       if (e.metaKey && e.key === 'f' && e.type === 'keydown') {
@@ -316,6 +332,10 @@ export class XtermBackend implements TerminalBackend {
       }
     })
     this.resizeObserver.observe(container)
+  }
+
+  setShiftEnterAsNewline(enabled: boolean): void {
+    this.shiftEnterAsNewline = enabled
   }
 
   write(data: string): void {

--- a/src/renderer/src/components/terminal/backends/types.ts
+++ b/src/renderer/src/components/terminal/backends/types.ts
@@ -1,3 +1,5 @@
+import type { Envelope } from '@shared/types/ipc-envelope'
+
 /**
  * Terminal backend abstraction layer.
  * Allows switching between xterm.js (cross-platform) and native Ghostty (macOS).
@@ -8,6 +10,11 @@ export type TerminalBackendType = 'xterm' | 'ghostty'
 export interface TerminalOpts {
   terminalId: string
   cwd: string
+  createTerminal?: (
+    terminalId: string,
+    cwd: string,
+    shell?: string
+  ) => Promise<Envelope<{ success: boolean; cols?: number; rows?: number; error?: string }>>
   fontFamily?: string
   fontSize?: number
   cursorStyle?: 'block' | 'bar' | 'underline'

--- a/src/renderer/src/components/terminal/backends/types.ts
+++ b/src/renderer/src/components/terminal/backends/types.ts
@@ -22,6 +22,12 @@ export interface TerminalOpts {
   theme?: Record<string, string>
   shell?: string
   /**
+   * When true, Shift+Enter is intercepted and ESC+CR (`\x1b\r`) is sent
+   * instead of the default `\r`. Claude-style chat TUIs parse this sequence
+   * as "newline" while plain Enter still submits.
+   */
+  shiftEnterAsNewline?: boolean
+  /**
    * Whether the terminal is visible at the moment of mount.
    *
    * Critical for Ghostty: the native NSView is positioned exclusively from JS

--- a/src/renderer/src/contexts/ClaudeCliSessionPortalContext.tsx
+++ b/src/renderer/src/contexts/ClaudeCliSessionPortalContext.tsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode
+} from 'react'
 
 interface ClaudeCliSessionPortalContextValue {
   registerTarget: (sessionId: string, el: HTMLDivElement | null) => void
@@ -32,8 +40,16 @@ export function ClaudeCliSessionPortalProvider({
     return targetsRef.current.get(sessionId) ?? null
   }, [])
 
+  // registerTarget/getTarget are stable, so the value identity changes only when
+  // `revision` does — preventing a parent re-render from re-rendering every
+  // portal consumer when nothing they depend on actually changed.
+  const value = useMemo(
+    () => ({ registerTarget, getTarget, revision }),
+    [registerTarget, getTarget, revision]
+  )
+
   return (
-    <ClaudeCliSessionPortalContext.Provider value={{ registerTarget, getTarget, revision }}>
+    <ClaudeCliSessionPortalContext.Provider value={value}>
       {children}
     </ClaudeCliSessionPortalContext.Provider>
   )

--- a/src/renderer/src/contexts/ClaudeCliSessionPortalContext.tsx
+++ b/src/renderer/src/contexts/ClaudeCliSessionPortalContext.tsx
@@ -1,0 +1,50 @@
+import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from 'react'
+
+interface ClaudeCliSessionPortalContextValue {
+  registerTarget: (sessionId: string, el: HTMLDivElement | null) => void
+  getTarget: (sessionId: string) => HTMLDivElement | null
+  revision: number
+}
+
+const ClaudeCliSessionPortalContext = createContext<ClaudeCliSessionPortalContextValue | null>(null)
+
+export function ClaudeCliSessionPortalProvider({
+  children
+}: {
+  children: ReactNode
+}): React.JSX.Element {
+  const targetsRef = useRef(new Map<string, HTMLDivElement>())
+  const [revision, setRevision] = useState(0)
+
+  const registerTarget = useCallback((sessionId: string, el: HTMLDivElement | null) => {
+    if (el) {
+      targetsRef.current.set(sessionId, el)
+      setRevision((r) => r + 1)
+    } else {
+      const hadTarget = targetsRef.current.delete(sessionId)
+      if (hadTarget) {
+        setRevision((r) => r + 1)
+      }
+    }
+  }, [])
+
+  const getTarget = useCallback((sessionId: string): HTMLDivElement | null => {
+    return targetsRef.current.get(sessionId) ?? null
+  }, [])
+
+  return (
+    <ClaudeCliSessionPortalContext.Provider value={{ registerTarget, getTarget, revision }}>
+      {children}
+    </ClaudeCliSessionPortalContext.Provider>
+  )
+}
+
+export function useClaudeCliSessionPortal(): ClaudeCliSessionPortalContextValue {
+  const ctx = useContext(ClaudeCliSessionPortalContext)
+  if (!ctx) {
+    throw new Error(
+      'useClaudeCliSessionPortal must be used within a ClaudeCliSessionPortalProvider'
+    )
+  }
+  return ctx
+}

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   setSessionStatus: vi.fn(),
+  setPendingPlan: vi.fn(),
   lastSendMode: new Map<string, 'plan' | 'build'>(),
   modeBySession: new Map<string, 'build' | 'plan' | 'super-plan'>(),
   sessionStatuses: {} as Record<string, { status: string } | null>
@@ -20,7 +21,8 @@ vi.mock('@/stores/useWorktreeStatusStore', () => ({
 vi.mock('@/stores/useSessionStore', () => ({
   useSessionStore: {
     getState: () => ({
-      modeBySession: mocks.modeBySession
+      modeBySession: mocks.modeBySession,
+      setPendingPlan: mocks.setPendingPlan
     })
   }
 }))
@@ -36,7 +38,13 @@ describe('useClaudeCliStatusListener', () => {
     | ((payload: {
         sessionId: string
         status: 'completed' | 'working' | 'plan_ready'
-        metadata?: { reason?: string; hookEventName?: string; hookPath?: string }
+        metadata?: {
+          reason?: string
+          hookEventName?: string
+          hookPath?: string
+          toolName?: string
+          plan?: string
+        }
       }) => void)
     | null
   const unsubscribe = vi.fn()
@@ -45,6 +53,7 @@ describe('useClaudeCliStatusListener', () => {
     subscribedCallback = null
     unsubscribe.mockClear()
     mocks.setSessionStatus.mockClear()
+    mocks.setPendingPlan.mockClear()
     mocks.lastSendMode.clear()
     mocks.modeBySession.clear()
     mocks.sessionStatuses = {}
@@ -81,6 +90,33 @@ describe('useClaudeCliStatusListener', () => {
 
     unmount()
     expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('stores raw ExitPlanMode plan text when a Claude CLI plan becomes ready', () => {
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'plan_ready',
+      metadata: {
+        hookEventName: 'PreToolUse',
+        hookPath: 'tool',
+        toolName: 'ExitPlanMode',
+        plan: '# Plan\n\n1. Add CLI card.'
+      }
+    })
+
+    expect(mocks.setPendingPlan).toHaveBeenCalledWith('hive-session-1', {
+      requestId: 'claude-cli:hive-session-1',
+      planContent: '# Plan\n\n1. Add CLI card.',
+      toolUseID: 'claude-cli:hive-session-1'
+    })
+    expect(mocks.setSessionStatus).toHaveBeenCalledWith('hive-session-1', 'plan_ready', {
+      hookEventName: 'PreToolUse',
+      hookPath: 'tool',
+      toolName: 'ExitPlanMode',
+      plan: '# Plan\n\n1. Add CLI card.'
+    })
   })
 
   it('does nothing when the preload API is unavailable', () => {

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   setSessionStatus: vi.fn(),
   setPendingPlan: vi.fn(),
+  clearPendingPlan: vi.fn(),
+  notifyKanbanSessionSync: vi.fn(),
   lastSendMode: new Map<string, 'plan' | 'build'>(),
   modeBySession: new Map<string, 'build' | 'plan' | 'super-plan'>(),
   sessionStatuses: {} as Record<string, { status: string } | null>
@@ -22,9 +24,14 @@ vi.mock('@/stores/useSessionStore', () => ({
   useSessionStore: {
     getState: () => ({
       modeBySession: mocks.modeBySession,
-      setPendingPlan: mocks.setPendingPlan
+      setPendingPlan: mocks.setPendingPlan,
+      clearPendingPlan: mocks.clearPendingPlan
     })
   }
+}))
+
+vi.mock('@/stores/store-coordination', () => ({
+  notifyKanbanSessionSync: mocks.notifyKanbanSessionSync
 }))
 
 vi.mock('@/lib/message-send-times', () => ({
@@ -54,6 +61,8 @@ describe('useClaudeCliStatusListener', () => {
     unsubscribe.mockClear()
     mocks.setSessionStatus.mockClear()
     mocks.setPendingPlan.mockClear()
+    mocks.clearPendingPlan.mockClear()
+    mocks.notifyKanbanSessionSync.mockClear()
     mocks.lastSendMode.clear()
     mocks.modeBySession.clear()
     mocks.sessionStatuses = {}
@@ -116,6 +125,31 @@ describe('useClaudeCliStatusListener', () => {
       hookPath: 'tool',
       toolName: 'ExitPlanMode',
       plan: '# Plan\n\n1. Add CLI card.'
+    })
+  })
+
+  it('implements the pending plan when terminal approval completes ExitPlanMode', () => {
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'working',
+      metadata: {
+        hookEventName: 'PostToolUse',
+        hookPath: 'tool',
+        toolName: 'ExitPlanMode'
+      }
+    })
+
+    expect(mocks.clearPendingPlan).toHaveBeenCalledWith('hive-session-1')
+    expect(mocks.notifyKanbanSessionSync).toHaveBeenCalledWith('hive-session-1', {
+      type: 'implement'
+    })
+    expect(mocks.lastSendMode.get('hive-session-1')).toBe('build')
+    expect(mocks.setSessionStatus).toHaveBeenCalledWith('hive-session-1', 'working', {
+      hookEventName: 'PostToolUse',
+      hookPath: 'tool',
+      toolName: 'ExitPlanMode'
     })
   })
 

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -1,0 +1,151 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  setSessionStatus: vi.fn(),
+  lastSendMode: new Map<string, 'plan' | 'build'>(),
+  modeBySession: new Map<string, 'build' | 'plan' | 'super-plan'>(),
+  sessionStatuses: {} as Record<string, { status: string } | null>
+}))
+
+vi.mock('@/stores/useWorktreeStatusStore', () => ({
+  useWorktreeStatusStore: {
+    getState: () => ({
+      sessionStatuses: mocks.sessionStatuses,
+      setSessionStatus: mocks.setSessionStatus
+    })
+  }
+}))
+
+vi.mock('@/stores/useSessionStore', () => ({
+  useSessionStore: {
+    getState: () => ({
+      modeBySession: mocks.modeBySession
+    })
+  }
+}))
+
+vi.mock('@/lib/message-send-times', () => ({
+  lastSendMode: mocks.lastSendMode
+}))
+
+import { useClaudeCliStatusListener } from '../useClaudeCliStatusListener'
+
+describe('useClaudeCliStatusListener', () => {
+  let subscribedCallback:
+    | ((payload: {
+        sessionId: string
+        status: 'completed' | 'working' | 'plan_ready'
+        metadata?: { reason?: string; hookEventName?: string; hookPath?: string }
+      }) => void)
+    | null
+  const unsubscribe = vi.fn()
+
+  beforeEach(() => {
+    subscribedCallback = null
+    unsubscribe.mockClear()
+    mocks.setSessionStatus.mockClear()
+    mocks.lastSendMode.clear()
+    mocks.modeBySession.clear()
+    mocks.sessionStatuses = {}
+
+    Object.defineProperty(window, 'terminalOps', {
+      configurable: true,
+      value: {
+        onClaudeCliStatus: vi.fn((callback) => {
+          subscribedCallback = callback
+          return unsubscribe
+        })
+      }
+    })
+  })
+
+  afterEach(() => {
+    delete (window as { terminalOps?: unknown }).terminalOps
+  })
+
+  it('subscribes to Claude CLI status IPC and writes payloads into the worktree status store', () => {
+    const { unmount } = renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'plan_ready',
+      metadata: { hookEventName: 'PreToolUse', hookPath: 'tool' }
+    })
+
+    expect(window.terminalOps.onClaudeCliStatus).toHaveBeenCalledTimes(1)
+    expect(mocks.setSessionStatus).toHaveBeenCalledWith('hive-session-1', 'plan_ready', {
+      hookEventName: 'PreToolUse',
+      hookPath: 'tool'
+    })
+
+    unmount()
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when the preload API is unavailable', () => {
+    delete (window as { terminalOps?: unknown }).terminalOps
+
+    const { unmount } = renderHook(() => useClaudeCliStatusListener())
+
+    expect(mocks.setSessionStatus).not.toHaveBeenCalled()
+    expect(() => unmount()).not.toThrow()
+  })
+
+  it('derives planning and plan_ready for Claude CLI plan-mode hook sequences', () => {
+    mocks.modeBySession.set('hive-session-1', 'plan')
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'working',
+      metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start' }
+    })
+    mocks.sessionStatuses = { 'hive-session-1': { status: 'planning' } }
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'completed',
+      metadata: { hookEventName: 'Stop', hookPath: 'stop' }
+    })
+
+    expect(mocks.lastSendMode.get('hive-session-1')).toBe('plan')
+    expect(mocks.setSessionStatus).toHaveBeenNthCalledWith(1, 'hive-session-1', 'planning', {
+      hookEventName: 'UserPromptSubmit',
+      hookPath: 'start'
+    })
+    expect(mocks.setSessionStatus).toHaveBeenNthCalledWith(2, 'hive-session-1', 'plan_ready', {
+      hookEventName: 'Stop',
+      hookPath: 'stop'
+    })
+  })
+
+  it('treats a prompt submitted while plan_ready as plan approval work', () => {
+    mocks.modeBySession.set('hive-session-1', 'plan')
+    mocks.sessionStatuses = { 'hive-session-1': { status: 'plan_ready' } }
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'working',
+      metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start' }
+    })
+    mocks.sessionStatuses = { 'hive-session-1': { status: 'working' } }
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'completed',
+      metadata: { hookEventName: 'Stop', hookPath: 'stop' }
+    })
+
+    expect(mocks.lastSendMode.get('hive-session-1')).toBe('build')
+    expect(mocks.setSessionStatus).toHaveBeenNthCalledWith(1, 'hive-session-1', 'working', {
+      hookEventName: 'UserPromptSubmit',
+      hookPath: 'start'
+    })
+    expect(mocks.setSessionStatus).toHaveBeenNthCalledWith(2, 'hive-session-1', 'completed', {
+      hookEventName: 'Stop',
+      hookPath: 'stop'
+    })
+  })
+})

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -6,9 +6,14 @@ const mocks = vi.hoisted(() => ({
   setPendingPlan: vi.fn(),
   clearPendingPlan: vi.fn(),
   notifyKanbanSessionSync: vi.fn(),
+  setSelectedTicketId: vi.fn(),
   lastSendMode: new Map<string, 'plan' | 'build'>(),
   modeBySession: new Map<string, 'build' | 'plan' | 'super-plan'>(),
-  sessionStatuses: {} as Record<string, { status: string } | null>
+  sessionStatuses: {} as Record<string, { status: string } | null>,
+  kanbanState: {
+    selectedTicketId: null as string | null,
+    tickets: new Map<string, Array<{ id: string; current_session_id: string | null }>>()
+  }
 }))
 
 vi.mock('@/stores/useWorktreeStatusStore', () => ({
@@ -30,6 +35,18 @@ vi.mock('@/stores/useSessionStore', () => ({
   }
 }))
 
+vi.mock('@/stores/useKanbanStore', () => ({
+  useKanbanStore: Object.assign(
+    (selector: (state: typeof mocks.kanbanState) => unknown) => selector(mocks.kanbanState),
+    {
+      getState: () => ({
+        ...mocks.kanbanState,
+        setSelectedTicketId: mocks.setSelectedTicketId
+      })
+    }
+  )
+}))
+
 vi.mock('@/stores/store-coordination', () => ({
   notifyKanbanSessionSync: mocks.notifyKanbanSessionSync
 }))
@@ -44,7 +61,7 @@ describe('useClaudeCliStatusListener', () => {
   let subscribedCallback:
     | ((payload: {
         sessionId: string
-        status: 'completed' | 'working' | 'plan_ready'
+        status: 'completed' | 'working' | 'planning' | 'plan_ready'
         metadata?: {
           reason?: string
           hookEventName?: string
@@ -54,18 +71,27 @@ describe('useClaudeCliStatusListener', () => {
         }
       }) => void)
     | null
+  let planFollowupCallback: ((payload: { sessionId: string }) => void) | null
   const unsubscribe = vi.fn()
+  const unsubscribePlanFollowup = vi.fn()
 
   beforeEach(() => {
     subscribedCallback = null
+    planFollowupCallback = null
     unsubscribe.mockClear()
+    unsubscribePlanFollowup.mockClear()
     mocks.setSessionStatus.mockClear()
     mocks.setPendingPlan.mockClear()
     mocks.clearPendingPlan.mockClear()
+    mocks.setSelectedTicketId.mockClear()
     mocks.notifyKanbanSessionSync.mockClear()
     mocks.lastSendMode.clear()
     mocks.modeBySession.clear()
     mocks.sessionStatuses = {}
+    mocks.kanbanState = {
+      selectedTicketId: null,
+      tickets: new Map()
+    }
 
     Object.defineProperty(window, 'terminalOps', {
       configurable: true,
@@ -73,6 +99,10 @@ describe('useClaudeCliStatusListener', () => {
         onClaudeCliStatus: vi.fn((callback) => {
           subscribedCallback = callback
           return unsubscribe
+        }),
+        onClaudeCliPlanFollowup: vi.fn((callback) => {
+          planFollowupCallback = callback
+          return unsubscribePlanFollowup
         })
       }
     })
@@ -99,6 +129,7 @@ describe('useClaudeCliStatusListener', () => {
 
     unmount()
     expect(unsubscribe).toHaveBeenCalledTimes(1)
+    expect(unsubscribePlanFollowup).toHaveBeenCalledTimes(1)
   })
 
   it('stores raw ExitPlanMode plan text when a Claude CLI plan becomes ready', () => {
@@ -216,6 +247,74 @@ describe('useClaudeCliStatusListener', () => {
     expect(mocks.setSessionStatus).toHaveBeenNthCalledWith(2, 'hive-session-1', 'completed', {
       hookEventName: 'Stop',
       hookPath: 'stop'
+    })
+  })
+
+  it('handles transcript-detected plan followups by returning the session and ticket to planning', () => {
+    renderHook(() => useClaudeCliStatusListener())
+
+    planFollowupCallback?.({ sessionId: 'hive-session-1' })
+
+    expect(mocks.clearPendingPlan).toHaveBeenCalledWith('hive-session-1')
+    expect(mocks.notifyKanbanSessionSync).toHaveBeenCalledWith('hive-session-1', {
+      type: 'plan_followup'
+    })
+    expect(mocks.lastSendMode.get('hive-session-1')).toBe('plan')
+    expect(mocks.setSessionStatus).toHaveBeenCalledWith('hive-session-1', 'planning', {
+      reason: 'claude_cli_plan_followup'
+    })
+  })
+
+  it('closes the selected ticket modal when a linked Claude CLI plan followup is detected', () => {
+    mocks.kanbanState = {
+      selectedTicketId: 'ticket-plan',
+      tickets: new Map([
+        ['project-1', [{ id: 'ticket-plan', current_session_id: 'hive-session-1' }]]
+      ])
+    }
+    renderHook(() => useClaudeCliStatusListener())
+
+    planFollowupCallback?.({ sessionId: 'hive-session-1' })
+
+    expect(mocks.setSelectedTicketId).toHaveBeenCalledWith(null)
+  })
+
+  it('does not close the selected ticket modal for a different session followup', () => {
+    mocks.kanbanState = {
+      selectedTicketId: 'ticket-plan',
+      tickets: new Map([
+        ['project-1', [{ id: 'ticket-plan', current_session_id: 'other-session' }]]
+      ])
+    }
+    renderHook(() => useClaudeCliStatusListener())
+
+    planFollowupCallback?.({ sessionId: 'hive-session-1' })
+
+    expect(mocks.setSelectedTicketId).not.toHaveBeenCalled()
+  })
+
+  it('handles ExitPlanMode failure hooks as plan followups', () => {
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'planning',
+      metadata: {
+        hookEventName: 'PostToolUseFailure',
+        hookPath: 'tool',
+        toolName: 'ExitPlanMode'
+      }
+    })
+
+    expect(mocks.clearPendingPlan).toHaveBeenCalledWith('hive-session-1')
+    expect(mocks.notifyKanbanSessionSync).toHaveBeenCalledWith('hive-session-1', {
+      type: 'plan_followup'
+    })
+    expect(mocks.lastSendMode.get('hive-session-1')).toBe('plan')
+    expect(mocks.setSessionStatus).toHaveBeenCalledWith('hive-session-1', 'planning', {
+      hookEventName: 'PostToolUseFailure',
+      hookPath: 'tool',
+      toolName: 'ExitPlanMode'
     })
   })
 })

--- a/src/renderer/src/hooks/index.ts
+++ b/src/renderer/src/hooks/index.ts
@@ -2,6 +2,7 @@ export { useKeyboardShortcut, useCommandK, useCommandP } from './useKeyboardShor
 export { useKeyboardShortcuts } from './useKeyboardShortcuts'
 export { useCommands } from './useCommands'
 export { useOpenCodeGlobalListener } from './useOpenCodeGlobalListener'
+export { useClaudeCliStatusListener } from './useClaudeCliStatusListener'
 export { useNotificationNavigation } from './useNotificationNavigation'
 export { useLifecycleActions } from './useLifecycleActions'
 export { useFileMentions } from './useFileMentions'

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -12,8 +12,22 @@ export function useClaudeCliStatusListener(): void {
     const unsubscribe = window.terminalOps?.onClaudeCliStatus
       ? window.terminalOps.onClaudeCliStatus(({ sessionId, status, metadata }) => {
           const worktreeStatus = useWorktreeStatusStore.getState()
+          const sessionStore = useSessionStore.getState()
           const currentStatus = worktreeStatus.sessionStatuses[sessionId]?.status
-          const currentMode = useSessionStore.getState().modeBySession.get(sessionId)
+          const currentMode = sessionStore.modeBySession.get(sessionId)
+
+          if (
+            status === 'plan_ready' &&
+            metadata?.toolName === 'ExitPlanMode' &&
+            typeof metadata.plan === 'string'
+          ) {
+            const syntheticId = `claude-cli:${sessionId}`
+            sessionStore.setPendingPlan(sessionId, {
+              requestId: syntheticId,
+              planContent: metadata.plan,
+              toolUseID: syntheticId
+            })
+          }
 
           if (
             status === 'working' &&

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { lastSendMode } from '@/lib/message-send-times'
+import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 
 function isPlanLike(mode: string | undefined): boolean {
   return mode === 'plan' || mode === 'super-plan'
@@ -15,6 +16,18 @@ export function useClaudeCliStatusListener(): void {
           const sessionStore = useSessionStore.getState()
           const currentStatus = worktreeStatus.sessionStatuses[sessionId]?.status
           const currentMode = sessionStore.modeBySession.get(sessionId)
+
+          if (
+            metadata?.hookEventName === 'PostToolUse' &&
+            metadata.toolName === 'ExitPlanMode'
+          ) {
+            // User approved ExitPlanMode from the terminal, matching the in-app implement action.
+            sessionStore.clearPendingPlan(sessionId)
+            notifyKanbanSessionSync(sessionId, { type: 'implement' })
+            lastSendMode.set(sessionId, 'build')
+            worktreeStatus.setSessionStatus(sessionId, 'working', metadata)
+            return
+          }
 
           if (
             status === 'plan_ready' &&

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -1,0 +1,53 @@
+import { useEffect } from 'react'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { lastSendMode } from '@/lib/message-send-times'
+
+function isPlanLike(mode: string | undefined): boolean {
+  return mode === 'plan' || mode === 'super-plan'
+}
+
+export function useClaudeCliStatusListener(): void {
+  useEffect(() => {
+    const unsubscribe = window.terminalOps?.onClaudeCliStatus
+      ? window.terminalOps.onClaudeCliStatus(({ sessionId, status, metadata }) => {
+          const worktreeStatus = useWorktreeStatusStore.getState()
+          const currentStatus = worktreeStatus.sessionStatuses[sessionId]?.status
+          const currentMode = useSessionStore.getState().modeBySession.get(sessionId)
+
+          if (
+            status === 'working' &&
+            metadata?.hookEventName === 'UserPromptSubmit' &&
+            currentStatus === 'plan_ready'
+          ) {
+            lastSendMode.set(sessionId, 'build')
+            worktreeStatus.setSessionStatus(sessionId, 'working', metadata)
+            return
+          }
+
+          if (
+            status === 'working' &&
+            metadata?.hookEventName === 'UserPromptSubmit' &&
+            isPlanLike(currentMode)
+          ) {
+            lastSendMode.set(sessionId, 'plan')
+            worktreeStatus.setSessionStatus(sessionId, 'planning', metadata)
+            return
+          }
+
+          if (
+            status === 'completed' &&
+            metadata?.hookEventName === 'Stop' &&
+            lastSendMode.get(sessionId) === 'plan'
+          ) {
+            worktreeStatus.setSessionStatus(sessionId, 'plan_ready', metadata)
+            return
+          }
+
+          worktreeStatus.setSessionStatus(sessionId, status, metadata)
+        })
+      : () => {}
+
+    return unsubscribe
+  }, [])
+}

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -4,6 +4,7 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { lastSendMode } from '@/lib/message-send-times'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
+import { isPlanLike } from '@/lib/constants'
 
 type ClaudeCliStatusMetadata = {
   reason?: string
@@ -11,10 +12,6 @@ type ClaudeCliStatusMetadata = {
   hookPath?: string
   toolName?: string
   plan?: string
-}
-
-function isPlanLike(mode: string | undefined): boolean {
-  return mode === 'plan' || mode === 'super-plan'
 }
 
 function closeLinkedTicketModal(sessionId: string): void {

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -1,15 +1,52 @@
 import { useEffect } from 'react'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useSessionStore } from '@/stores/useSessionStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
 import { lastSendMode } from '@/lib/message-send-times'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
+
+type ClaudeCliStatusMetadata = {
+  reason?: string
+  hookEventName?: string
+  hookPath?: string
+  toolName?: string
+  plan?: string
+}
 
 function isPlanLike(mode: string | undefined): boolean {
   return mode === 'plan' || mode === 'super-plan'
 }
 
+function closeLinkedTicketModal(sessionId: string): void {
+  const kanbanState = useKanbanStore.getState()
+  const selectedTicketId = kanbanState.selectedTicketId
+  if (!selectedTicketId) return
+
+  for (const projectTickets of kanbanState.tickets.values()) {
+    const selectedTicket = projectTickets.find((ticket) => ticket.id === selectedTicketId)
+    if (!selectedTicket) continue
+    if (selectedTicket.current_session_id === sessionId) {
+      kanbanState.setSelectedTicketId(null)
+    }
+    return
+  }
+}
+
 export function useClaudeCliStatusListener(): void {
   useEffect(() => {
+    const handlePlanFollowup = (
+      sessionId: string,
+      metadata: ClaudeCliStatusMetadata = {
+        reason: 'claude_cli_plan_followup'
+      }
+    ): void => {
+      useSessionStore.getState().clearPendingPlan(sessionId)
+      notifyKanbanSessionSync(sessionId, { type: 'plan_followup' })
+      closeLinkedTicketModal(sessionId)
+      lastSendMode.set(sessionId, 'plan')
+      useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'planning', metadata)
+    }
+
     const unsubscribe = window.terminalOps?.onClaudeCliStatus
       ? window.terminalOps.onClaudeCliStatus(({ sessionId, status, metadata }) => {
           const worktreeStatus = useWorktreeStatusStore.getState()
@@ -40,6 +77,16 @@ export function useClaudeCliStatusListener(): void {
               planContent: metadata.plan,
               toolUseID: syntheticId
             })
+          }
+
+          if (
+            status === 'planning' &&
+            ((metadata?.hookEventName === 'UserPromptSubmit' && currentStatus === 'plan_ready') ||
+              (metadata?.hookEventName === 'PostToolUseFailure' &&
+                metadata.toolName === 'ExitPlanMode'))
+          ) {
+            handlePlanFollowup(sessionId, metadata)
+            return
           }
 
           if (
@@ -75,6 +122,15 @@ export function useClaudeCliStatusListener(): void {
         })
       : () => {}
 
-    return unsubscribe
+    const unsubscribePlanFollowup = window.terminalOps?.onClaudeCliPlanFollowup
+      ? window.terminalOps.onClaudeCliPlanFollowup(({ sessionId }) => {
+          handlePlanFollowup(sessionId)
+        })
+      : () => {}
+
+    return () => {
+      unsubscribe()
+      unsubscribePlanFollowup()
+    }
   }, [])
 }

--- a/src/renderer/src/hooks/useLifecycleActions.ts
+++ b/src/renderer/src/hooks/useLifecycleActions.ts
@@ -220,7 +220,8 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
         undefined,
         {
           autoFocus: false,
-          modelOverride: reviewDefaultModel
+          modelOverride: reviewDefaultModel,
+          ...(reviewDefaultModel?.agentSdk === 'claude-code-cli' ? { pendingMessage: prompt } : {})
         }
       )
       if (!result.success || !result.session) {
@@ -240,6 +241,9 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
       const sessionId = result.session.id
       const worktreePath = worktree.path
       const agentSdk = result.session.agent_sdk
+      if (agentSdk === 'claude-code-cli') {
+        sessionStore.setPendingMessage(sessionId, prompt)
+      }
       const sessionModel =
         result.session.model_provider_id && result.session.model_id
           ? {
@@ -251,6 +255,27 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
 
       void (async () => {
         try {
+          if (agentSdk === 'claude-code-cli') {
+            messageSendTimes.set(sessionId, Date.now())
+            userExplicitSendTimes.set(sessionId, Date.now())
+            snapshotTokenBaseline(sessionId)
+            lastSendMode.set(sessionId, 'build')
+            useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+            bumpWorktreeLastMessage({ worktreeId })
+
+            const cliResult = unwrapEnvelope(
+              await window.terminalOps.createClaudeCli(sessionId, {
+                pendingPrompt: prompt
+              })
+            )
+            if (!cliResult.success) {
+              sessionStore.setPendingMessage(sessionId, prompt)
+            } else {
+              sessionStore.dequeuePendingMessage(sessionId)
+            }
+            return
+          }
+
           const connectResult = unwrapEnvelope(
             await window.opencodeOps.connect(worktreePath, sessionId)
           )

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -314,27 +314,17 @@ export function useOpenCodeGlobalListener(): void {
             return
           }
 
-          // Keep session.updated for background title sync (some events use this type)
+          // session.updated — sync title for both background and active sessions.
+          // ClaudeCliSessionView (active for claude-code-cli) has no opencode:stream
+          // listener of its own, so we cannot gate this on `sessionId !== activeId`
+          // or claude-cli renames would never reach the UI.
           if (event.type === 'session.updated') {
-            console.log('[TITLE_DEBUG] globalListener received session.updated', {
-              eventSessionId: sessionId,
-              activeId,
-              isBackground: sessionId !== activeId,
-              title: event.data?.info?.title || event.data?.title
-            })
-          }
-          if (event.type === 'session.updated' && sessionId !== activeId) {
             const rawTitle = event.data?.info?.title || event.data?.title
             const sessionTitle = rawTitle ? maybeExtractJsonTitle(rawTitle) : rawTitle
-            // Skip OpenCode default placeholder titles like "New session - 2026-02-12T21:33:03.013Z"
             const isOpenCodeDefault = /^New session\s*-?\s*\d{4}-\d{2}-\d{2}/i.test(
               sessionTitle || ''
             )
             if (sessionTitle && !isOpenCodeDefault) {
-              console.log('[TITLE_DEBUG] globalListener calling updateSessionName', {
-                sessionId,
-                sessionTitle
-              })
               useSessionStore.getState().updateSessionName(sessionId, sessionTitle)
             }
             return

--- a/src/renderer/src/hooks/useSessionStream.ts
+++ b/src/renderer/src/hooks/useSessionStream.ts
@@ -197,6 +197,9 @@ export function useSessionStream({
     }
 
     const currentGeneration = ++generationRef.current
+    let active = true
+    const isCurrentGeneration = (): boolean =>
+      active && generationRef.current === currentGeneration && typeof window !== 'undefined'
     hasFinalizedRef.current = false
     setIsLoading(true)
 
@@ -220,7 +223,7 @@ export function useSessionStream({
         const result = unwrapEnvelope(
           await window.opencodeOps.getMessages(worktreePath, opencodeSessionId)
         )
-        if (generationRef.current !== currentGeneration) return
+        if (!isCurrentGeneration()) return
 
         if (result.success && result.messages) {
           const refreshed = mapOpencodeMessagesToSessionViewMessages(result.messages as unknown[])
@@ -240,7 +243,9 @@ export function useSessionStream({
       } catch (error) {
         console.error('[useSessionStream] Failed to refresh messages:', error)
       } finally {
-        resetStreamingState()
+        if (isCurrentGeneration()) {
+          resetStreamingState()
+        }
       }
     }
 
@@ -253,7 +258,7 @@ export function useSessionStream({
           if (event.sessionId !== sessionId) return
 
           // Guard: generation check — prevents stale closures
-          if (generationRef.current !== currentGeneration) return
+          if (!isCurrentGeneration()) return
 
           // -----------------------------------------------------------
           // message.part.updated
@@ -605,7 +610,7 @@ export function useSessionStream({
           currentGeneration,
           generationRef.current
         )
-        if (generationRef.current !== currentGeneration) {
+        if (!isCurrentGeneration()) {
           console.info('[useSessionStream] stale generation after first getMessages, aborting')
           return
         }
@@ -616,11 +621,11 @@ export function useSessionStream({
         // OpenCode server hasn't finished loading session data).
         if (
           (!result.success || !result.messages || (result.messages as unknown[]).length === 0) &&
-          generationRef.current === currentGeneration
+          isCurrentGeneration()
         ) {
           console.info('[useSessionStream] empty result, retrying in 800ms...')
           await new Promise((r) => setTimeout(r, 800))
-          if (generationRef.current !== currentGeneration) {
+          if (!isCurrentGeneration()) {
             console.info('[useSessionStream] stale generation after retry delay, aborting')
             return
           }
@@ -632,7 +637,7 @@ export function useSessionStream({
             result.success,
             Array.isArray(result.messages) ? result.messages.length : 0
           )
-          if (generationRef.current !== currentGeneration) return
+          if (!isCurrentGeneration()) return
         }
 
         if (result.success && result.messages) {
@@ -708,7 +713,7 @@ export function useSessionStream({
       } catch (error) {
         console.error('[useSessionStream] Failed to load initial messages:', error)
       } finally {
-        if (generationRef.current === currentGeneration) {
+        if (isCurrentGeneration()) {
           setIsLoading(false)
         }
       }
@@ -718,6 +723,10 @@ export function useSessionStream({
 
     // ---- Cleanup ----
     return () => {
+      active = false
+      if (generationRef.current === currentGeneration) {
+        generationRef.current += 1
+      }
       unsubscribe()
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current)

--- a/src/renderer/src/lib/__tests__/handoffSelection.test.ts
+++ b/src/renderer/src/lib/__tests__/handoffSelection.test.ts
@@ -1,8 +1,18 @@
-import { describe, expect, it } from 'vitest'
-import { buildHandoffPrompt, type HandoffSelectionOverride } from '../handoffSelection'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  buildHandoffPrompt,
+  resolveSessionCreationSelection,
+  type HandoffSelectionOverride
+} from '../handoffSelection'
 import { SUPER_PLAN_MODE_PREFIX } from '../constants'
+import { useSettingsStore } from '@/stores/useSettingsStore'
 
 const model = { providerID: 'codex', modelID: 'gpt-5.5' }
+const initialSettingsState = useSettingsStore.getState()
+
+afterEach(() => {
+  useSettingsStore.setState(initialSettingsState, true)
+})
 
 describe('buildHandoffPrompt', () => {
   it('prefixes goal mode only for codex handoffs', () => {
@@ -54,5 +64,44 @@ describe('buildHandoffPrompt', () => {
     expect(buildHandoffPrompt(planContent, legacySuper)).toBe(
       'Implement the following plan\n1. Build the thing'
     )
+  })
+})
+
+describe('resolveSessionCreationSelection', () => {
+  it('preserves an explicit Claude CLI SDK even when a mode default uses Claude SDK', () => {
+    useSettingsStore.setState({
+      defaultAgentSdk: 'opencode',
+      selectedModel: null,
+      selectedModelByProvider: {
+        'claude-code-cli': {
+          providerID: 'anthropic',
+          modelID: 'sonnet',
+          variant: 'high'
+        }
+      },
+      defaultModels: {
+        build: {
+          agentSdk: 'claude-code',
+          providerID: 'anthropic',
+          modelID: 'claude-opus-4-5-20251101',
+          variant: 'max'
+        },
+        plan: null,
+        ask: null,
+        review: null
+      }
+    })
+
+    const selection = resolveSessionCreationSelection({
+      agentSdkOverride: 'claude-code-cli',
+      initialMode: 'build'
+    })
+
+    expect(selection.agentSdk).toBe('claude-code-cli')
+    expect(selection.model).toMatchObject({
+      providerID: 'anthropic',
+      modelID: 'sonnet',
+      variant: 'high'
+    })
   })
 })

--- a/src/renderer/src/lib/__tests__/handoffSelection.test.ts
+++ b/src/renderer/src/lib/__tests__/handoffSelection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { buildHandoffPrompt, type HandoffSelectionOverride } from '../handoffSelection'
+import { SUPER_PLAN_MODE_PREFIX } from '../constants'
 
 const model = { providerID: 'codex', modelID: 'gpt-5.5' }
 
@@ -32,5 +33,26 @@ describe('buildHandoffPrompt', () => {
       'Implement the following plan\n1. Build the thing'
     )
     expect(buildHandoffPrompt(planContent)).toBe('Implement the following plan\n1. Build the thing')
+  })
+
+  it('prefixes super-plan instructions for Claude CLI handoffs only', () => {
+    const planContent = '1. Build the thing'
+    const cliSuper: HandoffSelectionOverride = {
+      agentSdk: 'claude-code-cli',
+      model,
+      superPlan: true
+    }
+    const legacySuper: HandoffSelectionOverride = {
+      agentSdk: 'claude-code',
+      model,
+      superPlan: true
+    }
+
+    expect(buildHandoffPrompt(planContent, cliSuper)).toBe(
+      `${SUPER_PLAN_MODE_PREFIX}Implement the following plan\n1. Build the thing`
+    )
+    expect(buildHandoffPrompt(planContent, legacySuper)).toBe(
+      'Implement the following plan\n1. Build the thing'
+    )
   })
 })

--- a/src/renderer/src/lib/__tests__/handoffSelection.test.ts
+++ b/src/renderer/src/lib/__tests__/handoffSelection.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   buildHandoffPrompt,
+  getAvailableHandoffAgentSdks,
+  getHandoffSdkDisplayName,
   resolveSessionCreationSelection,
   type HandoffSelectionOverride
 } from '../handoffSelection'
@@ -103,5 +105,21 @@ describe('resolveSessionCreationSelection', () => {
       modelID: 'sonnet',
       variant: 'high'
     })
+  })
+})
+
+describe('handoff provider visuals', () => {
+  it('orders Claude Code second and Claude CLI last', () => {
+    expect(getAvailableHandoffAgentSdks({ opencode: true, claude: true, codex: true })).toEqual([
+      'opencode',
+      'claude-code',
+      'codex',
+      'claude-code-cli'
+    ])
+  })
+
+  it('displays Claude Code without legacy wording', () => {
+    expect(getHandoffSdkDisplayName('claude-code')).toBe('Claude Code')
+    expect(getHandoffSdkDisplayName('claude-code-cli')).toBe('Claude Code (CLI)')
   })
 })

--- a/src/renderer/src/lib/agent-sdk-availability.ts
+++ b/src/renderer/src/lib/agent-sdk-availability.ts
@@ -11,7 +11,7 @@ function getAgentSdkLabel(sdk: Exclude<SelectableAgentSdk, 'terminal'>): string 
     case 'opencode':
       return 'OpenCode'
     case 'claude-code':
-      return 'Claude Code (legacy SDK)'
+      return 'Claude Code'
     case 'claude-code-cli':
       return 'Claude Code (CLI)'
     case 'codex':

--- a/src/renderer/src/lib/agent-sdk-availability.ts
+++ b/src/renderer/src/lib/agent-sdk-availability.ts
@@ -4,14 +4,16 @@ export interface AvailableAgentSdks {
   codex: boolean
 }
 
-export type SelectableAgentSdk = 'opencode' | 'claude-code' | 'codex' | 'terminal'
+export type SelectableAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
 
 function getAgentSdkLabel(sdk: Exclude<SelectableAgentSdk, 'terminal'>): string {
   switch (sdk) {
     case 'opencode':
       return 'OpenCode'
     case 'claude-code':
-      return 'Claude Code'
+      return 'Claude Code (legacy SDK)'
+    case 'claude-code-cli':
+      return 'Claude Code (CLI)'
     case 'codex':
       return 'Codex'
   }
@@ -27,6 +29,7 @@ export function isAgentSdkAvailable(
     case 'opencode':
       return availableAgentSdks.opencode
     case 'claude-code':
+    case 'claude-code-cli':
       return availableAgentSdks.claude
     case 'codex':
       return availableAgentSdks.codex

--- a/src/renderer/src/lib/agent-sdk-availability.ts
+++ b/src/renderer/src/lib/agent-sdk-availability.ts
@@ -1,10 +1,13 @@
+import type { AgentSdk } from '@shared/types/agent-sdk'
+
 export interface AvailableAgentSdks {
   opencode: boolean
   claude: boolean
   codex: boolean
 }
 
-export type SelectableAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+/** Alias of the shared {@link AgentSdk} union, kept for this module's selection-focused naming. */
+export type SelectableAgentSdk = AgentSdk
 
 function getAgentSdkLabel(sdk: Exclude<SelectableAgentSdk, 'terminal'>): string {
   switch (sdk) {

--- a/src/renderer/src/lib/auto-launch.claude-cli.test.ts
+++ b/src/renderer/src/lib/auto-launch.claude-cli.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { autoLaunchTicket } from './auto-launch'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useUsageStore } from '@/stores/useUsageStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { Session } from '../../../main/db/types'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialUsageState = useUsageStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: 'anthropic',
+    model_id: 'opus',
+    model_variant: 'high',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    pinned_to_board: false,
+    ...overrides
+  }
+}
+
+function setupStores(): {
+  createSession: ReturnType<typeof vi.fn>
+  setSessionModel: ReturnType<typeof vi.fn>
+  updateTicket: ReturnType<typeof vi.fn>
+} {
+  const createSession = vi.fn(async (worktreeId: string, projectId: string, sdk: Session['agent_sdk'], mode: Session['mode']) => ({
+    success: true,
+    session: makeSession({ worktree_id: worktreeId, project_id: projectId, agent_sdk: sdk, mode })
+  }))
+  const setSessionModel = vi.fn(async () => undefined)
+  const updateTicket = vi.fn(async () => undefined)
+
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '/repo',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        last_accessed_at: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([
+      [
+        'project-1',
+        [
+          {
+            id: 'worktree-1',
+            project_id: 'project-1',
+            name: 'Feature',
+            branch_name: 'feature',
+            path: '/repo/feature',
+            status: 'active',
+            is_default: false,
+            branch_renamed: 0,
+            last_message_at: null,
+            session_titles: '[]',
+            last_model_provider_id: null,
+            last_model_id: null,
+            last_model_variant: null,
+            attachments: '[]',
+            created_at: '2026-01-01T00:00:00.000Z',
+            last_accessed_at: '2026-01-01T00:00:00.000Z',
+            github_pr_number: null,
+            github_pr_url: null
+          }
+        ]
+      ]
+    ])
+  })
+  useKanbanStore.setState({ updateTicket })
+  useSessionStore.setState({
+    createSession,
+    setSessionModel,
+    setSessionMode: vi.fn(async () => undefined)
+  })
+  useWorktreeStatusStore.setState({
+    setSessionStatus: vi.fn(),
+    setLastMessageTime: vi.fn()
+  })
+  useUsageStore.setState({
+    fetchUsageForProvider: vi.fn()
+  })
+
+  return { createSession, setSessionModel, updateTicket }
+}
+
+function setupWindowApis(): void {
+  Object.defineProperty(window, 'terminalOps', {
+    configurable: true,
+    writable: true,
+    value: {
+      createClaudeCli: vi.fn().mockResolvedValue({ success: true, value: { success: true } })
+    }
+  })
+  Object.defineProperty(window, 'opencodeOps', {
+    configurable: true,
+    writable: true,
+    value: {
+      connect: vi.fn().mockResolvedValue({ success: true, value: { success: true, sessionId: 'opc-1' } }),
+      prompt: vi.fn().mockResolvedValue({ success: true, value: { success: true } })
+    }
+  })
+  Object.defineProperty(window, 'db', {
+    configurable: true,
+    writable: true,
+    value: {
+      session: {
+        update: vi.fn().mockResolvedValue({ success: true, value: undefined })
+      }
+    }
+  })
+}
+
+describe('autoLaunchTicket Claude CLI', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupWindowApis()
+    setupStores()
+  })
+
+  afterEach(() => {
+    useSessionStore.setState(initialSessionState, true)
+    useWorktreeStore.setState(initialWorktreeState, true)
+    useKanbanStore.setState(initialKanbanState, true)
+    useProjectStore.setState(initialProjectState, true)
+    useUsageStore.setState(initialUsageState, true)
+    useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
+    delete (window as { terminalOps?: unknown }).terminalOps
+    delete (window as { opencodeOps?: unknown }).opencodeOps
+    delete (window as { db?: unknown }).db
+  })
+
+  it('consumes a Claude CLI pending launch by spawning terminalOps instead of OpenCode', async () => {
+    const { createSession, setSessionModel, updateTicket } = setupStores()
+    await autoLaunchTicket({
+      id: 'ticket-1',
+      project_id: 'project-1',
+      title: 'Launch Claude CLI',
+      pending_launch_config: JSON.stringify({
+        worktree: { type: 'existing', worktreeId: 'worktree-1' },
+        prompt: 'Implement the ticket',
+        mode: 'plan',
+        model: { providerID: 'anthropic', modelID: 'opus', variant: 'high' },
+        sdk: 'claude-code-cli',
+        codexFastMode: false,
+        goalMode: false,
+        goalSuccessCriteria: null
+      })
+    })
+
+    expect(createSession).toHaveBeenCalledWith('worktree-1', 'project-1', 'claude-code-cli', 'plan', {
+      autoFocus: false,
+      modelOverride: {
+        agentSdk: 'claude-code-cli',
+        providerID: 'anthropic',
+        modelID: 'opus',
+        variant: 'high'
+      },
+      pendingMessage: 'Implement the ticket'
+    })
+    expect(setSessionModel).toHaveBeenCalledWith('session-1', {
+      providerID: 'anthropic',
+      modelID: 'opus',
+      variant: 'high'
+    })
+    expect(updateTicket).toHaveBeenCalledWith('ticket-1', 'project-1', expect.objectContaining({
+      pending_launch_config: null,
+      current_session_id: 'session-1',
+      worktree_id: 'worktree-1',
+      mode: 'plan'
+    }))
+    expect(window.terminalOps.createClaudeCli).toHaveBeenCalledWith('session-1', {
+      pendingPrompt: 'Implement the ticket'
+    })
+    expect(window.opencodeOps.connect).not.toHaveBeenCalled()
+    expect(window.opencodeOps.prompt).not.toHaveBeenCalled()
+  })
+
+  it('wraps goal-mode prompts before spawning Claude CLI', async () => {
+    await autoLaunchTicket({
+      id: 'ticket-1',
+      project_id: 'project-1',
+      title: 'Launch Claude CLI',
+      pending_launch_config: JSON.stringify({
+        worktree: { type: 'existing', worktreeId: 'worktree-1' },
+        prompt: 'Implement the ticket',
+        mode: 'build',
+        model: null,
+        sdk: 'claude-code-cli',
+        codexFastMode: false,
+        goalMode: true,
+        goalSuccessCriteria: 'Tests pass'
+      })
+    })
+
+    expect(window.terminalOps.createClaudeCli).toHaveBeenCalledWith('session-1', {
+      pendingPrompt: '/goal Implement the ticket. Goal success criteria: Tests pass'
+    })
+  })
+})

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -172,7 +172,9 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
         })
 
       if (config.mode === 'super-plan') {
-        useSessionStore.getState().setSessionMode(sessionId, 'plan')
+        // Await so the persisted mode is committed before the main process
+        // reads it in buildClaudeCliPtySpawn (createClaudeCli).
+        await useSessionStore.getState().setSessionMode(sessionId, 'plan')
       }
 
       bumpWorktreeLastMessage({ worktreeId })

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -28,7 +28,7 @@ interface PendingLaunchConfig {
   prompt: string
   mode: AutoLaunchMode
   model: { providerID: string; modelID: string; variant?: string } | null
-  sdk: 'opencode' | 'claude-code' | 'codex'
+  sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex'
   codexFastMode: boolean
   goalMode: boolean
   goalSuccessCriteria: string | null
@@ -37,6 +37,34 @@ interface PendingLaunchConfig {
 function wrapGoalPrompt(prompt: string, criteria: string): string {
   const stripped = prompt.replace(/^\/goal\s+/, '')
   return `/goal ${stripped}. Goal success criteria: ${criteria}`
+}
+
+function composeAutoLaunchPrompt(
+  config: PendingLaunchConfig,
+  sessionAgentSdk: string | null | undefined,
+  configGoalMode: boolean,
+  configGoalSuccessCriteria: string | null,
+  options: { claudeCli: boolean }
+): string | null {
+  const trimmedPrompt = config.prompt.trim()
+  if (!trimmedPrompt) return null
+
+  const skipPrefix =
+    options.claudeCli ||
+    sessionAgentSdk === 'claude-code' ||
+    sessionAgentSdk === 'codex' ||
+    sessionAgentSdk === 'claude-code-cli'
+  const modePrefix =
+    config.mode === 'super-plan'
+      ? getSuperPlanModePrefix(sessionAgentSdk)
+      : config.mode === 'plan' && !skipPrefix
+        ? PLAN_MODE_PREFIX
+        : ''
+  const fullPrompt = modePrefix + trimmedPrompt
+
+  return configGoalMode && configGoalSuccessCriteria
+    ? wrapGoalPrompt(fullPrompt, configGoalSuccessCriteria)
+    : fullPrompt
 }
 
 export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> {
@@ -82,9 +110,21 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
     }
 
     // 2. Create session
+    const modelOverride = config.model ? { ...config.model, agentSdk: config.sdk } : undefined
+    const cliPendingPrompt =
+      config.sdk === 'claude-code-cli'
+        ? composeAutoLaunchPrompt(config, config.sdk, configGoalMode, configGoalSuccessCriteria, {
+            claudeCli: true
+          })
+        : null
+    const createOptions = {
+      autoFocus: false,
+      ...(modelOverride ? { modelOverride } : {}),
+      ...(cliPendingPrompt ? { pendingMessage: cliPendingPrompt } : {})
+    }
     const sessionResult = await useSessionStore
       .getState()
-      .createSession(worktreeId, ticket.project_id, config.sdk, config.mode, { autoFocus: false })
+      .createSession(worktreeId, ticket.project_id, config.sdk, config.mode, createOptions)
     if (!sessionResult.success || !sessionResult.session) {
       toast.error(`Auto-launch failed: ${sessionResult.error || 'Could not create session'}`)
       return
@@ -124,6 +164,29 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
     // 7. Toast notification
     toast.success(`Auto-launched: ${ticket.title}`)
 
+    if (sessionAgentSdk === 'claude-code-cli') {
+      const outboundPrompt =
+        cliPendingPrompt ??
+        composeAutoLaunchPrompt(config, sessionAgentSdk, configGoalMode, configGoalSuccessCriteria, {
+          claudeCli: true
+        })
+
+      if (config.mode === 'super-plan') {
+        useSessionStore.getState().setSessionMode(sessionId, 'plan')
+      }
+
+      bumpWorktreeLastMessage({ worktreeId })
+      const result = unwrapEnvelope(
+        await window.terminalOps.createClaudeCli(sessionId, {
+          pendingPrompt: outboundPrompt
+        })
+      )
+      if (result.success && outboundPrompt) {
+        useSessionStore.getState().dequeuePendingMessage(sessionId)
+      }
+      return
+    }
+
     // 8. Connect to OpenCode and send prompt
     const allWorktrees = Array.from(useWorktreeStore.getState().worktreesByProject.values()).flat()
     const worktree = allWorktrees.find((w) => w.id === worktreeId)
@@ -137,18 +200,13 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
 
     // 9. Send prompt
     if (config.prompt.trim()) {
-      const skipPrefix = sessionAgentSdk === 'claude-code' || sessionAgentSdk === 'codex'
-      const modePrefix =
-        config.mode === 'super-plan'
-          ? getSuperPlanModePrefix(sessionAgentSdk)
-          : config.mode === 'plan' && !skipPrefix
-            ? PLAN_MODE_PREFIX
-            : ''
-      const fullPrompt = modePrefix + config.prompt.trim()
-      const outboundPrompt =
-        configGoalMode && configGoalSuccessCriteria
-          ? wrapGoalPrompt(fullPrompt, configGoalSuccessCriteria)
-          : fullPrompt
+      const outboundPrompt = composeAutoLaunchPrompt(
+        config,
+        sessionAgentSdk,
+        configGoalMode,
+        configGoalSuccessCriteria,
+        { claudeCli: false }
+      )
       const promptOptions =
         sessionAgentSdk === 'codex' ? { codexFastMode: config.codexFastMode } : undefined
 

--- a/src/renderer/src/lib/backgroundSessionStart.claude-cli.test.ts
+++ b/src/renderer/src/lib/backgroundSessionStart.claude-cli.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { startBackgroundSessionPrompt } from './backgroundSessionStart'
+
+// Seed the store with a single claude-code-cli session so findSessionModelSource
+// resolves it. setState merges, so the store's methods stay intact.
+function seedClaudeCliSession(): void {
+  useSessionStore.setState({
+    sessionsByWorktree: new Map([
+      [
+        'wt1',
+        [
+          {
+            id: 's1',
+            agent_sdk: 'claude-code-cli',
+            model_provider_id: null,
+            model_id: null,
+            model_variant: null
+          }
+        ]
+      ]
+    ]),
+    sessionsByConnection: new Map(),
+    pendingMessages: new Map()
+  } as never)
+}
+
+function mockSendClaudeCliPrompt(delivered: boolean): ReturnType<typeof vi.fn> {
+  const sendClaudeCliPrompt = vi.fn().mockResolvedValue({ success: true, value: { delivered } })
+  ;(window as unknown as { terminalOps: { sendClaudeCliPrompt: unknown } }).terminalOps = {
+    sendClaudeCliPrompt
+  }
+  return sendClaudeCliPrompt
+}
+
+describe('startBackgroundSessionPrompt — claude-code-cli follow-up delivery', () => {
+  beforeEach(() => {
+    seedClaudeCliSession()
+  })
+
+  it('delivers straight to the live PTY and does not queue when delivered', async () => {
+    const sendClaudeCliPrompt = mockSendClaudeCliPrompt(true)
+
+    await startBackgroundSessionPrompt({
+      worktreePath: '/repo',
+      sessionId: 's1',
+      prompt: 'follow-up question',
+      bumpTarget: {}
+    })
+
+    expect(sendClaudeCliPrompt).toHaveBeenCalledWith('s1', 'follow-up question')
+    expect(useSessionStore.getState().pendingMessages.get('s1')).toBeUndefined()
+  })
+
+  it('queues the prompt for the next spawn when no live PTY exists', async () => {
+    const sendClaudeCliPrompt = mockSendClaudeCliPrompt(false)
+
+    await startBackgroundSessionPrompt({
+      worktreePath: '/repo',
+      sessionId: 's1',
+      prompt: 'follow-up question',
+      bumpTarget: {}
+    })
+
+    expect(sendClaudeCliPrompt).toHaveBeenCalledWith('s1', 'follow-up question')
+    expect(useSessionStore.getState().pendingMessages.get('s1')).toBe('follow-up question')
+  })
+})

--- a/src/renderer/src/lib/backgroundSessionStart.ts
+++ b/src/renderer/src/lib/backgroundSessionStart.ts
@@ -11,7 +11,7 @@ const db = unwrapEnvelopeApi(() => window.db)
 
 type SessionModelSource = {
   id: string
-  agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   model_provider_id: string | null
   model_id: string | null
   model_variant: string | null
@@ -53,6 +53,12 @@ export async function startBackgroundSessionPrompt(opts: {
   prompt: string
   bumpTarget: { worktreeId?: string | null; connectionId?: string | null }
 }): Promise<void> {
+  const session = findSessionModelSource(opts.sessionId)
+  if (session?.agent_sdk === 'claude-code-cli') {
+    useSessionStore.getState().setPendingMessage(opts.sessionId, opts.prompt)
+    return
+  }
+
   const connectResult = unwrapEnvelope(
     await window.opencodeOps.connect(opts.worktreePath, opts.sessionId)
   )

--- a/src/renderer/src/lib/backgroundSessionStart.ts
+++ b/src/renderer/src/lib/backgroundSessionStart.ts
@@ -1,4 +1,5 @@
 import type { SelectedModel } from '@/stores/useSettingsStore'
+import { type AgentSdk, isClaudeCli } from '@shared/types/agent-sdk'
 import { resolveModelForSdk } from '@/stores/useSettingsStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
@@ -11,7 +12,7 @@ const db = unwrapEnvelopeApi(() => window.db)
 
 type SessionModelSource = {
   id: string
-  agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agent_sdk: AgentSdk
   model_provider_id: string | null
   model_id: string | null
   model_variant: string | null
@@ -54,8 +55,17 @@ export async function startBackgroundSessionPrompt(opts: {
   bumpTarget: { worktreeId?: string | null; connectionId?: string | null }
 }): Promise<void> {
   const session = findSessionModelSource(opts.sessionId)
-  if (session?.agent_sdk === 'claude-code-cli') {
-    useSessionStore.getState().setPendingMessage(opts.sessionId, opts.prompt)
+  if (isClaudeCli(session?.agent_sdk)) {
+    // Deliver straight to the live PTY if the session is already running;
+    // otherwise queue it so the next spawn picks it up as the prompt argument
+    // (createClaudeTerminal -> dequeuePendingMessage). Without the live-PTY path
+    // a follow-up to a running CLI session would be silently dropped.
+    const { delivered } = unwrapEnvelope(
+      await window.terminalOps.sendClaudeCliPrompt(opts.sessionId, opts.prompt)
+    )
+    if (!delivered) {
+      useSessionStore.getState().setPendingMessage(opts.sessionId, opts.prompt)
+    }
     return
   }
 

--- a/src/renderer/src/lib/effect/run-ipc-effect.ts
+++ b/src/renderer/src/lib/effect/run-ipc-effect.ts
@@ -13,7 +13,20 @@ const messageFromUnknown = (error: unknown): string => {
   }
 }
 
-export const runIpcEffect = <A>(invoke: () => Promise<Envelope<A>>): Effect.Effect<A, IpcError> =>
+const isSuccessEnvelope = <A>(value: Envelope<A> | A): value is Extract<Envelope<A>, { success: true }> =>
+  Boolean(value && typeof value === 'object' && 'success' in value && value.success === true && 'value' in value)
+
+const isFailureEnvelope = <A>(value: Envelope<A> | A): value is Extract<Envelope<A>, { success: false }> =>
+  Boolean(
+    value &&
+      typeof value === 'object' &&
+      'success' in value &&
+      value.success === false &&
+      'errorCode' in value &&
+      'error' in value
+  )
+
+export const runIpcEffect = <A>(invoke: () => Promise<Envelope<A> | A>): Effect.Effect<A, IpcError> =>
   Effect.tryPromise({
     try: invoke,
     catch: (error) =>
@@ -23,15 +36,17 @@ export const runIpcEffect = <A>(invoke: () => Promise<Envelope<A>>): Effect.Effe
         details: error
       })
   }).pipe(
-    Effect.flatMap((envelope) =>
-      envelope.success
-        ? Effect.succeed(envelope.value)
-        : Effect.fail(
-            new IpcError({
-              errorCode: envelope.errorCode,
-              error: envelope.error,
-              details: envelope.details
-            })
-          )
-    )
+    Effect.flatMap((envelope) => {
+      if (isSuccessEnvelope(envelope)) return Effect.succeed(envelope.value)
+      if (isFailureEnvelope(envelope)) {
+        return Effect.fail(
+          new IpcError({
+            errorCode: envelope.errorCode,
+            error: envelope.error,
+            details: envelope.details
+          })
+        )
+      }
+      return Effect.succeed(envelope as A)
+    })
   )

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -15,6 +15,7 @@ import {
 } from '@/stores/useSettingsStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
+import { SUPER_PLAN_MODE_PREFIX } from '@/lib/constants'
 
 export interface EffectiveHandoffSelection {
   agentSdk: HandoffAgentSdk
@@ -30,6 +31,7 @@ export interface HandoffSelectionOverride {
   agentSdk: HandoffAgentSdk
   model: SelectedModel
   goalMode?: boolean
+  superPlan?: boolean
 }
 
 export function buildHandoffPrompt(
@@ -37,18 +39,22 @@ export function buildHandoffPrompt(
   override?: HandoffSelectionOverride
 ): string {
   const goalPrefix = override?.goalMode && override.agentSdk === 'codex' ? '/goal ' : ''
-  return `${goalPrefix}Implement the following plan\n${planContent}`
+  const superPrefix =
+    override?.superPlan && override.agentSdk === 'claude-code-cli' ? SUPER_PLAN_MODE_PREFIX : ''
+  return `${superPrefix}${goalPrefix}Implement the following plan\n${planContent}`
 }
 
 const SDK_DISPLAY_NAMES: Record<HandoffAgentSdk, string> = {
   opencode: 'OpenCode',
-  'claude-code': 'Claude Code',
+  'claude-code': 'Claude Code (legacy SDK)',
+  'claude-code-cli': 'Claude Code (CLI)',
   codex: 'Codex'
 }
 
 const FALLBACK_MODELS: Record<HandoffAgentSdk, SelectedModel> = {
   opencode: { providerID: 'anthropic', modelID: 'claude-opus-4-5-20251101' },
   'claude-code': { providerID: 'anthropic', modelID: 'claude-opus-4-5-20251101' },
+  'claude-code-cli': { providerID: 'anthropic', modelID: 'sonnet', variant: 'high' },
   codex: { providerID: 'codex', modelID: 'gpt-5.5' }
 }
 
@@ -56,9 +62,16 @@ const modelCatalogCache = new Map<HandoffAgentSdk, ProviderModels[]>()
 const inflightModelCatalogRequests = new Map<HandoffAgentSdk, Promise<ProviderModels[]>>()
 
 function normalizeHandoffSdk(
-  sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal' | null | undefined
+  sdk:
+    | 'opencode'
+    | 'claude-code'
+    | 'claude-code-cli'
+    | 'codex'
+    | 'terminal'
+    | null
+    | undefined
 ): HandoffAgentSdk {
-  if (sdk === 'claude-code' || sdk === 'codex') return sdk
+  if (sdk === 'claude-code' || sdk === 'claude-code-cli' || sdk === 'codex') return sdk
   return 'opencode'
 }
 
@@ -105,7 +118,7 @@ function getWorktreeFallbackModel(worktreeId?: string): SelectedModel | null {
 
 function resolveSessionSelection(opts: {
   worktreeId?: string
-  agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   mode?: 'build' | 'plan' | 'super-plan'
 }): EffectiveHandoffSelection {
   const settings = useSettingsStore.getState()
@@ -159,7 +172,7 @@ export function getHandoffSdkDisplayName(agentSdk: HandoffAgentSdk): string {
 export function getAvailableHandoffAgentSdks(
   availableAgentSdks?: AvailableAgentSdks | null
 ): HandoffAgentSdk[] {
-  const orderedSdks: HandoffAgentSdk[] = ['opencode', 'claude-code', 'codex']
+  const orderedSdks: HandoffAgentSdk[] = ['opencode', 'claude-code-cli', 'claude-code', 'codex']
   return orderedSdks.filter((sdk) => isAgentSdkAvailable(sdk, availableAgentSdks))
 }
 
@@ -191,8 +204,9 @@ export async function loadHandoffModelCatalog(
   if (inflight) return inflight
   if (typeof window.opencodeOps?.listModels !== 'function') return []
 
+  const listModelsSdk = agentSdk === 'claude-code-cli' ? 'claude-code' : agentSdk
   const request = window.opencodeOps
-    .listModels({ agentSdk })
+    .listModels({ agentSdk: listModelsSdk })
     .then(unwrapEnvelope)
     .then((result) => {
       const parsed = result.success ? cacheHandoffModelCatalog(agentSdk, result.providers) : []
@@ -253,11 +267,11 @@ export function getEffectiveHandoffSelection(opts: {
 
 export function resolveSessionCreationSelection(opts: {
   worktreeId?: string
-  agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  agentSdkOverride?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   initialMode?: 'build' | 'plan' | 'super-plan'
   modelOverride?: SelectedModel
 }): {
-  agentSdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  agentSdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   model: SelectedModel | null
 } {
   const settings = useSettingsStore.getState()

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -286,6 +286,15 @@ export function resolveSessionCreationSelection(opts: {
     return { agentSdk, model: opts.modelOverride }
   }
 
+  if (opts.agentSdkOverride) {
+    const resolvedAgentSdk = normalizeHandoffSdk(opts.agentSdkOverride)
+    const model = resolveModelForSdk(resolvedAgentSdk, settings)
+    return {
+      agentSdk: resolvedAgentSdk,
+      model: buildModelSelection(model, resolvedAgentSdk)
+    }
+  }
+
   const resolved = resolveSessionSelection({
     worktreeId: opts.worktreeId,
     agentSdk,

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -1,4 +1,5 @@
 import { isAgentSdkAvailable, type AvailableAgentSdks } from './agent-sdk-availability'
+import { type AgentSdk, toModelCatalogSdk } from '@shared/types/agent-sdk'
 import {
   findModelInfo,
   getFirstModelInfo,
@@ -118,7 +119,7 @@ function getWorktreeFallbackModel(worktreeId?: string): SelectedModel | null {
 
 function resolveSessionSelection(opts: {
   worktreeId?: string
-  agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agentSdk?: AgentSdk
   mode?: 'build' | 'plan' | 'super-plan'
   explicitSdk?: boolean
 }): EffectiveHandoffSelection {
@@ -213,7 +214,7 @@ export async function loadHandoffModelCatalog(
   if (inflight) return inflight
   if (typeof window.opencodeOps?.listModels !== 'function') return []
 
-  const listModelsSdk = agentSdk === 'claude-code-cli' ? 'claude-code' : agentSdk
+  const listModelsSdk = toModelCatalogSdk(agentSdk)
   const request = window.opencodeOps
     .listModels({ agentSdk: listModelsSdk })
     .then(unwrapEnvelope)
@@ -276,11 +277,11 @@ export function getEffectiveHandoffSelection(opts: {
 
 export function resolveSessionCreationSelection(opts: {
   worktreeId?: string
-  agentSdkOverride?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agentSdkOverride?: AgentSdk
   initialMode?: 'build' | 'plan' | 'super-plan'
   modelOverride?: SelectedModel
 }): {
-  agentSdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agentSdk: AgentSdk
   model: SelectedModel | null
 } {
   const settings = useSettingsStore.getState()

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -46,7 +46,7 @@ export function buildHandoffPrompt(
 
 const SDK_DISPLAY_NAMES: Record<HandoffAgentSdk, string> = {
   opencode: 'OpenCode',
-  'claude-code': 'Claude Code (legacy SDK)',
+  'claude-code': 'Claude Code',
   'claude-code-cli': 'Claude Code (CLI)',
   codex: 'Codex'
 }
@@ -181,7 +181,7 @@ export function getHandoffSdkDisplayName(agentSdk: HandoffAgentSdk): string {
 export function getAvailableHandoffAgentSdks(
   availableAgentSdks?: AvailableAgentSdks | null
 ): HandoffAgentSdk[] {
-  const orderedSdks: HandoffAgentSdk[] = ['opencode', 'claude-code-cli', 'claude-code', 'codex']
+  const orderedSdks: HandoffAgentSdk[] = ['opencode', 'claude-code', 'codex', 'claude-code-cli']
   return orderedSdks.filter((sdk) => isAgentSdkAvailable(sdk, availableAgentSdks))
 }
 

--- a/src/renderer/src/lib/ipc-envelope.ts
+++ b/src/renderer/src/lib/ipc-envelope.ts
@@ -1,8 +1,22 @@
 import type { Envelope } from '@shared/types/ipc-envelope'
 
-export function unwrapEnvelope<A>(envelope: Envelope<A>): A {
-  if (envelope.success) return envelope.value
-  throw new Error(envelope.error)
+export function unwrapEnvelope<A>(envelope: Envelope<A> | A): A {
+  if (envelope && typeof envelope === 'object') {
+    if ('success' in envelope && envelope.success === true && 'value' in envelope) {
+      return envelope.value as A
+    }
+
+    if (
+      'success' in envelope &&
+      envelope.success === false &&
+      'errorCode' in envelope &&
+      'error' in envelope
+    ) {
+      throw new Error(String(envelope.error))
+    }
+  }
+
+  return envelope as A
 }
 
 export type UnwrappedEnvelopeApi<T> = T extends (...args: infer Args) => Promise<Envelope<infer A>>
@@ -16,6 +30,7 @@ export type UnwrappedEnvelopeApi<T> = T extends (...args: infer Args) => Promise
 export function unwrapEnvelopeApi<T extends object>(api: T | (() => T)): UnwrappedEnvelopeApi<T> {
   const resolve = (): Record<PropertyKey, unknown> => {
     const value = typeof api === 'function' ? (api as () => T)() : api
+    if (!value || typeof value !== 'object') return {}
     return value as Record<PropertyKey, unknown>
   }
 

--- a/src/renderer/src/stores/__tests__/useSessionStore.mount-requests.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.mount-requests.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { useSessionStore } from '../useSessionStore'
+
+const initialSessionState = useSessionStore.getState()
+
+describe('useSessionStore session mount requests', () => {
+  afterEach(() => {
+    useSessionStore.setState(initialSessionState, true)
+  })
+
+  it('refcounts renderer-only session mount requests by session id', () => {
+    const store = useSessionStore.getState()
+
+    store.requestSessionMount('session-1')
+    store.requestSessionMount('session-1')
+    store.requestSessionMount('session-2')
+
+    expect(useSessionStore.getState().sessionMountRequests).toEqual(
+      new Map([
+        ['session-1', 2],
+        ['session-2', 1]
+      ])
+    )
+
+    useSessionStore.getState().releaseSessionMount('session-1')
+
+    expect(useSessionStore.getState().sessionMountRequests).toEqual(
+      new Map([
+        ['session-1', 1],
+        ['session-2', 1]
+      ])
+    )
+
+    useSessionStore.getState().releaseSessionMount('session-1')
+    useSessionStore.getState().releaseSessionMount('session-2')
+    useSessionStore.getState().releaseSessionMount('session-2')
+
+    expect(useSessionStore.getState().sessionMountRequests.size).toBe(0)
+  })
+})

--- a/src/renderer/src/stores/store-coordination.ts
+++ b/src/renderer/src/stores/store-coordination.ts
@@ -37,7 +37,7 @@ export function clearConnectionSelection(): void {
 // importing useKanbanStore.
 
 export interface KanbanSessionEvent {
-  type: 'session_completed' | 'session_error' | 'plan_ready' | 'supercharge' | 'mode_change' | 'implement' | 'session_working'
+  type: 'session_completed' | 'session_error' | 'plan_ready' | 'plan_followup' | 'supercharge' | 'mode_change' | 'implement' | 'session_working'
   /** The mode the session was running in (build / plan) — relevant for completed events */
   sessionMode?: 'build' | 'plan'
   /** For supercharge: the newly-created session that replaces the old one */

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -694,6 +694,23 @@ export const useKanbanStore = create<KanbanState>()(
                 break
               }
 
+              case 'plan_followup': {
+                // User rejected or revised a ready plan in the Claude CLI terminal.
+                // The session is planning again, so clear review state and return
+                // the ticket to active work.
+                if (ticket.plan_ready) {
+                  get()
+                    .updateTicket(ticket.id, projectId, { plan_ready: false })
+                    .catch(() => {})
+                }
+                if (ticket.column !== 'in_progress') {
+                  get()
+                    .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
+                    .catch(() => {})
+                }
+                break
+              }
+
               case 'supercharge': {
                 // Supercharge creates a new session — re-attach ticket and reset plan_ready
                 // Idempotent: skip if already pointing at the new session

--- a/src/renderer/src/stores/useSessionHistoryStore.ts
+++ b/src/renderer/src/stores/useSessionHistoryStore.ts
@@ -13,6 +13,13 @@ interface SessionWithWorktree {
   name: string | null
   status: 'active' | 'completed' | 'error'
   opencode_session_id: string | null
+  claude_session_id: string | null
+  agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  mode: 'build' | 'plan' | 'super-plan'
+  session_type: 'default' | 'board-assistant'
+  model_provider_id: string | null
+  model_id: string | null
+  model_variant: string | null
   created_at: string
   updated_at: string
   completed_at: string | null

--- a/src/renderer/src/stores/useSessionHistoryStore.ts
+++ b/src/renderer/src/stores/useSessionHistoryStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import type { AgentSdk } from '@shared/types/agent-sdk'
 import { mapOpencodeMessagesToSessionViewMessages } from '@/lib/opencode-transcript'
 import { unwrapEnvelope, unwrapEnvelopeApi } from '@/lib/ipc-envelope'
 
@@ -14,7 +15,7 @@ interface SessionWithWorktree {
   status: 'active' | 'completed' | 'error'
   opencode_session_id: string | null
   claude_session_id: string | null
-  agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agent_sdk: AgentSdk
   mode: 'build' | 'plan' | 'super-plan'
   session_type: 'default' | 'board-assistant'
   model_provider_id: string | null

--- a/src/renderer/src/stores/useSessionStore.claude-cli-permission-mode.test.ts
+++ b/src/renderer/src/stores/useSessionStore.claude-cli-permission-mode.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useSessionStore, syncClaudeCliPermissionModeIfNeeded } from '@/stores/useSessionStore'
+
+const SHIFT_TAB = '\u001b[Z'
+
+function seedSession(agentSdk: string): void {
+  useSessionStore.setState({
+    sessionsByWorktree: new Map([['wt1', [{ id: 's1', agent_sdk: agentSdk }]]]),
+    sessionsByConnection: new Map(),
+    boardAssistantByProject: new Map(),
+    orphanedSessions: new Map()
+  } as never)
+}
+
+function mockWrite(): ReturnType<typeof vi.fn> {
+  const write = vi.fn()
+  ;(window as unknown as { terminalOps: { write: unknown } }).terminalOps = { write }
+  return write
+}
+
+describe('syncClaudeCliPermissionModeIfNeeded — Shift+Tab press counts', () => {
+  beforeEach(() => {
+    seedSession('claude-code-cli')
+  })
+
+  it('sends two Shift+Tab presses entering plan mode (normal → accept-edits → plan)', () => {
+    const write = mockWrite()
+    syncClaudeCliPermissionModeIfNeeded(useSessionStore.getState(), 's1', 'build', 'plan')
+    expect(write).toHaveBeenCalledTimes(2)
+    expect(write).toHaveBeenNthCalledWith(1, 's1', SHIFT_TAB)
+    expect(write).toHaveBeenNthCalledWith(2, 's1', SHIFT_TAB)
+  })
+
+  it('sends one Shift+Tab press leaving plan mode (plan → normal)', () => {
+    const write = mockWrite()
+    syncClaudeCliPermissionModeIfNeeded(useSessionStore.getState(), 's1', 'plan', 'build')
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(write).toHaveBeenCalledWith('s1', SHIFT_TAB)
+  })
+
+  it('treats super-plan as plan-like (two presses to enter, one to leave)', () => {
+    const enter = mockWrite()
+    syncClaudeCliPermissionModeIfNeeded(useSessionStore.getState(), 's1', 'build', 'super-plan')
+    expect(enter).toHaveBeenCalledTimes(2)
+
+    const leave = mockWrite()
+    syncClaudeCliPermissionModeIfNeeded(useSessionStore.getState(), 's1', 'super-plan', 'build')
+    expect(leave).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when the plan-like boundary is not crossed (plan → super-plan)', () => {
+    const write = mockWrite()
+    syncClaudeCliPermissionModeIfNeeded(useSessionStore.getState(), 's1', 'plan', 'super-plan')
+    expect(write).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for non-claude-code-cli sessions', () => {
+    seedSession('opencode')
+    const write = mockWrite()
+    syncClaudeCliPermissionModeIfNeeded(useSessionStore.getState(), 's1', 'build', 'plan')
+    expect(write).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -151,7 +151,7 @@ interface SessionState {
     projectId: string,
     agentSdkOverride?: AgentSdk,
     initialMode?: SessionMode,
-    options?: { autoFocus?: boolean; modelOverride?: SelectedModel }
+    options?: { autoFocus?: boolean; modelOverride?: SelectedModel; pendingMessage?: string | null }
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
   closeSession: (sessionId: string) => Promise<{ success: boolean; error?: string }>
   reopenSession: (
@@ -225,7 +225,7 @@ interface SessionState {
     connectionId: string,
     agentSdkOverride?: AgentSdk,
     initialMode?: SessionMode,
-    opts?: { autoFocus?: boolean; modelOverride?: SelectedModel }
+    opts?: { autoFocus?: boolean; modelOverride?: SelectedModel; pendingMessage?: string | null }
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
   setActiveConnectionSession: (sessionId: string | null) => void
   setActiveConnection: (connectionId: string | null) => void
@@ -509,7 +509,15 @@ export const useSessionStore = create<SessionState>()(
             const base = {
               sessionsByWorktree: newSessionsMap,
               tabOrderByWorktree: newTabOrderMap,
-              modeBySession: newModeMap
+              modeBySession: newModeMap,
+              ...(options?.pendingMessage
+                ? {
+                    pendingMessages: new Map(state.pendingMessages).set(
+                      session.id,
+                      options.pendingMessage
+                    )
+                  }
+                : {})
             }
 
             // Focus state — only when autoFocus is true
@@ -2048,7 +2056,15 @@ export const useSessionStore = create<SessionState>()(
             const base = {
               sessionsByConnection: newSessionsMap,
               tabOrderByConnection: newTabOrderMap,
-              modeBySession: newModeMap
+              modeBySession: newModeMap,
+              ...(opts?.pendingMessage
+                ? {
+                    pendingMessages: new Map(state.pendingMessages).set(
+                      session.id,
+                      opts.pendingMessage
+                    )
+                  }
+                : {})
             }
 
             // Focus state — only when autoFocus is true

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -130,6 +130,9 @@ interface SessionState {
   // MainPane subscribes to this to prune mountedTerminalSessionIds.
   closedTerminalSessionIds: Set<string>
 
+  // Renderer-only refcount for sessions that need their always-mounted view kept alive.
+  sessionMountRequests: Map<string, number>
+
   // Orphaned sessions (from archived worktrees) - read-only, not attached to any worktree
   orphanedSessions: Map<string, Session>
 
@@ -143,6 +146,8 @@ interface SessionState {
 
   // Actions
   acknowledgeClosedTerminals: (ids: Set<string>) => void
+  requestSessionMount: (sessionId: string) => void
+  releaseSessionMount: (sessionId: string) => void
   openOrphanedSession: (session: Session) => void
   closeOrphanedSessions: () => void
   loadSessions: (worktreeId: string, projectId: string) => Promise<void>
@@ -168,6 +173,8 @@ interface SessionState {
   reorderTabs: (worktreeId: string, fromIndex: number, toIndex: number) => void
   getSessionsForWorktree: (worktreeId: string) => Session[]
   getTabOrderForWorktree: (worktreeId: string) => string[]
+  getSessionById: (sessionId: string) => Session | null
+  hydrateSession: (session: Session) => void
   getSessionMode: (sessionId: string) => SessionMode
   getSuperArmed: (sessionId: string) => boolean
   toggleSessionMode: (sessionId: string) => Promise<void>
@@ -198,6 +205,7 @@ interface SessionState {
   getPendingPlan: (sessionId: string) => PendingPlan | null
   setCodexGoal: (sessionId: string, goal: CodexThreadGoal) => void
   clearCodexGoal: (sessionId: string) => void
+  applyModeDefaultModel: (sessionId: string, newMode: SessionMode) => Promise<void>
 
   // Pinned session actions
   pinSessionToBoard: (sessionId: string) => Promise<void>
@@ -308,6 +316,7 @@ export const useSessionStore = create<SessionState>()(
       activeConnectionId: null,
       inlineConnectionSessionId: null,
       closedTerminalSessionIds: new Set<string>(),
+      sessionMountRequests: new Map(),
 
       // Orphaned sessions
       orphanedSessions: new Map(),
@@ -325,6 +334,27 @@ export const useSessionStore = create<SessionState>()(
           const remaining = new Set(state.closedTerminalSessionIds)
           for (const id of ids) remaining.delete(id)
           return { closedTerminalSessionIds: remaining }
+        })
+      },
+
+      requestSessionMount: (sessionId: string) => {
+        set((state) => {
+          const requests = new Map(state.sessionMountRequests)
+          requests.set(sessionId, (requests.get(sessionId) ?? 0) + 1)
+          return { sessionMountRequests: requests }
+        })
+      },
+
+      releaseSessionMount: (sessionId: string) => {
+        set((state) => {
+          const requests = new Map(state.sessionMountRequests)
+          const nextCount = (requests.get(sessionId) ?? 0) - 1
+          if (nextCount > 0) {
+            requests.set(sessionId, nextCount)
+          } else {
+            requests.delete(sessionId)
+          }
+          return { sessionMountRequests: requests }
         })
       },
 

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -7,10 +7,9 @@ import { useSettingsStore } from './useSettingsStore'
 import { getUnavailableAgentSdkMessage } from '@/lib/agent-sdk-availability'
 import { resolveSessionCreationSelection } from '@/lib/handoffSelection'
 import { unwrapEnvelope, unwrapEnvelopeApi } from '@/lib/ipc-envelope'
+import { type AgentSdk, isTerminalBacked } from '@shared/types/agent-sdk'
 
 const db = unwrapEnvelopeApi(() => window.db)
-
-type AgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
 
 /**
  * Push the follow-up-message queue state for a session into the main process
@@ -277,7 +276,15 @@ function findSessionInState(state: SessionState, sessionId: string): Session | n
   return state.orphanedSessions.get(sessionId) ?? null
 }
 
-function syncClaudeCliPermissionModeIfNeeded(
+// Shift+Tab — Claude Code's "cycle permission mode" key.
+const CLAUDE_CLI_SHIFT_TAB = '\u001b[Z'
+
+// Claude Code cycles permission modes with Shift+Tab in the order
+// normal → accept-edits → plan → normal. Reaching plan from a non-plan mode
+// therefore takes two presses, while returning from plan takes one. The
+// previous code sent a single press in both directions, which landed on
+// accept-edits (not plan) when entering plan mode.
+export function syncClaudeCliPermissionModeIfNeeded(
   state: SessionState,
   sessionId: string,
   previousMode: SessionMode,
@@ -288,7 +295,11 @@ function syncClaudeCliPermissionModeIfNeeded(
   const wasPlanLike = previousMode === 'plan' || previousMode === 'super-plan'
   const isPlanLike = nextMode === 'plan' || nextMode === 'super-plan'
   if (wasPlanLike === isPlanLike) return
-  window.terminalOps.write(sessionId, '\x1b[Z')
+
+  const presses = isPlanLike ? 2 : 1
+  for (let i = 0; i < presses; i++) {
+    window.terminalOps.write(sessionId, CLAUDE_CLI_SHIFT_TAB)
+  }
 }
 
 export const useSessionStore = create<SessionState>()(
@@ -603,8 +614,7 @@ export const useSessionStore = create<SessionState>()(
           for (const [worktreeId, sessions] of get().sessionsByWorktree.entries()) {
             const found = sessions.find((s) => s.id === sessionId)
             if (found) {
-              isTerminalSession =
-                found.agent_sdk === 'terminal' || found.agent_sdk === 'claude-code-cli'
+              isTerminalSession = isTerminalBacked(found.agent_sdk)
               opencodeSessionId = found.opencode_session_id
               sessionWorktreeId = worktreeId
               break
@@ -614,8 +624,7 @@ export const useSessionStore = create<SessionState>()(
             for (const sessions of get().sessionsByConnection.values()) {
               const found = sessions.find((s) => s.id === sessionId)
               if (found) {
-                isTerminalSession =
-                  found.agent_sdk === 'terminal' || found.agent_sdk === 'claude-code-cli'
+                isTerminalSession = isTerminalBacked(found.agent_sdk)
                 opencodeSessionId = found.opencode_session_id
                 break
               }
@@ -1141,20 +1150,13 @@ export const useSessionStore = create<SessionState>()(
       },
 
       // Get session by ID from either worktree or connection sessions
-      getSessionById: (sessionId: string): Session | null => {
-        for (const sessions of get().sessionsByWorktree.values()) {
-          const found = sessions.find((s) => s.id === sessionId)
-          if (found) return found
-        }
-        for (const sessions of get().sessionsByConnection.values()) {
-          const found = sessions.find((s) => s.id === sessionId)
-          if (found) return found
-        }
-        for (const session of get().boardAssistantByProject.values()) {
-          if (session.id === sessionId) return session
-        }
-        return null
-      },
+      getSessionById: (sessionId: string): Session | null =>
+        // Delegate to the shared lookup so orphaned sessions (worktree archived,
+        // reopened via openOrphanedSession) are found too. Otherwise an orphaned
+        // claude-code-cli session resolves to null here and the SessionView
+        // wrapper routes it to the OpenCode LegacySessionView instead of
+        // ClaudeCliSessionView.
+        findSessionInState(get(), sessionId),
 
       // Hydrate a session from the DB into the in-memory store.
       // Called when findSessionById discovers a session via DB fallback so
@@ -1413,7 +1415,7 @@ export const useSessionStore = create<SessionState>()(
 
         // Push to agent backend (SDK-aware) — skip for terminal sessions
         try {
-          if (agentSdk !== 'terminal' && agentSdk !== 'claude-code-cli') {
+          if (!isTerminalBacked(agentSdk)) {
             unwrapEnvelope(await window.opencodeOps.setModel({ ...model, agentSdk }))
           }
         } catch (error) {

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -10,6 +10,8 @@ import { unwrapEnvelope, unwrapEnvelopeApi } from '@/lib/ipc-envelope'
 
 const db = unwrapEnvelopeApi(() => window.db)
 
+type AgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+
 /**
  * Push the follow-up-message queue state for a session into the main process
  * via IPC. Main uses this to suppress session-complete notifications while
@@ -39,9 +41,7 @@ function isVisibleSession(session: { name: string | null; session_type?: string 
   return !isBoardAssistantSessionName(session.name)
 }
 
-function getUnavailableProviderError(
-  sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
-): string | null {
+function getUnavailableProviderError(sdk: AgentSdk): string | null {
   const { availableAgentSdks } = useSettingsStore.getState()
   return getUnavailableAgentSdkMessage(sdk, availableAgentSdks)
 }
@@ -77,7 +77,8 @@ interface Session {
   name: string | null
   status: 'active' | 'completed' | 'error'
   opencode_session_id: string | null
-  agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  claude_session_id: string | null
+  agent_sdk: AgentSdk
   mode: SessionMode
   session_type: 'default' | 'board-assistant'
   model_provider_id: string | null
@@ -148,7 +149,7 @@ interface SessionState {
   createSession: (
     worktreeId: string,
     projectId: string,
-    agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
+    agentSdkOverride?: AgentSdk,
     initialMode?: SessionMode,
     options?: { autoFocus?: boolean; modelOverride?: SelectedModel }
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
@@ -179,6 +180,7 @@ interface SessionState {
     options?: { skipGlobalUpdate?: boolean }
   ) => Promise<void>
   setOpenCodeSessionId: (sessionId: string, opencodeSessionId: string | null) => void
+  setClaudeSessionId: (sessionId: string, claudeSessionId: string | null) => void
   setPendingMessage: (sessionId: string, message: string) => void
   dequeuePendingMessage: (sessionId: string) => string | null
   requeuePendingMessage: (sessionId: string, message: string) => void
@@ -221,7 +223,7 @@ interface SessionState {
   loadConnectionSessions: (connectionId: string) => Promise<void>
   createConnectionSession: (
     connectionId: string,
-    agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
+    agentSdkOverride?: AgentSdk,
     initialMode?: SessionMode,
     opts?: { autoFocus?: boolean; modelOverride?: SelectedModel }
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
@@ -250,6 +252,35 @@ function findSessionScope(
     }
   }
   return null
+}
+
+function findSessionInState(state: SessionState, sessionId: string): Session | null {
+  for (const sessions of state.sessionsByWorktree.values()) {
+    const found = sessions.find((session) => session.id === sessionId)
+    if (found) return found
+  }
+  for (const sessions of state.sessionsByConnection.values()) {
+    const found = sessions.find((session) => session.id === sessionId)
+    if (found) return found
+  }
+  for (const session of state.boardAssistantByProject.values()) {
+    if (session.id === sessionId) return session
+  }
+  return state.orphanedSessions.get(sessionId) ?? null
+}
+
+function syncClaudeCliPermissionModeIfNeeded(
+  state: SessionState,
+  sessionId: string,
+  previousMode: SessionMode,
+  nextMode: SessionMode
+): void {
+  const session = findSessionInState(state, sessionId)
+  if (session?.agent_sdk !== 'claude-code-cli') return
+  const wasPlanLike = previousMode === 'plan' || previousMode === 'super-plan'
+  const isPlanLike = nextMode === 'plan' || nextMode === 'super-plan'
+  if (wasPlanLike === isPlanLike) return
+  window.terminalOps.write(sessionId, '\x1b[Z')
 }
 
 export const useSessionStore = create<SessionState>()(
@@ -415,7 +446,7 @@ export const useSessionStore = create<SessionState>()(
       createSession: async (
         worktreeId: string,
         projectId: string,
-        agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
+        agentSdkOverride?: AgentSdk,
         initialMode?: SessionMode,
         options?: { autoFocus?: boolean; modelOverride?: SelectedModel }
       ) => {
@@ -534,7 +565,8 @@ export const useSessionStore = create<SessionState>()(
           for (const [worktreeId, sessions] of get().sessionsByWorktree.entries()) {
             const found = sessions.find((s) => s.id === sessionId)
             if (found) {
-              isTerminalSession = found.agent_sdk === 'terminal'
+              isTerminalSession =
+                found.agent_sdk === 'terminal' || found.agent_sdk === 'claude-code-cli'
               opencodeSessionId = found.opencode_session_id
               sessionWorktreeId = worktreeId
               break
@@ -544,7 +576,8 @@ export const useSessionStore = create<SessionState>()(
             for (const sessions of get().sessionsByConnection.values()) {
               const found = sessions.find((s) => s.id === sessionId)
               if (found) {
-                isTerminalSession = found.agent_sdk === 'terminal'
+                isTerminalSession =
+                  found.agent_sdk === 'terminal' || found.agent_sdk === 'claude-code-cli'
                 opencodeSessionId = found.opencode_session_id
                 break
               }
@@ -1143,6 +1176,8 @@ export const useSessionStore = create<SessionState>()(
           newMode = 'build'
         }
 
+        syncClaudeCliPermissionModeIfNeeded(get(), sessionId, currentMode, newMode)
+
         // Update local state immediately
         set((state) => {
           const newModeMap = new Map(state.modeBySession)
@@ -1230,6 +1265,9 @@ export const useSessionStore = create<SessionState>()(
 
       // Set session mode explicitly (also applies mode-specific model default)
       setSessionMode: async (sessionId: string, mode: SessionMode) => {
+        const previousMode = get().modeBySession.get(sessionId) || 'build'
+        syncClaudeCliPermissionModeIfNeeded(get(), sessionId, previousMode, mode)
+
         set((state) => {
           const newModeMap = new Map(state.modeBySession)
           newModeMap.set(sessionId, mode)
@@ -1309,7 +1347,7 @@ export const useSessionStore = create<SessionState>()(
         }
 
         // Find the session's SDK to route correctly (search both scopes)
-        let agentSdk: 'opencode' | 'claude-code' | 'codex' | 'terminal' = 'opencode'
+        let agentSdk: AgentSdk = 'opencode'
         for (const sessions of get().sessionsByWorktree.values()) {
           const found = sessions.find((s) => s.id === sessionId)
           if (found?.agent_sdk) {
@@ -1337,7 +1375,7 @@ export const useSessionStore = create<SessionState>()(
 
         // Push to agent backend (SDK-aware) — skip for terminal sessions
         try {
-          if (agentSdk !== 'terminal') {
+          if (agentSdk !== 'terminal' && agentSdk !== 'claude-code-cli') {
             unwrapEnvelope(await window.opencodeOps.setModel({ ...model, agentSdk }))
           }
         } catch (error) {
@@ -1436,6 +1474,34 @@ export const useSessionStore = create<SessionState>()(
               opencode_session_id: opencodeSessionId
             })
             return { boardAssistantByProject: newBoardAssistantMap }
+          }
+
+          return {}
+        })
+      },
+
+      setClaudeSessionId: (sessionId: string, claudeSessionId: string | null) => {
+        set((state) => {
+          const newWorktreeSessionsMap = new Map(state.sessionsByWorktree)
+          for (const [worktreeId, sessions] of newWorktreeSessionsMap.entries()) {
+            const updatedSessions = sessions.map((s) =>
+              s.id === sessionId ? { ...s, claude_session_id: claudeSessionId } : s
+            )
+            if (updatedSessions.some((s, index) => s !== sessions[index])) {
+              newWorktreeSessionsMap.set(worktreeId, updatedSessions)
+              return { sessionsByWorktree: newWorktreeSessionsMap }
+            }
+          }
+
+          const newConnectionSessionsMap = new Map(state.sessionsByConnection)
+          for (const [connectionId, sessions] of newConnectionSessionsMap.entries()) {
+            const updatedSessions = sessions.map((s) =>
+              s.id === sessionId ? { ...s, claude_session_id: claudeSessionId } : s
+            )
+            if (updatedSessions.some((s, index) => s !== sessions[index])) {
+              newConnectionSessionsMap.set(connectionId, updatedSessions)
+              return { sessionsByConnection: newConnectionSessionsMap }
+            }
           }
 
           return {}
@@ -1922,7 +1988,7 @@ export const useSessionStore = create<SessionState>()(
       // Create a session scoped to a connection
       createConnectionSession: async (
         connectionId: string,
-        agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
+        agentSdkOverride?: AgentSdk,
         initialMode?: SessionMode,
         opts?: { autoFocus?: boolean; modelOverride?: SelectedModel }
       ) => {

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -2310,3 +2310,13 @@ export const useSessionStore = create<SessionState>()(
     }
   )
 )
+
+declare global {
+  interface Window {
+    __hive_useSessionStore__?: typeof useSessionStore
+  }
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  window.__hive_useSessionStore__ = useSessionStore
+}

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -4,6 +4,7 @@ import { APP_SETTINGS_DB_KEY } from '@shared/types/settings'
 import type { TelegramConfig } from '@shared/types/telegram'
 import type { UsageProvider } from '@shared/types/usage'
 import type { PetSettings } from '@shared/types/pet'
+import type { AgentSdk, HandoffAgentSdk } from '@shared/types/agent-sdk'
 import type { ReviewPromptType } from '@/constants/reviewPrompts'
 import type { CustomProjectCommand } from '@/lib/custom-commands'
 import { validateCustomCommand } from '@/lib/custom-commands'
@@ -31,8 +32,9 @@ export type TerminalPosition = 'sidebar' | 'bottom'
 export type MergeConflictMode = 'build' | 'plan' | 'always-ask'
 export type FollowUpTriggerColumn = 'review' | 'done'
 
-export type AgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
-export type HandoffAgentSdk = Exclude<AgentSdk, 'terminal'>
+// Re-exported from the shared single source of truth (see @shared/types/agent-sdk)
+// so existing `import { AgentSdk } from '@/stores/useSettingsStore'` sites keep working.
+export type { AgentSdk, HandoffAgentSdk }
 
 export interface SelectedModel {
   agentSdk?: HandoffAgentSdk

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -709,6 +709,7 @@ export const useSettingsStore = create<SettingsState>()(
 // Load from database on startup, then detect available agent SDKs
 if (typeof window !== 'undefined') {
   setTimeout(() => {
+    if (typeof window === 'undefined') return
     useSettingsStore
       .getState()
       .loadFromDatabase()

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -29,7 +29,7 @@ export type TerminalPosition = 'sidebar' | 'bottom'
 export type MergeConflictMode = 'build' | 'plan' | 'always-ask'
 export type FollowUpTriggerColumn = 'review' | 'done'
 
-export type AgentSdk = 'opencode' | 'claude-code' | 'codex' | 'terminal'
+export type AgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
 export type HandoffAgentSdk = Exclude<AgentSdk, 'terminal'>
 
 export interface SelectedModel {
@@ -528,8 +528,8 @@ export const useSettingsStore = create<SettingsState>()(
           delete current[agentSdk]
         }
         set({ selectedModelByProvider: current })
-        // Push to backend (skip for terminal — no backend service, or when caller already pushed)
-        if (agentSdk !== 'terminal' && !options?.skipBackendPush) {
+        // Push to backend only for SDKs with a structured implementer.
+        if (agentSdk !== 'terminal' && agentSdk !== 'claude-code-cli' && !options?.skipBackendPush) {
           try {
             unwrapEnvelope(await window.opencodeOps.setModel(model ? { ...model, agentSdk } : null))
           } catch (error) {

--- a/src/renderer/src/stores/useShortcutStore.ts
+++ b/src/renderer/src/stores/useShortcutStore.ts
@@ -135,6 +135,7 @@ async function saveToDatabase(bindings: Record<string, KeyBinding>): Promise<voi
 // Load from database on startup
 if (typeof window !== 'undefined') {
   setTimeout(() => {
+    if (typeof window === 'undefined') return
     useShortcutStore.getState().loadFromDatabase()
   }, 150)
 }

--- a/src/renderer/src/stores/useThemeStore.ts
+++ b/src/renderer/src/stores/useThemeStore.ts
@@ -223,6 +223,7 @@ if (typeof window !== 'undefined') {
 
   // Load from database (source of truth) once IPC is ready
   setTimeout(() => {
+    if (typeof window === 'undefined') return
     useThemeStore.getState().loadFromDatabase()
   }, 100)
 }

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { type AgentSdk, isClaudeFamily } from '@shared/types/agent-sdk'
 import type {
   UsageData,
   AnthropicRateLimitInfo,
@@ -360,7 +361,7 @@ interface SessionLike {
 }
 
 export function resolveUsageProvider(session: SessionLike): UsageProvider {
-  if (session.agent_sdk === 'claude-code' || session.agent_sdk === 'claude-code-cli') {
+  if (isClaudeFamily(session.agent_sdk)) {
     return 'anthropic'
   }
   if (session.model_provider_id === 'openai') return 'openai'
@@ -369,7 +370,7 @@ export function resolveUsageProvider(session: SessionLike): UsageProvider {
 }
 
 export function resolveDefaultUsageProvider(
-  agentSdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agentSdk: AgentSdk
 ): UsageProvider {
   if (agentSdk === 'codex') return 'openai'
   return 'anthropic'

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -125,14 +125,16 @@ interface SessionLike {
 }
 
 export function resolveUsageProvider(session: SessionLike): UsageProvider {
-  if (session.agent_sdk === 'claude-code') return 'anthropic'
+  if (session.agent_sdk === 'claude-code' || session.agent_sdk === 'claude-code-cli') {
+    return 'anthropic'
+  }
   if (session.model_provider_id === 'openai') return 'openai'
   if (session.model_id?.startsWith('gpt')) return 'openai'
   return 'anthropic'
 }
 
 export function resolveDefaultUsageProvider(
-  agentSdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  agentSdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
 ): UsageProvider {
   if (agentSdk === 'codex') return 'openai'
   return 'anthropic'

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -4,18 +4,12 @@ import { useConnectionStore } from './useConnectionStore'
 import { lastSendMode } from '@/lib/message-send-times'
 import { notifyKanbanSessionSync } from './store-coordination'
 import { unwrapEnvelopeApi } from '@/lib/ipc-envelope'
+import type { SessionStatusType } from '@shared/types/session-status'
+
+// Re-exported from the shared definition so existing importers keep working.
+export type { SessionStatusType }
 
 const db = unwrapEnvelopeApi(() => window.db)
-
-export type SessionStatusType =
-  | 'working'
-  | 'planning'
-  | 'answering'
-  | 'permission'
-  | 'command_approval'
-  | 'unread'
-  | 'completed'
-  | 'plan_ready'
 
 export interface SessionStatusEntry {
   status: SessionStatusType

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -26,6 +26,8 @@ export interface SessionStatusEntry {
   reason?: string
   hookEventName?: string
   hookPath?: string
+  toolName?: string
+  plan?: string
 }
 
 interface WorktreeStatusState {
@@ -49,6 +51,8 @@ interface WorktreeStatusState {
       reason?: string
       hookEventName?: string
       hookPath?: string
+      toolName?: string
+      plan?: string
     }
   ) => void
   clearSessionStatus: (sessionId: string) => void
@@ -101,6 +105,8 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
       reason?: string
       hookEventName?: string
       hookPath?: string
+      toolName?: string
+      plan?: string
     }
   ) => {
     set((state) => {

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -23,6 +23,9 @@ export interface SessionStatusEntry {
   word?: string
   durationMs?: number
   tokenDelta?: number
+  reason?: string
+  hookEventName?: string
+  hookPath?: string
 }
 
 interface WorktreeStatusState {
@@ -39,7 +42,14 @@ interface WorktreeStatusState {
   setSessionStatus: (
     sessionId: string,
     status: SessionStatusType | null,
-    metadata?: { word?: string; durationMs?: number; tokenDelta?: number }
+    metadata?: {
+      word?: string
+      durationMs?: number
+      tokenDelta?: number
+      reason?: string
+      hookEventName?: string
+      hookPath?: string
+    }
   ) => void
   clearSessionStatus: (sessionId: string) => void
   clearWorktreeUnread: (worktreeId: string) => void
@@ -84,7 +94,14 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
   setSessionStatus: (
     sessionId: string,
     status: SessionStatusType | null,
-    metadata?: { word?: string; durationMs?: number; tokenDelta?: number }
+    metadata?: {
+      word?: string
+      durationMs?: number
+      tokenDelta?: number
+      reason?: string
+      hookEventName?: string
+      hookPath?: string
+    }
   ) => {
     set((state) => {
       const next: Partial<WorktreeStatusState> = {
@@ -344,3 +361,13 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
     return worktreeId in get().reviewSessionByWorktree
   }
 }))
+
+declare global {
+  interface Window {
+    __hive_useWorktreeStatusStore__?: typeof useWorktreeStatusStore
+  }
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  window.__hive_useWorktreeStatusStore__ = useWorktreeStatusStore
+}

--- a/src/shared/types/agent-sdk.ts
+++ b/src/shared/types/agent-sdk.ts
@@ -1,0 +1,69 @@
+/**
+ * Single source of truth for the agent-SDK union and the capability checks that
+ * distinguish the SDKs. Previously the union was redeclared ~6 times (main DB
+ * types, shared session type, both renderer stores, the main implementer
+ * registry, the renderer availability helper) and the behaviors that set the
+ * SDKs apart were re-encoded as raw string comparisons (`=== 'claude-code-cli'`,
+ * `=== 'terminal' || === 'claude-code-cli'`, etc.) across many files.
+ *
+ * Centralizing both means adding a 6th SDK is a single-point change here, and
+ * the intent of each comparison ("is this terminal-backed?", "does it share the
+ * Claude model catalog?") is named rather than re-derived at each call site.
+ *
+ * The helpers accept `string | null | undefined` (not just `AgentSdk`) so they
+ * drop in at the many call sites where `agent_sdk` is carried as a plain string
+ * (DB rows, store records typed loosely, IPC payloads).
+ */
+
+/**
+ * The canonical list of agent-SDK identifiers. The {@link AgentSdk} type is
+ * derived from this, and the zod schemas that validate IPC/DB payloads build on
+ * it (`z.enum(AGENT_SDK_VALUES)`) — so the type and every runtime validator stay
+ * in lockstep and adding a 6th SDK is a one-line change here.
+ */
+export const AGENT_SDK_VALUES = [
+  'opencode',
+  'claude-code',
+  'claude-code-cli',
+  'codex',
+  'terminal'
+] as const
+
+export type AgentSdk = (typeof AGENT_SDK_VALUES)[number]
+
+/** SDKs a session can be handed off to / launched as — everything except the bare terminal. */
+export type HandoffAgentSdk = Exclude<AgentSdk, 'terminal'>
+
+type MaybeSdk = AgentSdk | string | null | undefined
+
+/** The Claude Code CLI session type (terminal-backed Claude, distinct from the SDK-driven `claude-code`). */
+export function isClaudeCli(sdk: MaybeSdk): boolean {
+  return sdk === 'claude-code-cli'
+}
+
+/**
+ * Sessions whose UI is a live terminal surface rather than the OpenCode-style
+ * streaming view: the bare `terminal` SDK and `claude-code-cli`. These share
+ * mount/teardown handling and must NOT be routed through the OpenCode IPC.
+ */
+export function isTerminalBacked(sdk: MaybeSdk): boolean {
+  return sdk === 'terminal' || sdk === 'claude-code-cli'
+}
+
+/** Either Claude variant — the SDK-driven `claude-code` or the terminal-backed `claude-code-cli`. */
+export function isClaudeFamily(sdk: MaybeSdk): boolean {
+  return sdk === 'claude-code' || sdk === 'claude-code-cli'
+}
+
+/**
+ * Map an SDK to the one whose model catalog it uses. `claude-code-cli` has no
+ * catalog of its own — it shares `claude-code`'s — so model-listing/selection
+ * code should resolve through this rather than special-casing the CLI inline.
+ * Overloaded so nullable inputs (optional IPC payload fields) pass `null` /
+ * `undefined` through unchanged.
+ */
+export function toModelCatalogSdk(sdk: AgentSdk): AgentSdk
+export function toModelCatalogSdk(sdk: AgentSdk | null | undefined): AgentSdk | null | undefined
+export function toModelCatalogSdk(sdk: AgentSdk | null | undefined): AgentSdk | null | undefined {
+  return sdk === 'claude-code-cli' ? 'claude-code' : sdk
+}

--- a/src/shared/types/session-status.ts
+++ b/src/shared/types/session-status.ts
@@ -1,0 +1,15 @@
+/**
+ * The set of session-activity statuses surfaced in the UI (tab badges, worktree
+ * indicators, pet) and emitted across the IPC boundary by the Claude CLI hook
+ * server. Defined once here so the main process, preload, and renderer share a
+ * single source of truth instead of re-declaring the union in three places.
+ */
+export type SessionStatusType =
+  | 'working'
+  | 'planning'
+  | 'answering'
+  | 'permission'
+  | 'command_approval'
+  | 'unread'
+  | 'completed'
+  | 'plan_ready'

--- a/src/shared/types/session.ts
+++ b/src/shared/types/session.ts
@@ -1,3 +1,5 @@
+import type { AgentSdk } from './agent-sdk'
+
 export type SessionType = 'default' | 'board-assistant'
 
 export interface Session {
@@ -9,7 +11,7 @@ export interface Session {
   status: 'active' | 'completed' | 'error'
   opencode_session_id: string | null
   claude_session_id: string | null
-  agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agent_sdk: AgentSdk
   mode: 'build' | 'plan'
   session_type: SessionType
   model_provider_id: string | null

--- a/src/shared/types/session.ts
+++ b/src/shared/types/session.ts
@@ -8,7 +8,8 @@ export interface Session {
   name: string | null
   status: 'active' | 'completed' | 'error'
   opencode_session_id: string | null
-  agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  claude_session_id: string | null
+  agent_sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   mode: 'build' | 'plan'
   session_type: SessionType
   model_provider_id: string | null

--- a/test/claude-session-title.test.ts
+++ b/test/claude-session-title.test.ts
@@ -21,7 +21,7 @@ vi.mock('../src/main/services/logger', () => ({
 }))
 
 vi.mock('../src/main/services/title-generation-shared', async (importOriginal) => {
-  const actual = await importOriginal() as any
+  const actual = await importOriginal<typeof import('../src/main/services/title-generation-shared')>()
   return {
     ...actual,
     spawnCLI: mockSpawnCLI,

--- a/test/kanban/board-assistant-create-navigation.test.tsx
+++ b/test/kanban/board-assistant-create-navigation.test.tsx
@@ -130,6 +130,14 @@ function seedStores(boardMode: 'sticky-tab' | 'toggle') {
     }
   })
 
+  Object.defineProperty(window, 'opencodeOps', {
+    writable: true,
+    configurable: true,
+    value: {
+      listModels: vi.fn().mockResolvedValue({ success: true, providers: [] })
+    }
+  })
+
   const store = useBoardChatStore.getState()
   const scope = {
     kind: 'project' as const,
@@ -138,36 +146,56 @@ function seedStores(boardMode: 'sticky-tab' | 'toggle') {
     projectPath: '/tmp/proj-1'
   }
   store.activateScope(scope, { scope })
+  const messages = [
+    {
+      id: assistantMessageId,
+      role: 'assistant' as const,
+      content: [
+        'Ready.',
+        '```board-ticket-drafts',
+        JSON.stringify({
+          drafts: [
+            {
+              draftKey: 'draft-1',
+              title: boardDraft.title,
+              description: boardDraft.description,
+              projectId,
+              dependsOn: [],
+              warnings: []
+            }
+          ]
+        }),
+        '```'
+      ].join('\n'),
+      timestamp: '2026-04-15T00:00:00.000Z',
+      kind: 'transcript' as const
+    }
+  ]
+  const seededSnapshot = {
+    scope,
+    messages,
+    drafts: [boardDraft],
+    createdDraftIds: [],
+    draftSourceMessageId: assistantMessageId,
+    status: 'awaiting_confirmation' as const,
+    selectedTargetProjectId: projectId,
+    error: null,
+    sessionId: null,
+    opencodeSessionId: null,
+    runtimePath: null,
+    selectedAgentSdkOverride: null,
+    selectedModelOverride: null,
+    composerValue: ''
+  }
   useBoardChatStore.setState({
     scope,
-    messages: [
-      {
-        id: assistantMessageId,
-        role: 'assistant',
-        content: [
-          'Ready.',
-          '```board-ticket-drafts',
-          JSON.stringify({
-            drafts: [
-              {
-                draftKey: 'draft-1',
-                title: boardDraft.title,
-                description: boardDraft.description,
-                projectId,
-                dependsOn: [],
-                warnings: []
-              }
-            ]
-          }),
-          '```'
-        ].join('\n'),
-        timestamp: '2026-04-15T00:00:00.000Z',
-        kind: 'transcript'
-      }
-    ],
+    messages,
     drafts: [boardDraft],
     draftSourceMessageId: assistantMessageId,
-    status: 'awaiting_confirmation'
+    status: 'awaiting_confirmation',
+    snapshots: {
+      [`project:${projectId}`]: seededSnapshot
+    }
   })
 }
 
@@ -180,7 +208,7 @@ describe('board assistant create navigation', () => {
     seedStores('sticky-tab')
 
     render(<BoardAssistantView projectId={projectId} />)
-    fireEvent.click(screen.getByRole('button', { name: 'Create all' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Create all' }))
 
     await waitFor(() => {
       expect(useSessionStore.getState().activeSessionId).toBe(BOARD_TAB_ID)
@@ -192,7 +220,7 @@ describe('board assistant create navigation', () => {
     seedStores('toggle')
 
     render(<BoardAssistantView projectId={projectId} />)
-    fireEvent.click(screen.getByRole('button', { name: 'Create all' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Create all' }))
 
     await waitFor(() => {
       expect(useKanbanStore.getState().isBoardViewActive).toBe(true)

--- a/test/kanban/session-10/session-kanban-coordination.test.ts
+++ b/test/kanban/session-10/session-kanban-coordination.test.ts
@@ -465,6 +465,36 @@ describe('Session 10: Session ↔ Kanban Store Coordination', () => {
     expect(mockKanban.ticket.move).toHaveBeenCalledWith('t1', 'review', 0)
   })
 
+  test('plan_followup event clears plan_ready and moves ticket back to in_progress', async () => {
+    const ticket = makeTicket({
+      id: 't1',
+      column: 'review',
+      current_session_id: 'session-7',
+      mode: 'plan',
+      plan_ready: true
+    })
+
+    act(() => {
+      useKanbanStore.setState({
+        tickets: new Map([['proj-1', [ticket]]])
+      })
+    })
+
+    await act(async () => {
+      useKanbanStore.getState().syncTicketWithSession('session-7', {
+        type: 'plan_followup'
+      } as KanbanSessionEvent)
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    const tickets = useKanbanStore.getState().tickets.get('proj-1')
+    const updated = tickets!.find((t) => t.id === 't1')
+    expect(updated!.plan_ready).toBe(false)
+    expect(updated!.column).toBe('in_progress')
+    expect(mockKanban.ticket.update).toHaveBeenCalledWith('t1', { plan_ready: false })
+    expect(mockKanban.ticket.move).toHaveBeenCalledWith('t1', 'in_progress', 0)
+  })
+
   // ────────────────────────────────────────────────────────────────────
   // Tickets across different projects are handled independently
   // ────────────────────────────────────────────────────────────────────

--- a/test/kanban/session-13/ticket-attachment.test.tsx
+++ b/test/kanban/session-13/ticket-attachment.test.tsx
@@ -439,7 +439,7 @@ describe('Session 13: Ticket Attachment', () => {
 
     render(
       <TicketAttachments
-        attachments={[ticketAttachment]}
+        ticketAttachments={[ticketAttachment]}
         onRemove={() => {}}
       />
     )
@@ -469,7 +469,7 @@ describe('Session 13: Ticket Attachment', () => {
 
     render(
       <TicketAttachments
-        attachments={attachments}
+        ticketAttachments={attachments}
         onRemove={() => {}}
       />
     )

--- a/test/phase-16/session-4/global-listener-follow-up-dispatch.test.ts
+++ b/test/phase-16/session-4/global-listener-follow-up-dispatch.test.ts
@@ -563,9 +563,11 @@ describe('Global listener background follow-up dispatcher', () => {
     })
     await flushAsync()
 
-    expect(mockPrompt).toHaveBeenCalledWith('/tmp/worktree-1', 'opc-real-123', [
-      { type: 'text', text: 'follow-up 2' }
-    ])
+    await waitFor(() => {
+      expect(mockPrompt).toHaveBeenCalledWith('/tmp/worktree-1', 'opc-real-123', [
+        { type: 'text', text: 'follow-up 2' }
+      ])
+    })
     expect(followUpQueues.has('session-B')).toBe(false)
   })
 

--- a/test/phase-17/session-10/commit-message-backend.test.ts
+++ b/test/phase-17/session-10/commit-message-backend.test.ts
@@ -16,9 +16,13 @@ describe('Session 10: Default Commit Message Backend', () => {
       expect(schema!.up).toContain("DEFAULT '[]'")
     })
 
-    test('migrations are sequential', () => {
+    test('migration versions are strictly increasing', () => {
+      // Versions must increase monotonically (so the runner applies them in
+      // order and never skips a higher version), but gaps are allowed: a
+      // version may be retired/reserved without renumbering later migrations.
+      // This still catches duplicate versions, the bug a strict +1 check caught.
       for (let i = 1; i < MIGRATIONS.length; i++) {
-        expect(MIGRATIONS[i].version).toBe(MIGRATIONS[i - 1].version + 1)
+        expect(MIGRATIONS[i].version).toBeGreaterThan(MIGRATIONS[i - 1].version)
       }
     })
   })

--- a/test/phase-21/session-5/ipc-messages-routing.test.ts
+++ b/test/phase-21/session-5/ipc-messages-routing.test.ts
@@ -7,7 +7,10 @@ const handlers = new Map<string, (...args: any[]) => any>()
 vi.mock('electron', () => ({
   ipcMain: {
     handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
-      handlers.set(channel, handler)
+      handlers.set(channel, async (...args: any[]) => {
+        const result = await handler(...args)
+        return result?.success === true && 'value' in result ? result.value : result
+      })
     })
   },
   app: {

--- a/test/phase-21/session-6/ipc-prompt-options.test.ts
+++ b/test/phase-21/session-6/ipc-prompt-options.test.ts
@@ -6,7 +6,10 @@ const handlers = new Map<string, (...args: any[]) => any>()
 vi.mock('electron', () => ({
   ipcMain: {
     handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
-      handlers.set(channel, handler)
+      handlers.set(channel, async (...args: any[]) => {
+        const result = await handler(...args)
+        return result?.success === true && 'value' in result ? result.value : result
+      })
     })
   }
 }))

--- a/test/phase-21/session-7/worktree-breed-collision-retry.test.ts
+++ b/test/phase-21/session-7/worktree-breed-collision-retry.test.ts
@@ -43,7 +43,7 @@ describe('Worktree breed-name collision retry', () => {
     // First git worktree add call fails with "already exists",
     // second call succeeds
     mockRaw
-      .mockImplementationOnce(async (args: string[]) => {
+      .mockImplementationOnce(async (_args: string[]) => {
         // getCurrentBranch raw call — not used directly (branch() is)
         return ''
       })
@@ -52,18 +52,15 @@ describe('Worktree breed-name collision retry', () => {
 
     const service = new GitService('/tmp/mock-repo')
 
-    // Spy on getAllBranches and listWorktrees to track call counts
-    const getAllBranchesSpy = vi.spyOn(service, 'getAllBranches').mockResolvedValue([])
-    const listWorktreesSpy = vi.spyOn(service, 'listWorktrees').mockResolvedValue([])
-    const getCurrentBranchSpy = vi.spyOn(service, 'getCurrentBranch').mockResolvedValue('main')
-
-    // Capture args to the underlying git.raw for worktree add calls
+    // Capture args to the underlying git.raw for worktree add calls.
     const rawCalls: string[][] = []
+    let worktreeAddCalls = 0
     const gitInstance = (service as unknown as { git: { raw: typeof mockRaw } }).git
     gitInstance.raw = vi.fn().mockImplementation(async (args: string[]) => {
       rawCalls.push(args)
       if (args[0] === 'worktree' && args[1] === 'add') {
-        if (rawCalls.filter((c) => c[0] === 'worktree').length === 1) {
+        worktreeAddCalls += 1
+        if (worktreeAddCalls === 1) {
           throw new Error("fatal: 'somename' already exists")
         }
       }
@@ -76,12 +73,9 @@ describe('Worktree breed-name collision retry', () => {
     expect(result.branchName).toBeTruthy()
     expect(result.path).toBeTruthy()
 
-    // getAllBranches should have been called at least twice (once per attempt)
-    expect(getAllBranchesSpy.mock.calls.length).toBeGreaterThanOrEqual(2)
-    expect(listWorktreesSpy.mock.calls.length).toBeGreaterThanOrEqual(2)
-
-    // getCurrentBranch should only be called once (outside the loop)
-    expect(getCurrentBranchSpy.mock.calls.length).toBe(1)
+    expect(mockBranch.mock.calls.length).toBeGreaterThanOrEqual(3)
+    expect(rawCalls.filter((call) => call.join(' ') === 'worktree list --porcelain')).toHaveLength(2)
+    expect(worktreeAddCalls).toBe(2)
   })
 
   test('createWorktree returns failure after 3 collisions', async () => {
@@ -107,18 +101,21 @@ describe('Worktree breed-name collision retry', () => {
 
     const service = new GitService('/tmp/mock-repo')
 
-    const getAllBranchesSpy = vi.spyOn(service, 'getAllBranches').mockResolvedValue([])
-    vi.spyOn(service, 'listWorktrees').mockResolvedValue([])
-    vi.spyOn(service, 'getCurrentBranch').mockResolvedValue('main')
-
     const gitInstance = (service as unknown as { git: { raw: typeof mockRaw } }).git
+    let worktreeAddCalls = 0
     gitInstance.raw = vi.fn().mockRejectedValue(new Error('fatal: not a git repository'))
+    gitInstance.raw = vi.fn().mockImplementation(async (args: string[]) => {
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        worktreeAddCalls += 1
+        throw new Error('fatal: not a git repository')
+      }
+      return ''
+    })
 
     const result = await service.createWorktree('my-project', 'dogs')
 
     expect(result.success).toBe(false)
-    // getAllBranches should only be called once — no retry on non-collision errors
-    expect(getAllBranchesSpy.mock.calls.length).toBe(1)
+    expect(worktreeAddCalls).toBe(1)
   })
 
   test('createWorktree succeeds on first attempt with no collision', async () => {
@@ -126,17 +123,19 @@ describe('Worktree breed-name collision retry', () => {
 
     const service = new GitService('/tmp/mock-repo')
 
-    const getAllBranchesSpy = vi.spyOn(service, 'getAllBranches').mockResolvedValue(['main'])
-    vi.spyOn(service, 'listWorktrees').mockResolvedValue([])
-    vi.spyOn(service, 'getCurrentBranch').mockResolvedValue('main')
-
     const gitInstance = (service as unknown as { git: { raw: typeof mockRaw } }).git
-    gitInstance.raw = vi.fn().mockResolvedValue('')
+    let worktreeAddCalls = 0
+    gitInstance.raw = vi.fn().mockImplementation(async (args: string[]) => {
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        worktreeAddCalls += 1
+      }
+      return ''
+    })
 
     const result = await service.createWorktree('my-project', 'dogs')
 
     expect(result.success).toBe(true)
-    expect(getAllBranchesSpy.mock.calls.length).toBe(1)
+    expect(worktreeAddCalls).toBe(1)
   })
 
   test('git-service.ts createWorktree contains retry loop logic', async () => {

--- a/test/phase-21/session-8/capabilities-ipc.test.ts
+++ b/test/phase-21/session-8/capabilities-ipc.test.ts
@@ -11,7 +11,10 @@ const handlers = new Map<string, (...args: any[]) => any>()
 vi.mock('electron', () => ({
   ipcMain: {
     handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
-      handlers.set(channel, handler)
+      handlers.set(channel, async (...args: any[]) => {
+        const result = await handler(...args)
+        return result?.success === true && 'value' in result ? result.value : result
+      })
     })
   },
   app: {

--- a/test/phase-21/session-8/ipc-undo-redo-routing.test.ts
+++ b/test/phase-21/session-8/ipc-undo-redo-routing.test.ts
@@ -7,7 +7,10 @@ const handlers = new Map<string, (...args: any[]) => any>()
 vi.mock('electron', () => ({
   ipcMain: {
     handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
-      handlers.set(channel, handler)
+      handlers.set(channel, async (...args: any[]) => {
+        const result = await handler(...args)
+        return result?.success === true && 'value' in result ? result.value : result
+      })
     })
   },
   app: {

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -390,7 +390,7 @@ describe('handoff model picker', () => {
     render(<HandoffSplitButton onHandoff={vi.fn()} testIdPrefix="plan-ready" />)
 
     const handoffButton = await screen.findByTestId('plan-ready-handoff-fab')
-    expect(handoffButton).toHaveTextContent('Claude Code (legacy SDK) /')
+    expect(handoffButton).toHaveTextContent('Claude Code /')
     expect(handoffButton).toHaveTextContent('Sonnet 4.6')
 
     act(() => {

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -333,7 +333,7 @@ describe('handoff model picker', () => {
     })
   })
 
-  test('controlled model selector hides provider filter when only one provider is available', async () => {
+  test('controlled model selector keeps provider filter when Claude legacy and CLI are available', async () => {
     useSettingsStore.setState({
       availableAgentSdks: {
         opencode: false,
@@ -348,7 +348,7 @@ describe('handoff model picker', () => {
       expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'claude-code' })
     })
 
-    expect(screen.queryByTestId('model-provider-filter')).not.toBeInTheDocument()
+    expect(screen.getByTestId('model-provider-filter')).toBeInTheDocument()
   })
 
   test('button label rerenders when lastHandoffOverride changes', async () => {
@@ -358,7 +358,7 @@ describe('handoff model picker', () => {
     render(<HandoffSplitButton onHandoff={vi.fn()} testIdPrefix="plan-ready" />)
 
     const handoffButton = await screen.findByTestId('plan-ready-handoff-fab')
-    expect(handoffButton).toHaveTextContent('Claude Code /')
+    expect(handoffButton).toHaveTextContent('Claude Code (legacy SDK) /')
     expect(handoffButton).toHaveTextContent('Sonnet 4.6')
 
     act(() => {
@@ -377,7 +377,7 @@ describe('handoff model picker', () => {
     })
   })
 
-  test('single-sdk rendering hides the chevron control', async () => {
+  test('Claude-only rendering keeps the chevron for legacy and CLI choices', async () => {
     cacheHandoffModelCatalog('claude-code', claudeProviders)
     useSettingsStore.setState({
       availableAgentSdks: {
@@ -389,9 +389,7 @@ describe('handoff model picker', () => {
 
     render(<HandoffSplitButton onHandoff={vi.fn()} testIdPrefix="plan-ready" />)
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('plan-ready-handoff-chevron')).not.toBeInTheDocument()
-    })
+    expect(await screen.findByTestId('plan-ready-handoff-chevron')).toBeInTheDocument()
   })
 
   test('picker only persists on confirm and switching SDK resets the model selection', async () => {

--- a/test/phase-22/session-11/model-selector-provider-pill.test.tsx
+++ b/test/phase-22/session-11/model-selector-provider-pill.test.tsx
@@ -27,18 +27,12 @@ const codexProviders = [
   }
 ]
 
-Object.defineProperty(window, 'opencodeOps', {
-  writable: true,
-  configurable: true,
-  value: {
-    listModels: vi.fn().mockImplementation(async ({ agentSdk }: { agentSdk?: string } = {}) => {
-      if (agentSdk === 'codex') {
-        return { success: true, providers: codexProviders }
-      }
-
-      return { success: true, providers: claudeProviders }
-    })
+const mockListModels = vi.fn().mockImplementation(async ({ agentSdk }: { agentSdk?: string } = {}) => {
+  if (agentSdk === 'codex') {
+    return { success: true, providers: codexProviders }
   }
+
+  return { success: true, providers: claudeProviders }
 })
 
 import { ModelSelector } from '@/components/sessions/ModelSelector'
@@ -48,6 +42,20 @@ describe('ModelSelector provider filter pill', () => {
   beforeEach(() => {
     cleanup()
     vi.clearAllMocks()
+    mockListModels.mockImplementation(async ({ agentSdk }: { agentSdk?: string } = {}) => {
+      if (agentSdk === 'codex') {
+        return { success: true, providers: codexProviders }
+      }
+
+      return { success: true, providers: claudeProviders }
+    })
+    Object.defineProperty(window, 'opencodeOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        listModels: mockListModels
+      }
+    })
 
     useSettingsStore.setState({
       defaultAgentSdk: 'claude-code',

--- a/test/phase-22/session-2/settings-codex-provider.test.tsx
+++ b/test/phase-22/session-2/settings-codex-provider.test.tsx
@@ -80,16 +80,20 @@ describe('SettingsGeneral: Codex provider button', () => {
     expect(codexButton).toHaveTextContent('Codex')
   })
 
-  it('renders all four provider buttons (OpenCode, Claude Code, Codex, Terminal)', async () => {
+  it('renders provider buttons in visual order with Claude Code before CLI', async () => {
     const { SettingsGeneral } = await import(
       '@/components/settings/SettingsGeneral'
     )
-    render(<SettingsGeneral />)
+    const { container } = render(<SettingsGeneral />)
 
-    expect(screen.getByTestId('agent-sdk-opencode')).toBeInTheDocument()
-    expect(screen.getByTestId('agent-sdk-claude-code')).toBeInTheDocument()
-    expect(screen.getByTestId('agent-sdk-codex')).toBeInTheDocument()
-    expect(screen.getByTestId('agent-sdk-terminal')).toBeInTheDocument()
+    const buttons = Array.from(container.querySelectorAll('[data-testid^="agent-sdk-"]'))
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      'OpenCode',
+      'Claude Code',
+      'Codex',
+      'Terminal',
+      'Claude Code (CLI)'
+    ])
   })
 
   it('clicking Codex button calls updateSetting with codex', async () => {

--- a/test/phase-22/session-2/system-info-opencode-detection.test.ts
+++ b/test/phase-22/session-2/system-info-opencode-detection.test.ts
@@ -34,6 +34,9 @@ describe('system-info: detectAgentSdks opencode launchability', () => {
       const binary = args[0]
       if (binary === 'claude') return '/usr/local/bin/claude\n'
       if (binary === 'codex') return '/usr/local/bin/codex\n'
+      if (_cmd === '/usr/local/bin/codex' && args.join(' ') === 'app-server --help') {
+        return 'Usage: codex app-server\n'
+      }
       throw new Error('not found')
     })
 

--- a/test/phase-22/session-5/ipc-codex-goal-command-routing.test.ts
+++ b/test/phase-22/session-5/ipc-codex-goal-command-routing.test.ts
@@ -6,7 +6,10 @@ const handlers = new Map<string, (...args: any[]) => any>()
 vi.mock('electron', () => ({
   ipcMain: {
     handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
-      handlers.set(channel, handler)
+      handlers.set(channel, async (...args: any[]) => {
+        const result = await handler(...args)
+        return result?.success === true && 'value' in result ? result.value : result
+      })
     })
   },
   app: {

--- a/test/phase-7/session-4/code-review.test.ts
+++ b/test/phase-7/session-4/code-review.test.ts
@@ -125,6 +125,12 @@ describe('Session 4: Code Review', () => {
         prompt: vi.fn().mockResolvedValue({ success: true })
       }
     })
+    Object.defineProperty(window, 'terminalOps', {
+      writable: true,
+      value: {
+        createClaudeCli: vi.fn().mockResolvedValue({ success: true, value: { success: true } })
+      }
+    })
   })
 
   // ---------------------------------------------------------------------------
@@ -428,6 +434,128 @@ describe('Session 4: Code Review', () => {
         autoFocus: false,
         modelOverride: reviewModel
       })
+    })
+
+    test('starts Claude CLI review sessions with the review prompt as pendingPrompt', async () => {
+      const { useGitStore } = await import('../../../src/renderer/src/stores/useGitStore')
+      const { useSessionStore } = await import('../../../src/renderer/src/stores/useSessionStore')
+      const { useSettingsStore } = await import('../../../src/renderer/src/stores/useSettingsStore')
+      const { useWorktreeStore } = await import('../../../src/renderer/src/stores/useWorktreeStore')
+      const { useWorktreeStatusStore } =
+        await import('../../../src/renderer/src/stores/useWorktreeStatusStore')
+      const { useLifecycleActions } =
+        await import('../../../src/renderer/src/hooks/useLifecycleActions')
+
+      const reviewModel = {
+        agentSdk: 'claude-code-cli' as const,
+        providerID: 'anthropic',
+        modelID: 'opus',
+        variant: 'high'
+      }
+      const createSession = vi.fn().mockResolvedValue({
+        success: true,
+        session: {
+          id: 'review-cli-session',
+          worktree_id: 'wt-1',
+          project_id: 'proj-1',
+          connection_id: null,
+          name: 'Session 14:00',
+          status: 'active',
+          opencode_session_id: null,
+          agent_sdk: 'claude-code-cli',
+          mode: 'build',
+          model_provider_id: 'anthropic',
+          model_id: 'opus',
+          model_variant: 'high',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          completed_at: null
+        }
+      })
+      const updateSessionName = vi.fn().mockResolvedValue(undefined)
+
+      act(() => {
+        useWorktreeStore.setState({
+          worktreesByProject: new Map([
+            [
+              'proj-1',
+              [
+                {
+                  id: 'wt-1',
+                  project_id: 'proj-1',
+                  name: 'feature-auth',
+                  branch_name: 'feature-auth',
+                  path: '/tmp/review-cli-worktree',
+                  status: 'active',
+                  is_default: false,
+                  branch_renamed: 0,
+                  last_message_at: null,
+                  session_titles: '[]',
+                  last_model_provider_id: null,
+                  last_model_id: null,
+                  last_model_variant: null,
+                  attachments: '[]',
+                  pinned: 0,
+                  context: null,
+                  github_pr_number: null,
+                  github_pr_url: null,
+                  base_branch: null,
+                  created_at: new Date().toISOString(),
+                  last_accessed_at: new Date().toISOString()
+                }
+              ]
+            ]
+          ])
+        })
+        useGitStore.setState({
+          branchInfoByWorktree: new Map([
+            [
+              '/tmp/review-cli-worktree',
+              { name: 'feature-auth', tracking: 'origin/main', ahead: 0, behind: 0 }
+            ]
+          ])
+        })
+        useSettingsStore.setState({
+          defaultModels: {
+            build: null,
+            plan: null,
+            ask: null,
+            review: reviewModel
+          }
+        })
+        useSessionStore.setState({
+          createSession,
+          updateSessionName,
+          setPendingMessage: vi.fn()
+        })
+        useWorktreeStatusStore.setState({
+          setReviewSession: vi.fn(),
+          setSessionStatus: vi.fn(),
+          clearSessionStatus: vi.fn(),
+          setLastMessageTime: vi.fn()
+        })
+      })
+
+      const { result } = renderHook(() => useLifecycleActions('wt-1'))
+
+      await result.current.createCodeReview('origin/main')
+
+      expect(createSession).toHaveBeenCalledWith('wt-1', 'proj-1', 'claude-code-cli', undefined, {
+        autoFocus: false,
+        modelOverride: reviewModel,
+        pendingMessage: expect.stringContaining('Compare the current branch (feature-auth)')
+      })
+      expect(useSessionStore.getState().setPendingMessage).toHaveBeenCalledWith(
+        'review-cli-session',
+        expect.stringContaining('Compare the current branch (feature-auth)')
+      )
+      await vi.waitFor(() => {
+        expect(window.terminalOps.createClaudeCli).toHaveBeenCalledWith('review-cli-session', {
+          pendingPrompt: expect.stringContaining('Compare the current branch (feature-auth)')
+        })
+      })
+      expect(window.opencodeOps.connect).not.toHaveBeenCalled()
+      expect(window.opencodeOps.prompt).not.toHaveBeenCalled()
     })
 
     test('focuses the new review tab when not currently on the board', async () => {

--- a/test/terminal/ghostty-backend-visibility.test.ts
+++ b/test/terminal/ghostty-backend-visibility.test.ts
@@ -330,6 +330,81 @@ describe('GhosttyBackend visibility', () => {
     backend.dispose()
   })
 
+  test('passes Shift+Enter newline mode to native surface creation', async () => {
+    const backend = new GhosttyBackend()
+    const container = document.createElement('div')
+    container.getBoundingClientRect = vi.fn(() => ({
+      left: 100,
+      top: 80,
+      width: 640,
+      height: 360,
+      right: 740,
+      bottom: 440,
+      x: 100,
+      y: 80,
+      toJSON: () => ({})
+    }))
+
+    backend.mount(
+      container,
+      {
+        terminalId: 'wt-1',
+        cwd: '/tmp/wt-1',
+        shiftEnterAsNewline: true
+      },
+      {
+        onStatusChange: vi.fn()
+      }
+    )
+
+    await flushPromises()
+    await flushPromises()
+
+    expect(mockTerminalOps.ghosttyCreateSurface).toHaveBeenCalledTimes(1)
+    expect(mockTerminalOps.ghosttyCreateSurface.mock.calls[0][2]).toMatchObject({
+      shiftEnterAsNewline: true
+    })
+
+    backend.dispose()
+  })
+
+  test('keeps Shift+Enter newline mode disabled by default for native Ghostty surfaces', async () => {
+    const backend = new GhosttyBackend()
+    const container = document.createElement('div')
+    container.getBoundingClientRect = vi.fn(() => ({
+      left: 100,
+      top: 80,
+      width: 640,
+      height: 360,
+      right: 740,
+      bottom: 440,
+      x: 100,
+      y: 80,
+      toJSON: () => ({})
+    }))
+
+    backend.mount(
+      container,
+      {
+        terminalId: 'wt-1',
+        cwd: '/tmp/wt-1'
+      },
+      {
+        onStatusChange: vi.fn()
+      }
+    )
+
+    await flushPromises()
+    await flushPromises()
+
+    expect(mockTerminalOps.ghosttyCreateSurface).toHaveBeenCalledTimes(1)
+    expect(mockTerminalOps.ghosttyCreateSurface.mock.calls[0][2]).toMatchObject({
+      shiftEnterAsNewline: false
+    })
+
+    backend.dispose()
+  })
+
   test('respects initialVisible=false from mount and never shows surface on-screen', async () => {
     // Regression test for: when TerminalView recreates a GhosttyBackend (e.g.,
     // after cwd change, fontSize change, or React StrictMode double-mount)

--- a/test/terminal/ghostty-native-shift-enter.test.ts
+++ b/test/terminal/ghostty-native-shift-enter.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('native Ghostty Shift+Enter handling', () => {
+  test('rewrites bare Shift+Enter to ESC+CR instead of relying on default return handling', () => {
+    const source = readFileSync(join(process.cwd(), 'src/native/src/nsview_host.mm'), 'utf8')
+
+    expect(source).toContain('shiftEnterAsNewline && isBareShiftEnterEvent(event)')
+    expect(source).toContain('pasteText(self.surfaceId, "\\x1b\\r")')
+    expect(source).not.toContain('ghosttyConsumedModsForKeyEvent')
+    expect(source).not.toContain('pasteText(self.surfaceId, "\\n")')
+  })
+})

--- a/test/terminal/terminal-view-shift-enter.test.tsx
+++ b/test/terminal/terminal-view-shift-enter.test.tsx
@@ -1,0 +1,82 @@
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { TerminalView } from '../../src/renderer/src/components/terminal/TerminalView'
+import { useLayoutStore } from '../../src/renderer/src/stores/useLayoutStore'
+import { useSettingsStore } from '../../src/renderer/src/stores/useSettingsStore'
+
+const xtermMount = vi.fn()
+const xtermSetShiftEnterAsNewline = vi.fn()
+
+vi.mock('@/components/terminal/backends/GhosttyBackend', () => ({
+  GhosttyBackend: class MockGhosttyBackend {
+    readonly type = 'ghostty' as const
+    readonly supportsSearch = false
+    mount = vi.fn()
+    resize = vi.fn()
+    focus = vi.fn()
+    setVisible = vi.fn()
+    clear = vi.fn()
+    dispose = vi.fn()
+  }
+}))
+
+vi.mock('@/components/terminal/backends/XtermBackend', () => ({
+  XtermBackend: class MockXtermBackend {
+    readonly type = 'xterm' as const
+    readonly supportsSearch = true
+    onSearchToggle?: () => void
+    mount = xtermMount
+    resize = vi.fn()
+    fit = vi.fn()
+    focus = vi.fn()
+    setVisible = vi.fn()
+    clear = vi.fn()
+    dispose = vi.fn()
+    updateTheme = vi.fn()
+    searchNext = vi.fn()
+    searchPrevious = vi.fn()
+    searchClose = vi.fn()
+    setShiftEnterAsNewline = xtermSetShiftEnterAsNewline
+  }
+}))
+
+describe('TerminalView Shift+Enter configuration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    act(() => {
+      useSettingsStore.setState({ embeddedTerminalBackend: 'xterm' })
+      useLayoutStore.setState({ ghosttyOverlaySuppressed: false })
+    })
+
+    Object.defineProperty(window, 'terminalOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        getConfig: vi.fn().mockResolvedValue({ success: true, value: {} })
+      }
+    })
+  })
+
+  test('updates the mounted xterm backend when Shift+Enter newline mode changes', async () => {
+    const { rerender } = render(<TerminalView terminalId="term-1" cwd="/tmp/project" isVisible />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    xtermSetShiftEnterAsNewline.mockClear()
+
+    rerender(
+      <TerminalView terminalId="term-1" cwd="/tmp/project" isVisible shiftEnterAsNewline />
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(xtermMount).toHaveBeenCalledTimes(1)
+    expect(xtermSetShiftEnterAsNewline).toHaveBeenCalledWith(true)
+  })
+})

--- a/test/terminal/xterm-backend-shift-enter.test.ts
+++ b/test/terminal/xterm-backend-shift-enter.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { XtermBackend } from '../../src/renderer/src/components/terminal/backends/XtermBackend'
+
+const mocks = vi.hoisted(() => ({
+  customKeyHandler: undefined as ((event: KeyboardEvent) => boolean) | undefined,
+  write: vi.fn(),
+  input: vi.fn(),
+  create: vi.fn(),
+  onData: vi.fn(),
+  onExit: vi.fn(),
+  resize: vi.fn(),
+  openPath: vi.fn()
+}))
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class MockTerminal {
+    options: Record<string, unknown> = {}
+
+    attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean): void {
+      mocks.customKeyHandler = handler
+    }
+
+    loadAddon(): void {}
+    open(): void {}
+    write(): void {}
+    input(data: string, wasUserInput?: boolean): void {
+      mocks.input(data, wasUserInput)
+    }
+    clear(): void {}
+    hasSelection(): boolean {
+      return false
+    }
+    getSelection(): string {
+      return ''
+    }
+    clearSelection(): void {}
+    focus(): void {}
+    dispose(): void {}
+    onData(): { dispose: () => void } {
+      return { dispose: vi.fn() }
+    }
+  }
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class MockFitAddon {
+    fit(): void {}
+    proposeDimensions(): { cols: number; rows: number } {
+      return { cols: 80, rows: 24 }
+    }
+  }
+}))
+
+vi.mock('@xterm/addon-search', () => ({
+  SearchAddon: class MockSearchAddon {
+    clearDecorations(): void {}
+    findNext(): void {}
+    findPrevious(): void {}
+  }
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: class MockWebLinksAddon {}
+}))
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: class MockWebglAddon {
+    onContextLoss(): void {}
+    dispose(): void {}
+  }
+}))
+
+class MockResizeObserver {
+  observe(): void {}
+  disconnect(): void {}
+}
+
+function mountBackend(opts: { shiftEnterAsNewline?: boolean } = {}): XtermBackend {
+  const backend = new XtermBackend()
+  const container = document.createElement('div')
+
+  backend.mount(
+    container,
+    {
+      terminalId: 'term-1',
+      cwd: '/tmp/project',
+      ...opts
+    },
+    {
+      onStatusChange: vi.fn()
+    }
+  )
+
+  return backend
+}
+
+describe('XtermBackend Shift+Enter handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.customKeyHandler = undefined
+    mocks.create.mockResolvedValue({ success: true })
+    mocks.onData.mockReturnValue(vi.fn())
+    mocks.onExit.mockReturnValue(vi.fn())
+    mocks.resize.mockResolvedValue({ success: true })
+    mocks.openPath.mockResolvedValue({ success: true })
+
+    Object.defineProperty(window, 'terminalOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        write: mocks.write,
+        create: mocks.create,
+        onData: mocks.onData,
+        onExit: mocks.onExit,
+        resize: mocks.resize
+      }
+    })
+
+    Object.defineProperty(window, 'projectOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        openPath: mocks.openPath
+      }
+    })
+
+    Object.defineProperty(window, 'ResizeObserver', {
+      writable: true,
+      configurable: true,
+      value: MockResizeObserver
+    })
+  })
+
+  test('rewrites bare Shift+Enter to ESC+CR through xterm input when opted in', () => {
+    mountBackend({ shiftEnterAsNewline: true })
+    const event = new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true })
+    const preventDefault = vi.spyOn(event, 'preventDefault')
+
+    const handled = mocks.customKeyHandler?.(event)
+
+    expect(handled).toBe(false)
+    expect(preventDefault).toHaveBeenCalled()
+    expect(mocks.input).toHaveBeenCalledWith('\x1b\r', true)
+    expect(mocks.write).not.toHaveBeenCalled()
+  })
+
+  test('recognizes Shift+Enter by physical key code when the key value differs', () => {
+    mountBackend({ shiftEnterAsNewline: true })
+
+    const handled = mocks.customKeyHandler?.(
+      new KeyboardEvent('keydown', { code: 'Enter', key: 'Return', shiftKey: true })
+    )
+
+    expect(handled).toBe(false)
+    expect(mocks.input).toHaveBeenCalledWith('\x1b\r', true)
+    expect(mocks.write).not.toHaveBeenCalled()
+  })
+
+  test('leaves Shift+Enter untouched by default', () => {
+    mountBackend()
+
+    const handled = mocks.customKeyHandler?.(
+      new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true })
+    )
+
+    expect(handled).toBe(true)
+    expect(mocks.input).not.toHaveBeenCalled()
+    expect(mocks.write).not.toHaveBeenCalled()
+  })
+})

--- a/test/title-real-output.test.ts
+++ b/test/title-real-output.test.ts
@@ -17,7 +17,7 @@ vi.mock('../src/main/services/logger', () => ({
 
 // Only mock spawnCLI — let extractTitleFromJSON and sanitizeTitle run for real
 vi.mock('../src/main/services/title-generation-shared', async (importOriginal) => {
-  const actual = (await importOriginal()) as any
+  const actual = await importOriginal<typeof import('../src/main/services/title-generation-shared')>()
   return {
     ...actual,
     spawnCLI: mockSpawnCLI

--- a/test/utils/effect-test-utils.ts
+++ b/test/utils/effect-test-utils.ts
@@ -79,6 +79,11 @@ export const expectExitFailure = <A, E>(
  *   yield* program.pipe(Effect.provide(Layer.provide(BashLive, layer)))
  */
 export const withTestLayers = (
-  ...overrides: ReadonlyArray<Layer.Layer<any, any, any>>
-): Layer.Layer<any, any, any> =>
-  Layer.mergeAll(...(overrides as [Layer.Layer<any, any, any>]))
+  ...overrides: ReadonlyArray<Layer.Layer<unknown, unknown, unknown>>
+): Layer.Layer<unknown, unknown, unknown> =>
+  Layer.mergeAll(
+    ...(overrides as [
+      Layer.Layer<unknown, unknown, unknown>,
+      ...Array<Layer.Layer<unknown, unknown, unknown>>
+    ])
+  )

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -38,6 +38,7 @@ export default defineWorkspace([
     test: {
       name: 'renderer',
       environment: 'jsdom',
+      testTimeout: 30000,
       include: ['test/**/*.test.{ts,tsx}', 'src/renderer/src/**/*.test.{ts,tsx}'],
       exclude: [
         'test/session-3/**/*.test.ts',


### PR DESCRIPTION
## Summary
- Adds a full Claude CLI terminal experience in the app, including session rendering, prompt handling, shift+enter newline support, and terminal visibility/exit-state behavior.
- Wires Claude CLI sessions into ticket and worktree flows so tickets can launch into the terminal, preserve handoff state, and reflect goal/plan status back into the UI.
- Introduces new backend services for Claude CLI spawning, title tracking, hook handling, transcript/session watching, Telegram forwarding, and plan follow-up restoration.
- Expands preload, IPC, and shared types to support the new session/status model and terminal coordination paths.
- Updates kanban, session, settings, and layout components to surface the new CLI-driven workflow in the main UI.
- Adds broad test coverage across terminal behavior, session listeners, handoff logic, worktree picker behavior, and Claude CLI service integrations.

## Testing
- Not run
- Added/updated Vitest coverage for terminal shift+enter handling, Claude CLI session state, ticket handoff, hook status tracking, and auto-launch/background session flows
- Added integration-style tests for kanban coordination, worktree picker behavior, and global listener follow-up dispatch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Spawns privileged local `claude` processes, runs a localhost hook server that can block tool use, and touches session DB migrations plus IPC routing for agent and terminal flows.
> 
> **Overview**
> Introduces **`claude-code-cli`**, a new agent backend that runs the **`claude` binary in a PTY** (full-bleed xterm in session UI) instead of the legacy Claude Agent SDK. Sessions persist **`claude_session_id`** for **`--resume`**, and the main process builds spawn argv (plan/super-plan flags, model/effort, inline hook settings, initial handoff prompt).
> 
> **Terminal IPC** gains `terminal:createClaudeCli`, `terminal:sendClaudeCliPrompt`, and consolidated per-session lifecycle for watchers, status, and teardown. A **loopback HTTP hook server** maps Claude hook events to **`claude-cli:status`** / plan follow-up IPC; optional **Telegram forwarding** can hold `AskUserQuestion` / `ExitPlanMode` hooks and route answers through existing question/plan reply paths. **OSC title parsing** auto-names sessions and can trigger worktree branch rename like other agents.
> 
> **OpenCode IPC** treats `claude-code-cli` (with `terminal`) as terminal-backed—no SDK connect/prompt/abort routing. Shared **`AgentSdk`** types and DB/Zod schemas are extended; schema version bumps add **`claude_session_id`** (migrations reordered to avoid collisions).
> 
> The renderer/kanban path wires **ticket and plan handoffs** into CLI spawn with pending prompts, portal UI for plan-ready cards, and broad Vitest coverage. Two **planning docs** (IPC→HTTP migration, Claude UI v2) are added but are not runtime changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a07f45da005c05f4cb36faef0eec1f6be47566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->