### PR TITLE
Fix clipboard copy on Wayland

### DIFF
--- a/src/renderer/src/components/error/ErrorBoundary.tsx
+++ b/src/renderer/src/components/error/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 import { AlertTriangle, RefreshCw, Bug, Copy, Check } from 'lucide-react'
 import { Button } from '../ui/button'
-import { projectApi } from '@/api/project-api'
+import { copyTextToClipboard } from '@/lib/clipboard'
 
 interface Props {
   children: ReactNode
@@ -65,19 +65,11 @@ Component Stack:
 ${errorInfo?.componentStack || 'No component stack'}
     `.trim()
 
-    try {
-      await navigator.clipboard.writeText(errorText)
+    if (await copyTextToClipboard(errorText)) {
       this.setState({ copied: true })
       setTimeout(() => this.setState({ copied: false }), 2000)
-    } catch {
-      // Fallback to the backend clipboard API if the browser clipboard API is unavailable.
-      try {
-        await projectApi.copyToClipboard(errorText)
-        this.setState({ copied: true })
-        setTimeout(() => this.setState({ copied: false }), 2000)
-      } catch {
-        console.error('Failed to copy error to clipboard')
-      }
+    } else {
+      console.error('Failed to copy error to clipboard')
     }
   }
 

--- a/src/renderer/src/components/pr-review/PrCommentCard.tsx
+++ b/src/renderer/src/components/pr-review/PrCommentCard.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react'
 import { MessageSquare, Copy } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { toast } from '@/lib/toast'
+import { copyTextToClipboard } from '@/lib/clipboard'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -58,8 +59,9 @@ export function PrCommentCard({
   const line = comment.line ?? comment.originalLine ?? '?'
 
   const handleCopyRaw = useCallback(() => {
-    navigator.clipboard.writeText(comment.bodyHTML || comment.body).then(() => {
-      toast.success('Raw comment HTML copied')
+    void copyTextToClipboard(comment.bodyHTML || comment.body).then((ok) => {
+      if (ok) toast.success('Raw comment HTML copied')
+      else toast.error('Failed to copy')
     })
   }, [comment.bodyHTML, comment.body])
 

--- a/src/renderer/src/components/sessions/CodeBlock.tsx
+++ b/src/renderer/src/components/sessions/CodeBlock.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { toast } from '@/lib/toast'
 import Ansi from 'ansi-to-react'
 import { containsAnsi, stripAnsi } from '@/lib/ansi-utils'
+import { copyTextToClipboard } from '@/lib/clipboard'
 
 interface CodeBlockProps {
   code: string
@@ -14,12 +15,11 @@ export const CodeBlock = memo(function CodeBlock({ code, language = 'typescript'
   const [copied, setCopied] = useState(false)
 
   const handleCopy = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(stripAnsi(code))
+    if (await copyTextToClipboard(stripAnsi(code))) {
       setCopied(true)
       toast.success('Code copied to clipboard')
       setTimeout(() => setCopied(false), 2000)
-    } catch {
+    } else {
       toast.error('Failed to copy code')
     }
   }

--- a/src/renderer/src/components/sessions/CopyMessageButton.tsx
+++ b/src/renderer/src/components/sessions/CopyMessageButton.tsx
@@ -2,6 +2,7 @@ import { useState, memo } from 'react'
 import { Copy, Check } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { toast } from '@/lib/toast'
+import { copyTextToClipboard } from '@/lib/clipboard'
 
 interface CopyMessageButtonProps {
   content: string
@@ -13,12 +14,11 @@ export const CopyMessageButton = memo(function CopyMessageButton({ content }: Co
   if (!content.trim()) return null
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(content)
+    if (await copyTextToClipboard(content)) {
       setCopied(true)
       toast.success('Copied to clipboard')
       setTimeout(() => setCopied(false), 2000)
-    } catch {
+    } else {
       toast.error('Failed to copy')
     }
   }

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -54,6 +54,7 @@ import { useVimModeStore } from '@/stores/useVimModeStore'
 import { useHintStore } from '@/stores/useHintStore'
 import { cn, parseColorQuad } from '@/lib/utils'
 import { toast } from '@/lib/toast'
+import { copyTextToClipboard } from '@/lib/clipboard'
 import { assignSessionHints } from '@/lib/hint-utils'
 import { HintBadge } from '@/components/ui/HintBadge'
 import {
@@ -420,8 +421,10 @@ function FileTab({
 }
 
 function copyToClipboard(text: string) {
-  navigator.clipboard.writeText(text)
-  toast.success('Copied to clipboard')
+  void copyTextToClipboard(text).then((ok) => {
+    if (ok) toast.success('Copied to clipboard')
+    else toast.error('Failed to copy')
+  })
 }
 
 interface DiffTabItemProps {

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -91,6 +91,7 @@ import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline, computeTokenDelta } from '@/lib/token-baselines'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
+import { copyTextToClipboard } from '@/lib/clipboard'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
 import {
   recordHivePromptIdleForSession,
@@ -5165,10 +5166,9 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
       return
     }
 
-    try {
-      await navigator.clipboard.writeText(planContent)
+    if (await copyTextToClipboard(planContent)) {
       toast.success('Plan copied to clipboard')
-    } catch {
+    } else {
       toast.error('Failed to copy')
     }
   }, [messages, pendingPlan?.planContent])

--- a/src/renderer/src/components/sessions/ToolCallContextMenu.tsx
+++ b/src/renderer/src/components/sessions/ToolCallContextMenu.tsx
@@ -8,6 +8,7 @@ import {
   ContextMenuItem
 } from '@/components/ui/context-menu'
 import { useSessionStore } from '@/stores/useSessionStore'
+import { copyTextToClipboard } from '@/lib/clipboard'
 import { ToolCallDebugModal } from './ToolCallDebugModal'
 import type { ToolUseInfo } from './ToolCard'
 
@@ -44,10 +45,9 @@ export function ToolCallContextMenu({ children, toolUse }: ToolCallContextMenuPr
       return
     }
 
-    try {
-      await navigator.clipboard.writeText(planContent)
+    if (await copyTextToClipboard(planContent)) {
       toast.success('Plan copied to clipboard')
-    } catch {
+    } else {
       toast.error('Failed to copy')
     }
   }
@@ -88,10 +88,9 @@ export function ToolCallContextMenu({ children, toolUse }: ToolCallContextMenuPr
       return
     }
 
-    try {
-      await navigator.clipboard.writeText(textToCopy)
+    if (await copyTextToClipboard(textToCopy)) {
       toast.success('Copied to clipboard')
-    } catch {
+    } else {
       toast.error('Failed to copy')
     }
   }

--- a/src/renderer/src/components/sessions/ToolCallDebugModal.tsx
+++ b/src/renderer/src/components/sessions/ToolCallDebugModal.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { toast } from '@/lib/toast'
+import { copyTextToClipboard } from '@/lib/clipboard'
 import type { ToolUseInfo, ToolStatus } from './ToolCard'
 
 function statusColor(status: ToolStatus): string {
@@ -35,12 +36,11 @@ function CopyButton({ text, label }: { text: string; label: string }) {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(text)
+    if (await copyTextToClipboard(text)) {
       setCopied(true)
       toast.success(`${label} copied to clipboard`)
       setTimeout(() => setCopied(false), 2000)
-    } catch {
+    } else {
       toast.error('Failed to copy')
     }
   }

--- a/src/renderer/src/components/terminal/backends/XtermBackend.ts
+++ b/src/renderer/src/components/terminal/backends/XtermBackend.ts
@@ -8,6 +8,7 @@ import { DEFAULT_XTERM_FONT_STACK } from './terminal-fonts'
 import { projectApi } from '@/api/project-api'
 import { terminalApi } from '@/api/terminal-api'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
+import { copyTextToClipboard } from '@/lib/clipboard'
 import type { GhosttyTerminalConfig } from '@shared/types/terminal'
 
 /** Default Catppuccin Mocha theme used when no Ghostty config is found */
@@ -211,7 +212,7 @@ export class XtermBackend implements TerminalBackend {
       // Cmd+C — copy if selection, otherwise SIGINT
       if (e.metaKey && e.key === 'c' && !e.shiftKey && e.type === 'keydown') {
         if (terminal.hasSelection()) {
-          navigator.clipboard.writeText(terminal.getSelection())
+          void copyTextToClipboard(terminal.getSelection())
           terminal.clearSelection()
           return false
         }
@@ -221,7 +222,7 @@ export class XtermBackend implements TerminalBackend {
       // Cmd+Shift+C — always copy
       if (e.metaKey && e.shiftKey && e.key === 'C' && e.type === 'keydown') {
         if (terminal.hasSelection()) {
-          navigator.clipboard.writeText(terminal.getSelection())
+          void copyTextToClipboard(terminal.getSelection())
           terminal.clearSelection()
         }
         return false

--- a/src/renderer/src/hooks/useLifecycleActions.ts
+++ b/src/renderer/src/hooks/useLifecycleActions.ts
@@ -5,6 +5,7 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { toast } from '@/lib/toast'
+import { copyTextToClipboard } from '@/lib/clipboard'
 import { REVIEW_PROMPTS, DEFAULT_REVIEW_PROMPT_TYPE } from '@/constants/reviewPrompts'
 import { resolveSessionCreationSelection } from '@/lib/handoffSelection'
 import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
@@ -395,8 +396,10 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
 
   const copyPRUrl = useCallback(() => {
     if (!storeAttachedPR?.url) return
-    navigator.clipboard.writeText(storeAttachedPR.url)
-    toast.success('PR URL copied')
+    void copyTextToClipboard(storeAttachedPR.url).then((ok) => {
+      if (ok) toast.success('PR URL copied')
+      else toast.error('Failed to copy')
+    })
   }, [storeAttachedPR?.url])
 
   const loadPRList = useCallback(async (): Promise<PRListItem[]> => {

--- a/src/renderer/src/lib/clipboard.ts
+++ b/src/renderer/src/lib/clipboard.ts
@@ -1,0 +1,58 @@
+import { projectApi } from '@/api/project-api'
+
+/**
+ * Copy text to the clipboard, robust against environments where the async
+ * Clipboard API (`navigator.clipboard`) is unavailable or silently rejects —
+ * notably some Linux/Wayland and containerized desktop setups.
+ *
+ * Strategy, in order:
+ *  1. `navigator.clipboard.writeText` — works in a secure, focused context.
+ *  2. Electron's main-process clipboard via `projectApi.copyToClipboard` —
+ *     reliable inside the desktop app even when the renderer's Clipboard API
+ *     is blocked. This mirrors the paste path in XtermBackend, which already
+ *     falls back to `projectApi.readFromClipboard` for the same reason.
+ *  3. Legacy `document.execCommand('copy')` — last resort.
+ *
+ * @returns true if any strategy reported success.
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  // 1) Async Clipboard API.
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    // Permission denied / insecure context / not focused — fall through.
+  }
+
+  // 2) Electron main-process clipboard.
+  try {
+    await projectApi.copyToClipboard(text)
+    return true
+  } catch {
+    // RPC unavailable or main-process write failed — fall through.
+  }
+
+  // 3) Legacy execCommand fallback.
+  try {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.setAttribute('readonly', '')
+    textarea.style.position = 'fixed'
+    textarea.style.top = '0'
+    textarea.style.left = '0'
+    textarea.style.opacity = '0'
+    textarea.style.pointerEvents = 'none'
+    document.body.appendChild(textarea)
+    textarea.focus()
+    textarea.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(textarea)
+    if (ok) return true
+  } catch {
+    // Nothing more to try.
+  }
+
+  return false
+}


### PR DESCRIPTION
## Summary
- Added a shared `copyTextToClipboard` helper that retries clipboard writes through the renderer API, Electron main-process clipboard, and a legacy `execCommand` fallback.
- Updated copy actions across error handling, PR comments, session views, tool menus, code blocks, terminal selection, and lifecycle actions to use the shared helper.
- Preserved existing success/error toasts while making copy behavior more reliable in Wayland and other constrained desktop environments.

## Testing
- Not run
- Manual check recommended: copy text from code blocks, session messages, PR URLs, and terminal selections on Wayland
- Manual check recommended: verify copy failures still surface the existing error toast paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Broad but mechanical refactor of copy UX with no auth or data-model changes; main risk is subtle clipboard behavior differences across fallback paths.
> 
> **Overview**
> Introduces a shared **`copyTextToClipboard`** helper that tries the renderer Clipboard API, then Electron **`projectApi.copyToClipboard`**, then **`document.execCommand('copy')`**, returning success/failure so callers can react consistently.
> 
> **Replaces** scattered `navigator.clipboard.writeText` usage across the renderer (error boundary, PR comments, session/code copy UI, tool menus, terminal selection copy, PR URL copy, file path copy in tabs). Several spots now show **error toasts** when copy fails instead of assuming success; terminal copy no longer blocks on the async clipboard API for selections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 181685578f76b7520a083166402d56bab6bb56f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->