### PR TITLE
Fix review prompt delivery for Claude CLI sessions

### DIFF
--- a/src/main/services/terminal-pty-bridge.claude-cli.test.ts
+++ b/src/main/services/terminal-pty-bridge.claude-cli.test.ts
@@ -163,6 +163,7 @@ describe('Claude CLI terminal hook status wiring', () => {
     __resetRuntimeRegistryForTests()
 
     setupDb()
+    mocks.ptyService.has.mockReturnValue(false)
     mocks.getClaudeHookServer.mockResolvedValue({ port: 45678 })
     mocks.buildClaudeCliHookSettings.mockReturnValue('{"hooks":{"mock":true}}')
     mocks.publishDesktopBackendEvent.mockResolvedValue(true)
@@ -206,6 +207,37 @@ describe('Claude CLI terminal hook status wiring', () => {
       'Implement the plan'
     ])
     expect(mocks.publishClaudeCliStatus).not.toHaveBeenCalled()
+  })
+
+  it('injects the pending prompt into an already-running PTY instead of dropping it', async () => {
+    mocks.ptyService.has.mockReturnValue(true)
+
+    const result = await createClaudeCliTerminal('hive-session-1', {
+      pendingPrompt: 'Review the diff'
+    })
+
+    expect(result).toEqual({
+      success: true,
+      cols: 120,
+      rows: 40
+    })
+    expect(mocks.ptyService.write).toHaveBeenCalledWith(
+      'hive-session-1',
+      '\x1b[200~Review the diff\x1b[201~\r'
+    )
+  })
+
+  it('does not write to an already-running PTY when no prompt is pending', async () => {
+    mocks.ptyService.has.mockReturnValue(true)
+
+    const result = await createClaudeCliTerminal('hive-session-1', {})
+
+    expect(result).toEqual({
+      success: true,
+      cols: 120,
+      rows: 40
+    })
+    expect(mocks.ptyService.write).not.toHaveBeenCalled()
   })
 
   it('does not register the old terminal:create IPC handler', () => {

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -9,6 +9,7 @@ import {
 } from './claude-hook-server'
 import { logClaudeBinaryVersion, resolveClaudeBinaryPath } from './claude-binary-resolver'
 import { buildClaudeCliPtySpawn } from './claude-cli-spawner'
+import { writeClaudeCliPrompt } from './claude-cli-pty-prompt'
 import { watchForClaudeSessionId, type ClaudeSessionWatchHandle } from './claude-session-watcher'
 import {
   watchForClaudePlanFollowup,
@@ -277,6 +278,16 @@ export async function createClaudeCliTerminal(
       args: spawn.args,
       env: spawn.env
     })
+    if (alreadyExists && pendingPrompt) {
+      // ptyService.create reused the live PTY, so the spawn args (and the
+      // prompt riding on them) never reached claude. Inject it as a paste so
+      // a racing promptless create call can't strand the prompt.
+      const { delivered } = writeClaudeCliPrompt(sessionId, pendingPrompt)
+      log.info('Claude CLI PTY already exists; injecting pending prompt', {
+        sessionId,
+        delivered
+      })
+    }
     claudeCliSessions.add(sessionId)
     claudeCliWorktreeBasenames.set(sessionId, path.basename(worktreePath))
     if (!pendingPrompt) {

--- a/src/renderer/src/components/git/GitStatusPanel.tsx
+++ b/src/renderer/src/components/git/GitStatusPanel.tsx
@@ -421,15 +421,18 @@ export function GitStatusPanel({
       const branchName = branchInfo?.name || 'unknown'
 
       const sessionStore = useSessionStore.getState()
-      const result = await sessionStore.createSession(selectedWorktreeId, projectId, undefined, resolvedMode)
+      // Queue the prompt atomically with session creation: queuing it after
+      // the updateSessionName roundtrip loses the race against
+      // ClaudeCliSessionView mounting and spawning a promptless PTY.
+      const result = await sessionStore.createSession(selectedWorktreeId, projectId, undefined, resolvedMode, {
+        pendingMessage: 'Fix merge conflicts'
+      })
       if (!result.success || !result.session) {
         toast.error('Failed to create session')
         return
       }
 
       await sessionStore.updateSessionName(result.session.id, `Merge Conflicts — ${branchName}`)
-
-      sessionStore.setPendingMessage(result.session.id, 'Fix merge conflicts')
     } catch (error) {
       console.error('Failed to start conflict resolution:', error)
       toast.error('Failed to start conflict resolution')

--- a/src/renderer/src/hooks/useConflictFixFlow.ts
+++ b/src/renderer/src/hooks/useConflictFixFlow.ts
@@ -70,7 +70,6 @@ export function useConflictFixFlow(worktreeId: string | null): {
   const mergeConflictMode = useSettingsStore((state) => state.mergeConflictMode)
   const createSession = useSessionStore((state) => state.createSession)
   const updateSessionName = useSessionStore((state) => state.updateSessionName)
-  const setPendingMessage = useSessionStore((state) => state.setPendingMessage)
   const setActiveSession = useSessionStore((state) => state.setActiveSession)
   const flow = useWorktreeStatusStore((state) =>
     worktreeId ? state.mergeConflictFlowByWorktree[worktreeId] : undefined
@@ -109,11 +108,15 @@ export function useConflictFixFlow(worktreeId: string | null): {
       const statusStore = useWorktreeStatusStore.getState()
       statusStore.setMergeConflictFlow(worktreeId, { phase: 'starting' })
 
+      // Queue the prompt atomically with session creation: queuing it after
+      // the updateSessionName roundtrip loses the race against
+      // ClaudeCliSessionView mounting and spawning a promptless PTY.
       const { success, session } = await createSession(
         worktreeId,
         currentWorktree.projectId,
         undefined,
-        resolvedMode
+        resolvedMode,
+        { pendingMessage: 'Fix merge conflicts' }
       )
       if (!success || !session) {
         statusStore.setMergeConflictFlow(worktreeId, null)
@@ -124,7 +127,6 @@ export function useConflictFixFlow(worktreeId: string | null): {
       useWorktreeStore.getState().selectWorktree(worktreeId)
       useSessionStore.getState().setActiveWorktree(worktreeId)
       await updateSessionName(session.id, `Merge Conflicts — ${currentWorktree.branchName}`)
-      setPendingMessage(session.id, 'Fix merge conflicts')
       setActiveSession(session.id)
       statusStore.setMergeConflictSession(worktreeId, session.id)
       statusStore.setMergeConflictFlow(worktreeId, {
@@ -133,14 +135,7 @@ export function useConflictFixFlow(worktreeId: string | null): {
         seenBusy: false
       })
     },
-    [
-      createSession,
-      mergeConflictMode,
-      setActiveSession,
-      setPendingMessage,
-      updateSessionName,
-      worktreeId
-    ]
+    [createSession, mergeConflictMode, setActiveSession, updateSessionName, worktreeId]
   )
 
   useEffect(() => {

--- a/src/renderer/src/hooks/useLifecycleActions.ts
+++ b/src/renderer/src/hooks/useLifecycleActions.ts
@@ -6,6 +6,7 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { toast } from '@/lib/toast'
 import { REVIEW_PROMPTS, DEFAULT_REVIEW_PROMPT_TYPE } from '@/constants/reviewPrompts'
+import { resolveSessionCreationSelection } from '@/lib/handoffSelection'
 import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
 import { messageSendTimes, userExplicitSendTimes, lastSendMode } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
@@ -213,6 +214,15 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
       ].join('\n')
 
       const sessionStore = useSessionStore.getState()
+      // Resolve the effective SDK the same way createSession will, so the
+      // prompt is queued atomically with session insertion even when no
+      // review default model is configured. Queuing it later loses the race
+      // against ClaudeCliSessionView mounting and spawning a promptless PTY.
+      const effectiveSelection = resolveSessionCreationSelection({
+        worktreeId,
+        agentSdkOverride: reviewDefaultModel?.agentSdk,
+        modelOverride: reviewDefaultModel
+      })
       const result = await sessionStore.createSession(
         worktreeId,
         projectId,
@@ -221,7 +231,7 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
         {
           autoFocus: false,
           modelOverride: reviewDefaultModel,
-          ...(reviewDefaultModel?.agentSdk === 'claude-code-cli' ? { pendingMessage: prompt } : {})
+          ...(effectiveSelection.agentSdk === 'claude-code-cli' ? { pendingMessage: prompt } : {})
         }
       )
       if (!result.success || !result.session) {
@@ -241,9 +251,6 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
       const sessionId = result.session.id
       const worktreePath = worktree.path
       const agentSdk = result.session.agent_sdk
-      if (agentSdk === 'claude-code-cli') {
-        sessionStore.setPendingMessage(sessionId, prompt)
-      }
       const sessionModel =
         result.session.model_provider_id && result.session.model_id
           ? {
@@ -263,15 +270,23 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
             useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
             bumpWorktreeLastMessage({ worktreeId })
 
-            const cliResult = unwrapEnvelope(
-              await terminalApi.createClaudeCli(sessionId, {
-                pendingPrompt: prompt
-              })
-            )
-            if (!cliResult.success) {
-              sessionStore.setPendingMessage(sessionId, prompt)
-            } else {
-              sessionStore.dequeuePendingMessage(sessionId)
+            // The pending-message queue is the single source of truth for the
+            // prompt: ClaudeCliSessionView dequeues it when its terminal
+            // mounts, so exactly one of the two racing createClaudeCli calls
+            // carries it. Sending `prompt` directly here would let the backend
+            // drop it when the view's promptless call won the PTY spawn.
+            const pendingPrompt = sessionStore.dequeuePendingMessage(sessionId)
+            try {
+              const cliResult = unwrapEnvelope(
+                await terminalApi.createClaudeCli(sessionId, { pendingPrompt })
+              )
+              if (!cliResult.success && pendingPrompt) {
+                sessionStore.requeuePendingMessage(sessionId, pendingPrompt)
+              }
+            } catch {
+              if (pendingPrompt) {
+                sessionStore.requeuePendingMessage(sessionId, pendingPrompt)
+              }
             }
             return
           }


### PR DESCRIPTION
## Summary
- Queue review and conflict-fix prompts at session creation time so they are not lost to the Claude CLI terminal race.
- Update lifecycle and conflict flows to pass the pending message through `createSession` instead of setting it afterward.
- Add backend handling to inject a pending prompt into an already-running PTY when the terminal already exists.
- Expand Claude CLI PTY bridge tests to cover prompt injection and the no-prompt path.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing-sensitive session and terminal startup paths for Claude CLI; incorrect ordering could still duplicate or miss prompts, but scope is limited to prompt delivery UX.
> 
> **Overview**
> Fixes **lost Claude CLI prompts** when review, merge-conflict, and eager lifecycle flows raced the session view’s promptless `createClaudeCli` call.
> 
> **Frontend:** Conflict-fix entry points (`GitStatusPanel`, `useConflictFixFlow`) and code review (`useLifecycleActions`) now pass **`pendingMessage` through `createSession`** instead of calling `setPendingMessage` after `updateSessionName`. Review also uses **`resolveSessionCreationSelection`** so the prompt is queued even when no review default model is set, and the background eager path **dequeues once** and forwards that value to `createClaudeCli` (with requeue on failure) so only one racing caller owns the prompt.
> 
> **Backend:** When **`ptyService` already has a live PTY** and a `pendingPrompt` is supplied, **`writeClaudeCliPrompt`** pastes the text into the terminal because reused PTYs never receive the prompt on spawn argv.
> 
> **Tests:** Claude CLI PTY bridge coverage for prompt injection vs. no write when no prompt is pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 597e60097725f8b2a67b80040faf1dbb6f26eae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->