### PR TITLE
Add kanban ticket move-to-project flow

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -2735,6 +2735,39 @@ export class DatabaseService {
     return this.getKanbanTicket(id)
   }
 
+  moveKanbanTicketToProject(id: string, targetProjectId: string): KanbanTicket | null {
+    const db = this.getDb()
+    const existing = this.getKanbanTicket(id)
+    if (!existing) return null
+
+    const targetProject = this.getProject(targetProjectId)
+    if (!targetProject) {
+      throw new Error(`Target project not found: ${targetProjectId}`)
+    }
+
+    // No-op if already in the target project
+    if (existing.project_id === targetProjectId) return existing
+
+    // Place at the bottom of the same column in the target project
+    const maxRow = db
+      .prepare(
+        'SELECT MAX(sort_order) as max_sort FROM kanban_tickets WHERE project_id = ? AND "column" = ? AND archived_at IS NULL'
+      )
+      .get(targetProjectId, existing.column) as { max_sort: number | null } | undefined
+    const sortOrder = (maxRow?.max_sort ?? -1) + 1
+
+    const now = new Date().toISOString()
+    // Detach worktree/session/PR references that belong to the source project
+    db.prepare(
+      `UPDATE kanban_tickets
+       SET project_id = ?, worktree_id = NULL, current_session_id = NULL,
+           github_pr_number = NULL, github_pr_url = NULL, sort_order = ?, updated_at = ?
+       WHERE id = ?`
+    ).run(targetProjectId, sortOrder, now, id)
+
+    return this.getKanbanTicket(id)
+  }
+
   reorderKanbanTicket(id: string, sortOrder: number): void {
     const db = this.getDb()
     const now = new Date().toISOString()

--- a/src/renderer/src/api/__tests__/kanban-api.test.ts
+++ b/src/renderer/src/api/__tests__/kanban-api.test.ts
@@ -252,6 +252,28 @@ describe('kanbanApi', () => {
     })
   })
 
+  it('routes ticket.moveToProject through the renderer RPC client', async () => {
+    const ticket = {
+      id: 'ticket-1',
+      project_id: 'project-2',
+      title: 'Relocated board fix',
+      column: 'todo',
+      worktree_id: null
+    }
+    const request = vi.fn().mockResolvedValue(ticket)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(
+      kanbanApi.ticket.moveToProject<typeof ticket>('ticket-1', 'project-2')
+    ).resolves.toEqual(ticket)
+    expect(request).toHaveBeenCalledWith('kanban.ticket.moveToProject', {
+      id: 'ticket-1',
+      targetProjectId: 'project-2'
+    })
+  })
+
   it('routes ticket.reorder through the renderer RPC client', async () => {
     const request = vi.fn().mockResolvedValue(undefined)
     const subscribe = vi.fn()

--- a/src/renderer/src/api/kanban-api.ts
+++ b/src/renderer/src/api/kanban-api.ts
@@ -36,6 +36,11 @@ export const kanbanApi = {
       getRendererRpcClient().request<number>('kanban.ticket.detachWorktree', { worktreeId }),
     move: async <TResult>(id: string, column: string, sortOrder: number): Promise<TResult> =>
       getRendererRpcClient().request<TResult>('kanban.ticket.move', { id, column, sortOrder }),
+    moveToProject: async <TResult>(id: string, targetProjectId: string): Promise<TResult> =>
+      getRendererRpcClient().request<TResult>('kanban.ticket.moveToProject', {
+        id,
+        targetProjectId
+      }),
     reorder: async (id: string, sortOrder: number): Promise<void> =>
       getRendererRpcClient().request<void>('kanban.ticket.reorder', { id, sortOrder }),
     addTokens: async <TResult>(id: string, tokens: number): Promise<TResult> =>

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -28,13 +28,15 @@ import {
   Play,
   ChevronDown,
   Hammer,
-  Map as MapIcon
+  Map as MapIcon,
+  FolderInput
 } from 'lucide-react'
 import { CheckeredFlagIcon } from './CheckeredFlagIcon'
 import { UpdateStatusModal } from './UpdateStatusModal'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
 import { NoteEditorModal } from './NoteEditorModal'
+import { MoveToProjectModal } from './MoveToProjectModal'
 import { cn } from '@/lib/utils'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { ProviderIcon, getProviderLabel } from '@/components/ui/provider-icon'
@@ -143,6 +145,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
   const [showStatusUpdate, setShowStatusUpdate] = useState(false)
   const [showPRPicker, setShowPRPicker] = useState(false)
   const [showNoteEditor, setShowNoteEditor] = useState(false)
+  const [showMoveToProject, setShowMoveToProject] = useState(false)
   const hasNote = !!ticket.note && ticket.note.trim().length > 0
   const isExternalTicket = !!ticket.external_provider
   const dragCloneRef = useRef<HTMLElement | null>(null)
@@ -654,6 +657,32 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       toast.error('Failed to archive ticket')
     }
   }, [ticket.id, ticket.project_id])
