### PR TITLE
Add goal mode support for Claude CLI handoffs

### DIFF
--- a/src/main/services/discord-session-bridge.ts
+++ b/src/main/services/discord-session-bridge.ts
@@ -9,7 +9,7 @@ import {
   type SharedSelectedModel
 } from '@shared/model-resolution'
 import { APP_SETTINGS_DB_KEY } from '@shared/types/settings'
-import type { AgentSdk } from '@shared/types/agent-sdk'
+import { supportsGoalMode, type AgentSdk } from '@shared/types/agent-sdk'
 import type { DiscordEmissionMode } from '@shared/types/discord'
 import { getDiscordToolEmoji, getToolLabel, isFileChangeTool } from '@shared/tool-label'
 import type { DatabaseService } from '../db/database'
@@ -1121,7 +1121,7 @@ export class DiscordSessionBridge {
     this.discordPending.set(requestId, pending)
     const sent = await target.channel.send({
       content,
-      components: this.buildPlanComponents(requestId, handoff.agentSdk === 'codex')
+      components: this.buildPlanComponents(requestId, supportsGoalMode(handoff.agentSdk))
     })
     this.trackSentMessage(pending, sent, content)
   }

--- a/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
@@ -33,28 +33,38 @@ vi.mock('../sessions/HandoffSplitButton', () => ({
     let goalMode = false
 
     return (
-      <button
-        type="button"
-        data-testid={`${testIdPrefix}-handoff-btn`}
-        disabled={disabled}
-        onContextMenu={(event) => {
-          event.preventDefault()
-          goalMode = true
-        }}
-        onClick={() =>
-          onHandoff(
-            goalMode
-              ? {
-                  agentSdk: 'codex',
-                  model: { providerID: 'codex', modelID: 'gpt-5.5' },
-                  goalMode: true
-                }
-              : { agentSdk: 'claude-code-cli' }
-          )
-        }
-      >
-        Handoff
-      </button>
+      <>
+        <button
+          type="button"
+          data-testid={`${testIdPrefix}-handoff-btn`}
+          disabled={disabled}
+          onContextMenu={(event) => {
+            event.preventDefault()
+            goalMode = true
+          }}
+          onClick={() =>
+            onHandoff(
+              goalMode
+                ? {
+                    agentSdk: 'codex',
+                    model: { providerID: 'codex', modelID: 'gpt-5.5' },
+                    goalMode: true
+                  }
+                : { agentSdk: 'claude-code-cli' }
+            )
+          }
+        >
+          Handoff
+        </button>
+        <button
+          type="button"
+          data-testid={`${testIdPrefix}-handoff-cli-goal-btn`}
+          disabled={disabled}
+          onClick={() => onHandoff({ agentSdk: 'claude-code-cli', goalMode: true })}
+        >
+          Handoff CLI goal
+        </button>
+      </>
     )
   }
 }))
