### PR TITLE
Externalize large Claude CLI goal handoffs

### DIFF
--- a/src/main/services/claude-cli-plan-handoff.test.ts
+++ b/src/main/services/claude-cli-plan-handoff.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+import { HANDOFF_PLAN_PROMPT_HEADER, SUPER_PLAN_MODE_PREFIX } from '@shared/agent-mode-prefixes'
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import { externalizeGoalHandoffPlan } from './claude-cli-plan-handoff'
+
+const WORKTREE = '/repo/worktree'
+const RAW_PLAN = '# My Plan\n\nDo the thing.\n\n## Success criteria\nIt works.'
+const SHORT_REFERENCE =
+  "/goal implement PLAN_fixed-uuid.md. the goal's success criteria is written there"
+
+describe('externalizeGoalHandoffPlan', () => {
+  it('writes the raw plan to PLAN_{uuid}.md and returns the short goal reference', () => {
+    const writeFile = vi.fn()
+    const prompt = `/goal ${HANDOFF_PLAN_PROMPT_HEADER}${RAW_PLAN}`
+
+    const result = externalizeGoalHandoffPlan(prompt, WORKTREE, {
+      uuid: 'fixed-uuid',
+      writeFile
+    })
+
+    expect(writeFile).toHaveBeenCalledTimes(1)
+    expect(writeFile).toHaveBeenCalledWith('/repo/worktree/PLAN_fixed-uuid.md', RAW_PLAN)
+    expect(result).toBe(SHORT_REFERENCE)
+  })
+
+  it('preserves a leading super-plan prefix while still externalizing', () => {
+    const writeFile = vi.fn()
+    const prompt = `${SUPER_PLAN_MODE_PREFIX}/goal ${HANDOFF_PLAN_PROMPT_HEADER}${RAW_PLAN}`
+
+    const result = externalizeGoalHandoffPlan(prompt, WORKTREE, {
+      uuid: 'fixed-uuid',
+      writeFile
+    })
+
+    expect(writeFile).toHaveBeenCalledWith('/repo/worktree/PLAN_fixed-uuid.md', RAW_PLAN)
+    expect(result).toBe(`${SUPER_PLAN_MODE_PREFIX}${SHORT_REFERENCE}`)
+  })
+
+  it('leaves non-goal prompts untouched and writes nothing', () => {
+    const writeFile = vi.fn()
+    const prompt = 'just a normal follow-up message'
+
+    const result = externalizeGoalHandoffPlan(prompt, WORKTREE, { writeFile })
+
+    expect(writeFile).not.toHaveBeenCalled()
+    expect(result).toBe(prompt)
+  })
+
+  it('leaves a goal prompt without the handoff header untouched (scope: handoffs only)', () => {
+    const writeFile = vi.fn()
+    const prompt = '/goal do the thing. Goal success criteria: it works'
+
+    const result = externalizeGoalHandoffPlan(prompt, WORKTREE, { writeFile })
+
+    expect(writeFile).not.toHaveBeenCalled()
+    expect(result).toBe(prompt)
+  })
+
+  it('falls back to the original prompt when the file write fails', () => {
+    const writeFile = vi.fn(() => {
+      throw new Error('disk full')
+    })
+    const prompt = `/goal ${HANDOFF_PLAN_PROMPT_HEADER}${RAW_PLAN}`
+
+    const result = externalizeGoalHandoffPlan(prompt, WORKTREE, {
+      uuid: 'fixed-uuid',
+      writeFile
+    })
+
+    expect(result).toBe(prompt)
+  })
+})