+
+  const handleMoveToProject = useCallback(
+    async (project: { id: string; name: string }) => {
+      setShowMoveToProject(false)
+      const sourceProjectId = ticket.project_id
+      try {
+        await useKanbanStore
+          .getState()
+          .moveTicketToProject(ticket.id, sourceProjectId, project.id)
+        toast.success(`Moved to ${project.name}`, {
+          action: {
+            label: 'Undo',
+            onClick: () => {
+              useKanbanStore
+                .getState()
+                .moveTicketToProject(ticket.id, project.id, sourceProjectId)
+                .catch(() => toast.error('Failed to undo move'))
+            }
+          }
+        })
+      } catch {
+        toast.error('Failed to move ticket')
+      }
+    },
+    [ticket.id, ticket.project_id]
+  )
 
   const handleUnarchive = useCallback(async () => {
     try {
@@ -1391,6 +1420,17 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
               </ContextMenuSubContent>
             </ContextMenuSub>
 
+            {!isExternalTicket && (
+              <ContextMenuItem
+                data-testid="ctx-move-to-project"
+                onClick={() => setShowMoveToProject(true)}
+                className="gap-2"
+              >
+                <FolderInput className="h-3.5 w-3.5" />
+                Move to project…
+              </ContextMenuItem>
+            )}
+
             <ContextMenuSeparator />
 
             {/* Archive/Unarchive (done tickets) or Delete (all others) */}
@@ -1489,6 +1529,16 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
         initialNote={ticket.note}
         onSave={handleSaveNote}
       />
+
+      {!isExternalTicket && (
+        <MoveToProjectModal
+          currentProjectId={ticket.project_id}
+          ticketTitle={ticket.title}
+          open={showMoveToProject}
+          onOpenChange={setShowMoveToProject}
+          onSelect={handleMoveToProject}
+        />
+      )}
     </>
   )
 })