@@ -477,6 +487,30 @@ describe('KanbanTicketModal handoff from Claude CLI plan review', () => {
     expect(createSession).toHaveBeenCalledWith('worktree-1', 'project-1', 'codex', undefined, {
       autoFocus: true,
       modelOverride: { providerID: 'codex', modelID: 'gpt-5.5' }
+    })
+    expect(setPendingMessage).toHaveBeenCalledWith(
+      'handoff-session',
+      '/goal Implement the following plan\nImplement the plan.'
+    )
+    expect(relinkTicketsForHandoff).toHaveBeenCalledWith(sourceSession.id, 'handoff-session', true)
+  })
+
+  it('marks the relinked ticket as goal mode when the Claude CLI plan card hands off to Claude CLI goal mode', async () => {
+    const { createSession, relinkTicketsForHandoff, setPendingMessage } = setupStores()
+    const user = userEvent.setup()
+
+    render(
+      <ClaudeCliSessionPortalProvider>
+        <ClaudeCliSessionView sessionId={sourceSession.id} />
+      </ClaudeCliSessionPortalProvider>
+    )
+
+    await user.click(screen.getByTestId('claude-cli-plan-ready-handoff-cli-goal-btn'))
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledTimes(1))
+    expect(createSession).toHaveBeenCalledWith('worktree-1', 'project-1', 'claude-code-cli', undefined, {
+      autoFocus: true,
+      modelOverride: undefined
     })
     expect(setPendingMessage).toHaveBeenCalledWith(
       'handoff-session',

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -90,6 +90,7 @@ import { useImagePaste } from '@/hooks/useImagePaste'
 import { buildHandoffPrompt, type HandoffSelectionOverride } from '@/lib/handoffSelection'
 import { registerHivePromptHandoff, startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
 import { canonicalizeTicketTitle, extractPlanTitle } from '@shared/types/branch-utils'
+import { supportsGoalMode } from '@shared/types/agent-sdk'
 import type { KanbanTicket, KanbanTicketUpdate, Session, Worktree } from '../../../../main/db/types'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { systemApi } from '@/api/system-api'
@@ -2008,7 +2009,7 @@ function PlanReviewModeContent({
 
       try {
         const sessionId = ticket.current_session_id
-        const handoffGoalMode = override?.goalMode === true && override?.agentSdk === 'codex'
+        const handoffGoalMode = override?.goalMode === true && supportsGoalMode(override?.agentSdk)
         useSessionStore.getState().clearPendingPlan(sessionId)
         useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
         lastSendMode.delete(sessionId)

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -37,6 +37,7 @@ import { gitApi } from '@/api/git-api'
 import { startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
 import type { KanbanTicket, Session } from '../../../../main/db/types'
 import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
+import { supportsGoalMode } from '@shared/types/agent-sdk'
 
 // Stable empty array to avoid referential-inequality loops in Zustand selectors
 const EMPTY_ARRAY: readonly never[] = []
@@ -233,7 +234,7 @@ export function WorktreePickerModal({
   }, [mode, baseAgentSdk, selectedSdk])
 
   const agentSdk = selectedSdk ?? selectedModel?.agentSdk ?? autoResolvedModel?.agentSdk ?? baseAgentSdk
-  const goalAvailable = agentSdk === 'codex' && mode === 'build' && !preAssignOnly
+  const goalAvailable = supportsGoalMode(agentSdk) && mode === 'build' && !preAssignOnly
   const availableSdkButtonCount = availableAgentSdks
     ? [
         availableAgentSdks.opencode,
@@ -318,7 +319,7 @@ export function WorktreePickerModal({
   const handleSdkChange = useCallback((sdk: PickerAgentSdk) => {
     setSelectedSdk(sdk)
     setSelectedModel(null) // reset model — new SDK has different models
-    if (sdk !== 'codex') {
+    if (!supportsGoalMode(sdk)) {
       setGoalMode(false)
       setGoalCriteria('')
     }

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -26,6 +26,7 @@ import { registerHivePromptHandoff } from '@/lib/hive-enterprise-telemetry'
 import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 import { extractPlanTitle } from '@shared/types/branch-utils'
+import { supportsGoalMode } from '@shared/types/agent-sdk'
 import '@xterm/xterm/css/xterm.css'
 import '@/styles/xterm.css'
 
@@ -362,7 +363,7 @@ export function ClaudeCliSessionView({
       useSessionStore.getState().clearPendingPlan(sessionId)
       useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
       lastSendMode.delete(sessionId)
-      const handoffGoalMode = override.goalMode === true && override.agentSdk === 'codex'
+      const handoffGoalMode = override.goalMode === true && supportsGoalMode(override.agentSdk)
 
       const handoffPrompt = buildHandoffPrompt(planContent, {
         ...override,

--- a/src/renderer/src/components/sessions/HandoffSplitButton.tsx
+++ b/src/renderer/src/components/sessions/HandoffSplitButton.tsx
@@ -7,6 +7,7 @@ import {
   type HandoffSelectionOverride
 } from '@/lib/handoffSelection'
 import { cn } from '@/lib/utils'
+import { supportsGoalMode } from '@shared/types/agent-sdk'
 import { HandoffModelPicker } from './HandoffModelPicker'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 
@@ -59,7 +60,7 @@ export function HandoffSplitButton({
   void selectedModelByProvider
   void catalogVersion
   const effective = getEffectiveHandoffSelection({ worktreeId })
-  const isGoalModeActive = goalMode && effective.agentSdk === 'codex'
+  const isGoalModeActive = goalMode && supportsGoalMode(effective.agentSdk)
 
   useEffect(() => {
     let active = true
@@ -75,13 +76,13 @@ export function HandoffSplitButton({
   }, [effective.agentSdk])
 
   useEffect(() => {
-    if (effective.agentSdk !== 'codex') {
+    if (!supportsGoalMode(effective.agentSdk)) {
       setGoalMode(false)
     }
   }, [effective.agentSdk])
 
   const withGoalMode = (override: HandoffSelectionOverride): HandoffSelectionOverride => {
-    const finalGoalMode = override.agentSdk === 'codex' ? isGoalModeActive : false
+    const finalGoalMode = supportsGoalMode(override.agentSdk) ? isGoalModeActive : false
     return { ...override, goalMode: finalGoalMode }
   }
 
@@ -102,7 +103,7 @@ export function HandoffSplitButton({
       onContextMenu={(e) => {
         e.preventDefault()
         if (disabled) return
-        if (effective.agentSdk !== 'codex') return
+        if (!supportsGoalMode(effective.agentSdk)) return
         setGoalMode((current) => !current)
       }}
     >

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -59,6 +59,7 @@ import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useContextStore } from '@/stores/useContextStore'
 import { maybeExtractJsonTitle } from '@shared/title-utils'
 import { canonicalizeTicketTitle, extractPlanTitle } from '@shared/types/branch-utils'
+import { supportsGoalMode } from '@shared/types/agent-sdk'
 import type { TokenInfo, SessionModelRef } from '@/stores/useContextStore'
 import {
   extractTokens,
@@ -5052,7 +5053,7 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
       useSessionStore.getState().clearPendingPlan(sessionId)
       useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
       lastSendMode.delete(sessionId)
-      const handoffGoalMode = override?.goalMode === true && override?.agentSdk === 'codex'
+      const handoffGoalMode = override?.goalMode === true && supportsGoalMode(override?.agentSdk)
 
       // Abort the original backend session so it stops spinning
       if (worktreePath && opencodeSessionId) {

--- a/src/renderer/src/lib/__tests__/handoffSelection.test.ts
+++ b/src/renderer/src/lib/__tests__/handoffSelection.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 })
 
 describe('buildHandoffPrompt', () => {
-  it('prefixes goal mode only for codex handoffs', () => {
+  it('prefixes goal mode only for codex and Claude CLI handoffs', () => {
     const planContent = '1. Build the thing'
     const codexGoal: HandoffSelectionOverride = {
       agentSdk: 'codex',
@@ -28,6 +28,11 @@ describe('buildHandoffPrompt', () => {
       agentSdk: 'codex',
       model,
       goalMode: false
+    }
+    const claudeCliGoal: HandoffSelectionOverride = {
+      agentSdk: 'claude-code-cli',
+      model,
+      goalMode: true
     }
     const claudeGoal: HandoffSelectionOverride = {
       agentSdk: 'claude-code',
@@ -40,6 +45,9 @@ describe('buildHandoffPrompt', () => {
     )
     expect(buildHandoffPrompt(planContent, codexPlain)).toBe(
       'Implement the following plan\n1. Build the thing'
+    )
+    expect(buildHandoffPrompt(planContent, claudeCliGoal)).toBe(
+      '/goal Implement the following plan\n1. Build the thing'
     )
     expect(buildHandoffPrompt(planContent, claudeGoal)).toBe(
       'Implement the following plan\n1. Build the thing'

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -1,5 +1,5 @@
 import { isAgentSdkAvailable, type AvailableAgentSdks } from './agent-sdk-availability'
-import { type AgentSdk, toModelCatalogSdk } from '@shared/types/agent-sdk'
+import { type AgentSdk, supportsGoalMode, toModelCatalogSdk } from '@shared/types/agent-sdk'
 import {
   findModelInfo,
   getFirstModelInfo,
@@ -40,7 +40,7 @@ export function buildHandoffPrompt(
   planContent: string,
   override?: HandoffSelectionOverride
 ): string {
-  const goalPrefix = override?.goalMode && override.agentSdk === 'codex' ? '/goal ' : ''
+  const goalPrefix = override?.goalMode && supportsGoalMode(override.agentSdk) ? '/goal ' : ''
   const superPrefix =
     override?.superPlan && override.agentSdk === 'claude-code-cli' ? SUPER_PLAN_MODE_PREFIX : ''
   return `${superPrefix}${goalPrefix}Implement the following plan\n${planContent}`

--- a/src/shared/types/agent-sdk.ts
+++ b/src/shared/types/agent-sdk.ts
@@ -55,6 +55,11 @@ export function isClaudeFamily(sdk: MaybeSdk): boolean {
   return sdk === 'claude-code' || sdk === 'claude-code-cli'
 }
 
+/** SDKs whose CLI understands the `/goal` prompt prefix (persistent goal mode). */
+export function supportsGoalMode(sdk: MaybeSdk): boolean {
+  return sdk === 'codex' || sdk === 'claude-code-cli'
+}
+
 /**
  * Map an SDK to the one whose model catalog it uses. `claude-code-cli` has no
  * catalog of its own — it shares `claude-code`'s — so model-listing/selection


### PR DESCRIPTION
## Summary
- Introduce `supportsGoalMode()` to centralize which SDKs can use the `/goal` prefix.
- Enable goal-mode handoffs for `claude-code-cli` across session handoff flows, prompt building, and Discord plan components.
- Update worktree and handoff UI logic so goal mode is preserved or cleared based on SDK capability instead of hard-coding Codex only.
- Expand tests to cover Claude CLI goal-mode handoffs and prompt generation.

## Testing
- Added/updated unit tests for `buildHandoffPrompt()` goal-mode prefix handling.
- Added handoff modal coverage for Claude CLI goal-mode relink behavior.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused refactor of handoff/UI gating with added tests; behavior change is enabling goal mode for Claude CLI where Codex already had it, with no auth or data-model changes.
> 
> **Overview**
> Adds **`supportsGoalMode()`** in shared agent-sdk types (`codex` and `claude-code-cli`) and replaces Codex-only checks so **goal mode** (`/goal` prefix, ticket `goal_mode`, UI toggles) applies wherever the target SDK supports it—not only Codex.
> 
> **Handoff and prompts:** `buildHandoffPrompt`, kanban plan review, `SessionView`, `ClaudeCliSessionView`, and `HandoffSplitButton` use the helper for prefixing, context-menu goal toggle, and clearing goal when switching SDK. **Worktree picker** exposes goal options for Claude CLI in build mode and resets goal state when the selected SDK does not support it.
> 
> **Discord:** Plan-ready messages show the **Handoff (goal)** button when the resolved handoff SDK supports goal mode (not only when it is Codex).
> 
> **Tests:** `buildHandoffPrompt` and kanban handoff tests cover Claude CLI goal-mode relink and pending message content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 409f23bd60767fd88b6080774b906b66c81207eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->