### PR TITLE
Add auto-create ticket flow for first session message

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -359,7 +359,8 @@ export class DatabaseService {
       pending_launch_config: (row.pending_launch_config as string) ?? null,
       goal_mode: row.goal_mode === 1,
       goal_success_criteria: (row.goal_success_criteria as string) ?? null,
-      note: (row.note as string) ?? null
+      note: (row.note as string) ?? null,
+      created_from_session: row.created_from_session === 1
     }
   }
 
@@ -657,6 +658,7 @@ export class DatabaseService {
     this.safeAddColumn('kanban_tickets', 'note', 'TEXT DEFAULT NULL')
     this.safeAddColumn('kanban_tickets', 'goal_mode', 'INTEGER NOT NULL DEFAULT 0')
     this.safeAddColumn('kanban_tickets', 'goal_success_criteria', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('kanban_tickets', 'created_from_session', 'INTEGER NOT NULL DEFAULT 0')
     this.safeAddColumn('sessions', 'session_type', "TEXT NOT NULL DEFAULT 'default'")
     this.safeAddColumn(
       'discord_resources',
@@ -2448,10 +2450,11 @@ export class DatabaseService {
     const githubPrNumber = data.github_pr_number ?? null
     const githubPrUrl = data.github_pr_url ?? null
     const mark = data.mark ?? null
+    const createdFromSession = data.created_from_session ? 1 : 0
 
     db.prepare(
-      `INSERT INTO kanban_tickets (id, project_id, title, description, attachments, "column", sort_order, current_session_id, worktree_id, mode, plan_ready, external_provider, external_id, external_url, github_pr_number, github_pr_url, mark, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO kanban_tickets (id, project_id, title, description, attachments, "column", sort_order, current_session_id, worktree_id, mode, plan_ready, external_provider, external_id, external_url, github_pr_number, github_pr_url, mark, created_from_session, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       id,
       data.project_id,
@@ -2470,6 +2473,7 @@ export class DatabaseService {
       githubPrNumber,
       githubPrUrl,
       mark,
+      createdFromSession,
       now,
       now
     )
@@ -2492,6 +2496,7 @@ export class DatabaseService {
       github_pr_number: githubPrNumber,
       github_pr_url: githubPrUrl,
       mark,
+      created_from_session: createdFromSession,
       total_tokens: 0,
       created_at: now,
       updated_at: now

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -471,6 +471,8 @@ export interface KanbanTicket {
   goal_success_criteria: string | null
   /** Personal annotation. MUST NOT be included in any LLM prompt. */
   note: string | null
+  /** True when auto-created by the "automatically create ticket" setting on a session's first message. */
+  created_from_session: boolean
 }
 
 export interface KanbanTicketCreate {
@@ -491,6 +493,7 @@ export interface KanbanTicketCreate {
   github_pr_number?: number | null
   github_pr_url?: string | null
   mark?: TicketMark | null
+  created_from_session?: boolean
 }
 
 export interface KanbanTicketUpdate {

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -1,8 +1,10 @@
 import http from 'http'
 import type { SessionStatusType } from '@shared/types/session-status'
+import { OPENCODE_STREAM_CHANNEL } from '@shared/opencode-events'
 import { createLogger } from './logger'
 import { cliHookTransportRouter } from './cli-hook-transport-router'
 import { handleClaudeCliHiveTelemetryHook } from './hive-enterprise-claude-cli-telemetry'
+import { publishDesktopBackendEvent } from '../desktop/backend-event-publisher'
 
 export interface ParsedClaudeHook {
   hook_event_name?: string
@@ -38,6 +40,11 @@ let boundPort: number | null = null
 let startingPromise: Promise<{ port: number }> | null = null
 const lastStatusBySession = new Map<string, SessionStatusType>()
 const statusSubscribers = new Set<(payload: ClaudeCliStatusPayload) => void>()
+// Sessions whose first UserPromptSubmit we've already announced (so the
+// "automatically create ticket" feature fires at most once per session). The
+// renderer's getBySession idempotency check is the real guard; this just keeps
+// us from re-emitting on every prompt.
+const firstPromptAnnounced = new Set<string>()
 
 function hookUrl(port: number, hiveSessionId: string, path: string): string {
   return `http://${host}:${port}/hook/${encodeURIComponent(hiveSessionId)}/${path}`
@@ -254,6 +261,22 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
         })
       }
       void handleClaudeCliHiveTelemetryHook(route.sessionId, body)
+      // First user prompt of this CLI session → tell the renderer so it can
+      // auto-create a kanban ticket (if the setting is on). Fires for prompts
+      // typed straight into the terminal as well as composer/handoff prompts.
+      if (
+        body.hook_event_name === 'UserPromptSubmit' &&
+        typeof body.prompt === 'string' &&
+        body.prompt.trim().length > 0 &&
+        !firstPromptAnnounced.has(route.sessionId)
+      ) {
+        firstPromptAnnounced.add(route.sessionId)
+        void publishDesktopBackendEvent(OPENCODE_STREAM_CHANNEL, {
+          type: 'claude-cli.first-prompt-detected',
+          sessionId: route.sessionId,
+          data: { promptText: body.prompt }
+        })
+      }
       // For forwarded CLI sessions a transport may take ownership of the
       // response (held open until answered). Otherwise behavior is unchanged.
       owned = cliHookTransportRouter.routeHook(route.sessionId, body, res)

--- a/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
@@ -224,7 +224,8 @@ const ticket: KanbanTicket = {
   pending_launch_config: null,
   goal_mode: false,
   goal_success_criteria: null,
-  note: null
+  note: null,
+  created_from_session: false
 }
 
 const worktree: Worktree = {

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -102,6 +102,7 @@ const baseTicket: KanbanTicket = {
   goal_mode: false,
   goal_success_criteria: null,
   pending_launch_config: null,
+  created_from_session: false,
   attachments: [],
   created_at: '2026-01-01T00:00:00.000Z',
   updated_at: '2026-01-01T00:00:00.000Z'

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -89,7 +89,10 @@ import { COMPLETION_WORDS } from '@/lib/format-utils'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline, computeTokenDelta } from '@/lib/token-baselines'
-import { notifyKanbanSessionSync } from '@/stores/store-coordination'
+import {
+  notifyKanbanSessionSync,
+  notifyKanbanAutoCreateTicket
+} from '@/stores/store-coordination'
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
@@ -4632,6 +4635,18 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
           optimisticPrContext + optimisticModePrefix + trimmedValue,
           diffComments
         )
+
+        // First genuine message in this session (not a bash/slash command, which
+        // returned earlier) → optionally auto-create a kanban ticket. Detect before
+        // the optimistic append; messagesRef still reflects the pre-send state, and
+        // is non-empty for resumed sessions, so this only fires on a true first send.
+        if (messagesRef.current.length === 0) {
+          try {
+            notifyKanbanAutoCreateTicket({ sessionId, rawPrompt: trimmedValue })
+          } catch {
+            // Best-effort — never block the send.
+          }
+        }
 
         setMessages((prev) => {
           let base = prev

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -121,6 +121,7 @@ export function SettingsGeneral(): React.JSX.Element {
     boardMode,
     followUpTriggerColumn,
     autoPinBaseWorktreeOnBoardPrompt,
+    automaticallyCreateTicket,
     vimModeEnabled,
     keepAwakeEnabled,
     mergeConflictMode,
@@ -337,6 +338,35 @@ export function SettingsGeneral(): React.JSX.Element {
             className={cn(
               'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
               autoPinBaseWorktreeOnBoardPrompt ? 'translate-x-4' : 'translate-x-0'
+            )}
+          />
+        </button>
+      </div>
+
+      {/* Automatically create ticket */}
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <label className="text-sm font-medium">Automatically create ticket</label>
+          <p className="text-xs text-muted-foreground">
+            When you send the first message in a session you started yourself, create a ticket in
+            that project (using the first words of your prompt as the title) and keep its title in
+            sync as the session is renamed.
+          </p>
+        </div>
+        <button
+          role="switch"
+          aria-checked={automaticallyCreateTicket}
+          onClick={() => updateSetting('automaticallyCreateTicket', !automaticallyCreateTicket)}
+          className={cn(
+            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+            automaticallyCreateTicket ? 'bg-primary' : 'bg-muted'
+          )}
+          data-testid="automatically-create-ticket-toggle"
+        >
+          <span
+            className={cn(
+              'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+              automaticallyCreateTicket ? 'translate-x-4' : 'translate-x-0'
             )}
           />
         </button>

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -26,7 +26,10 @@ import { checkAutoApprove } from '@/lib/permissionUtils'
 import { isPlanLike } from '@/lib/constants'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
 import { useKanbanStore } from '@/stores/useKanbanStore'
-import { notifyKanbanSessionSync } from '@/stores/store-coordination'
+import {
+  notifyKanbanSessionSync,
+  notifyKanbanAutoCreateTicket
+} from '@/stores/store-coordination'
 import { dbApi } from '@/api/db-api'
 import { opencodeApi } from '@/api/opencode-api'
 import { connectionApi } from '@/api/connection-api'
@@ -271,6 +274,19 @@ export function useOpenCodeGlobalListener(): void {
           | undefined
         if (newId) {
           useSessionStore.getState().setOpenCodeSessionId(sessionId, newId)
+        }
+        return
+      }
+
+      // First user prompt in a terminal-backed Claude CLI session — captured in
+      // the main process by the UserPromptSubmit hook (covers prompts typed
+      // straight into the terminal as well as composer/handoff prompts). The
+      // renderer creation helper applies the setting gate, exclusions and the
+      // idempotency check (so a ticket-originated CLI session is skipped).
+      if (event.type === 'claude-cli.first-prompt-detected') {
+        const promptText = (event.data as { promptText?: unknown } | undefined)?.promptText
+        if (typeof promptText === 'string') {
+          notifyKanbanAutoCreateTicket({ sessionId, rawPrompt: promptText })
         }
         return
       }

--- a/src/renderer/src/stores/store-coordination.ts
+++ b/src/renderer/src/stores/store-coordination.ts
@@ -78,3 +78,41 @@ export function notifyKanbanNewSession(
 ): void {
   _kanbanNewSession?.(sessionId, worktreeId, projectId, sessionMode)
 }
+
+// ── Kanban ↔ Session: auto-create a ticket from a session's first message ──
+// Fired when the user sends the first message in a manually-created session.
+// The kanban store decides (setting gate, exclusions, idempotency) whether to
+// create a ticket; the renderer resolves project/worktree/mode from the
+// session record, so only the prompt text needs to travel here.
+export interface KanbanAutoCreateTicketParams {
+  sessionId: string
+  /** The raw text the user typed (NOT the augmented / mode-prefixed payload). */
+  rawPrompt: string
+}
+
+type KanbanAutoCreateTicketFn = (params: KanbanAutoCreateTicketParams) => void
+
+let _kanbanAutoCreateTicket: KanbanAutoCreateTicketFn | null = null
+
+export function registerKanbanAutoCreateTicket(fn: KanbanAutoCreateTicketFn): void {
+  _kanbanAutoCreateTicket = fn
+}
+
+export function notifyKanbanAutoCreateTicket(params: KanbanAutoCreateTicketParams): void {
+  _kanbanAutoCreateTicket?.(params)
+}
+
+// ── Kanban ↔ Session: session renamed (manual or LLM auto-title) ──────────
+// Fired after a session's name is persisted. The kanban store syncs the title
+// of the auto-created ticket linked to this session (if the setting is on).
+type KanbanRenameSyncFn = (sessionId: string, name: string) => void
+
+let _kanbanRenameSync: KanbanRenameSyncFn | null = null
+
+export function registerKanbanRenameSync(fn: KanbanRenameSyncFn): void {
+  _kanbanRenameSync = fn
+}
+
+export function notifyKanbanRenameSync(sessionId: string, name: string): void {
+  _kanbanRenameSync?.(sessionId, name)
+}

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -9,6 +9,8 @@ import type {
 import {
   registerKanbanSessionSync,
   registerKanbanNewSession,
+  registerKanbanAutoCreateTicket,
+  registerKanbanRenameSync,
   type KanbanSessionEvent
 } from './store-coordination'
 import { isPlanLike } from '../lib/constants'
@@ -1247,4 +1249,93 @@ registerKanbanNewSession((sessionId, worktreeId, projectId, sessionMode) => {
       sessionId
     })
   }
+})
+
+// ── Register auto-create-ticket callback (first message of a session) ──
+// Creates a kanban ticket in the session's project on the first user message,
+// when the "automatically create ticket" setting is on. Idempotent: skips if a
+// ticket is already linked to the session (e.g. auto-attach above already ran).
+registerKanbanAutoCreateTicket(({ sessionId, rawPrompt }) => {
+  void (async () => {
+    try {
+      const [{ useSettingsStore }, { useSessionStore }] = await Promise.all([
+        import('./useSettingsStore'),
+        import('./useSessionStore')
+      ])
+      if (!useSettingsStore.getState().automaticallyCreateTicket) return
+
+      const session = useSessionStore.getState().getSessionById(sessionId)
+      if (!session) return
+      // Raw terminals and the board assistant have no real "prompt" to capture.
+      if (session.session_type === 'board-assistant' || session.agent_sdk === 'terminal') return
+
+      // Idempotency gate (authoritative — immune to the auto-attach timing and a
+      // stale in-memory tickets map): skip if any non-archived ticket is linked.
+      const existing = await kanbanApi.ticket.getBySession<KanbanTicket>(sessionId)
+      if (existing.some((t) => !t.archived_at)) return
+
+      const trimmed = rawPrompt.trim()
+      const hasText = trimmed.length > 0
+      const title = hasText ? trimmed.split(/\s+/).slice(0, 10).join(' ') : 'Untitled session'
+
+      const store = useKanbanStore.getState()
+      const sortOrder = store.computeSortOrder(
+        store.getTicketsByColumn(session.project_id, 'in_progress'),
+        0
+      )
+      await store.createTicket(session.project_id, {
+        project_id: session.project_id,
+        title,
+        description: hasText ? rawPrompt : null,
+        column: 'in_progress',
+        sort_order: sortOrder,
+        current_session_id: sessionId,
+        worktree_id: session.worktree_id,
+        mode: session.mode,
+        created_from_session: true
+      })
+    } catch {
+      // Best-effort — never disrupt the user's send/prompt flow.
+    }
+  })()
+})
+
+// ── Register rename-sync callback (session renamed → ticket title) ────
+// Keeps an auto-created ticket's title in sync with its session's name, for
+// both manual renames and LLM auto-titles. Gated on the setting so disabling it
+// freezes existing auto-created tickets too. Only touches created_from_session
+// tickets, so a session started FROM a hand-written ticket is never clobbered.
+registerKanbanRenameSync((sessionId, name) => {
+  void (async () => {
+    try {
+      const { useSettingsStore } = await import('./useSettingsStore')
+      if (!useSettingsStore.getState().automaticallyCreateTicket) return
+      if (/^Session \d+$/.test(name.trim())) return // never sync a placeholder over a real title
+
+      const store = useKanbanStore.getState()
+      for (const [projectId, tickets] of store.tickets.entries()) {
+        for (const ticket of tickets) {
+          if (
+            ticket.current_session_id === sessionId &&
+            ticket.created_from_session &&
+            !ticket.archived_at
+          ) {
+            if (ticket.title !== name) {
+              store.updateTicket(ticket.id, projectId, { title: name }).catch(() => {})
+            }
+            return
+          }
+        }
+      }
+
+      // Fallback: the ticket's board may not be loaded into the map yet.
+      const linked = await kanbanApi.ticket.getBySession<KanbanTicket>(sessionId)
+      const target = linked.find((t) => t.created_from_session && !t.archived_at)
+      if (target && target.title !== name) {
+        store.updateTicket(target.id, target.project_id, { title: name }).catch(() => {})
+      }
+    } catch {
+      // Best-effort.
+    }
+  })()
 })

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -2,7 +2,11 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import type { SelectedModel } from './useSettingsStore'
 import { useWorktreeStore } from './useWorktreeStore'
-import { notifyKanbanSessionSync, notifyKanbanNewSession } from './store-coordination'
+import {
+  notifyKanbanSessionSync,
+  notifyKanbanNewSession,
+  notifyKanbanRenameSync
+} from './store-coordination'
 import { useSettingsStore } from './useSettingsStore'
 import { getUnavailableAgentSdkMessage } from '@/lib/agent-sdk-availability'
 import { resolveSessionCreationSelection } from '@/lib/handoffSelection'
@@ -1086,6 +1090,10 @@ export const useSessionStore = create<SessionState>()(
             if (!isDefault && scope?.type === 'worktree') {
               useWorktreeStore.getState().appendSessionTitle(scope.scopeId, name)
             }
+
+            // Keep an auto-created ticket's title in sync with the session name
+            // (covers both manual renames and LLM auto-titles, which also route here).
+            notifyKanbanRenameSync(sessionId, name)
 
             return true
           }

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -81,6 +81,8 @@ export interface AppSettings {
   boardMode: 'toggle' | 'sticky-tab'
   followUpTriggerColumn: FollowUpTriggerColumn
   autoPinBaseWorktreeOnBoardPrompt: boolean
+  /** Auto-create a kanban ticket on the first message of a manually-created session. */
+  automaticallyCreateTicket: boolean
 
   // Editor
   defaultEditor: EditorOption
@@ -198,6 +200,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   boardMode: 'sticky-tab',
   followUpTriggerColumn: 'done',
   autoPinBaseWorktreeOnBoardPrompt: false,
+  automaticallyCreateTicket: false,
   defaultEditor: 'vscode',
   customEditorCommand: '',
   defaultTerminal: 'terminal',
@@ -419,6 +422,7 @@ function extractSettings(state: SettingsState): AppSettings {
     boardMode: state.boardMode,
     followUpTriggerColumn: state.followUpTriggerColumn,
     autoPinBaseWorktreeOnBoardPrompt: state.autoPinBaseWorktreeOnBoardPrompt,
+    automaticallyCreateTicket: state.automaticallyCreateTicket,
     defaultEditor: state.defaultEditor,
     customEditorCommand: state.customEditorCommand,
     defaultTerminal: state.defaultTerminal,
@@ -783,6 +787,7 @@ export const useSettingsStore = create<SettingsState>()(
         boardMode: state.boardMode,
         followUpTriggerColumn: state.followUpTriggerColumn,
         autoPinBaseWorktreeOnBoardPrompt: state.autoPinBaseWorktreeOnBoardPrompt,
+        automaticallyCreateTicket: state.automaticallyCreateTicket,
         defaultEditor: state.defaultEditor,
         customEditorCommand: state.customEditorCommand,
         defaultTerminal: state.defaultTerminal,

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -159,7 +159,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: false,
       goal_success_criteria: null,
-      note: null
+      note: null,
+      created_from_session: false
     }
     const calls: unknown[] = []
     const router = makeRpcRouter({
@@ -264,7 +265,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: false,
       goal_success_criteria: null,
-      note: null
+      note: null,
+      created_from_session: false
     }
     const secondTicket = {
       ...firstTicket,
@@ -394,7 +396,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: false,
       goal_success_criteria: null,
-      note: null
+      note: null,
+      created_from_session: false
     }
     const calls: string[] = []
     const router = makeRpcRouter({
@@ -491,7 +494,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: false,
       goal_success_criteria: null,
-      note: null
+      note: null,
+      created_from_session: false
     }
     const calls: Array<{ projectId: string; includeArchived: boolean | undefined }> = []
     const router = makeRpcRouter({
@@ -589,7 +593,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: true,
       goal_success_criteria: 'Build passes',
-      note: 'Keep private'
+      note: 'Keep private',
+      created_from_session: false
     }
     const calls: Array<{ id: string; data: unknown }> = []
     const router = makeRpcRouter({
@@ -623,7 +628,8 @@ describe('rpc router', () => {
       mark: 'rare' as const,
       goal_mode: true,
       goal_success_criteria: 'Build passes',
-      note: 'Keep private'
+      note: 'Keep private',
+      created_from_session: false
     }
     const response = await Effect.runPromise(
       router.handle({
@@ -769,7 +775,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: false,
       goal_success_criteria: null,
-      note: null
+      note: null,
+      created_from_session: false
     }
     const calls: string[] = []
     const router = makeRpcRouter({
@@ -938,7 +945,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: false,
       goal_success_criteria: null,
-      note: null
+      note: null,
+      created_from_session: false
     }
     const calls: string[] = []
     const router = makeRpcRouter({
@@ -1036,7 +1044,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: false,
       goal_success_criteria: null,
-      note: null
+      note: null,
+      created_from_session: false
     }
     const calls: Array<{ id: string; column: string; sortOrder: number }> = []
     const router = makeRpcRouter({
@@ -1205,7 +1214,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: false,
       goal_success_criteria: null,
-      note: null
+      note: null,
+      created_from_session: false
     }
     const calls: string[] = []
     const router = makeRpcRouter({
@@ -1305,7 +1315,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: false,
       goal_success_criteria: null,
-      note: null
+      note: null,
+      created_from_session: false
     }
     const calls: Array<{ id: string; tokens: number }> = []
     const router = makeRpcRouter({
@@ -2062,7 +2073,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: false,
       goal_success_criteria: null,
-      note: null
+      note: null,
+      created_from_session: false
     }
     const calls: string[] = []
     const router = makeRpcRouter({
@@ -2171,7 +2183,8 @@ describe('rpc router', () => {
       pending_launch_config: null,
       goal_mode: false,
       goal_success_criteria: null,
-      note: null
+      note: null,
+      created_from_session: false
     }
     const calls: string[] = []
     const router = makeRpcRouter({

--- a/src/server/rpc/domains/kanban.ts
+++ b/src/server/rpc/domains/kanban.ts
@@ -154,7 +154,8 @@ const kanbanTicketCreateSchema = z
     external_url: z.string().nullable().optional(),
     github_pr_number: z.number().nullable().optional(),
     github_pr_url: z.string().nullable().optional(),
-    mark: ticketMarkSchema.nullable().optional()
+    mark: ticketMarkSchema.nullable().optional(),
+    created_from_session: z.boolean().optional()
   })
   .strict() satisfies z.ZodType<KanbanTicketCreate>
 


### PR DESCRIPTION
## Summary
- Adds a new `Automatically create ticket` setting and persists it in app settings.
- Detects the first user prompt in a manually created Claude CLI session and creates a linked kanban ticket on the session's project.
- Marks auto-created tickets with `created_from_session` so later session renames can sync ticket titles without overwriting hand-made ticket links.
- Wires session rename events through the renderer so auto-created ticket titles stay aligned with session names.
- Updates database schema, RPC validation, and tests to account for the new ticket field.

## Testing
- Updated TypeScript/test fixtures to include `created_from_session: false` where required.
- Added/adjusted renderer and RPC tests to cover the new ticket field and session flow.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches kanban creation, SQLite schema, and cross-process events; mitigated by setting gate, idempotency, and scoping title sync to `created_from_session` tickets only.
> 
> **Overview**
> Adds an **Automatically create ticket** setting (off by default) that creates a linked **in progress** kanban ticket when the user sends the first real message in a session they started, using the first words of the prompt as the title.
> 
> **Detection** runs on composer send in `SessionView` (empty transcript) and, for Claude CLI, on the first `UserPromptSubmit` hook in the main process (`claude-cli.first-prompt-detected` via the OpenCode stream), so terminal-typed prompts are covered too. Creation is best-effort, gated on the setting, skips board-assistant/terminal sessions, and is idempotent if a non-archived ticket is already linked.
> 
> New tickets are stored with **`created_from_session`** so rename sync only updates auto-created tickets, not ones opened from an existing ticket. Session renames call **`notifyKanbanRenameSync`** to mirror the session name onto that ticket (skipping `Session N` placeholders). Schema, types, RPC create validation, and test fixtures were updated for the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a24142904a452ef190166e39b052acd63934f12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->