### PR TITLE
Blank Session Provider Switch

### DIFF
--- a/docs/superpowers/specs/2026-06-01-blank-session-provider-switch-design.md
+++ b/docs/superpowers/specs/2026-06-01-blank-session-provider-switch-design.md
@@ -67,11 +67,12 @@ A session is durably blank only when all of the following are true:
 2. `window.db.sessionMessage.list(sessionId)` returns no messages.
 3. `window.db.sessionActivity.list(sessionId)` returns no activities.
 4. If an existing `opencode_session_id` exists, the live backend transcript can be verified and is empty.
-5. No prompt is currently sending.
-6. No stream is active.
-7. No queued follow-up or pending follow-up prompt exists.
-8. The session is not a bare Terminal session.
-9. No pending initial prompt exists for the session.
+5. If the session is Claude Code CLI, no `claude_session_id` has been captured yet; launched CLI transcripts are treated as unverifiable and therefore nonblank for switching.
+6. No prompt is currently sending.
+7. No stream is active.
+8. No queued follow-up or pending follow-up prompt exists.
+9. The session is not a bare Terminal session.
+10. No pending initial prompt exists for the session.
 
 Draft input does not affect blankness. A session with unsent composer text is still blank if the durable checks above pass.
 
@@ -103,22 +104,23 @@ Action flow:
 2. Reject bare Terminal sessions.
 3. Check durable blankness with `sessionMessage.list` and `sessionActivity.list`; reject if either API is unavailable or throws.
 4. If the current session has an `opencode_session_id`, query the live backend transcript and reject if it is nonempty or cannot be verified.
-5. Reject if provider availability is unknown or if `nextAgentSdk` is unavailable.
-6. Reject if any sent message, activity, active stream, queued prompt, pending follow-up, pending initial prompt, or store-owned local send/stream/queued-follow-up activity exists.
-7. Resolve a default model for `nextAgentSdk` if `nextModel` is not supplied.
-8. Update the session row:
+5. If the current session is Claude CLI and has a `claude_session_id`, reject because Hive has no reliable session-only transcript verification API for the live CLI transcript.
+6. Reject if provider availability is unknown or if `nextAgentSdk` is unavailable.
+7. Reject if any sent message, activity, active stream, queued prompt, pending follow-up, pending initial prompt, or store-owned local send/stream/queued-follow-up activity exists.
+8. Resolve a default model for `nextAgentSdk` if `nextModel` is not supplied.
+9. Update the session row:
    - `agent_sdk = nextAgentSdk`
    - `model_provider_id = resolvedModel.providerID`
    - `model_id = resolvedModel.modelID`
    - `model_variant = resolvedModel.variant ?? null`
    - `opencode_session_id = null`
    - `claude_session_id = null`
-9. After the database update succeeds, best-effort tear down the old runtime:
+10. After the database update succeeds, best-effort tear down the old runtime:
    - Disconnect the old `opencode_session_id` through `opencodeOps.disconnect`.
    - Destroy the old Claude CLI PTY through `terminalOps.destroy(sessionId)`.
-10. Update the in-memory session in the owning scope.
-11. Do not update worktree `last_model_*`.
-12. Do not update global or per-SDK selected model defaults as a side effect.
+11. Update the in-memory session in the owning scope.
+12. Do not update worktree `last_model_*`.
+13. Do not update global or per-SDK selected model defaults as a side effect.
 
 `setSessionModel` remains responsible for explicit model changes and can keep its current last-used default behavior.
 
@@ -169,6 +171,7 @@ Claude CLI model choice remains a launch-time concern. Hive may persist `model_i
 | Durable-blank validation fails | Do not switch; return an error |
 | Durable-blank validation cannot be verified | Fail closed; do not switch |
 | Live backend transcript cannot be verified | Fail closed; do not switch |
+| Launched Claude CLI transcript exists but cannot be verified | Fail closed; show static provider text |
 | Database update fails | Keep old provider and old runtime; show a toast |
 | Old backend teardown fails after DB update | Log and continue |
 | Store update succeeds but new provider connect fails | Keep selected provider; show existing connection retry UI |

--- a/docs/superpowers/specs/2026-06-01-blank-session-provider-switch-design.md
+++ b/docs/superpowers/specs/2026-06-01-blank-session-provider-switch-design.md
@@ -67,7 +67,7 @@ A session is durably blank only when all of the following are true:
 2. `window.db.sessionMessage.list(sessionId)` returns no messages.
 3. `window.db.sessionActivity.list(sessionId)` returns no activities.
 4. If an existing `opencode_session_id` exists, the live backend transcript can be verified and is empty.
-5. If the session is Claude Code CLI, no `claude_session_id` has been captured yet; launched CLI transcripts are treated as unverifiable and therefore nonblank for switching.
+5. The session is not already Claude Code CLI; live CLI transcripts cannot be verified through a reliable session-only API, so CLI sessions are treated as nonblank for switching.
 6. No prompt is currently sending.
 7. No stream is active.
 8. No queued follow-up or pending follow-up prompt exists.
@@ -104,7 +104,7 @@ Action flow:
 2. Reject bare Terminal sessions.
 3. Check durable blankness with `sessionMessage.list` and `sessionActivity.list`; reject if either API is unavailable or throws.
 4. If the current session has an `opencode_session_id`, query the live backend transcript and reject if it is nonempty or cannot be verified.
-5. If the current session is Claude CLI and has a `claude_session_id`, reject because Hive has no reliable session-only transcript verification API for the live CLI transcript.
+5. If the current session is Claude CLI, reject because Hive has no reliable session-only transcript verification API for the live CLI transcript.
 6. Reject if provider availability is unknown or if `nextAgentSdk` is unavailable.
 7. Reject if any sent message, activity, active stream, queued prompt, pending follow-up, pending initial prompt, or store-owned local send/stream/queued-follow-up activity exists.
 8. Resolve a default model for `nextAgentSdk` if `nextModel` is not supplied.
@@ -117,7 +117,7 @@ Action flow:
    - `claude_session_id = null`
 10. After the database update succeeds, best-effort tear down the old runtime:
    - Disconnect the old `opencode_session_id` through `opencodeOps.disconnect`.
-   - Destroy the old Claude CLI PTY through `terminalOps.destroy(sessionId)`.
+   - Do not tear down Claude CLI here; switching away from current Claude CLI sessions fails before the database update.
 11. Update the in-memory session in the owning scope.
 12. Do not update worktree `last_model_*`.
 13. Do not update global or per-SDK selected model defaults as a side effect.
@@ -171,7 +171,7 @@ Claude CLI model choice remains a launch-time concern. Hive may persist `model_i
 | Durable-blank validation fails | Do not switch; return an error |
 | Durable-blank validation cannot be verified | Fail closed; do not switch |
 | Live backend transcript cannot be verified | Fail closed; do not switch |
-| Launched Claude CLI transcript exists but cannot be verified | Fail closed; show static provider text |
+| Current session is Claude CLI | Fail closed; show static provider text |
 | Database update fails | Keep old provider and old runtime; show a toast |
 | Old backend teardown fails after DB update | Log and continue |
 | Store update succeeds but new provider connect fails | Keep selected provider; show existing connection retry UI |
