### PR TITLE
Fix Codex session startup errors and prompt model validation

### DIFF
--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -155,6 +155,17 @@ function composePromptForSdk(
     : fullPrompt
 }
 
+// Strip a SelectedModel down to the shape the prompt RPC accepts. The renderer's
+// model objects carry an extra `agentSdk` field used for SDK routing, but the
+// `opencodeOps.prompt` model schema is .strict() and rejects unknown keys — so
+// passing the raw model fails with "RPC parameters failed validation".
+function toRequestModel(
+  model: { providerID: string; modelID: string; variant?: string } | undefined
+): { providerID: string; modelID: string; variant?: string } | undefined {
+  if (!model) return undefined
+  return { providerID: model.providerID, modelID: model.modelID, variant: model.variant }
+}
+
 // ── Component ───────────────────────────────────────────────────────
 export function WorktreePickerModal({
   ticket,
@@ -547,7 +558,10 @@ export function WorktreePickerModal({
         if (!connectionPath) return
 
         const connectResult = unwrapEnvelope(await opencodeApi.connect(connectionPath, sessionId))
-        if (!connectResult.success || !connectResult.sessionId) return
+        if (!connectResult.success || !connectResult.sessionId) {
+          toast.error(connectResult.error || 'Failed to start session')
+          return
+        }
 
         useSessionStore.getState().setOpenCodeSessionId(sessionId, connectResult.sessionId)
         await dbApi.session.update<Session>(sessionId, {
@@ -585,14 +599,14 @@ export function WorktreePickerModal({
               connectionPath,
               connectResult.sessionId,
               [{ type: 'text', text: outboundPrompt }],
-              effectiveModel,
+              toRequestModel(effectiveModel),
               promptOptions
             )
           )
         }
         return // Done with connection path
-      } catch {
-        toast.error('Failed to start session')
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to start session')
       } finally {
         setIsSending(false)
       }
@@ -827,7 +841,10 @@ export function WorktreePickerModal({
 
       // Connect to OpenCode to create the AI session
       const connectResult = unwrapEnvelope(await opencodeApi.connect(worktree.path, sessionId))
-      if (!connectResult.success || !connectResult.sessionId) return
+      if (!connectResult.success || !connectResult.sessionId) {
+        toast.error(connectResult.error || 'Failed to start session')
+        return
+      }
 
       // Persist the opencodeSessionId to Zustand + DB
       useSessionStore.getState().setOpenCodeSessionId(sessionId, connectResult.sessionId)
@@ -868,13 +885,13 @@ export function WorktreePickerModal({
             worktree.path,
             connectResult.sessionId,
             [{ type: 'text', text: outboundPrompt }],
-            effectiveModel,
+            toRequestModel(effectiveModel),
             promptOptions
           )
         )
       }
-    } catch {
-      toast.error('Failed to start session')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to start session')
     } finally {
       setIsSending(false)
     }

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -206,7 +206,10 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
     if (!worktree?.path) return
 
     const connectResult = unwrapEnvelope(await opencodeApi.connect(worktree.path, sessionId))
-    if (!connectResult.success || !connectResult.sessionId) return
+    if (!connectResult.success || !connectResult.sessionId) {
+      toast.error(`Auto-launch failed: ${connectResult.error || 'Could not start session'}`)
+      return
+    }
 
     useSessionStore.getState().setOpenCodeSessionId(sessionId, connectResult.sessionId)
     await dbApi.session.update(sessionId, { opencode_session_id: connectResult.sessionId })
@@ -244,13 +247,22 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
           worktree.path,
           connectResult.sessionId,
           [{ type: 'text', text: outboundPrompt }],
-          effectiveModel,
+          // Strip `agentSdk` — the prompt RPC model schema is .strict() and
+          // rejects it ("RPC parameters failed validation").
+          effectiveModel
+            ? {
+                providerID: effectiveModel.providerID,
+                modelID: effectiveModel.modelID,
+                variant: effectiveModel.variant
+              }
+            : undefined,
           promptOptions
         )
       )
     }
   } catch (err) {
     console.error('Auto-launch failed for ticket:', ticket.id, err)
-    toast.error(`Auto-launch failed for: ${ticket.title}`)
+    const detail = err instanceof Error ? err.message : null
+    toast.error(`Auto-launch failed for: ${ticket.title}${detail ? ` — ${detail}` : ''}`)
   }
 }

--- a/test/kanban/session-9/worktree-picker-modal.test.tsx
+++ b/test/kanban/session-9/worktree-picker-modal.test.tsx
@@ -147,6 +147,15 @@ vi.mock('@/api/terminal-api', () => ({ terminalApi: apiMocks.terminalApi }))
 vi.mock('@/api/script-api', () => ({ scriptApi: apiMocks.scriptApi }))
 vi.mock('@/lib/hive-enterprise-telemetry', () => apiMocks.hiveTelemetry)
 
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  message: vi.fn()
+}))
+vi.mock('sonner', () => ({ toast: toastMocks }))
+
 const mockKanban = apiMocks.kanbanApi
 const mockDbSession = apiMocks.dbApi.session
 const mockDbWorktree = apiMocks.dbApi.worktree
