### PR TITLE
Handle Escape/Ctrl+C interrupts in Claude CLI terminals

### DIFF
--- a/src/main/desktop/backend-manager.test.ts
+++ b/src/main/desktop/backend-manager.test.ts
@@ -54,7 +54,8 @@ const fileTreeHandlerMocks = vi.hoisted(() => ({
 
 const terminalHandlerMocks = vi.hoisted(() => ({
   createClaudeCliTerminal: vi.fn(),
-  destroyNodePtyTerminal: vi.fn()
+  destroyNodePtyTerminal: vi.fn(),
+  handleClaudeCliTerminalInput: vi.fn()
 }))
 
 const settingsHandlerMocks = vi.hoisted(() => ({
@@ -157,7 +158,8 @@ vi.mock('../services/file-tree-watcher', () => ({
 
 vi.mock('../services/terminal-pty-bridge', () => ({
   createClaudeCliTerminal: terminalHandlerMocks.createClaudeCliTerminal,
-  destroyNodePtyTerminal: terminalHandlerMocks.destroyNodePtyTerminal
+  destroyNodePtyTerminal: terminalHandlerMocks.destroyNodePtyTerminal,
+  handleClaudeCliTerminalInput: terminalHandlerMocks.handleClaudeCliTerminalInput
 }))
 
 vi.mock('../services/settings-openers', () => ({
@@ -275,6 +277,7 @@ describe('desktop backend manager', () => {
     fileTreeHandlerMocks.stopFileTreeWatcher.mockClear()
     terminalHandlerMocks.createClaudeCliTerminal.mockClear()
     terminalHandlerMocks.destroyNodePtyTerminal.mockClear()
+    terminalHandlerMocks.handleClaudeCliTerminalInput.mockClear()
     settingsHandlerMocks.openPathWithEditor.mockClear()
     settingsHandlerMocks.openPathWithTerminal.mockClear()
     scriptRunnerMocks.killProcess.mockClear()
@@ -3595,6 +3598,41 @@ describe('desktop backend manager', () => {
       }),
       expect.any(Function)
     )
+  })
+
+  it('routes backend terminalWrite data through the Claude CLI interrupt detector', async () => {
+    const child = new FakeChildProcess()
+    ptyServiceMocks.has.mockReturnValue(true)
+
+    await startDesktopBackend(
+      {
+        executablePath: '/electron',
+        entryPath: '/app/server.js',
+        cwd: '/app',
+        baseDir: mkdtempSync(join(tmpdir(), 'hive-backend-manager-')),
+        port: 0
+      },
+      {
+        spawnProcess: vi.fn(() => child as never),
+        fetch: vi.fn(async () => new Response('{}', { status: 200 })),
+        logger: makeLogger()
+      }
+    )
+
+    child.emit(
+      'message',
+      makeDesktopCommandRequest('terminal-write-2', 'terminalWrite', {
+        terminalId: 'terminal-1',
+        data: '\x1b'
+      })
+    )
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(terminalHandlerMocks.handleClaudeCliTerminalInput).toHaveBeenCalledWith(
+      'terminal-1',
+      '\x1b'
+    )
+    expect(ptyServiceMocks.write).toHaveBeenCalledWith('terminal-1', '\x1b')
   })
 
   it('forwards backend terminalCreateClaudeCli commands to the legacy terminal handler', async () => {

--- a/src/main/desktop/backend-manager.ts
+++ b/src/main/desktop/backend-manager.ts
@@ -56,7 +56,11 @@ import { scriptRunner } from '../services/script-runner'
 import { ptyService } from '../services/pty-service'
 import { ghosttyService } from '../services/ghostty-service'
 import { startFileTreeWatcher, stopFileTreeWatcher } from '../services/file-tree-watcher'
-import { createClaudeCliTerminal, destroyNodePtyTerminal } from '../services/terminal-pty-bridge'
+import {
+  createClaudeCliTerminal,
+  destroyNodePtyTerminal,
+  handleClaudeCliTerminalInput
+} from '../services/terminal-pty-bridge'
 import { claudeCliTelegramBridge } from '../services/claude-cli-telegram-bridge'
 import { openPathWithEditor, openPathWithTerminal } from '../services/settings-openers'
 import {
@@ -2845,6 +2849,7 @@ const handleDesktopBackendCommand = (
       if (!ptyService.has(message.payload.terminalId)) {
         throw new Error('Terminal not found')
       }
+      handleClaudeCliTerminalInput(message.payload.terminalId, message.payload.data)
       ptyService.write(message.payload.terminalId, message.payload.data)
       sendDesktopBackendCommandResult(
         child,

--- a/src/main/services/terminal-pty-bridge.claude-cli.test.ts
+++ b/src/main/services/terminal-pty-bridge.claude-cli.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => {
     getDatabase: vi.fn(),
     getClaudeHookServer: vi.fn(),
     buildClaudeCliHookSettings: vi.fn(),
+    getLastClaudeCliStatus: vi.fn(),
     publishClaudeCliStatus: vi.fn(),
     subscribeClaudeCliStatus: vi.fn(() => vi.fn()),
     ptyService: {
@@ -101,6 +102,7 @@ vi.mock('./claude-session-watcher', () => ({
 vi.mock('./claude-hook-server', () => ({
   getClaudeHookServer: mocks.getClaudeHookServer,
   buildClaudeCliHookSettings: mocks.buildClaudeCliHookSettings,
+  getLastClaudeCliStatus: mocks.getLastClaudeCliStatus,
   publishClaudeCliStatus: mocks.publishClaudeCliStatus,
   subscribeClaudeCliStatus: mocks.subscribeClaudeCliStatus
 }))
@@ -113,7 +115,8 @@ import type { Session } from '../db/types'
 import {
   cleanupTerminals,
   destroyNodePtyTerminal,
-  createClaudeCliTerminal
+  createClaudeCliTerminal,
+  handleClaudeCliTerminalInput
 } from './terminal-pty-bridge'
 import { __resetRuntimeRegistryForTests } from '../effect/_shared/runtime'
 
@@ -406,6 +409,76 @@ describe('Claude CLI terminal hook status wiring', () => {
       status: 'completed',
       metadata: { reason: 'pty_start' }
     })
+  })
+
+  describe('handleClaudeCliTerminalInput', () => {
+    it.each(['\x1b', '\x03'])(
+      'publishes completed with user_interrupt when %j is typed while working',
+      async (key) => {
+        await createClaudeCliTerminal('hive-session-1', {})
+        mocks.getLastClaudeCliStatus.mockReturnValue('working')
+        mocks.publishClaudeCliStatus.mockClear()
+
+        handleClaudeCliTerminalInput('hive-session-1', key)
+
+        expect(mocks.publishClaudeCliStatus).toHaveBeenCalledWith({
+          sessionId: 'hive-session-1',
+          status: 'completed',
+          metadata: { reason: 'user_interrupt' }
+        })
+      }
+    )
+
+    it.each(['planning', 'permission'])(
+      'publishes completed when Escape is typed while %s',
+      async (status) => {
+        await createClaudeCliTerminal('hive-session-1', {})
+        mocks.getLastClaudeCliStatus.mockReturnValue(status)
+        mocks.publishClaudeCliStatus.mockClear()
+
+        handleClaudeCliTerminalInput('hive-session-1', '\x1b')
+
+        expect(mocks.publishClaudeCliStatus).toHaveBeenCalledWith({
+          sessionId: 'hive-session-1',
+          status: 'completed',
+          metadata: { reason: 'user_interrupt' }
+        })
+      }
+    )
+
+    it('ignores terminals that are not Claude CLI sessions', () => {
+      mocks.getLastClaudeCliStatus.mockReturnValue('working')
+
+      handleClaudeCliTerminalInput('plain-terminal', '\x1b')
+
+      expect(mocks.publishClaudeCliStatus).not.toHaveBeenCalled()
+    })
+
+    it.each(['a', '\r', '\x1b[A', '\x1b[200~paste\x1b[201~'])(
+      'ignores non-interrupt input %j',
+      async (data) => {
+        await createClaudeCliTerminal('hive-session-1', {})
+        mocks.getLastClaudeCliStatus.mockReturnValue('working')
+        mocks.publishClaudeCliStatus.mockClear()
+
+        handleClaudeCliTerminalInput('hive-session-1', data)
+
+        expect(mocks.publishClaudeCliStatus).not.toHaveBeenCalled()
+      }
+    )
+
+    it.each(['completed', 'plan_ready', 'answering', undefined])(
+      'ignores Escape when the last published status is %s',
+      async (status) => {
+        await createClaudeCliTerminal('hive-session-1', {})
+        mocks.getLastClaudeCliStatus.mockReturnValue(status)
+        mocks.publishClaudeCliStatus.mockClear()
+
+        handleClaudeCliTerminalInput('hive-session-1', '\x1b')
+
+        expect(mocks.publishClaudeCliStatus).not.toHaveBeenCalled()
+      }
+    )
   })
 
   it('removes the Claude CLI PTY-exit safety net when the terminal is destroyed', async () => {

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -3,6 +3,7 @@ import { getDatabase } from '../db'
 import {
   buildClaudeCliHookSettings,
   getClaudeHookServer,
+  getLastClaudeCliStatus,
   publishClaudeCliStatus,
   subscribeClaudeCliStatus,
   type ClaudeCliStatusPayload
@@ -92,6 +93,31 @@ function ensureClaudeCliStatusSubscription(): void {
     ) {
       closeClaudePlanFollowupWatcher(payload.sessionId)
     }
+  })
+}
+
+// Lone Escape / Ctrl+C. A bare Escape keypress arrives as exactly '\x1b';
+// multi-byte sequences (arrow keys, bracketed pastes) never match exactly.
+const INTERRUPT_KEYS = new Set(['\x1b', '\x03'])
+const INTERRUPTIBLE_STATUSES = new Set(['working', 'planning', 'permission'])
+
+/**
+ * Claude Code never fires its Stop hook when the user interrupts a running
+ * turn with Escape/Ctrl+C, and the CLI keeps running so the pty_exit fallback
+ * never fires either — the session would stay stuck on 'working'. Mirror the
+ * keypress itself into a status update instead. plan_ready/answering are
+ * excluded: escaping those dialogs fires PostToolUseFailure hooks that the
+ * existing pipeline already handles.
+ */
+export function handleClaudeCliTerminalInput(terminalId: string, data: string): void {
+  if (!claudeCliSessions.has(terminalId)) return
+  if (!INTERRUPT_KEYS.has(data)) return
+  const last = getLastClaudeCliStatus(terminalId)
+  if (!last || !INTERRUPTIBLE_STATUSES.has(last)) return
+  publishClaudeCliStatus({
+    sessionId: terminalId,
+    status: 'completed',
+    metadata: { reason: 'user_interrupt' }
   })
 }
 


### PR DESCRIPTION
## Summary
- Detect bare `Escape` and `Ctrl+C` input for active Claude CLI terminals and publish a `completed` status with `user_interrupt` metadata.
- Route backend `terminalWrite` payloads through the new interrupt detector before writing to the PTY.
- Add coverage for interrupt keys, non-interrupt input, status gating, and backend forwarding behavior.

## Testing
- `Not run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live Claude CLI session status signaling on every terminal write path; incorrect gating could mark sessions completed early, but scope is limited to exact interrupt bytes and three statuses with tests.
> 
> **Overview**
> Fixes Claude CLI sessions staying stuck on **working** (or similar) when the user interrupts with **Escape** or **Ctrl+C**, because Claude Code does not fire its Stop hook and the PTY keeps running.
> 
> Adds **`handleClaudeCliTerminalInput`** in `terminal-pty-bridge`: for registered Claude CLI terminals only, a lone `\x1b` or `\x03` while the last published status is `working`, `planning`, or `permission` publishes **`completed`** with **`user_interrupt`** metadata (via `getLastClaudeCliStatus`). Other input, non–Claude CLI terminals, and statuses like `plan_ready` / `answering` / `completed` are ignored so arrow keys, pastes, and hook-driven dialogs are unaffected.
> 
> **`terminalWrite`** in the desktop backend now invokes this handler **before** writing to the PTY. Unit tests cover interrupt keys, gating, non-interrupt input, and backend forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b30176e39fc783d383b071585d2912d4cb31e82d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->