### PR TITLE
Add right-click sleep option for idle coffee mug

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -77,6 +77,7 @@ import { openCodeService } from './services/opencode-service'
 import { agentEventBus } from './services/agent-event-bus'
 import { telegramForwardingService } from './services/telegram-forwarding-service'
 import { setKeepAwake, cleanupPowerSaveBlocker } from './services/power-save-blocker'
+import { sleepNow } from './services/sleep-now'
 import {
   configurePetWindow,
   destroyPetWindow,
@@ -495,6 +496,8 @@ function registerSystemHandlers(openCodeLaunchSpec: OpenCodeLaunchSpec | null): 
   ipcMain.handle('system:setKeepAwake', (_event, active: boolean) => {
     setKeepAwake(Boolean(active))
   })
+
+  ipcMain.handle('system:sleepNow', () => sleepNow())
 
   // Mirror renderer-side follow-up message queue state into the main process so
   // notification-service can suppress session-complete notifications while more

--- a/src/main/services/sleep-now.ts
+++ b/src/main/services/sleep-now.ts
@@ -1,0 +1,27 @@
+import { exec } from 'node:child_process'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'SleepNow' })
+
+/**
+ * Put the machine to sleep now.
+ *
+ * macOS-only (`pmset sleepnow`, no sudo needed); logged no-op on other
+ * platforms. Returns true if a command was issued.
+ */
+export function sleepNow(): boolean {
+  if (process.platform !== 'darwin') {
+    log.warn('sleepNow on unsupported platform', { platform: process.platform })
+    return false
+  }
+
+  exec('pmset sleepnow', (err) => {
+    if (err) {
+      log.error('pmset sleepnow failed', err instanceof Error ? err : new Error(String(err)))
+      return
+    }
+    log.info('Issued pmset sleepnow')
+  })
+
+  return true
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -748,6 +748,7 @@ declare global {
       isPackaged: () => Promise<boolean>
       getPlatform: () => Promise<string>
       setKeepAwake: (active: boolean) => Promise<void>
+      sleepNow: () => Promise<boolean>
       setSessionQueuedState: (sessionId: string, hasQueued: boolean) => Promise<void>
     }
     petOps: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -661,6 +661,9 @@ const systemOps = {
   setKeepAwake: (active: boolean): Promise<void> =>
     ipcRenderer.invoke('system:setKeepAwake', active),
 
+  // Ask the main process to put the machine to sleep now.
+  sleepNow: (): Promise<boolean> => ipcRenderer.invoke('system:sleepNow'),
+
   // Push the renderer's follow-up-message queue state into the main process so
   // `notificationService.showSessionComplete` can suppress notifications while
   // more queued messages are about to be auto-sent.

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -21,6 +21,7 @@ import { useWorktreeWatcher } from '@/hooks/useWorktreeWatcher'
 import { useConnectionWatcher } from '@/hooks/useConnectionWatcher'
 import { useAutoUpdate } from '@/hooks/useAutoUpdate'
 import { useKeepAwake } from '@/hooks/useKeepAwake'
+import { useSleepWhenIdle } from '@/hooks/useSleepWhenIdle'
 import { ErrorBoundary, ErrorFallback } from '@/components/error'
 import { CreatePRModal } from '@/components/pr/CreatePRModal'
 import { ProjectSettingsDialog } from '@/components/projects/ProjectSettingsDialog'
@@ -142,6 +143,8 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
   useAutoUpdate()
   // Keep the computer awake while any session is actively streaming (opt-in via settings)
   useKeepAwake()
+  // One-shot sleep after all sessions have been idle for a continuous minute.
+  useSleepWhenIdle()
 
   // Drag-and-drop from Finder
   const activeSessionId = useSessionStore((s) => s.activeSessionId)

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -18,7 +18,8 @@ import {
   Copy,
   Hammer,
   Map,
-  Check
+  Check,
+  MoonStar
 } from 'lucide-react'
 import { KanbanIcon } from '@/components/kanban/KanbanIcon'
 import { Button } from '@/components/ui/button'
@@ -35,6 +36,7 @@ import {
   ContextMenuTrigger,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuCheckboxItem,
   ContextMenuSeparator
 } from '@/components/ui/context-menu'
 import { cn } from '@/lib/utils'
@@ -47,6 +49,7 @@ import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useGitStore } from '@/stores/useGitStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useSleepWhenIdleStore } from '@/stores/useSleepWhenIdleStore'
 import { useVimModeStore } from '@/stores/useVimModeStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useTipStore } from '@/stores/useTipStore'
@@ -90,6 +93,9 @@ export function Header(): React.JSX.Element {
       (entry) => entry && (entry.status === 'working' || entry.status === 'planning')
     ).length
   )
