### PR TITLE
Add pet animation speed scaling

### DIFF
--- a/src/main/services/pet-window.ts
+++ b/src/main/services/pet-window.ts
@@ -22,6 +22,8 @@ export const DEFAULT_PET_SETTINGS: PetSettings = {
   petId: 'bee',
   size: 'M',
   opacity: 1,
+  animationSpeedEnabled: false,
+  animationSpeed: 5,
   hasHatched: false
 }
 
@@ -80,7 +82,11 @@ const PET_SIZE_PX: Record<PetSize, number> = {
 
 let petWindow: BrowserWindow | null = null
 let getMainWindow: (() => BrowserWindow | null) | null = null
-let latestStatus: PetStatusPayload = { state: 'idle', sourceWorktreeId: null }
+let latestStatus: PetStatusPayload = {
+  state: 'idle',
+  sourceWorktreeId: null,
+  workingSessionCount: 0
+}
 let latestSettings: PetSettings = DEFAULT_PET_SETTINGS
 let petPointerInteractionActive = false
 let petPointerInteractionTimer: NodeJS.Timeout | null = null
@@ -101,12 +107,7 @@ function constrainPosition(position: PetPosition, size = petWindowSize()): PetPo
   const display =
     displays.find((candidate) => {
       const { x, y, width, height } = candidate.workArea
-      return (
-        position.x >= x &&
-        position.y >= y &&
-        position.x < x + width &&
-        position.y < y + height
-      )
+      return position.x >= x && position.y >= y && position.x < x + width && position.y < y + height
     }) ?? screen.getDisplayNearestPoint(position)
 
   const { x, y, width, height } = display.workArea
@@ -173,9 +174,7 @@ function broadcast(channel: string, payload: unknown): void {
   }
 }
 
