### PR TITLE
feat: isolate `pnpm dev` data with interactive first-run clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ scripts/*
 !scripts/prepare-win-deps.sh
 !scripts/codex-app-server-probe.ts
 !scripts/dev-desktop.mjs
+!scripts/dev-data-setup.mjs
 !scripts/dev-web.mjs
 !scripts/probe-effect-logger.ts
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,37 @@ pnpm install
 pnpm dev
 ```
 
+### Data Isolation in Development
+
+`pnpm dev` keeps its data fully separate from an installed (official/daily) Hive app, so you can develop safely without touching — or racing — your real data:
+
+| Data                 | Installed app       | `pnpm dev`              |
+| -------------------- | ------------------- | ----------------------- |
+| Database & resources | `~/.hive`           | `~/.hive-dev`           |
+| Git worktrees        | `~/.hive-worktrees` | `~/.hive-dev-worktrees` |
+
+Because of this, the official app and a dev build can run at the same time without fighting over the same SQLite database.
+
+**First run, you choose: clone everything, or start fresh.** The first time you start dev with no `~/.hive-dev` yet, the launcher prompts you (on a TTY):
+
+1. **Sync (default)** clones _everything_ from the official app into the isolated dev location — the full database, `logs/`, `attachments/`, `project-icons/`, `connections/`, `custom-commands.json`, **and** all of your git worktrees (a complete clone, including uncommitted and gitignored files). This covers worktrees you created at a custom location outside `~/.hive-worktrees` too — they're cloned into the dev tree rather than left pointing at the shared original. **Start fresh** gives you an empty database instead.
+2. If you chose Sync, a second prompt asks to **quit the official Hive app** (default **No** → cancel, nothing copied). A consistent DB + worktree snapshot requires the official app closed; the launcher quits it for you, then clones.
+
+Your official data is treated as strictly **read-only — never modified, moved, or deleted.** Sync only reads `~/.hive` and writes a separate `~/.hive-dev` copy.
+
+**Worktrees and the `hive-dev_` branch prefix.** A git branch can be checked out in only one worktree at a time, so each cloned worktree gets a new branch off the same commit, prefixed `hive-dev_` (e.g. `golden-retriever` → `hive-dev_golden-retriever`). The clone registers these `hive-dev_*` branches in your real repos — that is the _only_ change made to them. Remove them anytime with `git branch -D hive-dev_<name>` / `git worktree remove`. Every cloned worktree lands under `~/.hive-dev-worktrees`: ones from `~/.hive-worktrees` keep their `<project>/<leaf>` sub-path, and custom-location worktrees are consolidated under `~/.hive-dev-worktrees/<project>/<dir-name>`, so the whole dev tree resets with a single `rm -rf`.
+
+> **Known limitation:** dev and the official app share the underlying project repos, so `git worktree list` in a repo shows both installs' worktrees. The clone gives dev its _own_ copy of every worktree (`hive-dev_*`, fully independent — no dev row points at an official working dir), but on a later project refresh dev may still _import_ the official app's worktree rows (and vice-versa); avoid operating from dev on any worktree whose path isn't under `~/.hive-dev-worktrees`. In particular, a project's default `(no-worktree)` entry points at your real repo checkout (not a `~/.hive-dev-worktrees` copy), so a dev session on it runs agents in — and can modify — your actual repository; add a worktree for isolated dev work instead. True per-worktree isolation isn't possible without cloning the repos themselves; this is inherent to separating the databases and is strictly better than the old shared-everything setup.
+
+To reset and be prompted again on the next run:
+
+```bash
+rm -rf ~/.hive-dev ~/.hive-dev-worktrees
+# optionally clean up the dev branches/worktrees registered in your real repos:
+#   git -C <repo> worktree remove <path>   # for each ~/.hive-dev-worktrees/... entry
+#   git -C <repo> branch -D hive-dev_<name>
+```
+
 ### Ghostty Terminal (Optional)
 
 Hive includes an optional native terminal powered by [Ghostty](https://ghostty.org/)'s `libghostty`. This is only needed if you want to work on the embedded terminal feature.

--- a/docs/features/dev-data-isolation.md
+++ b/docs/features/dev-data-isolation.md
@@ -1,0 +1,252 @@
+# Dev Data Isolation
+
+`pnpm dev` keeps its data fully separate from an installed (official/daily) Hive app, so you
+can develop against Hive while still using Hive day-to-day without the two racing the same
+SQLite database or sharing logs, attachments, and worktrees.
+
+| Data                 | Installed app       | `pnpm dev`              |
+| -------------------- | ------------------- | ----------------------- |
+| Database & resources | `~/.hive`           | `~/.hive-dev`           |
+| Git worktrees        | `~/.hive-worktrees` | `~/.hive-dev-worktrees` |
+
+The official data (`~/.hive` / `~/.hive-worktrees`) is treated as strictly **read-only** —
+never modified, moved, or deleted. The dev launcher only ever reads it and writes a separate
+copy.
+
+## How it works
+
+`src/main/services/hive-paths.ts` is the single source of truth for every on-disk Hive path.
+Each helper (`getHiveDataDir`, `getHiveDbPath`, `getHiveLogsDir`, `getHiveWorktreesDir`, …)
+resolves an environment override first, falling back to the historical `~/.hive` /
+`~/.hive-worktrees` layout:
+
+- `HIVE_DATA_DIR` → root for the data tree (db, logs, attachments, project-icons,
+  connections, custom-commands).
+- `HIVE_WORKTREES_DIR` → root for git worktrees.
+
+`scripts/dev-desktop.mjs` (the `pnpm dev` launcher) pins those two vars to the fixed dev dirs
+(`~/.hive-dev` / `~/.hive-dev-worktrees`) for the dev process and the server child it spawns.
+With no overrides set, the installed app resolves to the default `~/.hive` layout unchanged —
+so this feature has no effect on the daily app.
+
+## First-run experience
+
+The first time dev runs in isolated mode (no `~/.hive-dev` yet), the launcher prompts on a
+TTY. There are two gates:
+
+1. **Clone vs fresh** (default **clone**). Clone copies everything from the official app into
+   the dev location; fresh starts with an empty database.
+2. **Quit the official app** (default **No** → cancel). A consistent DB + worktree snapshot
+   requires the official app closed (an open SQLite database copies torn). Choosing yes quits
+   the app for you, waits until it exits, then clones. The official data is still only read.
+
+Non-interactive runs (CI / piped, no TTY) skip both prompts and start fresh — they never
+prompt or quit the app.
+
+## What gets cloned
+
+Sync copies the full data tree (`~/.hive` → `~/.hive-dev`: db incl. `-wal`/`-shm`, logs,
+attachments, project-icons, connections, custom-commands) **and every live worktree**,
+including uncommitted, gitignored, and untracked files.
+
+A git branch can be checked out in only one worktree at a time, so each cloned worktree gets
+a new branch off the same commit, prefixed `hive-dev_` (e.g. `golden-retriever` →
+`hive-dev_golden-retriever`). These branches are registered in your **real project repos** —
+that is the only change made to them. A detached-HEAD worktree is cloned detached at the same
+commit, with no branch.
+
+| Source worktree location                      | Cloned into                                                 |
+| --------------------------------------------- | ----------------------------------------------------------- |
+| under `~/.hive-worktrees/<project>/<leaf>`    | `~/.hive-dev-worktrees/<project>/<leaf>` (same sub-path)    |
+| a custom location outside `~/.hive-worktrees` | `~/.hive-dev-worktrees/<project>/<dir-name>` (consolidated) |
+
+> Because the `hive-dev_*` branches are added to whichever real repo each worktree belongs
+> to, a clone can touch **multiple repos** — one per project that has live worktrees. The
+> entire dev worktree tree still resets with a single `rm -rf ~/.hive-dev-worktrees`.
+
+Each worktree is cloned independently and wrapped in error handling — a single failure logs a
+skip and never aborts the dev launch.
+
+## Resetting
+
+To wipe the dev data and be prompted again on the next run (spans every repo a clone touched):
+
+```bash
+rm -rf ~/.hive-dev ~/.hive-dev-worktrees
+# optionally drop the hive-dev_* branches/worktrees registered in your real repos:
+for repo in /path/to/hive /path/to/other-project; do
+  git -C "$repo" worktree prune
+  for b in $(git -C "$repo" branch --list 'hive-dev_*' | tr -d ' '); do
+    git -C "$repo" branch -D "$b"
+  done
+done
+```
+
+## Manual verification
+
+### Setup
+
+Be on the feature branch and set a var for the repo you launch from, plus one per other
+project repo that has worktrees:
+
+```bash
+cd /path/to/hive
+git branch --show-current      # → feat/dev-data-isolation
+
+HIVE=/path/to/hive             # the Hive repo you run pnpm dev from
+REPO_2=/path/to/other-project  # any other project repo that has live worktrees
+```
+
+List which repos will receive `hive-dev_*` branches before testing:
+
+```bash
+sqlite3 ~/.hive/hive.db \
+  "SELECT DISTINCT p.name, p.path
+     FROM worktrees w JOIN projects p ON p.id = w.project_id
+    WHERE w.is_default = 0 AND w.status = 'active';"
+```
+
+### Step 0 — Snapshot official data (read-only proof)
+
+Run before testing; compare after. Record the printed values.
+
+```bash
+shasum ~/.hive/hive.db
+stat -f '%z bytes  mtime=%Sm' ~/.hive/hive.db
+git -C "$HIVE" worktree list
+git -C "$REPO_2" worktree list
+```
+
+### Path 1 — Clone (default; the main feature)
+
+```bash
+rm -rf ~/.hive-dev ~/.hive-dev-worktrees     # clean first-run state
+cd "$HIVE"
+pnpm dev
+```
+
+At the prompts:
+
+1. **Prompt 1** (clone vs fresh) → press **Enter** (= clone). The preview lists every
+   worktree with its `hive-dev_` branch and dev path.
+2. **Prompt 2** (quit official app) → type **`y`** + Enter. It quits Hive.app, waits until
+   gone, then clones.
+
+The dev app launches on `~/.hive-dev`. Leave it running; in another terminal, verify:
+
+```bash
+# (a) data tree cloned
+ls ~/.hive-dev                  # hive.db, logs, attachments, project-icons, connections, custom-commands.json
+ls ~/.hive-dev-worktrees/       # one dir per project that had worktrees
+
+# (b) new hive-dev_ branches in each real repo
+git -C "$HIVE"   branch --list 'hive-dev_*'
+git -C "$REPO_2" branch --list 'hive-dev_*'
+
+# (c) dev worktrees registered on those branches
+git -C "$HIVE"   worktree list | grep hive-dev
+git -C "$REPO_2" worktree list | grep hive-dev
+
+# (d) uncommitted / gitignored / untracked files copied (pick any cloned worktree dir)
+ls -la ~/.hive-dev-worktrees/<project>/<dir-name>/
+
+# (e) dev DB points at the dev paths (never prod paths)
+sqlite3 ~/.hive-dev/hive.db \
+  "SELECT branch_name, path FROM worktrees WHERE is_default = 0 AND status = 'active';"
+#   every path under ~/.hive-dev-worktrees; branches prefixed hive-dev_
+```
+
+**Read-only proof — official data unchanged** (must match Step 0 exactly):
+
+```bash
+shasum ~/.hive/hive.db                          # identical hash
+stat -f '%z bytes  mtime=%Sm' ~/.hive/hive.db   # identical size + mtime
+git -C "$HIVE"   worktree list                  # original entries intact; hive-dev_ ones ADDED
+git -C "$REPO_2" worktree list                  # original entries intact; hive-dev_ ones ADDED
+```
+
+In the running dev app: confirm your projects and sessions are present and clickable.
+
+Quit the dev app, then reset before trying another path.
+
+### Path 2 — Start fresh
+
+```bash
+rm -rf ~/.hive-dev ~/.hive-dev-worktrees
+cd "$HIVE"
+pnpm dev
+# Prompt 1 → type  f  + Enter
+```
+
+- No Prompt 2; official app never touched.
+- Dev opens with an empty database.
+
+```bash
+ls ~/.hive-dev                                  # created (empty db + dirs)
+ls ~/.hive-dev-worktrees 2>/dev/null            # empty or absent — nothing cloned
+sqlite3 ~/.hive-dev/hive.db "SELECT count(*) FROM projects;"   # 0
+```
+
+### Path 3 — Abort (default No on the quit gate)
+
+```bash
+rm -rf ~/.hive-dev ~/.hive-dev-worktrees
+cd "$HIVE"
+pnpm dev
+# Prompt 1 → Enter (clone)
+# Prompt 2 → Enter (= No, default)
+```
+
+- Prints `Cancelled — official app left running, nothing copied. Exiting.` and exits.
+- Confirm nothing was created and the official app still runs:
+
+```bash
+ls -d ~/.hive-dev ~/.hive-dev-worktrees 2>&1    # both: No such file or directory
+pgrep -fl '/Hive.app/Contents/MacOS/Hive'       # still running (if it was)
+```
+
+### Path 4 (optional) — Non-TTY = silent fresh
+
+Confirms CI / piped runs never prompt or quit the app:
+
+```bash
+rm -rf ~/.hive-dev ~/.hive-dev-worktrees
+echo "" | node scripts/dev-desktop.mjs &        # stdin not a TTY
+sleep 3; kill %1 2>/dev/null
+ls -d ~/.hive-dev                               # created fresh, no prompt shown
+rm -rf ~/.hive-dev ~/.hive-dev-worktrees
+```
+
+### Pass criteria
+
+- **Path 1** — dev opens on `~/.hive-dev` with all projects/sessions; every worktree cloned
+  under `~/.hive-dev-worktrees`; `hive-dev_*` branches present in each real repo; dev DB
+  paths all under `~/.hive-dev-worktrees`; official `~/.hive/hive.db` byte-identical to
+  Step 0 and every repo's original worktrees intact.
+- **Path 2** — empty dev DB, no Prompt 2, app untouched.
+- **Path 3** — clean exit, nothing created, app left running.
+
+## Known limitation
+
+Dev and the official app share the underlying project repos, so `git worktree list` shows
+both installs' worktrees, and a later project refresh in dev may import the official app's
+worktree rows (and vice-versa). The clone gives dev its own copy of every worktree
+(`hive-dev_*`, fully independent) — avoid operating from dev on any worktree whose path is
+not under `~/.hive-dev-worktrees`. In particular, a project's default `(no-worktree)` row
+points at the repo checkout itself (its path is your real repo, not a `~/.hive-dev-worktrees`
+copy), so a dev session opened on that default entry runs agents in — and can modify — your
+actual repository; for isolated dev work, add a worktree (which lands under
+`~/.hive-dev-worktrees`) rather than using the default `(no-worktree)` entry. True
+per-worktree isolation isn't possible without cloning the repos themselves; separating the
+databases is strictly better than the previous shared-everything state.
+
+## Implementation
+
+- `src/main/services/hive-paths.ts` — path resolver honoring `HIVE_DATA_DIR` /
+  `HIVE_WORKTREES_DIR`; every former `~/.hive` call site routes through it.
+- `scripts/dev-desktop.mjs` — pins the dev env vars and runs the first-run clone flow
+  (`ensureDevDataReady` → prompts → quit official app → copy data tree → clone worktrees).
+- `src/server/config.ts` — server base-dir precedence: `HIVE_DATA_DIR` >
+  `HIVE_SERVER_BASE_DIR` > `~/.hive`.
+- `test/dev-desktop-script.test.ts` — unit tests for env pinning, prompt parsing, the
+  worktree dev-path mapping, and branch prefixing.

--- a/scripts/dev-data-setup.mjs
+++ b/scripts/dev-data-setup.mjs
@@ -1,0 +1,887 @@
+// First-run data setup for `pnpm dev` (isolated mode).
+//
+// The dev launcher (scripts/dev-desktop.mjs) keeps its data separate from the
+// installed/official ("daily") Hive app by pinning HIVE_DATA_DIR /
+// HIVE_WORKTREES_DIR to the fixed dev dirs below; getHiveDataDir() /
+// getHiveWorktreesDir() in src/main/services/hive-paths.ts read those env vars
+// and relocate the whole data tree accordingly. Without this, `pnpm dev` and
+// /Applications/Hive.app both open ~/.hive/hive.db (and share logs, icons,
+// attachments, worktrees) — running both at once races the same SQLite file.
+//
+// This module owns the *first run* in isolated mode (no ~/.hive-dev yet): we
+// let the dev either CLONE everything from the official ~/.hive into the dev
+// location, or start with an empty database. The official data is treated as
+// strictly READ-only: we never move, modify, or delete it. Two explicit gates:
+// choose clone-vs-fresh, then a hard confirm to quit the official app (required
+// for a consistent SQLite + worktree snapshot; default = No = abort).
+//
+// It is kept out of dev-desktop.mjs so the launcher stays a small process
+// supervisor; the launcher only imports ensureDevDataReady + the dev dirs.
+
+import { spawnSync } from 'node:child_process'
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { basename, dirname, join, sep } from 'node:path'
+import * as readline from 'node:readline/promises'
+import process from 'node:process'
+
+export const LEGACY_DATA_DIR = join(homedir(), '.hive')
+export const LEGACY_WORKTREES_DIR = join(homedir(), '.hive-worktrees')
+export const DEV_DATA_DIR = join(homedir(), '.hive-dev')
+export const DEV_WORKTREES_DIR = join(homedir(), '.hive-dev-worktrees')
+
+const sleep = (ms) => new Promise((resolveSleep) => setTimeout(resolveSleep, ms))
+
+const tildify = (p) => {
+  const home = homedir()
+  return p === home || p.startsWith(home + sep) ? '~' + p.slice(home.length) : p
+}
+
+// Pure: parse the clone-vs-fresh answer. Empty input = the default (clone).
+export const parseSyncAnswer = (input) => {
+  const value = String(input ?? '')
+    .trim()
+    .toLowerCase()
+  if (value === '') return 'sync'
+  if (['s', 'sync', 'y', 'yes'].includes(value)) return 'sync'
+  if (['f', 'fresh', 'n', 'no', 'scratch'].includes(value)) return 'fresh'
+  return 'sync' // unrecognized -> safe default (read-only clone, still gated below)
+}
+
+// Pure: parse the quit-official-app confirm. Default (empty / anything but an
+// explicit yes) = No = abort, so a stray keypress never quits the daily app.
+export const parseQuitAnswer = (input) => {
+  const value = String(input ?? '')
+    .trim()
+    .toLowerCase()
+  return value === 'y' || value === 'yes'
+}
+
+// Pure: sanitize a project name into a single safe path segment (no separators,
+// no leading dots) so it can't escape ~/.hive-dev-worktrees.
+const safePathSegment = (value) =>
+  String(value ?? '')
+    .trim()
+    .replace(/[/\\]+/g, '-')
+    .replace(/^[.\-]+/, '')
+
+// Pure: map a prod worktree path to its dev twin under ~/.hive-dev-worktrees.
+//   - Paths under ~/.hive-worktrees keep their full sub-path (the
+//     <proj>/<leaf> convention):
+//       ~/.hive-worktrees/<proj>/<leaf> -> ~/.hive-dev-worktrees/<proj>/<leaf>
+//   - Foreign paths (worktrees the user created at a CUSTOM location, e.g.
+//     a sibling of the repo) are consolidated under
+//       ~/.hive-dev-worktrees/<projectName>/<basename>
+//     so every dev worktree lives in one isolated, easy-to-reset tree instead
+//     of being left pointing at the shared prod working dir.
+export const mapWorktreeDevPath = (
+  prodPath,
+  {
+    legacyWorktreesDir = LEGACY_WORKTREES_DIR,
+    devWorktreesDir = DEV_WORKTREES_DIR,
+    projectName = ''
+  } = {}
+) => {
+  if (prodPath === legacyWorktreesDir || prodPath.startsWith(legacyWorktreesDir + sep)) {
+    return devWorktreesDir + prodPath.slice(legacyWorktreesDir.length)
+  }
+  const project = safePathSegment(projectName)
+  const leaf = basename(prodPath)
+  return project ? join(devWorktreesDir, project, leaf) : join(devWorktreesDir, leaf)
+}
+
+// Pure: a git branch checks out in only ONE worktree, so each dev clone gets a
+// fresh "hive-dev_"-prefixed branch off the same commit. Detached worktrees
+// have no branch, so the DB branch_name is left unchanged.
+export const devBranchName = (oldBranch, { detached = false } = {}) =>
+  detached ? oldBranch : `hive-dev_${oldBranch}`
+
+const describeError = (error) => (error instanceof Error ? error.message : String(error))
+
+const sqlStr = (value) => `'${String(value).replace(/'/g, "''")}'`
+
+const runGit = (args, { cwd } = {}) => spawnSync('git', args, { cwd, encoding: 'utf8' })
+
+// Fresh setup guarantees ~/.hive-dev is absent, so any dir already sitting at a
+// target dev worktree path is orphaned from a prior aborted/removed run. Clear
+// the dir AND its git registration so `git worktree add` recovers it instead of
+// failing on "<path> already exists" and archiving the row. Without this, a clone
+// that dies between worktree creation and the atomic publish can never be retried
+// — the leftover dev worktrees survive the data-dir cleanup and block the next run.
+const clearStaleDevWorktree = (sourceRepoPath, devPath) => {
+  if (existsSync(devPath)) {
+    runGit(['worktree', 'remove', '--force', devPath], { cwd: sourceRepoPath })
+    rmSync(devPath, { recursive: true, force: true })
+  }
+  runGit(['worktree', 'prune'], { cwd: sourceRepoPath })
+}
+
+// better-sqlite3 is built against Electron's ABI and unusable from plain node,
+// so we shell out to /usr/bin/sqlite3 for the seeding queries. -readonly opens
+// the DB read-only: every caller here only SELECTs, and the Prompt-1 preview
+// touches the OFFICIAL ~/.hive/hive.db before the user has agreed to anything —
+// a writable handle would create/modify -wal/-shm side files on official data.
+const sqlite3Query = (dbPath, sql) => {
+  const result = spawnSync('sqlite3', ['-readonly', '-json', dbPath, sql], { encoding: 'utf8' })
+  if (result.status !== 0) {
+    throw new Error(`sqlite3 query failed: ${result.stderr || result.stdout || result.status}`)
+  }
+  const out = (result.stdout || '').trim()
+  return out ? JSON.parse(out) : []
+}
+
+const sqlite3Exec = (dbPath, sql) => {
+  const result = spawnSync('sqlite3', [dbPath, sql], { encoding: 'utf8' })
+  if (result.status !== 0) {
+    throw new Error(`sqlite3 exec failed: ${result.stderr || result.stdout || result.status}`)
+  }
+}
+
+// The clone path shells out to the system `sqlite3` CLI (better-sqlite3 is built
+// for Electron's ABI and unusable from plain node). macOS ships it at
+// /usr/bin/sqlite3; elsewhere it may be absent. Probe once so we can fall back
+// to a fresh dev DB instead of letting runClone throw mid-copy.
+const sqlite3Available = ({ spawnSyncImpl = spawnSync } = {}) => {
+  const result = spawnSyncImpl('sqlite3', ['-version'], { encoding: 'utf8' })
+  return result.status === 0 && !result.error
+}
+
+const isOfficialAppRunning = ({ spawnSyncImpl = spawnSync } = {}) => {
+  // pgrep exits 0 when at least one process matches, 1 when none do.
+  const result = spawnSyncImpl('pgrep', ['-f', '/Hive.app/Contents/MacOS/Hive'])
+  return result.status === 0
+}
+
+const quitOfficialApp = ({ spawnSyncImpl = spawnSync } = {}) => {
+  if (!isOfficialAppRunning({ spawnSyncImpl })) return
+  spawnSyncImpl('osascript', ['-e', 'tell application "Hive" to quit'], { stdio: 'ignore' })
+}
+
+const waitUntilOfficialAppGone = async ({
+  timeoutMs = 15000,
+  intervalMs = 500,
+  log = console
+} = {}) => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!isOfficialAppRunning()) return true
+    await sleep(intervalMs)
+  }
+  log.warn?.('[dev] official Hive app still running after 15s; proceeding anyway.')
+  return false
+}
+
+// Reads the (already-copied) dev DB or the prod DB to list every live,
+// non-default worktree to clone — both Hive's own ~/.hive-worktrees ones and
+// worktrees the user created at a custom location. project_name (via the
+// projects join) gives foreign-path worktrees a stable parent segment.
+const listActiveWorktrees = (dbPath) =>
+  sqlite3Query(
+    dbPath,
+    'SELECT w.id AS id, w.name AS name, w.branch_name AS branch_name, w.path AS path, ' +
+      'p.name AS project_name FROM worktrees w LEFT JOIN projects p ON p.id = w.project_id ' +
+      "WHERE w.is_default = 0 AND w.status = 'active'"
+  )
+
+// Informational preview shown in Prompt 1, computed from the prod DB (the dev
+// DB doesn't exist yet). Best-effort: any failure yields an empty preview.
+const buildWorktreePreview = ({
+  legacyDataDir = LEGACY_DATA_DIR,
+  legacyWorktreesDir = LEGACY_WORKTREES_DIR,
+  devWorktreesDir = DEV_WORKTREES_DIR
+} = {}) => {
+  try {
+    return listActiveWorktrees(join(legacyDataDir, 'hive.db'))
+      .filter(
+        (row) =>
+          row.path && row.path !== devWorktreesDir && !row.path.startsWith(devWorktreesDir + sep)
+      )
+      .map((row) => ({
+        branch: devBranchName(row.branch_name),
+        path: mapWorktreeDevPath(row.path, {
+          legacyWorktreesDir,
+          devWorktreesDir,
+          projectName: row.project_name
+        })
+      }))
+  } catch {
+    return []
+  }
+}
+
+const printSyncPrompt = (log = console) => {
+  const preview = buildWorktreePreview()
+  const worktreeLines = preview.length
+    ? preview.map((w) => `                branch ${w.branch}  |  path ${tildify(w.path)}`)
+    : ['                (no live worktrees to clone)']
+
+  log.log?.(
+    [
+      '',
+      '⚠  Hive dev — no ~/.hive-dev found (first isolated run)',
+      '',
+      '  ✅ Your official Hive data is NEVER changed, NEVER moved, NEVER deleted.',
+      '     Sync only READS ~/.hive and writes a SEPARATE ~/.hive-dev copy.',
+      '',
+      '  Sync clones everything into the isolated dev location:',
+      '      Data      ~/.hive  ──►  ~/.hive-dev',
+      '                db · logs · attachments · project-icons · connections · custom-commands',
+      '      Worktrees full clone — incl. uncommitted + gitignored files.',
+      '                Git limit: a branch checks out in only ONE worktree, so each',
+      '                clone gets a NEW branch (prefix "hive-dev_") off the same commit.',
+      '                (Only change to your real repos: these hive-dev_* branches are',
+      '                 added — remove anytime with `git branch -D` / `git worktree remove`.)',
+      ...worktreeLines,
+      '',
+      '  Fresh starts dev with an empty database.',
+      '',
+      'Sync from official app, or start fresh?',
+      '  [S] Sync (default)      [F] Start fresh'
+    ].join('\n')
+  )
+}
+
+const printQuitPrompt = (log = console) => {
+  log.log?.(
+    [
+      '',
+      '⚠  Must quit the official Hive app to continue',
+      '',
+      'A consistent clone of the DB & worktrees REQUIRES the official Hive app',
+      'fully closed — an open SQLite database copies torn / half-written.',
+      '',
+      'Pressing Yes quits the official Hive app for you, then clones.',
+      'Your data is STILL never modified — quitting just flushes it to disk.',
+      '',
+      'Quit the official Hive app now and continue?',
+      '  [y] Yes — quit it & sync',
+      '  [N] No  — cancel & exit          (default)'
+    ].join('\n')
+  )
+}
+
+const ask = async (query) => {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    return await rl.question(query)
+  } finally {
+    rl.close()
+  }
+}
+
+// Clone every live, non-default worktree into the dev worktrees dir on a fresh
+// hive-dev_* branch, then rewrite the dev DB rows to point at the new
+// path/branch. Mirrors Hive's own "duplicate" worktree flow (git worktree add
+// -b + copy of the working tree). All git ops target the prod worktree dir
+// (`git -C row.path`), which auto-resolves the shared real repo; prod worktrees
+// and the prod DB are never written. A failed worktree is logged and skipped —
+// it never aborts the whole launch.
+const cloneWorktrees = ({
+  log = console,
+  devDataDir = DEV_DATA_DIR,
+  legacyWorktreesDir = LEGACY_WORKTREES_DIR,
+  devWorktreesDir = DEV_WORKTREES_DIR
+} = {}) => {
+  const dbPath = join(devDataDir, 'hive.db')
+  const cloned = []
+  const skipped = []
+  // Two active worktrees can map to the SAME dev leaf — same project with an
+  // identical leaf dir, or distinct foreign paths consolidated by basename
+  // (mapWorktreeDevPath is intentionally pure, so it can't see siblings). Left
+  // unresolved, the second clone's clearStaleDevWorktree wipes the first's
+  // checkout and both DB rows end up pointing at one shared dir. Track every
+  // assigned dev path and suffix any collision with the unique worktree id.
+  const usedDevPaths = new Set()
+
+  let rows
+  try {
+    rows = listActiveWorktrees(dbPath)
+  } catch (error) {
+    // Fatal: the copied DB still has every active worktree row pointing at the
+    // OFFICIAL ~/.hive-worktrees paths. If we can't read them we can't rewrite or
+    // archive them, so publishing the clone now would let dev list and operate on
+    // the user's real worktrees, breaking the read-only isolation guarantee.
+    // Throw so runClone rolls back the staging + dev dirs and the next run
+    // re-prompts, rather than silently shipping a leaky DB.
+    throw new Error(
+      `could not read worktrees from ${dbPath} to isolate them: ${describeError(error)}`
+    )
+  }
+
+  for (const row of rows) {
+    try {
+      if (!row.path) continue
+      // A row already under ~/.hive-dev-worktrees can only have reached this DB
+      // via cross-visibility import: the staged DB is a fresh copy of OFFICIAL,
+      // and a prior dev refresh's worktree shows up in the shared repo, then gets
+      // imported onto an official project refresh. It is NOT output of this clone
+      // run, and a fresh sync rebuilds the dev tree from scratch — so preserving
+      // it active would (a) leave a row whose dir we may be about to recreate,
+      // escaping the missing-dir archive, and (b) skip collision tracking, so a
+      // real worktree mapping to the same dev path could leave two active rows on
+      // one checkout. Archive it (via skipped) so dev neither lists it nor races
+      // a real clone for its path; the authoritative copy is re-cloned below.
+      if (row.path === devWorktreesDir || row.path.startsWith(devWorktreesDir + sep)) {
+        skipped.push({
+          id: row.id,
+          branch: row.branch_name,
+          path: row.path,
+          reason: 'imported dev-path row (cross-visibility); rebuilt from official'
+        })
+        continue
+      }
+      // Archived worktree whose dir is gone — nothing to copy.
+      if (!existsSync(row.path)) {
+        skipped.push({
+          id: row.id,
+          branch: row.branch_name,
+          path: row.path,
+          reason: 'directory missing'
+        })
+        continue
+      }
+
+      const headRef = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: row.path })
+      if (headRef.status !== 0) {
+        skipped.push({
+          id: row.id,
+          branch: row.branch_name,
+          path: row.path,
+          reason: `not a git worktree (${(headRef.stderr || '').trim()})`
+        })
+        continue
+      }
+
+      const headBranch = headRef.stdout.trim()
+      const detached = headBranch === 'HEAD'
+      let devPath = mapWorktreeDevPath(row.path, {
+        legacyWorktreesDir,
+        devWorktreesDir,
+        projectName: row.project_name
+      })
+      if (usedDevPaths.has(devPath)) {
+        const unique = `${devPath}--${row.id}`
+        log.warn?.(
+          `[dev] dev worktree path collision at ${tildify(devPath)}; ` +
+            `cloning to ${tildify(unique)} instead`
+        )
+        devPath = unique
+      }
+      usedDevPaths.add(devPath)
+      mkdirSync(dirname(devPath), { recursive: true })
+      // Reclaim any leftover dev worktree dir/registration from a prior aborted run
+      // so the add below recovers instead of failing on a pre-existing directory.
+      clearStaleDevWorktree(row.path, devPath)
+
+      let newBranch
+      if (detached) {
+        // No branch to fork — check out the same commit detached.
+        const commit = runGit(['rev-parse', 'HEAD'], { cwd: row.path }).stdout.trim()
+        const add = runGit(['worktree', 'add', '--detach', devPath, commit], { cwd: row.path })
+        if (add.status !== 0) {
+          skipped.push({
+            id: row.id,
+            branch: row.branch_name,
+            path: row.path,
+            reason: (add.stderr || '').trim()
+          })
+          continue
+        }
+        newBranch = row.branch_name // unchanged in DB
+      } else {
+        newBranch = devBranchName(headBranch)
+        // -B creates-or-RESETS the hive-dev_ branch to the source commit. On a
+        // re-seed (dev dir removed but the branch lingers in the real repo) this
+        // produces a branch off the SAME commit instead of reattaching a stale
+        // one — otherwise the rsync overlay below would surface as uncommitted
+        // diff against an old HEAD rather than the clean clone the prompt promises.
+        let add = runGit(['worktree', 'add', '-B', newBranch, devPath, headBranch], {
+          cwd: row.path
+        })
+        if (add.status !== 0 && /already (used by|checked out)/i.test(add.stderr || '')) {
+          // Stale registration from a prior dev worktree dir that was rm -rf'd.
+          runGit(['worktree', 'prune'], { cwd: row.path })
+          add = runGit(['worktree', 'add', '-B', newBranch, devPath, headBranch], { cwd: row.path })
+        }
+        if (add.status !== 0) {
+          skipped.push({
+            id: row.id,
+            branch: row.branch_name,
+            path: row.path,
+            reason: (add.stderr || '').trim()
+          })
+          continue
+        }
+      }
+
+      // Overlay the prod working tree (uncommitted + gitignored + untracked) onto
+      // the freshly checked-out worktree. --delete mirrors uncommitted deletions
+      // (so files deleted in the source aren't resurrected from the checkout);
+      // --exclude=/.git is anchored to the transfer root so the worktree's own
+      // .git file (created by `worktree add`, linking it to the SHARED repo) is
+      // left intact while the rest of the tree — including submodule working
+      // content — is copied.
+      const rs = spawnSync(
+        'rsync',
+        ['-a', '--delete', '--exclude=/.git', `${row.path}/`, `${devPath}/`],
+        { encoding: 'utf8' }
+      )
+      if (rs.status !== 0) {
+        // The git checkout itself succeeded, so the worktree is on the right
+        // branch/commit and fully isolated; only the working-tree overlay may be
+        // incomplete. Keep it (it never points at prod), but say so loudly.
+        log.warn?.(
+          `[dev] rsync overlay incomplete for ${tildify(devPath)} (exit ${rs.status}); ` +
+            `uncommitted/gitignored state may be partial: ${(rs.stderr || '').trim()}`
+        )
+      }
+
+      // The copied submodule .git files still carry a `gitdir:` pointing at the
+      // SOURCE worktree's module store (under official ~/.hive-worktrees or the
+      // user's repo). Left in place, any git command run inside a dev submodule
+      // would read/write the OFFICIAL metadata — breaking the read-only guarantee.
+      // Drop those nested link files (the depth-1 root .git is kept) so dev
+      // submodules are inert until re-inited dev-locally; the submodule working
+      // content copied above is preserved.
+      const neutralize = spawnSync(
+        'find',
+        [devPath, '-mindepth', '2', '-name', '.git', '-type', 'f', '-delete'],
+        { encoding: 'utf8' }
+      )
+      if (neutralize.status !== 0) {
+        log.warn?.(
+          `[dev] could not neutralize submodule git links under ${tildify(devPath)}: ` +
+            `${(neutralize.stderr || '').trim()}`
+        )
+      }
+
+      sqlite3Exec(
+        dbPath,
+        `UPDATE worktrees SET path = ${sqlStr(devPath)}, branch_name = ${sqlStr(
+          newBranch
+        )}, branch_renamed = 1 WHERE id = ${sqlStr(row.id)};`
+      )
+      cloned.push({ id: row.id, branch: newBranch, path: devPath })
+    } catch (error) {
+      skipped.push({
+        id: row.id,
+        branch: row.branch_name,
+        path: row.path,
+        reason: describeError(error)
+      })
+    }
+  }
+
+  // A skipped row still points at its ORIGINAL (official/foreign) path in the
+  // copied dev DB. Archiving it keeps dev from LISTING it, but that alone is not
+  // enough: getWorktree()/db.worktree.get resolve a row by id WITHOUT filtering
+  // status (src/main/db/database.ts getWorktree), so anything still holding this
+  // worktree's id can fetch the archived row and read its still-official `path`.
+  // Every surface that launches an agent from a worktree id is a leak vector:
+  //   - Kanban jump-to-session reads kanban_tickets.worktree_id / current_session_id
+  //   - SessionView resume reads sessions.worktree_id
+  //   - a Discord message resolves discord_resources.worktree_id (discord-service.ts)
+  // each then runs the agent against that path — i.e. the user's REAL checkout,
+  // breaking read-only isolation. The schema declares these FKs ON DELETE SET
+  // NULL (and ON DELETE CASCADE for discord), but we archive (not delete) the
+  // row, so none of that fires. Null them ourselves: orphan every ticket / card
+  // / session / Discord reference to a skipped worktree, then archive the row.
+  // (Files on disk are left untouched.)
+  for (const s of skipped) {
+    if (s.id == null) continue
+    const id = sqlStr(s.id)
+    // Order matters: clear links that select this worktree via its sessions
+    // BEFORE nulling sessions.worktree_id (those subqueries read it).
+    const statements = [
+      `UPDATE kanban_tickets SET current_session_id = NULL ` +
+        `WHERE current_session_id IN (SELECT id FROM sessions WHERE worktree_id = ${id});`,
+      `UPDATE markdown_kanban_card_state SET current_session_id = NULL ` +
+        `WHERE current_session_id IN (SELECT id FROM sessions WHERE worktree_id = ${id});`,
+      // Clear the Discord resource's managed-session link before its worktree_id
+      // (both filter on worktree_id, so the worktree_id null must come last).
+      `UPDATE discord_resources SET managed_session_id = NULL WHERE worktree_id = ${id};`,
+      `UPDATE kanban_tickets SET worktree_id = NULL WHERE worktree_id = ${id};`,
+      `UPDATE markdown_kanban_card_state SET worktree_id = NULL WHERE worktree_id = ${id};`,
+      // Unlinking worktree_id makes discord-service.ts:handleUserMessage early-return
+      // (`if (!provisionedChannel.worktree_id) return`) instead of resolving a path.
+      `UPDATE discord_resources SET worktree_id = NULL WHERE worktree_id = ${id};`,
+      `UPDATE sessions SET worktree_id = NULL WHERE worktree_id = ${id};`,
+      `UPDATE worktrees SET status = 'archived' WHERE id = ${id};`
+    ]
+    for (const sql of statements) {
+      try {
+        sqlite3Exec(dbPath, sql)
+      } catch (error) {
+        log.warn?.(`[dev] could not isolate skipped worktree ${s.id}: ${describeError(error)}`)
+      }
+    }
+  }
+
+  return { cloned, skipped }
+}
+
+// Connection working dirs live under <dataDir>/connections, and connections.path
+// stores that absolute location. cpSync copies the dir, but the copied DB rows
+// still point at the OFFICIAL ~/.hive/connections; add/delete-member then create
+// or remove symlinks (and rewrite AGENTS.md) there, mutating the official tree.
+// Rewrite the column prefix to the dev copy so those ops stay isolated.
+const rewriteConnectionPaths = (dbPath, { sourceDataDir, devDataDir }) => {
+  const legacy = join(sourceDataDir, 'connections')
+  const dev = join(devDataDir, 'connections')
+  // substr-prefix compare (not LIKE) so a '_'/'%' in the home path can't mis-match.
+  sqlite3Exec(
+    dbPath,
+    `UPDATE connections SET path = ${sqlStr(dev)} || substr(path, ${legacy.length + 1}) ` +
+      `WHERE substr(path, 1, ${legacy.length}) = ${sqlStr(legacy)};`
+  )
+}
+
+// Image ticket attachments are saved by saveAttachment() as ABSOLUTE paths under
+// <dataDir>/attachments and stored verbatim in the attachments JSON of
+// kanban_tickets / markdown_kanban_card_state (worktrees.attachments only holds
+// external jira/figma URLs). cpSync copies the files into the dev tree, but the
+// copied DB still points each image url at ~/.hive/attachments/… — so dev
+// thumbnails read the OFFICIAL file and break if it is later removed or changed.
+// Rewrite that prefix to the dev copy. Paths are embedded inside a JSON string so
+// we replace() on the column text; the prefix includes a trailing '/attachments/'
+// so it only matches real attachment paths (jira/figma URLs and the '.hive-dev'
+// dir never contain it) and is a no-op on rows without it. Best-effort per table
+// — an older DB missing a table/column must not abort the clone (unlike worktree
+// isolation, a stale thumbnail path is a degraded read, not a read-only breach).
+const rewriteAttachmentPaths = (dbPath, { sourceDataDir, devDataDir, log = console }) => {
+  const legacy = join(sourceDataDir, 'attachments') + sep
+  const dev = join(devDataDir, 'attachments') + sep
+  for (const table of ['kanban_tickets', 'markdown_kanban_card_state', 'worktrees']) {
+    try {
+      sqlite3Exec(
+        dbPath,
+        `UPDATE ${table} SET attachments = replace(attachments, ${sqlStr(legacy)}, ${sqlStr(dev)});`
+      )
+    } catch (error) {
+      log.warn?.(`[dev] could not rewrite attachment paths in ${table}: ${describeError(error)}`)
+    }
+  }
+}
+
+// Mirror of generateConnectionInstructions() in
+// src/main/services/connection-service.ts. Each connection dir holds an AGENTS.md
+// and a CLAUDE.md, generated from the connection's absolute path and each member's
+// absolute worktree path. cpSync copies them verbatim, so the dev copies still
+// embed the OFFICIAL connection path and official worktree paths — telling a dev
+// agent to "ONLY work inside ~/.hive/connections/…" and listing real-repo paths,
+// which would steer work straight back at the official checkout. We rebuild them
+// from the staged (rewritten) DB below. Keep this template in sync with the source.
+export const buildConnectionInstructions = (connectionPath, members) => {
+  const sections = members.map(
+    (m) => `### ${m.symlinkName}/
+- **Project:** ${m.projectName}
+- **Branch:** ${m.branchName}
+- **Real path:** ${m.worktreePath}`
+  )
+
+  return `# Connected Worktrees
+
+This workspace contains **symlinked** worktrees from multiple projects.
+Each subdirectory is a symlink pointing to a real git repository on disk.
+
+## IMPORTANT — Symlink Safety
+
+- **Every subdirectory here is a symlink** to a real project. Edits you make here directly modify the original project files.
+- **ONLY work on files inside this directory (\`${connectionPath}\`).** Do not navigate to or edit files using the real paths listed below.
+- **Do NOT create commits, run git operations, or push changes** unless the user explicitly asks you to.
+- Treat this workspace as a read/write view into the linked projects — not as your own repo to manage.
+
+## Projects
+
+${sections.join('\n\n')}
+`
+}
+
+// A connection is a working dir full of symlinks (one per member worktree) that
+// the cpSync copied verbatim — so every member symlink still points at the
+// ORIGINAL worktree location, and connection_members is not filtered by worktree
+// status. Left alone, opening a dev connection follows those links straight back
+// to the official/foreign repo. Reconcile both cases against the staged DB+dir:
+//   - cloned worktree  -> repoint its member symlinks at the new dev worktree;
+//   - skipped worktree -> drop its member rows + stale symlinks so dev neither
+//     lists it (archived above) nor can reach it through a connection.
+// Best-effort per member: a failure is logged and never aborts the clone.
+const reconcileConnections = ({ dbPath, stagingDir, devDataDir, cloned, skipped, log }) => {
+  // connections.path was rewritten to the FINAL dev location, but the files still
+  // live in the staging dir until the atomic rename — map the prefix back.
+  const toStagingDir = (storedPath) =>
+    storedPath === devDataDir || storedPath.startsWith(devDataDir + sep)
+      ? stagingDir + storedPath.slice(devDataDir.length)
+      : null
+  const membersFor = (worktreeId) => {
+    try {
+      return sqlite3Query(
+        dbPath,
+        'SELECT cm.symlink_name AS symlink_name, c.path AS conn_path FROM connection_members cm ' +
+          `JOIN connections c ON c.id = cm.connection_id WHERE cm.worktree_id = ${sqlStr(worktreeId)}`
+      )
+    } catch (error) {
+      log.warn?.(
+        `[dev] could not read connection members for ${worktreeId}: ${describeError(error)}`
+      )
+      return []
+    }
+  }
+
+  for (const w of cloned) {
+    if (w.id == null) continue
+    for (const m of membersFor(w.id)) {
+      const base = toStagingDir(m.conn_path)
+      if (!base || !m.symlink_name) continue
+      const link = join(base, m.symlink_name)
+      try {
+        rmSync(link, { force: true })
+        symlinkSync(w.path, link, 'dir')
+      } catch (error) {
+        log.warn?.(
+          `[dev] could not repoint connection link ${tildify(link)}: ${describeError(error)}`
+        )
+      }
+    }
+  }
+
+  for (const s of skipped) {
+    if (s.id == null) continue
+    for (const m of membersFor(s.id)) {
+      const base = toStagingDir(m.conn_path)
+      if (!base || !m.symlink_name) continue
+      try {
+        rmSync(join(base, m.symlink_name), { force: true })
+      } catch (error) {
+        log.warn?.(
+          `[dev] could not remove stale connection link for ${s.id}: ${describeError(error)}`
+        )
+      }
+    }
+    try {
+      sqlite3Exec(dbPath, `DELETE FROM connection_members WHERE worktree_id = ${sqlStr(s.id)};`)
+    } catch (error) {
+      log.warn?.(`[dev] could not drop connection members for ${s.id}: ${describeError(error)}`)
+    }
+  }
+}
+
+// After symlinks + DB rows are reconciled, the copied AGENTS.md/CLAUDE.md in each
+// connection dir still embed the official connection + worktree paths. Rebuild
+// them from the staged DB (whose connection.path + member worktree.path columns
+// now point at the dev tree) so a dev agent reading them is never directed back
+// at the real checkout. Best-effort per connection — a failure is logged, never
+// fatal. Connections with no surviving members regenerate with an empty Projects
+// list, dropping any stale official paths the old file listed.
+const regenerateConnectionInstructions = ({ dbPath, stagingDir, devDataDir, log }) => {
+  const toStagingDir = (storedPath) =>
+    storedPath === devDataDir || storedPath.startsWith(devDataDir + sep)
+      ? stagingDir + storedPath.slice(devDataDir.length)
+      : null
+
+  let rows
+  try {
+    rows = sqlite3Query(
+      dbPath,
+      'SELECT c.id AS conn_id, c.path AS conn_path, cm.symlink_name AS symlink_name, ' +
+        'w.path AS worktree_path, w.branch_name AS branch_name, p.name AS project_name ' +
+        'FROM connections c ' +
+        'LEFT JOIN connection_members cm ON cm.connection_id = c.id ' +
+        'LEFT JOIN worktrees w ON w.id = cm.worktree_id ' +
+        'LEFT JOIN projects p ON p.id = cm.project_id ' +
+        "WHERE c.status = 'active' ORDER BY c.id, cm.added_at"
+    )
+  } catch (error) {
+    log.warn?.(
+      `[dev] could not read connections to regenerate instructions: ${describeError(error)}`
+    )
+    return
+  }
+
+  const byConn = new Map()
+  for (const r of rows) {
+    if (!byConn.has(r.conn_id)) byConn.set(r.conn_id, { path: r.conn_path, members: [] })
+    if (r.symlink_name) {
+      byConn.get(r.conn_id).members.push({
+        symlinkName: r.symlink_name,
+        projectName: r.project_name,
+        branchName: r.branch_name,
+        worktreePath: r.worktree_path
+      })
+    }
+  }
+
+  for (const { path: connPath, members } of byConn.values()) {
+    const base = toStagingDir(connPath)
+    if (!base || !existsSync(base)) continue
+    const content = buildConnectionInstructions(connPath, members)
+    for (const file of ['AGENTS.md', 'CLAUDE.md']) {
+      try {
+        writeFileSync(join(base, file), content, 'utf8')
+      } catch (error) {
+        log.warn?.(
+          `[dev] could not regenerate ${file} for ${tildify(connPath)}: ${describeError(error)}`
+        )
+      }
+    }
+  }
+}
+
+const runClone = ({
+  log = console,
+  sourceDataDir = LEGACY_DATA_DIR,
+  devDataDir = DEV_DATA_DIR,
+  legacyWorktreesDir = LEGACY_WORKTREES_DIR,
+  devWorktreesDir = DEV_WORKTREES_DIR
+} = {}) => {
+  log.log?.(`[dev] cloning ${tildify(sourceDataDir)} → ${tildify(devDataDir)} …`)
+
+  // Stage the copy in a sibling .partial dir and only publish it with an atomic
+  // rename once everything succeeds. A mid-clone failure (disk full, permission,
+  // interruption) therefore never leaves a half-populated ~/.hive-dev that the
+  // existsSync gate would mistake for a finished setup — the next run re-prompts.
+  const stagingDir = devDataDir + '.partial'
+  rmSync(stagingDir, { recursive: true, force: true })
+
+  try {
+    // Full copy: db (incl. -wal/-shm), logs, attachments, project-icons,
+    // connections, custom-commands. The source is only read.
+    cpSync(sourceDataDir, stagingDir, { recursive: true })
+
+    // Rewrite copied rows to the FINAL dev paths (staging is renamed to devDataDir
+    // below, so connections + worktrees end up consistent once published).
+    rewriteConnectionPaths(join(stagingDir, 'hive.db'), { sourceDataDir, devDataDir })
+    rewriteAttachmentPaths(join(stagingDir, 'hive.db'), { sourceDataDir, devDataDir, log })
+
+    const { cloned, skipped } = cloneWorktrees({
+      log,
+      devDataDir: stagingDir,
+      legacyWorktreesDir,
+      devWorktreesDir
+    })
+
+    if (cloned.length) {
+      log.log?.(`[dev] cloned ${cloned.length} worktree(s):`)
+      for (const w of cloned) log.log?.(`        ${w.branch}  →  ${tildify(w.path)}`)
+    } else {
+      log.log?.('[dev] no worktrees cloned.')
+    }
+    if (skipped.length) {
+      log.warn?.(`[dev] skipped ${skipped.length} worktree(s) (archived in dev DB):`)
+      for (const w of skipped) log.warn?.(`        ${w.branch ?? '?'} — ${w.reason}`)
+    }
+
+    // Repoint/clean connection member symlinks against the staged copy so dev
+    // connections never follow a link back to the official or foreign repo.
+    reconcileConnections({
+      dbPath: join(stagingDir, 'hive.db'),
+      stagingDir,
+      devDataDir,
+      cloned,
+      skipped,
+      log
+    })
+
+    // The connection dirs' AGENTS.md/CLAUDE.md were copied verbatim and still
+    // embed the official connection + worktree paths; regenerate them from the
+    // staged DB so a dev agent is never told to work in the real checkout.
+    regenerateConnectionInstructions({
+      dbPath: join(stagingDir, 'hive.db'),
+      stagingDir,
+      devDataDir,
+      log
+    })
+
+    renameSync(stagingDir, devDataDir)
+    log.log?.(`[dev] done. Official ${tildify(sourceDataDir)} left untouched.`)
+  } catch (error) {
+    rmSync(stagingDir, { recursive: true, force: true })
+    rmSync(devDataDir, { recursive: true, force: true })
+    throw error
+  }
+}
+
+// Called before build:server so the dev answers the prompt up front instead of
+// waiting behind a build. No-op once ~/.hive-dev exists.
+export const ensureDevDataReady = async ({ log = console } = {}) => {
+  if (existsSync(DEV_DATA_DIR)) return
+
+  if (!process.stdin.isTTY) {
+    mkdirSync(DEV_DATA_DIR, { recursive: true })
+    log.log?.('[dev] non-interactive shell (no TTY) → starting fresh with an empty dev database.')
+    return
+  }
+
+  // The clone flow is macOS-only: it quits the official app via `osascript` and
+  // detects it via `pgrep` against the .app bundle path, and the seeded paths it
+  // rewrites are POSIX. On Windows/Linux those primitives don't exist (and
+  // isOfficialAppRunning would falsely report "not running", risking a torn copy
+  // of a live SQLite tree), so we skip cloning and start fresh. Isolation still
+  // holds everywhere — HIVE_DATA_DIR/HIVE_WORKTREES_DIR are pinned to the dev
+  // dirs regardless of platform; only the convenience one-time clone is skipped.
+  if (process.platform !== 'darwin') {
+    mkdirSync(DEV_DATA_DIR, { recursive: true })
+    log.log?.(
+      `[dev] cloning the official app is macOS-only (current platform: ${process.platform}) → ` +
+        'starting fresh with an empty, isolated dev database.'
+    )
+    return
+  }
+
+  // Defensive: the clone reads/writes the DB through the system `sqlite3` CLI.
+  // If it's missing, fall back to fresh rather than throwing mid-clone (which
+  // would roll back and exit). Recovery: install sqlite3, then `rm -rf
+  // ~/.hive-dev` and re-run `pnpm dev` to get the clone prompt again.
+  if (!sqlite3Available()) {
+    mkdirSync(DEV_DATA_DIR, { recursive: true })
+    log.log?.(
+      '[dev] `sqlite3` CLI not found on PATH → starting fresh with an empty, isolated dev ' +
+        'database. To clone official data instead, install sqlite3, then `rm -rf ~/.hive-dev` ' +
+        'and re-run `pnpm dev`.'
+    )
+    return
+  }
+
+  if (!existsSync(join(LEGACY_DATA_DIR, 'hive.db'))) {
+    mkdirSync(DEV_DATA_DIR, { recursive: true })
+    log.log?.(
+      `[dev] no official data found at ${tildify(LEGACY_DATA_DIR)} → starting fresh with an empty dev database.`
+    )
+    return
+  }
+
+  printSyncPrompt(log)
+  const choice = parseSyncAnswer(await ask('> '))
+  if (choice === 'fresh') {
+    mkdirSync(DEV_DATA_DIR, { recursive: true })
+    log.log?.('[dev] starting fresh with an empty dev database.')
+    return
+  }
+
+  printQuitPrompt(log)
+  if (!parseQuitAnswer(await ask('> '))) {
+    log.log?.('[dev] Cancelled — official app left running, nothing copied. Exiting.')
+    process.exit(0)
+  }
+
+  log.log?.('[dev] Quitting official Hive…')
+  quitOfficialApp()
+  if (!(await waitUntilOfficialAppGone({ log }))) {
+    // The whole point of the gate is a quiescent SQLite + worktree snapshot.
+    // If the app won't quit, refuse rather than silently clone a torn DB.
+    log.log?.(
+      '[dev] Official Hive app is still running — aborting to avoid a torn snapshot. ' +
+        'Quit it manually, then run `pnpm dev` again. Nothing copied.'
+    )
+    process.exit(0)
+  }
+  runClone({ log })
+}

--- a/scripts/dev-desktop.mjs
+++ b/scripts/dev-desktop.mjs
@@ -4,30 +4,58 @@ import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import process from 'node:process'
+import { DEV_DATA_DIR, DEV_WORKTREES_DIR, ensureDevDataReady } from './dev-data-setup.mjs'
 
 const DEV_SERVER_DIR = '.dev-server'
 const SERVER_ENTRY = 'server.js'
 const SERVER_CHUNKS = 'server-chunks'
 
+const nonEmpty = (value) => (value && value.length > 0 ? value : undefined)
+
+// Isolate dev data from the installed/official ("daily") app. Without this,
+// `pnpm dev` and /Applications/Hive.app both open ~/.hive/hive.db (and share
+// logs, icons, attachments, worktrees) — running both at once races the same
+// SQLite file. Pin HIVE_DATA_DIR/HIVE_WORKTREES_DIR to the fixed dev dirs
+// (defined in dev-data-setup.mjs); getHiveDataDir()/getHiveWorktreesDir() in
+// src/main/services/hive-paths.ts read those env vars and relocate the whole
+// data tree accordingly. External overrides are ignored — dev is always
+// isolated. First-run cloning of ~/.hive into the dev dirs lives in
+// dev-data-setup.mjs (ensureDevDataReady, called from runDevDesktop below).
 export const createDevDesktopEnv = ({ cwd = process.cwd(), env = process.env } = {}) => {
   const childEnv = { ...env }
   delete childEnv.ELECTRON_RUN_AS_NODE
+  // Strip inherited DB-location overrides. resolveDatabasePath() honors these
+  // BEFORE the HIVE_DATA_DIR-derived fallback, so a parent shell that exported
+  // either one would make dev open the official ~/.hive database even though we
+  // pin HIVE_DATA_DIR below — silently defeating the isolation guarantee. The
+  // server child re-derives its own HIVE_SERVER_DB_PATH from the dev base dir.
+  delete childEnv.HIVE_SERVER_DB_PATH
+  delete childEnv.HIVE_SERVER_BASE_DIR
 
   return {
     ...childEnv,
+    HIVE_DATA_DIR: DEV_DATA_DIR,
+    HIVE_WORKTREES_DIR: DEV_WORKTREES_DIR,
     HIVE_SERVER_ENTRY_PATH:
-      env.HIVE_SERVER_ENTRY_PATH && env.HIVE_SERVER_ENTRY_PATH.length > 0
-        ? env.HIVE_SERVER_ENTRY_PATH
-        : resolve(cwd, DEV_SERVER_DIR, SERVER_ENTRY)
+      nonEmpty(env.HIVE_SERVER_ENTRY_PATH) ?? resolve(cwd, DEV_SERVER_DIR, SERVER_ENTRY)
   }
 }
 
 export const createDevHeadlessEnv = ({ env = process.env } = {}) => {
   const childEnv = { ...env }
   delete childEnv.ELECTRON_RUN_AS_NODE
+  // Headless dev must be isolated from the official ~/.hive too: without the
+  // pins below the plain-Node server resolves the DB via getHiveDbPath() and
+  // would read/write the official database while the installed app is open. The
+  // DB-location overrides are stripped for the same reason as the desktop env —
+  // resolveDatabasePath() honors them ahead of the HIVE_DATA_DIR fallback.
+  delete childEnv.HIVE_SERVER_DB_PATH
+  delete childEnv.HIVE_SERVER_BASE_DIR
 
   return {
     ...childEnv,
+    HIVE_DATA_DIR: DEV_DATA_DIR,
+    HIVE_WORKTREES_DIR: DEV_WORKTREES_DIR,
     HIVE_HEADLESS: '1',
     HIVE_SERVER_MODE: env.HIVE_SERVER_MODE ?? 'browser',
     HIVE_SERVER_HOST: env.HIVE_SERVER_HOST ?? '127.0.0.1',
@@ -194,6 +222,11 @@ const runDevHeadless = async () => {
   process.once('SIGINT', () => shutdown(0))
   process.once('SIGTERM', () => shutdown(0))
 
+  // Same first-run isolation as desktop: clone/seed ~/.hive-dev before the
+  // server opens its DB, so headless dev never touches the official ~/.hive.
+  // Non-interactive runs (CI / piped) start fresh without prompting.
+  await ensureDevDataReady()
+
   await run('pnpm', ['run', 'build:server'])
   copyDevServerBundle()
 
@@ -217,12 +250,18 @@ const runDevHeadless = async () => {
 }
 
 const runDevDesktop = async () => {
+  process.once('SIGINT', () => shutdown(0))
+  process.once('SIGTERM', () => shutdown(0))
+
+  // Prompt for first-run data setup BEFORE installing the raw-mode TTY handler
+  // (readline needs cooked-mode stdin) and BEFORE the long build, so the dev
+  // answers up front instead of waiting behind build:server.
+  await ensureDevDataReady()
+
   const disposeInteractiveInterruptHandler = installInteractiveInterruptHandler()
   const disposeForegroundProcessGroupReclaimer = installForegroundProcessGroupReclaimer()
   process.once('exit', disposeInteractiveInterruptHandler)
   process.once('exit', disposeForegroundProcessGroupReclaimer)
-  process.once('SIGINT', () => shutdown(0))
-  process.once('SIGTERM', () => shutdown(0))
 
   await run('pnpm', ['run', 'build:server'])
   copyDevServerBundle()

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -4,8 +4,8 @@ import Database from 'better-sqlite3'
 import { dirname, join } from 'path'
 import { existsSync, mkdirSync, statSync } from 'fs'
 import { randomUUID } from 'crypto'
-import { homedir } from 'os'
 import { Worker as NodeWorker } from 'node:worker_threads'
+import { getHiveDbPath } from '../services/hive-paths'
 import { MIGRATIONS } from './schema'
 import type {
   Project,
@@ -76,13 +76,18 @@ export function resolveDatabasePath(options?: {
   }
 
   const serverBaseDir = options?.serverBaseDir ?? process.env.HIVE_SERVER_BASE_DIR
-  const homeDir = options?.homeDir ?? homedir()
 
   if (serverBaseDir) {
     return join(serverBaseDir, 'userdata', 'state.sqlite')
   }
 
-  return join(homeDir, '.hive', 'hive.db')
+  // Explicit test/home override keeps the historical layout; otherwise route
+  // through the shared data dir so HIVE_DATA_DIR (`pnpm dev`) is honored.
+  if (options?.homeDir) {
+    return join(options.homeDir, '.hive', 'hive.db')
+  }
+
+  return getHiveDbPath()
 }
 
 type ProjectRow = Omit<Project, 'auto_assign_port' | 'custom_commands'> & {

--- a/src/main/desktop/backend-manager.ts
+++ b/src/main/desktop/backend-manager.ts
@@ -40,6 +40,7 @@ import {
 import { openInApp } from '../services/open-in-app'
 import { openInChrome } from '../services/open-in-chrome'
 import { createLogger } from '../services/logger'
+import { getHiveDataDir, getHiveProjectIconsDir } from '../services/hive-paths'
 import { updateMenuState } from '../menu'
 import { setKeepAwake } from '../services/power-save-blocker'
 import { sleepNow } from '../services/sleep-now'
@@ -535,7 +536,7 @@ export const startDesktopBackend = async (
 
   const log = deps.logger ?? defaultLog
   const headless = input.headless ?? false
-  const baseDir = input.baseDir ?? join(app.getPath('home'), '.hive')
+  const baseDir = input.baseDir ?? getHiveDataDir()
   // `dev:web` pins the backend to a known free port via HIVE_DESKTOP_BACKEND_PORT so
   // its Vite dev server can target it. When set, scan only that single port.
   const pinnedPort = parseDesktopBackendPortEnv(process.env.HIVE_DESKTOP_BACKEND_PORT)
@@ -903,7 +904,7 @@ const handleDesktopBackendCommand = (
           return
         }
 
-        const iconDir = join(app.getPath('home'), '.hive', 'project-icons')
+        const iconDir = getHiveProjectIconsDir()
         const value = saveProjectIcon(message.payload.projectId, result.filePaths[0], iconDir)
         sendDesktopBackendCommandResult(
           child,
@@ -925,7 +926,7 @@ const handleDesktopBackendCommand = (
 
   if (message.command === 'projectRemoveProjectIcon') {
     try {
-      const iconDir = join(app.getPath('home'), '.hive', 'project-icons')
+      const iconDir = getHiveProjectIconsDir()
       const value = removeProjectIcon(message.payload.projectId, iconDir)
       sendDesktopBackendCommandResult(
         child,
@@ -947,7 +948,7 @@ const handleDesktopBackendCommand = (
 
   if (message.command === 'projectGetProjectIconPath') {
     try {
-      const iconDir = join(app.getPath('home'), '.hive', 'project-icons')
+      const iconDir = getHiveProjectIconsDir()
       const value = getProjectIconDataUrl(message.payload.filename, iconDir)
       sendDesktopBackendCommandResult(
         child,

--- a/src/main/effect/git/layers.ts
+++ b/src/main/effect/git/layers.ts
@@ -1,7 +1,7 @@
 import { execFile, spawn } from 'child_process'
 import { existsSync, mkdirSync, rmSync, cpSync, writeFileSync, unlinkSync, readdirSync, readFileSync, appendFileSync, mkdtempSync } from 'fs'
 import { readFile as readFileAsync } from 'fs/promises'
-import { homedir, tmpdir } from 'os'
+import { tmpdir } from 'os'
 import { basename, dirname, join } from 'path'
 import { promisify } from 'util'
 import { Effect, Either, Layer, Ref } from 'effect'
@@ -9,6 +9,7 @@ import simpleGit, { type SimpleGit, type BranchSummary } from 'simple-git'
 
 import { getImageMimeType } from '@shared/types/file-utils'
 import { selectUniqueBreedName } from '../../services/breed-names'
+import { getHiveWorktreesDir } from '../../services/hive-paths'
 import { normalizeWorktreePath } from '../../services/path-utils'
 import { classifyGitError } from './classifier'
 import { GitUnknown, type GitError } from './errors'
@@ -23,8 +24,13 @@ const normalizeBranchDisplayName = (branchName: string): string =>
 
 export const resolveGitWorktreesDir = (
   projectName: string,
-  homeDir: string = homedir()
-): string => join(homeDir, '.hive-worktrees', projectName)
+  // Explicit homeDir keeps the historical layout (used in tests); otherwise route
+  // through the shared worktrees dir so HIVE_WORKTREES_DIR (`pnpm dev`) is honored.
+  homeDir?: string
+): string =>
+  homeDir !== undefined
+    ? join(homeDir, '.hive-worktrees', projectName)
+    : join(getHiveWorktreesDir(), projectName)
 
 const ensureWorktreesDir = (projectName: string): string => {
   const projectWorktreesDir = resolveGitWorktreesDir(projectName)

--- a/src/main/services/attachment-storage.ts
+++ b/src/main/services/attachment-storage.ts
@@ -1,8 +1,8 @@
 import { join, resolve } from 'path'
 import { mkdir, writeFile, unlink, access } from 'fs/promises'
-import { homedir } from 'os'
 import { randomUUID } from 'crypto'
 import { createLogger } from './logger'
+import { getHiveAttachmentsDir } from './hive-paths'
 
 const log = createLogger({ component: 'AttachmentStorage' })
 
@@ -10,7 +10,7 @@ const MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB
 const ALLOWED_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'])
 
 async function getAttachmentsDir(): Promise<string> {
-  const dir = join(homedir(), '.hive', 'attachments')
+  const dir = getHiveAttachmentsDir()
   await mkdir(dir, { recursive: true })
   return dir
 }

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -1,8 +1,8 @@
-import { app } from 'electron'
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 
 import { createLogger } from './logger'
+import { getHiveLogsDir } from './hive-paths'
 import { agentEventBus } from './agent-event-bus'
 import { notificationService } from './notification-service'
 import { loadClaudeSDK } from './claude-sdk-loader'
@@ -517,7 +517,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         extraArgs: { 'replay-user-messages': null },
         thinking: { type: 'adaptive' },
         effort: effortLevel,
-        debugFile: join(app.getPath('home'), '.hive', 'logs', 'claude-debug.log'),
+        debugFile: join(getHiveLogsDir(), 'claude-debug.log'),
         env: {
           ...process.env,
           ...getUserEnvironmentVariables(this.dbService),

--- a/src/main/services/codex-debug-logger.ts
+++ b/src/main/services/codex-debug-logger.ts
@@ -1,6 +1,6 @@
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { appendFileSync, mkdirSync, existsSync, writeFileSync } from 'node:fs'
+import { getHiveLogsDir } from './hive-paths'
 
 const LOG_FILE_NAME = 'codex.jsonl'
 
@@ -11,7 +11,7 @@ let resetPerSession = true
 
 function getLogFilePath(): string {
   if (!logFilePath) {
-    const logDir = join(homedir(), '.hive', 'logs')
+    const logDir = getHiveLogsDir()
     if (!existsSync(logDir)) {
       mkdirSync(logDir, { recursive: true })
     }

--- a/src/main/services/connection-service.ts
+++ b/src/main/services/connection-service.ts
@@ -1,5 +1,4 @@
 import { join } from 'path'
-import { homedir } from 'os'
 import {
   existsSync,
   mkdirSync,
@@ -11,14 +10,12 @@ import {
   writeFileSync
 } from 'fs'
 import { createLogger } from './logger'
+import { getHiveConnectionsDir } from './hive-paths'
 
 const log = createLogger({ component: 'ConnectionService' })
 
-const CONNECTIONS_DIR_NAME = 'connections'
-
 export function getConnectionsBaseDir(): string {
-  const homeDir = homedir()
-  return join(homeDir, '.hive', CONNECTIONS_DIR_NAME)
+  return getHiveConnectionsDir()
 }
 
 export function ensureConnectionsDir(): void {

--- a/src/main/services/custom-commands-file-service.ts
+++ b/src/main/services/custom-commands-file-service.ts
@@ -1,20 +1,19 @@
 // src/main/services/custom-commands-file-service.ts
 
-import { app } from 'electron'
-import { join, dirname } from 'path'
+import { dirname } from 'path'
 import { existsSync, statSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import {
   validateCustomCommand,
   type CustomProjectCommand
 } from '@shared/lib/custom-commands'
+import { getHiveCustomCommandsFile } from './hive-paths'
 
 /**
  * Gets the full path to custom commands file
  * @returns Path to ~/.hive/custom-commands.json
  */
 export function getCustomCommandsFilePath(): string {
-  const homeDir = app.getPath('home')
-  return join(homeDir, '.hive', 'custom-commands.json')
+  return getHiveCustomCommandsFile()
 }
 
 /**

--- a/src/main/services/git-service.ts
+++ b/src/main/services/git-service.ts
@@ -1,7 +1,7 @@
 import simpleGit, { type SimpleGit } from 'simple-git'
-import { homedir } from 'os'
 import { join, basename } from 'path'
 import { existsSync, mkdirSync } from 'fs'
+import { getHiveWorktreesDir } from './hive-paths'
 import {
   ALL_BREED_NAMES,
   LEGACY_CITY_NAMES,
@@ -131,7 +131,7 @@ export class GitService {
    * Get the base directory for all Hive worktrees
    */
   static getWorktreesBaseDir(): string {
-    return join(homedir(), '.hive-worktrees')
+    return getHiveWorktreesDir()
   }
 
   /**

--- a/src/main/services/hive-paths.ts
+++ b/src/main/services/hive-paths.ts
@@ -1,0 +1,70 @@
+import { homedir } from 'os'
+import { join, resolve } from 'path'
+
+// Single source of truth for where Hive keeps its user data on disk.
+//
+// Historically every call site hardcoded `~/.hive` (and `~/.hive-worktrees`),
+// which meant `pnpm dev` and the installed desktop app shared one database and
+// one set of resource folders — running both at once raced the same SQLite
+// file. Routing every path through these helpers lets a single env var
+// (HIVE_DATA_DIR) relocate the whole tree, so dev can run against ~/.hive-dev
+// in complete isolation from the daily app.
+//
+// IMPORTANT: keep this module dependency-free (only `os` + `path`). It is
+// imported by logger.ts, which nearly everything else imports — pulling in any
+// other internal module here risks an import cycle.
+
+const DEFAULT_DATA_DIR_NAME = '.hive'
+const DEFAULT_WORKTREES_DIR_NAME = '.hive-worktrees'
+
+// Root for the Hive data tree (DB, logs, attachments, icons, connections, ...).
+// Resolution order, first match wins:
+//   1. HIVE_DATA_DIR — explicit override (set by `pnpm dev` -> ~/.hive-dev). The
+//                      desktop main process and its spawned server child both
+//                      inherit it, so they agree without any other coupling.
+//   2. ~/.hive       — default for the installed/daily app.
+//
+// We deliberately do NOT key off HIVE_SERVER_BASE_DIR here: that var is also set
+// in standalone server/browser mode, and following it would silently relocate
+// these resource folders away from the historical ~/.hive. Desktop already pins
+// the database via HIVE_SERVER_DB_PATH, so it needs no help from this function.
+export function getHiveDataDir(): string {
+  const explicit = process.env.HIVE_DATA_DIR?.trim()
+  if (explicit) return resolve(explicit)
+
+  return join(homedir(), DEFAULT_DATA_DIR_NAME)
+}
+
+export function getHiveDbPath(): string {
+  return join(getHiveDataDir(), 'hive.db')
+}
+
+export function getHiveLogsDir(): string {
+  return join(getHiveDataDir(), 'logs')
+}
+
+export function getHiveAttachmentsDir(): string {
+  return join(getHiveDataDir(), 'attachments')
+}
+
+export function getHiveProjectIconsDir(): string {
+  return join(getHiveDataDir(), 'project-icons')
+}
+
+export function getHiveConnectionsDir(): string {
+  return join(getHiveDataDir(), 'connections')
+}
+
+export function getHiveCustomCommandsFile(): string {
+  return join(getHiveDataDir(), 'custom-commands.json')
+}
+
+// Git worktrees live in a sibling of the data dir (~/.hive-worktrees by
+// default) rather than inside it. HIVE_WORKTREES_DIR relocates them so dev runs
+// don't drop worktrees next to the daily app's.
+export function getHiveWorktreesDir(): string {
+  const explicit = process.env.HIVE_WORKTREES_DIR?.trim()
+  if (explicit) return resolve(explicit)
+
+  return join(homedir(), DEFAULT_WORKTREES_DIR_NAME)
+}

--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { existsSync, mkdirSync, appendFileSync, readdirSync, statSync, unlinkSync } from 'fs'
-import { homedir } from 'os'
+import { getHiveLogsDir } from './hive-paths'
 
 export enum LogLevel {
   DEBUG = 0,
@@ -37,7 +37,6 @@ const LOG_LEVELS: Record<LogLevel, string> = {
 // Configuration
 const MAX_LOG_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const MAX_LOG_FILES = 5
-const LOG_DIR_NAME = 'logs'
 
 export class LoggerService {
   private static instance: LoggerService | null = null
@@ -46,9 +45,8 @@ export class LoggerService {
   private minLevel: LogLevel
 
   private constructor() {
-    // Use ~/.hive/logs/ for logs
-    const homeDir = homedir()
-    this.logDir = join(homeDir, '.hive', LOG_DIR_NAME)
+    // Use ~/.hive/logs/ for logs (relocatable via HIVE_DATA_DIR for `pnpm dev`)
+    this.logDir = getHiveLogsDir()
     this.ensureLogDir()
     this.currentLogFile = this.getLogFileName()
     this.minLevel = process.env.NODE_ENV === 'development' ? LogLevel.DEBUG : LogLevel.INFO

--- a/src/main/services/perf-diagnostics.ts
+++ b/src/main/services/perf-diagnostics.ts
@@ -1,8 +1,8 @@
 import { join } from 'path'
 import { existsSync, mkdirSync, appendFileSync, statSync, renameSync } from 'fs'
-import { homedir } from 'os'
 import * as v8 from 'v8'
 import { createLogger } from './logger'
+import { getHiveLogsDir } from './hive-paths'
 
 const log = createLogger({ component: 'PerfDiagnostics' })
 
@@ -81,8 +81,7 @@ class PerfDiagnosticsService {
   private running = false
 
   constructor() {
-    const homeDir = homedir()
-    this.logDir = join(homeDir, '.hive', 'logs')
+    this.logDir = getHiveLogsDir()
     this.logFile = join(this.logDir, 'perf-diagnostics.jsonl')
   }
 

--- a/src/main/services/project-ops.ts
+++ b/src/main/services/project-ops.ts
@@ -1,4 +1,3 @@
-import { app } from 'electron'
 import {
   existsSync,
   statSync,
@@ -9,6 +8,7 @@ import {
 } from 'fs'
 import { join, basename, extname } from 'path'
 import { createLogger } from './logger'
+import { getHiveProjectIconsDir } from './hive-paths'
 import { getDatabase } from '../db'
 import type { DatabaseService } from '../db/database'
 import type { Project, ProjectCreate } from '../db/types'
@@ -40,14 +40,17 @@ const MIME_TYPES: Record<string, string> = {
   '.ico': 'image/x-icon'
 }
 
-const iconDir = join(app.getPath('home'), '.hive', 'project-icons')
+// Resolved lazily on each call (not captured at module load) so it always
+// reflects the current HIVE_DATA_DIR — matching every other migrated call site
+// and avoiding a stale path if this module is imported before the env is set.
+const iconDir = (): string => getHiveProjectIconsDir()
 
 /**
  * Ensure the project-icons directory exists
  */
 function ensureIconDir(): void {
-  if (!existsSync(iconDir)) {
-    mkdirSync(iconDir, { recursive: true })
+  if (!existsSync(iconDir())) {
+    mkdirSync(iconDir(), { recursive: true })
   }
 }
 
@@ -125,7 +128,7 @@ export function createProjectWithDefaultWorktree(
  * Resolve an icon filename to a data URL
  */
 export function getIconDataUrl(filename: string): string | null {
-  return getProjectIconDataUrl(filename, iconDir)
+  return getProjectIconDataUrl(filename, iconDir())
 }
 
 /**
@@ -156,17 +159,18 @@ export function uploadIcon(
     ensureIconDir()
 
     // Remove any previous icon for this project (different extension)
-    const existing = readdirSync(iconDir).filter((f) => f.startsWith(`${projectId}.`))
+    const dir = iconDir()
+    const existing = readdirSync(dir).filter((f) => f.startsWith(`${projectId}.`))
     for (const old of existing) {
       try {
-        unlinkSync(join(iconDir, old))
+        unlinkSync(join(dir, old))
       } catch {
         // ignore cleanup errors
       }
     }
 
     const buffer = Buffer.from(base64Data, 'base64')
-    writeFileSync(join(iconDir, destFilename), buffer)
+    writeFileSync(join(dir, destFilename), buffer)
 
     // Update the project record in the database
     const db = getDatabase()
@@ -191,5 +195,5 @@ export function uploadIcon(
  * Remove a custom project icon from disk.
  */
 export function removeIcon(projectId: string): { success: boolean; error?: string } {
-  return removeProjectIcon(projectId, iconDir)
+  return removeProjectIcon(projectId, iconDir())
 }

--- a/src/main/services/response-logger.ts
+++ b/src/main/services/response-logger.ts
@@ -1,15 +1,14 @@
 import { join } from 'path'
 import { existsSync, mkdirSync, appendFileSync } from 'fs'
-import { homedir } from 'os'
 import { createLogger } from './logger'
+import { getHiveLogsDir } from './hive-paths'
 
 const log = createLogger({ component: 'ResponseLogger' })
 
 const RESPONSE_LOG_DIR = 'responses'
 
 function getResponseLogDir(): string {
-  const homeDir = homedir()
-  return join(homeDir, '.hive', 'logs', RESPONSE_LOG_DIR)
+  return join(getHiveLogsDir(), RESPONSE_LOG_DIR)
 }
 
 function ensureLogDir(): void {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -81,7 +81,11 @@ export const resolveServerConfig = (
         throw new Error('BIND_IP requires HIVE_SERVER_REQUIRE_AUTH=true')
       }
 
-      const baseDir = resolve(input.baseDir ?? env.HIVE_SERVER_BASE_DIR ?? join(homedir(), '.hive'))
+      // Precedence mirrors @main/services/hive-paths getHiveDataDir():
+      // HIVE_DATA_DIR (dev override) > HIVE_SERVER_BASE_DIR (desktop child) > ~/.hive.
+      const baseDir = resolve(
+        input.baseDir ?? env.HIVE_DATA_DIR ?? env.HIVE_SERVER_BASE_DIR ?? join(homedir(), '.hive')
+      )
       return {
         mode: input.mode ?? parseMode(env.HIVE_SERVER_MODE),
         host: input.host ?? env.HIVE_SERVER_HOST ?? bindIp ?? DEFAULT_HOST,

--- a/test/dev-data-setup.test.ts
+++ b/test/dev-data-setup.test.ts
@@ -1,0 +1,127 @@
+import { homedir } from 'node:os'
+import { resolve } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+describe('dev data setup', () => {
+  test('exposes the fixed dev data + worktrees dirs', async () => {
+    const { DEV_DATA_DIR, DEV_WORKTREES_DIR } = await import('../scripts/dev-data-setup.mjs')
+
+    expect(DEV_DATA_DIR).toBe(resolve(homedir(), '.hive-dev'))
+    expect(DEV_WORKTREES_DIR).toBe(resolve(homedir(), '.hive-dev-worktrees'))
+  })
+
+  test('parses the clone-vs-fresh answer (empty defaults to sync)', async () => {
+    const { parseSyncAnswer } = await import('../scripts/dev-data-setup.mjs')
+
+    for (const fresh of ['f', 'F', 'fresh', 'FRESH', 'n', 'no', 'scratch', '  fresh  ']) {
+      expect(parseSyncAnswer(fresh)).toBe('fresh')
+    }
+    for (const sync of ['', '  ', 's', 'S', 'sync', 'y', 'YES', 'huh?']) {
+      expect(parseSyncAnswer(sync)).toBe('sync')
+    }
+    expect(parseSyncAnswer(undefined)).toBe('sync')
+  })
+
+  test('parses the quit-official-app confirm (default No)', async () => {
+    const { parseQuitAnswer } = await import('../scripts/dev-data-setup.mjs')
+
+    for (const yes of ['y', 'Y', 'yes', 'YES', '  yes  ']) {
+      expect(parseQuitAnswer(yes)).toBe(true)
+    }
+    for (const no of ['', '  ', 'n', 'no', 'nope', 'sync', undefined]) {
+      expect(parseQuitAnswer(no)).toBe(false)
+    }
+  })
+
+  test('maps a convention-path worktree to its dev twin keeping the full sub-path', async () => {
+    const { mapWorktreeDevPath } = await import('../scripts/dev-data-setup.mjs')
+
+    const legacyWorktreesDir = '/home/me/.hive-worktrees'
+    const devWorktreesDir = '/home/me/.hive-dev-worktrees'
+    const prodPath = `${legacyWorktreesDir}/my-proj/my-proj--golden-retriever`
+
+    expect(
+      mapWorktreeDevPath(prodPath, {
+        legacyWorktreesDir,
+        devWorktreesDir,
+        projectName: 'my-proj'
+      })
+    ).toBe(`${devWorktreesDir}/my-proj/my-proj--golden-retriever`)
+  })
+
+  test('consolidates a foreign-path worktree under devWorktreesDir/<project>/<basename>', async () => {
+    const { mapWorktreeDevPath } = await import('../scripts/dev-data-setup.mjs')
+
+    const legacyWorktreesDir = '/home/me/.hive-worktrees'
+    const devWorktreesDir = '/home/me/.hive-dev-worktrees'
+    // A worktree the user created at a custom location (sibling of the repo).
+    const prodPath = '/home/me/Personal/wellifiy-ror-standalone-1'
+
+    expect(
+      mapWorktreeDevPath(prodPath, {
+        legacyWorktreesDir,
+        devWorktreesDir,
+        projectName: 'wellifiy-ror'
+      })
+    ).toBe(`${devWorktreesDir}/wellifiy-ror/wellifiy-ror-standalone-1`)
+  })
+
+  test('foreign-path mapping sanitizes the project segment and tolerates a missing name', async () => {
+    const { mapWorktreeDevPath } = await import('../scripts/dev-data-setup.mjs')
+
+    const legacyWorktreesDir = '/home/me/.hive-worktrees'
+    const devWorktreesDir = '/home/me/.hive-dev-worktrees'
+    const prodPath = '/tmp/custom/wt-foo'
+
+    // A name containing separators / leading dots can't escape devWorktreesDir.
+    expect(
+      mapWorktreeDevPath(prodPath, {
+        legacyWorktreesDir,
+        devWorktreesDir,
+        projectName: '../evil/name'
+      })
+    ).toBe(`${devWorktreesDir}/evil-name/wt-foo`)
+
+    // No project name → fall back to devWorktreesDir/<basename>.
+    expect(
+      mapWorktreeDevPath(prodPath, { legacyWorktreesDir, devWorktreesDir, projectName: '' })
+    ).toBe(`${devWorktreesDir}/wt-foo`)
+  })
+
+  test('prefixes cloned branches with hive-dev_, leaving detached unchanged', async () => {
+    const { devBranchName } = await import('../scripts/dev-data-setup.mjs')
+
+    expect(devBranchName('golden-retriever')).toBe('hive-dev_golden-retriever')
+    expect(devBranchName('feature/x')).toBe('hive-dev_feature/x')
+    expect(devBranchName('HEAD', { detached: true })).toBe('HEAD')
+  })
+
+  test('connection instructions embed the given (dev) connection + worktree paths', async () => {
+    const { buildConnectionInstructions } = await import('../scripts/dev-data-setup.mjs')
+
+    const content = buildConnectionInstructions('/Users/me/.hive-dev/connections/abc', [
+      {
+        symlinkName: 'web',
+        projectName: 'Web',
+        branchName: 'hive-dev_main',
+        worktreePath: '/Users/me/.hive-dev-worktrees/web/web--main'
+      }
+    ])
+
+    // The active path the agent is told to stay inside is the dev copy…
+    expect(content).toContain('(`/Users/me/.hive-dev/connections/abc`)')
+    expect(content).toContain('**Real path:** /Users/me/.hive-dev-worktrees/web/web--main')
+    // …and never the official locations.
+    expect(content).not.toContain('/.hive/connections/')
+    expect(content).not.toContain('/.hive-worktrees/')
+  })
+
+  test('connection instructions render an empty Projects list with no members', async () => {
+    const { buildConnectionInstructions } = await import('../scripts/dev-data-setup.mjs')
+
+    const content = buildConnectionInstructions('/Users/me/.hive-dev/connections/abc', [])
+
+    expect(content).toContain('## Projects')
+    expect(content).not.toContain('**Real path:**')
+  })
+})

--- a/test/dev-desktop-script.test.ts
+++ b/test/dev-desktop-script.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { EventEmitter } from 'node:events'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import { spawn } from 'node:child_process'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -23,6 +23,23 @@ describe('dev desktop script', () => {
     })
 
     expect(env.HIVE_SERVER_ENTRY_PATH).toBe(resolve('/repo/hive/.dev-server/server.js'))
+  })
+
+  test('pins HIVE_DATA_DIR and HIVE_WORKTREES_DIR to the fixed dev dirs', async () => {
+    const { createDevDesktopEnv } = await import('../scripts/dev-desktop.mjs')
+
+    const env = createDevDesktopEnv({
+      cwd: '/repo/hive',
+      env: {
+        PATH: '/bin',
+        // External overrides are intentionally ignored — dev is always isolated.
+        HIVE_DATA_DIR: '/somewhere/else',
+        HIVE_WORKTREES_DIR: '/somewhere/else-worktrees'
+      }
+    })
+
+    expect(env.HIVE_DATA_DIR).toBe(resolve(homedir(), '.hive-dev'))
+    expect(env.HIVE_WORKTREES_DIR).toBe(resolve(homedir(), '.hive-dev-worktrees'))
   })
 
   test('preserves an explicit HIVE_SERVER_ENTRY_PATH', async () => {
@@ -52,6 +69,23 @@ describe('dev desktop script', () => {
 
     expect(env.PATH).toBe('/bin')
     expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined()
+  })
+
+  test('strips inherited DB-location overrides so dev stays isolated', async () => {
+    const { createDevDesktopEnv } = await import('../scripts/dev-desktop.mjs')
+
+    const env = createDevDesktopEnv({
+      cwd: '/repo/hive',
+      env: {
+        PATH: '/bin',
+        HIVE_SERVER_DB_PATH: '/Users/me/.hive/hive.db',
+        HIVE_SERVER_BASE_DIR: '/Users/me/.hive'
+      }
+    })
+
+    expect(env.HIVE_SERVER_DB_PATH).toBeUndefined()
+    expect(env.HIVE_SERVER_BASE_DIR).toBeUndefined()
+    expect(env.HIVE_DATA_DIR).toBeDefined()
   })
 
   test('defaults headless server env for plain Node server mode', async () => {
@@ -89,6 +123,23 @@ describe('dev desktop script', () => {
     expect(env.HIVE_SERVER_HOST).toBe('0.0.0.0')
     expect(env.HIVE_SERVER_PORT).toBe('0')
     expect(env.HIVE_SERVER_REQUIRE_AUTH).toBe('false')
+  })
+
+  test('isolates headless dev from the official data dir', async () => {
+    const { createDevHeadlessEnv } = await import('../scripts/dev-desktop.mjs')
+
+    const env = createDevHeadlessEnv({
+      env: {
+        PATH: '/bin',
+        HIVE_SERVER_DB_PATH: '/Users/me/.hive/hive.db',
+        HIVE_SERVER_BASE_DIR: '/Users/me/.hive'
+      }
+    })
+
+    expect(env.HIVE_DATA_DIR).toBeDefined()
+    expect(env.HIVE_WORKTREES_DIR).toBeDefined()
+    expect(env.HIVE_SERVER_DB_PATH).toBeUndefined()
+    expect(env.HIVE_SERVER_BASE_DIR).toBeUndefined()
   })
 
   test('routes interactive TTY Ctrl-C bytes through launcher shutdown', async () => {


### PR DESCRIPTION
## Description

`pnpm dev` and the installed/daily Hive app both used `~/.hive` (database, logs, attachments, project-icons, connections, custom-commands) and `~/.hive-worktrees`. Running the two at once raced the same SQLite file, so developing against Hive while using Hive day-to-day risked corruption and cross-talk.

This PR isolates development data. `pnpm dev` now runs against a separate `~/.hive-dev` (data) and `~/.hive-dev-worktrees` (worktrees) tree, redirected through a new single source of truth for on-disk paths. On the first isolated run (no `~/.hive-dev` yet), an interactive two-step prompt lets the developer either **clone everything** from the official install — DB + all resource folders **and** git worktrees, including uncommitted and gitignored files — or **start fresh** with an empty database.

The official `~/.hive` is strictly **read-only**: it is never modified, moved, or deleted. Cloning only reads it and writes a separate copy.

## Related Issue

N/A — developer-experience / data-safety improvement.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ♻️ Code refactoring
- [x] 📝 Documentation update

## Changes Made

- **New `src/main/services/hive-paths.ts`** — single source of truth for every Hive on-disk path (`getHiveDataDir`, `getHiveDbPath`, `getHiveLogsDir`, `getHiveAttachmentsDir`, `getHiveProjectIconsDir`, `getHiveConnectionsDir`, `getHiveCustomCommandsFile`, `getHiveWorktreesDir`). Honors `HIVE_DATA_DIR` / `HIVE_WORKTREES_DIR` env overrides, falling back to `~/.hive` / `~/.hive-worktrees`. Dependency-free (only `os` + `path`) to avoid import cycles, since `logger.ts` imports it.
- **Routed ~14 call sites** that hardcoded `~/.hive` / `~/.hive-worktrees` (database, backend-manager, effect/git layers, attachment-storage, claude-code-implementer, codex-debug-logger, connection-service, custom-commands-file-service, git-service, logger, perf-diagnostics, project-ops, response-logger, server/config) through the new helpers. Explicit `homeDir`/`baseDir` args still take precedence so existing tests keep the historical layout.
- **New `scripts/dev-data-setup.mjs`** — owns the first-run seeding logic (`ensureDevDataReady`), the four dev/legacy path constants, and the pure helpers (`parseSyncAnswer`, `parseQuitAnswer`, `mapWorktreeDevPath`, `devBranchName`). Extracted into its own module so the launcher stays small and the seeding logic is independently testable:
  - Prompt 1 (default **clone**): clone everything from `~/.hive` into `~/.hive-dev`, or start fresh.
  - Prompt 2 (default **No** = abort): a consistent SQLite + worktree snapshot requires the official app closed, so this gate quits it for the developer before cloning. No / Enter cancels and exits without touching anything.
  - Clone copies the full data tree (`cpSync`) and clones **every** live worktree: `git worktree add` a new `hive-dev_`-prefixed branch off the same commit, `rsync -a --exclude=.git` to bring uncommitted + gitignored + untracked files, then rewrites the dev DB's `worktrees.path` / `branch_name` to the dev location. Each worktree is wrapped in try/catch so one failure never aborts the launch.
  - This includes worktrees the user created at a **custom location** outside `~/.hive-worktrees`: those are consolidated under `~/.hive-dev-worktrees/<project>/<dir-name>` (project name via the `worktrees → projects` join, sanitized to a single safe path segment) rather than left pointing at the shared original working dir. Convention-path worktrees keep their `<project>/<leaf>` sub-path. The whole dev worktree tree therefore resets with one `rm -rf ~/.hive-dev-worktrees`.
  - Non-TTY (CI / piped) → silently starts fresh, no prompts, no app-quit.
- **`scripts/dev-desktop.mjs`** — pins `HIVE_DATA_DIR=~/.hive-dev` and `HIVE_WORKTREES_DIR=~/.hive-dev-worktrees` for the dev launch and calls `ensureDevDataReady()` before the build, importing both from `dev-data-setup.mjs`. The launcher itself stays focused on process lifecycle (spawn/shutdown, interrupt handling, foreground-group reclaim).
- **`.gitignore`** — `scripts/*` is ignored with explicit allowlist negations; added `!scripts/dev-data-setup.mjs` so the new module is tracked alongside `dev-desktop.mjs` (otherwise the launcher's import would break on checkout).
- **`README.md`** — rewrote "Data Isolation in Development" to document the full clone, the two-step prompt, the read-only guarantee, the `hive-dev_` branch-prefix rationale, the known cross-visibility limitation, and how to reset (`rm -rf ~/.hive-dev ~/.hive-dev-worktrees` + `git branch -D hive-dev_*`).
- **New `docs/features/dev-data-isolation.md`** — long-form feature doc: how the path indirection works, the first-run experience, exactly what gets cloned, how to reset, a step-by-step manual-verification walkthrough (clone / fresh / abort / non-TTY paths with copy-paste commands and pass criteria), the known limitation, and implementation pointers.
- **Tests** — `test/dev-data-setup.test.ts` (new) covers the pure helpers now living in the extracted module (path constants, both prompt parsers, worktree dev-path mapping incl. foreign-path consolidation + sanitization, branch prefixing incl. detached-HEAD). `test/dev-desktop-script.test.ts` keeps the launcher-level tests (env pinning, interrupt handler, foreground reclaim, package.json scripts, child-exit integration).

## Screenshots

N/A — no UI changes (developer-facing CLI launcher only).

## Manual Tests

### Preconditions

Current app has data & worktrees

#### First isolate run - Select Fresh
Dev Hive App open with Fresh data  => OK!

<img width="2558" height="1439" alt="image" src="https://github.com/user-attachments/assets/b3a7a16c-bc07-46e2-a270-e7202df8056a" />

https://github.com/user-attachments/assets/bea5cfe1-766d-4a6b-b26f-2be63f6440ec

Production App stay the same => OK!

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/aa22cb70-6be0-43cc-8177-ca9ce098344e" />

#### First isolate run - Select Sync
Dev Hive App open with COPIED Production data => OK!

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/fb1c53ff-f6cb-4957-b693-91c5c0510c37" />

https://github.com/user-attachments/assets/81015937-4575-4edb-ab17-de871632ee9a

Production App stay the same => OK!

<img width="2545" height="1432" alt="image" src="https://github.com/user-attachments/assets/2f76fea2-281a-461e-afee-3d3a498b95a8" />

#### Production App data isolate with Dev App data
Dev Hive App add new ticket, data isolated with the Production App => OK!

Production App
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/3fca4267-f8a9-4c7b-9d90-4d13742d03bb" />

Dev App
<img width="2556" height="1439" alt="image" src="https://github.com/user-attachments/assets/e64ae5e5-d6f3-4da1-a483-e1c633a32b50" />


## Testing

### Test Configuration
- **OS**: macOS 15.3.2
- **Node Version**: v24.1.0 (project requires ≥ 20)
- **pnpm**: 10.24.0
- **Test Type**: Unit + Manual

### Test Steps
1. `pnpm exec vitest run test/dev-data-setup.test.ts test/dev-desktop-script.test.ts`.
2. `pnpm exec eslint` + `pnpm exec prettier --check` on the touched scripts and tests.
3. `pnpm exec tsc -p tsconfig.node.json` — confirm no net-new type errors vs `main`.
4. `pnpm run build:server` — confirm the server bundle builds.
5. Manual clone path: quit official app → `pnpm dev` → Enter (clone) → `y` (quit & clone) → dev opens on `~/.hive-dev` with projects/sessions and cloned worktrees on `hive-dev_*` branches; official `~/.hive` byte-identical and its worktrees untouched.
6. Manual fresh path: `rm -rf ~/.hive-dev*` → `pnpm dev` → `f` → empty dev DB.
7. Manual abort path: Enter (clone) → Enter (No) → launcher exits, nothing created.

### Test Results
- [x] All existing tests pass
- [x] New tests added (if applicable)
- [x] Manual testing completed

> Note: one pre-existing test (`dev-desktop` headless `/var` vs `/private/var` macOS symlink path comparison) is flaky on this machine independent of these changes — it fails identically on `main`, and the diff confirms this PR does not touch that test. It is being addressed in a separate PR and is unrelated to this feature.

## Checklist

- [x] My code follows the project's code style
- [x] I have run `pnpm lint` and fixed any issues
- [x] I have run `pnpm format` to format my code
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation (if needed)
- [x] I have added comments to complex code sections
- [x] I have checked for any console errors
- [x] I have tested on macOS (required)
- [x] I have updated documentation (for significant changes)

## Performance Impact

- [x] No performance impact

Path resolution adds a single env-var lookup per call; cloning happens once on first dev run.

## Breaking Changes

- [x] No breaking changes

The installed/daily app's behavior is unchanged — with no env overrides set, every helper resolves to the historical `~/.hive` / `~/.hive-worktrees`. Only `pnpm dev` is redirected.

## Additional Notes

**Known limitation (documented):** dev and the official install share the underlying project repos, so each repo's `git worktree list` shows both installs' worktrees, and a project refresh in dev may import official worktree rows (and vice-versa). Dev's own cloned `hive-dev_*` worktrees are fully independent. True per-worktree isolation is impossible without cloning the repos themselves; separating the databases is strictly better than the previous shared-everything state.