+  const sleepWhenIdleArmed = useSleepWhenIdleStore((s) => s.armed)
+  const toggleSleepWhenIdle = useSleepWhenIdleStore((s) => s.toggle)
+  const mugIsOn = keepAwakeEnabled && streamingCount > 0
   const showVimHints = vimModeEnabled && vimMode === 'normal'
   const isBoardViewActive = useKanbanStore((s) => s.isBoardViewActive)
   const toggleBoardView = useKanbanStore((s) => s.toggleBoardView)
@@ -218,19 +224,45 @@ export function Header(): React.JSX.Element {
           <span className="text-sm font-medium">Hive</span>
         )}
         {keepAwakeEnabled && (
-          <Tooltip>
-            <TooltipTrigger asChild>
+          <ContextMenu>
+            <ContextMenuTrigger asChild disabled={!mugIsOn}>
               <span
-                className={cn('shrink-0', streamingCount > 0 ? 'text-amber-500' : 'text-muted-foreground')}
-                data-testid="keep-awake-indicator"
+                className="inline-flex shrink-0"
+                style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
               >
-                <Coffee className="h-4 w-4" />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className={cn(
+                        'shrink-0',
+                        streamingCount > 0 ? 'text-amber-500' : 'text-muted-foreground',
+                        sleepWhenIdleArmed && 'text-indigo-400'
+                      )}
+                      data-testid="keep-awake-indicator"
+                    >
+                      <Coffee className="h-4 w-4" />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" sideOffset={8}>
+                    {sleepWhenIdleArmed
+                      ? 'Will sleep when all sessions have been idle for 1 minute.'
+                      : 'Prevents your computer from sleeping while a session is running'}
+                  </TooltipContent>
+                </Tooltip>
               </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" sideOffset={8}>
-              Prevents your computer from sleeping while a session is running
-            </TooltipContent>
-          </Tooltip>
+            </ContextMenuTrigger>
+            {mugIsOn && (
+              <ContextMenuContent>
+                <ContextMenuCheckboxItem
+                  checked={sleepWhenIdleArmed}
+                  onCheckedChange={toggleSleepWhenIdle}
+                >
+                  <MoonStar className="h-4 w-4 mr-2" />
+                  Sleep when idle
+                </ContextMenuCheckboxItem>
+              </ContextMenuContent>
+            )}
+          </ContextMenu>
         )}
         {vimModeEnabled && (
           <span

--- a/src/renderer/src/hooks/__tests__/useSleepWhenIdle.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useSleepWhenIdle.test.tsx
@@ -1,0 +1,122 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSleepWhenIdle } from '../useSleepWhenIdle'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSleepWhenIdleStore } from '@/stores/useSleepWhenIdleStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+
+describe('useSleepWhenIdle', () => {
+  const initialSettingsState = useSettingsStore.getState()
+  const initialStatusState = useWorktreeStatusStore.getState()
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    useSettingsStore.setState({ ...initialSettingsState, keepAwakeEnabled: true }, true)
+    useWorktreeStatusStore.setState({ ...initialStatusState, sessionStatuses: {} }, true)
+    useSleepWhenIdleStore.setState({ armed: true })
+
+    Object.defineProperty(window, 'systemOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        sleepNow: vi.fn().mockResolvedValue(true)
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    useSettingsStore.setState(initialSettingsState, true)
+    useWorktreeStatusStore.setState(initialStatusState, true)
+    useSleepWhenIdleStore.setState({ armed: false })
+    delete (window as { systemOps?: unknown }).systemOps
+  })
+
+  it('sleeps once after all sessions have been idle for one continuous minute', async () => {
+    renderHook(() => useSleepWhenIdle())
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(59_999)
+    })
+    expect(window.systemOps.sleepNow).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+
+    expect(window.systemOps.sleepNow).toHaveBeenCalledTimes(1)
+    expect(useSleepWhenIdleStore.getState().armed).toBe(false)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    expect(window.systemOps.sleepNow).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets the idle timer when work resumes before the debounce expires', async () => {
+    renderHook(() => useSleepWhenIdle())
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      useWorktreeStatusStore.setState({
+        sessionStatuses: { session1: { status: 'working', timestamp: Date.now() } }
+      })
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    expect(window.systemOps.sleepNow).not.toHaveBeenCalled()
+    expect(useSleepWhenIdleStore.getState().armed).toBe(true)
+
+    await act(async () => {
+      useWorktreeStatusStore.setState({
+        sessionStatuses: { session1: { status: 'completed', timestamp: Date.now() } }
+      })
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(59_999)
+    })
+    expect(window.systemOps.sleepNow).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(window.systemOps.sleepNow).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not sleep while a session is waiting on user approval', async () => {
+    useWorktreeStatusStore.setState({
+      sessionStatuses: { session1: { status: 'permission', timestamp: Date.now() } }
+    })
+
+    renderHook(() => useSleepWhenIdle())
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+
+    expect(window.systemOps.sleepNow).not.toHaveBeenCalled()
+    expect(useSleepWhenIdleStore.getState().armed).toBe(true)
+  })
+
+  it('disarms without sleeping when keep awake is disabled', async () => {
+    renderHook(() => useSleepWhenIdle())
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      useSettingsStore.setState({ keepAwakeEnabled: false })
+    })
+
+    expect(useSleepWhenIdleStore.getState().armed).toBe(false)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+
+    expect(window.systemOps.sleepNow).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/useSleepWhenIdle.ts
+++ b/src/renderer/src/hooks/useSleepWhenIdle.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from 'react'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSleepWhenIdleStore } from '@/stores/useSleepWhenIdleStore'
+import { useWorktreeStatusStore, type SessionStatusType } from '@/stores/useWorktreeStatusStore'
+
+const IDLE_DEBOUNCE_MS = 60_000
+const NON_IDLE = new Set<SessionStatusType>([
+  'working',
+  'planning',
+  'answering',
+  'permission',
+  'command_approval'
+])
+
+function hasNonIdleSession(): boolean {
+  return Object.values(useWorktreeStatusStore.getState().sessionStatuses).some(
+    (entry) => entry && NON_IDLE.has(entry.status)
+  )
+}
+
+export function useSleepWhenIdle(): void {
+  const armed = useSleepWhenIdleStore((state) => state.armed)
+  const disarm = useSleepWhenIdleStore((state) => state.disarm)
+  const keepAwakeEnabled = useSettingsStore((state) => state.keepAwakeEnabled)
+  const anyNonIdle = useWorktreeStatusStore((state) =>
+    Object.values(state.sessionStatuses).some((entry) => entry && NON_IDLE.has(entry.status))
+  )
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const clear = (): void => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+
+    if (!armed || !keepAwakeEnabled) {
+      clear()
+      if (!keepAwakeEnabled) disarm()
+      return clear
+    }
+
+    if (anyNonIdle) {
+      clear()
+      return clear
+    }
+
+    if (!timerRef.current) {
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        const stillIdle = !hasNonIdleSession()
+
+        if (
+          stillIdle &&
+          useSleepWhenIdleStore.getState().armed &&
+          useSettingsStore.getState().keepAwakeEnabled
+        ) {
+          window.systemOps?.sleepNow?.().catch((err) => {
+            console.error('[sleepWhenIdle] failed', err)
+          })
+        }
+
+        disarm()
+      }, IDLE_DEBOUNCE_MS)
+    }
+
+    return clear
+  }, [armed, keepAwakeEnabled, anyNonIdle, disarm])
+}