--- a/src/renderer/src/components/kanban/MoveToProjectModal.tsx
+++ b/src/renderer/src/components/kanban/MoveToProjectModal.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Search, X } from 'lucide-react'
+import type { Project } from '@shared/types/project'
+import { useProjectStore } from '@/stores'
+import { subsequenceMatch } from '@/lib/subsequence-match'
+import { LanguageIcon } from '@/components/projects/LanguageIcon'
+import { HighlightedText } from '@/components/projects/HighlightedText'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+
+interface MoveToProjectModalProps {
+  /** Project the ticket currently belongs to (excluded from the list). */
+  currentProjectId: string
+  ticketTitle: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (project: Project) => void
+}
+
+export function MoveToProjectModal({
+  currentProjectId,
+  ticketTitle,
+  open,
+  onOpenChange,
+  onSelect
+}: MoveToProjectModalProps): React.JSX.Element {
+  const projects = useProjectStore((s) => s.projects)
+  const loadProjects = useProjectStore((s) => s.loadProjects)
+  const [query, setQuery] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Reset query and ensure projects are loaded each time the modal opens
+  useEffect(() => {
+    if (!open) return
+    setQuery('')
+    if (projects.length === 0) loadProjects()
+    requestAnimationFrame(() => inputRef.current?.focus())
+  }, [open, projects.length, loadProjects])
+
+  const filtered = useMemo(() => {
+    const others = projects.filter((p) => p.id !== currentProjectId)
+    if (!query.trim()) {
+      return others.map((project) => ({ project, nameMatch: null, pathMatch: null }))
+    }
+    return others
+      .map((project) => ({
+        project,
+        nameMatch: subsequenceMatch(query, project.name),
+        pathMatch: subsequenceMatch(query, project.path)
+      }))
+      .filter(({ nameMatch, pathMatch }) => nameMatch.matched || pathMatch.matched)
+      .sort((a, b) => {
+        const aScore = a.nameMatch.matched ? a.nameMatch.score : a.pathMatch.score + 1000
+        const bScore = b.nameMatch.matched ? b.nameMatch.score : b.pathMatch.score + 1000
+        return aScore - bScore
+      })
+  }, [projects, currentProjectId, query])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md" data-testid="move-to-project-dialog">
+        <DialogHeader>
+          <DialogTitle>Move to project</DialogTitle>
+          <DialogDescription className="truncate">
+            Move &ldquo;{ticketTitle}&rdquo; to another project.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="relative flex items-center">
+          <Search className="absolute left-3.5 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search projects..."
+            className="h-8 w-full text-sm px-2 pl-8 pr-8 rounded-md border border-input bg-transparent placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            data-testid="move-to-project-search"
+          />
+          {query && (
+            <button
+              onClick={() => {
+                setQuery('')
+                inputRef.current?.focus()
+              }}
+              className="absolute right-3 h-3.5 w-3.5 flex items-center justify-center text-muted-foreground hover:text-foreground"
+              data-testid="move-to-project-clear"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+
+        <div className="max-h-72 overflow-y-auto -mx-1 px-1">
+          {filtered.length === 0 ? (
+            <div className="text-xs text-muted-foreground text-center py-6">
+              {projects.length <= 1 ? 'No other projects' : 'No matching projects'}
+            </div>
+          ) : (
+            <div className="space-y-0.5">
+              {filtered.map(({ project, nameMatch, pathMatch }) => (
+                <button
+                  key={project.id}
+                  onClick={() => onSelect(project)}
+                  className="group flex w-full items-center gap-2 px-2 py-1.5 rounded-md text-left cursor-pointer transition-colors hover:bg-accent/50"
+                  data-testid={`move-to-project-option-${project.id}`}
+                >
+                  <LanguageIcon
+                    language={project.language}
+                    customIcon={project.custom_icon}
+                    detectedIcon={project.detected_icon}
+                  />
+                  <div className="flex-1 min-w-0">
+                    {nameMatch?.matched ? (
+                      <HighlightedText
+                        text={project.name}
+                        indices={nameMatch.indices}
+                        className="text-sm truncate block"
+                      />
+                    ) : (
+                      <span className="text-sm truncate block" title={project.path}>
+                        {project.name}
+                      </span>
+                    )}
+                    {pathMatch?.matched && !nameMatch?.matched && (
+                      <HighlightedText
+                        text={project.path}
+                        indices={pathMatch.indices}
+                        className="text-[10px] text-muted-foreground truncate block"
+                      />
+                    )}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -120,6 +120,11 @@ interface KanbanState {
   createTicket: (projectId: string, data: KanbanTicketCreate) => Promise<KanbanTicket>
   updateTicket: (ticketId: string, projectId: string, data: KanbanTicketUpdate) => Promise<void>
   deleteTicket: (ticketId: string, projectId: string) => Promise<void>
+  moveTicketToProject: (
+    ticketId: string,
+    sourceProjectId: string,
+    targetProjectId: string
+  ) => Promise<KanbanTicket | null>
   moveTicket: (
     ticketId: string,
     projectId: string,
@@ -325,6 +330,81 @@ export const useKanbanStore = create<KanbanState>()(
           set((state) => {
             const next = new Map(state.tickets)
             next.set(projectId, snapshot)
+            return { tickets: next }
+          })
+          throw err
+        }
+      },
+
+      // ── moveTicketToProject (optimistic) ─────────────────────────
+      moveTicketToProject: async (
+        ticketId: string,
+        sourceProjectId: string,
+        targetProjectId: string
+      ) => {
+        if (sourceProjectId === targetProjectId) return null
+
+        const prevSource = get().tickets.get(sourceProjectId) ?? []
+        const moved = prevSource.find((t) => t.id === ticketId)
+        if (!moved) return null
+        const sourceSnapshot = prevSource.map((t) => ({ ...t }))
+
+        // Optimistic: remove from the source project's list
+        set((state) => {
+          const next = new Map(state.tickets)
+          next.set(
+            sourceProjectId,
+            (next.get(sourceProjectId) ?? []).filter((t) => t.id !== ticketId)
+          )
+          const update: Partial<KanbanState> = { tickets: next }
+          // Selection lives under the source board; clear it if this ticket was selected
+          if (state.selectedTicketId === ticketId) update.selectedTicketId = null
+          return update
+        })
+
+        try {
+          const updated = await kanbanApi.ticket.moveToProject<KanbanTicket | null>(
+            ticketId,
+            targetProjectId
+          )
+
+          // If the target board is already loaded, surface the moved ticket there
+          if (updated) {
+            set((state) => {
+              if (!state.tickets.has(targetProjectId)) return {}
+              const next = new Map(state.tickets)
+              const targetTickets = next.get(targetProjectId) ?? []
+              if (targetTickets.some((t) => t.id === ticketId)) return {}
+              next.set(targetProjectId, [...targetTickets, updated])
+              return { tickets: next }
+            })
+          }
+
+          // Detach dependency links (they reference the source project's board)
+          kanbanApi.dependency.removeAll(ticketId).catch(() => {})
+          set((state) => {
+            const newMap = new Map(state.dependencyMap)
+            newMap.delete(ticketId)
+            for (const [depId, blockers] of newMap) {
+              if (blockers.has(ticketId)) {
+                const newSet = new Set(blockers)
+                newSet.delete(ticketId)
+                if (newSet.size === 0) {
+                  newMap.delete(depId)
+                } else {
+                  newMap.set(depId, newSet)
+                }
+              }
+            }
+            return { dependencyMap: newMap }
+          })
+
+          return updated
+        } catch (err) {
+          // Revert on failure
+          set((state) => {
+            const next = new Map(state.tickets)
+            next.set(sourceProjectId, sourceSnapshot)
             return { tickets: next }
           })
           throw err

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -1107,6 +1107,106 @@ describe('rpc router', () => {
     })
   })
 
+  it('handles kanban.ticket.moveToProject through the kanban RPC domain', async () => {
+    const ticket = {
+      id: 'ticket-1',
+      project_id: 'project-2',
+      title: 'Relocated migration',
+      description: null,
+      attachments: [],
+      column: 'todo' as const,
+      sort_order: 0,
+      current_session_id: null,
+      worktree_id: null,
+      mode: null,
+      plan_ready: false,
+      created_at: '2026-05-26T00:05:00.000Z',
+      updated_at: '2026-05-26T00:08:00.000Z',
+      archived_at: null,
+      external_provider: null,
+      external_id: null,
+      external_url: null,
+      github_pr_number: null,
+      github_pr_url: null,
+      mark: null,
+      total_tokens: 0,
+      pending_launch_config: null,
+      goal_mode: false,
+      goal_success_criteria: null,
+      note: null
+    }
+    const calls: Array<{ id: string; targetProjectId: string }> = []
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      kanban: {
+        createTicket: () => Effect.die(new Error('createTicket should not run')),
+        createTicketBatch: () => Effect.die(new Error('createTicketBatch should not run')),
+        getTicket: () => Effect.die(new Error('getTicket should not run')),
+        getTicketsByProject: () => Effect.die(new Error('getTicketsByProject should not run')),
+        updateTicket: () => Effect.die(new Error('updateTicket should not run')),
+        deleteTicket: () => Effect.die(new Error('deleteTicket should not run')),
+        archiveTicket: () => Effect.die(new Error('archiveTicket should not run')),
+        archiveAllDoneTickets: () => Effect.die(new Error('archiveAllDoneTickets should not run')),
+        unarchiveTicket: () => Effect.die(new Error('unarchiveTicket should not run')),
+        moveTicket: () => Effect.die(new Error('moveTicket should not run')),
+        moveTicketToProject: (id, targetProjectId) =>
+          Effect.sync(() => {
+            calls.push({ id, targetProjectId })
+            return ticket
+          })
+      }
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'kanban-ticket-move-to-project-1',
+        method: 'kanban.ticket.moveToProject',
+        params: { id: 'ticket-1', targetProjectId: 'project-2' }
+      })
+    )
+
+    expect(response).toEqual({
+      id: 'kanban-ticket-move-to-project-1',
+      ok: true,
+      value: ticket
+    })
+    expect(calls).toEqual([{ id: 'ticket-1', targetProjectId: 'project-2' }])
+  })
+
+  it('validates kanban.ticket.moveToProject params', async () => {
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      kanban: {
+        createTicket: () => Effect.die(new Error('createTicket should not run')),
+        createTicketBatch: () => Effect.die(new Error('createTicketBatch should not run')),
+        getTicket: () => Effect.die(new Error('getTicket should not run')),
+        getTicketsByProject: () => Effect.die(new Error('getTicketsByProject should not run')),
+        updateTicket: () => Effect.die(new Error('updateTicket should not run')),
+        deleteTicket: () => Effect.die(new Error('deleteTicket should not run')),
+        archiveTicket: () => Effect.die(new Error('archiveTicket should not run')),
+        archiveAllDoneTickets: () => Effect.die(new Error('archiveAllDoneTickets should not run')),
+        unarchiveTicket: () => Effect.die(new Error('unarchiveTicket should not run')),
+        moveTicket: () => Effect.die(new Error('moveTicket should not run')),
+        moveTicketToProject: () =>
+          Effect.die(new Error('moveTicketToProject should not run for invalid params'))
+      }
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'kanban-ticket-move-to-project-2',
+        method: 'kanban.ticket.moveToProject',
+        params: { id: 'ticket-1' }
+      })
+    )
+
+    expect(response).toMatchObject({
+      id: 'kanban-ticket-move-to-project-2',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
+
   it('handles kanban.ticket.reorder through the kanban RPC domain', async () => {
     const calls: Array<{ id: string; sortOrder: number }> = []
     const router = makeRpcRouter({

--- a/src/server/rpc/domains/kanban.ts
+++ b/src/server/rpc/domains/kanban.ts
@@ -67,6 +67,10 @@ export interface KanbanRpcService {
     column: KanbanTicket['column'],
     sortOrder: number
   ) => Effect.Effect<KanbanTicket | null, unknown, never>
+  readonly moveTicketToProject?: (
+    id: string,
+    targetProjectId: string
+  ) => Effect.Effect<KanbanTicket | null, unknown, never>
   readonly reorderTicket?: (id: string, sortOrder: number) => Effect.Effect<void, unknown, never>
   readonly getTicketsBySession?: (
     sessionId: string
@@ -211,6 +215,12 @@ const moveTicketParamsSchema = z
     id: z.string(),
     column: ticketColumnSchema,
     sortOrder: z.number()
+  })
+  .strict()
+const moveTicketToProjectParamsSchema = z
+  .object({
+    id: z.string(),
+    targetProjectId: z.string()
   })
   .strict()
 const reorderTicketParamsSchema = z
@@ -409,6 +419,14 @@ export const makeLiveKanbanRpcService = (): KanbanRpcService => ({
       try: async () => {
         const { getDatabase } = await import('../../../main/db')
         return getDatabase().moveKanbanTicket(id, column, sortOrder)
+      },
+      catch: (cause) => cause
+    }),
+  moveTicketToProject: (id, targetProjectId) =>
+    Effect.tryPromise({
+      try: async () => {
+        const { getDatabase } = await import('../../../main/db')
+        return getDatabase().moveKanbanTicketToProject(id, targetProjectId)
       },
       catch: (cause) => cause
     }),
@@ -920,6 +938,22 @@ export const makeKanbanRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.moveTicket(id, column, sortOrder)
+        })
+    ],
+    [
+      'kanban.ticket.moveToProject',
+      (params) =>
+        Effect.gen(function* () {
+          const { id, targetProjectId } = yield* Effect.try({
+            try: () => moveTicketToProjectParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          if (!service.moveTicketToProject) {
+            return yield* Effect.die(
+              new Error('kanban.ticket.moveToProject service is not implemented')
+            )
+          }
+          return yield* service.moveTicketToProject(id, targetProjectId)
         })
     ],
     [


### PR DESCRIPTION
## Summary
- Added a kanban ticket action to move a ticket to another project from the card context menu.
- Introduced a project picker modal with search, highlighting, and exclusion of the current project.
- Wired the renderer store, API client, RPC router, and database layer to support moving tickets across projects.
- Preserved undo behavior in the UI and cleared project-local references on the server when a ticket is moved.
- Added unit coverage for the renderer API and RPC routing/validation for the new method.

## Testing
- Added renderer API test coverage for `kanban.ticket.moveToProject` routing.
- Added RPC router tests for successful `kanban.ticket.moveToProject` handling.
- Added RPC router validation test for missing `targetProjectId`.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cross-project ticket moves mutate persisted kanban state and detach worktree/session/PR references; undo depends on the same path without extra server-side dependency restoration beyond what the client triggers.
> 
> **Overview**
> Adds **move ticket to another project** end-to-end: card context menu → searchable project picker → optimistic store update → `kanban.ticket.moveToProject` RPC → `moveKanbanTicketToProject` in the database.
> 
> On move, the server updates `project_id`, appends the ticket at the bottom of the **same column** in the target project, and clears **worktree**, **session**, and **GitHub PR** links that belonged to the source project. The store also strips **dependency** edges via `kanban.dependency.removeAll` and local `dependencyMap` cleanup.
> 
> UI includes toast **Undo** (reverse move), hidden for external/synced tickets. Tests cover renderer API routing and RPC success/validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d7343f0e5bcf14b05aca9ef580b6c8b2e299d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->