### PR TITLE
Handle Claude CLI follow-ups through the terminal

### DIFF
--- a/src/main/services/opencode-session-commands.ts
+++ b/src/main/services/opencode-session-commands.ts
@@ -8,6 +8,7 @@ import { ClaudeCodeImplementer } from './claude-code-implementer'
 import { CodexImplementer } from './codex-implementer'
 import { claudeCliTelegramBridge } from './claude-cli-telegram-bridge'
 import { toError } from './error-utils'
+import { isClaudeCli, isTerminalBacked } from '@shared/types/agent-sdk'
 
 const log = createLogger({ component: 'OpenCodeSessionCommands' })
 type PromptMessage =
@@ -192,9 +193,18 @@ export async function promptOpenCodeSession(
         worktreePath,
         requestedSessionId: opencodeSessionId,
         sdkId,
-        route: sdkId && sdkId !== 'opencode' && sdkId !== 'terminal' ? 'sdk' : 'opencode'
+        route: sdkId && sdkId !== 'opencode' && !isTerminalBacked(sdkId) ? 'sdk' : 'opencode'
       })
-      if (sdkId && sdkId !== 'opencode' && sdkId !== 'terminal') {
+      if (isClaudeCli(sdkId)) {
+        // Terminal-backed Claude: prompts go through the PTY (bracketed paste /
+        // pending-prompt spawn), never the SDK implementer. Routing it there
+        // would corrupt the claude-code implementer's session state.
+        return {
+          success: false,
+          error: 'claude-code-cli sessions receive prompts via the terminal, not the prompt API'
+        }
+      }
+      if (sdkId && sdkId !== 'opencode' && !isTerminalBacked(sdkId)) {
         const impl = sdkManager.getImplementer(toImplementerSdk(sdkId))
         await impl.prompt(worktreePath, opencodeSessionId, promptMessage, model, options)
         telemetryService.track('prompt_sent', { agent_sdk: sdkId })

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -94,7 +94,7 @@ import {
   startHivePromptTelemetry
 } from '@/lib/hive-enterprise-telemetry'
 import { canonicalizeTicketTitle, extractPlanTitle } from '@shared/types/branch-utils'
-import { supportsGoalMode } from '@shared/types/agent-sdk'
+import { isClaudeCli, supportsGoalMode } from '@shared/types/agent-sdk'
 import type { KanbanTicket, KanbanTicketUpdate, Session, Worktree } from '../../../../main/db/types'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { systemApi } from '@/api/system-api'
@@ -336,13 +336,6 @@ async function sendFollowupToSession(opts: {
     throw new Error(`Working path not found for session: ${opts.sessionId}`)
   }
 
-  if (!session.opencode_session_id) {
-    console.error(
-      `[KanbanTicketModal] sendFollowupToSession: opencode_session_id is null — sessionId=${opts.sessionId}`
-    )
-    throw new Error(`No opencode session ID for session: ${opts.sessionId}`)
-  }
-
   // Set session mode so the agent SDK knows we're in plan mode (matches Tab toggle in SessionView).
   // This updates modeBySession, persists to DB, and applies mode-specific default model.
   await useSessionStore.getState().setSessionMode(opts.sessionId, opts.followUpMode)
@@ -386,6 +379,34 @@ async function sendFollowupToSession(opts: {
     modelVariant: model?.variant,
     mode: opts.followUpMode
   })
+
+  if (isClaudeCli(session.agent_sdk)) {
+    // Terminal-backed session: deliver to the live TUI via bracketed paste.
+    // If no terminal is running (app restart, claude exited), respawn it
+    // headlessly — createClaudeCli resumes via --resume <claude_session_id>
+    // and submits the pending prompt.
+    const { delivered } = unwrapEnvelope(
+      await terminalApi.sendClaudeCliPrompt(opts.sessionId, fullPrompt)
+    )
+    if (!delivered) {
+      const result = unwrapEnvelope(
+        await terminalApi.createClaudeCli(opts.sessionId, { pendingPrompt: fullPrompt })
+      )
+      if (!result.success) {
+        throw new Error(result.error ?? 'Failed to start Claude CLI terminal for followup')
+      }
+    }
+    return
+  }
+
+  // claude-code-cli sessions are terminal-backed and have no opencode_session_id,
+  // so this guard only applies after the terminal branch above.
+  if (!session.opencode_session_id) {
+    console.error(
+      `[KanbanTicketModal] sendFollowupToSession: opencode_session_id is null — sessionId=${opts.sessionId}`
+    )
+    throw new Error(`No opencode session ID for session: ${opts.sessionId}`)
+  }
 
   // Ensure the session is loaded in the agent SDK implementer's in-memory map.
   // SessionView does this on mount via initializeSession(), but the kanban


### PR DESCRIPTION
## Summary
- Route terminal-backed Claude CLI sessions away from the prompt API and block unsupported SDK prompt calls.
- Add a Claude CLI-specific follow-up path in the kanban modal that sends prompts to the live terminal session.
- Respawn Claude CLI headlessly with a pending prompt when no terminal session is active.
- Preserve the existing SDK-based follow-up flow for non-terminal-backed agents.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how kanban follow-ups and IPC prompts reach `claude-code-cli` sessions; mis-handling could break follow-ups after restarts, but avoids corrupting SDK session state.
> 
> **Overview**
> Kanban **follow-ups** for **`claude-code-cli`** no longer go through the OpenCode/SDK prompt path. They are sent to the live Claude TUI via **`terminalApi.sendClaudeCliPrompt`**, with **`createClaudeCli`** and a **pending prompt** when no PTY is running (e.g. after restart).
> 
> On the main process, **`promptOpenCodeSession`** treats **`claude-code-cli`** (and other **`isTerminalBacked`** SDKs) as non-SDK routes: Claude CLI prompts are **rejected** with a clear error instead of hitting the **`claude-code`** implementer, which would corrupt in-memory session state. The **`opencode_session_id`** requirement in **`sendFollowupToSession`** now runs **only after** the terminal-backed branch, so CLI sessions without that ID can still receive follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f03fbae7e1175d4c8b33fb583cad86eb5a3dbb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->