### PR TITLE
Fix all-providers mode defaults

### DIFF
--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -163,6 +163,20 @@ export const ModelSelector = memo(function ModelSelector({
     [providers, agentSdk]
   )
 
+  const isModelPortableToAllCatalogSdks = useCallback(
+    (providerID: string, modelID: string, variant?: string): boolean => {
+      if (catalogAgentSdks.length === 0) return false
+      return catalogAgentSdks.every((sdk) => {
+        const sdkProviders = providers.filter((provider) => provider.agentSdk === sdk)
+        if (sdkProviders.length === 0) return false
+        const sdkModel = findModelInfo(sdkProviders, providerID, modelID)
+        if (!sdkModel) return false
+        return !variant || getModelVariantKeys(sdkModel).includes(variant)
+      })
+    },
+    [providers, catalogAgentSdks]
+  )
+
   const buildSelectedModel = useCallback(
     (
       model: SelectableModelInfo,
@@ -173,7 +187,7 @@ export const ModelSelector = memo(function ModelSelector({
         options?.includeAgentSdk ??
         (allowAgentSdkSelection &&
           (agentSdkFilter !== null ||
-            !isModelPortableToCurrentSdk(model.providerID, model.id, variant)))
+            !isModelPortableToAllCatalogSdks(model.providerID, model.id, variant)))
       return {
         ...(includeAgentSdk ? { agentSdk: model.agentSdk } : {}),
         providerID: model.providerID,
@@ -181,7 +195,7 @@ export const ModelSelector = memo(function ModelSelector({
         variant
       }
     },
-    [allowAgentSdkSelection, agentSdkFilter, isModelPortableToCurrentSdk]
+    [allowAgentSdkSelection, agentSdkFilter, isModelPortableToAllCatalogSdks]
   )
 
   const rememberSelectedModel = useCallback((model: SelectedModel, sdk: HandoffAgentSdk): void => {
@@ -270,7 +284,7 @@ export const ModelSelector = memo(function ModelSelector({
     if (!sdk) {
       if (onChange && selectedModel?.agentSdk) {
         if (
-          isModelPortableToCurrentSdk(
+          isModelPortableToAllCatalogSdks(
             selectedModel.providerID,
             selectedModel.modelID,
             selectedModel.variant

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -153,6 +153,14 @@ export const ModelSelector = memo(function ModelSelector({
     }
   }, [catalogAgentSdks])
 
+  const isModelAvailableForCurrentSdk = useCallback(
+    (providerID: string, modelID: string): boolean => {
+      const currentSdkProviders = providers.filter((provider) => provider.agentSdk === agentSdk)
+      return findModelInfo(currentSdkProviders, providerID, modelID) !== null
+    },
+    [providers, agentSdk]
+  )
+
   const buildSelectedModel = useCallback(
     (
       model: SelectableModelInfo,
@@ -160,7 +168,9 @@ export const ModelSelector = memo(function ModelSelector({
       options?: { includeAgentSdk?: boolean }
     ): SelectedModel => {
       const includeAgentSdk =
-        options?.includeAgentSdk ?? (allowAgentSdkSelection && agentSdkFilter !== null)
+        options?.includeAgentSdk ??
+        (allowAgentSdkSelection &&
+          (agentSdkFilter !== null || !isModelAvailableForCurrentSdk(model.providerID, model.id)))
       return {
         ...(includeAgentSdk ? { agentSdk: model.agentSdk } : {}),
         providerID: model.providerID,
@@ -168,7 +178,7 @@ export const ModelSelector = memo(function ModelSelector({
         variant
       }
     },
-    [allowAgentSdkSelection, agentSdkFilter]
+    [allowAgentSdkSelection, agentSdkFilter, isModelAvailableForCurrentSdk]
   )
 
   const rememberSelectedModel = useCallback((model: SelectedModel, sdk: HandoffAgentSdk): void => {
@@ -256,11 +266,15 @@ export const ModelSelector = memo(function ModelSelector({
     setAgentSdkFilter(sdk)
     if (!sdk) {
       if (onChange && selectedModel?.agentSdk) {
-        onChange({
-          providerID: selectedModel.providerID,
-          modelID: selectedModel.modelID,
-          variant: selectedModel.variant
-        })
+        if (isModelAvailableForCurrentSdk(selectedModel.providerID, selectedModel.modelID)) {
+          onChange({
+            providerID: selectedModel.providerID,
+            modelID: selectedModel.modelID,
+            variant: selectedModel.variant
+          })
+        } else {
+          onChange(selectedModel)
+        }
       }
       return
     }

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -154,15 +154,21 @@ export const ModelSelector = memo(function ModelSelector({
   }, [catalogAgentSdks])
 
   const buildSelectedModel = useCallback(
-    (model: SelectableModelInfo, variant?: string): SelectedModel => {
+    (
+      model: SelectableModelInfo,
+      variant?: string,
+      options?: { includeAgentSdk?: boolean }
+    ): SelectedModel => {
+      const includeAgentSdk =
+        options?.includeAgentSdk ?? (allowAgentSdkSelection && agentSdkFilter !== null)
       return {
-        ...(allowAgentSdkSelection ? { agentSdk: model.agentSdk } : {}),
+        ...(includeAgentSdk ? { agentSdk: model.agentSdk } : {}),
         providerID: model.providerID,
         modelID: model.id,
         variant
       }
     },
-    [allowAgentSdkSelection]
+    [allowAgentSdkSelection, agentSdkFilter]
   )
 
   const rememberSelectedModel = useCallback((model: SelectedModel, sdk: HandoffAgentSdk): void => {
@@ -210,7 +216,9 @@ export const ModelSelector = memo(function ModelSelector({
 
     const fallbackModel = getFallbackModelForSdk(sdk)
     if (!fallbackModel) return null
-    return buildSelectedModel(fallbackModel, getModelVariantKeys(fallbackModel)[0])
+    return buildSelectedModel(fallbackModel, getModelVariantKeys(fallbackModel)[0], {
+      includeAgentSdk: true
+    })
   }
 
   function handleSelectModel(model: SelectableModelInfo): void {
@@ -246,7 +254,16 @@ export const ModelSelector = memo(function ModelSelector({
 
   function handleSelectAgentSdkFilter(sdk: HandoffAgentSdk | null): void {
     setAgentSdkFilter(sdk)
-    if (!sdk) return
+    if (!sdk) {
+      if (onChange && selectedModel?.agentSdk) {
+        onChange({
+          providerID: selectedModel.providerID,
+          modelID: selectedModel.modelID,
+          variant: selectedModel.variant
+        })
+      }
+      return
+    }
     const nextModel = resolveSelectableModelForSdk(sdk)
     if (nextModel) applySelectedModel(nextModel, sdk)
   }
@@ -254,6 +271,9 @@ export const ModelSelector = memo(function ModelSelector({
   function isActiveModel(model: SelectableModelInfo): boolean {
     if (!selectedModel) {
       return model.providerID === 'anthropic' && model.id === 'claude-opus-4-5-20251101'
+    }
+    if (allowAgentSdkSelection && !selectedModel.agentSdk && agentSdkFilter === null) {
+      return selectedModel.providerID === model.providerID && selectedModel.modelID === model.id
     }
     const selectedAgentSdk = selectedModel.agentSdk ?? agentSdk
     return (
@@ -268,9 +288,12 @@ export const ModelSelector = memo(function ModelSelector({
     const modelID = selectedModel?.modelID || 'claude-opus-4-5-20251101'
     const providerID = selectedModel?.providerID || 'anthropic'
     const selectedAgentSdk = selectedModel?.agentSdk ?? agentSdk
-    const sdkProviders = providers.filter((provider) => provider.agentSdk === selectedAgentSdk)
+    const sdkProviders =
+      allowAgentSdkSelection && selectedModel && !selectedModel.agentSdk && agentSdkFilter === null
+        ? providers
+        : providers.filter((provider) => provider.agentSdk === selectedAgentSdk)
     return findModelInfo(sdkProviders, providerID, modelID) as SelectableModelInfo | null
-  }, [selectedModel, providers, agentSdk])
+  }, [selectedModel, providers, agentSdk, allowAgentSdkSelection, agentSdkFilter])
 
   const providerPrefix = useMemo(() => {
     if (hideProviderPrefix || !showModelProvider) return null
@@ -360,17 +383,15 @@ export const ModelSelector = memo(function ModelSelector({
     }
   }, [agentSdkFilter, sdkFilterOptions])
 
-  const effectiveAgentSdkFilter =
-    agentSdkFilter ?? (allowAgentSdkSelection ? (value?.agentSdk ?? null) : null)
   const selectedProviderFilterLabel =
-    sdkFilterOptions.find((option) => option.agentSdk === effectiveAgentSdkFilter)?.label ??
+    sdkFilterOptions.find((option) => option.agentSdk === agentSdkFilter)?.label ??
     'All providers'
   const showProviderFilter = sdkFilterOptions.length > 1
 
   const providerScopedProviders = useMemo(() => {
-    if (!effectiveAgentSdkFilter) return providers
-    return providers.filter((provider) => provider.agentSdk === effectiveAgentSdkFilter)
-  }, [providers, effectiveAgentSdkFilter])
+    if (!agentSdkFilter) return providers
+    return providers.filter((provider) => provider.agentSdk === agentSdkFilter)
+  }, [providers, agentSdkFilter])
 
   const filteredProviders = useMemo(() => {
     if (!filter.trim()) return providerScopedProviders

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -153,10 +153,12 @@ export const ModelSelector = memo(function ModelSelector({
     }
   }, [catalogAgentSdks])
 
-  const isModelAvailableForCurrentSdk = useCallback(
-    (providerID: string, modelID: string): boolean => {
+  const isModelPortableToCurrentSdk = useCallback(
+    (providerID: string, modelID: string, variant?: string): boolean => {
       const currentSdkProviders = providers.filter((provider) => provider.agentSdk === agentSdk)
-      return findModelInfo(currentSdkProviders, providerID, modelID) !== null
+      const currentSdkModel = findModelInfo(currentSdkProviders, providerID, modelID)
+      if (!currentSdkModel) return false
+      return !variant || getModelVariantKeys(currentSdkModel).includes(variant)
     },
     [providers, agentSdk]
   )
@@ -170,7 +172,8 @@ export const ModelSelector = memo(function ModelSelector({
       const includeAgentSdk =
         options?.includeAgentSdk ??
         (allowAgentSdkSelection &&
-          (agentSdkFilter !== null || !isModelAvailableForCurrentSdk(model.providerID, model.id)))
+          (agentSdkFilter !== null ||
+            !isModelPortableToCurrentSdk(model.providerID, model.id, variant)))
       return {
         ...(includeAgentSdk ? { agentSdk: model.agentSdk } : {}),
         providerID: model.providerID,
@@ -178,7 +181,7 @@ export const ModelSelector = memo(function ModelSelector({
         variant
       }
     },
-    [allowAgentSdkSelection, agentSdkFilter, isModelAvailableForCurrentSdk]
+    [allowAgentSdkSelection, agentSdkFilter, isModelPortableToCurrentSdk]
   )
 
   const rememberSelectedModel = useCallback((model: SelectedModel, sdk: HandoffAgentSdk): void => {
@@ -266,7 +269,13 @@ export const ModelSelector = memo(function ModelSelector({
     setAgentSdkFilter(sdk)
     if (!sdk) {
       if (onChange && selectedModel?.agentSdk) {
-        if (isModelAvailableForCurrentSdk(selectedModel.providerID, selectedModel.modelID)) {
+        if (
+          isModelPortableToCurrentSdk(
+            selectedModel.providerID,
+            selectedModel.modelID,
+            selectedModel.variant
+          )
+        ) {
           onChange({
             providerID: selectedModel.providerID,
             modelID: selectedModel.modelID,
@@ -290,7 +299,11 @@ export const ModelSelector = memo(function ModelSelector({
       const matchesModel =
         selectedModel.providerID === model.providerID && selectedModel.modelID === model.id
       if (!matchesModel) return false
-      return isModelAvailableForCurrentSdk(selectedModel.providerID, selectedModel.modelID)
+      return isModelPortableToCurrentSdk(
+        selectedModel.providerID,
+        selectedModel.modelID,
+        selectedModel.variant
+      )
         ? model.agentSdk === agentSdk
         : true
     }

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -287,7 +287,12 @@ export const ModelSelector = memo(function ModelSelector({
       return model.providerID === 'anthropic' && model.id === 'claude-opus-4-5-20251101'
     }
     if (allowAgentSdkSelection && !selectedModel.agentSdk && agentSdkFilter === null) {
-      return selectedModel.providerID === model.providerID && selectedModel.modelID === model.id
+      const matchesModel =
+        selectedModel.providerID === model.providerID && selectedModel.modelID === model.id
+      if (!matchesModel) return false
+      return isModelAvailableForCurrentSdk(selectedModel.providerID, selectedModel.modelID)
+        ? model.agentSdk === agentSdk
+        : true
     }
     const selectedAgentSdk = selectedModel.agentSdk ?? agentSdk
     return (
@@ -302,10 +307,24 @@ export const ModelSelector = memo(function ModelSelector({
     const modelID = selectedModel?.modelID || 'claude-opus-4-5-20251101'
     const providerID = selectedModel?.providerID || 'anthropic'
     const selectedAgentSdk = selectedModel?.agentSdk ?? agentSdk
-    const sdkProviders =
-      allowAgentSdkSelection && selectedModel && !selectedModel.agentSdk && agentSdkFilter === null
-        ? providers
-        : providers.filter((provider) => provider.agentSdk === selectedAgentSdk)
+    if (
+      allowAgentSdkSelection &&
+      selectedModel &&
+      !selectedModel.agentSdk &&
+      agentSdkFilter === null
+    ) {
+      const currentSdkProviders = providers.filter((provider) => provider.agentSdk === agentSdk)
+      const currentSdkModel = findModelInfo(
+        currentSdkProviders,
+        providerID,
+        modelID
+      ) as SelectableModelInfo | null
+      if (currentSdkModel) return currentSdkModel
+
+      return findModelInfo(providers, providerID, modelID) as SelectableModelInfo | null
+    }
+
+    const sdkProviders = providers.filter((provider) => provider.agentSdk === selectedAgentSdk)
     return findModelInfo(sdkProviders, providerID, modelID) as SelectableModelInfo | null
   }, [selectedModel, providers, agentSdk, allowAgentSdkSelection, agentSdkFilter])
 

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -1466,6 +1466,7 @@ export const useSessionStore = create<SessionState>()(
         // Cross-SDK mode default on a live session is impossible to apply because the
         // provider cannot change in an existing session. The mode still flips; model stays.
         if (modeDefault?.agentSdk && modeDefault.agentSdk !== sessionSdk) return
+        if (modeDefault && !modeDefault.agentSdk && sessionSdk !== settings.defaultAgentSdk) return
 
         const newModeDefault = modeDefault ?? resolveModelForSdk(sessionSdk, settings)
         if (!newModeDefault) return

--- a/test/phase-22/session-11/apply-mode-default-model.test.ts
+++ b/test/phase-22/session-11/apply-mode-default-model.test.ts
@@ -117,6 +117,18 @@ describe('applyModeDefaultModel', () => {
     })
   })
 
+  test('does not apply unset-SDK mode default to a non-default live session SDK', async () => {
+    seedSession('codex')
+    seedSettings(claudeUnsetSdkDefault)
+    const setSessionModel = vi
+      .spyOn(useSessionStore.getState(), 'setSessionModel')
+      .mockResolvedValue(undefined)
+
+    await useSessionStore.getState().applyModeDefaultModel('session-1', 'plan')
+
+    expect(setSessionModel).not.toHaveBeenCalled()
+  })
+
   test('does not change the model when modeDefault.agentSdk differs from the session SDK', async () => {
     seedSettings(codexPlanDefault)
     const setSessionModel = vi

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -7,6 +7,22 @@ const mockSettingsDb = {
   set: vi.fn().mockResolvedValue({ success: true, value: undefined })
 }
 
+const opencodeProviders = [
+  {
+    id: 'anthropic',
+    name: 'Anthropic',
+    models: {
+      'sonnet-4.6': {
+        id: 'sonnet-4.6',
+        name: 'OpenCode Sonnet 4.6',
+        variants: {
+          low: {}
+        }
+      }
+    }
+  }
+]
+
 const claudeProviders = [
   {
     id: 'anthropic',
@@ -78,6 +94,10 @@ Object.defineProperty(window, 'opencodeOps', {
   configurable: true,
   value: {
     listModels: vi.fn().mockImplementation(async ({ agentSdk }: { agentSdk?: string } = {}) => {
+      if (agentSdk === 'opencode') {
+        return { success: true, value: { success: true, providers: opencodeProviders } }
+      }
+
       if (agentSdk === 'codex') {
         return { success: true, value: { success: true, providers: codexProviders } }
       }
@@ -131,6 +151,7 @@ describe('handoff model picker', () => {
       },
       lastHandoffOverride: null,
       defaultAgentSdk: 'claude-code',
+      showModelProvider: false,
       availableAgentSdks: {
         opencode: true,
         claude: true,
@@ -337,6 +358,34 @@ describe('handoff model picker', () => {
       modelID: 'gpt-5.5',
       variant: 'high'
     })
+  })
+
+  test('controlled model selector resolves SDK-agnostic defaults against the current SDK first', async () => {
+    useSettingsStore.setState({
+      showModelProvider: true,
+      defaultAgentSdk: 'claude-code'
+    })
+
+    render(
+      <ModelSelector
+        value={{
+          providerID: 'anthropic',
+          modelID: 'sonnet-4.6',
+          variant: 'high'
+        }}
+        onChange={vi.fn()}
+        allowAgentSdkSelection
+      />
+    )
+
+    await waitFor(() => {
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'opencode' })
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'claude-code' })
+    })
+
+    expect(await screen.findByText('Claude Code')).toBeInTheDocument()
+    expect(screen.getByTestId('model-selector')).toHaveTextContent('Sonnet 4.6')
+    expect(screen.getByTestId('model-selector')).not.toHaveTextContent('OpenCode Sonnet 4.6')
   })
 
   test('controlled model selector keeps agentSdk when selecting under a specific provider', async () => {

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -20,6 +20,19 @@ const opencodeProviders = [
         }
       }
     }
+  },
+  {
+    id: 'shared',
+    name: 'Shared',
+    models: {
+      portable: {
+        id: 'portable',
+        name: 'Portable Model',
+        variants: {
+          high: {}
+        }
+      }
+    }
   }
 ]
 
@@ -34,6 +47,19 @@ const claudeProviders = [
         variants: {
           high: {},
           xhigh: {}
+        }
+      }
+    }
+  },
+  {
+    id: 'shared',
+    name: 'Shared',
+    models: {
+      portable: {
+        id: 'portable',
+        name: 'Portable Model',
+        variants: {
+          high: {}
         }
       }
     }
@@ -64,6 +90,19 @@ const codexProviders = [
       'gpt-5.4-mini': {
         id: 'gpt-5.4-mini',
         name: 'GPT-5.4 Mini'
+      }
+    }
+  },
+  {
+    id: 'shared',
+    name: 'Shared',
+    models: {
+      portable: {
+        id: 'portable',
+        name: 'Portable Model',
+        variants: {
+          high: {}
+        }
       }
     }
   }
@@ -296,7 +335,7 @@ describe('handoff model picker', () => {
     })
   })
 
-  test('controlled model selector clears SDK scope when All providers is selected', async () => {
+  test('controlled model selector keeps SDK scope when a model is only portable to the current SDK', async () => {
     const onChange = vi.fn()
     const user = userEvent.setup()
 
@@ -317,6 +356,7 @@ describe('handoff model picker', () => {
     await user.click(await screen.findByTestId('model-provider-filter-option-all'))
 
     expect(onChange).toHaveBeenCalledWith({
+      agentSdk: 'claude-code',
       providerID: 'anthropic',
       modelID: 'sonnet-4.6',
       variant: 'high'
@@ -328,6 +368,61 @@ describe('handoff model picker', () => {
       expect(screen.getAllByTestId('model-item-sonnet-4.6').length).toBeGreaterThan(0)
     })
     expect(await screen.findByTestId('model-item-gpt-5.5')).toBeInTheDocument()
+  })
+
+  test('controlled model selector clears SDK scope when a model is portable to every SDK catalog', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ModelSelector
+        value={{
+          agentSdk: 'claude-code',
+          providerID: 'shared',
+          modelID: 'portable',
+          variant: 'high'
+        }}
+        onChange={onChange}
+        allowAgentSdkSelection
+      />
+    )
+
+    await waitFor(() => {
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'opencode' })
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'claude-code' })
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'codex' })
+    })
+
+    await user.click(await screen.findByTestId('model-provider-filter'))
+    await user.click(await screen.findByTestId('model-provider-filter-option-all'))
+
+    expect(onChange).toHaveBeenCalledWith({
+      providerID: 'shared',
+      modelID: 'portable',
+      variant: 'high'
+    })
+  })
+
+  test('controlled model selector saves All providers picks without SDK only when portable to every SDK catalog', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ModelSelector value={null} onChange={onChange} allowAgentSdkSelection />)
+
+    await waitFor(() => {
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'opencode' })
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'claude-code' })
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'codex' })
+    })
+
+    await user.click(screen.getByTestId('model-selector'))
+    await user.click((await screen.findAllByTestId('model-item-portable'))[0])
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      providerID: 'shared',
+      modelID: 'portable',
+      variant: 'high'
+    })
   })
 
   test('controlled model selector keeps SDK scope for cross-catalog All providers picks', async () => {

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -268,6 +268,68 @@ describe('handoff model picker', () => {
     await user.click(await screen.findByTestId('model-item-gpt-5.5'))
 
     expect(onChange).toHaveBeenCalledWith({
+      providerID: 'codex',
+      modelID: 'gpt-5.5',
+      variant: 'high'
+    })
+  })
+
+  test('controlled model selector clears SDK scope when All providers is selected', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ModelSelector
+        value={{
+          agentSdk: 'claude-code',
+          providerID: 'anthropic',
+          modelID: 'sonnet-4.6',
+          variant: 'high'
+        }}
+        onChange={onChange}
+        allowAgentSdkSelection
+      />
+    )
+
+    await user.click(await screen.findByTestId('model-provider-filter'))
+    await user.click(await screen.findByTestId('model-provider-filter-option-all'))
+
+    expect(onChange).toHaveBeenCalledWith({
+      providerID: 'anthropic',
+      modelID: 'sonnet-4.6',
+      variant: 'high'
+    })
+
+    await user.click(screen.getByTestId('model-selector'))
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('model-item-sonnet-4.6').length).toBeGreaterThan(0)
+    })
+    expect(await screen.findByTestId('model-item-gpt-5.5')).toBeInTheDocument()
+  })
+
+  test('controlled model selector keeps agentSdk when selecting under a specific provider', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ModelSelector
+        value={{
+          providerID: 'anthropic',
+          modelID: 'sonnet-4.6',
+          variant: 'high'
+        }}
+        onChange={onChange}
+        allowAgentSdkSelection
+      />
+    )
+
+    await user.click(await screen.findByTestId('model-provider-filter'))
+    await user.click(await screen.findByTestId('model-provider-filter-option-codex'))
+    await user.click(screen.getByTestId('model-selector'))
+    await user.click(await screen.findByTestId('model-item-gpt-5.5'))
+
+    expect(onChange).toHaveBeenLastCalledWith({
       agentSdk: 'codex',
       providerID: 'codex',
       modelID: 'gpt-5.5',

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -268,6 +268,7 @@ describe('handoff model picker', () => {
     await user.click(await screen.findByTestId('model-item-gpt-5.5'))
 
     expect(onChange).toHaveBeenCalledWith({
+      agentSdk: 'codex',
       providerID: 'codex',
       modelID: 'gpt-5.5',
       variant: 'high'
@@ -306,6 +307,36 @@ describe('handoff model picker', () => {
       expect(screen.getAllByTestId('model-item-sonnet-4.6').length).toBeGreaterThan(0)
     })
     expect(await screen.findByTestId('model-item-gpt-5.5')).toBeInTheDocument()
+  })
+
+  test('controlled model selector keeps SDK scope for cross-catalog All providers picks', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ModelSelector
+        value={{
+          agentSdk: 'claude-code',
+          providerID: 'anthropic',
+          modelID: 'sonnet-4.6',
+          variant: 'high'
+        }}
+        onChange={onChange}
+        allowAgentSdkSelection
+      />
+    )
+
+    await user.click(await screen.findByTestId('model-provider-filter'))
+    await user.click(await screen.findByTestId('model-provider-filter-option-all'))
+    await user.click(screen.getByTestId('model-selector'))
+    await user.click(await screen.findByTestId('model-item-gpt-5.5'))
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      agentSdk: 'codex',
+      providerID: 'codex',
+      modelID: 'gpt-5.5',
+      variant: 'high'
+    })
   })
 
   test('controlled model selector keeps agentSdk when selecting under a specific provider', async () => {

--- a/test/phase-22/session-11/handoff-model-picker.test.tsx
+++ b/test/phase-22/session-11/handoff-model-picker.test.tsx
@@ -360,6 +360,38 @@ describe('handoff model picker', () => {
     })
   })
 
+  test('controlled model selector keeps SDK scope for non-portable variants', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ModelSelector
+        value={{
+          providerID: 'anthropic',
+          modelID: 'sonnet-4.6',
+          variant: 'high'
+        }}
+        onChange={onChange}
+        allowAgentSdkSelection
+      />
+    )
+
+    await waitFor(() => {
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'opencode' })
+      expect(window.opencodeOps.listModels).toHaveBeenCalledWith({ agentSdk: 'claude-code' })
+    })
+
+    await user.click(screen.getByTestId('model-selector'))
+    await user.click(await screen.findByTestId('variant-chip-low'))
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      agentSdk: 'opencode',
+      providerID: 'anthropic',
+      modelID: 'sonnet-4.6',
+      variant: 'low'
+    })
+  })
+
   test('controlled model selector resolves SDK-agnostic defaults against the current SDK first', async () => {
     useSettingsStore.setState({
       showModelProvider: true,

--- a/test/phase-22/session-11/model-selector-provider-pill.test.tsx
+++ b/test/phase-22/session-11/model-selector-provider-pill.test.tsx
@@ -87,7 +87,9 @@ describe('ModelSelector provider filter pill', () => {
       />
     )
 
-    expect(await screen.findByTestId('model-provider-filter')).toHaveTextContent('Codex')
+    await waitFor(() => {
+      expect(screen.getByTestId('model-provider-filter')).toHaveTextContent('Codex')
+    })
   })
 
   test('updates the provider pill when the controlled SDK changes', async () => {


### PR DESCRIPTION
## Description
Fixes the Models settings provider filter so “All providers” works correctly for mode defaults. The selector now treats “All providers” as an SDK-agnostic scope only when the selected provider/model/variant is portable to the current default SDK; cross-catalog or non-portable selections keep their `agentSdk` so invalid model defaults are not applied to the wrong backend.

## Related Issue
N/A

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] ♻️ Code refactoring
- [x] 🧪 Test improvement
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Changes Made
- Made the model selector’s provider filter state authoritative, so “All providers” no longer falls back to the selected model’s SDK.
- Preserve `agentSdk` for cross-catalog selections and variants that are not supported by the current/default SDK.
- Prefer the current/default SDK when resolving SDK-agnostic defaults that appear in multiple SDK catalogs.
- Guard live-session mode toggles so SDK-less mode defaults are only applied to sessions using the configured default SDK.
- Added regression tests for SDK-agnostic defaults, cross-catalog selections, variant portability, and live mode toggles.

## Screenshots
<details>
<summary>Screenshots (if applicable)</summary>

**After**
<img width="1468" height="1061" alt="Screenshot 2026-05-31 at 13 37 26" src="https://github.com/user-attachments/assets/d04d6641-4da8-4631-af05-0bce2c3314c2" />


</details>

## Testing

### Test Configuration
- **OS**: macOS 26.5
- **Node Version**: v25.8.1
- **Test Type**: Unit / component

### Test Steps
1. Ran focused Vitest coverage for model selection, handoff model picking, and live mode-default application.
2. Manually verified that “All providers” works for Build Mode Default in Settings.
3. Confirmed `git diff --check` passes.

### Test Results
- [ ] All existing tests pass
- [x] New tests added (if applicable)
- [x] Manual testing completed

Focused test command:
```bash
npm test -- test/phase-22/session-11/apply-mode-default-model.test.ts test/phase-22/session-11/model-selector-provider-pill.test.tsx test/phase-22/session-11/handoff-model-picker.test.tsx
```

Result: 3 files passed, 26 tests passed.

## Checklist
- [x] My code follows the project's code style
- [ ] I have run `pnpm lint` and fixed any issues
- [ ] I have run `pnpm format` to format my code
- [ ] I have run `pnpm test` and all tests pass
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation (if needed)
- [ ] I have added comments to complex code sections
- [ ] I have checked for any console errors
- [x] I have tested on macOS (required)
- [ ] I have updated documentation (for significant changes)

## Performance Impact
- [x] No performance impact
- [ ] Improves performance
- [ ] May affect performance (please explain)

## Breaking Changes
- [x] No breaking changes

## Additional Notes
The template’s full `pnpm test`, `pnpm lint`, and `pnpm format` checks were not run; only the focused regression suite and `git diff --check` were run.

## Post-Merge Tasks
- [ ] Update documentation site
- [ ] Notify users of breaking changes
- [ ] Update README examples
- [ ] Other:
