### PR TITLE
bindport

### DIFF
--- a/src/main/desktop/backend-config.test.ts
+++ b/src/main/desktop/backend-config.test.ts
@@ -79,13 +79,26 @@ describe('desktop backend config', () => {
     const config = await makeDesktopBackendSpawnConfig({
       baseDir,
       port: 0,
-      env: { BIND_IP: '0.0.0.0' }
+      env: { BIND_IP: '0.0.0.0', HIVE_SERVER_REQUIRE_AUTH: 'true' }
     })
 
     expect(config.host).toBe('0.0.0.0')
     expect(config.httpBaseUrl).toBe(`http://0.0.0.0:${config.port}`)
     expect(config.wsBaseUrl).toBe(`ws://0.0.0.0:${config.port}/ws`)
     expect(config.env.HIVE_SERVER_HOST).toBe('0.0.0.0')
+    expect(config.env.HIVE_SERVER_REQUIRE_AUTH).toBe('true')
+  })
+
+  it('fails startup config when BIND_IP explicitly disables auth', async () => {
+    const baseDir = mkdtempSync(join(tmpdir(), 'hive-desktop-backend-'))
+
+    await expect(
+      makeDesktopBackendSpawnConfig({
+        baseDir,
+        port: 0,
+        env: { BIND_IP: '0.0.0.0', HIVE_SERVER_REQUIRE_AUTH: 'false' }
+      })
+    ).rejects.toThrow('BIND_IP requires HIVE_SERVER_REQUIRE_AUTH=true')
   })
 
   it('prefers an explicit backend host over BIND_IP', async () => {
@@ -94,7 +107,7 @@ describe('desktop backend config', () => {
       baseDir,
       host: '127.0.0.1',
       port: 0,
-      env: { BIND_IP: '0.0.0.0' }
+      env: { BIND_IP: '0.0.0.0', HIVE_SERVER_REQUIRE_AUTH: 'true' }
     })
 
     expect(config.host).toBe('127.0.0.1')

--- a/src/main/desktop/backend-config.test.ts
+++ b/src/main/desktop/backend-config.test.ts
@@ -74,6 +74,33 @@ describe('desktop backend config', () => {
     expect(config.env.KEEP_ME).toBe('yes')
   })
 
+  it('uses BIND_IP as the default backend host when set', async () => {
+    const baseDir = mkdtempSync(join(tmpdir(), 'hive-desktop-backend-'))
+    const config = await makeDesktopBackendSpawnConfig({
+      baseDir,
+      port: 0,
+      env: { BIND_IP: '0.0.0.0' }
+    })
+
+    expect(config.host).toBe('0.0.0.0')
+    expect(config.httpBaseUrl).toBe(`http://0.0.0.0:${config.port}`)
+    expect(config.wsBaseUrl).toBe(`ws://0.0.0.0:${config.port}/ws`)
+    expect(config.env.HIVE_SERVER_HOST).toBe('0.0.0.0')
+  })
+
+  it('prefers an explicit backend host over BIND_IP', async () => {
+    const baseDir = mkdtempSync(join(tmpdir(), 'hive-desktop-backend-'))
+    const config = await makeDesktopBackendSpawnConfig({
+      baseDir,
+      host: '127.0.0.1',
+      port: 0,
+      env: { BIND_IP: '0.0.0.0' }
+    })
+
+    expect(config.host).toBe('127.0.0.1')
+    expect(config.env.HIVE_SERVER_HOST).toBe('127.0.0.1')
+  })
+
   it('serves the web UI without auth on loopback', async () => {
     const baseDir = mkdtempSync(join(tmpdir(), 'hive-desktop-backend-'))
     const config = await makeDesktopBackendSpawnConfig({

--- a/src/main/desktop/backend-config.ts
+++ b/src/main/desktop/backend-config.ts
@@ -52,6 +52,9 @@ const parseDesktopBackendBindIpEnv = (value: string | undefined): string | undef
   return bindIp ? bindIp : undefined
 }
 
+const isAuthExplicitlyDisabled = (value: string | undefined): boolean =>
+  value === 'false' || value === '0'
+
 export const isPortAvailable = (host: string, port: number): Promise<boolean> =>
   new Promise((resolvePortAvailable) => {
     const server = createServer()
@@ -112,7 +115,13 @@ export const makeDesktopBackendSpawnConfig = async (
     ...process.env,
     ...input.env
   }
-  const host = input.host ?? parseDesktopBackendBindIpEnv(env.BIND_IP) ?? DEFAULT_DESKTOP_BACKEND_HOST
+  const bindIp = parseDesktopBackendBindIpEnv(env.BIND_IP)
+  if (bindIp && isAuthExplicitlyDisabled(env.HIVE_SERVER_REQUIRE_AUTH)) {
+    throw new Error('BIND_IP requires HIVE_SERVER_REQUIRE_AUTH=true')
+  }
+
+  const host = input.host ?? bindIp ?? DEFAULT_DESKTOP_BACKEND_HOST
+  const requireAuth = bindIp ? 'true' : (env.HIVE_SERVER_REQUIRE_AUTH ?? 'false')
   const port = await selectDesktopBackendPort(
     host,
     input.port ?? DEFAULT_DESKTOP_BACKEND_PORT,
@@ -143,10 +152,10 @@ export const makeDesktopBackendSpawnConfig = async (
       HIVE_SERVER_PORT: String(port),
       HIVE_SERVER_BASE_DIR: input.baseDir,
       HIVE_DESKTOP_BOOTSTRAP_TOKEN: bootstrapToken,
-      // Also serve the built web UI from the same loopback origin, with auth
-      // disabled so a plain browser tab can connect without a bootstrap token.
+      // Keep loopback browser serving unauthenticated by default. Public BIND_IP
+      // overrides must authenticate so token-less WebSocket RPC is not exposed.
       HIVE_SERVER_STATIC_DIR: staticDir,
-      HIVE_SERVER_REQUIRE_AUTH: 'false'
+      HIVE_SERVER_REQUIRE_AUTH: requireAuth
     }
   }
 }

--- a/src/main/desktop/backend-config.ts
+++ b/src/main/desktop/backend-config.ts
@@ -47,6 +47,11 @@ export const parseDesktopBackendPortEnv = (value: string | undefined): number | 
   return Number.isInteger(parsed) && parsed >= 0 && parsed <= 65535 ? parsed : undefined
 }
 
+const parseDesktopBackendBindIpEnv = (value: string | undefined): string | undefined => {
+  const bindIp = value?.trim()
+  return bindIp ? bindIp : undefined
+}
+
 export const isPortAvailable = (host: string, port: number): Promise<boolean> =>
   new Promise((resolvePortAvailable) => {
     const server = createServer()
@@ -103,7 +108,11 @@ export const resolveDesktopWebStaticDir = (serverEntryPath: string): string => {
 export const makeDesktopBackendSpawnConfig = async (
   input: DesktopBackendConfigInput
 ): Promise<DesktopBackendSpawnConfig> => {
-  const host = input.host ?? DEFAULT_DESKTOP_BACKEND_HOST
+  const env = {
+    ...process.env,
+    ...input.env
+  }
+  const host = input.host ?? parseDesktopBackendBindIpEnv(env.BIND_IP) ?? DEFAULT_DESKTOP_BACKEND_HOST
   const port = await selectDesktopBackendPort(
     host,
     input.port ?? DEFAULT_DESKTOP_BACKEND_PORT,
@@ -127,8 +136,7 @@ export const makeDesktopBackendSpawnConfig = async (
     baseDir: input.baseDir,
     bootstrapToken,
     env: {
-      ...process.env,
-      ...input.env,
+      ...env,
       ELECTRON_RUN_AS_NODE: '1',
       HIVE_SERVER_MODE: 'desktop',
       HIVE_SERVER_HOST: host,

--- a/src/main/desktop/backend-manager.test.ts
+++ b/src/main/desktop/backend-manager.test.ts
@@ -380,6 +380,7 @@ describe('desktop backend manager', () => {
 
   it('uses BIND_IP as the desktop backend bind host', async () => {
     vi.stubEnv('BIND_IP', '0.0.0.0')
+    vi.stubEnv('HIVE_SERVER_REQUIRE_AUTH', 'true')
     const child = new FakeChildProcess()
     const spawnProcess = vi.fn(() => child as never)
 
@@ -406,10 +407,36 @@ describe('desktop backend manager', () => {
       ['/app/server.js'],
       expect.objectContaining({
         env: expect.objectContaining({
-          HIVE_SERVER_HOST: '0.0.0.0'
+          HIVE_SERVER_HOST: '0.0.0.0',
+          HIVE_SERVER_REQUIRE_AUTH: 'true'
         })
       })
     )
+  })
+
+  it('fails before spawning when BIND_IP disables backend auth', async () => {
+    vi.stubEnv('BIND_IP', '0.0.0.0')
+    vi.stubEnv('HIVE_SERVER_REQUIRE_AUTH', 'false')
+    const spawnProcess = vi.fn()
+
+    await expect(
+      startDesktopBackend(
+        {
+          executablePath: '/electron',
+          entryPath: '/app/server.js',
+          cwd: '/app',
+          baseDir: mkdtempSync(join(tmpdir(), 'hive-backend-manager-')),
+          port: 0
+        },
+        {
+          spawnProcess,
+          fetch: vi.fn(async () => new Response('{}', { status: 200 })),
+          logger: makeLogger()
+        }
+      )
+    ).rejects.toThrow('BIND_IP requires HIVE_SERVER_REQUIRE_AUTH=true')
+
+    expect(spawnProcess).not.toHaveBeenCalled()
   })
 
   it('authenticates before publishing desktop backend events over HTTP', async () => {

--- a/src/main/desktop/backend-manager.test.ts
+++ b/src/main/desktop/backend-manager.test.ts
@@ -378,6 +378,40 @@ describe('desktop backend manager', () => {
     )
   })
 
+  it('uses BIND_IP as the desktop backend bind host', async () => {
+    vi.stubEnv('BIND_IP', '0.0.0.0')
+    const child = new FakeChildProcess()
+    const spawnProcess = vi.fn(() => child as never)
+
+    const backend = await startDesktopBackend(
+      {
+        executablePath: '/electron',
+        entryPath: '/app/server.js',
+        cwd: '/app',
+        baseDir: mkdtempSync(join(tmpdir(), 'hive-backend-manager-')),
+        port: 0
+      },
+      {
+        spawnProcess,
+        fetch: vi.fn(async () => new Response('{}', { status: 200 })),
+        logger: makeLogger()
+      }
+    )
+
+    expect(backend.config.host).toBe('0.0.0.0')
+    expect(backend.config.env.HIVE_SERVER_HOST).toBe('0.0.0.0')
+    expect(backend.config.httpBaseUrl).toBe(`http://0.0.0.0:${backend.config.port}`)
+    expect(spawnProcess).toHaveBeenCalledWith(
+      '/electron',
+      ['/app/server.js'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          HIVE_SERVER_HOST: '0.0.0.0'
+        })
+      })
+    )
+  })
+
   it('authenticates before publishing desktop backend events over HTTP', async () => {
     const child = new FakeChildProcess()
     const fetchImpl = vi

--- a/src/main/desktop/backend-manager.ts
+++ b/src/main/desktop/backend-manager.ts
@@ -74,7 +74,6 @@ import {
   updatePetSettings
 } from '../services/pet-window'
 import {
-  DEFAULT_DESKTOP_BACKEND_HOST,
   DEFAULT_DESKTOP_BACKEND_MAX_PORT,
   DEFAULT_DESKTOP_BACKEND_PORT,
   makeDesktopBackendSpawnConfig,
@@ -542,7 +541,7 @@ export const startDesktopBackend = async (
     entryPath: input.entryPath,
     cwd: input.cwd,
     baseDir,
-    host: input.host ?? DEFAULT_DESKTOP_BACKEND_HOST,
+    host: input.host,
     port: input.port ?? pinnedPort ?? DEFAULT_DESKTOP_BACKEND_PORT,
     maxPort: input.maxPort ?? pinnedPort ?? DEFAULT_DESKTOP_BACKEND_MAX_PORT,
     bootstrapToken: envBootstrapToken,

--- a/src/server/__tests__/server-config.test.ts
+++ b/src/server/__tests__/server-config.test.ts
@@ -77,6 +77,29 @@ describe('server config', () => {
     expect(config.requireAuth).toBe(false)
   })
 
+  it('uses BIND_IP as the server host override', async () => {
+    const config = await Effect.runPromise(
+      resolveServerConfig(
+        { baseDir: mkdtempSync(join(tmpdir(), 'hive-server-config-')) },
+        { BIND_IP: '0.0.0.0' }
+      )
+    )
+
+    expect(config.host).toBe('0.0.0.0')
+    expect(config.requireAuth).toBe(true)
+  })
+
+  it('rejects BIND_IP when auth is disabled', async () => {
+    await expect(
+      Effect.runPromise(
+        resolveServerConfig(
+          { baseDir: mkdtempSync(join(tmpdir(), 'hive-server-config-')) },
+          { BIND_IP: '0.0.0.0', HIVE_SERVER_REQUIRE_AUTH: 'false' }
+        )
+      )
+    ).rejects.toThrow('BIND_IP requires HIVE_SERVER_REQUIRE_AUTH=true')
+  })
+
   it('resolves the static directory from HIVE_SERVER_STATIC_DIR', async () => {
     const config = await Effect.runPromise(
       resolveServerConfig(
@@ -88,4 +111,3 @@ describe('server config', () => {
     expect(config.staticDir).toBe('/tmp/hive-web')
   })
 })
-

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -64,24 +64,37 @@ const parseLogLevel = (value: string | undefined): ServerLogLevel =>
 const parseRequireAuth = (value: string | undefined): boolean =>
   value === 'false' || value === '0' ? false : true
 
+const parseBindIp = (value: string | undefined): string | undefined => {
+  const bindIp = value?.trim()
+  return bindIp ? bindIp : undefined
+}
+
 export const resolveServerConfig = (
   input: ServerConfigInput = {},
   env: NodeJS.ProcessEnv = process.env
-): Effect.Effect<ServerConfig> =>
-  Effect.sync(() => {
-    const baseDir = resolve(input.baseDir ?? env.HIVE_SERVER_BASE_DIR ?? join(homedir(), '.hive'))
-    return {
-      mode: input.mode ?? parseMode(env.HIVE_SERVER_MODE),
-      host: input.host ?? env.HIVE_SERVER_HOST ?? DEFAULT_HOST,
-      port: input.port ?? parsePort(env.HIVE_SERVER_PORT, DEFAULT_PORT),
-      baseDir,
-      devUrl: input.devUrl ?? env.HIVE_SERVER_DEV_URL ?? null,
-      staticDir: input.staticDir ?? env.HIVE_SERVER_STATIC_DIR ?? null,
-      desktopBootstrapToken:
-        input.desktopBootstrapToken ?? env.HIVE_DESKTOP_BOOTSTRAP_TOKEN ?? null,
-      requireAuth: input.requireAuth ?? parseRequireAuth(env.HIVE_SERVER_REQUIRE_AUTH),
-      logLevel: input.logLevel ?? parseLogLevel(env.HIVE_SERVER_LOG_LEVEL),
-      ...deriveServerPaths(baseDir)
-    }
-  })
+): Effect.Effect<ServerConfig, Error> =>
+  Effect.try({
+    try: () => {
+      const bindIp = parseBindIp(env.BIND_IP)
+      const requireAuth = input.requireAuth ?? parseRequireAuth(env.HIVE_SERVER_REQUIRE_AUTH)
+      if (bindIp && !requireAuth) {
+        throw new Error('BIND_IP requires HIVE_SERVER_REQUIRE_AUTH=true')
+      }
 
+      const baseDir = resolve(input.baseDir ?? env.HIVE_SERVER_BASE_DIR ?? join(homedir(), '.hive'))
+      return {
+        mode: input.mode ?? parseMode(env.HIVE_SERVER_MODE),
+        host: input.host ?? env.HIVE_SERVER_HOST ?? bindIp ?? DEFAULT_HOST,
+        port: input.port ?? parsePort(env.HIVE_SERVER_PORT, DEFAULT_PORT),
+        baseDir,
+        devUrl: input.devUrl ?? env.HIVE_SERVER_DEV_URL ?? null,
+        staticDir: input.staticDir ?? env.HIVE_SERVER_STATIC_DIR ?? null,
+        desktopBootstrapToken:
+          input.desktopBootstrapToken ?? env.HIVE_DESKTOP_BOOTSTRAP_TOKEN ?? null,
+        requireAuth,
+        logLevel: input.logLevel ?? parseLogLevel(env.HIVE_SERVER_LOG_LEVEL),
+        ...deriveServerPaths(baseDir)
+      }
+    },
+    catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause)))
+  })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes listen address and auth defaults for network-exposed binds; misconfiguration could expose unauthenticated RPC/WebSocket if guards were bypassed, though explicit rejection of BIND_IP without auth mitigates that.
> 
> **Overview**
> Adds a **`BIND_IP`** environment variable so the desktop backend and Hive server can listen on a non-loopback address (e.g. `0.0.0.0`) instead of defaulting to `127.0.0.1`.
> 
> **Desktop spawn config** (`makeDesktopBackendSpawnConfig`) now resolves host as explicit `input.host` → `BIND_IP` → loopback, updates HTTP/WS URLs and `HIVE_SERVER_HOST`, and sets **`HIVE_SERVER_REQUIRE_AUTH` to `true` whenever `BIND_IP` is set** (otherwise unchanged default `false` for local browser UI). Startup **throws** if `BIND_IP` is set while auth is explicitly disabled (`HIVE_SERVER_REQUIRE_AUTH=false`/`0`). **`startDesktopBackend`** no longer forces the default loopback host so `BIND_IP` can apply.
> 
> **Server config** (`resolveServerConfig`) mirrors the same rules: `BIND_IP` can override host (after explicit `input.host` / `HIVE_SERVER_HOST`), enforces auth when binding publicly, and rejects the unsafe bind+no-auth combo. Config resolution now surfaces errors via `Effect.try` instead of always succeeding.
> 
> Tests cover bind host, auth enforcement, precedence, and manager behavior (fail before spawn).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a587261d19ba69bbe0446872deee53590ba53e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->