-export function configurePetWindow(options: {
-  getMainWindow: () => BrowserWindow | null
-}): void {
+export function configurePetWindow(options: { getMainWindow: () => BrowserWindow | null }): void {
   getMainWindow = options.getMainWindow
 }
 

--- a/src/renderer/src/components/pet/PetStatusBridge.tsx
+++ b/src/renderer/src/components/pet/PetStatusBridge.tsx
@@ -11,7 +11,11 @@ import {
 } from '@/stores'
 
 function sameStatus(a: PetStatusPayload | null, b: PetStatusPayload): boolean {
-  return a?.state === b.state && a.sourceWorktreeId === b.sourceWorktreeId
+  return (
+    a?.state === b.state &&
+    a.sourceWorktreeId === b.sourceWorktreeId &&
+    a.workingSessionCount === b.workingSessionCount
+  )
 }
 
 function computeStatus(): PetStatusPayload {

--- a/src/renderer/src/components/settings/SettingsPet.tsx
+++ b/src/renderer/src/components/settings/SettingsPet.tsx
@@ -15,6 +15,7 @@ const SIZE_OPTIONS: Array<{ id: PetSize; label: string; description: string }> =
 export function SettingsPet(): React.JSX.Element {
   const { pet, updateSetting } = useSettingsStore()
   const pets = listPets()
+  const animationSpeed = Math.min(Math.max(pet.animationSpeed, 2), 5)
 
   const updatePet = (partial: Partial<PetSettings>): void => {
     updateSetting('pet', { ...pet, ...partial })
@@ -114,6 +115,47 @@ export function SettingsPet(): React.JSX.Element {
           className="w-full accent-primary"
           data-testid="pet-opacity-slider"
         />
+      </div>
+
+      <div className="space-y-2">
+        <label className="flex items-start gap-2 text-sm font-medium">
+          <input
+            type="checkbox"
+            checked={pet.animationSpeedEnabled}
+            onChange={(event) => updatePet({ animationSpeedEnabled: event.target.checked })}
+            className="mt-0.5 h-4 w-4 accent-primary"
+            data-testid="pet-animation-speed-enabled-checkbox"
+          />
+          <span>
+            <span className="block">Scale animation speed</span>
+            <span className="block text-xs font-normal text-muted-foreground">
+              Speeds up the working animation as more sessions are active.
+            </span>
+          </span>
+        </label>
+        <div className="flex items-center justify-between">
+          <label className="text-sm font-medium">Max animation speed</label>
+          <span className="text-xs text-muted-foreground">
+            {pet.animationSpeedEnabled ? `${animationSpeed}x` : '1x'}
+          </span>
+        </div>
+        <input
+          type="range"
+          min={2}
+          max={5}
+          step={1}
+          value={animationSpeed}
+          onChange={(event) => updatePet({ animationSpeed: Number(event.target.value) })}
+          disabled={!pet.animationSpeedEnabled}
+          className={cn(
+            'w-full accent-primary',
+            !pet.animationSpeedEnabled && 'cursor-not-allowed opacity-50'
+          )}
+          data-testid="pet-animation-speed-slider"
+        />
+        <p className="text-xs text-muted-foreground">
+          When disabled, the working animation always runs at normal speed.
+        </p>
       </div>
 
       {pet.enabled && (

--- a/src/renderer/src/lib/pet-status-aggregator.ts
+++ b/src/renderer/src/lib/pet-status-aggregator.ts
@@ -23,6 +23,8 @@ const PET_STATE_BY_STATUS: Record<SessionStatusType, PetState> = {
   unread: 'idle'
 }
 
+const WORKING_SESSION_STATUSES = new Set<SessionStatusType>(['working', 'planning'])
+
 type SessionRef = { id: string }
 type ConnectionRef = { id: string; members: Array<{ worktree_id: string }> }
 
@@ -63,6 +65,9 @@ function chooseBetter(current: Candidate | null, next: Candidate): Candidate {
 
 export function aggregatePetStatus(input: PetAggregateInput): PetStatusPayload {
   let best: Candidate | null = null
+  const workingSessionCount = Object.values(input.sessionStatuses).filter((entry) =>
+    entry?.status ? WORKING_SESSION_STATUSES.has(entry.status) : false
+  ).length
 
   for (const [worktreeId, sessions] of input.worktreeSessions.entries()) {
     const status = bestStatusForSessions(sessions, input.sessionStatuses)
@@ -85,11 +90,12 @@ export function aggregatePetStatus(input: PetAggregateInput): PetStatusPayload {
     })
   }
 
-  if (!best) return { state: 'idle', sourceWorktreeId: null }
+  if (!best) return { state: 'idle', sourceWorktreeId: null, workingSessionCount }
 
   const state = PET_STATE_BY_STATUS[best.status]
   return {
     state,
-    sourceWorktreeId: state === 'idle' ? null : best.sourceWorktreeId
+    sourceWorktreeId: state === 'idle' ? null : best.sourceWorktreeId,
+    workingSessionCount
   }
 }

--- a/src/renderer/src/pet/DotLottieSprite.tsx
+++ b/src/renderer/src/pet/DotLottieSprite.tsx
@@ -31,15 +31,19 @@ export function DotLottieSprite({
   fallbackSrc,
   scale,
   size,
+  speed = 1,
   state
 }: {
   src: string
   fallbackSrc: string
   scale: number
   size: number
+  speed?: number
   state: string
 }): React.JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const playerRef = useRef<DotLottie | null>(null)
+  const speedRef = useRef(speed)
   const [hasRendered, setHasRendered] = useState(false)
 
   useEffect(() => {
@@ -68,6 +72,8 @@ export function DotLottieSprite({
             freezeOnOffscreen: false
           }
         })
+        playerRef.current = player
+        player.setSpeed(speedRef.current)
 
         player.addEventListener('render', () => {
           requestAnimationFrame(() => {
@@ -83,9 +89,15 @@ export function DotLottieSprite({
 
     return () => {
       cancelled = true
+      playerRef.current = null
       player?.destroy()
     }
   }, [src])
+
+  useEffect(() => {
+    speedRef.current = speed
+    playerRef.current?.setSpeed(speed)
+  }, [speed])
 
   return (
     <span className="pet-lottie-stage">

--- a/src/renderer/src/pet/PetApp.tsx
+++ b/src/renderer/src/pet/PetApp.tsx
@@ -8,7 +8,11 @@ import { usePetDrag } from './usePetDrag'
 import { usePetHover } from './usePetHover'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 
-const DEFAULT_STATUS: PetStatusPayload = { state: 'idle', sourceWorktreeId: null }
+const DEFAULT_STATUS: PetStatusPayload = {
+  state: 'idle',
+  sourceWorktreeId: null,
+  workingSessionCount: 0
+}
 
 export function PetApp(): React.JSX.Element {
   const [settings, setSettings] = useState<PetSettings | null>(null)
@@ -93,6 +97,7 @@ export function PetApp(): React.JSX.Element {
           pet={pet}
           state={visibleState}
           settings={settings}
+          workingSessionCount={status.workingSessionCount}
           onPointerDown={onPointerDown}
           onMouseEnter={hover.onMouseEnter}
           onMouseLeave={hover.onMouseLeave}

--- a/src/renderer/src/pet/PetSprite.tsx
+++ b/src/renderer/src/pet/PetSprite.tsx
@@ -9,11 +9,17 @@ const SIZE_PX: Record<PetSettings['size'], number> = {
   L: 128
 }
 
-function animationForState(state: PetState): Record<string, unknown> {
+function workingAnimationSpeed(settings: PetSettings, workingSessionCount: number): number {
+  if (!settings.animationSpeedEnabled) return 1
+  const maxSpeed = Math.min(Math.max(settings.animationSpeed, 2), 5)
+  return Math.min(Math.max(workingSessionCount, 1), maxSpeed)
+}
+
+function animationForState(state: PetState, speed: number): Record<string, unknown> {
   if (state === 'working') {
     return {
       animate: { rotate: [-4, 4, -4], y: [0, -3, 0] },
-      transition: { duration: 1.8, repeat: Infinity, ease: 'easeInOut' }
+      transition: { duration: 1.8 / speed, repeat: Infinity, ease: 'easeInOut' }
     }
   }
   if (state === 'question') {
@@ -48,6 +54,7 @@ export function PetSprite({
   pet,
   state,
   settings,
+  workingSessionCount,
   onPointerDown,
   onMouseEnter,
   onMouseLeave,
@@ -57,6 +64,7 @@ export function PetSprite({
   pet: LoadedPet
   state: PetState
   settings: PetSettings
+  workingSessionCount: number
   onPointerDown: (event: React.PointerEvent<HTMLElement>) => void
   onMouseEnter: () => void
   onMouseLeave: () => void
@@ -64,10 +72,11 @@ export function PetSprite({
   onContextMenu: (event: React.MouseEvent<HTMLElement>) => void
 }): React.JSX.Element {
   const size = SIZE_PX[settings.size]
+  const speed = workingAnimationSpeed(settings, workingSessionCount)
   const overlay = overlayForState(state)
   const lottieSrc = state === 'working' ? pet.resolvedLottieAssets?.working : undefined
   const lottieScale = state === 'working' ? (pet.lottieScale?.working ?? 1) : 1
-  const activeAnimation = lottieSrc ? {} : animationForState(state)
+  const activeAnimation = lottieSrc ? {} : animationForState(state, speed)
 
   return (
     <button
@@ -93,6 +102,7 @@ export function PetSprite({
             fallbackSrc={pet.resolvedAssets[state]}
             scale={lottieScale}
             size={size}
+            speed={speed}
             state={state}
           />
         ) : (

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -230,6 +230,8 @@ const DEFAULT_SETTINGS: AppSettings = {
     petId: 'bee',
     size: 'M',
     opacity: 1,
+    animationSpeedEnabled: false,
+    animationSpeed: 5,
     hasHatched: false
   },
   environmentVariables: [],
@@ -559,7 +561,11 @@ export const useSettingsStore = create<SettingsState>()(
         }
         set({ selectedModelByProvider: current })
         // Push to backend only for SDKs with a structured implementer.
-        if (agentSdk !== 'terminal' && agentSdk !== 'claude-code-cli' && !options?.skipBackendPush) {
+        if (
+          agentSdk !== 'terminal' &&
+          agentSdk !== 'claude-code-cli' &&
+          !options?.skipBackendPush
+        ) {
           try {
             unwrapEnvelope(await window.opencodeOps.setModel(model ? { ...model, agentSdk } : null))
           } catch (error) {

--- a/src/shared/types/pet.ts
+++ b/src/shared/types/pet.ts
@@ -6,12 +6,15 @@ export interface PetSettings {
   petId: string
   size: PetSize
   opacity: number
+  animationSpeedEnabled: boolean
+  animationSpeed: number
   hasHatched: boolean
 }
 
 export interface PetStatusPayload {
   state: PetState
   sourceWorktreeId: string | null
+  workingSessionCount: number
 }
 
 export interface PetManifest {

--- a/test/pet/pet-drag-click.test.tsx
+++ b/test/pet/pet-drag-click.test.tsx
@@ -40,11 +40,23 @@ describe('PetApp drag and click behavior', () => {
     Element.prototype.setPointerCapture = vi.fn()
 
     petOps().getConfig.mockResolvedValue({
-      settings: { enabled: true, petId: 'bee', size: 'M', opacity: 1, hasHatched: true },
+      settings: {
+        enabled: true,
+        petId: 'bee',
+        size: 'M',
+        opacity: 1,
+        animationSpeedEnabled: false,
+        animationSpeed: 5,
+        hasHatched: true
+      },
       position: { x: 10, y: 20 },
       manifest: { id: 'bee', name: 'Bee', version: '1.0.0', assets: {} }
     })
-    petOps().getCurrentStatus.mockResolvedValue({ state: 'idle', sourceWorktreeId: 'worktree-1' })
+    petOps().getCurrentStatus.mockResolvedValue({
+      state: 'idle',
+      sourceWorktreeId: 'worktree-1',
+      workingSessionCount: 0
+    })
     petOps().onStatus.mockReturnValue(() => {})
     petOps().onSettingsUpdated.mockReturnValue(() => {})
   })

--- a/test/pet/pet-lottie-rendering.test.tsx
+++ b/test/pet/pet-lottie-rendering.test.tsx
@@ -24,7 +24,8 @@ vi.mock('@lottiefiles/dotlottie-web', () => ({
     vi.fn().mockImplementation(() => ({
       addEventListener: vi.fn(),
       destroy: vi.fn(),
-      resize: vi.fn()
+      resize: vi.fn(),
+      setSpeed: vi.fn()
     })),
     { setWasmUrl: vi.fn() }
   )
@@ -39,6 +40,8 @@ const settings: PetSettings = {
   petId: 'bee',
   size: 'M',
   opacity: 1,
+  animationSpeedEnabled: false,
+  animationSpeed: 5,
   hasHatched: true
 }
 
@@ -107,6 +110,7 @@ describe('pet Lottie rendering', () => {
         pet={pet}
         state="working"
         settings={settings}
+        workingSessionCount={1}
         onPointerDown={vi.fn()}
         onMouseEnter={vi.fn()}
         onMouseLeave={vi.fn()}
@@ -141,6 +145,7 @@ describe('pet Lottie rendering', () => {
         pet={pet}
         state="question"
         settings={settings}
+        workingSessionCount={1}
         onPointerDown={vi.fn()}
         onMouseEnter={vi.fn()}
         onMouseLeave={vi.fn()}
@@ -161,6 +166,7 @@ describe('pet Lottie rendering', () => {
         pet={pet}
         state="working"
         settings={{ ...settings, petId: 'corgi' }}
+        workingSessionCount={1}
         onPointerDown={vi.fn()}
         onMouseEnter={vi.fn()}
         onMouseLeave={vi.fn()}
@@ -183,6 +189,7 @@ describe('pet Lottie rendering', () => {
         pet={pet}
         state="permission"
         settings={{ ...settings, petId: 'corgi' }}
+        workingSessionCount={1}
         onPointerDown={vi.fn()}
         onMouseEnter={vi.fn()}
         onMouseLeave={vi.fn()}
@@ -193,5 +200,89 @@ describe('pet Lottie rendering', () => {
 
     expect(screen.queryByTestId('pet-lottie-working')).not.toBeInTheDocument()
     expect(container.querySelector('img')?.getAttribute('src')).toContain('corgi-static')
+  })
+
+  it('caps the working Lottie speed at the configured animation speed', async () => {
+    const pet = getPet('corgi')
+
+    render(
+      <PetSprite
+        pet={pet}
+        state="working"
+        settings={
+          {
+            ...settings,
+            petId: 'corgi',
+            animationSpeed: 2,
+            animationSpeedEnabled: true
+          } as PetSettings
+        }
+        workingSessionCount={5}
+        onPointerDown={vi.fn()}
+        onMouseEnter={vi.fn()}
+        onMouseLeave={vi.fn()}
+        onClick={vi.fn()}
+        onContextMenu={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(DotLottie).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(DotLottie).mock.results[0]?.value.setSpeed).toHaveBeenCalledWith(2)
+  })
+
+  it('keeps the working Lottie at 1x when animation speed scaling is disabled', async () => {
+    const pet = getPet('corgi')
+
+    render(
+      <PetSprite
+        pet={pet}
+        state="working"
+        settings={
+          {
+            ...settings,
+            petId: 'corgi',
+            animationSpeed: 5,
+            animationSpeedEnabled: false
+          } as PetSettings
+        }
+        workingSessionCount={5}
+        onPointerDown={vi.fn()}
+        onMouseEnter={vi.fn()}
+        onMouseLeave={vi.fn()}
+        onClick={vi.fn()}
+        onContextMenu={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(DotLottie).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(DotLottie).mock.results[0]?.value.setSpeed).toHaveBeenCalledWith(1)
+  })
+
+  it('caps enabled working Lottie speed at 5x', async () => {
+    const pet = getPet('corgi')
+
+    render(
+      <PetSprite
+        pet={pet}
+        state="working"
+        settings={
+          {
+            ...settings,
+            petId: 'corgi',
+            animationSpeed: 10,
+            animationSpeedEnabled: true
+          } as PetSettings
+        }
+        workingSessionCount={10}
+        onPointerDown={vi.fn()}
+        onMouseEnter={vi.fn()}
+        onMouseLeave={vi.fn()}
+        onClick={vi.fn()}
+        onContextMenu={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(DotLottie).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(DotLottie).mock.results[0]?.value.setSpeed).toHaveBeenCalledWith(5)
   })
 })

--- a/test/pet/pet-status-aggregator.test.ts
+++ b/test/pet/pet-status-aggregator.test.ts
@@ -21,7 +21,7 @@ describe('aggregatePetStatus', () => {
       connections: []
     })
 
-    expect(result).toEqual({ state: 'idle', sourceWorktreeId: null })
+    expect(result).toEqual({ state: 'idle', sourceWorktreeId: null, workingSessionCount: 0 })
   })
 
   it('maps the highest-priority worktree status to a pet state', () => {
@@ -38,7 +38,11 @@ describe('aggregatePetStatus', () => {
       connections: []
     })
 
-    expect(result).toEqual({ state: 'permission', sourceWorktreeId: 'wt-permission' })
+    expect(result).toEqual({
+      state: 'permission',
+      sourceWorktreeId: 'wt-permission',
+      workingSessionCount: 1
+    })
   })
 
   it('uses connection sessions for member worktrees and reports the member as the source', () => {
@@ -57,6 +61,35 @@ describe('aggregatePetStatus', () => {
       ]
     })
 
-    expect(result).toEqual({ state: 'question', sourceWorktreeId: 'wt2' })
+    expect(result).toEqual({ state: 'question', sourceWorktreeId: 'wt2', workingSessionCount: 1 })
+  })
+
+  it('counts all working and planning sessions across worktrees and connections', () => {
+    const result = aggregatePetStatus({
+      sessionStatuses: {
+        working1: entry('working'),
+        planning1: entry('planning'),
+        planning2: entry('planning'),
+        permission: entry('permission'),
+        completed: entry('completed')
+      },
+      worktreeSessions: new Map([
+        ['wt-working', [{ id: 'working1' }, { id: 'completed' }]],
+        ['wt-permission', [{ id: 'permission' }]]
+      ]),
+      connectionSessions: new Map([['conn1', [{ id: 'planning1' }, { id: 'planning2' }]]]),
+      connections: [
+        {
+          id: 'conn1',
+          members: [{ worktree_id: 'wt-connected' }]
+        }
+      ]
+    })
+
+    expect(result).toEqual({
+      state: 'permission',
+      sourceWorktreeId: 'wt-permission',
+      workingSessionCount: 3
+    })
   })
 })

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -154,11 +154,23 @@ if (typeof window !== 'undefined') {
         move: vi.fn(),
         focusMain: vi.fn().mockResolvedValue(undefined),
         getConfig: vi.fn().mockResolvedValue({
-          settings: { enabled: false, petId: 'bee', size: 'M', opacity: 1, hasHatched: true },
+          settings: {
+            enabled: false,
+            petId: 'bee',
+            size: 'M',
+            opacity: 1,
+            animationSpeedEnabled: false,
+            animationSpeed: 5,
+            hasHatched: true
+          },
           position: { x: 0, y: 0 },
           manifest: { id: 'bee', name: 'Bee', version: '1.0.0', assets: {} }
         }),
-        getCurrentStatus: vi.fn().mockResolvedValue({ state: 'idle', sourceWorktreeId: null }),
+        getCurrentStatus: vi.fn().mockResolvedValue({
+          state: 'idle',
+          sourceWorktreeId: null,
+          workingSessionCount: 0
+        }),
         updateSettings: vi.fn(),
         markHatched: vi.fn(),
         onStatus: vi.fn().mockReturnValue(() => {}),


### PR DESCRIPTION
## Summary
- Add pet animation speed settings with an enable toggle and configurable max speed in the settings UI.
- Scale working pet motion and Lottie playback speed based on the number of active working/planning sessions, capped by the configured maximum.
- Extend pet status payloads to carry `workingSessionCount` through main and renderer state.
- Update shared defaults and tests to cover the new settings and speed behavior.

## Testing
- `Not run`
- Added/updated unit tests for pet status aggregation, drag/click setup defaults, and Lottie speed scaling behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only pet overlay and status aggregation changes; no auth, data migration, or core app flows beyond optional pet settings defaults.
> 
> **Overview**
> Adds **pet animation speed scaling** tied to how many sessions are actively working or planning.
> 
> New pet settings (`animationSpeedEnabled`, `animationSpeed` 2–5x) appear in **Settings → Pet**, with defaults wired through main process, settings store, and DB merge. Pet status now carries **`workingSessionCount`** from `aggregatePetStatus` (global count of `working`/`planning` sessions), propagated via `PetStatusBridge` and main `latestStatus` so updates publish when only the count changes.
> 
> While the pet is in the **working** state, playback speed scales from 1x up to the configured max based on that count when enabled; **Lottie** (`setSpeed`) and **non-Lottie** motion (`duration: 1.8 / speed`) both respect the same cap. Tests cover aggregation, defaults, and Lottie speed behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8a04158cf84233705bf82491dbce7a79753f7eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->