### PR TITLE
Add Codex skills to slash command picker

### DIFF
--- a/src/main/ipc/opencode-handlers.ts
+++ b/src/main/ipc/opencode-handlers.ts
@@ -24,6 +24,11 @@ const modelSchema = z
     agentSdk: agentSdkSchema.optional()
   })
   .passthrough()
+const promptOptionsSchema = z
+  .object({
+    codexFastMode: z.boolean().optional()
+  })
+  .passthrough()
 const promptArgsSchema = z.union([
   z.object({}).passthrough(),
   z.tuple([z.unknown(), z.unknown(), z.unknown()]).rest(z.unknown())
@@ -464,7 +469,8 @@ export function registerOpenCodeHandlers(
             const sdkId = resolveSdkId(dbService, sessionId)
             if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
               const impl = sdkManager.getImplementer(sdkId)
-              const commands = await impl.listCommands(worktreePath)
+              const resolvedAgentSessionId = resolveAgentSessionId(dbService, sessionId)
+              const commands = await impl.listCommands(worktreePath, resolvedAgentSessionId)
               return { success: true, commands }
             }
           }
@@ -501,11 +507,12 @@ export function registerOpenCodeHandlers(
       sessionId: z.string().min(1),
       command: z.string().min(1),
       args: z.string(),
-      model: modelSchema.optional()
+      model: modelSchema.optional(),
+      options: promptOptionsSchema.optional()
     }),
-    ({ worktreePath, sessionId, command, args, model }) =>
+    ({ worktreePath, sessionId, command, args, model, options }) =>
       opencodeEffect(async () => {
-        log.info('IPC: opencode:command', { worktreePath, sessionId, command, args, model })
+        log.info('IPC: opencode:command', { worktreePath, sessionId, command, args, model, options })
         try {
           // SDK-aware dispatch: route non-OpenCode sessions to their implementer
           if (sdkManager && dbService) {
@@ -524,7 +531,7 @@ export function registerOpenCodeHandlers(
             })
             if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
               const impl = sdkManager.getImplementer(sdkId)
-              await impl.sendCommand(worktreePath, resolvedAgentSessionId, command, args)
+              await impl.sendCommand(worktreePath, resolvedAgentSessionId, command, args, model, options)
               return { success: true }
             }
           }

--- a/src/main/services/agent-sdk-types.ts
+++ b/src/main/services/agent-sdk-types.ts
@@ -88,12 +88,14 @@ export interface AgentSdkImplementer {
   redo(worktreePath: string, agentSessionId: string, hiveSessionId: string): Promise<unknown>
 
   // Commands
-  listCommands(worktreePath: string): Promise<unknown[]>
+  listCommands(worktreePath: string, agentSessionId?: string): Promise<unknown[]>
   sendCommand(
     worktreePath: string,
     agentSessionId: string,
     command: string,
-    args?: string
+    args?: string,
+    modelOverride?: { providerID: string; modelID: string; variant?: string },
+    options?: PromptOptions
   ): Promise<void>
 
   // Session management

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -31,6 +31,8 @@ import type { CommandExecutionRequestApprovalParams } from '@shared/codex-schema
 import type { FileChangeRequestApprovalParams } from '@shared/codex-schemas/v2/FileChangeRequestApprovalParams'
 import type { ToolRequestUserInputParams } from '@shared/codex-schemas/v2/ToolRequestUserInputParams'
 import type { ToolRequestUserInputAnswer } from '@shared/codex-schemas/v2/ToolRequestUserInputAnswer'
+import type { UserInput } from '@shared/codex-schemas/v2/UserInput'
+import type { SkillsListResponse } from '@shared/codex-schemas/v2/SkillsListResponse'
 import type { ServerNotification } from '@shared/codex-schemas/ServerNotification'
 import type { ServerRequest } from '@shared/codex-schemas/ServerRequest'
 import type { ThreadResumeParams } from '@shared/codex-schemas/v2/ThreadResumeParams'
@@ -134,7 +136,7 @@ export interface CodexStartSessionOptions {
 
 export interface CodexTurnInput {
   text?: string
-  input?: Array<{ type: string; text: string }>
+  input?: UserInput[]
   model?: string
   reasoningEffort?: string
   serviceTier?: string | null
@@ -747,6 +749,18 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       turnId,
       threadId: context.session.threadId
     }
+  }
+
+  async listSkills(
+    threadId: string,
+    worktreePath: string,
+    forceReload = false
+  ): Promise<SkillsListResponse> {
+    const context = this.getSessionContextForThreadRpc(threadId, 'listSkills')
+    return this.sendRequest<SkillsListResponse>(context, 'skills/list', {
+      cwds: [worktreePath],
+      forceReload
+    })
   }
 
   async steerTurn(threadId: string, input: CodexTurnInput, expectedTurnId: string): Promise<CodexTurnSteerResult> {

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -37,6 +37,9 @@ import type { ThreadItem } from '@shared/codex-schemas/v2/ThreadItem'
 import type { Thread } from '@shared/codex-schemas/v2/Thread'
 import type { ThreadGoal } from '@shared/codex-schemas/v2/ThreadGoal'
 import type { ThreadGoalStatus } from '@shared/codex-schemas/v2/ThreadGoalStatus'
+import type { SkillMetadata } from '@shared/codex-schemas/v2/SkillMetadata'
+import type { SkillsListResponse } from '@shared/codex-schemas/v2/SkillsListResponse'
+import type { SkillScope } from '@shared/codex-schemas/v2/SkillScope'
 import type { OpenCodeStreamEvent } from '@shared/types/opencode'
 
 const log = createLogger({ component: 'CodexImplementer' })
@@ -49,6 +52,25 @@ const CODEX_GOAL_COMMAND = {
   template: '/goal ',
   source: 'codex',
   hints: ['clear', 'pause', 'resume']
+}
+
+interface CodexSlashCommand {
+  name: string
+  description?: string
+  template: string
+  agent?: string
+  builtIn?: boolean
+  source?: 'command' | 'mcp' | 'skill' | 'codex'
+  path?: string
+  scope?: SkillScope
+  enabled?: boolean
+  hints?: string[]
+}
+
+interface CodexSkillCommand extends CodexSlashCommand {
+  source: 'skill'
+  path: string
+  enabled: true
 }
 const HITL_REQUEST_METHODS = new Set([
   'item/tool/requestUserInput',
@@ -299,6 +321,7 @@ export class CodexImplementer implements AgentSdkImplementer {
   private pendingQuestions = new Map<string, PendingHitlEntry>()
   private pendingApprovalSessions = new Map<string, PendingHitlEntry>()
   private promptHandledThreadIds = new Set<string>()
+  private skillCommandsBySessionKey = new Map<string, CodexSkillCommand[]>()
 
   // ── Window binding ───────────────────────────────────────────────
 
@@ -347,6 +370,17 @@ export class CodexImplementer implements AgentSdkImplementer {
     // Handle thread name updates from the Codex provider (title generation)
     if (event.kind === 'notification' && event.method === 'thread/name/updated') {
       this.handleProviderTitleUpdate(event).catch(() => {})
+      return
+    }
+
+    if (event.kind === 'notification' && event.method === 'skills/changed') {
+      if (targetSession) {
+        this.sendCommandsAvailable(targetSession)
+      } else {
+        for (const session of this.sessions.values()) {
+          this.sendCommandsAvailable(session)
+        }
+      }
       return
     }
 
@@ -674,6 +708,7 @@ export class CodexImplementer implements AgentSdkImplementer {
 
     // Clean up local state
     this.sessions.delete(key)
+    this.skillCommandsBySessionKey.delete(key)
     this.cleanupPendingForThread(agentSessionId)
 
     log.info('Disconnected', { worktreePath, agentSessionId })
@@ -695,6 +730,7 @@ export class CodexImplementer implements AgentSdkImplementer {
 
     // Clear local state
     this.sessions.clear()
+    this.skillCommandsBySessionKey.clear()
     this.pendingQuestions.clear()
     this.pendingApprovalSessions.clear()
     this.managerListenerAttached = false
@@ -739,6 +775,28 @@ export class CodexImplementer implements AgentSdkImplementer {
       log.warn('Prompt: empty text, ignoring', { worktreePath, agentSessionId })
       return
     }
+
+    await this.runUserTurn(
+      session,
+      worktreePath,
+      agentSessionId,
+      text,
+      [{ type: 'text', text, text_elements: [] }],
+      modelOverride,
+      options
+    )
+  }
+
+  private async runUserTurn(
+    session: CodexSessionState,
+    worktreePath: string,
+    agentSessionId: string,
+    displayText: string,
+    turnInput: UserInput[],
+    modelOverride?: { providerID: string; modelID: string; variant?: string },
+    options?: PromptOptions
+  ): Promise<void> {
+    const text = displayText
 
     if (!session.titleGenerationStarted) {
       const currentTitle = this.dbService?.getSession(session.hiveSessionId)?.name ?? null
@@ -987,7 +1045,7 @@ export class CodexImplementer implements AgentSdkImplementer {
 
       const reasoningEffort = modelOverride?.variant ?? this.selectedVariant
       await this.manager.sendTurn(session.threadId, {
-        text,
+        input: turnInput,
         model,
         ...(options?.codexFastMode ? { serviceTier: 'fast' } : {}),
         ...(reasoningEffort ? { reasoningEffort } : {}),
@@ -1651,19 +1709,66 @@ export class CodexImplementer implements AgentSdkImplementer {
 
   // ── Commands ─────────────────────────────────────────────────────
 
-  async listCommands(_worktreePath: string): Promise<unknown[]> {
-    return [CODEX_GOAL_COMMAND]
+  async listCommands(worktreePath: string, agentSessionId?: string): Promise<unknown[]> {
+    if (!agentSessionId) {
+      log.warn('listCommands: no Codex thread id available; returning goal command only', {
+        worktreePath
+      })
+      return [CODEX_GOAL_COMMAND]
+    }
+
+    const sessionKey = this.getSessionKey(worktreePath, agentSessionId)
+    try {
+      const response = await this.manager.listSkills(agentSessionId, worktreePath)
+      const skillCommands = this.mapSkillsListResponseToCommands(response, worktreePath)
+      this.skillCommandsBySessionKey.set(sessionKey, skillCommands)
+      return [CODEX_GOAL_COMMAND, ...skillCommands]
+    } catch (error) {
+      log.warn('listCommands: skills/list failed; returning goal command only', {
+        worktreePath,
+        agentSessionId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return [CODEX_GOAL_COMMAND]
+    }
   }
 
   async sendCommand(
     worktreePath: string,
     agentSessionId: string,
     command: string,
-    args?: string
+    args?: string,
+    modelOverride?: { providerID: string; modelID: string; variant?: string },
+    options?: PromptOptions
   ): Promise<void> {
     const normalizedCommand = command.trim().replace(/^\//, '').toLowerCase()
     if (normalizedCommand !== 'goal') {
-      throw new Error(`Unsupported Codex command: /${normalizedCommand || command}`)
+      const skill = this.findCachedSkillCommand(worktreePath, agentSessionId, normalizedCommand)
+      if (!skill) {
+        throw new Error(`Unsupported Codex command: /${normalizedCommand || command}`)
+      }
+
+      const session = this.sessions.get(this.getSessionKey(worktreePath, agentSessionId))
+      if (!session) {
+        throw new Error(`Command failed: session not found for ${worktreePath} / ${agentSessionId}`)
+      }
+
+      const trimmedArgs = (args ?? '').trim()
+      const displayText = `/${skill.name}${trimmedArgs ? ` ${trimmedArgs}` : ''}`
+      const turnInput: UserInput[] = [{ type: 'skill', name: skill.name, path: skill.path }]
+      if (trimmedArgs) {
+        turnInput.push({ type: 'text', text: trimmedArgs, text_elements: [] })
+      }
+      await this.runUserTurn(
+        session,
+        worktreePath,
+        agentSessionId,
+        displayText,
+        turnInput,
+        modelOverride,
+        options
+      )
+      return
     }
 
     const session = this.sessions.get(this.getSessionKey(worktreePath, agentSessionId))
@@ -1703,6 +1808,79 @@ export class CodexImplementer implements AgentSdkImplementer {
     }
 
     this.emitCommandMessage(session, summary)
+  }
+
+  private findCachedSkillCommand(
+    worktreePath: string,
+    agentSessionId: string,
+    commandName: string
+  ): CodexSkillCommand | undefined {
+    const sessionKey = this.getSessionKey(worktreePath, agentSessionId)
+    return this.skillCommandsBySessionKey
+      .get(sessionKey)
+      ?.find((skill) => skill.name.toLowerCase() === commandName.toLowerCase())
+  }
+
+  private mapSkillsListResponseToCommands(
+    response: SkillsListResponse,
+    worktreePath: string
+  ): CodexSkillCommand[] {
+    const entries = Array.isArray(response.data) ? response.data : []
+    for (const entry of entries) {
+      for (const error of entry.errors ?? []) {
+        log.warn('skills/list returned cwd error', {
+          cwd: entry.cwd,
+          error: toJsonSnapshot(error, 500)
+        })
+      }
+    }
+
+    const exactEntry = entries.find((entry) => entry.cwd === worktreePath)
+    const skills = exactEntry
+      ? exactEntry.skills
+      : entries.flatMap((entry) => entry.skills ?? [])
+
+    if (!exactEntry && entries.length > 0) {
+      log.warn('skills/list did not return exact cwd match; flattening all skills', {
+        worktreePath,
+        returnedCwds: entries.map((entry) => entry.cwd)
+      })
+    }
+
+    return skills.flatMap((skill) => {
+      const command = this.mapSkillMetadataToCommand(skill)
+      return command ? [command] : []
+    })
+  }
+
+  private mapSkillMetadataToCommand(skill: SkillMetadata): CodexSkillCommand | null {
+    if (!skill.enabled) return null
+
+    const name = skill.name?.trim()
+    const path = skill.path?.trim()
+    if (!name || !path) {
+      log.debug('Skipping invalid Codex skill metadata', {
+        name: skill.name,
+        hasPath: Boolean(skill.path)
+      })
+      return null
+    }
+
+    const defaultPrompt = skill.interface?.defaultPrompt?.trim()
+    const template = defaultPrompt
+      ? `/${name} ${defaultPrompt}${/\s$/.test(skill.interface?.defaultPrompt ?? '') ? '' : ' '}`
+      : `/${name} `
+
+    return {
+      name,
+      description:
+        skill.interface?.shortDescription ?? skill.shortDescription ?? skill.description,
+      template,
+      source: 'skill',
+      path,
+      scope: skill.scope,
+      enabled: true
+    }
   }
 
   // ── Session management ───────────────────────────────────────────
@@ -1807,6 +1985,14 @@ export class CodexImplementer implements AgentSdkImplementer {
     if (event.method === 'item/tool/requestUserInput/answered' && event.requestId) {
       this.clearPendingHitlRequest(session, event.requestId)
     }
+  }
+
+  private sendCommandsAvailable(session: CodexSessionState): void {
+    this.sendToRenderer('opencode:stream', {
+      type: 'session.commands_available',
+      sessionId: session.hiveSessionId,
+      data: {}
+    })
   }
 
   private cleanupPendingForThread(threadId: string): void {

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -387,8 +387,12 @@ export class CodexImplementer implements AgentSdkImplementer {
 
     if (event.kind === 'notification' && event.method === 'skills/changed') {
       if (targetSession) {
+        this.skillCommandsBySessionKey.delete(
+          this.getSessionKey(targetSession.worktreePath, targetSession.threadId)
+        )
         this.sendCommandsAvailable(targetSession)
       } else {
+        this.skillCommandsBySessionKey.clear()
         for (const session of this.sessions.values()) {
           this.sendCommandsAvailable(session)
         }
@@ -803,13 +807,11 @@ export class CodexImplementer implements AgentSdkImplementer {
     session: CodexSessionState,
     worktreePath: string,
     agentSessionId: string,
-    displayText: string,
+    text: string,
     turnInput: UserInput[],
     modelOverride?: { providerID: string; modelID: string; variant?: string },
     options?: PromptOptions
   ): Promise<void> {
-    const text = displayText
-
     if (!session.titleGenerationStarted) {
       const currentTitle = this.dbService?.getSession(session.hiveSessionId)?.name ?? null
       const shouldGenerateTitle = isDefaultSessionTitle(currentTitle)
@@ -1741,6 +1743,7 @@ export class CodexImplementer implements AgentSdkImplementer {
         agentSessionId,
         error: error instanceof Error ? error.message : String(error)
       })
+      this.skillCommandsBySessionKey.delete(sessionKey)
       return [CODEX_GOAL_COMMAND]
     }
   }
@@ -1879,9 +1882,7 @@ export class CodexImplementer implements AgentSdkImplementer {
     }
 
     const defaultPrompt = skill.interface?.defaultPrompt?.trim()
-    const template = defaultPrompt
-      ? `/${name} ${defaultPrompt}${/\s$/.test(skill.interface?.defaultPrompt ?? '') ? '' : ' '}`
-      : `/${name} `
+    const template = defaultPrompt ? `/${name} ${defaultPrompt} ` : `/${name} `
 
     return {
       name,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -931,7 +931,8 @@ declare global {
         opencodeSessionId: string,
         command: string,
         args: string,
-        model?: { providerID: string; modelID: string; variant?: string }
+        model?: { providerID: string; modelID: string; variant?: string },
+        options?: { codexFastMode?: boolean }
       ) => Promise<Envelope<{ success: boolean; error?: string }>>
       // List available slash commands from the SDK
       commands: (
@@ -2013,7 +2014,10 @@ declare global {
     template: string
     agent?: string
     model?: string
-    source?: 'command' | 'mcp' | 'skill'
+    source?: 'command' | 'mcp' | 'skill' | 'codex'
+    path?: string
+    scope?: 'user' | 'repo' | 'system' | 'admin'
+    enabled?: boolean
     subtask?: boolean
     hints?: string[]
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1685,14 +1685,16 @@ const opencodeOps = {
     opencodeSessionId: string,
     command: string,
     args: string,
-    model?: { providerID: string; modelID: string; variant?: string }
+    model?: { providerID: string; modelID: string; variant?: string },
+    options?: { codexFastMode?: boolean }
   ): Promise<Envelope<{ success: boolean; error?: string }>> =>
     ipcRenderer.invoke('opencode:command', {
       worktreePath,
       sessionId: opencodeSessionId,
       command,
       args,
-      model
+      model,
+      options
     }),
 
   // List available slash commands from the SDK
@@ -1709,6 +1711,9 @@ const opencodeOps = {
         agent?: string
         model?: string
         source?: string
+        path?: string
+        scope?: string
+        enabled?: boolean
         subtask?: boolean
         hints?: string[]
       }>

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -138,6 +138,10 @@ interface SlashCommandInfo {
   template: string
   agent?: string
   builtIn?: boolean
+  source?: 'command' | 'mcp' | 'skill' | 'codex'
+  path?: string
+  scope?: 'user' | 'repo' | 'system' | 'admin'
+  enabled?: boolean
 }
 
 export const BUILT_IN_SLASH_COMMANDS: SlashCommandInfo[] = [
@@ -4682,7 +4686,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                   opencodeSessionId,
                   commandName,
                   commandArgs,
-                  requestModel
+                  requestModel,
+                  codexPromptOptions
                 )
               )
               if (!result.success) {
@@ -5529,9 +5534,10 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     [sessionId, slashDismissed, fileMentionsOpen, fileMentionCount, updateFileMentions]
   )
 
-  const handleCommandSelect = useCallback((cmd: { name: string; template: string }) => {
-    setInputValue(`/${cmd.name} `)
-    inputValueRef.current = `/${cmd.name} `
+  const handleCommandSelect = useCallback((cmd: SlashCommandInfo) => {
+    const template = /\s$/.test(cmd.template) ? cmd.template : `${cmd.template} `
+    setInputValue(template)
+    inputValueRef.current = template
     setSlashDismissed(false)
     textareaRef.current?.focus()
   }, [])

--- a/src/renderer/src/components/sessions/SlashCommandPopover.tsx
+++ b/src/renderer/src/components/sessions/SlashCommandPopover.tsx
@@ -7,12 +7,16 @@ interface SlashCommand {
   template: string
   agent?: string
   builtIn?: boolean
+  source?: 'command' | 'mcp' | 'skill' | 'codex'
+  path?: string
+  scope?: 'user' | 'repo' | 'system' | 'admin'
+  enabled?: boolean
 }
 
 interface SlashCommandPopoverProps {
   commands: SlashCommand[]
   filter: string
-  onSelect: (command: { name: string; template: string }) => void
+  onSelect: (command: SlashCommand) => void
   onClose: () => void
   visible: boolean
 }
@@ -68,7 +72,7 @@ export function SlashCommandPopover({
         e.stopPropagation()
         const cmd = filtered[selectedIndex]
         if (cmd) {
-          onSelect({ name: cmd.name, template: cmd.template })
+          onSelect(cmd)
         }
       } else if (e.key === 'Escape') {
         e.preventDefault()
@@ -109,9 +113,19 @@ export function SlashCommandPopover({
                 index === selectedIndex && 'bg-accent text-accent-foreground'
               )}
               onMouseEnter={() => setSelectedIndex(index)}
-              onClick={() => onSelect({ name: cmd.name, template: cmd.template })}
+              onClick={() => onSelect(cmd)}
             >
               <span className="font-mono text-xs text-muted-foreground">/{cmd.name}</span>
+              {cmd.source === 'skill' && (
+                <span className="text-[10px] px-1 rounded bg-amber-500/20 text-amber-500">
+                  skill
+                </span>
+              )}
+              {cmd.source === 'codex' && (
+                <span className="text-[10px] px-1 rounded bg-cyan-500/20 text-cyan-500">
+                  codex
+                </span>
+              )}
               {cmd.agent && (
                 <span
                   className={cn(

--- a/src/shared/types/opencode.ts
+++ b/src/shared/types/opencode.ts
@@ -17,7 +17,10 @@ export interface OpenCodeCommand {
   template: string
   agent?: string
   model?: string
-  source?: 'command' | 'mcp' | 'skill'
+  source?: 'command' | 'mcp' | 'skill' | 'codex'
+  path?: string
+  scope?: 'user' | 'repo' | 'system' | 'admin'
+  enabled?: boolean
   subtask?: boolean
   hints?: string[]
 }

--- a/test/phase-22/session-3/codex-implementer-skeleton.test.ts
+++ b/test/phase-22/session-3/codex-implementer-skeleton.test.ts
@@ -233,7 +233,7 @@ describe('CodexImplementer skeleton', () => {
                   shortDescription: 'Legacy short',
                   interface: {
                     shortDescription: 'Explore requirements',
-                    defaultPrompt: 'design this'
+                    defaultPrompt: '  design this  '
                   },
                   path: '/skills/brainstorming/SKILL.md',
                   scope: 'user',
@@ -374,6 +374,41 @@ describe('CodexImplementer skeleton', () => {
       ])
     })
 
+    it('clears cached skills when skills/list fails after a previous successful fetch', async () => {
+      const manager = {
+        listSkills: vi
+          .fn()
+          .mockResolvedValueOnce({
+            data: [
+              {
+                cwd: '/path',
+                skills: [
+                  {
+                    name: 'imagegen',
+                    description: 'Generate an image',
+                    path: '/skills/imagegen/SKILL.md',
+                    scope: 'system',
+                    enabled: true
+                  }
+                ],
+                errors: []
+              }
+            ]
+          })
+          .mockRejectedValueOnce(new Error('protocol unavailable'))
+      }
+      ;(impl as any).manager = manager
+
+      await impl.listCommands('/path', 'thread-1')
+      await expect(impl.listCommands('/path', 'thread-1')).resolves.toEqual([
+        expect.objectContaining({ name: 'goal' })
+      ])
+
+      await expect(impl.sendCommand('/path', 'thread-1', 'imagegen', 'a poster')).rejects.toThrow(
+        'Unsupported Codex command: /imagegen'
+      )
+    })
+
     it('emits commands_available when Codex reports skills/changed', () => {
       seedCodexSession()
       const mockWindow = {
@@ -392,6 +427,55 @@ describe('CodexImplementer skeleton', () => {
         payload: {}
       })
 
+      expect(mockWindow.webContents.send).toHaveBeenCalledWith('opencode:stream', {
+        type: 'session.commands_available',
+        sessionId: 'hive-1',
+        data: {}
+      })
+    })
+
+    it('clears cached skills for the changed session before notifying commands_available', async () => {
+      seedCodexSession()
+      const manager = {
+        listSkills: vi.fn().mockResolvedValue({
+          data: [
+            {
+              cwd: '/path',
+              skills: [
+                {
+                  name: 'imagegen',
+                  description: 'Generate an image',
+                  path: '/skills/imagegen/SKILL.md',
+                  scope: 'system',
+                  enabled: true
+                }
+              ],
+              errors: []
+            }
+          ]
+        })
+      }
+      ;(impl as any).manager = manager
+      const mockWindow = {
+        isDestroyed: () => false,
+        webContents: { send: vi.fn() }
+      } as any
+      impl.setMainWindow(mockWindow)
+
+      await impl.listCommands('/path', 'thread-1')
+      ;(impl as any).handleManagerEvent({
+        id: 'skills-changed-1',
+        kind: 'notification',
+        provider: 'codex',
+        threadId: 'thread-1',
+        createdAt: new Date().toISOString(),
+        method: 'skills/changed',
+        payload: {}
+      })
+
+      await expect(impl.sendCommand('/path', 'thread-1', 'imagegen', 'a poster')).rejects.toThrow(
+        'Unsupported Codex command: /imagegen'
+      )
       expect(mockWindow.webContents.send).toHaveBeenCalledWith('opencode:stream', {
         type: 'session.commands_available',
         sessionId: 'hive-1',

--- a/test/phase-22/session-3/codex-implementer-skeleton.test.ts
+++ b/test/phase-22/session-3/codex-implementer-skeleton.test.ts
@@ -23,6 +23,25 @@ describe('CodexImplementer skeleton', () => {
     impl = new CodexImplementer()
   })
 
+  function seedCodexSession(): void {
+    ;(impl as any).sessions.set('/path::thread-1', {
+      threadId: 'thread-1',
+      hiveSessionId: 'hive-1',
+      worktreePath: '/path',
+      status: 'ready',
+      messages: [],
+      pendingHitlRequestIds: new Set<string>(),
+      liveAssistantDraft: null,
+      currentTurnId: null,
+      currentAssistantMessageId: null,
+      revertMessageID: null,
+      revertDiff: null,
+      titleGenerated: true,
+      titleGenerationStarted: true,
+      persistDebounceTimer: null
+    })
+  }
+
   // ── Identity & capabilities ────────────────────────────────────
 
   describe('identity', () => {
@@ -196,6 +215,264 @@ describe('CodexImplementer skeleton', () => {
           expect.objectContaining({
             name: 'goal',
             template: '/goal '
+          })
+        ])
+      )
+    })
+
+    it('lists enabled Codex skills after the goal command', async () => {
+      const manager = {
+        listSkills: vi.fn().mockResolvedValue({
+          data: [
+            {
+              cwd: '/path',
+              skills: [
+                {
+                  name: 'brainstorming',
+                  description: 'Full description',
+                  shortDescription: 'Legacy short',
+                  interface: {
+                    shortDescription: 'Explore requirements',
+                    defaultPrompt: 'design this'
+                  },
+                  path: '/skills/brainstorming/SKILL.md',
+                  scope: 'user',
+                  enabled: true
+                },
+                {
+                  name: 'disabled-skill',
+                  description: 'Disabled',
+                  path: '/skills/disabled/SKILL.md',
+                  scope: 'user',
+                  enabled: false
+                },
+                {
+                  name: 'missing-path',
+                  description: 'Invalid',
+                  path: '',
+                  scope: 'user',
+                  enabled: true
+                }
+              ],
+              errors: [{ message: 'bad repo skill' }]
+            }
+          ]
+        })
+      }
+      ;(impl as any).manager = manager
+
+      const commands = (await impl.listCommands('/path', 'thread-1')) as any[]
+
+      expect(commands[0]).toMatchObject({ name: 'goal', source: 'codex' })
+      expect(commands).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'brainstorming',
+            description: 'Explore requirements',
+            template: '/brainstorming design this ',
+            source: 'skill',
+            path: '/skills/brainstorming/SKILL.md',
+            scope: 'user',
+            enabled: true
+          })
+        ])
+      )
+      expect(commands.find((command) => command.name === 'disabled-skill')).toBeUndefined()
+      expect(commands.find((command) => command.name === 'missing-path')).toBeUndefined()
+    })
+
+    it('prefers exact skills/list cwd matches over fallback flattening', async () => {
+      const manager = {
+        listSkills: vi.fn().mockResolvedValue({
+          data: [
+            {
+              cwd: '/other',
+              skills: [
+                {
+                  name: 'other-skill',
+                  description: 'Other',
+                  path: '/skills/other/SKILL.md',
+                  scope: 'user',
+                  enabled: true
+                }
+              ],
+              errors: []
+            },
+            {
+              cwd: '/path',
+              skills: [
+                {
+                  name: 'exact-skill',
+                  description: 'Exact',
+                  path: '/skills/exact/SKILL.md',
+                  scope: 'repo',
+                  enabled: true
+                }
+              ],
+              errors: []
+            }
+          ]
+        })
+      }
+      ;(impl as any).manager = manager
+
+      const commands = (await impl.listCommands('/path', 'thread-1')) as any[]
+
+      expect(commands.find((command) => command.name === 'exact-skill')).toBeDefined()
+      expect(commands.find((command) => command.name === 'other-skill')).toBeUndefined()
+    })
+
+    it('flattens skills/list entries when no exact cwd match is returned', async () => {
+      const manager = {
+        listSkills: vi.fn().mockResolvedValue({
+          data: [
+            {
+              cwd: '/other-a',
+              skills: [
+                {
+                  name: 'skill-a',
+                  description: 'A',
+                  path: '/skills/a/SKILL.md',
+                  scope: 'user',
+                  enabled: true
+                }
+              ],
+              errors: []
+            },
+            {
+              cwd: '/other-b',
+              skills: [
+                {
+                  name: 'skill-b',
+                  description: 'B',
+                  path: '/skills/b/SKILL.md',
+                  scope: 'system',
+                  enabled: true
+                }
+              ],
+              errors: []
+            }
+          ]
+        })
+      }
+      ;(impl as any).manager = manager
+
+      const commands = (await impl.listCommands('/path', 'thread-1')) as any[]
+
+      expect(commands.find((command) => command.name === 'skill-a')).toBeDefined()
+      expect(commands.find((command) => command.name === 'skill-b')).toBeDefined()
+    })
+
+    it('falls back to goal only when skills/list fails', async () => {
+      const manager = {
+        listSkills: vi.fn().mockRejectedValue(new Error('protocol unavailable'))
+      }
+      ;(impl as any).manager = manager
+
+      await expect(impl.listCommands('/path', 'thread-1')).resolves.toEqual([
+        expect.objectContaining({ name: 'goal' })
+      ])
+    })
+
+    it('emits commands_available when Codex reports skills/changed', () => {
+      seedCodexSession()
+      const mockWindow = {
+        isDestroyed: () => false,
+        webContents: { send: vi.fn() }
+      } as any
+      impl.setMainWindow(mockWindow)
+
+      ;(impl as any).handleManagerEvent({
+        id: 'skills-changed-1',
+        kind: 'notification',
+        provider: 'codex',
+        threadId: 'thread-1',
+        createdAt: new Date().toISOString(),
+        method: 'skills/changed',
+        payload: {}
+      })
+
+      expect(mockWindow.webContents.send).toHaveBeenCalledWith('opencode:stream', {
+        type: 'session.commands_available',
+        sessionId: 'hive-1',
+        data: {}
+      })
+    })
+
+    it('sends known skill commands as structured Codex input through the turn lifecycle', async () => {
+      seedCodexSession()
+      const manager = new EventEmitter() as any
+      manager.listSkills = vi.fn().mockResolvedValue({
+        data: [
+          {
+            cwd: '/path',
+            skills: [
+              {
+                name: 'imagegen',
+                description: 'Generate an image',
+                path: '/skills/imagegen/SKILL.md',
+                scope: 'system',
+                enabled: true
+              }
+            ],
+            errors: []
+          }
+        ]
+      })
+      manager.sendTurn = vi.fn(async (threadId: string) => {
+        setTimeout(() => {
+          manager.emit('event', {
+            id: 'event-1',
+            kind: 'notification',
+            provider: 'codex',
+            threadId,
+            createdAt: new Date().toISOString(),
+            method: 'turn/completed',
+            turnId: 'turn-1',
+            payload: { turn: { id: 'turn-1', status: 'completed' } }
+          })
+        }, 0)
+        return { threadId, turnId: 'turn-1' }
+      })
+      ;(impl as any).manager = manager
+      const mockWindow = {
+        isDestroyed: () => false,
+        webContents: { send: vi.fn() }
+      } as any
+      impl.setMainWindow(mockWindow)
+
+      await impl.listCommands('/path', 'thread-1')
+      await impl.sendCommand(
+        '/path',
+        'thread-1',
+        'imagegen',
+        'a clean product mockup',
+        { providerID: 'codex', modelID: 'gpt-5.5', variant: 'high' },
+        { codexFastMode: true }
+      )
+
+      expect(manager.sendTurn).toHaveBeenCalledWith(
+        'thread-1',
+        expect.objectContaining({
+          input: [
+            { type: 'skill', name: 'imagegen', path: '/skills/imagegen/SKILL.md' },
+            { type: 'text', text: 'a clean product mockup', text_elements: [] }
+          ],
+          model: 'gpt-5.5',
+          reasoningEffort: 'high',
+          serviceTier: 'fast'
+        })
+      )
+      expect((impl as any).sessions.get('/path::thread-1').messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: 'user',
+            parts: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'text',
+                text: '/imagegen a clean product mockup'
+              })
+            ])
           })
         ])
       )

--- a/test/phase-22/session-5/codex-app-server-manager.test.ts
+++ b/test/phase-22/session-5/codex-app-server-manager.test.ts
@@ -248,6 +248,75 @@ describe('CodexAppServerManager — collaborationMode in sendTurn', () => {
     expect(params.collaborationMode).toBeUndefined()
   })
 
+  it('sends skills/list for the requested cwd', async () => {
+    const { context, stdin } = createTestContext()
+    seedSession(context)
+
+    const skillsPromise = manager.listSkills('thread-123', '/test/project', true)
+
+    const messages = getWrittenMessages(stdin)
+    const listMsg = messages.find((m: any) => m.method === 'skills/list')
+    expect(listMsg).toBeDefined()
+    expect(listMsg.params).toEqual({
+      cwds: ['/test/project'],
+      forceReload: true
+    })
+
+    manager.handleStdoutLine(
+      context,
+      JSON.stringify({
+        id: listMsg.id,
+        result: {
+          data: [
+            {
+              cwd: '/test/project',
+              skills: [],
+              errors: []
+            }
+          ]
+        }
+      })
+    )
+
+    await expect(skillsPromise).resolves.toEqual({
+      data: [
+        {
+          cwd: '/test/project',
+          skills: [],
+          errors: []
+        }
+      ]
+    })
+  })
+
+  it('preserves structured UserInput arrays in turn/start', async () => {
+    const { context, stdin } = createTestContext()
+    seedSession(context)
+
+    const turnPromise = manager.sendTurn('thread-123', {
+      input: [
+        { type: 'skill', name: 'imagegen', path: '/skills/imagegen/SKILL.md' },
+        { type: 'text', text: 'make it crisp', text_elements: [] }
+      ],
+      model: 'gpt-5.4'
+    })
+
+    const messages = getWrittenMessages(stdin)
+    const turnStartMsg = messages.find((m: any) => m.method === 'turn/start')
+    expect(turnStartMsg).toBeDefined()
+    expect(turnStartMsg.params.input).toEqual([
+      { type: 'skill', name: 'imagegen', path: '/skills/imagegen/SKILL.md' },
+      { type: 'text', text: 'make it crisp', text_elements: [] }
+    ])
+
+    manager.handleStdoutLine(
+      context,
+      JSON.stringify({ id: turnStartMsg.id, result: { turn: { id: 'turn-skill' } } })
+    )
+
+    await turnPromise
+  })
+
   it('collaborationMode.settings.model matches the provided model', async () => {
     const { context, stdin } = createTestContext({ model: 'gpt-5.4' })
     seedSession(context)
@@ -329,8 +398,8 @@ describe('CodexAppServerManager — collaborationMode in sendTurn', () => {
       reasoningEffort: 'low',
       developerInstructions: 'Title only instructions',
       input: [
-        { type: 'text', text: 'Generate a title for this conversation:\n' },
-        { type: 'text', text: 'Fix auth refresh token bug' }
+        { type: 'text', text: 'Generate a title for this conversation:\n', text_elements: [] },
+        { type: 'text', text: 'Fix auth refresh token bug', text_elements: [] }
       ]
     })
 
@@ -346,8 +415,8 @@ describe('CodexAppServerManager — collaborationMode in sendTurn', () => {
 
     const params = getTurnStartParams(messages)
     expect(params.input).toEqual([
-      { type: 'text', text: 'Generate a title for this conversation:\n' },
-      { type: 'text', text: 'Fix auth refresh token bug' }
+      { type: 'text', text: 'Generate a title for this conversation:\n', text_elements: [] },
+      { type: 'text', text: 'Fix auth refresh token bug', text_elements: [] }
     ])
     expect(params.effort).toBe('low')
     expect(params.collaborationMode.mode).toBe('default')

--- a/test/phase-22/session-5/ipc-codex-goal-command-routing.test.ts
+++ b/test/phase-22/session-5/ipc-codex-goal-command-routing.test.ts
@@ -64,9 +64,9 @@ describe('IPC Codex goal command routing', () => {
     expect(dbService.getAgentSdkForSession).toHaveBeenCalledWith('hive-1')
     expect(dbService.getSession).toHaveBeenCalledWith('hive-1')
     expect(sdkManager.getImplementer).toHaveBeenCalledWith('codex')
-    expect(codexImpl.listCommands).toHaveBeenCalledWith('/project')
+    expect(codexImpl.listCommands).toHaveBeenCalledWith('/project', 'hive-1')
     expect(openCodeService.listCommands).not.toHaveBeenCalled()
-    expect(result).toEqual({
+    expect(result.value).toEqual({
       success: true,
       commands: [{ name: 'goal', template: '/goal ' }]
     })
@@ -93,11 +93,20 @@ describe('IPC Codex goal command routing', () => {
       worktreePath: '/project',
       sessionId: 'hive-1',
       command: 'goal',
-      args: 'ship the feature'
+      args: 'ship the feature',
+      model: { providerID: 'codex', modelID: 'gpt-5', variant: 'high' },
+      options: { codexFastMode: true }
     })
 
-    expect(codexImpl.sendCommand).toHaveBeenCalledWith('/project', 'thread-1', 'goal', 'ship the feature')
+    expect(codexImpl.sendCommand).toHaveBeenCalledWith(
+      '/project',
+      'thread-1',
+      'goal',
+      'ship the feature',
+      { providerID: 'codex', modelID: 'gpt-5', variant: 'high' },
+      { codexFastMode: true }
+    )
     expect(openCodeService.sendCommand).not.toHaveBeenCalled()
-    expect(result).toEqual({ success: true })
+    expect(result.value).toEqual({ success: true })
   })
 })

--- a/test/phase-22/session-5/ipc-codex-goal-command-routing.test.ts
+++ b/test/phase-22/session-5/ipc-codex-goal-command-routing.test.ts
@@ -69,7 +69,7 @@ describe('IPC Codex goal command routing', () => {
     expect(sdkManager.getImplementer).toHaveBeenCalledWith('codex')
     expect(codexImpl.listCommands).toHaveBeenCalledWith('/project', 'hive-1')
     expect(openCodeService.listCommands).not.toHaveBeenCalled()
-    expect(result.value).toEqual({
+    expect(result).toEqual({
       success: true,
       commands: [{ name: 'goal', template: '/goal ' }]
     })
@@ -110,6 +110,6 @@ describe('IPC Codex goal command routing', () => {
       { codexFastMode: true }
     )
     expect(openCodeService.sendCommand).not.toHaveBeenCalled()
-    expect(result.value).toEqual({ success: true })
+    expect(result).toEqual({ success: true })
   })
 })

--- a/test/phase-6/session-7/slash-commands.test.tsx
+++ b/test/phase-6/session-7/slash-commands.test.tsx
@@ -78,6 +78,30 @@ describe('Session 7: Slash Commands', () => {
       expect(screen.queryByTestId('slash-item-compact')).toBeNull()
     })
 
+    test('Skill commands render a skill badge and filter by name', () => {
+      render(
+        <SlashCommandPopover
+          commands={[
+            ...mockCommands,
+            {
+              name: 'imagegen',
+              description: 'Generate or edit raster images',
+              template: '/imagegen ',
+              source: 'skill'
+            }
+          ]}
+          filter="/image"
+          onSelect={onSelect}
+          onClose={onClose}
+          visible={true}
+        />
+      )
+
+      expect(screen.getByTestId('slash-item-imagegen')).toBeTruthy()
+      expect(screen.getByText('skill')).toBeTruthy()
+      expect(screen.queryByTestId('slash-item-compact')).toBeNull()
+    })
+
     test('Fuzzy filter: "/comp" matches "compact"', () => {
       render(
         <SlashCommandPopover
@@ -135,7 +159,9 @@ describe('Session 7: Slash Commands', () => {
       )
 
       fireEvent.click(screen.getByTestId('slash-item-compact'))
-      expect(onSelect).toHaveBeenCalledWith({ name: 'compact', template: '/compact' })
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'compact', template: '/compact' })
+      )
     })
 
     test('Enter selects highlighted command', () => {
@@ -151,7 +177,9 @@ describe('Session 7: Slash Commands', () => {
 
       // First item is selected by default, press Enter
       fireEvent.keyDown(window, { key: 'Enter' })
-      expect(onSelect).toHaveBeenCalledWith({ name: 'compact', template: '/compact' })
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'compact', template: '/compact' })
+      )
     })
 
     test('Arrow down selects next item', () => {
@@ -168,7 +196,9 @@ describe('Session 7: Slash Commands', () => {
       // Press ArrowDown to move to second item, then Enter
       fireEvent.keyDown(window, { key: 'ArrowDown' })
       fireEvent.keyDown(window, { key: 'Enter' })
-      expect(onSelect).toHaveBeenCalledWith({ name: 'using-superpowers', template: '/using-superpowers' })
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'using-superpowers', template: '/using-superpowers' })
+      )
     })
 
     test('Arrow up selects previous item', () => {
@@ -187,7 +217,9 @@ describe('Session 7: Slash Commands', () => {
       fireEvent.keyDown(window, { key: 'ArrowDown' })
       fireEvent.keyDown(window, { key: 'ArrowUp' })
       fireEvent.keyDown(window, { key: 'Enter' })
-      expect(onSelect).toHaveBeenCalledWith({ name: 'using-superpowers', template: '/using-superpowers' })
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'using-superpowers', template: '/using-superpowers' })
+      )
     })
 
     test('Escape closes popover', () => {
@@ -266,7 +298,9 @@ describe('Session 7: Slash Commands', () => {
 
       // Press Enter — should select first filtered item
       fireEvent.keyDown(window, { key: 'Enter' })
-      expect(onSelect).toHaveBeenCalledWith({ name: 'compact', template: '/compact' })
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'compact', template: '/compact' })
+      )
     })
   })
 
@@ -305,14 +339,14 @@ describe('Session 7: Slash Commands', () => {
   })
 
   describe('Command selection', () => {
-    test('handleCommandSelect sets input to "/commandName "', () => {
+    test('handleCommandSelect inserts command template', () => {
       let inputValue = '/'
       const handleCommandSelect = (cmd: { name: string; template: string }): void => {
-        inputValue = `/${cmd.name} `
+        inputValue = /\s$/.test(cmd.template) ? cmd.template : `${cmd.template} `
       }
 
-      handleCommandSelect({ name: 'compact', template: '/compact' })
-      expect(inputValue).toBe('/compact ')
+      handleCommandSelect({ name: 'imagegen', template: '/imagegen default prompt' })
+      expect(inputValue).toBe('/imagegen default prompt ')
     })
 
     test('handleCommandSelect hides popover', () => {


### PR DESCRIPTION
## Description
Adds Codex skills to Hive’s composer slash-command picker for Codex sessions.

Hive now asks Codex app-server for enabled skills via `skills/list`, shows them alongside built-in slash commands, and invokes selected skills as structured Codex `UserInput` instead of sending plain slash text.

## Related Issue
N/A

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] ♻️ Code refactoring
- [x] 🧪 Test improvement
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Changes Made
- Added Codex `skills/list` discovery to the command flow for Codex sessions.
- Render enabled Codex skills in the slash-command popover with a `skill` badge.
- Preserve built-in command and `/goal` precedence when names collide with skills.
- Invoke selected skills using structured Codex `UserInput[]`, including optional text arguments.
- Pass selected model, reasoning variant, and Codex prompt options through command execution.
- Refresh command availability when Codex emits `skills/changed`.
- Added focused tests for discovery, filtering, structured invocation, IPC routing, and renderer behavior.

## Screenshots
<details>
<summary>Screenshots</summary>

### Before

<img width="1468" height="1061" alt="Screenshot 2026-05-31 at 10 15 40" src="https://github.com/user-attachments/assets/a5157b52-fdef-47f1-9681-14cbd9df48a5" />

### After

<img width="1468" height="1061" alt="Screenshot 2026-05-31 at 10 16 40" src="https://github.com/user-attachments/assets/62c1e369-0862-4dfd-9ad3-c2d3641c54cb" />

</details>

## Testing

### Test Configuration
- **OS**: macOS 26.5
- **Node Version**: v24.15.0
- **Test Type**: Unit / Typecheck / Build / Manual

### Test Steps
1. Started Hive with a Codex session.
2. Typed `/` in the composer and verified enabled Codex skills appear in the slash-command picker.
3. Selected a skill and verified Codex receives it as structured skill input.
4. Ran focused Vitest suites for Codex implementer, app-server manager, IPC command routing, and slash-command renderer behavior.
5. Ran TypeScript typechecking.
6. Ran the production build.

### Test Results
- [ ] All existing tests pass
- [x] New tests added (if applicable)
- [x] Manual testing completed

Commands run:

```text
pnpm exec vitest run test/phase-22/session-3/codex-implementer-skeleton.test.ts test/phase-22/session-5/codex-app-server-manager.test.ts test/phase-22/session-5/ipc-codex-goal-command-routing.test.ts test/phase-6/session-7/slash-commands.test.tsx
pnpm exec tsc --noEmit
pnpm run build
```

Focused result:

```text
4 files passed, 94 tests passed
```

## Checklist
- [x] My code follows the project's code style
- [ ] I have run `pnpm lint` and fixed any issues
- [ ] I have run `pnpm format` to format my code
- [ ] I have run `pnpm test` and all tests pass
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation (if needed)
- [ ] I have added comments to complex code sections
- [x] I have checked for any console errors
- [x] I have tested on macOS (required)
- [x] I have updated documentation (for significant changes)

## Performance Impact
- [x] No performance impact
- [ ] Improves performance
- [ ] May affect performance (please explain)

## Breaking Changes
- [x] No breaking changes

## Additional Notes
Skill discovery is scoped to Codex sessions only. OpenCode and Claude Code command behavior is unchanged.

If `skills/list` fails or no Codex thread id is available, Hive falls back to showing `/goal` only.

## Post-Merge Tasks
- [ ] Update documentation site
- [ ] Notify users of breaking changes
- [ ] Update README examples
- [ ] Other:
