### PR TITLE
Hide top-bar controls in Claude CLI mode

### DIFF
--- a/src/renderer/src/components/kanban/FollowupInput.tsx
+++ b/src/renderer/src/components/kanban/FollowupInput.tsx
@@ -25,6 +25,8 @@ interface FollowupInputProps {
   placeholder: string
   testIdPrefix: string
   showInlineSendButton?: boolean
+  // Claude CLI sessions manage plan/build inside the terminal — the toggle has no effect there.
+  hideModeToggle?: boolean
   textareaRef?: React.RefObject<HTMLTextAreaElement>
 }
 
@@ -41,6 +43,7 @@ export function FollowupInput({
   placeholder,
   testIdPrefix,
   showInlineSendButton = false,
+  hideModeToggle = false,
   textareaRef
 }: FollowupInputProps) {
   const hasContent = text.trim().length > 0 || attachments.length > 0
@@ -108,26 +111,28 @@ export function FollowupInput({
         <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
           Followup
         </label>
-        <Tip tipId="super-plan-shortcut" enabled={followUpMode === 'super-plan'}>
-          <button
-            data-testid={`${testIdPrefix}-mode-toggle`}
-            data-mode={followUpMode}
-            type="button"
-            onClick={onToggleMode}
-            className={cn(
-              'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
-              'border select-none',
-              followUpMode === 'build'
-                ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
-                : followUpMode === 'plan'
-                  ? 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
-                  : 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20'
-            )}
-          >
-            <ModeIcon className="h-3 w-3" />
-            <span>{modeLabel}</span>
-          </button>
-        </Tip>
+        {!hideModeToggle && (
+          <Tip tipId="super-plan-shortcut" enabled={followUpMode === 'super-plan'}>
+            <button
+              data-testid={`${testIdPrefix}-mode-toggle`}
+              data-mode={followUpMode}
+              type="button"
+              onClick={onToggleMode}
+              className={cn(
+                'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
+                'border select-none',
+                followUpMode === 'build'
+                  ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
+                  : followUpMode === 'plan'
+                    ? 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
+                    : 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20'
+              )}
+            >
+              <ModeIcon className="h-3 w-3" />
+              <span>{modeLabel}</span>
+            </button>
+          </Tip>
+        )}
       </div>
 
       {/* Attachment previews */}

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1084,6 +1084,7 @@ function KanbanTicketModalContent({
           moveTicket={moveTicket}
           updateTicket={updateTicket}
           dualPane={wantsDualPane}
+          isClaudeCli={isClaudeCli}
           runScriptState={runScriptState}
         />
       )
@@ -1094,6 +1095,7 @@ function KanbanTicketModalContent({
           ticket={ticket}
           onClose={forceClose}
           dualPane={wantsDualPane}
+          isClaudeCli={isClaudeCli}
           runScriptState={runScriptState}
         />
       )
@@ -2717,6 +2719,7 @@ function ReviewModeContent({
   moveTicket,
   updateTicket,
   dualPane = false,
+  isClaudeCli = false,
   runScriptState
 }: {
   ticket: KanbanTicket
@@ -2729,6 +2732,7 @@ function ReviewModeContent({
   ) => Promise<void>
   updateTicket: (ticketId: string, projectId: string, data: KanbanTicketUpdate) => Promise<void>
   dualPane?: boolean
+  isClaudeCli?: boolean
   runScriptState: TicketRunScriptState
 }) {
   const worktree = useMemo(
@@ -2931,8 +2935,10 @@ function ReviewModeContent({
     setFollowUpMode((prev) => (prev === 'super-plan' ? 'plan' : 'super-plan'))
   }, [])
 
-  // Tab key toggles mode, Shift+Tab toggles super-plan
+  // Tab key toggles mode, Shift+Tab toggles super-plan.
+  // Claude CLI sessions handle Tab/Shift+Tab inside the terminal instead.
   useEffect(() => {
+    if (isClaudeCli) return
     const handler = (e: KeyboardEvent): void => {
       if (e.key === 'Tab' && !e.ctrlKey && !e.metaKey && !e.altKey) {
         // Only intercept when the modal is focused
@@ -2950,7 +2956,7 @@ function ReviewModeContent({
     }
     window.addEventListener('keydown', handler, true)
     return () => window.removeEventListener('keydown', handler, true)
-  }, [toggleMode, toggleSuperMode])
+  }, [isClaudeCli, toggleMode, toggleSuperMode])
 
   // ── Send followup ─────────────────────────────────────────────────
   const handleSendFollowup = useCallback(async () => {
@@ -3130,6 +3136,7 @@ function ReviewModeContent({
         isSending={isSending}
         placeholder="Provide followup instructions... (Enter to send)"
         testIdPrefix="review"
+        hideModeToggle={isClaudeCli}
         textareaRef={textareaRef}
       />
 
@@ -3249,11 +3256,13 @@ function ErrorModeContent({
   ticket,
   onClose,
   dualPane = false,
+  isClaudeCli = false,
   runScriptState
 }: {
   ticket: KanbanTicket
   onClose: () => void
   dualPane?: boolean
+  isClaudeCli?: boolean
   runScriptState: TicketRunScriptState
 }) {
   const [followUpText, setFollowUpText] = useState('')
@@ -3329,8 +3338,10 @@ function ErrorModeContent({
     setFollowUpMode((prev) => (prev === 'super-plan' ? 'plan' : 'super-plan'))
   }, [])
 
-  // Tab key toggles mode, Shift+Tab toggles super-plan
+  // Tab key toggles mode, Shift+Tab toggles super-plan.
+  // Claude CLI sessions handle Tab/Shift+Tab inside the terminal instead.
   useEffect(() => {
+    if (isClaudeCli) return
     const handler = (e: KeyboardEvent): void => {
       if (e.key === 'Tab' && !e.ctrlKey && !e.metaKey && !e.altKey) {
         const modal = document.querySelector('[data-testid="kanban-ticket-modal"]')
@@ -3347,7 +3358,7 @@ function ErrorModeContent({
     }
     window.addEventListener('keydown', handler, true)
     return () => window.removeEventListener('keydown', handler, true)
-  }, [toggleMode, toggleSuperMode])
+  }, [isClaudeCli, toggleMode, toggleSuperMode])
 
   // ── Send followup for error retry ─────────────────────────────────
   const handleSendFollowup = useCallback(async () => {
@@ -3438,6 +3449,7 @@ function ErrorModeContent({
         isSending={isSending}
         placeholder="Describe the fix or retry instructions... (Enter to send)"
         testIdPrefix="error"
+        hideModeToggle={isClaudeCli}
       />
 
       {/* Drag-and-drop overlay */}

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -12,9 +12,6 @@ import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useQuestionStore } from '@/stores/useQuestionStore'
 import { useTelegramStore } from '@/stores/useTelegramStore'
 import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalContext'
-import { ModeToggle } from './ModeToggle'
-import { SuperToggle } from './SuperToggle'
-import { ModelSelector } from './ModelSelector'
 import { QuestionPrompt } from './QuestionPrompt'
 import { ClaudeCliEndedOverlay } from './ClaudeCliEndedOverlay'
 import { HandoffSplitButton } from './HandoffSplitButton'
@@ -289,7 +286,6 @@ export function ClaudeCliSessionView({
   const [terminalKey, setTerminalKey] = useState(0)
   const [ended, setEnded] = useState(false)
   const [planSavedAsTicket, setPlanSavedAsTicket] = useState(false)
-  const pendingMessage = useSessionStore((state) => state.pendingMessages.get(sessionId) ?? null)
   const pendingPlan = useSessionStore((state) => state.pendingPlans.get(sessionId) ?? null)
   const mode = useSessionStore((state) => state.modeBySession.get(sessionId) ?? 'build')
   const { getTarget, revision: portalRevision } = useClaudeCliSessionPortal()
@@ -548,17 +544,6 @@ export function ClaudeCliSessionView({
       data-testid="claude-cli-session-view"
       data-session-id={sessionId}
     >
-      <div className="flex items-center justify-between gap-3 border-b border-border bg-background px-3 py-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <ModeToggle sessionId={sessionId} />
-          <SuperToggle sessionId={sessionId} />
-          {pendingMessage && (
-            <span className="truncate text-xs text-muted-foreground">handoff prompt pending</span>
-          )}
-        </div>
-        <ModelSelector sessionId={sessionId} />
-      </div>
-
       <div className="relative min-h-0 flex-1">
         <TerminalView
           ref={terminalRef}


### PR DESCRIPTION
## Summary
- Remove the session top bar from Claude CLI session view so the terminal takes the full available space.
- Hide the follow-up mode toggle in kanban followup inputs when the session is Claude CLI.
- Disable Tab and Shift+Tab mode interception in kanban ticket modals for Claude CLI sessions so those keys stay in the terminal.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes scoped to Claude CLI session and kanban follow-up; no auth, data, or API contract changes.
> 
> **Overview**
> Claude CLI sessions no longer show redundant **plan/build controls** in the Hive chrome so the terminal can use the full pane and keep **Tab** / **Shift+Tab** for the TUI.
> 
> **`ClaudeCliSessionView`** drops the top bar (`ModeToggle`, `SuperToggle`, `ModelSelector`, handoff-pending hint); the xterm area expands to fill the column.
> 
> **Kanban ticket modals** pass `isClaudeCli` into review and error follow-up flows: **`FollowupInput`** gains **`hideModeToggle`** to omit the Build/Plan/Super Plan chip, and the modal stops capturing Tab/Shift+Tab for mode cycling when the session is CLI-backed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0044955159602e662131b70d5fb7765fdbd7bf68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->