### PR TITLE
Fix Claude CLI handoff prompt mode leakage

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -2066,9 +2066,7 @@ function PlanReviewModeContent({
           const result = await sessionStore.createConnectionSession(
             sessionRecord.connection_id,
             override?.agentSdk,
-            override?.agentSdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
-              ? 'super-plan'
-              : undefined,
+            undefined,
             { autoFocus: false, modelOverride: override?.model }
           )
           if (!result.success || !result.session) {
@@ -2076,21 +2074,10 @@ function PlanReviewModeContent({
             return
           }
 
-          const handoffPrompt = buildHandoffPrompt(
-            planContent,
-            override
-              ? {
-                  ...override,
-                  superPlan: sessionRecord?.mode === 'super-plan'
-                }
-              : undefined
-          )
+          const handoffPrompt = buildHandoffPrompt(planContent, override)
           const newSession = result.session
           const newSessionId = newSession.id
-          const setModePromise =
-            newSession.agent_sdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
-              ? Promise.resolve()
-              : sessionStore.setSessionMode(newSessionId, 'build')
+          const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
 
           prepareTicketBuildSession(newSessionId, handoffGoalMode)
           if (newSession.agent_sdk === 'claude-code-cli') {
@@ -2151,9 +2138,7 @@ function PlanReviewModeContent({
           worktreeId,
           ticket.project_id,
           override?.agentSdk,
-          override?.agentSdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
-            ? 'super-plan'
-            : undefined,
+          undefined,
           { autoFocus: false, modelOverride: override?.model }
         )
         if (!result.success || !result.session) {
@@ -2161,21 +2146,10 @@ function PlanReviewModeContent({
           return
         }
 
-        const handoffPrompt = buildHandoffPrompt(
-          planContent,
-          override
-            ? {
-                ...override,
-                superPlan: sessionRecord?.mode === 'super-plan'
-              }
-            : undefined
-        )
+        const handoffPrompt = buildHandoffPrompt(planContent, override)
         const newSession = result.session
         const newSessionId = newSession.id
-        const setModePromise =
-          newSession.agent_sdk === 'claude-code-cli' && sessionRecord?.mode === 'super-plan'
-            ? Promise.resolve()
-            : sessionStore.setSessionMode(newSessionId, 'build')
+        const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
         const localWorktreePath = findWorktreePathById(worktreeId)
         if (!localWorktreePath) {
           toast.error('Could not find worktree path')

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -287,7 +287,6 @@ export function ClaudeCliSessionView({
   const [ended, setEnded] = useState(false)
   const [planSavedAsTicket, setPlanSavedAsTicket] = useState(false)
   const pendingPlan = useSessionStore((state) => state.pendingPlans.get(sessionId) ?? null)
-  const mode = useSessionStore((state) => state.modeBySession.get(sessionId) ?? 'build')
   const { getTarget, revision: portalRevision } = useClaudeCliSessionPortal()
   void portalRevision
   const isMountedInTicketModal = !!getTarget(sessionId)
@@ -365,19 +364,14 @@ export function ClaudeCliSessionView({
       lastSendMode.delete(sessionId)
       const handoffGoalMode = override.goalMode === true && supportsGoalMode(override.agentSdk)
 
-      const handoffPrompt = buildHandoffPrompt(planContent, {
-        ...override,
-        superPlan: mode === 'super-plan'
-      })
+      const handoffPrompt = buildHandoffPrompt(planContent, override)
       const sessionStore = useSessionStore.getState()
 
       if (sessionRecord?.connection_id) {
         const result = await sessionStore.createConnectionSession(
           sessionRecord.connection_id,
           override.agentSdk,
-          override.agentSdk === 'claude-code-cli' && mode === 'super-plan'
-            ? 'super-plan'
-            : undefined,
+          undefined,
           { autoFocus: !isMountedInTicketModal, modelOverride: override.model }
         )
         if (!result.success || !result.session) {
@@ -385,10 +379,7 @@ export function ClaudeCliSessionView({
           return
         }
 
-        const setModePromise =
-          result.session.agent_sdk === 'claude-code-cli' && mode === 'super-plan'
-            ? Promise.resolve()
-            : sessionStore.setSessionMode(result.session.id, 'build')
+        const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
         registerHivePromptHandoff(sessionId, result.session.id)
         sessionStore.setPendingMessage(result.session.id, handoffPrompt)
         await useKanbanStore
@@ -425,9 +416,7 @@ export function ClaudeCliSessionView({
         sessionRecord.worktree_id,
         sessionRecord.project_id,
         override.agentSdk,
-        override.agentSdk === 'claude-code-cli' && mode === 'super-plan'
-          ? 'super-plan'
-          : undefined,
+        undefined,
         { autoFocus: !isMountedInTicketModal, modelOverride: override.model }
       )
       if (!result.success || !result.session) {
@@ -435,10 +424,7 @@ export function ClaudeCliSessionView({
         return
       }
 
-      const setModePromise =
-        result.session.agent_sdk === 'claude-code-cli' && mode === 'super-plan'
-          ? Promise.resolve()
-          : sessionStore.setSessionMode(result.session.id, 'build')
+      const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
       registerHivePromptHandoff(sessionId, result.session.id)
       sessionStore.setPendingMessage(result.session.id, handoffPrompt)
       await useKanbanStore
@@ -464,7 +450,7 @@ export function ClaudeCliSessionView({
       sessionStore.setActiveSession(result.session.id)
       await setModePromise
     },
-    [isMountedInTicketModal, mode, pendingPlan?.planContent, sessionId, sessionRecord]
+    [isMountedInTicketModal, pendingPlan?.planContent, sessionId, sessionRecord]
   )
 
   const handlePlanReadySaveAsTicket = useCallback(async () => {

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -5088,27 +5088,19 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
       }
 
       if (connectionId) {
-        const handoffPrompt = buildHandoffPrompt(planContent, {
-          ...override,
-          superPlan: mode === 'super-plan'
-        })
+        const handoffPrompt = buildHandoffPrompt(planContent, override)
         const sessionStore = useSessionStore.getState()
         const result = await sessionStore.createConnectionSession(
           connectionId,
           override?.agentSdk,
-          override?.agentSdk === 'claude-code-cli' && mode === 'super-plan'
-            ? 'super-plan'
-            : undefined,
+          undefined,
           { modelOverride: override?.model }
         )
         if (!result.success || !result.session) {
           toast.error(result.error ?? 'Failed to create handoff session')
           return
         }
-        const setModePromise =
-          result.session.agent_sdk === 'claude-code-cli' && mode === 'super-plan'
-            ? Promise.resolve()
-            : sessionStore.setSessionMode(result.session.id, 'build')
+        const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
         registerHivePromptHandoff(sessionId, result.session.id)
         sessionStore.setPendingMessage(result.session.id, handoffPrompt)
         await useKanbanStore
@@ -5126,19 +5118,14 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
         return
       }
 
-      const handoffPrompt = buildHandoffPrompt(planContent, {
-        ...override,
-        superPlan: mode === 'super-plan'
-      })
+      const handoffPrompt = buildHandoffPrompt(planContent, override)
 
       const sessionStore = useSessionStore.getState()
       const result = await sessionStore.createSession(
         currentWorktreeId,
         currentProjectId,
         override?.agentSdk,
-        override?.agentSdk === 'claude-code-cli' && mode === 'super-plan'
-          ? 'super-plan'
-          : undefined,
+        undefined,
         { modelOverride: override?.model }
       )
       if (!result.success || !result.session) {
@@ -5146,10 +5133,7 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
         return
       }
 
-      const setModePromise =
-        result.session.agent_sdk === 'claude-code-cli' && mode === 'super-plan'
-          ? Promise.resolve()
-          : sessionStore.setSessionMode(result.session.id, 'build')
+      const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
       registerHivePromptHandoff(sessionId, result.session.id)
       sessionStore.setPendingMessage(result.session.id, handoffPrompt)
       await useKanbanStore
@@ -5166,8 +5150,7 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
       sessionId,
       worktreePath,
       opencodeSessionId,
-      pendingPlan,
-      mode
+      pendingPlan
     ]
   )
 

--- a/src/renderer/src/lib/__tests__/handoffSelection.test.ts
+++ b/src/renderer/src/lib/__tests__/handoffSelection.test.ts
@@ -6,7 +6,6 @@ import {
   resolveSessionCreationSelection,
   type HandoffSelectionOverride
 } from '../handoffSelection'
-import { SUPER_PLAN_MODE_PREFIX } from '../constants'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 
 const model = { providerID: 'codex', modelID: 'gpt-5.5' }
@@ -55,24 +54,28 @@ describe('buildHandoffPrompt', () => {
     expect(buildHandoffPrompt(planContent)).toBe('Implement the following plan\n1. Build the thing')
   })
 
-  it('prefixes super-plan instructions for Claude CLI handoffs only', () => {
+  it('never prepends the super-plan prefix on handoff, even from a super-plan source', () => {
     const planContent = '1. Build the thing'
-    const cliSuper: HandoffSelectionOverride = {
+    // A handoff means "implement this plan", so the prompt must stay clean regardless
+    // of the source session's mode. Force a stale superPlan flag through to prove it is
+    // ignored (the field no longer exists on HandoffSelectionOverride).
+    const cliSuper = {
       agentSdk: 'claude-code-cli',
       model,
       superPlan: true
-    }
-    const legacySuper: HandoffSelectionOverride = {
-      agentSdk: 'claude-code',
+    } as unknown as HandoffSelectionOverride
+    const cliSuperGoal = {
+      agentSdk: 'claude-code-cli',
       model,
+      goalMode: true,
       superPlan: true
-    }
+    } as unknown as HandoffSelectionOverride
 
     expect(buildHandoffPrompt(planContent, cliSuper)).toBe(
-      `${SUPER_PLAN_MODE_PREFIX}Implement the following plan\n1. Build the thing`
-    )
-    expect(buildHandoffPrompt(planContent, legacySuper)).toBe(
       'Implement the following plan\n1. Build the thing'
+    )
+    expect(buildHandoffPrompt(planContent, cliSuperGoal)).toBe(
+      '/goal Implement the following plan\n1. Build the thing'
     )
   })
 })

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -17,7 +17,6 @@ import {
 } from '@/stores/useSettingsStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
-import { SUPER_PLAN_MODE_PREFIX } from '@/lib/constants'
 import { opencodeApi } from '@/api/opencode-api'
 
 export interface EffectiveHandoffSelection {
@@ -34,17 +33,17 @@ export interface HandoffSelectionOverride {
   agentSdk: HandoffAgentSdk
   model: SelectedModel
   goalMode?: boolean
-  superPlan?: boolean
 }
 
 export function buildHandoffPrompt(
   planContent: string,
   override?: HandoffSelectionOverride
 ): string {
+  // A handoff always means "implement this plan", so the prompt is sent as-is.
+  // Goal mode is the only decoration; the source session's planning mode (plan /
+  // super-plan) must never leak into the implementor's prompt.
   const goalPrefix = override?.goalMode && supportsGoalMode(override.agentSdk) ? '/goal ' : ''
-  const superPrefix =
-    override?.superPlan && override.agentSdk === 'claude-code-cli' ? SUPER_PLAN_MODE_PREFIX : ''
-  return `${superPrefix}${goalPrefix}${HANDOFF_PLAN_PROMPT_HEADER}${planContent}`
+  return `${goalPrefix}${HANDOFF_PLAN_PROMPT_HEADER}${planContent}`
 }
 
 const SDK_DISPLAY_NAMES: Record<HandoffAgentSdk, string> = {


### PR DESCRIPTION
## Summary
- Remove `super-plan` propagation from handoff session creation so implementor sessions always start with a clean build prompt.
- Keep goal mode support for Claude CLI handoffs, but stop carrying the source session's planning mode into the new session.
- Simplify handoff prompt generation by treating handoffs as implementation-only prompts.
- Update tests to cover the new behavior and verify `superPlan` no longer affects generated prompts.

## Testing
- Updated unit coverage in `src/renderer/src/lib/__tests__/handoffSelection.test.ts`.
- Verified `buildHandoffPrompt` no longer prepends the super-plan prefix.
- Verified goal mode still prepends `/goal` when supported.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple handoff entry points and session mode initialization; wrong behavior would mis-route agents but changes are narrowly scoped to handoff paths.
> 
> **Overview**
> Fixes **plan handoffs** so the new implementor session always behaves like **build**, regardless of whether the source was in `super-plan`.
> 
> **Prompt generation** (`buildHandoffPrompt`): drops the Claude CLI `SUPER_PLAN_MODE_PREFIX` and the `superPlan` field on `HandoffSelectionOverride`. Handoff text is implementation-only; **`/goal`** is still applied when goal mode is selected.
> 
> **Session creation** (Kanban plan review, `SessionView`, `ClaudeCliSessionView`): new sessions are no longer created with `super-plan` when the source was super-plan, and **`setSessionMode(..., 'build')`** always runs instead of skipping mode set for Claude CLI super-plan handoffs.
> 
> Tests now assert that a stale `superPlan` flag does not affect the generated prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 142a29fed7a59ab9a5029d381cd4349ced1df68f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->