### PR TITLE
Remove timeout from native project dialogs

### DIFF
--- a/src/server/rpc/domains/project-ops.ts
+++ b/src/server/rpc/domains/project-ops.ts
@@ -227,10 +227,12 @@ const requestProjectOpenDirectoryDialog = (): Promise<string | null> => {
   const id = `project-open-directory-dialog-${Date.now()}-${Math.random().toString(36).slice(2)}`
   const command = 'projectOpenDirectoryDialog'
 
+  // No timeout: this opens a native folder picker that blocks on the user. The main
+  // process always replies once the dialog closes (path, or null on cancel), so the
+  // promise still settles — it just waits as long as the user needs.
   return new Promise<string | null>((resolve, reject) => {
     let settled = false
     const cleanup = (): void => {
-      clearTimeout(timeout)
       process.off('message', onMessage)
     }
     const finish = (value?: string | null, error?: Error): void => {
@@ -243,9 +245,6 @@ const requestProjectOpenDirectoryDialog = (): Promise<string | null> => {
       }
       resolve(value ?? null)
     }
-    const timeout = setTimeout(() => {
-      finish(null, new Error(`Timed out waiting for desktop command response: ${command}`))
-    }, 5_000)
 
     const onMessage = (message: unknown): void => {
       if (!isDesktopCommandResult(message) || message.id !== id) return
@@ -469,10 +468,12 @@ const requestProjectPickProjectIcon = (projectId: string): Promise<PickProjectIc
   const id = `project-pick-project-icon-${Date.now()}-${Math.random().toString(36).slice(2)}`
   const command = 'projectPickProjectIcon'
 
+  // No timeout: this opens a native image picker that blocks on the user. The main
+  // process always replies once the dialog closes, so the promise still settles — it
+  // just waits as long as the user needs.
   return new Promise<PickProjectIconResult>((resolve, reject) => {
     let settled = false
     const cleanup = (): void => {
-      clearTimeout(timeout)
       process.off('message', onMessage)
     }
     const finish = (value?: PickProjectIconResult, error?: Error): void => {
@@ -485,12 +486,6 @@ const requestProjectPickProjectIcon = (projectId: string): Promise<PickProjectIc
       }
       resolve(value ?? { success: false, error: 'cancelled' })
     }
-    const timeout = setTimeout(() => {
-      finish(
-        undefined,
-        new Error(`Timed out waiting for desktop command response: ${command}`)
-      )
-    }, 5_000)
 
     const onMessage = (message: unknown): void => {
       if (!isDesktopCommandResult(message) || message.id !== id) return


### PR DESCRIPTION
## Summary
- Removed the 5-second timeout from the project folder picker flow.
- Removed the 5-second timeout from the project icon picker flow.
- Left both requests to settle only when the native dialog returns a result or is cancelled.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to two user-blocking dialog RPCs; other desktop commands still time out at 5s.
> 
> **Overview**
> Fixes **false timeouts** when users take longer than five seconds in native project dialogs.
> 
> The RPC helpers for **`projectOpenDirectoryDialog`** and **`projectPickProjectIcon`** no longer use a 5s `setTimeout` that rejected with “Timed out waiting for desktop command response”. Those flows now wait until the main process returns a path, a cancel/`null` result, or a real error—matching how the native folder and image pickers block on user input.
> 
> Comments document why timeouts were removed here while other desktop commands in the same file still use 5s limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0691d98d49fec95df0029ff9fbc205548936e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->