### PR TITLE
docs: update English README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@
 - [Features](#features)
 - [Why Hive?](#why-hive)
 - [Quick Start](#quick-start)
-- [Connections - The Game Changer](#-connections---the-game-changer)
-- [Screenshots](#screenshots)
+- [Worktree Connections - The Game Changer](#-worktree-connections---the-game-changer)
+- [See It In Action](#see-it-in-action)
 - [Community & Support](#community--support)
 - [Roadmap](#roadmap)
 - [Development](#development)
   - [Prerequisites](#prerequisites)
   - [Setup](#setup)
+  - [Ghostty Terminal (Optional)](#ghostty-terminal-optional)
   - [Commands](#commands)
   - [Architecture](#architecture)
   - [Project Structure](#project-structure)
@@ -254,6 +255,8 @@ Connect any two worktrees to:
 Want to influence the roadmap? [Join the discussion](https://github.com/morapelker/hive/discussions/categories/ideas) or [contribute](CONTRIBUTING.md)!
 
 ---
+
+<a id="development"></a>
 
 <details>
 <summary><strong>Development</strong></summary>


### PR DESCRIPTION
## Description
Fix the Table of Contents in the English `README.md` so every entry matches an actual heading/anchor in the document, and polish the doc.

## Related Issue
N/A — documentation maintenance.

## Type of Change
- [x] 📝 Documentation update

## Changes Made
- Renamed ToC entry `Connections - The Game Changer` → `Worktree Connections - The Game Changer` and fixed its anchor to `#-worktree-connections---the-game-changer` (heading was renamed; link was broken).
- Replaced stale ToC entry `Screenshots` (`#screenshots`, no such heading) with `See It In Action` → `#see-it-in-action`.
- Added missing ToC sub-entry `Ghostty Terminal (Optional)` → `#ghostty-terminal-optional` under Development.
- Added `<a id="development"></a>` anchor so the `Development` ToC link resolves (the section lives inside a `<details>` block, which has no auto-generated heading anchor).
- Verified all 20 remaining ToC links resolve to real headings/anchors.

## Screenshots
<details>
<summary>Screenshots (if applicable)</summary>

N/A — no UI changes.

</details>

## Testing
### Test Configuration
- **OS**: macOS
- **Test Type**: Manual

### Test Steps
1. `npx prettier --check README.md` → passes.
2. Cross-checked every ToC anchor against `grep -nE '^#{2,3} '` heading slugs.

### Test Results
- [x] All existing tests pass (docs-only change; no code touched)
- [x] Manual testing completed

## Checklist
- [x] My code follows the project's code style
- [x] I have run `pnpm format` to format my code (README confirmed already formatted via prettier)
- [x] I have updated the documentation (if needed)
- [x] I have tested on macOS (required)

## Performance Impact
- [x] No performance impact

## Breaking Changes
- [x] No breaking changes

## Additional Notes
Docs-only change. `pnpm lint`/`pnpm test` not applicable — they target `src/**` `.ts`/`.tsx`; no source files changed.