@@ -197,7 +197,7 @@ Claude CLI model choice remains a launch-time concern. Hive may persist `model_i
 11. Missing history APIs or failed status verification reject the switch.
 12. Database update failure does not disconnect OpenCode or destroy a Claude CLI PTY.
 13. Plain `completed` status is allowed after durable blankness is verified.
-14. Switching away from Claude CLI tears down the PTY after a successful DB update.
+14. Claude CLI sessions reject provider switching before DB update or PTY teardown.
 15. Live backend transcript history blocks switching.
 16. Live backend transcript verification failure rejects the switch.
 17. Unknown provider availability rejects the switch.

--- a/docs/superpowers/specs/2026-06-01-blank-session-provider-switch-design.md
+++ b/docs/superpowers/specs/2026-06-01-blank-session-provider-switch-design.md
@@ -1,0 +1,244 @@
+# Blank Session Provider Switch
+
+**Date:** 2026-06-01  
+**Status:** Design Approved  
+**Feature:** Allow changing the AI provider for durable-blank sessions
+
+## Overview
+
+Allow users to change the AI provider for a newly created session before any conversation history exists. The static provider label in the composer becomes a provider selector while the session is still durably blank. After the first durable message or activity exists, the selector disappears and the same provider text is shown as a fixed label.
+
+This keeps provider selection close to the existing composer controls, preserves the current session tab and draft, and avoids changing the provider for sessions that already have meaningful history.
+
+## Problem Statement
+
+Hive currently lets users choose the provider for new sessions through Settings or by right-clicking the `+` tab button. However, auto-created empty sessions already show a composer with a static provider label such as `CODEX` or `OPENCODE-GO`. If the user wants a different provider at that moment, the UI does not offer a direct switch in the place where they are about to type.
+
+Changing the provider after a real conversation starts is risky because the session's `agent_sdk` controls routing, reconnect behavior, capabilities, model catalog, and the view type. The safe window is before the session has durable history.
+
+## Goals
+
+1. Let users change the AI provider from the composer for newly created blank sessions.
+2. Preserve draft text while switching providers.
+3. Preserve the existing session tab, active focus, mode, and tab order.
+4. Make provider switching unavailable once durable conversation history exists.
+5. Include only AI providers: OpenCode, Claude Code, Codex, and Claude Code CLI.
+6. Keep Terminal out of this composer provider selector.
+7. Avoid updating worktree/global last-used defaults merely because the user previewed a provider in a blank session.
+
+## Non-Goals
+
+1. Do not allow provider changes after durable history exists.
+2. Do not add an `All providers` option to the composer provider selector.
+3. Do not replace the existing right-click `+` provider creation menu.
+4. Do not support switching to Terminal from the composer provider selector.
+5. Do not redesign the full composer or settings model UI.
+
+## User Experience
+
+### Blank Session
+
+When a session is durably blank, the existing static provider label position becomes a compact dropdown trigger:
+
+- `OPENCODE`
+- `CLAUDE CODE`
+- `CODEX`
+- `CLAUDE CLI`
+
+The dropdown lists only installed/available AI providers. If provider availability has not loaded or cannot be verified, the control stays as static provider text and no switch targets are shown. For OpenCode-style sessions, the model selector remains immediately to the right and updates to the default model for the selected provider. For Claude Code CLI sessions, the model selector is intentionally hidden because the live CLI process does not consume Hive's post-spawn model changes.
+
+Draft text in the composer remains untouched. If the user typed a prompt but has not sent it, switching providers should not clear or alter that draft.
+
+### Nonblank Session
+
+When a session is no longer durably blank, the provider selector is replaced by a static provider label in the same location. The caret disappears. For OpenCode-style sessions, the model selector continues to work within the existing provider's model catalog, matching today's behavior. Claude Code CLI continues to hide the model selector.
+
+### Failure Feedback
+
+Provider changes should be immediate and should not require confirmation. If the switch cannot be completed, show a toast and leave the session on its previous provider.
+
+If switching succeeds but the new provider cannot connect, keep the session row on the selected provider and let the existing session connection error/retry UI handle the failure.
+
+## Durable Blank Definition
+
+A session is durably blank only when all of the following are true:
+
+1. The visible message list is empty.
+2. `window.db.sessionMessage.list(sessionId)` returns no messages.
+3. `window.db.sessionActivity.list(sessionId)` returns no activities.
+4. If an existing `opencode_session_id` exists, the live backend transcript can be verified and is empty.
+5. No prompt is currently sending.
+6. No stream is active.
+7. No queued follow-up or pending follow-up prompt exists.
+8. The session is not a bare Terminal session.
+9. No pending initial prompt exists for the session.
+
+Draft input does not affect blankness. A session with unsent composer text is still blank if the durable checks above pass.
+
+The UI may use local visible state for quick rendering, but it must keep durable history state fresh after mount with a subscription-style or polling check. Once durable messages or activities appear, the dropdown becomes the static provider label even if the visible message list is empty or filtered.
+
+The store action must enforce durable blankness before mutating the provider. It fails closed if it cannot verify messages, activities, live backend transcript history, provider availability, or live session status because a missing preload/API surface must not permit provider mutation. Local send/stream/queued follow-up activity must be mirrored into store-owned transient state so the action can reject active sessions without trusting a mounted component's local state.
+
+Session status only blocks switching when it represents active work or an interaction gate: `working`, `planning`, `answering`, `permission`, `command_approval`, or `plan_ready`. Plain `completed` status does not block switching when durable DB messages and activities are empty.
+
+## Architecture
+
+### Session Store Action
+
+Add one explicit action to `useSessionStore`:
+
+```ts
+changeBlankSessionProvider(
+  sessionId: string,
+  nextAgentSdk: 'opencode' | 'claude-code' | 'codex' | 'claude-code-cli',
+  nextModel?: SelectedModel
+): Promise<{ success: boolean; error?: string }>
+```
+
+This action owns the safety invariant so UI components do not duplicate partial checks.
+
+Action flow:
+
+1. Find the session in worktree or connection session state, then verify it exists in the database.
+2. Reject bare Terminal sessions.
+3. Check durable blankness with `sessionMessage.list` and `sessionActivity.list`; reject if either API is unavailable or throws.
+4. If the current session has an `opencode_session_id`, query the live backend transcript and reject if it is nonempty or cannot be verified.
+5. Reject if provider availability is unknown or if `nextAgentSdk` is unavailable.
+6. Reject if any sent message, activity, active stream, queued prompt, pending follow-up, pending initial prompt, or store-owned local send/stream/queued-follow-up activity exists.
+7. Resolve a default model for `nextAgentSdk` if `nextModel` is not supplied.
+8. Update the session row:
+   - `agent_sdk = nextAgentSdk`
+   - `model_provider_id = resolvedModel.providerID`
+   - `model_id = resolvedModel.modelID`
+   - `model_variant = resolvedModel.variant ?? null`
+   - `opencode_session_id = null`
+   - `claude_session_id = null`
+9. After the database update succeeds, best-effort tear down the old runtime:
+   - Disconnect the old `opencode_session_id` through `opencodeOps.disconnect`.
+   - Destroy the old Claude CLI PTY through `terminalOps.destroy(sessionId)`.
+10. Update the in-memory session in the owning scope.
+11. Do not update worktree `last_model_*`.
+12. Do not update global or per-SDK selected model defaults as a side effect.
+
+`setSessionModel` remains responsible for explicit model changes and can keep its current last-used default behavior.
+
+### Provider And Model Resolution
+
+The provider selector should resolve the selected provider's model using the same precedence as new-session creation where possible:
+
+1. Mode-specific default if it is valid for the selected SDK.
+2. Per-SDK selected model from settings.
+3. First available catalog model.
+4. Existing fallback model for that SDK.
+
+Provider switching intentionally skips worktree `last_model_*` fallback so an explicit switch cannot reuse a model from the previous SDK. A mode default without `agentSdk` may still be used for an explicit provider switch when it is verified as valid for the selected SDK; unknown validity must fail closed and fall through to the next precedence step.
+
+In code, use `agentSdk` or `sessionProvider` naming for the session-level provider. Reserve `model_provider_id` for model catalog providers such as `anthropic`, `codex`, or `openai`.
+
+### Session View Reconnect
+
+After the store action changes `agent_sdk` and clears agent session IDs, `SessionView` should reconnect through the existing initialization path. If the provider changes to Claude Code CLI, the active main pane may need to swap from the OpenCode-style session view to the terminal-backed `ClaudeCliSessionView`.
+
+That swap is expected and should be tested explicitly. Once the Claude CLI view is mounted, opening the provider dropdown must not hide or unmount it. Dropdowns may suppress native Ghostty overlays, but that suppression applies only to actual Ghostty surfaces; Claude CLI is xterm-backed and must remain visible so dropdown anchors stay stable.
+
+When a Claude CLI session is moved into or out of a ticket modal, the mounted `SessionView`/`ClaudeCliSessionView` subtree must remain stable. Main pane mounting should use a stable host element that moves between the inline pane and modal target instead of switching between inline rendering and a new portal subtree. This prevents `TerminalView` from disposing and recreating the xterm backend while preserving correct dropdown anchoring.
+
+## UI Component Changes
+
+Introduce a small adjacent `SessionProviderSelector` for the static-label position. The final implementation should preserve this UI behavior:
+
+1. Use the existing provider label location in the composer.
+2. Render a dropdown only when durable blankness is true.
+3. Render static text when durable blankness is false.
+4. Do not show `All providers`.
+5. Do not show Terminal.
+6. Omit unavailable AI providers.
+7. Treat unknown provider availability as unavailable: show static provider text and no dropdown menu until availability is known.
+8. Keep the model selector immediately to the right for OpenCode-style session views.
+9. Render `ModelSelector` with `hideProviderPrefix` so provider identity is shown once.
+10. In Claude CLI session headers, keep the provider control but do not render `ModelSelector`.
+
+The key requirement is that model selection and session-provider selection remain distinct in code.
+
+Claude CLI model choice remains a launch-time concern. Hive may persist `model_id` and `model_variant` and pass them to `claude --model` and `--effort` when creating the PTY, but changing Hive model state after the PTY is running does not update the live Claude process. Injecting `/model` into the PTY is intentionally out of scope because it is brittle and can mutate the user's Claude Code default. Hiding the selector avoids a control that appears to work while only changing Hive state.
+
+## Error Handling
+
+| Case | Behavior |
+| ---- | -------- |
+| Durable-blank validation fails | Do not switch; return an error |
+| Durable-blank validation cannot be verified | Fail closed; do not switch |
+| Live backend transcript cannot be verified | Fail closed; do not switch |
+| Database update fails | Keep old provider and old runtime; show a toast |
+| Old backend teardown fails after DB update | Log and continue |
+| Store update succeeds but new provider connect fails | Keep selected provider; show existing connection retry UI |
+| Provider availability unknown | Fail closed; show static provider text and reject switching |
+| Provider unavailable | Omit from dropdown |
+| Current provider unavailable | Keep current label; omit unavailable switch targets |
+| Claude CLI switch triggers view swap | Allow swap; verify draft preservation where applicable |
+
+## Testing Plan
+
+### Store Tests
+
+1. `changeBlankSessionProvider` succeeds when messages and activities are empty.
+2. Draft input does not block switching.
+3. Existing session messages block switching.
+4. Existing session activities block switching.
+5. Active/queued/pending prompt state blocks switching.
+6. Old agent session IDs are cleared after a successful switch.
+7. Existing unused backend session is disconnected best-effort.
+8. Disconnect failure does not corrupt local state.
+9. Worktree `last_model_*` defaults are not updated.
+10. Global/per-SDK selected model defaults are not updated.
+11. Missing history APIs or failed status verification reject the switch.
+12. Database update failure does not disconnect OpenCode or destroy a Claude CLI PTY.
+13. Plain `completed` status is allowed after durable blankness is verified.
+14. Switching away from Claude CLI tears down the PTY after a successful DB update.
+15. Live backend transcript history blocks switching.
+16. Live backend transcript verification failure rejects the switch.
+17. Unknown provider availability rejects the switch.
+18. Store-owned sending, streaming, and queued local follow-up activity reject the switch.
+
+### Component Tests
+
+1. Blank session renders provider dropdown in the static provider label location.
+2. Nonblank session renders static provider label.
+3. Choosing a provider calls the store action.
+4. Model selector updates to the selected provider's resolved model.
+5. Unavailable providers are omitted.
+6. No `All providers` option appears.
+7. Terminal does not appear.
+8. Durable history appearing after mount flips the dropdown back to static provider text.
+9. Claude CLI renders the provider control and omits the model selector.
+10. Unknown provider availability renders static provider text and no dropdown.
+11. SessionView syncs send/stream/queued follow-up activity into store-owned provider-switch activity state and clears it on unmount.
+
+### Regression Tests
+
+1. Existing model switching still works after first message.
+2. Right-click `+` provider creation still works.
+3. Switching a blank OpenCode-style session to Claude Code CLI transitions cleanly to the terminal-backed view.
+4. Auto-start blank sessions can switch provider before first send.
+5. Explicit non-default provider switch uses a valid bare mode default.
+6. Provider switching does not reuse worktree `last_model_*` fallback.
+7. Unknown validity for a bare mode default falls back to the selected provider/default.
+8. Opening the provider dropdown in a Claude CLI session keeps the xterm-backed Claude CLI view mounted and visible.
+9. Moving a Claude CLI session into and out of a ticket modal does not remount `SessionView` or recreate the terminal backend.
+
+## Manual Verification
+
+1. Open a worktree with auto-start enabled.
+2. Confirm the blank session shows a provider dropdown where the provider label normally appears.
+3. Type a draft without sending it.
+4. Switch provider from OpenCode to Codex.
+5. Confirm the draft remains.
+6. Switch back to another AI provider.
+7. Send the prompt.
+8. Confirm the selected provider and model are used for OpenCode-style sessions.
+9. Confirm Claude CLI sessions show no model selector.
+10. Confirm the provider control becomes a static label after history exists.
+
+## Open Decisions
+
+No open product decisions remain for this design. The provider control is a separate `SessionProviderSelector`, and session-provider and model-provider concepts remain clearly separated.

--- a/src/renderer/src/components/layout/MainPane.test.tsx
+++ b/src/renderer/src/components/layout/MainPane.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MainPane } from './MainPane'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -11,29 +11,33 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 
+const mainPaneMocks = vi.hoisted(() => ({
+  sessionViewHostAttachedOnMount: [] as boolean[],
+  claudeCliModalTarget: null as HTMLDivElement | null,
+  claudeCliPortalRevision: 0
+}))
+
 vi.mock('@/components/sessions', () => ({
   SessionTabs: () => <div data-testid="session-tabs" />,
-  SessionView: ({
-    sessionId,
-    isVisible
-  }: {
-    sessionId: string
-    isVisible?: boolean
-  }) => (
-    <div data-testid={`session-view-${sessionId}`} data-visible={String(isVisible)}>
+  SessionView: ({ sessionId, isVisible }: { sessionId: string; isVisible?: boolean }) => (
+    <div
+      ref={(node) => {
+        if (node) {
+          mainPaneMocks.sessionViewHostAttachedOnMount.push(
+            Boolean(node.parentElement?.parentElement)
+          )
+        }
+      }}
+      data-testid={`session-view-${sessionId}`}
+      data-visible={String(isVisible)}
+    >
       session {sessionId}
     </div>
   )
 }))
 
 vi.mock('@/components/sessions/SessionTerminalView', () => ({
-  SessionTerminalView: ({
-    sessionId,
-    isVisible
-  }: {
-    sessionId: string
-    isVisible?: boolean
-  }) => (
+  SessionTerminalView: ({ sessionId, isVisible }: { sessionId: string; isVisible?: boolean }) => (
     <div data-testid={`terminal-view-${sessionId}`} data-visible={String(isVisible)}>
       terminal {sessionId}
     </div>
@@ -56,6 +60,13 @@ vi.mock('@/components/kanban/BoardAssistantView', () => ({
 
 vi.mock('@/components/pr/PRNotificationStack', () => ({
   PRNotificationStack: () => null
+}))
+
+vi.mock('@/contexts/ClaudeCliSessionPortalContext', () => ({
+  useClaudeCliSessionPortal: () => ({
+    getTarget: () => mainPaneMocks.claudeCliModalTarget,
+    revision: mainPaneMocks.claudeCliPortalRevision
+  })
 }))
 
 vi.mock('./MainPaneTerminalPanel', () => ({
@@ -178,6 +189,9 @@ function setupMainPaneState(session: MainPaneSession = makeSession()): void {
 
 afterEach(() => {
   cleanup()
+  mainPaneMocks.claudeCliModalTarget = null
+  mainPaneMocks.claudeCliPortalRevision = 0
+  mainPaneMocks.sessionViewHostAttachedOnMount = []
   useConnectionStore.setState(initialConnectionState, true)
   useFileViewerStore.setState(initialFileViewerState, true)
   useKanbanStore.setState(initialKanbanState, true)
@@ -215,7 +229,6 @@ describe('MainPane terminal visibility', () => {
 
     const terminal = screen.getByTestId('session-view-session-1')
     expect(terminal.getAttribute('data-visible')).toBe('false')
-    expect(terminal.parentElement?.classList.contains('hidden')).toBe(true)
   })
 
   it('keeps a plain terminal session mounted but hidden during board view', () => {
@@ -227,5 +240,102 @@ describe('MainPane terminal visibility', () => {
     const terminal = screen.getByTestId('terminal-view-terminal-1')
     expect(terminal.getAttribute('data-visible')).toBe('false')
     expect(terminal.parentElement?.classList.contains('hidden')).toBe(true)
+  })
+
+  it('keeps Claude CLI mounted and visible while a dropdown suppresses Ghostty overlays', () => {
+    setupMainPaneState()
+    useLayoutStore.setState({ ghosttyOverlaySuppressed: true })
+
+    render(<MainPane />)
+
+    const terminal = screen.getByTestId('session-view-session-1')
+    expect(terminal.getAttribute('data-visible')).toBe('true')
+    expect(terminal.parentElement?.classList.contains('hidden')).toBe(false)
+  })
+
+  it('moves Claude CLI into and out of a modal target without remounting the session view', async () => {
+    setupMainPaneState()
+    const { rerender } = render(<MainPane />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-view-session-1').getAttribute('data-visible')).toBe('true')
+    })
+    const initialView = screen.getByTestId('session-view-session-1')
+    const inlineHost = initialView.parentElement
+    expect(inlineHost?.parentElement).toBeTruthy()
+
+    const modalTarget = document.createElement('div')
+    document.body.appendChild(modalTarget)
+
+    act(() => {
+      mainPaneMocks.claudeCliModalTarget = modalTarget
+      mainPaneMocks.claudeCliPortalRevision += 1
+    })
+    rerender(<MainPane />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-view-session-1').parentElement?.parentElement).toBe(
+        modalTarget
+      )
+    })
+    expect(screen.getByTestId('session-view-session-1')).toBe(initialView)
+    expect(screen.getByTestId('session-view-session-1').getAttribute('data-visible')).toBe('true')
+
+    act(() => {
+      mainPaneMocks.claudeCliModalTarget = null
+      mainPaneMocks.claudeCliPortalRevision += 1
+    })
+    rerender(<MainPane />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-view-session-1').parentElement).toBe(inlineHost)
+    })
+    expect(screen.getByTestId('session-view-session-1')).toBe(initialView)
+    modalTarget.remove()
+  })
+
+  it('mounts Claude CLI after provider switch and prunes it when switching back', async () => {
+    const opencodeSession = makeSession({
+      id: 'session-1',
+      name: 'Session 1',
+      agent_sdk: 'opencode'
+    })
+    setupMainPaneState(opencodeSession)
+
+    render(<MainPane />)
+
+    expect(screen.getAllByTestId('session-view-session-1')).toHaveLength(1)
+    expect(screen.getByTestId('session-view-session-1').getAttribute('data-visible')).toBe(
+      'undefined'
+    )
+
+    act(() => {
+      mainPaneMocks.sessionViewHostAttachedOnMount = []
+      useSessionStore.setState({
+        activeSessionId: 'session-1',
+        sessionsByWorktree: new Map([
+          ['worktree-1', [{ ...opencodeSession, agent_sdk: 'claude-code-cli' }]]
+        ])
+      })
+    })
+
+    expect(screen.getAllByTestId('session-view-session-1')).toHaveLength(1)
+    await waitFor(() => {
+      expect(screen.getByTestId('session-view-session-1').getAttribute('data-visible')).toBe('true')
+    })
+    expect(mainPaneMocks.sessionViewHostAttachedOnMount).not.toContain(false)
+
+    act(() => {
+      useSessionStore.setState({
+        activeSessionId: 'session-1',
+        sessionsByWorktree: new Map([['worktree-1', [opencodeSession]]])
+      })
+    })
+
+    expect(screen.getAllByTestId('session-view-session-1')).toHaveLength(1)
+    expect(screen.getByTestId('session-view-session-1').getAttribute('data-visible')).toBe(
+      'undefined'
+    )
+    expect(screen.queryByTestId('terminal-view-session-1')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -20,7 +20,6 @@ import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useSessionStore, BOARD_TAB_ID } from '@/stores/useSessionStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useFileViewerStore } from '@/stores/useFileViewerStore'
-import { useLayoutStore } from '@/stores/useLayoutStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { usePinnedStore } from '@/stores/usePinnedStore'
@@ -61,8 +60,8 @@ function ClaudeCliSessionPortal({
     host.className = 'flex-1 flex flex-col min-h-0'
     hostRef.current = host
   }
-
   const [localTarget, setLocalTarget] = useState<HTMLDivElement | null>(null)
+  const [hostAttached, setHostAttached] = useState(false)
   const modalTarget = getTarget(sessionId)
   const targetParent = modalTarget ?? localTarget
 
@@ -72,6 +71,7 @@ function ClaudeCliSessionPortal({
     if (host.parentElement !== targetParent) {
       targetParent.appendChild(host)
     }
+    setHostAttached(true)
   }, [targetParent])
 
   useEffect(() => {
@@ -81,15 +81,15 @@ function ClaudeCliSessionPortal({
     }
   }, [])
 
-  const sessionView = (
-    <SessionView sessionId={sessionId} isVisible={modalTarget ? true : isActive} />
-  )
-
   return (
     <>
       <div ref={setLocalTarget} className="flex-1 flex flex-col min-h-0" />
-      {hostRef.current && targetParent
-        ? createPortal(sessionView, hostRef.current, sessionId)
+      {hostRef.current && hostAttached
+        ? createPortal(
+            <SessionView sessionId={sessionId} isVisible={modalTarget ? true : isActive} />,
+            hostRef.current,
+            sessionId
+          )
         : null}
     </>
   )
@@ -105,7 +105,6 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const activeDiff = useFileViewerStore((state) => state.activeDiff)
   const contextEditorWorktreeId = useFileViewerStore((state) => state.contextEditorWorktreeId)
   const closedTerminalSessionIds = useSessionStore((state) => state.closedTerminalSessionIds)
-  const ghosttyOverlaySuppressed = useLayoutStore((state) => state.ghosttyOverlaySuppressed)
   const activePinnedSessionId = useSessionStore((state) => state.activePinnedSessionId)
   const activeBoardAssistantProjectId = useSessionStore((state) => state.activeBoardAssistantProjectId)
   const isBoardViewActive = useKanbanStore((state) => state.isBoardViewActive)
@@ -191,8 +190,22 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     })
   }, [terminalSessions, getAgentSdk])
 
-  // Prune terminals that were explicitly closed (tab close).
-  // This is the ONLY path that removes from mountedTerminalSessionIds.
+  useEffect(() => {
+    setMountedTerminalSessionIds((current) => {
+      const filtered = current.filter((sessionId) => {
+        const agentSdk =
+          getAgentSdk(sessionId) ?? mountedTerminalAgentSdkBySessionId.current.get(sessionId)
+        if (!agentSdk) return true
+        if (isStatefulTerminalSession(agentSdk)) return true
+        mountedTerminalAgentSdkBySessionId.current.delete(sessionId)
+        return false
+      })
+      return filtered.length === current.length ? current : filtered
+    })
+  }, [sessionsByWorktree, sessionsByConnection, getAgentSdk])
+
+  // Prune terminals that were explicitly closed (tab close). Provider switching
+  // can also prune stale terminal-backed mounts when a session changes SDK.
   useEffect(() => {
     if (closedTerminalSessionIds.size === 0) return
 
@@ -211,10 +224,6 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   // Determine which terminal session is currently visible (if any).
   // A terminal is visible when it's the active session AND no diff/file/loading overlay is on top.
   const visibleTerminalId = useMemo(() => {
-    if (ghosttyOverlaySuppressed) {
-      return null
-    }
-
     // When the board, pinned board, or board assistant is occupying the main
     // pane, hide all stateful terminal sessions — otherwise the always-mounted
     // terminal would render as flex-1 alongside the board and split the pane.
@@ -248,10 +257,11 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     activeDiff,
     activeFilePath,
     getAgentSdk,
-    ghosttyOverlaySuppressed,
     isBoardViewActive,
     isPinnedBoardActive,
-    activeBoardAssistantProjectId
+    activeBoardAssistantProjectId,
+    sessionsByWorktree,
+    sessionsByConnection
   ])
 
   const handleCloseDiff = useCallback(() => {
@@ -463,16 +473,21 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
         {/* Always-mounted terminal sessions — kept alive to preserve PTY state across tab switches */}
         {mountedTerminalSessionIds.map((sessionId) => {
           const isActive = visibleTerminalId === sessionId
+          const currentAgentSdk = getAgentSdk(sessionId)
+          if (currentAgentSdk && !isStatefulTerminalSession(currentAgentSdk)) {
+            return null
+          }
           const agentSdk =
-            getAgentSdk(sessionId) ?? mountedTerminalAgentSdkBySessionId.current.get(sessionId)
+            currentAgentSdk ?? mountedTerminalAgentSdkBySessionId.current.get(sessionId)
+          if (!isStatefulTerminalSession(agentSdk ?? null)) {
+            return null
+          }
           return (
             <div key={sessionId} className={isActive ? 'flex-1 flex flex-col min-h-0' : 'hidden'}>
               {agentSdk === 'terminal' ? (
                 <SessionTerminalView sessionId={sessionId} isVisible={isActive} />
-              ) : agentSdk === 'claude-code-cli' ? (
-                <ClaudeCliSessionPortal sessionId={sessionId} isActive={isActive} />
               ) : (
-                <SessionView sessionId={sessionId} isVisible={isActive} />
+                <ClaudeCliSessionPortal sessionId={sessionId} isActive={isActive} />
               )}
             </div>
           )

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.blank-provider-switch.test.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.blank-provider-switch.test.tsx
@@ -1,0 +1,134 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ClaudeCliSessionView } from './ClaudeCliSessionView'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+
+vi.mock('@/components/terminal/TerminalView', () => ({
+  TerminalView: () => <div data-testid="terminal-view" />
+}))
+
+vi.mock('@/contexts/ClaudeCliSessionPortalContext', () => ({
+  useClaudeCliSessionPortal: () => ({
+    getTarget: () => null,
+    revision: 0
+  })
+}))
+
+vi.mock('./ModeToggle', () => ({
+  ModeToggle: () => <div data-testid="mode-toggle" />
+}))
+
+vi.mock('./SuperToggle', () => ({
+  SuperToggle: () => <div data-testid="super-toggle" />
+}))
+
+const initialSessionState = useSessionStore.getState()
+const initialSettingsState = useSettingsStore.getState()
+const initialStatusState = useWorktreeStatusStore.getState()
+let sessionMessageList: ReturnType<typeof vi.fn>
+let sessionActivityList: ReturnType<typeof vi.fn>
+
+const session = {
+  id: 'session-1',
+  worktree_id: 'worktree-1',
+  project_id: 'project-1',
+  connection_id: null,
+  name: 'Claude CLI',
+  status: 'active' as const,
+  opencode_session_id: null,
+  claude_session_id: null,
+  agent_sdk: 'claude-code-cli' as const,
+  mode: 'build' as const,
+  session_type: 'default' as const,
+  model_provider_id: 'anthropic',
+  model_id: 'sonnet',
+  model_variant: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  completed_at: null
+}
+
+describe('ClaudeCliSessionView blank provider switch', () => {
+  beforeEach(() => {
+    useSessionStore.setState(initialSessionState, true)
+    useSettingsStore.setState(initialSettingsState, true)
+    useWorktreeStatusStore.setState(initialStatusState, true)
+
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([['worktree-1', [session]]]),
+      sessionsByConnection: new Map(),
+      modeBySession: new Map([['session-1', 'build']]),
+      pendingMessages: new Map(),
+      pendingFollowUpMessages: new Map(),
+      pendingPlans: new Map()
+    })
+    useSettingsStore.setState({
+      availableAgentSdks: { opencode: true, claude: true, codex: true }
+    })
+    sessionMessageList = vi.fn(async () => [])
+    sessionActivityList = vi.fn(async () => [])
+    Object.defineProperty(window, 'db', {
+      writable: true,
+      configurable: true,
+      value: {
+        sessionMessage: {
+          list: sessionMessageList
+        },
+        sessionActivity: {
+          list: sessionActivityList
+        }
+      }
+    })
+    Object.defineProperty(window, 'terminalOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        onClaudeSessionId: vi.fn(() => vi.fn())
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('keeps the provider selector enabled for an idle pty_start status', async () => {
+    useWorktreeStatusStore.setState({
+      sessionStatuses: {
+        'session-1': {
+          status: 'completed',
+          reason: 'pty_start',
+          timestamp: Date.now()
+        }
+      }
+    })
+
+    render(<ClaudeCliSessionView sessionId="session-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-provider-selector')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('session-provider-label')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('model-selector')).not.toBeInTheDocument()
+  })
+
+  it('returns to static provider text when durable history appears after mount', async () => {
+    render(<ClaudeCliSessionView sessionId="session-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-provider-selector')).toBeInTheDocument()
+    })
+
+    sessionMessageList.mockResolvedValue([{ id: 'message-1' }])
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('session-provider-label')).toBeInTheDocument()
+      },
+      { timeout: 2500 }
+    )
+    expect(screen.queryByTestId('session-provider-selector')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.blank-provider-switch.test.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.blank-provider-switch.test.tsx
@@ -94,7 +94,7 @@ describe('ClaudeCliSessionView blank provider switch', () => {
     cleanup()
   })
 
-  it('keeps the provider selector enabled for an idle pty_start status', async () => {
+  it('renders static provider text for an idle pty_start status', async () => {
     useWorktreeStatusStore.setState({
       sessionStatuses: {
         'session-1': {
@@ -108,17 +108,17 @@ describe('ClaudeCliSessionView blank provider switch', () => {
     render(<ClaudeCliSessionView sessionId="session-1" />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('session-provider-selector')).toBeInTheDocument()
+      expect(screen.getByTestId('session-provider-label')).toBeInTheDocument()
     })
-    expect(screen.queryByTestId('session-provider-label')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('session-provider-selector')).not.toBeInTheDocument()
     expect(screen.queryByTestId('model-selector')).not.toBeInTheDocument()
   })
 
-  it('returns to static provider text when durable history appears after mount', async () => {
+  it('keeps static provider text when durable history appears after mount', async () => {
     render(<ClaudeCliSessionView sessionId="session-1" />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('session-provider-selector')).toBeInTheDocument()
+      expect(screen.getByTestId('session-provider-label')).toBeInTheDocument()
     })
 
     sessionMessageList.mockResolvedValue([{ id: 'message-1' }])

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { TerminalView, type TerminalViewHandle } from '@/components/terminal/TerminalView'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { useSessionStore, BOARD_TAB_ID } from '@/stores/useSessionStore'
-import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import {
+  isProviderSwitchBlockingSessionStatus,
+  useWorktreeStatusStore
+} from '@/stores/useWorktreeStatusStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -12,7 +15,8 @@ import { useTelegramStore } from '@/stores/useTelegramStore'
 import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalContext'
 import { ModeToggle } from './ModeToggle'
 import { SuperToggle } from './SuperToggle'
-import { ModelSelector } from './ModelSelector'
+import { SessionProviderSelector } from './SessionProviderSelector'
+import { useDurableSessionHistory } from './useDurableSessionHistory'
 import { QuestionPrompt } from './QuestionPrompt'
 import { ClaudeCliEndedOverlay } from './ClaudeCliEndedOverlay'
 import { HandoffSplitButton } from './HandoffSplitButton'
@@ -25,6 +29,7 @@ import { cn } from '@/lib/utils'
 import { extractPlanTitle } from '@shared/types/branch-utils'
 import '@xterm/xterm/css/xterm.css'
 import '@/styles/xterm.css'
+import { toHandoffAgentSdk } from '@shared/types/agent-sdk'
 
 interface ClaudeCliSessionViewProps {
   sessionId: string
@@ -284,10 +289,15 @@ export function ClaudeCliSessionView({
   const pendingMessage = useSessionStore((state) => state.pendingMessages.get(sessionId) ?? null)
   const pendingPlan = useSessionStore((state) => state.pendingPlans.get(sessionId) ?? null)
   const mode = useSessionStore((state) => state.modeBySession.get(sessionId) ?? 'build')
+  const pendingFollowUpMessages =
+    useSessionStore((state) => state.pendingFollowUpMessages.get(sessionId)) ?? []
+  const sessionStatus = useWorktreeStatusStore((state) => state.sessionStatuses[sessionId] ?? null)
   const { getTarget, revision: portalRevision } = useClaudeCliSessionPortal()
   void portalRevision
   const isMountedInTicketModal = !!getTarget(sessionId)
   const sessionRecord = useSessionStore((state) => state.getSessionById(sessionId))
+  const selectableAgentSdk = toHandoffAgentSdk(sessionRecord?.agent_sdk)
+  const hasDurableHistory = useDurableSessionHistory(sessionId)
 
   // While Telegram forwarding is active, AskUserQuestion is intercepted by the
   // hook bridge (so it never renders in the terminal) and surfaced through the
@@ -295,6 +305,15 @@ export function ClaudeCliSessionView({
   // providers use; when forwarding is off the question shows natively in the CLI.
   const activeQuestion = useQuestionStore((state) => state.getActiveQuestion(sessionId))
   const isForwarding = useTelegramStore((state) => state.activeForwardingSessionId === sessionId)
+
+  const canChangeBlankSessionProvider =
+    !!selectableAgentSdk &&
+    sessionRecord?.session_type === 'default' &&
+    !hasDurableHistory &&
+    !pendingMessage &&
+    pendingFollowUpMessages.length === 0 &&
+    !pendingPlan &&
+    !isProviderSwitchBlockingSessionStatus(sessionStatus)
 
   useEffect(() => {
     setPlanSavedAsTicket(false)
@@ -333,16 +352,13 @@ export function ClaudeCliSessionView({
     })
   }, [sessionId])
 
-  const handleStatusChange = useCallback(
-    (status: 'creating' | 'running' | 'exited') => {
-      if (status === 'running') {
-        setEnded(false)
-      } else if (status === 'exited') {
-        setEnded(true)
-      }
-    },
-    []
-  )
+  const handleStatusChange = useCallback((status: 'creating' | 'running' | 'exited') => {
+    if (status === 'running') {
+      setEnded(false)
+    } else if (status === 'exited') {
+      setEnded(true)
+    }
+  }, [])
 
   const handleRestart = useCallback(() => {
     setEnded(false)
@@ -423,9 +439,7 @@ export function ClaudeCliSessionView({
         sessionRecord.worktree_id,
         sessionRecord.project_id,
         override.agentSdk,
-        override.agentSdk === 'claude-code-cli' && mode === 'super-plan'
-          ? 'super-plan'
-          : undefined,
+        override.agentSdk === 'claude-code-cli' && mode === 'super-plan' ? 'super-plan' : undefined,
         { autoFocus: !isMountedInTicketModal, modelOverride: override.model }
       )
       if (!result.success || !result.session) {
@@ -506,7 +520,9 @@ export function ClaudeCliSessionView({
   const handleQuestionReply = useCallback(
     async (requestId: string, answers: string[][]) => {
       try {
-        unwrapEnvelope(await window.opencodeOps.questionReply(requestId, answers, resolveQuestionPath()))
+        unwrapEnvelope(
+          await window.opencodeOps.questionReply(requestId, answers, resolveQuestionPath())
+        )
       } catch (err) {
         console.error('Failed to reply to question:', err)
         toast.error('Failed to send answer')
@@ -541,7 +557,15 @@ export function ClaudeCliSessionView({
             <span className="truncate text-xs text-muted-foreground">handoff prompt pending</span>
           )}
         </div>
-        <ModelSelector sessionId={sessionId} />
+        <div className="flex min-w-0 items-center gap-2">
+          {selectableAgentSdk && (
+            <SessionProviderSelector
+              sessionId={sessionId}
+              agentSdk={selectableAgentSdk}
+              canChange={canChangeBlankSessionProvider}
+            />
+          )}
+        </div>
       </div>
 
       <div className="relative min-h-0 flex-1">

--- a/src/renderer/src/components/sessions/SessionProviderSelector.test.tsx
+++ b/src/renderer/src/components/sessions/SessionProviderSelector.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SessionProviderSelector } from './SessionProviderSelector'
+
+const storeMocks = vi.hoisted(() => ({
+  settingsState: {
+    availableAgentSdks: {
+      opencode: true,
+      claude: true,
+      codex: true
+    } as { opencode: boolean; claude: boolean; codex: boolean } | null
+  },
+  sessionState: {
+    changeBlankSessionProvider: vi.fn(async () => ({ success: true }))
+  }
+}))
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: (
+    selector: (state: typeof storeMocks.settingsState) => unknown
+  ): unknown => selector(storeMocks.settingsState)
+}))
+
+vi.mock('@/stores/useSessionStore', () => ({
+  useSessionStore: (
+    selector: (state: typeof storeMocks.sessionState) => unknown
+  ): unknown => selector(storeMocks.sessionState)
+}))
+
+describe('SessionProviderSelector', () => {
+  beforeEach(() => {
+    storeMocks.settingsState.availableAgentSdks = {
+      opencode: true,
+      claude: true,
+      codex: true
+    }
+    storeMocks.sessionState.changeBlankSessionProvider = vi.fn(async () => ({ success: true }))
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders static provider text when the session is not blank', () => {
+    render(<SessionProviderSelector sessionId="session-1" agentSdk="codex" canChange={false} />)
+
+    expect(screen.getByTestId('session-provider-label')).toHaveTextContent('CODEX')
+    expect(screen.queryByTestId('session-provider-selector')).not.toBeInTheDocument()
+  })
+
+  it('lists only available AI providers and omits Terminal and All providers', async () => {
+    storeMocks.settingsState.availableAgentSdks = {
+      opencode: true,
+      claude: false,
+      codex: true
+    }
+
+    render(<SessionProviderSelector sessionId="session-1" agentSdk="opencode" canChange />)
+    await userEvent.click(screen.getByTestId('session-provider-selector'))
+
+    expect(await screen.findByTestId('session-provider-option-opencode')).toBeInTheDocument()
+    expect(screen.getByTestId('session-provider-option-codex')).toBeInTheDocument()
+    expect(screen.queryByTestId('session-provider-option-claude-code')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('session-provider-option-claude-code-cli')).not.toBeInTheDocument()
+    expect(screen.queryByText('Terminal')).not.toBeInTheDocument()
+    expect(screen.queryByText('All providers')).not.toBeInTheDocument()
+  })
+
+  it('renders static provider text while availability is unknown', () => {
+    storeMocks.settingsState.availableAgentSdks = null
+
+    render(<SessionProviderSelector sessionId="session-1" agentSdk="opencode" canChange />)
+
+    expect(screen.getByTestId('session-provider-label')).toHaveTextContent('OPENCODE')
+    expect(screen.queryByTestId('session-provider-selector')).not.toBeInTheDocument()
+  })
+
+  it('calls the store action when a different provider is selected', async () => {
+    render(<SessionProviderSelector sessionId="session-1" agentSdk="opencode" canChange />)
+    await userEvent.click(screen.getByTestId('session-provider-selector'))
+    await userEvent.click(await screen.findByTestId('session-provider-option-claude-code'))
+
+    await waitFor(() => {
+      expect(storeMocks.sessionState.changeBlankSessionProvider).toHaveBeenCalledWith(
+        'session-1',
+        'claude-code'
+      )
+    })
+  })
+})

--- a/src/renderer/src/components/sessions/SessionProviderSelector.tsx
+++ b/src/renderer/src/components/sessions/SessionProviderSelector.tsx
@@ -1,0 +1,109 @@
+import { memo, useMemo, useState } from 'react'
+import { Check, ChevronDown } from 'lucide-react'
+import { getAvailableHandoffAgentSdks, getHandoffSdkDisplayName } from '@/lib/handoffSelection'
+import { toast } from '@/lib/toast'
+import { cn } from '@/lib/utils'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import type { HandoffAgentSdk } from '@shared/types/agent-sdk'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+
+interface SessionProviderSelectorProps {
+  sessionId: string
+  agentSdk: HandoffAgentSdk
+  canChange: boolean
+}
+
+function getCompactProviderLabel(agentSdk: HandoffAgentSdk): string {
+  switch (agentSdk) {
+    case 'opencode':
+      return 'OPENCODE'
+    case 'claude-code':
+      return 'CLAUDE CODE'
+    case 'codex':
+      return 'CODEX'
+    case 'claude-code-cli':
+      return 'CLAUDE CLI'
+  }
+}
+
+export const SessionProviderSelector = memo(function SessionProviderSelector({
+  sessionId,
+  agentSdk,
+  canChange
+}: SessionProviderSelectorProps): React.JSX.Element {
+  const availableAgentSdks = useSettingsStore((state) => state.availableAgentSdks)
+  const changeBlankSessionProvider = useSessionStore((state) => state.changeBlankSessionProvider)
+  const [isChanging, setIsChanging] = useState(false)
+
+  const options = useMemo(
+    () => (availableAgentSdks ? getAvailableHandoffAgentSdks(availableAgentSdks) : []),
+    [availableAgentSdks]
+  )
+  const label = getCompactProviderLabel(agentSdk)
+
+  if (!canChange || !availableAgentSdks) {
+    return (
+      <span
+        className="text-[10px] font-medium text-muted-foreground uppercase shrink-0"
+        data-testid="session-provider-label"
+      >
+        {label}
+      </span>
+    )
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={cn(
+            'flex items-center gap-1 text-[10px] font-medium uppercase shrink-0',
+            'text-muted-foreground hover:text-foreground transition-colors',
+            'disabled:cursor-not-allowed disabled:opacity-60'
+          )}
+          type="button"
+          disabled={isChanging}
+          aria-label={`Current provider: ${getHandoffSdkDisplayName(agentSdk)}. Click to change provider`}
+          title="Change provider"
+          data-testid="session-provider-selector"
+        >
+          <span>{label}</span>
+          <ChevronDown className="h-3 w-3 shrink-0 opacity-50" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-52">
+        {options.map((option) => {
+          const isActive = option === agentSdk
+          return (
+            <DropdownMenuItem
+              key={option}
+              onClick={async () => {
+                if (isActive || isChanging) return
+                setIsChanging(true)
+                try {
+                  const result = await changeBlankSessionProvider(sessionId, option)
+                  if (!result.success) {
+                    toast.error(result.error ?? 'Failed to change provider')
+                  }
+                } finally {
+                  setIsChanging(false)
+                }
+              }}
+              className="flex items-center justify-between gap-2 cursor-pointer"
+              data-testid={`session-provider-option-${option}`}
+            >
+              <span className="truncate text-sm">{getHandoffSdkDisplayName(option)}</span>
+              {isActive && <Check className="h-4 w-4 shrink-0 text-primary" />}
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+})

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -20,6 +20,9 @@ import { toast } from '@/lib/toast'
 import { ModeToggle } from './ModeToggle'
 import { SuperToggle } from './SuperToggle'
 import { ModelSelector } from './ModelSelector'
+import { SessionProviderSelector } from './SessionProviderSelector'
+import { useDurableSessionHistory } from './useDurableSessionHistory'
+import { useProviderSwitchActivitySync } from './useProviderSwitchActivitySync'
 import {
   VirtualizedMessageList,
   type VirtualizedMessageListHandle,
@@ -93,6 +96,7 @@ import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
 import { buildSdkPlanImplementationPrompt, looksLikeCodexProposedPlan } from '@/lib/proposedPlan'
 import { buildHandoffPrompt, type HandoffSelectionOverride } from '@/lib/handoffSelection'
+import { toHandoffAgentSdk } from '@shared/types/agent-sdk'
 
 const db = unwrapEnvelopeApi(() => window.db)
 
@@ -687,6 +691,15 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
   useEffect(() => {
     isStreamingRef.current = isStreaming
   }, [isStreaming])
+  const providerSwitchActivity = useMemo(
+    () => ({
+      sending: isSending,
+      streaming: isStreaming,
+      queuedLocalFollowUps: queuedMessages.length
+    }),
+    [isSending, isStreaming, queuedMessages.length]
+  )
+  useProviderSwitchActivitySync(sessionId, providerSwitchActivity)
   const [isCompacting, setIsCompacting] = useState(false)
   const {
     runs: bashRuns,
@@ -794,6 +807,8 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
 
   // Pending plan approval (ExitPlanMode blocking tool)
   const pendingPlan = useSessionStore((s) => s.pendingPlans.get(sessionId) ?? null)
+  const hasPendingInitialPrompt = useSessionStore((s) => s.pendingMessages.has(sessionId))
+  const hasDurableHistory = useDurableSessionHistory(sessionId)
 
   // Completion badge — reactive subscription to this session's status entry
   const completionEntry = useWorktreeStatusStore((state) => {
@@ -1490,20 +1505,28 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
     planXmlDetectionRef.current = { state: 'scanning', buffer: '', cardId: null }
   }, [])
 
+  // Load saved draft only when the Hive session changes. Provider switches
+  // reconnect the view in-place and must not overwrite unsaved composer edits
+  // with a stale debounced DB draft.
+  useEffect(() => {
+    let mounted = true
+    db.session.getDraft(sessionId).then((draft) => {
+      if (mounted && draft) {
+        setInputValue(draft)
+        inputValueRef.current = draft
+      }
+    })
+    return () => {
+      mounted = false
+    }
+  }, [sessionId])
+
   // Load session info and connect to OpenCode
   useEffect(() => {
     finalizedMessageIdsRef.current.clear()
     hasFinalizedCurrentResponseRef.current = false
     sessionModelHydratedRef.current = false
     childToSubtaskIndexRef.current.clear()
-
-    // Load saved draft for this session
-    db.session.getDraft(sessionId).then((draft) => {
-      if (draft) {
-        setInputValue(draft)
-        inputValueRef.current = draft
-      }
-    })
 
     transcriptSourceRef.current = {
       worktreePath: null,
@@ -3569,7 +3592,7 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
       // event subscriptions alive so responses are not lost.
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId])
+  }, [sessionId, sessionRecord?.agent_sdk])
 
   // Save draft on unmount or session change
   useEffect(() => {
@@ -6026,6 +6049,21 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
 
   const isActive = isStreaming || isSending
   const elapsedTimerText = useSessionTimer(sessionId, isActive)
+  const selectableAgentSdk = toHandoffAgentSdk(sessionRecord?.agent_sdk)
+  const canChangeBlankSessionProvider =
+    !!selectableAgentSdk &&
+    sessionRecord?.session_type === 'default' &&
+    !isOrphanedSession &&
+    viewState.status === 'connected' &&
+    visibleMessages.length === 0 &&
+    !hasStreamingContent &&
+    !hasDurableHistory &&
+    !isSending &&
+    !isStreaming &&
+    queuedMessages.length === 0 &&
+    !hasPendingInitialPrompt &&
+    persistedFollowUpMessages.length === 0 &&
+    !pendingPlan
 
   // Render based on view state
   if (viewState.status === 'connecting') {
@@ -6312,7 +6350,14 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
             {/* Bottom row: model selector + context indicator + hint text + send/implement buttons */}
             <div className="flex items-center justify-between px-3 pb-2.5 @container">
               <div className="flex items-center gap-2 min-w-0 overflow-hidden">
-                <ModelSelector sessionId={sessionId} />
+                {selectableAgentSdk && (
+                  <SessionProviderSelector
+                    sessionId={sessionId}
+                    agentSdk={selectableAgentSdk}
+                    canChange={canChangeBlankSessionProvider}
+                  />
+                )}
+                <ModelSelector sessionId={sessionId} hideProviderPrefix />
                 {sessionAgentSdk === 'codex' && (
                   <CodexFastToggle
                     enabled={codexFastMode}

--- a/src/renderer/src/components/sessions/useDurableSessionHistory.test.tsx
+++ b/src/renderer/src/components/sessions/useDurableSessionHistory.test.tsx
@@ -1,0 +1,126 @@
+import { cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDurableSessionHistory } from './useDurableSessionHistory'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+const initialConnectionState = useConnectionStore.getState()
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+
+const session = {
+  id: 'session-1',
+  worktree_id: 'worktree-1',
+  project_id: 'project-1',
+  connection_id: null,
+  name: 'Session 1',
+  status: 'active' as const,
+  opencode_session_id: 'runtime-1',
+  claude_session_id: null,
+  agent_sdk: 'opencode' as const,
+  mode: 'build' as const,
+  session_type: 'default' as const,
+  model_provider_id: 'anthropic',
+  model_id: 'opus',
+  model_variant: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  completed_at: null
+}
+
+describe('useDurableSessionHistory', () => {
+  beforeEach(() => {
+    useConnectionStore.setState(initialConnectionState, true)
+    useSessionStore.setState(initialSessionState, true)
+    useWorktreeStore.setState(initialWorktreeState, true)
+
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([['worktree-1', [session]]]),
+      sessionsByConnection: new Map()
+    })
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        [
+          'project-1',
+          [
+            {
+              id: 'worktree-1',
+              project_id: 'project-1',
+              name: 'Main',
+              branch_name: 'main',
+              path: '/repo',
+              is_default: true,
+              status: 'active',
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+              base_branch: null,
+              branch_renamed: 0,
+              last_message_at: null,
+              last_model_provider_id: null,
+              last_model_id: null,
+              last_model_variant: null,
+              pinned: 0,
+              github_pr_number: null,
+              github_pr_url: null
+            }
+          ]
+        ]
+      ])
+    })
+    Object.defineProperty(window, 'db', {
+      writable: true,
+      configurable: true,
+      value: {
+        sessionMessage: {
+          list: vi.fn(async () => [])
+        },
+        sessionActivity: {
+          list: vi.fn(async () => [])
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('treats live backend transcript messages as durable history', async () => {
+    const getMessages = vi.fn(async () => ({
+      success: true,
+      messages: [{ id: 'message-1' }]
+    }))
+    Object.defineProperty(window, 'opencodeOps', {
+      writable: true,
+      configurable: true,
+      value: { getMessages }
+    })
+
+    const { result } = renderHook(() => useDurableSessionHistory('session-1'))
+
+    await waitFor(() => {
+      expect(getMessages).toHaveBeenCalledWith('/repo', 'runtime-1')
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it('returns false when DB and live transcript history are empty', async () => {
+    Object.defineProperty(window, 'opencodeOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        getMessages: vi.fn(async () => ({
+          success: true,
+          messages: []
+        }))
+      }
+    })
+
+    const { result } = renderHook(() => useDurableSessionHistory('session-1'))
+
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+  })
+})

--- a/src/renderer/src/components/sessions/useDurableSessionHistory.test.tsx
+++ b/src/renderer/src/components/sessions/useDurableSessionHistory.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, renderHook, waitFor } from '@testing-library/react'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useDurableSessionHistory } from './useDurableSessionHistory'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -29,16 +29,20 @@ const session = {
   completed_at: null
 }
 
+function seedSession(overrides: Partial<typeof session> = {}): void {
+  useSessionStore.setState({
+    sessionsByWorktree: new Map([['worktree-1', [{ ...session, ...overrides }]]]),
+    sessionsByConnection: new Map()
+  })
+}
+
 describe('useDurableSessionHistory', () => {
   beforeEach(() => {
     useConnectionStore.setState(initialConnectionState, true)
     useSessionStore.setState(initialSessionState, true)
     useWorktreeStore.setState(initialWorktreeState, true)
 
-    useSessionStore.setState({
-      sessionsByWorktree: new Map([['worktree-1', [session]]]),
-      sessionsByConnection: new Map()
-    })
+    seedSession()
     useWorktreeStore.setState({
       worktreesByProject: new Map([
         [
@@ -122,5 +126,73 @@ describe('useDurableSessionHistory', () => {
     await waitFor(() => {
       expect(result.current).toBe(false)
     })
+  })
+
+  it('treats launched Claude CLI sessions as durable when transcript cannot be verified', async () => {
+    seedSession({
+      agent_sdk: 'claude-code-cli',
+      opencode_session_id: null,
+      claude_session_id: 'claude-session-1'
+    })
+    Object.defineProperty(window, 'opencodeOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        getMessages: vi.fn(async () => ({
+          success: true,
+          messages: []
+        }))
+      }
+    })
+
+    const { result } = renderHook(() => useDurableSessionHistory('session-1'))
+
+    await waitFor(() => {
+      expect(result.current).toBe(true)
+    })
+    expect(window.opencodeOps.getMessages).not.toHaveBeenCalled()
+  })
+
+  it('returns false for not-yet-launched Claude CLI sessions with empty DB history', async () => {
+    seedSession({
+      agent_sdk: 'claude-code-cli',
+      opencode_session_id: null,
+      claude_session_id: null
+    })
+
+    const { result } = renderHook(() => useDurableSessionHistory('session-1'))
+
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+  })
+
+  it('does not reset or recheck when unrelated session fields change', async () => {
+    const getMessages = vi.fn(async () => ({
+      success: true,
+      messages: []
+    }))
+    Object.defineProperty(window, 'opencodeOps', {
+      writable: true,
+      configurable: true,
+      value: { getMessages }
+    })
+
+    const { result } = renderHook(() => useDurableSessionHistory('session-1'))
+
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+    expect(getMessages).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      seedSession({
+        name: 'Renamed Session',
+        updated_at: '2026-01-01T00:00:02.000Z'
+      })
+    })
+
+    expect(result.current).toBe(false)
+    expect(getMessages).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/sessions/useDurableSessionHistory.test.tsx
+++ b/src/renderer/src/components/sessions/useDurableSessionHistory.test.tsx
@@ -153,7 +153,7 @@ describe('useDurableSessionHistory', () => {
     expect(window.opencodeOps.getMessages).not.toHaveBeenCalled()
   })
 
-  it('returns false for not-yet-launched Claude CLI sessions with empty DB history', async () => {
+  it('treats Claude CLI sessions without a captured session id as durable', async () => {
     seedSession({
       agent_sdk: 'claude-code-cli',
       opencode_session_id: null,
@@ -163,7 +163,7 @@ describe('useDurableSessionHistory', () => {
     const { result } = renderHook(() => useDurableSessionHistory('session-1'))
 
     await waitFor(() => {
-      expect(result.current).toBe(false)
+      expect(result.current).toBe(true)
     })
   })
 

--- a/src/renderer/src/components/sessions/useDurableSessionHistory.ts
+++ b/src/renderer/src/components/sessions/useDurableSessionHistory.ts
@@ -43,7 +43,6 @@ export function useDurableSessionHistory(sessionId: string): boolean {
   const [hasDurableHistory, setHasDurableHistory] = useState(true)
   const session = useSessionStore((state) => state.getSessionById(sessionId))
   const opencodeSessionId = session?.opencode_session_id
-  const claudeSessionId = session?.claude_session_id
   const agentSdk = session?.agent_sdk
   const worktreeId = session?.worktree_id
   const connectionId = session?.connection_id
@@ -66,7 +65,7 @@ export function useDurableSessionHistory(sessionId: string): boolean {
           return
         }
 
-        if (agentSdk === 'claude-code-cli' && claudeSessionId) {
+        if (agentSdk === 'claude-code-cli') {
           if (mounted) setHasDurableHistory(true)
           return
         }
@@ -111,7 +110,7 @@ export function useDurableSessionHistory(sessionId: string): boolean {
       mounted = false
       window.clearInterval(intervalId)
     }
-  }, [sessionId, opencodeSessionId, claudeSessionId, agentSdk, worktreeId, connectionId])
+  }, [sessionId, opencodeSessionId, agentSdk, worktreeId, connectionId])
 
   return hasDurableHistory
 }

--- a/src/renderer/src/components/sessions/useDurableSessionHistory.ts
+++ b/src/renderer/src/components/sessions/useDurableSessionHistory.ts
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react'
+import { unwrapEnvelope, unwrapEnvelopeApi } from '@/lib/ipc-envelope'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+const db = unwrapEnvelopeApi(() => window.db)
+const DEFAULT_POLL_MS = 1000
+
+function getWorktreePath(worktreeId: string | null): string | null {
+  if (!worktreeId) return null
+  for (const worktrees of useWorktreeStore.getState().worktreesByProject.values()) {
+    const worktree = worktrees.find((candidate) => candidate.id === worktreeId)
+    if (worktree) return worktree.path
+  }
+  return null
+}
+
+async function getRuntimePath(session: {
+  worktree_id: string | null
+  connection_id: string | null
+}): Promise<string | null> {
+  const worktreePath = getWorktreePath(session.worktree_id)
+  if (worktreePath) return worktreePath
+
+  if (!session.connection_id) return null
+
+  const localConnection = useConnectionStore
+    .getState()
+    .connections.find((connection) => connection.id === session.connection_id)
+  if (localConnection?.path) return localConnection.path
+
+  if (!window.connectionOps?.get) return null
+  try {
+    const result = unwrapEnvelope(await window.connectionOps.get(session.connection_id))
+    return result.success && result.connection ? result.connection.path : null
+  } catch {
+    return null
+  }
+}
+
+export function useDurableSessionHistory(sessionId: string): boolean {
+  const [hasDurableHistory, setHasDurableHistory] = useState(true)
+  const session = useSessionStore((state) => state.getSessionById(sessionId))
+
+  useEffect(() => {
+    let mounted = true
+
+    async function checkDurableHistory(): Promise<void> {
+      try {
+        if (!db.sessionMessage?.list || !db.sessionActivity?.list) {
+          if (mounted) setHasDurableHistory(true)
+          return
+        }
+        const [messageRows, activityRows] = await Promise.all([
+          db.sessionMessage.list(sessionId),
+          db.sessionActivity.list(sessionId)
+        ])
+        if (messageRows.length > 0 || activityRows.length > 0) {
+          if (mounted) setHasDurableHistory(true)
+          return
+        }
+
+        if (session?.opencode_session_id) {
+          if (!window.opencodeOps?.getMessages) {
+            if (mounted) setHasDurableHistory(true)
+            return
+          }
+          const runtimePath = await getRuntimePath(session)
+          if (!runtimePath) {
+            if (mounted) setHasDurableHistory(true)
+            return
+          }
+          const result = unwrapEnvelope(
+            await window.opencodeOps.getMessages(runtimePath, session.opencode_session_id)
+          )
+          if (!result.success || !Array.isArray(result.messages)) {
+            if (mounted) setHasDurableHistory(true)
+            return
+          }
+          if (mounted) setHasDurableHistory(result.messages.length > 0)
+          return
+        }
+
+        if (mounted) setHasDurableHistory(false)
+      } catch {
+        if (mounted) setHasDurableHistory(true)
+      }
+    }
+
+    setHasDurableHistory(true)
+    void checkDurableHistory()
+    const intervalId = window.setInterval(() => {
+      void checkDurableHistory()
+    }, DEFAULT_POLL_MS)
+
+    return () => {
+      mounted = false
+      window.clearInterval(intervalId)
+    }
+  }, [session, sessionId])
+
+  return hasDurableHistory
+}

--- a/src/renderer/src/components/sessions/useDurableSessionHistory.ts
+++ b/src/renderer/src/components/sessions/useDurableSessionHistory.ts
@@ -42,6 +42,11 @@ async function getRuntimePath(session: {
 export function useDurableSessionHistory(sessionId: string): boolean {
   const [hasDurableHistory, setHasDurableHistory] = useState(true)
   const session = useSessionStore((state) => state.getSessionById(sessionId))
+  const opencodeSessionId = session?.opencode_session_id
+  const claudeSessionId = session?.claude_session_id
+  const agentSdk = session?.agent_sdk
+  const worktreeId = session?.worktree_id
+  const connectionId = session?.connection_id
 
   useEffect(() => {
     let mounted = true
@@ -61,18 +66,26 @@ export function useDurableSessionHistory(sessionId: string): boolean {
           return
         }
 
-        if (session?.opencode_session_id) {
+        if (agentSdk === 'claude-code-cli' && claudeSessionId) {
+          if (mounted) setHasDurableHistory(true)
+          return
+        }
+
+        if (opencodeSessionId) {
           if (!window.opencodeOps?.getMessages) {
             if (mounted) setHasDurableHistory(true)
             return
           }
-          const runtimePath = await getRuntimePath(session)
+          const runtimePath = await getRuntimePath({
+            worktree_id: worktreeId ?? null,
+            connection_id: connectionId ?? null
+          })
           if (!runtimePath) {
             if (mounted) setHasDurableHistory(true)
             return
           }
           const result = unwrapEnvelope(
-            await window.opencodeOps.getMessages(runtimePath, session.opencode_session_id)
+            await window.opencodeOps.getMessages(runtimePath, opencodeSessionId)
           )
           if (!result.success || !Array.isArray(result.messages)) {
             if (mounted) setHasDurableHistory(true)
@@ -98,7 +111,7 @@ export function useDurableSessionHistory(sessionId: string): boolean {
       mounted = false
       window.clearInterval(intervalId)
     }
-  }, [session, sessionId])
+  }, [sessionId, opencodeSessionId, claudeSessionId, agentSdk, worktreeId, connectionId])
 
   return hasDurableHistory
 }

--- a/src/renderer/src/components/sessions/useProviderSwitchActivitySync.test.tsx
+++ b/src/renderer/src/components/sessions/useProviderSwitchActivitySync.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { useSessionStore, type ProviderSwitchActivity } from '@/stores/useSessionStore'
+import { useProviderSwitchActivitySync } from './useProviderSwitchActivitySync'
+
+const initialSessionState = useSessionStore.getState()
+
+describe('useProviderSwitchActivitySync', () => {
+  beforeEach(() => {
+    useSessionStore.setState(initialSessionState, true)
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('syncs activity into the session store and clears it on unmount', () => {
+    const initialActivity: ProviderSwitchActivity = {
+      sending: true,
+      streaming: false,
+      queuedLocalFollowUps: 0
+    }
+    const { rerender, unmount } = renderHook(
+      ({ activity }) => useProviderSwitchActivitySync('session-1', activity),
+      { initialProps: { activity: initialActivity } }
+    )
+
+    expect(useSessionStore.getState().providerSwitchActivityBySession.get('session-1')).toEqual(
+      initialActivity
+    )
+
+    const nextActivity: ProviderSwitchActivity = {
+      sending: false,
+      streaming: true,
+      queuedLocalFollowUps: 2
+    }
+    rerender({ activity: nextActivity })
+
+    expect(useSessionStore.getState().providerSwitchActivityBySession.get('session-1')).toEqual(
+      nextActivity
+    )
+
+    unmount()
+
+    expect(useSessionStore.getState().providerSwitchActivityBySession.has('session-1')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sessions/useProviderSwitchActivitySync.ts
+++ b/src/renderer/src/components/sessions/useProviderSwitchActivitySync.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+import { useSessionStore, type ProviderSwitchActivity } from '@/stores/useSessionStore'
+
+export function useProviderSwitchActivitySync(
+  sessionId: string,
+  activity: ProviderSwitchActivity
+): void {
+  useEffect(() => {
+    useSessionStore.getState().setProviderSwitchActivity(sessionId, activity)
+  }, [activity, sessionId])
+
+  useEffect(() => {
+    return () => {
+      useSessionStore.getState().setProviderSwitchActivity(sessionId, null)
+    }
+  }, [sessionId])
+}

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -91,7 +91,8 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   const ghosttyFontSize = useSettingsStore((s) => s.ghosttyFontSize)
   const ghosttyOverlaySuppressed = useLayoutStore((s) => s.ghosttyOverlaySuppressed)
 
-  const effectiveVisible = isVisible && !ghosttyOverlaySuppressed
+  const effectiveVisible =
+    isVisible && (effectiveBackendType !== 'ghostty' || !ghosttyOverlaySuppressed)
 
   // Always-current ref so setupTerminal (a useCallback whose deps intentionally
   // do NOT include effectiveVisible) can read the latest value when it

--- a/src/renderer/src/lib/__tests__/handoffSelection.test.ts
+++ b/src/renderer/src/lib/__tests__/handoffSelection.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   buildHandoffPrompt,
+  cacheHandoffModelCatalog,
+  clearHandoffModelCatalogCache,
   getAvailableHandoffAgentSdks,
   getHandoffSdkDisplayName,
   resolveSessionCreationSelection,
@@ -8,12 +10,16 @@ import {
 } from '../handoffSelection'
 import { SUPER_PLAN_MODE_PREFIX } from '../constants'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
 
 const model = { providerID: 'codex', modelID: 'gpt-5.5' }
 const initialSettingsState = useSettingsStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
 
 afterEach(() => {
   useSettingsStore.setState(initialSettingsState, true)
+  useWorktreeStore.setState(initialWorktreeState, true)
+  clearHandoffModelCatalogCache()
 })
 
 describe('buildHandoffPrompt', () => {
@@ -104,6 +110,220 @@ describe('resolveSessionCreationSelection', () => {
       providerID: 'anthropic',
       modelID: 'sonnet',
       variant: 'high'
+    })
+  })
+
+  it('uses a bare mode default for an explicit SDK when it is the configured default SDK', () => {
+    cacheHandoffModelCatalog('codex', {
+      providers: [
+        {
+          id: 'codex',
+          name: 'Codex',
+          models: {
+            'mode-default': {
+              id: 'mode-default',
+              name: 'Mode Default'
+            }
+          }
+        }
+      ]
+    })
+    useSettingsStore.setState({
+      defaultAgentSdk: 'codex',
+      selectedModel: null,
+      selectedModelByProvider: {
+        codex: {
+          providerID: 'codex',
+          modelID: 'fallback'
+        }
+      },
+      defaultModels: {
+        build: {
+          providerID: 'codex',
+          modelID: 'mode-default'
+        },
+        plan: null,
+        ask: null,
+        review: null
+      }
+    })
+
+    const selection = resolveSessionCreationSelection({
+      agentSdkOverride: 'codex',
+      initialMode: 'build'
+    })
+
+    expect(selection.agentSdk).toBe('codex')
+    expect(selection.model).toMatchObject({
+      providerID: 'codex',
+      modelID: 'mode-default'
+    })
+  })
+
+  it('skips bare mode defaults when explicit SDK validity is unknown', () => {
+    useSettingsStore.setState({
+      defaultAgentSdk: 'opencode',
+      selectedModel: null,
+      selectedModelByProvider: {
+        codex: {
+          providerID: 'codex',
+          modelID: 'fallback'
+        }
+      },
+      defaultModels: {
+        build: {
+          providerID: 'anthropic',
+          modelID: 'claude-opus'
+        },
+        plan: null,
+        ask: null,
+        review: null
+      }
+    })
+
+    const selection = resolveSessionCreationSelection({
+      agentSdkOverride: 'codex',
+      initialMode: 'build'
+    })
+
+    expect(selection.agentSdk).toBe('codex')
+    expect(selection.model).toMatchObject({
+      providerID: 'codex',
+      modelID: 'fallback'
+    })
+  })
+
+  it('does not use worktree fallback for explicit SDK session creation', () => {
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        [
+          'project-1',
+          [
+            {
+              id: 'worktree-with-anthropic-last-model',
+              project_id: 'project-1',
+              name: 'Main',
+              branch_name: 'main',
+              path: '/repo',
+              is_default: true,
+              status: 'active',
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+              base_branch: null,
+              branch_renamed: 0,
+              last_message_at: null,
+              last_model_provider_id: 'anthropic',
+              last_model_id: 'opus',
+              last_model_variant: null,
+              pinned: 0,
+              github_pr_number: null,
+              github_pr_url: null
+            }
+          ]
+        ]
+      ])
+    })
+    useSettingsStore.setState({
+      defaultAgentSdk: 'opencode',
+      selectedModel: null,
+      selectedModelByProvider: {},
+      defaultModels: null
+    })
+
+    const selection = resolveSessionCreationSelection({
+      worktreeId: 'worktree-with-anthropic-last-model',
+      agentSdkOverride: 'codex',
+      initialMode: 'build'
+    })
+
+    expect(selection.agentSdk).toBe('codex')
+    expect(selection.model).toMatchObject({
+      providerID: 'codex',
+      modelID: 'gpt-5.5'
+    })
+  })
+
+  it('does not use legacy selectedModel from another SDK for explicit SDK session creation', () => {
+    cacheHandoffModelCatalog('codex', {
+      providers: [
+        {
+          id: 'codex',
+          name: 'Codex',
+          models: {
+            'catalog-codex-model': {
+              id: 'catalog-codex-model',
+              name: 'Catalog Codex Model'
+            }
+          }
+        }
+      ]
+    })
+    useSettingsStore.setState({
+      defaultAgentSdk: 'opencode',
+      selectedModel: {
+        providerID: 'anthropic',
+        modelID: 'claude-opus'
+      },
+      selectedModelByProvider: {},
+      defaultModels: null
+    })
+
+    const selection = resolveSessionCreationSelection({
+      agentSdkOverride: 'codex',
+      initialMode: 'build'
+    })
+
+    expect(selection.agentSdk).toBe('codex')
+    expect(selection.model).toMatchObject({
+      providerID: 'codex',
+      modelID: 'catalog-codex-model'
+    })
+  })
+
+  it('uses a valid bare mode default for an explicit non-default SDK', () => {
+    cacheHandoffModelCatalog('codex', {
+      providers: [
+        {
+          id: 'codex',
+          name: 'Codex',
+          models: {
+            'mode-default': {
+              id: 'mode-default',
+              name: 'Mode Default'
+            }
+          }
+        }
+      ]
+    })
+    useSettingsStore.setState({
+      defaultAgentSdk: 'opencode',
+      selectedModel: null,
+      selectedModelByProvider: {
+        codex: {
+          providerID: 'codex',
+          modelID: 'fallback'
+        }
+      },
+      defaultModels: {
+        build: {
+          providerID: 'codex',
+          modelID: 'mode-default'
+        },
+        plan: null,
+        ask: null,
+        review: null
+      }
+    })
+
+    const selection = resolveSessionCreationSelection({
+      agentSdkOverride: 'codex',
+      initialMode: 'build'
+    })
+
+    expect(selection.agentSdk).toBe('codex')
+    expect(selection.model).toMatchObject({
+      providerID: 'codex',
+      modelID: 'mode-default'
     })
   })
 })

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -63,14 +63,7 @@ const modelCatalogCache = new Map<HandoffAgentSdk, ProviderModels[]>()
 const inflightModelCatalogRequests = new Map<HandoffAgentSdk, Promise<ProviderModels[]>>()
 
 function normalizeHandoffSdk(
-  sdk:
-    | 'opencode'
-    | 'claude-code'
-    | 'claude-code-cli'
-    | 'codex'
-    | 'terminal'
-    | null
-    | undefined
+  sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal' | null | undefined
 ): HandoffAgentSdk {
   if (sdk === 'claude-code' || sdk === 'claude-code-cli' || sdk === 'codex') return sdk
   return 'opencode'
@@ -98,6 +91,15 @@ function buildModelSelection(
   }
 
   return FALLBACK_MODELS[agentSdk]
+}
+
+function modelBelongsToSdk(model: SelectedModel, agentSdk: HandoffAgentSdk): boolean {
+  if (model.agentSdk) return normalizeHandoffSdk(model.agentSdk) === agentSdk
+
+  const cachedProviders = getCachedModelCatalog(agentSdk)
+  if (!cachedProviders) return false
+
+  return !!findModelInfo(cachedProviders, model.providerID, model.modelID)
 }
 
 function getWorktreeFallbackModel(worktreeId?: string): SelectedModel | null {
@@ -132,10 +134,16 @@ function resolveSessionSelection(opts: {
   const modeDefault = settings.getModelForMode(getModeDefaultKey(opts.mode))
   // Session creation can pass an explicit SDK; in that case the mode default may only
   // supply a model that already belongs to the requested SDK.
-  if (modeDefault && (modeDefault.agentSdk || requestedSdk === configuredDefaultSdk)) {
+  if (
+    modeDefault &&
+    (modeDefault.agentSdk || opts.explicitSdk || requestedSdk === configuredDefaultSdk)
+  ) {
     const modeDefaultSdk = modeDefault.agentSdk ? normalizeHandoffSdk(modeDefault.agentSdk) : null
     if (opts.explicitSdk) {
-      if (modeDefaultSdk === requestedSdk) {
+      if (
+        modeDefaultSdk === requestedSdk ||
+        (!modeDefaultSdk && modelBelongsToSdk(modeDefault, requestedSdk))
+      ) {
         model = modeDefault
       }
     } else {
@@ -145,10 +153,23 @@ function resolveSessionSelection(opts: {
   }
 
   if (!model) {
-    model = resolveModelForSdk(resolvedSdk, settings)
+    if (opts.explicitSdk) {
+      const sdkModel = settings.selectedModelByProvider[resolvedSdk]
+      if (sdkModel) {
+        model = sdkModel
+      } else if (
+        Object.keys(settings.selectedModelByProvider).length === 0 &&
+        settings.selectedModel &&
+        modelBelongsToSdk(settings.selectedModel, resolvedSdk)
+      ) {
+        model = settings.selectedModel
+      }
+    } else {
+      model = resolveModelForSdk(resolvedSdk, settings)
+    }
   }
 
-  if (!model && Object.keys(settings.selectedModelByProvider).length === 0) {
+  if (!model && !opts.explicitSdk && Object.keys(settings.selectedModelByProvider).length === 0) {
     model = getWorktreeFallbackModel(opts.worktreeId)
   }
 
@@ -298,10 +319,15 @@ export function resolveSessionCreationSelection(opts: {
 
   if (opts.agentSdkOverride) {
     const resolvedAgentSdk = normalizeHandoffSdk(opts.agentSdkOverride)
-    const model = resolveModelForSdk(resolvedAgentSdk, settings)
+    const resolved = resolveSessionSelection({
+      worktreeId: opts.worktreeId,
+      agentSdk: resolvedAgentSdk,
+      mode: opts.initialMode,
+      explicitSdk: true
+    })
     return {
       agentSdk: resolvedAgentSdk,
-      model: buildModelSelection(model, resolvedAgentSdk)
+      model: resolved.model
     }
   }
 

--- a/src/renderer/src/stores/__tests__/useSessionStore.blank-provider-switch.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.blank-provider-switch.test.ts
@@ -1,0 +1,518 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSessionStore } from '../useSessionStore'
+import { useSettingsStore } from '../useSettingsStore'
+import { useWorktreeStatusStore } from '../useWorktreeStatusStore'
+import { useWorktreeStore } from '../useWorktreeStore'
+
+const initialSessionState = useSessionStore.getState()
+const initialSettingsState = useSettingsStore.getState()
+const initialStatusState = useWorktreeStatusStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+
+type TestSession = NonNullable<ReturnType<typeof useSessionStore.getState>['getSessionById']>
+
+function makeSession(overrides: Partial<TestSession> = {}): TestSession {
+  return {
+    id: 'session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: 'old-runtime-1',
+    claude_session_id: 'old-claude-1',
+    agent_sdk: 'opencode',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: 'anthropic',
+    model_id: 'old-model',
+    model_variant: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    ...overrides
+  }
+}
+
+function seedSession(session = makeSession()): void {
+  useSessionStore.setState({
+    sessionsByWorktree: new Map([[session.worktree_id ?? 'worktree-1', [session]]]),
+    sessionsByConnection: new Map(),
+    modeBySession: new Map([[session.id, session.mode]]),
+    pendingMessages: new Map(),
+    pendingPlans: new Map(),
+    pendingFollowUpMessages: new Map()
+  })
+}
+
+function setupWindowDb(session = makeSession()): {
+  sessionUpdate: ReturnType<typeof vi.fn>
+  worktreeUpdateModel: ReturnType<typeof vi.fn>
+  sessionMessageList: ReturnType<typeof vi.fn>
+  sessionActivityList: ReturnType<typeof vi.fn>
+} {
+  const sessionUpdate = vi.fn(async (_sessionId: string, data: Partial<TestSession>) => ({
+    ...session,
+    ...data,
+    updated_at: '2026-01-01T00:00:01.000Z'
+  }))
+  const worktreeUpdateModel = vi.fn()
+  const sessionMessageList = vi.fn(async () => [])
+  const sessionActivityList = vi.fn(async () => [])
+
+  Object.defineProperty(window, 'db', {
+    writable: true,
+    configurable: true,
+    value: {
+      session: {
+        get: vi.fn(async () => session),
+        update: sessionUpdate
+      },
+      sessionMessage: {
+        list: sessionMessageList
+      },
+      sessionActivity: {
+        list: sessionActivityList
+      },
+      worktree: {
+        updateModel: worktreeUpdateModel
+      }
+    }
+  })
+
+  return { sessionUpdate, worktreeUpdateModel, sessionMessageList, sessionActivityList }
+}
+
+describe('useSessionStore.changeBlankSessionProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useSessionStore.setState(initialSessionState, true)
+    useSettingsStore.setState(initialSettingsState, true)
+    useWorktreeStatusStore.setState(initialStatusState, true)
+    useWorktreeStore.setState(initialWorktreeState, true)
+
+    useSettingsStore.setState({
+      defaultAgentSdk: 'opencode',
+      availableAgentSdks: { opencode: true, claude: true, codex: true },
+      selectedModel: null,
+      selectedModelByProvider: {
+        codex: { providerID: 'codex', modelID: 'gpt-5.5' },
+        'claude-code': { providerID: 'anthropic', modelID: 'opus' },
+        'claude-code-cli': { providerID: 'anthropic', modelID: 'sonnet', variant: 'high' }
+      },
+      defaultModels: null
+    })
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        [
+          'project-1',
+          [
+            {
+              id: 'worktree-1',
+              project_id: 'project-1',
+              name: 'Main',
+              branch_name: 'main',
+              path: '/repo',
+              is_default: true,
+              status: 'active',
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+              base_branch: null,
+              branch_renamed: 0,
+              last_message_at: null,
+              last_model_provider_id: null,
+              last_model_id: null,
+              last_model_variant: null,
+              pinned: 0,
+              github_pr_number: null,
+              github_pr_url: null
+            }
+          ]
+        ]
+      ])
+    })
+
+    Object.defineProperty(window, 'opencodeOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        disconnect: vi.fn(async () => ({ success: true })),
+        getMessages: vi.fn(async () => ({ success: true, messages: [] })),
+        setModel: vi.fn(async () => ({ success: true }))
+      }
+    })
+    Object.defineProperty(window, 'terminalOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        destroy: vi.fn(async () => ({ success: true }))
+      }
+    })
+  })
+
+  it('switches a durable-blank session and clears old runtime IDs', async () => {
+    const session = makeSession()
+    seedSession(session)
+    const { sessionUpdate, worktreeUpdateModel } = setupWindowDb(session)
+    const setSelectedModelForSdk = vi.spyOn(useSettingsStore.getState(), 'setSelectedModelForSdk')
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result.success).toBe(true)
+    expect(window.opencodeOps.disconnect).toHaveBeenCalledWith('/repo', 'old-runtime-1')
+    expect(sessionUpdate).toHaveBeenCalledWith('session-1', {
+      agent_sdk: 'codex',
+      model_provider_id: 'codex',
+      model_id: 'gpt-5.5',
+      model_variant: null,
+      opencode_session_id: null,
+      claude_session_id: null
+    })
+    expect(useSessionStore.getState().getSessionById('session-1')).toMatchObject({
+      agent_sdk: 'codex',
+      model_provider_id: 'codex',
+      model_id: 'gpt-5.5',
+      opencode_session_id: null,
+      claude_session_id: null
+    })
+    expect(worktreeUpdateModel).not.toHaveBeenCalled()
+    expect(setSelectedModelForSdk).not.toHaveBeenCalled()
+    expect(window.opencodeOps.setModel).not.toHaveBeenCalled()
+  })
+
+  it('does not use worktree last-used model when switching providers', async () => {
+    const session = makeSession()
+    seedSession(session)
+    useSettingsStore.setState({
+      selectedModelByProvider: {},
+      selectedModel: null
+    })
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        [
+          'project-1',
+          [
+            {
+              id: 'worktree-1',
+              project_id: 'project-1',
+              name: 'Main',
+              branch_name: 'main',
+              path: '/repo',
+              is_default: true,
+              status: 'active',
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+              base_branch: null,
+              branch_renamed: 0,
+              last_message_at: null,
+              last_model_provider_id: 'anthropic',
+              last_model_id: 'opus',
+              last_model_variant: null,
+              pinned: 0,
+              github_pr_number: null,
+              github_pr_url: null
+            }
+          ]
+        ]
+      ])
+    })
+    const { sessionUpdate } = setupWindowDb(session)
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result.success).toBe(true)
+    expect(sessionUpdate).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        agent_sdk: 'codex',
+        model_provider_id: 'codex',
+        model_id: 'gpt-5.5'
+      })
+    )
+  })
+
+  it('rejects sessions with durable messages or activities', async () => {
+    const session = makeSession()
+    seedSession(session)
+    const { sessionMessageList, sessionActivityList, sessionUpdate } = setupWindowDb(session)
+    sessionMessageList.mockResolvedValueOnce([{ id: 'message-1' }])
+
+    const messageResult = await useSessionStore
+      .getState()
+      .changeBlankSessionProvider('session-1', 'codex')
+    expect(messageResult.success).toBe(false)
+
+    sessionMessageList.mockResolvedValueOnce([])
+    sessionActivityList.mockResolvedValueOnce([{ id: 'activity-1' }])
+    const activityResult = await useSessionStore
+      .getState()
+      .changeBlankSessionProvider('session-1', 'codex')
+    expect(activityResult.success).toBe(false)
+    expect(sessionUpdate).not.toHaveBeenCalled()
+  })
+
+  it('rejects sessions with live transcript history', async () => {
+    const session = makeSession()
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+    window.opencodeOps.getMessages.mockResolvedValueOnce({
+      success: true,
+      messages: [{ id: 'runtime-message-1' }]
+    })
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Provider can only be changed before history exists'
+    })
+    expect(window.opencodeOps.getMessages).toHaveBeenCalledWith('/repo', 'old-runtime-1')
+    expect(sessionUpdate).not.toHaveBeenCalled()
+  })
+
+  it('rejects when live transcript history cannot be verified', async () => {
+    const session = makeSession()
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+    window.opencodeOps.getMessages.mockResolvedValueOnce({
+      success: false,
+      error: 'not connected'
+    })
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Could not verify whether this session has live transcript history'
+    })
+    expect(sessionUpdate).not.toHaveBeenCalled()
+  })
+
+  it('rejects when durable history cannot be verified', async () => {
+    const session = makeSession()
+    seedSession(session)
+    setupWindowDb(session)
+    Object.defineProperty(window, 'db', {
+      writable: true,
+      configurable: true,
+      value: {
+        session: {
+          get: vi.fn(async () => session),
+          update: vi.fn()
+        },
+        sessionMessage: {},
+        sessionActivity: {
+          list: vi.fn(async () => [])
+        }
+      }
+    })
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Could not verify whether this session has history'
+    })
+    expect(window.db.session.update).not.toHaveBeenCalled()
+  })
+
+  it('rejects pending prompts and queued follow-ups', async () => {
+    const session = makeSession()
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+
+    useSessionStore.setState({ pendingMessages: new Map([['session-1', 'start']]) })
+    expect(
+      await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+    ).toMatchObject({ success: false })
+
+    useSessionStore.setState({
+      pendingMessages: new Map(),
+      pendingFollowUpMessages: new Map([['session-1', ['next']]])
+    })
+    expect(
+      await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+    ).toMatchObject({ success: false })
+
+    expect(sessionUpdate).not.toHaveBeenCalled()
+  })
+
+  it('rejects when provider availability has not loaded', async () => {
+    const session = makeSession()
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+    useSettingsStore.setState({ availableAgentSdks: null })
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Provider availability has not loaded yet'
+    })
+    expect(sessionUpdate).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['sending', { sending: true, streaming: false, queuedLocalFollowUps: 0 }],
+    ['streaming', { sending: false, streaming: true, queuedLocalFollowUps: 0 }],
+    ['queued local follow-ups', { sending: false, streaming: false, queuedLocalFollowUps: 1 }]
+  ])('rejects provider switching while local activity is %s', async (_label, activity) => {
+    const session = makeSession()
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+    useSessionStore.getState().setProviderSwitchActivity('session-1', activity)
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Provider cannot change while the session is active'
+    })
+    expect(sessionUpdate).not.toHaveBeenCalled()
+  })
+
+  it('rejects active session status', async () => {
+    const session = makeSession()
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+    useWorktreeStatusStore.setState({
+      sessionStatuses: {
+        'session-1': {
+          status: 'working',
+          timestamp: Date.now()
+        }
+      }
+    })
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result.success).toBe(false)
+    expect(sessionUpdate).not.toHaveBeenCalled()
+  })
+
+  it('allows ordinary completed status after durable blankness is verified', async () => {
+    const session = makeSession()
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+    useWorktreeStatusStore.setState({
+      sessionStatuses: {
+        'session-1': {
+          status: 'completed',
+          timestamp: Date.now()
+        }
+      }
+    })
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result.success).toBe(true)
+    expect(sessionUpdate).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        agent_sdk: 'codex'
+      })
+    )
+  })
+
+  it('allows idle Claude CLI pty_start status and tears down the PTY', async () => {
+    const session = makeSession({
+      agent_sdk: 'claude-code-cli',
+      opencode_session_id: null,
+      claude_session_id: null
+    })
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+    useWorktreeStatusStore.setState({
+      sessionStatuses: {
+        'session-1': {
+          status: 'completed',
+          reason: 'pty_start',
+          timestamp: Date.now()
+        }
+      }
+    })
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result.success).toBe(true)
+    expect(window.terminalOps.destroy).toHaveBeenCalledWith('session-1')
+    expect(window.opencodeOps.disconnect).not.toHaveBeenCalled()
+    expect(sessionUpdate).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        agent_sdk: 'codex',
+        opencode_session_id: null,
+        claude_session_id: null
+      })
+    )
+  })
+
+  it('continues when old backend disconnect fails', async () => {
+    const session = makeSession()
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+    window.opencodeOps.disconnect.mockRejectedValueOnce(new Error('already gone'))
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result.success).toBe(true)
+    expect(sessionUpdate).toHaveBeenCalled()
+    expect(useSessionStore.getState().getSessionById('session-1')?.agent_sdk).toBe('codex')
+  })
+
+  it('disconnects the pre-update database runtime id when memory is stale', async () => {
+    const memorySession = makeSession({
+      opencode_session_id: null,
+      claude_session_id: null
+    })
+    const dbSession = makeSession({
+      opencode_session_id: 'db-runtime-1',
+      claude_session_id: 'db-claude-1'
+    })
+    seedSession(memorySession)
+    setupWindowDb(dbSession)
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result.success).toBe(true)
+    expect(window.opencodeOps.getMessages).toHaveBeenCalledWith('/repo', 'db-runtime-1')
+    expect(window.opencodeOps.disconnect).toHaveBeenCalledWith('/repo', 'db-runtime-1')
+  })
+
+  it('does not mutate local state when the database update fails', async () => {
+    const session = makeSession()
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+    sessionUpdate.mockRejectedValueOnce(new Error('write failed'))
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result.success).toBe(false)
+    expect(useSessionStore.getState().getSessionById('session-1')).toMatchObject({
+      agent_sdk: 'opencode',
+      model_id: 'old-model',
+      opencode_session_id: 'old-runtime-1'
+    })
+    expect(window.opencodeOps.disconnect).not.toHaveBeenCalled()
+    expect(window.terminalOps.destroy).not.toHaveBeenCalled()
+  })
+
+  it('does not tear down a Claude CLI PTY when the database update fails', async () => {
+    const session = makeSession({
+      agent_sdk: 'claude-code-cli',
+      opencode_session_id: null,
+      claude_session_id: null
+    })
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+    sessionUpdate.mockRejectedValueOnce(new Error('write failed'))
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result.success).toBe(false)
+    expect(window.terminalOps.destroy).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().getSessionById('session-1')?.agent_sdk).toBe(
+      'claude-code-cli'
+    )
+  })
+})

--- a/src/renderer/src/stores/__tests__/useSessionStore.blank-provider-switch.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.blank-provider-switch.test.ts
@@ -447,6 +447,25 @@ describe('useSessionStore.changeBlankSessionProvider', () => {
     )
   })
 
+  it('fails closed for launched Claude CLI sessions with an unverifiable transcript', async () => {
+    const session = makeSession({
+      agent_sdk: 'claude-code-cli',
+      opencode_session_id: null,
+      claude_session_id: 'claude-session-1'
+    })
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+
+    const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Could not verify whether this session has live transcript history'
+    })
+    expect(sessionUpdate).not.toHaveBeenCalled()
+    expect(window.terminalOps.destroy).not.toHaveBeenCalled()
+  })
+
   it('continues when old backend disconnect fails', async () => {
     const session = makeSession()
     seedSession(session)

--- a/src/renderer/src/stores/__tests__/useSessionStore.blank-provider-switch.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.blank-provider-switch.test.ts
@@ -231,6 +231,34 @@ describe('useSessionStore.changeBlankSessionProvider', () => {
     )
   })
 
+  it('still allows switching a blank OpenCode-style session into Claude CLI', async () => {
+    const session = makeSession({
+      agent_sdk: 'opencode',
+      opencode_session_id: null,
+      claude_session_id: null
+    })
+    seedSession(session)
+    const { sessionUpdate } = setupWindowDb(session)
+
+    const result = await useSessionStore
+      .getState()
+      .changeBlankSessionProvider('session-1', 'claude-code-cli')
+
+    expect(result.success).toBe(true)
+    expect(sessionUpdate).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        agent_sdk: 'claude-code-cli',
+        model_provider_id: 'anthropic',
+        model_id: 'sonnet',
+        model_variant: 'high',
+        opencode_session_id: null,
+        claude_session_id: null
+      })
+    )
+    expect(window.terminalOps.destroy).not.toHaveBeenCalled()
+  })
+
   it('rejects sessions with durable messages or activities', async () => {
     const session = makeSession()
     seedSession(session)
@@ -414,7 +442,7 @@ describe('useSessionStore.changeBlankSessionProvider', () => {
     )
   })
 
-  it('allows idle Claude CLI pty_start status and tears down the PTY', async () => {
+  it('fails closed for Claude CLI sessions before a session id is captured', async () => {
     const session = makeSession({
       agent_sdk: 'claude-code-cli',
       opencode_session_id: null,
@@ -434,17 +462,13 @@ describe('useSessionStore.changeBlankSessionProvider', () => {
 
     const result = await useSessionStore.getState().changeBlankSessionProvider('session-1', 'codex')
 
-    expect(result.success).toBe(true)
-    expect(window.terminalOps.destroy).toHaveBeenCalledWith('session-1')
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Could not verify whether this session has live transcript history'
+    })
+    expect(sessionUpdate).not.toHaveBeenCalled()
+    expect(window.terminalOps.destroy).not.toHaveBeenCalled()
     expect(window.opencodeOps.disconnect).not.toHaveBeenCalled()
-    expect(sessionUpdate).toHaveBeenCalledWith(
-      'session-1',
-      expect.objectContaining({
-        agent_sdk: 'codex',
-        opencode_session_id: null,
-        claude_session_id: null
-      })
-    )
   })
 
   it('fails closed for launched Claude CLI sessions with an unverifiable transcript', async () => {

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -340,6 +340,7 @@ async function getSessionRuntimePath(session: Session): Promise<string | null> {
 }
 
 async function hasLiveTranscriptHistory(session: Session): Promise<boolean | null> {
+  if (session.agent_sdk === 'claude-code-cli' && session.claude_session_id) return null
   if (!session.opencode_session_id) return false
   if (!window.opencodeOps?.getMessages) return null
 

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -340,7 +340,7 @@ async function getSessionRuntimePath(session: Session): Promise<string | null> {
 }
 
 async function hasLiveTranscriptHistory(session: Session): Promise<boolean | null> {
-  if (session.agent_sdk === 'claude-code-cli' && session.claude_session_id) return null
+  if (session.agent_sdk === 'claude-code-cli') return null
   if (!session.opencode_session_id) return false
   if (!window.opencodeOps?.getMessages) return null
 

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -7,7 +7,7 @@ import { useSettingsStore } from './useSettingsStore'
 import { getUnavailableAgentSdkMessage } from '@/lib/agent-sdk-availability'
 import { resolveSessionCreationSelection } from '@/lib/handoffSelection'
 import { unwrapEnvelope, unwrapEnvelopeApi } from '@/lib/ipc-envelope'
-import { type AgentSdk, isTerminalBacked } from '@shared/types/agent-sdk'
+import { type AgentSdk, type HandoffAgentSdk, isTerminalBacked } from '@shared/types/agent-sdk'
 
 const db = unwrapEnvelopeApi(() => window.db)
 
@@ -40,8 +40,14 @@ function isVisibleSession(session: { name: string | null; session_type?: string 
   return !isBoardAssistantSessionName(session.name)
 }
 
-function getUnavailableProviderError(sdk: AgentSdk): string | null {
+function getUnavailableProviderError(
+  sdk: AgentSdk,
+  options?: { failWhenUnknown?: boolean }
+): string | null {
   const { availableAgentSdks } = useSettingsStore.getState()
+  if (!availableAgentSdks && options?.failWhenUnknown) {
+    return 'Provider availability has not loaded yet'
+  }
   return getUnavailableAgentSdkMessage(sdk, availableAgentSdks)
 }
 
@@ -65,6 +71,12 @@ export interface CodexThreadGoal {
   createdAt: number
   updatedAt: number
   observedAtMs?: number
+}
+
+export interface ProviderSwitchActivity {
+  sending: boolean
+  streaming: boolean
+  queuedLocalFollowUps: number
 }
 
 // Session type matching the database schema
@@ -103,6 +115,8 @@ interface SessionState {
   pendingPlans: Map<string, PendingPlan>
   // Pending follow-up messages - keyed by session ID, ordered queue of messages to auto-send
   pendingFollowUpMessages: Map<string, string[]>
+  // Renderer-owned transient activity that blocks blank-session provider switching.
+  providerSwitchActivityBySession: Map<string, ProviderSwitchActivity>
   // Current Codex thread goals - keyed by Hive session ID
   codexGoalsBySession: Map<string, CodexThreadGoal>
   isLoading: boolean
@@ -185,6 +199,15 @@ interface SessionState {
     model: SelectedModel,
     options?: { skipGlobalUpdate?: boolean }
   ) => Promise<void>
+  changeBlankSessionProvider: (
+    sessionId: string,
+    nextAgentSdk: HandoffAgentSdk,
+    nextModel?: SelectedModel
+  ) => Promise<{ success: boolean; error?: string }>
+  setProviderSwitchActivity: (
+    sessionId: string,
+    activity: ProviderSwitchActivity | null
+  ) => void
   setOpenCodeSessionId: (sessionId: string, opencodeSessionId: string | null) => void
   setClaudeSessionId: (sessionId: string, claudeSessionId: string | null) => void
   setPendingMessage: (sessionId: string, message: string) => void
@@ -276,6 +299,64 @@ function findSessionInState(state: SessionState, sessionId: string): Session | n
   return state.orphanedSessions.get(sessionId) ?? null
 }
 
+function findSessionWithScope(
+  state: SessionState,
+  sessionId: string
+):
+  | { type: 'worktree'; scopeId: string; session: Session }
+  | { type: 'connection'; scopeId: string; session: Session }
+  | null {
+  for (const [worktreeId, sessions] of state.sessionsByWorktree.entries()) {
+    const found = sessions.find((session) => session.id === sessionId)
+    if (found) return { type: 'worktree', scopeId: worktreeId, session: found }
+  }
+  for (const [connectionId, sessions] of state.sessionsByConnection.entries()) {
+    const found = sessions.find((session) => session.id === sessionId)
+    if (found) return { type: 'connection', scopeId: connectionId, session: found }
+  }
+  return null
+}
+
+function getWorktreePath(worktreeId: string | null): string | null {
+  if (!worktreeId) return null
+  for (const worktrees of useWorktreeStore.getState().worktreesByProject.values()) {
+    const worktree = worktrees.find((candidate) => candidate.id === worktreeId)
+    if (worktree) return worktree.path
+  }
+  return null
+}
+
+async function getSessionRuntimePath(session: Session): Promise<string | null> {
+  const worktreePath = getWorktreePath(session.worktree_id)
+  if (worktreePath) return worktreePath
+
+  if (!session.connection_id || !window.connectionOps?.get) return null
+  try {
+    const result = unwrapEnvelope(await window.connectionOps.get(session.connection_id))
+    return result.success && result.connection ? result.connection.path : null
+  } catch {
+    return null
+  }
+}
+
+async function hasLiveTranscriptHistory(session: Session): Promise<boolean | null> {
+  if (!session.opencode_session_id) return false
+  if (!window.opencodeOps?.getMessages) return null
+
+  const runtimePath = await getSessionRuntimePath(session)
+  if (!runtimePath) return null
+
+  try {
+    const result = unwrapEnvelope(
+      await window.opencodeOps.getMessages(runtimePath, session.opencode_session_id)
+    )
+    if (!result.success || !Array.isArray(result.messages)) return null
+    return result.messages.length > 0
+  } catch {
+    return null
+  }
+}
+
 // Shift+Tab — Claude Code's "cycle permission mode" key.
 const CLAUDE_CLI_SHIFT_TAB = '\u001b[Z'
 
@@ -313,6 +394,7 @@ export const useSessionStore = create<SessionState>()(
       pendingMessages: new Map(),
       pendingPlans: new Map(),
       pendingFollowUpMessages: new Map(),
+      providerSwitchActivityBySession: new Map(),
       codexGoalsBySession: new Map(),
       isLoading: false,
       error: null,
@@ -1450,6 +1532,204 @@ export const useSessionStore = create<SessionState>()(
             /* non-critical */
           }
         }
+      },
+
+      changeBlankSessionProvider: async (
+        sessionId: string,
+        nextAgentSdk: HandoffAgentSdk,
+        nextModel?: SelectedModel
+      ) => {
+        try {
+          const initialScope = findSessionWithScope(get(), sessionId)
+          if (!initialScope) {
+            return { success: false, error: 'Session not found' }
+          }
+          if (initialScope.session.session_type !== 'default') {
+            return { success: false, error: 'This session cannot change providers' }
+          }
+          if (initialScope.session.agent_sdk === 'terminal') {
+            return { success: false, error: 'Terminal sessions cannot change providers' }
+          }
+          if (initialScope.session.agent_sdk === nextAgentSdk && !nextModel) {
+            return { success: true }
+          }
+
+          const unavailableProviderError = getUnavailableProviderError(nextAgentSdk, {
+            failWhenUnknown: true
+          })
+          if (unavailableProviderError) {
+            return { success: false, error: unavailableProviderError }
+          }
+
+          const dbSession = await db.session.get(sessionId)
+          if (!dbSession) {
+            return { success: false, error: 'Session not found in database' }
+          }
+          if (dbSession.session_type !== 'default') {
+            return { success: false, error: 'This session cannot change providers' }
+          }
+          if (dbSession.agent_sdk === 'terminal') {
+            return { success: false, error: 'Terminal sessions cannot change providers' }
+          }
+
+          if (!db.sessionMessage?.list || !db.sessionActivity?.list) {
+            return {
+              success: false,
+              error: 'Could not verify whether this session has history'
+            }
+          }
+          const [messageRows, activityRows] = await Promise.all([
+            db.sessionMessage.list(sessionId),
+            db.sessionActivity.list(sessionId)
+          ])
+          if (messageRows.length > 0 || activityRows.length > 0) {
+            return { success: false, error: 'Provider can only be changed before history exists' }
+          }
+          const liveTranscriptHasHistory = await hasLiveTranscriptHistory(dbSession)
+          if (liveTranscriptHasHistory === null) {
+            return {
+              success: false,
+              error: 'Could not verify whether this session has live transcript history'
+            }
+          }
+          if (liveTranscriptHasHistory) {
+            return { success: false, error: 'Provider can only be changed before history exists' }
+          }
+
+          const latestScope = findSessionWithScope(get(), sessionId)
+          if (!latestScope) {
+            return { success: false, error: 'Session not found' }
+          }
+          if (latestScope.session.agent_sdk === 'terminal') {
+            return { success: false, error: 'Terminal sessions cannot change providers' }
+          }
+          const activity = get().providerSwitchActivityBySession.get(sessionId)
+          if (activity?.sending || activity?.streaming || activity?.queuedLocalFollowUps) {
+            return { success: false, error: 'Provider cannot change while the session is active' }
+          }
+          if (get().pendingMessages.has(sessionId)) {
+            return {
+              success: false,
+              error: 'Provider cannot change while an initial prompt is pending'
+            }
+          }
+          if ((get().pendingFollowUpMessages.get(sessionId)?.length ?? 0) > 0) {
+            return {
+              success: false,
+              error: 'Provider cannot change while follow-up messages are queued'
+            }
+          }
+          if (get().pendingPlans.has(sessionId)) {
+            return { success: false, error: 'Provider cannot change while a plan is pending' }
+          }
+
+          try {
+            const { isProviderSwitchBlockingSessionStatus, useWorktreeStatusStore } = await import(
+              './useWorktreeStatusStore'
+            )
+            const status = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
+            if (isProviderSwitchBlockingSessionStatus(status)) {
+              return { success: false, error: 'Provider cannot change while the session is active' }
+            }
+          } catch {
+            return {
+              success: false,
+              error: 'Could not verify whether this session is active'
+            }
+          }
+
+          const { model: resolvedModel } = resolveSessionCreationSelection({
+            agentSdkOverride: nextAgentSdk,
+            initialMode: latestScope.session.mode,
+            modelOverride: nextModel ? { ...nextModel, agentSdk: nextAgentSdk } : undefined
+          })
+
+          if (!resolvedModel) {
+            return { success: false, error: 'Could not resolve a model for the selected provider' }
+          }
+
+          const updatedSession = await db.session.update(sessionId, {
+            agent_sdk: nextAgentSdk,
+            model_provider_id: resolvedModel.providerID,
+            model_id: resolvedModel.modelID,
+            model_variant: resolvedModel.variant ?? null,
+            opencode_session_id: null,
+            claude_session_id: null
+          })
+
+          if (!updatedSession) {
+            return { success: false, error: 'Failed to update session provider' }
+          }
+
+          const previousOpencodeSessionId = dbSession.opencode_session_id
+          if (previousOpencodeSessionId && window.opencodeOps?.disconnect) {
+            try {
+              const runtimePath = await getSessionRuntimePath(dbSession)
+              if (runtimePath) {
+                unwrapEnvelope(
+                  await window.opencodeOps.disconnect(runtimePath, previousOpencodeSessionId)
+                )
+              }
+            } catch (error) {
+              console.warn('Failed to disconnect previous provider session:', error)
+            }
+          }
+          if (dbSession.agent_sdk === 'claude-code-cli' && window.terminalOps?.destroy) {
+            try {
+              unwrapEnvelope(await window.terminalOps.destroy(sessionId))
+            } catch (error) {
+              console.warn('Failed to destroy previous Claude CLI session:', error)
+            }
+          }
+
+          set((state) => {
+            const scope = findSessionWithScope(state, sessionId)
+            if (!scope) return {}
+
+            if (scope.type === 'worktree') {
+              const sessionsByWorktree = new Map(state.sessionsByWorktree)
+              const sessions = sessionsByWorktree.get(scope.scopeId) ?? []
+              sessionsByWorktree.set(
+                scope.scopeId,
+                sessions.map((session) => (session.id === sessionId ? updatedSession : session))
+              )
+              return { sessionsByWorktree }
+            }
+
+            const sessionsByConnection = new Map(state.sessionsByConnection)
+            const sessions = sessionsByConnection.get(scope.scopeId) ?? []
+            sessionsByConnection.set(
+              scope.scopeId,
+              sessions.map((session) => (session.id === sessionId ? updatedSession : session))
+            )
+            return { sessionsByConnection }
+          })
+
+          return { success: true }
+        } catch (error) {
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to change session provider'
+          }
+        }
+      },
+
+      setProviderSwitchActivity: (
+        sessionId: string,
+        activity: ProviderSwitchActivity | null
+      ) => {
+        set((state) => {
+          const next = new Map(state.providerSwitchActivityBySession)
+          const isIdle =
+            !activity ||
+            (!activity.sending && !activity.streaming && activity.queuedLocalFollowUps === 0)
+          if (isIdle) {
+            next.delete(sessionId)
+          } else {
+            next.set(sessionId, activity)
+          }
+          return { providerSwitchActivityBySession: next }
+        })
       },
 
       // Apply mode-specific default model when toggling modes

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -24,6 +24,19 @@ export interface SessionStatusEntry {
   plan?: string
 }
 
+export function isProviderSwitchBlockingSessionStatus(
+  entry: SessionStatusEntry | null | undefined
+): boolean {
+  return (
+    entry?.status === 'working' ||
+    entry?.status === 'planning' ||
+    entry?.status === 'answering' ||
+    entry?.status === 'permission' ||
+    entry?.status === 'command_approval' ||
+    entry?.status === 'plan_ready'
+  )
+}
+
 export type MergeConflictFlow =
   | { phase: 'starting' }
   | { phase: 'running'; sessionId: string; seenBusy: boolean }

--- a/src/shared/types/__tests__/agent-sdk.test.ts
+++ b/src/shared/types/__tests__/agent-sdk.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { AGENT_SDK_VALUES, toHandoffAgentSdk } from '../agent-sdk'
+
+describe('toHandoffAgentSdk', () => {
+  it('returns every known non-terminal SDK unchanged', () => {
+    const handoffSdks = AGENT_SDK_VALUES.filter((sdk) => sdk !== 'terminal')
+
+    for (const sdk of handoffSdks) {
+      expect(toHandoffAgentSdk(sdk)).toBe(sdk)
+    }
+  })
+
+  it('returns null for terminal, unknown, and empty values', () => {
+    expect(toHandoffAgentSdk('terminal')).toBeNull()
+    expect(toHandoffAgentSdk('unknown-sdk')).toBeNull()
+    expect(toHandoffAgentSdk(null)).toBeNull()
+    expect(toHandoffAgentSdk(undefined)).toBeNull()
+  })
+})

--- a/src/shared/types/agent-sdk.ts
+++ b/src/shared/types/agent-sdk.ts
@@ -36,6 +36,15 @@ export type HandoffAgentSdk = Exclude<AgentSdk, 'terminal'>
 
 type MaybeSdk = AgentSdk | string | null | undefined
 
+/**
+ * Narrow a loosely-carried SDK value to a handoff-capable SDK. Unknown strings
+ * and the bare terminal are not handoff providers.
+ */
+export function toHandoffAgentSdk(sdk: MaybeSdk): HandoffAgentSdk | null {
+  if (!sdk || sdk === 'terminal') return null
+  return (AGENT_SDK_VALUES as readonly string[]).includes(sdk) ? (sdk as HandoffAgentSdk) : null
+}
+
 /** The Claude Code CLI session type (terminal-backed Claude, distinct from the SDK-driven `claude-code`). */
 export function isClaudeCli(sdk: MaybeSdk): boolean {
   return sdk === 'claude-code-cli'


### PR DESCRIPTION
## Description
Adds a blank-session provider switcher so users can change the AI provider before a session has any durable history. The selector appears only for durably blank sessions, preserves draft text and tab identity, and supports OpenCode, Claude Code, Codex, and Claude Code CLI. Once history exists, the provider control becomes a static label again.

This also tightens store-side safety checks, keeps Claude CLI terminal sessions mounted correctly during provider/dropdown/modal interactions, and hides the Claude CLI model selector because runtime model changes are not applied by the live CLI process.

## Related Issue
Fixes #(issue number)

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] ♻️ Code refactoring
- [x] 🧪 Test improvement
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Changes Made
- Added a session provider selector for durably blank AI sessions, with store-enforced blankness checks and provider availability validation.
- Preserved drafts/session identity while switching providers and avoided updating global or worktree model defaults.
- Added post-commit runtime teardown for previous OpenCode/Claude CLI runtimes.
- Updated Claude CLI handling so provider switching works for blank CLI sessions, dropdowns do not blank the terminal, and ticket-modal moves do not remount the terminal view.
- Removed the Claude CLI model selector because live Claude CLI sessions do not consume Hive model changes after PTY spawn.
- Added shared agent SDK narrowing helper and focused tests/docs for the new behavior.

## Screenshots
<details>
<summary>Screenshots</summary>

**Screenshot 1: blank session with active provider switcher**
<img width="827" height="207" alt="Screenshot 2026-06-02 at 20 29 39" src="https://github.com/user-attachments/assets/8e8aa932-839a-45c6-aabe-e120ae4236a3" />


**Screenshot 2: nonblank session showing static provider label**
<img width="835" height="553" alt="Screenshot 2026-06-02 at 20 31 06" src="https://github.com/user-attachments/assets/9d9781ba-7b0c-456c-a9e0-5fe1d4d50f02" />


**Screenshot 3: Claude Code CLI showing provider control with no model selector**
<img width="848" height="197" alt="Screenshot 2026-06-02 at 20 30 12" src="https://github.com/user-attachments/assets/090d91ff-537c-47d8-9593-1f73b4762481" />


</details>

## Testing

### Test Configuration
- **OS**: macOS 26.5
- **Node Version**: v25.8.1
- **Test Type**: Unit/Integration/Manual

### Test Steps
1. Created/opened a blank session and verified the provider selector appears before any messages exist.
2. Switched between available AI providers and verified draft text/session tab identity are preserved.
3. Sent a message and verified the provider selector becomes a static label.
4. Verified Claude Code CLI sessions keep the provider control but do not render a model selector.
5. Verified Claude CLI remains mounted/visible while dropdowns are opened and when moved into/out of ticket modal context.

### Test Results
- [x] All existing targeted tests pass
- [x] New tests added (if applicable)
- [x] Manual testing completed

Targeted checks run:
- `npm test -- src/shared/types/__tests__/agent-sdk.test.ts`
- `npm test -- src/renderer/src/components/sessions/ClaudeCliSessionView.blank-provider-switch.test.tsx`
- `npm test -- src/renderer/src/components/sessions/SessionProviderSelector.test.tsx`
- `npm test -- src/renderer/src/components/sessions/useDurableSessionHistory.test.tsx`
- `npm test -- src/renderer/src/components/sessions/useProviderSwitchActivitySync.test.tsx`
- `npm test -- src/renderer/src/components/layout/MainPane.test.tsx`
- `npm test -- src/renderer/src/stores/__tests__/useSessionStore.blank-provider-switch.test.ts`
- `npm test -- src/renderer/src/lib/__tests__/handoffSelection.test.ts`
- `npx tsc --noEmit`
- `git diff --check`

## Checklist
- [x] My code follows the project's code style
- [ ] I have run `pnpm lint` and fixed any issues
- [ ] I have run `pnpm format` to format my code
- [ ] I have run `pnpm test` and all tests pass
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation (if needed)
- [x] I have added comments to complex code sections
- [x] I have checked for any console errors
- [x] I have tested on macOS (required)
- [x] I have updated documentation (for significant changes)

## Performance Impact
- [x] No performance impact
- [ ] Improves performance
- [ ] May affect performance (please explain)

## Breaking Changes
- [x] No breaking changes

## Additional Notes
Claude Code CLI model selection is intentionally hidden. Hive can pass the selected model/effort when spawning the CLI, but changing Hive model state after the PTY is already running does not update the live Claude Code process. Injecting `/model` into the terminal was avoided because it is brittle and may mutate the user's Claude Code defaults.

## Post-Merge Tasks
- [ ] Update documentation site
- [ ] Notify users of breaking changes
- [ ] Update README examples
- [ ] Other: