### PR TITLE
test: canonicalize temp dir so macOS symlink path matches process.cwd()

### DIFF
--- a/test/dev-desktop-script.test.ts
+++ b/test/dev-desktop-script.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { EventEmitter } from 'node:events'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
@@ -317,7 +325,7 @@ process.exit(1)
 })
 
 const mkTempDir = (): string => {
-  const dir = mkdtempSync(resolve(tmpdir(), 'hive-dev-desktop-script-'))
+  const dir = realpathSync(mkdtempSync(resolve(tmpdir(), 'hive-dev-desktop-script-')))
   tempDirs.push(dir)
   return dir
 }


### PR DESCRIPTION
## Description
Fixes a macOS-only flaky test in `test/dev-desktop-script.test.ts`. `mkTempDir()` returned an unresolved symlink path under `/var/folders/...`, but the spawned dev launcher's `process.cwd()` canonicalizes it to `/private/var/...`. The `argv[0]` assertion then compared two strings that point to the same directory but differ textually, so it failed intermittently. Linux CI never trips it because `/tmp` isn't symlinked. Pre-existing in upstream and independent of any feature work.

## Related Issue
N/A — no tracked issue; pre-existing flake discovered during local test runs.

## Type of Change
- [x] 🧪 Test improvement

## Changes Made
- Wrap `mkdtempSync(...)` in `realpathSync(...)` inside `mkTempDir` so the temp dir is canonical from creation, matching the path the spawned child reports via `process.cwd()`.
- Import `realpathSync` from `node:fs` (import wrapped to satisfy the 100-char line limit).

`realpathSync` is a no-op on non-symlinked Linux `/tmp`, so CI behavior is unchanged.

## Testing

### Test Configuration
- **OS**: macOS 15.3.2
- **Node Version**: 24.1.0
- **Test Type**: Unit

### Test Steps
1. `corepack pnpm install`
2. `corepack pnpm vitest run test/dev-desktop-script.test.ts`
3. `corepack pnpm exec tsc -p tsconfig.node.json --noEmit`
4. `corepack pnpm exec eslint test/dev-desktop-script.test.ts`

### Test Results
- [x] All existing tests pass (13/13 in the affected file)
- [ ] New tests added (not applicable — fix makes an existing test deterministic)
- [x] Manual testing completed

## Checklist
- [x] My code follows the project's code style (no semicolons, single quotes, 2-space indent, 100-char lines, no trailing commas)
- [x] I have run `eslint` on the changed file with no issues
- [x] My changed lines are Prettier-clean
- [x] I have run the affected test suite and all tests pass
- [ ] I have added tests that prove my fix/feature works (existing test now deterministic; no new test needed)
- [x] I have tested on macOS (required)

## Performance Impact
- [x] No performance impact

## Breaking Changes
- [x] No breaking changes

## Additional Notes
- **Prettier scope**: this file was already Prettier-non-compliant on `upstream/main` (numerous pre-existing style deviations). I formatted only the lines I touched to keep the diff minimal; running `pnpm format` across the whole file would reformat ~28 unrelated lines and bloat the diff.
- **tsc baseline**: `tsc -p tsconfig.node.json --noEmit` reports only the pre-existing upstream baseline errors (in `src/server/...`), zero net-new from this change.
- **Rebase note**: if another in-flight PR also touches `test/dev-desktop-script.test.ts`, whichever lands second will need a trivial rebase.