@@ -1226,6 +1235,111 @@ describe('Session 9: Worktree Picker Modal', () => {
       undefined,
       { codexFastMode: true }
     )
+  })
+
+  test('sends a clean model (no agentSdk) to opencodeApi.prompt for a Codex session', async () => {
+    // The configured model carries an `agentSdk` field, but the prompt RPC model
+    // schema is .strict() and rejects it ("RPC parameters failed validation").
+    // The modal must strip it before sending, like SessionView's getModelForRequests.
+    act(() => {
+      useSettingsStore.setState({
+        codexFastMode: true,
+        codexFastModeAccepted: true,
+        selectedModelByProvider: {
+          codex: { agentSdk: 'codex', providerID: 'codex', modelID: 'gpt-5.5', variant: 'high' }
+        }
+      })
+    })
+
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    fireEvent.click(screen.getByTestId('worktree-item-wt-1'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('wt-picker-send-btn'))
+    })
+
+    await waitFor(() => {
+      expect(mockOpencodeOps.prompt).toHaveBeenCalled()
+    })
+
+    const modelArg = mockOpencodeOps.prompt.mock.calls.at(-1)?.[3]
+    expect(modelArg).toEqual({ providerID: 'codex', modelID: 'gpt-5.5', variant: 'high' })
+    expect(modelArg).not.toHaveProperty('agentSdk')
+  })
+
+  test('surfaces the real error when a Codex connect throws (e.g. desktop command timeout)', async () => {
+    // Simulate the transport-level failure (10s desktop-command timeout) that
+    // unwrapEnvelope re-throws into handleSend. Previously the bare `catch {}`
+    // hid this behind a generic "Failed to start session".
+    mockOpencodeOps.connect.mockRejectedValueOnce(
+      new Error('Timed out waiting for desktop command response: opencodeConnect')
+    )
+
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    fireEvent.click(screen.getByTestId('worktree-item-wt-1'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('wt-picker-send-btn'))
+    })
+
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalledWith(
+        'Timed out waiting for desktop command response: opencodeConnect',
+        expect.anything()
+      )
+    })
+    expect(mockOpencodeOps.prompt).not.toHaveBeenCalled()
+  })
+
+  test('surfaces the connect error when a Codex connect returns success:false', async () => {
+    // A failed connect (success:false) must not be silently swallowed — the
+    // user should see why, instead of a session that never starts.
+    mockOpencodeOps.connect.mockResolvedValueOnce({
+      success: false,
+      error: 'Installed Codex CLI does not support app-server'
+    })
+
+    render(
+      <WorktreePickerModal
+        ticket={defaultTicket}
+        projectId="proj-1"
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    fireEvent.click(screen.getByTestId('worktree-item-wt-1'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('wt-picker-send-btn'))
+    })
+
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalledWith(
+        'Installed Codex CLI does not support app-server',
+        expect.anything()
+      )
+    })
+    expect(mockOpencodeOps.prompt).not.toHaveBeenCalled()
   })
 
   test('super-plan prompts use request_user_input wording for Codex sessions', async () => {


### PR DESCRIPTION
## Summary
- Strip the renderer-only `agentSdk` field before sending prompt requests so the strict RPC model schema accepts Codex sessions.
- Surface connect failures and thrown errors as actionable toast messages instead of silently failing to start a session.
- Mirror the same validation/error-handling fixes in auto-launch flow.
- Add regression tests covering clean model serialization and both thrown and `success: false` connect failures.

## Testing
- Ran the new `worktree-picker-modal` regression tests covering prompt payload cleanup and connect error handling.
- Verified prompt requests exclude `agentSdk` and preserve `providerID`, `modelID`, and `variant`.
- Verified connect failures now produce visible toast errors for both rejected promises and `success: false` responses.
- Not run: full repository test suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted renderer fixes for RPC validation and user-visible errors in kanban launch paths; no auth or data-model changes.
> 
> **Overview**
> Fixes **Codex session startup** from the kanban worktree picker and **auto-launch** when prompts or connects fail validation or OpenCode connect.
> 
> **Prompt model payload:** Renderer models include `agentSdk` for routing, but `opencodeOps.prompt` uses a **strict** schema and rejects extra keys. The picker now passes models through `toRequestModel` (provider/model/variant only); auto-launch applies the same shape inline before `opencodeApi.prompt`.
> 
> **Connect / errors:** Failed `opencodeApi.connect` (`success: false` or missing session id) now shows a **toast** with `connectResult.error` instead of returning silently. `catch` blocks show the thrown `Error.message` instead of a generic "Failed to start session".
> 
> **Tests:** `worktree-picker-modal` tests assert the prompt model arg has no `agentSdk`, and that connect rejections and `success: false` surface via toast without calling `prompt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84eb8598b80ad3a84f660d5e1cee1bb483080307. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->