### PR TITLE
docs: fix corrupted Vietnamese characters in README.vi.md

### DIFF
--- a/README.vi.md
+++ b/README.vi.md
@@ -110,7 +110,7 @@ Xem cách Hive biến đổi quy trình git của bạn:
 | **Xem thay đổi file** | `git status` → `git diff file.ts` | Cây trực quan với diff inline |
 | **So sánh nhánh** | Nhiều tab terminal, copy/paste qua lại | Kết nối worktree để chia sẻ ngữ cảnh |
 | **Tìm worktree** | `cd ~/projects/...` → nhớ tên thư mục | Tất cả worktree trong một thanh bên |
-| **Dọn d���p worktree** | `git worktree remove` → `rm -rf directory` | Click "Lưu trữ" → Xử lý mọi thứ |
+| **Dọn dẹp worktree** | `git worktree remove` → `rm -rf directory` | Click "Lưu trữ" → Xử lý mọi thứ |
 
 ## Khởi động nhanh
 
@@ -240,7 +240,7 @@ Kết nối bất kỳ hai worktree nào để:
 - **Phát triển từ xa** — Phát triển dựa trên SSH và container
 - **Kết nối ba chiều** — Kết nối và merge nhiều nhánh trực quan
 - **Tích hợp CI/CD** — Giám sát GitHub Actions, GitLab CI, Jenkins
-- **Tự động kết n��i** — Tự động kết nối nhánh liên quan theo mẫu
+- **Tự động kết nối** — Tự động kết nối nhánh liên quan theo mẫu
 - **Chế độ review code** — Loại kết nối đặc biệt tối ưu cho review
 - **Theo dõi thời gian** — Phân tích hoạt động cho từng worktree và kết nối
 
@@ -396,7 +396,7 @@ Chúng tôi yêu thích đóng góp! Hive được xây dựng bởi developer, 
 - 📝 **Cải thiện tài liệu** để giúp người khác bắt đầu
 - 🎨 **Gửi cải tiến UI/UX** cho khả năng sử dụng tốt hơn
 - 🔧 **Sửa lỗi** từ issue tracker của chúng tôi
-- ⚡ **T���i ưu hiệu năng** ở các đường dẫn quan trọng
+- ⚡ **Tối ưu hiệu năng** ở các đường dẫn quan trọng
 - 🧪 **Thêm test** để cải thiện coverage
 - 🌐 **Dịch** ứng dụng sang ngôn ngữ của bạn
 


### PR DESCRIPTION
## Description
The Vietnamese README (`README.vi.md`) contained corrupted characters (`�`, U+FFFD replacement characters) introduced by a bad encoding pass. Three Vietnamese words rendered incorrectly. This PR restores the correct UTF-8 characters so the document displays properly.

## Related Issue
N/A — reported via internal ticket "Update Vi README".

## Type of Change
- [x] 📝 Documentation update

## Changes Made
- Line 113: `Dọn d��p worktree` → `Dọn dẹp worktree` (restored `ẹ`)
- Line 243: `Tự động kết n��i` → `Tự động kết nối` (restored `ố`)
- Line 399: `T��i ưu hiệu năng` → `Tối ưu hiệu năng` (restored `ố`)

## Screenshots
<details>
<summary>Screenshots (if applicable)</summary>

N/A — text-only documentation change.

</details>

## Testing

### Test Configuration
- **OS**: macOS
- **Test Type**: Manual

### Test Steps
1. `grep -n $'\xef\xbf\xbd' README.vi.md` → 0 matches (no replacement characters remain)
2. Visually confirmed the three lines now render valid Vietnamese

### Test Results
- [x] Manual testing completed
- [ ] All existing tests pass (no code changed; tests unaffected)

## Checklist
- [x] My code follows the project's code style
- [x] I have updated the documentation (if needed)
- [x] I have tested on macOS (required)

## Performance Impact
- [x] No performance impact

## Breaking Changes
- [x] No breaking changes

## Additional Notes
Documentation-only change scoped to `README.vi.md`. No source code or tests touched.
