### PR TITLE
Add auto-pin of base worktree for board prompts

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -57,6 +57,7 @@ import { useCommandApprovalStore } from '@/stores/useCommandApprovalStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
 import { isBlockerSatisfied } from '@/lib/blocker-utils'
+import { autoPinBaseWorktree } from '@/lib/auto-pin'
 import { useGitStore } from '@/stores/useGitStore'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
@@ -88,7 +89,10 @@ import { TicketAttachmentEditor } from './TicketAttachmentEditor'
 import { TicketDiscardChangesDialog } from './TicketDiscardChangesDialog'
 import { useImagePaste } from '@/hooks/useImagePaste'
 import { buildHandoffPrompt, type HandoffSelectionOverride } from '@/lib/handoffSelection'
-import { registerHivePromptHandoff, startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
+import {
+  registerHivePromptHandoff,
+  startHivePromptTelemetry
+} from '@/lib/hive-enterprise-telemetry'
 import { canonicalizeTicketTitle, extractPlanTitle } from '@shared/types/branch-utils'
 import { supportsGoalMode } from '@shared/types/agent-sdk'
 import type { KanbanTicket, KanbanTicketUpdate, Session, Worktree } from '../../../../main/db/types'
@@ -311,8 +315,10 @@ async function sendFollowupToSession(opts: {
   prompt: string
   followUpMode: FollowUpMode
   ticketId: string
+  projectId: string
   attachments?: Attachment[]
 }): Promise<void> {
+  void autoPinBaseWorktree(opts.projectId)
   const result = await findSessionById(opts.sessionId)
   if (!result) {
     console.error(
@@ -1587,7 +1593,10 @@ function EditModeContent({
               variant="outline"
               className="gap-1.5"
               disabled={lifecycleLoading}
-              onClick={() => pinAndActivateSession(() => lifecycle.createCodeReview())}
+              onClick={() => {
+                void autoPinBaseWorktree(ticket.project_id)
+                pinAndActivateSession(() => lifecycle.createCodeReview())
+              }}
             >
               <FileSearch className="h-3.5 w-3.5" />
               Review
@@ -1853,6 +1862,7 @@ function PlanReviewModeContent({
             prompt: feedback,
             followUpMode,
             ticketId: ticket.id,
+            projectId: ticket.project_id,
             attachments
           }).catch((err) => {
             console.error('[KanbanTicketModal] sendFollowupToSession failed:', err)
@@ -1886,6 +1896,7 @@ function PlanReviewModeContent({
         prompt: feedback,
         followUpMode,
         ticketId: ticket.id,
+        projectId: ticket.project_id,
         attachments
       }).catch((err) => {
         console.error('[KanbanTicketModal] sendFollowupToSession failed:', err)
@@ -1948,7 +1959,8 @@ function PlanReviewModeContent({
             pendingBeforeAction.planContent
           ),
           followUpMode: 'build',
-          ticketId: ticket.id
+          ticketId: ticket.id,
+          projectId: ticket.project_id
         }).catch((err) => {
           const reason = err instanceof Error ? err.message : String(err)
           console.error('[KanbanTicketModal] background implement send failed:', err)
@@ -2208,6 +2220,7 @@ function PlanReviewModeContent({
   // in_progress so the kanban board reflects the new work before the modal closes.
   const prepareTicketBuildSession = useCallback(
     (newSessionId: string, goalMode: boolean): void => {
+      void autoPinBaseWorktree(ticket.project_id)
       useKanbanStore
         .getState()
         .updateTicket(ticket.id, ticket.project_id, {
@@ -2966,6 +2979,7 @@ function ReviewModeContent({
         prompt,
         followUpMode: mode,
         ticketId,
+        projectId,
         attachments: currentAttachments
       }).catch((err) => {
         console.error('[KanbanTicketModal] sendFollowupToSession failed:', err)
@@ -3119,7 +3133,10 @@ function ReviewModeContent({
             variant="outline"
             className="gap-1.5"
             disabled={lifecycleLoading}
-            onClick={() => pinAndActivateSession(() => lifecycle.createCodeReview())}
+            onClick={() => {
+              void autoPinBaseWorktree(ticket.project_id)
+              pinAndActivateSession(() => lifecycle.createCodeReview())
+            }}
           >
             <FileSearch className="h-3.5 w-3.5" />
             Review
@@ -3327,6 +3344,7 @@ function ErrorModeContent({
         prompt: followUpText.trim(),
         followUpMode,
         ticketId: ticket.id,
+        projectId: ticket.project_id,
         attachments
       })
 

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -28,6 +28,7 @@ import { CodexFastToggle } from '@/components/sessions/CodexFastToggle'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
+import { autoPinBaseWorktree } from '@/lib/auto-pin'
 import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
 import { toast } from '@/lib/toast'
 import { opencodeApi } from '@/api/opencode-api'
@@ -233,7 +234,8 @@ export function WorktreePickerModal({
     return resolveModelForSdk(baseAgentSdk) ?? null
   }, [mode, baseAgentSdk, selectedSdk])
 
-  const agentSdk = selectedSdk ?? selectedModel?.agentSdk ?? autoResolvedModel?.agentSdk ?? baseAgentSdk
+  const agentSdk =
+    selectedSdk ?? selectedModel?.agentSdk ?? autoResolvedModel?.agentSdk ?? baseAgentSdk
   const goalAvailable = supportsGoalMode(agentSdk) && mode === 'build' && !preAssignOnly
   const availableSdkButtonCount = availableAgentSdks
     ? [
@@ -497,6 +499,8 @@ export function WorktreePickerModal({
           goal_success_criteria: goalMode ? goalCriteria.trim() : null
         })
 
+        void autoPinBaseWorktree(ticket.project_id)
+
         // Trigger usage refresh so the board shows up-to-date usage (debounced in store)
         useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(agentSdk))
 
@@ -682,6 +686,8 @@ export function WorktreePickerModal({
         toast.success('Worktree assigned')
         return
       }
+
+      void autoPinBaseWorktree(projectId)
 
       // Create new worktree if needed
       if (isNewWorktree && project) {

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -120,6 +120,7 @@ export function SettingsGeneral(): React.JSX.Element {
     warnBeforeQuitting,
     boardMode,
     followUpTriggerColumn,
+    autoPinBaseWorktreeOnBoardPrompt,
     vimModeEnabled,
     keepAwakeEnabled,
     mergeConflictMode,
@@ -309,6 +310,36 @@ export function SettingsGeneral(): React.JSX.Element {
             Done
           </button>
         </div>
+      </div>
+
+      {/* Auto-pin project on board prompts */}
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <label className="text-sm font-medium">Auto-pin project on board prompts</label>
+          <p className="text-xs text-muted-foreground">
+            When a board action sends a prompt for a ticket, automatically pin the project's base
+            worktree so its tickets appear on the pinned board.
+          </p>
+        </div>
+        <button
+          role="switch"
+          aria-checked={autoPinBaseWorktreeOnBoardPrompt}
+          onClick={() =>
+            updateSetting('autoPinBaseWorktreeOnBoardPrompt', !autoPinBaseWorktreeOnBoardPrompt)
+          }
+          className={cn(
+            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+            autoPinBaseWorktreeOnBoardPrompt ? 'bg-primary' : 'bg-muted'
+          )}
+          data-testid="auto-pin-base-worktree-toggle"
+        >
+          <span
+            className={cn(
+              'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+              autoPinBaseWorktreeOnBoardPrompt ? 'translate-x-4' : 'translate-x-0'
+            )}
+          />
+        </button>
       </div>
 
       {/* Vim mode */}
@@ -647,11 +678,11 @@ export function SettingsGeneral(): React.JSX.Element {
         </div>
         {availableAgentSdks &&
           (!opencodeAvailable || !claudeAvailable || !claudeCliAvailable || !codexAvailable) && (
-          <p className="text-xs text-muted-foreground/70 italic">
-            Unavailable providers are disabled until their CLI is installed and launchable from
-            Hive.
-          </p>
-        )}
+            <p className="text-xs text-muted-foreground/70 italic">
+              Unavailable providers are disabled until their CLI is installed and launchable from
+              Hive.
+            </p>
+          )}
         {defaultAgentSdk === 'terminal' && (
           <p className="text-xs text-muted-foreground/70 italic">
             Opens a terminal window. Run any AI tool manually (claude, aider, cursor, etc.)

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -15,6 +15,7 @@ import { opencodeApi } from '@/api/opencode-api'
 import { dbApi } from '@/api/db-api'
 import { terminalApi } from '@/api/terminal-api'
 import { startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
+import { autoPinBaseWorktree } from '@/lib/auto-pin'
 
 type AutoLaunchMode = 'build' | 'plan' | 'super-plan'
 
@@ -87,6 +88,8 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
     console.error('Project not found for auto-launch:', ticket.project_id)
     return
   }
+
+  void autoPinBaseWorktree(ticket.project_id)
 
   try {
     // 1. Resolve worktree

--- a/src/renderer/src/lib/auto-pin.ts
+++ b/src/renderer/src/lib/auto-pin.ts
@@ -1,0 +1,30 @@
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { usePinnedStore } from '@/stores/usePinnedStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+/**
+ * When the "auto-pin project on board prompts" setting is enabled, pin the
+ * project's base (is_default) worktree so the project's tickets appear on the
+ * pinned board. Never throws — call fire-and-forget via `void`.
+ */
+export async function autoPinBaseWorktree(projectId: string | null | undefined): Promise<void> {
+  try {
+    if (!projectId) return
+    if (!useSettingsStore.getState().autoPinBaseWorktreeOnBoardPrompt) return
+
+    let base = useWorktreeStore.getState().getDefaultWorktree(projectId)
+    if (!base) {
+      // The project's worktrees may not be loaded yet (e.g. auto-launch firing
+      // from a store subscription shortly after startup)
+      await useWorktreeStore.getState().loadWorktrees(projectId)
+      base = useWorktreeStore.getState().getDefaultWorktree(projectId)
+    }
+    if (!base) return
+
+    const pinned = usePinnedStore.getState()
+    if (pinned.isWorktreePinned(base.id)) return
+    await pinned.pinWorktree(base.id)
+  } catch (err) {
+    console.error('[auto-pin] failed to auto-pin base worktree:', err)
+  }
+}

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -80,6 +80,7 @@ export interface AppSettings {
   mergeConflictMode: MergeConflictMode
   boardMode: 'toggle' | 'sticky-tab'
   followUpTriggerColumn: FollowUpTriggerColumn
+  autoPinBaseWorktreeOnBoardPrompt: boolean
 
   // Editor
   defaultEditor: EditorOption
@@ -196,6 +197,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   mergeConflictMode: 'always-ask',
   boardMode: 'sticky-tab',
   followUpTriggerColumn: 'done',
+  autoPinBaseWorktreeOnBoardPrompt: false,
   defaultEditor: 'vscode',
   customEditorCommand: '',
   defaultTerminal: 'terminal',
@@ -416,6 +418,7 @@ function extractSettings(state: SettingsState): AppSettings {
     mergeConflictMode: state.mergeConflictMode,
     boardMode: state.boardMode,
     followUpTriggerColumn: state.followUpTriggerColumn,
+    autoPinBaseWorktreeOnBoardPrompt: state.autoPinBaseWorktreeOnBoardPrompt,
     defaultEditor: state.defaultEditor,
     customEditorCommand: state.customEditorCommand,
     defaultTerminal: state.defaultTerminal,
@@ -779,6 +782,7 @@ export const useSettingsStore = create<SettingsState>()(
         mergeConflictMode: state.mergeConflictMode,
         boardMode: state.boardMode,
         followUpTriggerColumn: state.followUpTriggerColumn,
+        autoPinBaseWorktreeOnBoardPrompt: state.autoPinBaseWorktreeOnBoardPrompt,
         defaultEditor: state.defaultEditor,
         customEditorCommand: state.customEditorCommand,
         defaultTerminal: state.defaultTerminal,


### PR DESCRIPTION
## Summary
- Add a new settings toggle to automatically pin a project's base worktree when board-driven prompts are sent.
- Introduce `autoPinBaseWorktree` to resolve and pin the default worktree for a project, with safe no-op/error handling.
- Wire auto-pin into kanban prompt flows, worktree selection, and auto-launch so pinned board state stays in sync.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is gated by a new default-off setting and only affects pinned-board UI state via existing pin APIs, with non-throwing fire-and-forget calls.
> 
> **Overview**
> Adds an **opt-in** setting (**Auto-pin project on board prompts**, default off) and a shared **`autoPinBaseWorktree`** helper that pins the project’s default worktree when enabled, so board-driven work shows up on the pinned board without manual pinning.
> 
> **`autoPinBaseWorktree`** no-ops when the setting is off or the worktree is already pinned; it can **`loadWorktrees`** if defaults aren’t loaded yet, and errors are swallowed (intended for fire-and-forget `void` calls).
> 
> The helper is hooked into kanban flows that send or start agent work: ticket modal **followups** (with **`projectId`** passed through), **code review** from edit/review modes, **handoff/supercharge** session prep, **worktree picker** session start (worktree and connection paths), and **auto-launch** when dependencies resolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07501c7f1033f7778d60a35db4f512dc7a47e3ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->