### PR TITLE
Fix branch update propagation for renames and conflicts

### DIFF
--- a/src/main/services/__tests__/claude-cli-title-handler.test.ts
+++ b/src/main/services/__tests__/claude-cli-title-handler.test.ts
@@ -238,7 +238,8 @@ describe('applyClaudeCliTitle', () => {
     })
     expect(mocks.emitWorktreeBranchRenamed).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
-      newBranch: 'new-title'
+      newBranch: 'new-title',
+      worktreePath: '/repo/wt'
     })
   })
 

--- a/src/main/services/branch-watcher.test.ts
+++ b/src/main/services/branch-watcher.test.ts
@@ -1,0 +1,116 @@
+import { mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const gitEventMocks = vi.hoisted(() => ({
+  emitGitBranchChanged: vi.fn()
+}))
+
+vi.mock('./git-events', () => ({
+  emitGitBranchChanged: gitEventMocks.emitGitBranchChanged
+}))
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+import { cleanupBranchWatchers, watchBranch } from './branch-watcher'
+
+// Git updates HEAD the same way on every symref change: write HEAD.lock, then
+// rename it over HEAD (atomic replace). This swaps the inode, which is exactly
+// what made a direct file watch go permanently stale on macOS.
+const rewriteHeadLikeGit = (gitDir: string, content: string): void => {
+  const lockPath = join(gitDir, 'HEAD.lock')
+  writeFileSync(lockPath, content)
+  renameSync(lockPath, join(gitDir, 'HEAD'))
+}
+
+describe('branch watcher', () => {
+  let worktreePath: string
+  let gitDir: string
+
+  beforeEach(() => {
+    gitEventMocks.emitGitBranchChanged.mockClear()
+    worktreePath = mkdtempSync(join(tmpdir(), 'hive-branch-watcher-'))
+    gitDir = join(worktreePath, '.git')
+    mkdirSync(gitDir)
+    writeFileSync(join(gitDir, 'HEAD'), 'ref: refs/heads/main\n')
+  })
+
+  afterEach(async () => {
+    await cleanupBranchWatchers()
+    rmSync(worktreePath, { recursive: true, force: true })
+  })
+
+  it('emits branch changed for repeated atomic HEAD rewrites', { timeout: 15000 }, async () => {
+    await watchBranch(worktreePath)
+    // Give chokidar's initial scan a moment to settle before mutating
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    rewriteHeadLikeGit(gitDir, 'ref: refs/heads/renamed-once\n')
+    await vi.waitFor(
+      () =>
+        expect(gitEventMocks.emitGitBranchChanged).toHaveBeenCalledWith({
+          worktreePath
+        }),
+      { timeout: 5000, interval: 50 }
+    )
+
+    // The second rewrite is the regression: a stale file watch on the replaced
+    // inode never fires again, while the directory watch keeps working.
+    gitEventMocks.emitGitBranchChanged.mockClear()
+    rewriteHeadLikeGit(gitDir, 'ref: refs/heads/renamed-twice\n')
+    await vi.waitFor(
+      () =>
+        expect(gitEventMocks.emitGitBranchChanged).toHaveBeenCalledWith({
+          worktreePath
+        }),
+      { timeout: 5000, interval: 50 }
+    )
+  })
+
+  it('ignores changes to other gitdir files', { timeout: 15000 }, async () => {
+    await watchBranch(worktreePath)
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    writeFileSync(join(gitDir, 'index'), 'not-head')
+    writeFileSync(join(gitDir, 'COMMIT_EDITMSG'), 'message')
+    // Wait past the debounce window — nothing should have been emitted
+    await new Promise((resolve) => setTimeout(resolve, 800))
+
+    expect(gitEventMocks.emitGitBranchChanged).not.toHaveBeenCalled()
+  })
+
+  it('resolves linked-worktree gitdir pointers', { timeout: 15000 }, async () => {
+    // Linked worktrees have a .git FILE pointing at the real gitdir
+    const linkedRoot = mkdtempSync(join(tmpdir(), 'hive-linked-wt-'))
+    const realGitDir = join(linkedRoot, 'repo.git', 'worktrees', 'feature')
+    mkdirSync(realGitDir, { recursive: true })
+    writeFileSync(join(realGitDir, 'HEAD'), 'ref: refs/heads/feature\n')
+    const linkedWorktree = join(linkedRoot, 'feature')
+    mkdirSync(linkedWorktree)
+    writeFileSync(join(linkedWorktree, '.git'), `gitdir: ${realGitDir}\n`)
+
+    try {
+      await watchBranch(linkedWorktree)
+      await new Promise((resolve) => setTimeout(resolve, 300))
+
+      rewriteHeadLikeGit(realGitDir, 'ref: refs/heads/feature-renamed\n')
+      await vi.waitFor(
+        () =>
+          expect(gitEventMocks.emitGitBranchChanged).toHaveBeenCalledWith({
+            worktreePath: linkedWorktree
+          }),
+        { timeout: 5000, interval: 50 }
+      )
+    } finally {
+      await cleanupBranchWatchers()
+      rmSync(linkedRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/services/branch-watcher.ts
+++ b/src/main/services/branch-watcher.ts
@@ -25,6 +25,7 @@ const DEBOUNCE_MS = 300
 
 interface PathEntry {
   worktreePath: string
+  gitDir: string
   debounceTimer: ReturnType<typeof setTimeout> | null
   refCount: number
 }
@@ -96,11 +97,18 @@ export async function watchBranch(worktreePath: string): Promise<void> {
     sharedWatcher = chokidar.watch([], {
       persistent: true,
       ignoreInitial: true,
+      // Every path added to this watcher is a gitdir directory; only its direct
+      // children matter (we filter to HEAD below).
+      depth: 0,
       // The native fsevents backend deadlocks during process teardown — never use it
       useFsEvents: false
     })
 
-    sharedWatcher.on('change', (changedPath) => {
+    // Git rewrites HEAD via lockfile-rename (HEAD.lock → rename over HEAD). A watch
+    // on the HEAD file itself goes permanently stale on macOS once the inode is
+    // replaced, so we watch the gitdir directory instead and filter events down to
+    // HEAD. The rename can surface as change OR unlink+add — handle all three.
+    const handleEvent = (changedPath: string): void => {
       const entry = watchedPaths.get(changedPath)
       if (!entry) return
 
@@ -109,7 +117,11 @@ export async function watchBranch(worktreePath: string): Promise<void> {
         entry.debounceTimer = null
         emitBranchChanged(entry.worktreePath)
       }, DEBOUNCE_MS)
-    })
+    }
+
+    sharedWatcher.on('change', handleEvent)
+    sharedWatcher.on('add', handleEvent)
+    sharedWatcher.on('unlink', handleEvent)
 
     sharedWatcher.on('error', (error) => {
       log.error('Branch watcher error', error)
@@ -118,9 +130,9 @@ export async function watchBranch(worktreePath: string): Promise<void> {
     log.info('Shared branch watcher created')
   }
 
-  // Add this HEAD path to the shared watcher
-  sharedWatcher.add(headPath)
-  watchedPaths.set(headPath, { worktreePath, debounceTimer: null, refCount: 1 })
+  // Watch the gitdir directory; events are filtered to HEAD via watchedPaths
+  sharedWatcher.add(gitDir)
+  watchedPaths.set(headPath, { worktreePath, gitDir, debounceTimer: null, refCount: 1 })
   worktreeToHead.set(worktreePath, headPath)
 
   log.info('Branch watcher started', { worktreePath, headPath, totalPaths: watchedPaths.size })
@@ -146,7 +158,7 @@ export async function unwatchBranch(worktreePath: string): Promise<void> {
 
   // Remove path from shared watcher
   if (sharedWatcher) {
-    sharedWatcher.unwatch(headPath)
+    sharedWatcher.unwatch(entry.gitDir)
   }
 
   watchedPaths.delete(headPath)

--- a/src/main/services/claude-cli-title-handler.ts
+++ b/src/main/services/claude-cli-title-handler.ts
@@ -179,7 +179,8 @@ export async function applyClaudeCliTitle({
         if (result.renamed) {
           emitWorktreeBranchRenamed({
             worktreeId: worktree.id,
-            newBranch: result.newBranch
+            newBranch: result.newBranch,
+            worktreePath: worktree.path
           })
         } else if (result.error) {
           log.warn('branch rename failed', { sessionId, error: result.error })
@@ -212,7 +213,8 @@ export async function applyClaudeCliTitle({
         if (result.renamed) {
           emitWorktreeBranchRenamed({
             worktreeId: memberWt.id,
-            newBranch: result.newBranch
+            newBranch: result.newBranch,
+            worktreePath: memberWt.path
           })
         }
       } catch (err) {

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -1797,7 +1797,8 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
           if (result.renamed) {
             this.sendToRenderer(WORKTREE_BRANCH_RENAMED_CHANNEL, {
               worktreeId: worktree.id,
-              newBranch: result.newBranch
+              newBranch: result.newBranch,
+              worktreePath: worktree.path
             })
             log.info('handleTitleGeneration: auto-renamed branch', {
               oldBranch: worktree.branch_name,
@@ -1836,7 +1837,8 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
                 if (result.renamed) {
                   this.sendToRenderer(WORKTREE_BRANCH_RENAMED_CHANNEL, {
                     worktreeId: memberWorktree.id,
-                    newBranch: result.newBranch
+                    newBranch: result.newBranch,
+                    worktreePath: memberWorktree.path
                   })
                   log.info('handleTitleGeneration: auto-renamed connection member', {
                     connectionId: dbSession.connection_id,

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -3731,7 +3731,8 @@ export class CodexImplementer implements AgentSdkImplementer {
         if (result.renamed) {
           this.sendToRenderer(WORKTREE_BRANCH_RENAMED_CHANNEL, {
             worktreeId: worktree.id,
-            newBranch: result.newBranch
+            newBranch: result.newBranch,
+            worktreePath: worktree.path
           })
           log.info('applyGeneratedTitle: auto-renamed branch', {
             oldBranch: worktree.branch_name,
@@ -3768,7 +3769,8 @@ export class CodexImplementer implements AgentSdkImplementer {
         if (result.renamed) {
           this.sendToRenderer(WORKTREE_BRANCH_RENAMED_CHANNEL, {
             worktreeId: memberWorktree.id,
-            newBranch: result.newBranch
+            newBranch: result.newBranch,
+            worktreePath: memberWorktree.path
           })
           log.info('applyGeneratedTitle: auto-renamed connection member', {
             connectionId: dbSession.connection_id,

--- a/src/main/services/opencode-service.ts
+++ b/src/main/services/opencode-service.ts
@@ -1275,7 +1275,8 @@ class OpenCodeService {
               if (result.renamed) {
                 this.sendToRenderer(WORKTREE_BRANCH_RENAMED_CHANNEL, {
                   worktreeId: worktree.id,
-                  newBranch: result.newBranch
+                  newBranch: result.newBranch,
+                  worktreePath: worktree.path
                 })
                 log.info('Auto-renamed branch from session title', {
                   worktreeId: worktree.id,
@@ -1317,7 +1318,8 @@ class OpenCodeService {
                     if (result.renamed) {
                       this.sendToRenderer(WORKTREE_BRANCH_RENAMED_CHANNEL, {
                         worktreeId: memberWorktree.id,
-                        newBranch: result.newBranch
+                        newBranch: result.newBranch,
+                        worktreePath: memberWorktree.path
                       })
                       log.info('Auto-renamed connection member branch', {
                         connectionId: session.connection_id,

--- a/src/main/services/worktree-events.test.ts
+++ b/src/main/services/worktree-events.test.ts
@@ -9,32 +9,60 @@ vi.mock('../desktop/backend-event-publisher', () => ({
   publishDesktopBackendEvent: mocks.publishDesktopBackendEvent
 }))
 
-import { emitWorktreeBranchRenamed } from './worktree-events'
+import { emitWorktreeBranchRenamed, setWorktreeEventPublisher } from './worktree-events'
 
 describe('worktree events', () => {
   beforeEach(() => {
     mocks.publishDesktopBackendEvent.mockClear()
+    setWorktreeEventPublisher(null)
   })
 
-  it('publishes worktree branch renamed events without IPC mirroring', () => {
-    const payload = { worktreeId: 'worktree-1', newBranch: 'feature-renamed' }
+  it('publishes worktree branch renamed events through the backend event bus', async () => {
+    const payload = {
+      worktreeId: 'worktree-1',
+      newBranch: 'feature-renamed',
+      worktreePath: '/tmp/hive/worktree-1'
+    }
 
     emitWorktreeBranchRenamed(payload)
 
-    expect(mocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
-      WORKTREE_BRANCH_RENAMED_CHANNEL,
-      payload
+    await vi.waitFor(() =>
+      expect(mocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        WORKTREE_BRANCH_RENAMED_CHANNEL,
+        payload
+      )
     )
   })
 
-  it('publishes worktree branch renamed events without a window dependency', () => {
-    const payload = { worktreeId: 'worktree-1', newBranch: 'feature-renamed' }
+  it('publishes worktree branch renamed events through an injected server publisher', () => {
+    const payload = {
+      worktreeId: 'worktree-1',
+      newBranch: 'feature-renamed',
+      worktreePath: '/tmp/hive/worktree-1'
+    }
+    const publisher = vi.fn()
+    setWorktreeEventPublisher(publisher)
 
     emitWorktreeBranchRenamed(payload)
 
-    expect(mocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
-      WORKTREE_BRANCH_RENAMED_CHANNEL,
-      payload
+    expect(publisher).toHaveBeenCalledWith(WORKTREE_BRANCH_RENAMED_CHANNEL, payload)
+    expect(mocks.publishDesktopBackendEvent).not.toHaveBeenCalled()
+  })
+
+  it('publishes worktree branch renamed events without a window dependency', async () => {
+    const payload = {
+      worktreeId: 'worktree-1',
+      newBranch: 'feature-renamed',
+      worktreePath: '/tmp/hive/worktree-1'
+    }
+
+    emitWorktreeBranchRenamed(payload)
+
+    await vi.waitFor(() =>
+      expect(mocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        WORKTREE_BRANCH_RENAMED_CHANNEL,
+        payload
+      )
     )
   })
 })

--- a/src/main/services/worktree-events.ts
+++ b/src/main/services/worktree-events.ts
@@ -2,8 +2,26 @@ import {
   WORKTREE_BRANCH_RENAMED_CHANNEL,
   type WorktreeBranchRenamedEvent
 } from '../../shared/worktree-events'
-import { publishDesktopBackendEvent } from '../desktop/backend-event-publisher'
+
+type WorktreeEventPublisher = (channel: string, payload: unknown) => void | Promise<void>
+
+let worktreeEventPublisher: WorktreeEventPublisher | null = null
+
+export const setWorktreeEventPublisher = (publisher: WorktreeEventPublisher | null): void => {
+  worktreeEventPublisher = publisher
+}
+
+const publishWorktreeEvent = (channel: string, payload: unknown): void => {
+  if (worktreeEventPublisher) {
+    void Promise.resolve(worktreeEventPublisher(channel, payload))
+    return
+  }
+
+  void import('../desktop/backend-event-publisher').then(({ publishDesktopBackendEvent }) =>
+    publishDesktopBackendEvent(channel, payload)
+  )
+}
 
 export const emitWorktreeBranchRenamed = (payload: WorktreeBranchRenamedEvent): void => {
-  void publishDesktopBackendEvent(WORKTREE_BRANCH_RENAMED_CHANNEL, payload)
+  publishWorktreeEvent(WORKTREE_BRANCH_RENAMED_CHANNEL, payload)
 }

--- a/src/main/services/worktree-ops.ts
+++ b/src/main/services/worktree-ops.ts
@@ -10,11 +10,13 @@ import { makeDbService } from '../effect/db/layers'
 import { getRuntime as getDbRuntime } from '../effect/db/runtime'
 import { Db } from '../effect/db/service'
 import { type BreedType } from './breed-names'
+import { emitGitBranchChanged } from './git-events'
 import { createGitService, isAutoNamedBranch } from './git-service'
 import { createLogger } from './logger'
 import { normalizeWorktreePath } from './path-utils'
 import { assignPort, releasePort } from './port-registry'
 import { scriptRunner } from './script-runner'
+import { emitWorktreeBranchRenamed } from './worktree-events'
 
 const log = createLogger({ component: 'WorktreeOps' })
 
@@ -488,6 +490,13 @@ export const renameWorktreeBranchOpEffect = (
           ? { name: getImportedWorktreeName(params.newBranch, params.worktreePath) }
           : {})
       })
+
+      emitWorktreeBranchRenamed({
+        worktreeId: params.worktreeId,
+        newBranch: params.newBranch,
+        worktreePath: params.worktreePath
+      })
+      emitGitBranchChanged({ worktreePath: params.worktreePath })
     }),
     'renameWorktreeBranchOp'
   )

--- a/src/main/services/worktree-watcher.test.ts
+++ b/src/main/services/worktree-watcher.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { GIT_STATUS_CHANGED_CHANNEL } from '../../shared/git-events'
 
@@ -58,5 +61,49 @@ describe('worktree watcher', () => {
       worktreePath: '/tmp/hive'
     })
     expect(gitEventMocks.emitGitStatusChanged).not.toHaveBeenCalled()
+  })
+
+  it('watches MERGE_HEAD even when it does not exist at watch start', async () => {
+    // Two chokidar watchers are created (git metadata + working tree) — capture
+    // each instance's paths and handlers separately.
+    const instances: Array<{ paths: unknown; handlers: Map<string, (path: string) => void> }> = []
+    chokidarMocks.watch.mockImplementation((paths: unknown) => {
+      const handlers = new Map<string, (path: string) => void>()
+      instances.push({ paths, handlers })
+      return {
+        on: vi.fn((event: string, handler: (path: string) => void) => {
+          handlers.set(event, handler)
+        }),
+        close: vi.fn().mockResolvedValue(undefined)
+      }
+    })
+
+    const worktreePath = mkdtempSync(join(tmpdir(), 'hive-watcher-'))
+    const gitDir = join(worktreePath, '.git')
+    mkdirSync(gitDir)
+    writeFileSync(join(gitDir, 'HEAD'), 'ref: refs/heads/main\n')
+
+    try {
+      const publishGitEvent = vi.fn()
+      await watchWorktree(worktreePath, { publishGitEvent })
+
+      // First watcher instance is the git metadata watcher
+      const gitWatcherPaths = instances[0].paths as string[]
+      const mergeHeadPath = join(gitDir, 'MERGE_HEAD')
+      expect(gitWatcherPaths).toContain(mergeHeadPath)
+      expect(gitWatcherPaths).toContain(join(gitDir, 'REBASE_HEAD'))
+      expect(gitWatcherPaths).toContain(join(gitDir, 'CHERRY_PICK_HEAD'))
+
+      // A merge starting later surfaces as an 'add' for MERGE_HEAD
+      instances[0].handlers.get('add')?.(mergeHeadPath)
+      await vi.advanceTimersByTimeAsync(300)
+
+      expect(publishGitEvent).toHaveBeenCalledWith(GIT_STATUS_CHANGED_CHANNEL, {
+        worktreePath
+      })
+    } finally {
+      await cleanupWorktreeWatchers()
+      rmSync(worktreePath, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/services/worktree-watcher.ts
+++ b/src/main/services/worktree-watcher.ts
@@ -192,12 +192,12 @@ export async function watchWorktree(
       gitPaths.push(refsPath)
     }
 
-    // Optionally watch MERGE_HEAD, REBASE_HEAD (in worktree gitdir)
+    // Watch MERGE_HEAD, REBASE_HEAD, CHERRY_PICK_HEAD (in worktree gitdir).
+    // These rarely exist when the watcher starts — chokidar watches the
+    // not-yet-existing path via the gitdir and emits 'add' when a merge/rebase
+    // begins and 'unlink' when it ends, so in-progress states reflect live.
     for (const specialFile of ['MERGE_HEAD', 'REBASE_HEAD', 'CHERRY_PICK_HEAD']) {
-      const path = join(gitDir, specialFile)
-      if (existsSync(path)) {
-        gitPaths.push(path)
-      }
+      gitPaths.push(join(gitDir, specialFile))
     }
 
     if (gitPaths.length > 0) {

--- a/src/renderer/src/api/__tests__/worktree-api.test.ts
+++ b/src/renderer/src/api/__tests__/worktree-api.test.ts
@@ -252,7 +252,11 @@ describe('worktreeApi', () => {
 
     listener?.({
       channel: WORKTREE_BRANCH_RENAMED_CHANNEL,
-      payload: { worktreeId: 'worktree-1', newBranch: 'feature-renamed' }
+      payload: {
+        worktreeId: 'worktree-1',
+        newBranch: 'feature-renamed',
+        worktreePath: '/tmp/worktree-1'
+      }
     })
     listener?.({
       channel: WORKTREE_BRANCH_RENAMED_CHANNEL,
@@ -262,7 +266,8 @@ describe('worktreeApi', () => {
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith({
       worktreeId: 'worktree-1',
-      newBranch: 'feature-renamed'
+      newBranch: 'feature-renamed',
+      worktreePath: '/tmp/worktree-1'
     })
   })
 

--- a/src/renderer/src/api/worktree-api.ts
+++ b/src/renderer/src/api/worktree-api.ts
@@ -107,7 +107,9 @@ const isWorktreeBranchRenamedEvent = (payload: unknown): payload is WorktreeBran
   'worktreeId' in payload &&
   typeof payload.worktreeId === 'string' &&
   'newBranch' in payload &&
-  typeof payload.newBranch === 'string'
+  typeof payload.newBranch === 'string' &&
+  'worktreePath' in payload &&
+  typeof payload.worktreePath === 'string'
 
 const isWorktreeRow = (payload: unknown): payload is WorktreeRow =>
   !!payload &&

--- a/src/renderer/src/components/git/GitPushPull.tsx
+++ b/src/renderer/src/components/git/GitPushPull.tsx
@@ -303,7 +303,16 @@ export function GitPushPull({
         // Re-check if the merged branch is now up-to-date
         setMergedCheckVersion((v) => v + 1)
       } else {
-        toast.error('Merge failed', { description: result.error })
+        if (result.conflicts && result.conflicts.length > 0) {
+          toast.error(
+            `Merge has ${result.conflicts.length} conflict${result.conflicts.length === 1 ? '' : 's'}`,
+            { description: 'Resolve conflicts, then commit' }
+          )
+        } else {
+          toast.error('Merge failed', { description: result.error })
+        }
+        // A failed merge can leave conflicts or a dirty tree — show it immediately
+        await refreshStatuses(worktreePath)
       }
     } finally {
       setIsMerging(false)

--- a/src/renderer/src/components/worktrees/WorktreeList.tsx
+++ b/src/renderer/src/components/worktrees/WorktreeList.tsx
@@ -42,7 +42,11 @@ export function WorktreeList({ project }: WorktreeListProps): React.JSX.Element 
 
   // Watch all worktree paths for branch changes (lightweight HEAD-only watchers)
   const worktreePaths = useMemo(() => worktrees.map((w) => w.path), [worktrees])
-  useSidebarBranchWatcher(worktreePaths)
+  const watcherProject = useMemo(
+    () => ({ projectId: project.id, projectPath: project.path }),
+    [project.id, project.path]
+  )
+  useSidebarBranchWatcher(worktreePaths, watcherProject)
 
   // Drag state
   const [draggedWorktreeId, setDraggedWorktreeId] = useState<string | null>(null)

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useSessionStore } from '@/stores/useSessionStore'
 import type { CodexThreadGoal } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useGitStore } from '@/stores/useGitStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useQuestionStore } from '@/stores/useQuestionStore'
@@ -229,8 +230,13 @@ export function useOpenCodeGlobalListener(): void {
   // Listen for branch auto-rename events from the main process
   useEffect(() => {
     const unsubscribe = worktreeApi.onBranchRenamed((data) => {
-      const { worktreeId, newBranch } = data
+      const { worktreeId, newBranch, worktreePath } = data
       useWorktreeStore.getState().updateWorktreeBranch(worktreeId, newBranch)
+      // The displayed name prefers the live branch info from the git store —
+      // refresh it so the rename shows without waiting for a watcher event.
+      if (worktreePath) {
+        void useGitStore.getState().loadBranchInfo(worktreePath, { force: true })
+      }
     })
 
     return unsubscribe

--- a/src/renderer/src/hooks/useSidebarBranchWatcher.ts
+++ b/src/renderer/src/hooks/useSidebarBranchWatcher.ts
@@ -1,6 +1,12 @@
 import { useEffect, useRef } from 'react'
 import { useGitStore } from '@/stores/useGitStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { gitApi } from '@/api/git-api'
+
+interface SidebarBranchWatcherProject {
+  readonly projectId: string
+  readonly projectPath: string
+}
 
 /**
  * Watches .git/HEAD for all provided worktree paths to keep sidebar
@@ -11,10 +17,14 @@ import { gitApi } from '@/api/git-api'
  *
  * Lifecycle:
  * - On mount / path change: starts watchers + loads initial branch info
- * - On git:branchChanged event: refreshes branch info for matching path
+ * - On git:branchChanged event: refreshes branch info for matching path,
+ *   and reconciles the DB record when the branch was renamed externally
  * - On unmount / path removal: stops watchers
  */
-export function useSidebarBranchWatcher(worktreePaths: string[]): void {
+export function useSidebarBranchWatcher(
+  worktreePaths: string[],
+  project?: SidebarBranchWatcherProject
+): void {
   const previousPathsRef = useRef<string[]>([])
 
   // Stable key for change detection
@@ -69,16 +79,36 @@ export function useSidebarBranchWatcher(worktreePaths: string[]): void {
 
     const unsubscribe = gitApi.onBranchChanged((event) => {
       const currentPaths = previousPathsRef.current
-      if (currentPaths.includes(event.worktreePath)) {
-        useGitStore.getState().loadBranchInfo(event.worktreePath, { force: true })
-      }
+      if (!currentPaths.includes(event.worktreePath)) return
+
+      void useGitStore
+        .getState()
+        .loadBranchInfo(event.worktreePath, { force: true })
+        ?.then(() => {
+          // If the branch was renamed externally (terminal), the DB record still
+          // holds the old name — flows like merge-on-done and PR creation read it.
+          // syncWorktrees reuses the existing external-rename reconciliation in
+          // syncWorktreesOpEffect and reloads the worktree store afterward.
+          if (!project) return
+          const liveBranch = useGitStore.getState().branchInfoByWorktree.get(event.worktreePath)
+          // 'HEAD' means detached (mid-rebase etc.) — not a rename, skip
+          if (!liveBranch || liveBranch.name === 'HEAD') return
+          const worktreeStore = useWorktreeStore.getState()
+          const worktrees = worktreeStore.worktreesByProject.get(project.projectId) ?? []
+          const worktree = worktrees.find((w) => w.path === event.worktreePath)
+          if (worktree && worktree.branch_name !== liveBranch.name) {
+            void worktreeStore.syncWorktrees(project.projectId, project.projectPath, {
+              force: true
+            })
+          }
+        })
     })
 
     return () => {
       unsubscribe()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pathsKey])
+  }, [pathsKey, project?.projectId, project?.projectPath])
 
   // Cleanup all watchers on unmount
   useEffect(() => {

--- a/src/server/rpc/domains/git-ops.merge.test.ts
+++ b/src/server/rpc/domains/git-ops.merge.test.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Effect } from 'effect'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../main/services/telemetry-service', () => ({
+  telemetryService: { track: vi.fn() }
+}))
+
+import { makeLiveGitOpsRpcService } from './git-ops'
+
+const git = (cwd: string, ...args: string[]): string =>
+  execFileSync('git', args, { cwd, encoding: 'utf8' })
+
+describe('gitOps merge conflict extraction', () => {
+  let repoPath: string
+  const service = makeLiveGitOpsRpcService()
+
+  beforeAll(() => {
+    repoPath = mkdtempSync(join(tmpdir(), 'hive-merge-test-'))
+    git(repoPath, 'init', '-b', 'main')
+    git(repoPath, 'config', 'user.email', 'test@test.local')
+    git(repoPath, 'config', 'user.name', 'Test')
+    git(repoPath, 'config', 'commit.gpgsign', 'false')
+
+    writeFileSync(join(repoPath, 'shared.txt'), 'base\n')
+    git(repoPath, 'add', '.')
+    git(repoPath, 'commit', '-m', 'base')
+
+    git(repoPath, 'checkout', '-b', 'feature')
+    writeFileSync(join(repoPath, 'shared.txt'), 'feature change\n')
+    git(repoPath, 'commit', '-am', 'feature change')
+
+    git(repoPath, 'checkout', 'main')
+    writeFileSync(join(repoPath, 'shared.txt'), 'main change\n')
+    git(repoPath, 'commit', '-am', 'main change')
+  })
+
+  afterAll(() => {
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('returns conflicted files when the merge has conflicts', async () => {
+    const result = await Effect.runPromise(
+      service.merge(repoPath, 'feature').pipe(Effect.orDie)
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.conflicts).toEqual(['shared.txt'])
+
+    git(repoPath, 'merge', '--abort')
+  })
+
+  it('returns a plain error without conflicts for non-conflict failures', async () => {
+    const result = await Effect.runPromise(
+      service.merge(repoPath, 'no-such-branch').pipe(Effect.orDie)
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.conflicts).toBeUndefined()
+    expect(result.error).toBeTruthy()
+  })
+
+  it('returns success on a clean merge', async () => {
+    git(repoPath, 'checkout', '-b', 'clean-feature')
+    writeFileSync(join(repoPath, 'other.txt'), 'no conflict\n')
+    git(repoPath, 'add', '.')
+    git(repoPath, 'commit', '-m', 'clean change')
+    git(repoPath, 'checkout', 'main')
+
+    const result = await Effect.runPromise(
+      service.merge(repoPath, 'clean-feature').pipe(Effect.orDie)
+    )
+
+    expect(result).toEqual({ success: true })
+  })
+})

--- a/src/server/rpc/domains/git-ops.ts
+++ b/src/server/rpc/domains/git-ops.ts
@@ -15,7 +15,7 @@ import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
 import { promisify } from 'node:util'
 import { Effect } from 'effect'
-import simpleGit from 'simple-git'
+import simpleGit, { GitResponseError, type MergeResult } from 'simple-git'
 import { z } from 'zod'
 import { isDesktopCommandResult, makeDesktopCommandRequest } from '@shared/desktop-command'
 import { GIT_STATUS_CHANGED_CHANNEL } from '@shared/git-events'
@@ -924,10 +924,26 @@ export const makeLiveGitOpsRpcService = (
             await simpleGit(worktreePath).merge([sourceBranch])
             return { success: true }
           } catch (error) {
-            return {
-              success: false,
-              error: error instanceof Error ? error.message : String(error)
+            const message = error instanceof Error ? error.message : String(error)
+            if (error instanceof GitResponseError) {
+              const summary = error.git as MergeResult | undefined
+              const conflicts = (summary?.conflicts ?? [])
+                .map((conflict) => conflict.file)
+                .filter((file): file is string => typeof file === 'string' && file.length > 0)
+              if (conflicts.length > 0) {
+                return { success: false, error: message, conflicts }
+              }
             }
+            // Fallback: conflict entries without parseable file names
+            try {
+              const status = await simpleGit(worktreePath).status()
+              if (status.conflicted.length > 0) {
+                return { success: false, error: message, conflicts: status.conflicted }
+              }
+            } catch {
+              // Status check is best-effort — fall through to the plain error
+            }
+            return { success: false, error: message }
           }
         },
         catch: (cause) => cause

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,6 +11,7 @@ import { resolveStaticFile, serveStaticFile } from './static'
 import { isDesktopBackendEventMessage } from '../shared/desktop-command'
 import { cleanupBranchWatchers } from '../main/services/branch-watcher'
 import { setGitEventPublisher } from '../main/services/git-events'
+import { setWorktreeEventPublisher } from '../main/services/worktree-events'
 import { cleanupWorktreeWatchers } from '../main/services/worktree-watcher'
 import { getDatabase } from '../main/db'
 
@@ -49,6 +50,14 @@ export const startHiveServer = (
     process.on('message', desktopBackendEventForwarder)
 
     setGitEventPublisher((channel, payload) =>
+      Effect.runPromise(
+        eventBus.publish({
+          channel,
+          payload
+        })
+      )
+    )
+    setWorktreeEventPublisher((channel, payload) =>
       Effect.runPromise(
         eventBus.publish({
           channel,
@@ -233,6 +242,7 @@ export const startHiveServer = (
                   .then(({ discordService }) => discordService.stopListening())
                   .catch(() => undefined)
                 setGitEventPublisher(null)
+                setWorktreeEventPublisher(null)
                 if (desktopBackendEventForwarder) {
                   process.off('message', desktopBackendEventForwarder)
                   desktopBackendEventForwarder = null

--- a/src/shared/worktree-events.ts
+++ b/src/shared/worktree-events.ts
@@ -6,6 +6,7 @@ export const WORKTREE_CREATED_CHANNEL = 'worktree:created'
 export interface WorktreeBranchRenamedEvent {
   readonly worktreeId: string
   readonly newBranch: string
+  readonly worktreePath: string
 }
 
 export interface WorktreeCreatedEvent {

--- a/test/claude-code-title-integration.test.ts
+++ b/test/claude-code-title-integration.test.ts
@@ -162,7 +162,8 @@ describe('handleTitleGeneration', () => {
     })
     expect(mockEmitWorktreeBranchRenamed).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
-      newBranch: 'fix-auth-refresh'
+      newBranch: 'fix-auth-refresh',
+      worktreePath: '/path/to/worktree'
     })
   })
 
@@ -246,7 +247,8 @@ describe('handleTitleGeneration', () => {
     expect(mockAutoRenameWorktreeBranch).toHaveBeenCalled()
     expect(mockEmitWorktreeBranchRenamed).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
-      newBranch: 'fix-auth-refresh-2'
+      newBranch: 'fix-auth-refresh-2',
+      worktreePath: '/path/to/worktree'
     })
   })
 

--- a/test/codex-session-title-integration.test.ts
+++ b/test/codex-session-title-integration.test.ts
@@ -151,7 +151,8 @@ describe('Codex title integration', () => {
     )
     expect(mockEmitWorktreeBranchRenamed).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
-      newBranch: 'fix-auth-refresh'
+      newBranch: 'fix-auth-refresh',
+      worktreePath: '/path/to/worktree'
     })
   })
 

--- a/test/phase-12/renderer-api-cleanup.test.ts
+++ b/test/phase-12/renderer-api-cleanup.test.ts
@@ -12563,9 +12563,8 @@ describe('renderer API cleanup', () => {
     expect(effectSource).toContain('const unsubscribe = gitApi.onBranchChanged((event) => {')
     expect(effectSource).toContain('const currentPaths = previousPathsRef.current')
     expect(effectSource).toContain('currentPaths.includes(event.worktreePath)')
-    expect(effectSource).toContain(
-      'useGitStore.getState().loadBranchInfo(event.worktreePath, { force: true })'
-    )
+    expect(effectSource).toContain('useGitStore')
+    expect(effectSource).toContain('.loadBranchInfo(event.worktreePath, { force: true })')
     expect(effectSource).toContain('unsubscribe()')
     expect(effectSource).not.toContain('window.gitOps.onBranchChanged')
   })
@@ -19860,7 +19859,7 @@ describe('renderer API cleanup', () => {
     expect(effectStart).toBeGreaterThan(-1)
     expect(effectEnd).toBeGreaterThan(effectStart)
     expect(source).toContain("import { worktreeApi } from '@/api/worktree-api'")
-    expect(subscriptionSource).toContain('const { worktreeId, newBranch } = data')
+    expect(subscriptionSource).toContain('const { worktreeId, newBranch, worktreePath } = data')
     expect(subscriptionSource).toContain(
       'useWorktreeStore.getState().updateWorktreeBranch(worktreeId, newBranch)'
     )
@@ -19881,8 +19880,9 @@ describe('renderer API cleanup', () => {
     expect(preloadSource).not.toContain("ipcRenderer.removeListener('worktree:branchRenamed'")
     expect(worktreeEventsSource).not.toContain('webContents.send(WORKTREE_BRANCH_RENAMED_CHANNEL')
     expect(worktreeEventsSource).toContain(
-      'publishDesktopBackendEvent(WORKTREE_BRANCH_RENAMED_CHANNEL, payload)'
+      'publishWorktreeEvent(WORKTREE_BRANCH_RENAMED_CHANNEL, payload)'
     )
+    expect(worktreeEventsSource).toContain('publishDesktopBackendEvent(channel, payload)')
   })
 
   it('removes the old empty worktreeOps preload global exposure', () => {

--- a/test/session-7/worktree-ops-effect.test.ts
+++ b/test/session-7/worktree-ops-effect.test.ts
@@ -45,9 +45,23 @@ vi.mock('../../src/main/services/git-service', () => ({
   isAutoNamedBranch: vi.fn(() => false)
 }))
 
+const eventMocks = vi.hoisted(() => ({
+  emitWorktreeBranchRenamed: vi.fn(),
+  emitGitBranchChanged: vi.fn()
+}))
+
+vi.mock('../../src/main/services/worktree-events', () => ({
+  emitWorktreeBranchRenamed: eventMocks.emitWorktreeBranchRenamed
+}))
+
+vi.mock('../../src/main/services/git-events', () => ({
+  emitGitBranchChanged: eventMocks.emitGitBranchChanged
+}))
+
 import {
   createWorktreeOpEffect,
   deleteWorktreeOpEffect,
+  renameWorktreeBranchOpEffect,
   syncWorktreesOpEffect
 } from '../../src/main/services/worktree-ops'
 
@@ -103,6 +117,64 @@ describeIf('Session 7: worktree-ops Effect orchestrators', () => {
     expect(result.success).toBe(true)
     const after = testDb.db.getWorktree(wt.id)
     expect(after?.status).toBe('archived')
+  })
+
+  test('renameWorktreeBranchOpEffect emits rename + branch-changed events on success', async () => {
+    const wt = testDb.db.createWorktree({
+      project_id: projectId,
+      name: 'feature-old',
+      branch_name: 'feature-old',
+      path: '/tmp/feature-old'
+    })
+
+    const result = expectExitSuccess(
+      await run(
+        renameWorktreeBranchOpEffect({
+          worktreeId: wt.id,
+          worktreePath: wt.path,
+          oldBranch: 'feature-old',
+          newBranch: 'feature-new'
+        })
+      )
+    )
+
+    expect(result.success).toBe(true)
+    expect(testDb.db.getWorktree(wt.id)?.branch_name).toBe('feature-new')
+    expect(eventMocks.emitWorktreeBranchRenamed).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      newBranch: 'feature-new',
+      worktreePath: wt.path
+    })
+    expect(eventMocks.emitGitBranchChanged).toHaveBeenCalledWith({ worktreePath: wt.path })
+  })
+
+  test('renameWorktreeBranchOpEffect emits no events when the git rename fails', async () => {
+    const wt = testDb.db.createWorktree({
+      project_id: projectId,
+      name: 'feature-old',
+      branch_name: 'feature-old',
+      path: '/tmp/feature-old'
+    })
+    gitServiceMocks.renameBranch.mockResolvedValueOnce({
+      success: false,
+      error: 'branch exists'
+    } as never)
+
+    const result = expectExitSuccess(
+      await run(
+        renameWorktreeBranchOpEffect({
+          worktreeId: wt.id,
+          worktreePath: wt.path,
+          oldBranch: 'feature-old',
+          newBranch: 'feature-new'
+        })
+      )
+    )
+
+    expect(result.success).toBe(false)
+    expect(testDb.db.getWorktree(wt.id)?.branch_name).toBe('feature-old')
+    expect(eventMocks.emitWorktreeBranchRenamed).not.toHaveBeenCalled()
+    expect(eventMocks.emitGitBranchChanged).not.toHaveBeenCalled()
   })
 
   test('syncWorktreesOpEffect does not import the main checkout as an app worktree', async () => {


### PR DESCRIPTION
## Summary
- Make branch watchers resilient to Git's atomic `HEAD` rewrites by watching the gitdir directory instead of the `HEAD` file directly.
- Propagate `worktreePath` through branch-rename events so renderer and server listeners can refresh the correct worktree state immediately.
- Reconcile external branch renames back into worktree state and force live branch info reloads in the sidebar when needed.
- Improve merge handling to surface conflicted files and refresh status immediately after a failed merge.
- Expand watcher coverage for merge/rebase in-progress files and add tests for the new event flow.

## Testing
- Added/updated Vitest coverage for branch watcher behavior, worktree watcher special-file tracking, worktree event publishing, and merge conflict extraction.
- Updated integration and renderer API tests to assert the new `worktreePath` payload and rename refresh behavior.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem watchers and git/merge RPC paths used by sidebar and worktree sync; behavior changes are intentional but affect real repos and server mode event routing.
> 
> **Overview**
> Fixes **branch rename and HEAD change detection** so the UI and DB stay aligned after Git rewrites `HEAD` (macOS inode issue), auto-renames, and external renames.
> 
> The **branch watcher** now watches the **gitdir** (not `HEAD` directly), handles `change`/`add`/`unlink`, and unwatch uses `gitDir`. **Worktree branch renamed** events require **`worktreePath`** everywhere; the renderer forces **`loadBranchInfo`** on rename and the sidebar watcher can **`syncWorktrees`** when live branch ≠ DB after **`git:branchChanged`**.
> 
> **Worktree rename ops** emit **`worktree:branchRenamed`** and **`git:branchChanged`**; **worktree events** can publish via an injected server bus (like git events). **Worktree watcher** always watches `MERGE_HEAD` / rebase / cherry-pick paths even if missing at start.
> 
> **Merge RPC** returns **`conflicts`** on conflict failures; **GitPushPull** shows conflict toasts and refreshes status after failed merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dd0bcce4e00ba8cd85d69767dd5aa4204699062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->