### PR TITLE
Auto-pin base worktree when auto-created tickets are created

### DIFF
--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -1534,7 +1534,7 @@ registerKanbanAutoCreateTicket(({ sessionId, rawPrompt }) => {
 
       // Idempotency gate (authoritative — immune to the auto-attach timing and a
       // stale in-memory tickets map): skip if any non-archived ticket is linked.
-      const existing = await kanbanApi.ticket.getBySession<KanbanTicket>(sessionId)
+      const existing = await kanban.ticket.getBySession<KanbanTicket>(sessionId)
       if (existing.some((t) => !t.archived_at)) return
 
       const trimmed = rawPrompt.trim()
@@ -1557,6 +1557,12 @@ registerKanbanAutoCreateTicket(({ sessionId, rawPrompt }) => {
         mode: session.mode,
         created_from_session: true
       })
+
+      // Mirror the manual-open behavior: when auto-pin is enabled, pin the
+      // project's root/base worktree so the auto-created ticket shows on the
+      // pinned board. No-op unless `autoPinBaseWorktreeOnBoardPrompt` is on.
+      const { autoPinBaseWorktree } = await import('@/lib/auto-pin')
+      void autoPinBaseWorktree(session.project_id)
     } catch {
       // Best-effort — never disrupt the user's send/prompt flow.
     }
@@ -1592,7 +1598,7 @@ registerKanbanRenameSync((sessionId, name) => {
       }
 
       // Fallback: the ticket's board may not be loaded into the map yet.
-      const linked = await kanbanApi.ticket.getBySession<KanbanTicket>(sessionId)
+      const linked = await kanban.ticket.getBySession<KanbanTicket>(sessionId)
       const target = linked.find((t) => t.created_from_session && !t.archived_at)
       if (target && target.title !== name) {
         store.updateTicket(target.id, target.project_id, { title: name }).catch(() => {})


### PR DESCRIPTION
## Summary
- Switched ticket lookup calls to use the shared `kanban` API instance in the auto-create and rename sync paths.
- Added a best-effort `autoPinBaseWorktree(session.project_id)` call after auto-creating a ticket so the board updates to the pinned base worktree when auto-pin is enabled.
- Kept the behavior non-blocking so ticket creation and prompt flow are not disrupted by auto-pin failures.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, best-effort UX alignment in kanban coordination callbacks; failures are swallowed and do not affect ticket creation.
> 
> **Overview**
> After the first-message **auto-create ticket** path finishes, the store now fire-and-forgets **`autoPinBaseWorktree(session.project_id)`** so auto-created cards show on the pinned board when **auto-pin on board prompt** is enabled—matching manual board-open behavior without blocking send/prompt flow.
> 
> Session ticket lookups in the auto-create idempotency check and rename-sync fallback were switched from **`kanbanApi`** to the shared **`kanban`** import alias used elsewhere in the store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a9dcf4a80a584559a7cc2ab23b9cec75cd9987d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->