--- a/src/renderer/src/stores/useSleepWhenIdleStore.ts
+++ b/src/renderer/src/stores/useSleepWhenIdleStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand'
+
+interface SleepWhenIdleState {
+  armed: boolean
+  arm: () => void
+  disarm: () => void
+  toggle: () => void
+}
+
+export const useSleepWhenIdleStore = create<SleepWhenIdleState>((set) => ({
+  armed: false,
+  arm: () => set({ armed: true }),
+  disarm: () => set({ armed: false }),
+  toggle: () => set((state) => ({ armed: !state.armed }))
+}))


### PR DESCRIPTION
## Summary
- Adds a `sleep when idle` context menu action to the keep-awake coffee mug indicator.
- Introduces renderer state and hook logic to arm a one-shot sleep after all sessions stay idle for 1 minute.
- Adds a main-process `sleepNow` IPC handler that issues `pmset sleepnow` on macOS and no-ops elsewhere.
- Covers the idle-sleep behavior with renderer hook tests for idle, resumed work, permission states, and disabled keep-awake.

## Testing
- `vitest src/renderer/src/hooks/__tests__/useSleepWhenIdle.test.tsx`
- Not run: full app or platform integration verification for `pmset sleepnow` on macOS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Triggers system sleep via shell on macOS when armed; wrong idle detection could sleep during long approvals, though permission states are excluded.
> 
> **Overview**
> Adds an optional **sleep when idle** flow tied to the existing keep-awake coffee mug: right-click the mug (while keep-awake is on and a session is streaming) to arm a one-shot sleep after **all** sessions stay idle for **1 minute**. Permission and command-approval states count as non-idle, so the machine won’t sleep while waiting on you.
> 
> The renderer gets `useSleepWhenIdleStore`, `useSleepWhenIdle`, and wiring in `AppLayout` and `Header` (tooltip + indigo styling when armed). Main process exposes `system:sleepNow` / `systemOps.sleepNow`, implemented on macOS via `pmset sleepnow` with a logged no-op elsewhere. Hook tests cover idle timing, work resuming, permission states, and disabling keep-awake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e7f4a4d997a651c6d9df2fe231323322db9583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->