--- a/src/main/services/claude-cli-plan-handoff.ts
+++ b/src/main/services/claude-cli-plan-handoff.ts
@@ -1,0 +1,56 @@
+import { randomUUID } from 'node:crypto'
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { HANDOFF_PLAN_PROMPT_HEADER } from '@shared/agent-mode-prefixes'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'ClaudeCliPlanHandoff' })
+
+const GOAL_PREFIX = '/goal '
+// '/goal Implement the following plan\n' — uniquely identifies a claude-cli goal-mode
+// handoff (the `/goal ` prefix == goal mode; the header == plan→implementor handoff).
+const HANDOFF_MARKER = GOAL_PREFIX + HANDOFF_PLAN_PROMPT_HEADER
+
+export interface ExternalizeGoalHandoffPlanOptions {
+  /** Override the generated UUID (tests). */
+  uuid?: string
+  /** Override the file writer (tests). */
+  writeFile?: (filePath: string, content: string) => void
+}
+
+/**
+ * claude-cli rejects `/goal` statements longer than ~4k characters. When a plan is handed
+ * off to a claude-cli implementor in goal mode, the whole plan rides inline on the prompt
+ * and large plans fail to start. This writes the raw plan to `PLAN_{uuid}.md` in the
+ * implementor's worktree and replaces the inline plan with a short reference.
+ *
+ * Returns the (possibly rewritten) prompt. Prompts that are not goal-mode handoffs — and any
+ * prompt where the file write fails — pass through unchanged so the session still starts.
+ */
+export function externalizeGoalHandoffPlan(
+  prompt: string,
+  worktreePath: string,
+  opts?: ExternalizeGoalHandoffPlanOptions
+): string {
+  const idx = prompt.indexOf(HANDOFF_MARKER)
+  if (idx === -1) return prompt
+
+  const leadingPrefix = prompt.slice(0, idx) // preserves any leading super-plan prefix
+  const planBody = prompt.slice(idx + HANDOFF_MARKER.length) // the raw plan content
+  const uuid = opts?.uuid ?? randomUUID()
+  const fileName = `PLAN_${uuid}.md`
+
+  try {
+    ;(opts?.writeFile ?? writeFileSync)(join(worktreePath, fileName), planBody)
+  } catch (error) {
+    log.warn('Failed to write handoff plan file; falling back to inline prompt', {
+      worktreePath,
+      fileName,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return prompt
+  }
+
+  log.info('Externalized goal handoff plan', { worktreePath, fileName })
+  return `${leadingPrefix}${GOAL_PREFIX}implement ${fileName}. the goal's success criteria is written there`
+}

--- a/src/main/services/claude-cli-pty-prompt.test.ts
+++ b/src/main/services/claude-cli-pty-prompt.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { ptyService } = vi.hoisted(() => ({
+  ptyService: { has: vi.fn(() => true), write: vi.fn() }
+}))
+vi.mock('./pty-service', () => ({ ptyService }))
+
+import { reassertClaudeCliPromptSubmit, writeClaudeCliPrompt } from './claude-cli-pty-prompt'
+
+afterEach(() => {
+  vi.clearAllMocks()
+  ptyService.has.mockReturnValue(true)
+})
+
+describe('writeClaudeCliPrompt', () => {
+  it('sends a bracketed paste with a submitting CR when the PTY is live', () => {
+    const result = writeClaudeCliPrompt('s1', '/goal implement PLAN_x.md')
+    expect(result).toEqual({ delivered: true })
+    expect(ptyService.write).toHaveBeenCalledWith('s1', '\x1b[200~/goal implement PLAN_x.md\x1b[201~\r')
+  })
+
+  it('reports not delivered (and writes nothing) when there is no PTY', () => {
+    ptyService.has.mockReturnValue(false)
+    expect(writeClaudeCliPrompt('s1', 'hi')).toEqual({ delivered: false })
+    expect(ptyService.write).not.toHaveBeenCalled()
+  })
+})
+
+describe('reassertClaudeCliPromptSubmit', () => {
+  // Run the scheduler synchronously so we can assert the CRs without real timers.
+  const sync = (fn: () => void): void => fn()
+
+  it('re-sends a bare CR for each scheduled retry while the PTY is live', () => {
+    reassertClaudeCliPromptSubmit('s1', { delaysMs: [400, 900, 1600], schedule: sync })
+    expect(ptyService.write).toHaveBeenCalledTimes(3)
+    expect(ptyService.write.mock.calls.every(([id, data]) => id === 's1' && data === '\r')).toBe(true)
+  })
+
+  it('skips the CR once the PTY is gone (no writes to a torn-down terminal)', () => {
+    ptyService.has.mockReturnValue(false)
+    reassertClaudeCliPromptSubmit('s1', { delaysMs: [400, 900], schedule: sync })
+    expect(ptyService.write).not.toHaveBeenCalled()
+  })
+
+  it('defaults to setTimeout-based scheduling without firing synchronously', () => {
+    vi.useFakeTimers()
+    try {
+      reassertClaudeCliPromptSubmit('s1')
+      expect(ptyService.write).not.toHaveBeenCalled() // nothing fires immediately
+      vi.advanceTimersByTime(3000)
+      expect(ptyService.write).toHaveBeenCalled()
+      expect(ptyService.write).toHaveBeenCalledWith('s1', '\r')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/services/claude-cli-pty-prompt.ts
+++ b/src/main/services/claude-cli-pty-prompt.ts
@@ -21,3 +21,37 @@ export function writeClaudeCliPrompt(sessionId: string, prompt: string): { deliv
   ptyService.write(sessionId, `\x1b[200~${prompt}\x1b[201~\r`)
   return { delivered: true }
 }
+
+// Re-send Enter at these offsets (ms) after a paste to cover claude's boot window.
+const SUBMIT_REASSERT_DELAYS_MS = [400, 900, 1600, 2600]
+
+/**
+ * Re-assert the submitting Enter across claude's startup window.
+ *
+ * A bracketed paste delivered before claude's TUI is input-ready buffers the
+ * pasted text but silently drops the trailing CR, so the prompt lands in the
+ * input box yet is never submitted (the user sees the prompt "just sitting
+ * there"). This happens on handoffs when a racing promptless spawn wins the
+ * PTY and the prompt-carrying call pastes into a still-booting claude.
+ *
+ * Re-sending a bare CR once claude finishes initializing submits the
+ * already-buffered text. A CR that arrives after the prompt is submitted — or
+ * while the input is empty — is a harmless no-op, so a fixed retry schedule is
+ * safe. The `ptyService.has` guard avoids writing to a torn-down PTY.
+ *
+ * `schedule` is injectable for tests; it defaults to `setTimeout`.
+ */
+export function reassertClaudeCliPromptSubmit(
+  sessionId: string,
+  opts?: { delaysMs?: number[]; schedule?: (fn: () => void, ms: number) => void }
+): void {
+  const delays = opts?.delaysMs ?? SUBMIT_REASSERT_DELAYS_MS
+  const schedule = opts?.schedule ?? ((fn, ms) => void setTimeout(fn, ms))
+  for (const ms of delays) {
+    schedule(() => {
+      if (ptyService.has(sessionId)) {
+        ptyService.write(sessionId, '\r')
+      }
+    }, ms)
+  }
+}

--- a/src/main/services/terminal-pty-bridge.claude-cli.test.ts
+++ b/src/main/services/terminal-pty-bridge.claude-cli.test.ts
@@ -90,6 +90,17 @@ vi.mock('./claude-binary-resolver', () => ({
   logClaudeBinaryVersion: vi.fn()
 }))
 
+vi.mock('./claude-cli-plan-handoff', () => ({
+  externalizeGoalHandoffPlan: vi.fn((prompt: string) => prompt)
+}))
+
+// Keep the real writeClaudeCliPrompt (bracketed paste) but stub the timer-based
+// submit re-assert with a spy so no real setTimeout leaks across tests.
+vi.mock('./claude-cli-pty-prompt', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./claude-cli-pty-prompt')>()),
+  reassertClaudeCliPromptSubmit: vi.fn()
+}))
+
 vi.mock('./claude-session-watcher', () => ({
   watchForClaudeSessionId: vi.fn(
     (worktreePath: string, callback: (claudeSessionId: string) => void) => {
@@ -118,6 +129,8 @@ import {
   createClaudeCliTerminal,
   handleClaudeCliTerminalInput
 } from './terminal-pty-bridge'
+import { externalizeGoalHandoffPlan } from './claude-cli-plan-handoff'
+import { reassertClaudeCliPromptSubmit } from './claude-cli-pty-prompt'
 import { __resetRuntimeRegistryForTests } from '../effect/_shared/runtime'
 
 function makeSession(overrides: Partial<Session> = {}): Session {
@@ -227,6 +240,48 @@ describe('Claude CLI terminal hook status wiring', () => {
     expect(mocks.ptyService.write).toHaveBeenCalledWith(
       'hive-session-1',
       '\x1b[200~Review the diff\x1b[201~\r'
+    )
+    // The paste can land before claude is input-ready (dropping the CR), so the
+    // submit must be re-asserted across the boot window.
+    expect(reassertClaudeCliPromptSubmit).toHaveBeenCalledWith('hive-session-1')
+  })
+
+  it('does not re-assert submit when there is no pending prompt to paste', async () => {
+    mocks.ptyService.has.mockReturnValue(true)
+
+    await createClaudeCliTerminal('hive-session-1', {})
+
+    expect(reassertClaudeCliPromptSubmit).not.toHaveBeenCalled()
+  })
+
+  it('externalizes the pending prompt (with the worktree path) before placing it on the argv', async () => {
+    const rawPrompt = '/goal Implement the following plan\nbig plan body'
+    const shortPrompt = "/goal implement PLAN_abc.md. the goal's success criteria is written there"
+    vi.mocked(externalizeGoalHandoffPlan).mockReturnValueOnce(shortPrompt)
+
+    await createClaudeCliTerminal('hive-session-1', { pendingPrompt: rawPrompt })
+
+    expect(externalizeGoalHandoffPlan).toHaveBeenCalledWith(rawPrompt, '/repo/worktree')
+
+    const [, options] = mocks.ptyService.create.mock.calls.at(-1)! as unknown as [
+      string,
+      { args: string[] }
+    ]
+    expect(options.args.at(-1)).toBe(shortPrompt)
+  })
+
+  it('injects the externalized prompt (not the raw plan) into an already-running PTY', async () => {
+    mocks.ptyService.has.mockReturnValue(true)
+    const shortPrompt = "/goal implement PLAN_abc.md. the goal's success criteria is written there"
+    vi.mocked(externalizeGoalHandoffPlan).mockReturnValueOnce(shortPrompt)
+
+    await createClaudeCliTerminal('hive-session-1', {
+      pendingPrompt: '/goal Implement the following plan\nbig plan body'
+    })
+
+    expect(mocks.ptyService.write).toHaveBeenCalledWith(
+      'hive-session-1',
+      `\x1b[200~${shortPrompt}\x1b[201~\r`
     )
   })
 

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -10,7 +10,8 @@ import {
 } from './claude-hook-server'
 import { logClaudeBinaryVersion, resolveClaudeBinaryPath } from './claude-binary-resolver'
 import { buildClaudeCliPtySpawn } from './claude-cli-spawner'
-import { writeClaudeCliPrompt } from './claude-cli-pty-prompt'
+import { externalizeGoalHandoffPlan } from './claude-cli-plan-handoff'
+import { reassertClaudeCliPromptSubmit, writeClaudeCliPrompt } from './claude-cli-pty-prompt'
 import { watchForClaudeSessionId, type ClaudeSessionWatchHandle } from './claude-session-watcher'
 import {
   watchForClaudePlanFollowup,
@@ -218,7 +219,7 @@ export async function createClaudeCliTerminal(
   sessionId: string,
   opts?: { pendingPrompt?: string | null }
 ): Promise<{ success: boolean; cols?: number; rows?: number; error?: string }> {
-  const pendingPrompt = opts?.pendingPrompt ?? null
+  let pendingPrompt = opts?.pendingPrompt ?? null
   log.info('RPC: terminalOps.createClaudeCli', { sessionId, hasPrompt: !!pendingPrompt })
   try {
     const db = getDatabase()
@@ -238,6 +239,13 @@ export async function createClaudeCliTerminal(
     }
     if (!worktreePath) {
       return { success: false, error: 'Could not resolve session working directory' }
+    }
+
+    // Oversized claude-cli goal-mode handoffs are rejected (>~4k chars). Externalize the
+    // plan to PLAN_{uuid}.md in the worktree and send a short reference instead. Runs before
+    // both delivery paths below (spawn args and paste injection).
+    if (pendingPrompt) {
+      pendingPrompt = externalizeGoalHandoffPlan(pendingPrompt, worktreePath)
     }
 
     const claudeBinary = resolveClaudeBinaryPath()
@@ -309,6 +317,12 @@ export async function createClaudeCliTerminal(
       // prompt riding on them) never reached claude. Inject it as a paste so
       // a racing promptless create call can't strand the prompt.
       const { delivered } = writeClaudeCliPrompt(sessionId, pendingPrompt)
+      if (delivered) {
+        // The paste can land before claude's TUI is input-ready, which buffers
+        // the text but drops the submitting CR — leaving the prompt sitting
+        // unsent. Re-assert Enter across the boot window so it actually submits.
+        reassertClaudeCliPromptSubmit(sessionId)
+      }
       log.info('Claude CLI PTY already exists; injecting pending prompt', {
         sessionId,
         delivered

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -1,5 +1,6 @@
 import { isAgentSdkAvailable, type AvailableAgentSdks } from './agent-sdk-availability'
 import { type AgentSdk, supportsGoalMode, toModelCatalogSdk } from '@shared/types/agent-sdk'
+import { HANDOFF_PLAN_PROMPT_HEADER } from '@shared/agent-mode-prefixes'
 import {
   findModelInfo,
   getFirstModelInfo,
@@ -43,7 +44,7 @@ export function buildHandoffPrompt(
   const goalPrefix = override?.goalMode && supportsGoalMode(override.agentSdk) ? '/goal ' : ''
   const superPrefix =
     override?.superPlan && override.agentSdk === 'claude-code-cli' ? SUPER_PLAN_MODE_PREFIX : ''
-  return `${superPrefix}${goalPrefix}Implement the following plan\n${planContent}`
+  return `${superPrefix}${goalPrefix}${HANDOFF_PLAN_PROMPT_HEADER}${planContent}`
 }
 
 const SDK_DISPLAY_NAMES: Record<HandoffAgentSdk, string> = {

--- a/src/shared/agent-mode-prefixes.ts
+++ b/src/shared/agent-mode-prefixes.ts
@@ -7,6 +7,11 @@ export const SUPER_PLAN_MODE_PREFIX =
 export const CODEX_SUPER_PLAN_MODE_PREFIX =
   'Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.\n\nIf a question can be answered by exploring the codebase, explore the codebase instead.\nAll questions should be asked using the request_user_input tool if possible\n\n'
 
+// Header that introduces the raw plan in a plan→implementor handoff prompt. Shared so the
+// renderer (which writes it in buildHandoffPrompt) and the main process (which detects and
+// strips it when externalizing oversized claude-cli goal handoffs) can't drift apart.
+export const HANDOFF_PLAN_PROMPT_HEADER = 'Implement the following plan\n'
+
 export function getSuperPlanModePrefix(agentSdk: string | null | undefined): string {
   return agentSdk === 'codex' ? CODEX_SUPER_PLAN_MODE_PREFIX : SUPER_PLAN_MODE_PREFIX
 }


### PR DESCRIPTION
## Summary
- Add goal-handoff externalization for `claude-cli` so oversized `/goal` prompts are written to `PLAN_{uuid}.md` in the worktree and replaced with a short reference.
- Re-assert Enter after bracketed paste delivery to avoid prompts getting buffered without submission during Claude CLI startup.
- Share the handoff header across renderer and main process to keep prompt generation and detection aligned.
- Add tests covering handoff externalization, prompt submit retries, and terminal bridge wiring.

## Testing
- `vitest src/main/services/claude-cli-plan-handoff.test.ts`
- `vitest src/main/services/claude-cli-pty-prompt.test.ts`
- `vitest src/main/services/terminal-pty-bridge.claude-cli.test.ts`
- Not run: full app test suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Claude CLI session startup and prompt delivery (spawn argv and PTY injection); failures fall back to inline prompts, but wrong detection could rewrite non-handoff `/goal` prompts or leave plans unstarted if writes fail silently from the user’s perspective.
> 
> **Overview**
> Fixes **Claude CLI plan→implementor handoffs** that fail when inline `/goal` prompts exceed ~4k characters, and prompts that paste into a still-booting TUI but never submit.
> 
> **Plan externalization:** Before spawn args or PTY paste, `createClaudeCliTerminal` runs `externalizeGoalHandoffPlan` on pending prompts. Recognized handoffs (`/goal` + shared `HANDOFF_PLAN_PROMPT_HEADER` + plan body) are written to `PLAN_{uuid}.md` in the worktree and replaced with a short `/goal implement PLAN_….md` reference; super-plan prefixes are preserved, non-handoffs and write failures pass through unchanged.
> 
> **Submit re-assert:** After a successful bracketed paste into an existing PTY, `reassertClaudeCliPromptSubmit` sends bare Enter at staggered delays so buffered text submits once the CLI is input-ready.
> 
> **Shared header:** `HANDOFF_PLAN_PROMPT_HEADER` lives in `@shared/agent-mode-prefixes` and is used by `buildHandoffPrompt` and main-process detection so generation and stripping stay aligned.
> 
> Tests cover externalization, PTY prompt/retry behavior, and terminal bridge wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d8d8489c0bb05e8d4b4b4ab925847d93acce9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->