### PR TITLE
Improve markdown kanban settings flow

### DIFF
--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -1685,6 +1685,44 @@ export async function moveKanbanTicketToProject(
   }
 }
 
+function pluralize(count: number, singular: string): string {
+  return count === 1 ? singular : `${singular}s`
+}
+
+function formatBlockingTicketTitles(tickets: KanbanTicket[]): string {
+  const visibleTitles = tickets.slice(0, 3).map((ticket) => `"${ticket.title}"`)
+  const remaining = tickets.length - visibleTitles.length
+  if (remaining > 0) {
+    visibleTitles.push(`${remaining} more`)
+  }
+  return visibleTitles.join(', ')
+}
+
+function formatInternalTicketModeBlockerError(tickets: KanbanTicket[]): string {
+  const activeTickets = tickets.filter((ticket) => !ticket.archived_at)
+  const activeCount = activeTickets.length
+  const archivedCount = tickets.length - activeCount
+  const parts: string[] = []
+  if (activeCount > 0) {
+    parts.push(`${activeCount} active internal ${pluralize(activeCount, 'card')}`)
+  }
+  if (archivedCount > 0) {
+    parts.push(`${archivedCount} archived internal ${pluralize(archivedCount, 'card')}`)
+  }
+  const activeDetails =
+    activeCount > 0
+      ? ` Active ${pluralize(activeCount, 'blocker')}: ${formatBlockingTicketTitles(activeTickets)}.`
+      : ''
+  const archivedInstruction =
+    archivedCount > 0
+      ? ` To find archived cards, turn on the archive toggle in the Done column, unarchive them, then remove the remaining internal cards before switching storage.`
+      : ' Remove the internal cards before switching storage.'
+
+  return `Markdown mode cannot be enabled because this project still has ${parts.join(
+    ' and '
+  )}.${activeDetails}${archivedInstruction}`
+}
+
 export function getKanbanStorageConfig(projectId: string): KanbanStorageConfig {
   const project = requireProject(projectId)
   const parsed = parseMarkdownConfigResult(project)
@@ -1704,14 +1742,19 @@ export async function updateKanbanMarkdownConfig(
 ): Promise<KanbanStorageConfig> {
   validateMarkdownConfigShape(config)
   const project = requireProject(projectId)
-  await validateConfiguredFolders(project, config)
+  const currentMode = getProjectStorageMode(projectId)
+  if (currentMode === 'markdown') {
+    await validateConfiguredFolders(project, config)
+  }
   const previousConfig = parseMarkdownConfig(project)
-  if (getProjectStorageMode(projectId) === 'markdown' && previousConfig.layout !== config.layout) {
+  if (currentMode === 'markdown' && previousConfig.layout !== config.layout) {
     await migrateMarkdownLayout(projectId, project, previousConfig, config)
   }
   getDatabase().updateProjectKanbanMarkdownConfig(projectId, JSON.stringify(config))
   markdownBackend.invalidate(projectId)
-  await restartMarkdownKanbanProjectWatch(projectId)
+  if (currentMode === 'markdown') {
+    await restartMarkdownKanbanProjectWatch(projectId)
+  }
   return getKanbanStorageConfig(projectId)
 }
 
@@ -1725,8 +1768,7 @@ export async function setKanbanStorageMode(
   if (internalTickets.length > 0) {
     return {
       success: false,
-      error:
-        'Changing Kanban storage mode is only supported for projects with no active or archived internal cards.'
+      error: formatInternalTicketModeBlockerError(internalTickets)
     }
   }
   if (currentMode === 'markdown' && (await markdownBackend.hasAnyCardLikeFiles(projectId))) {
@@ -1737,6 +1779,16 @@ export async function setKanbanStorageMode(
     }
   }
   if (currentMode === 'internal' && mode === 'markdown') {
+    const project = requireProject(projectId)
+    const config = parseMarkdownConfig(project)
+    try {
+      await validateConfiguredFolders(project, config)
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
     await markdownBackend.repairAdoptedCards(projectId)
   }
   getDatabase().updateProjectKanbanStorageMode(projectId, mode)

--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -1689,18 +1689,8 @@ function pluralize(count: number, singular: string): string {
   return count === 1 ? singular : `${singular}s`
 }
 
-function formatBlockingTicketTitles(tickets: KanbanTicket[]): string {
-  const visibleTitles = tickets.slice(0, 3).map((ticket) => `"${ticket.title}"`)
-  const remaining = tickets.length - visibleTitles.length
-  if (remaining > 0) {
-    visibleTitles.push(`${remaining} more`)
-  }
-  return visibleTitles.join(', ')
-}
-
 function formatInternalTicketModeBlockerError(tickets: KanbanTicket[]): string {
-  const activeTickets = tickets.filter((ticket) => !ticket.archived_at)
-  const activeCount = activeTickets.length
+  const activeCount = tickets.filter((ticket) => !ticket.archived_at).length
   const archivedCount = tickets.length - activeCount
   const parts: string[] = []
   if (activeCount > 0) {
@@ -1709,18 +1699,14 @@ function formatInternalTicketModeBlockerError(tickets: KanbanTicket[]): string {
   if (archivedCount > 0) {
     parts.push(`${archivedCount} archived internal ${pluralize(archivedCount, 'card')}`)
   }
-  const activeDetails =
-    activeCount > 0
-      ? ` Active ${pluralize(activeCount, 'blocker')}: ${formatBlockingTicketTitles(activeTickets)}.`
-      : ''
   const archivedInstruction =
     archivedCount > 0
       ? ` To find archived cards, turn on the archive toggle in the Done column, unarchive them, then remove the remaining internal cards before switching storage.`
-      : ' Remove the internal cards before switching storage.'
+      : ` Remove the internal ${pluralize(activeCount, 'card')} before switching storage.`
 
   return `Markdown mode cannot be enabled because this project still has ${parts.join(
     ' and '
-  )}.${activeDetails}${archivedInstruction}`
+  )}.${archivedInstruction}`
 }
 
 export function getKanbanStorageConfig(projectId: string): KanbanStorageConfig {

--- a/src/renderer/src/components/projects/ProjectSettingsDialog.test.tsx
+++ b/src/renderer/src/components/projects/ProjectSettingsDialog.test.tsx
@@ -151,7 +151,7 @@ describe('ProjectSettingsDialog', () => {
     expect(screen.getByPlaceholderText(/git worktree add --no-checkout/)).toBeTruthy()
   })
 
-  it('saves project fields before showing a Kanban mode-change failure', async () => {
+  it('refreshes projects after saved project fields are followed by a Kanban mode-change failure', async () => {
     const user = userEvent.setup()
     const onOpenChange = vi.fn()
     kanbanApiMocks.config.setMode.mockResolvedValue({
@@ -185,6 +185,21 @@ describe('ProjectSettingsDialog', () => {
         'Changing Kanban storage mode is only supported for projects with no cards.'
       )
     ).toBeTruthy()
+    expect(mocks.loadProjects).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not refresh projects when project field save fails before Kanban updates', async () => {
+    const user = userEvent.setup()
+    mocks.updateProject.mockResolvedValue(false)
+
+    renderDialog({})
+
+    await waitFor(() => expect(projectApiMocks.detectSetupSuggestions).toHaveBeenCalled())
+    await user.click(screen.getByRole('button', { name: 'Markdown' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(kanbanApiMocks.config.update).not.toHaveBeenCalled()
+    expect(kanbanApiMocks.config.setMode).not.toHaveBeenCalled()
     expect(mocks.loadProjects).not.toHaveBeenCalled()
   })
 
@@ -257,7 +272,51 @@ describe('ProjectSettingsDialog', () => {
     expect(await screen.findByTestId('kanban-missing-folders-state')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Markdown' })).toHaveClass('bg-primary')
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
-    expect(mocks.loadProjects).not.toHaveBeenCalled()
+    expect(mocks.loadProjects).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show create-folder CTA for internal-card blockers that mention not found', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const blockerMessage =
+      'Markdown mode cannot be enabled because this project still has 1 active internal card. Remove the internal card before switching storage.'
+    kanbanApiMocks.config.setMode.mockResolvedValue({
+      success: false,
+      error: blockerMessage
+    })
+
+    renderDialog({}, onOpenChange)
+
+    await waitFor(() => expect(projectApiMocks.detectSetupSuggestions).toHaveBeenCalled())
+    await user.click(screen.getByRole('button', { name: 'Markdown' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText(blockerMessage)).toBeTruthy()
+    expect(screen.queryByTestId('kanban-missing-folders-state')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Create folder and enable' })).toBeNull()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it('does not show create-folder CTA for realpath permission failures', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const permissionMessage = "EACCES: permission denied, realpath '/tmp/hive/docs/kanban'"
+    kanbanApiMocks.config.setMode.mockResolvedValue({
+      success: false,
+      error: permissionMessage
+    })
+
+    renderDialog({}, onOpenChange)
+
+    await waitFor(() => expect(projectApiMocks.detectSetupSuggestions).toHaveBeenCalled())
+    await user.click(screen.getByRole('button', { name: 'Markdown' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText(permissionMessage)).toBeTruthy()
+    expect(screen.queryByTestId('kanban-missing-folders-state')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Create folder and enable' })).toBeNull()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    expect(mocks.loadProjects).toHaveBeenCalledTimes(1)
   })
 
   it('falls back to default Markdown folders when loaded config fields are missing', async () => {

--- a/src/renderer/src/components/projects/ProjectSettingsDialog.test.tsx
+++ b/src/renderer/src/components/projects/ProjectSettingsDialog.test.tsx
@@ -116,9 +116,10 @@ describe('ProjectSettingsDialog', () => {
 
     await waitFor(() => expect(projectApiMocks.detectSetupSuggestions).toHaveBeenCalled())
 
-    expect(
-      screen.getByRole('button', { name: /worktree create script/i })
-    ).toHaveProperty('ariaExpanded', 'false')
+    expect(screen.getByRole('button', { name: /worktree create script/i })).toHaveProperty(
+      'ariaExpanded',
+      'false'
+    )
     expect(screen.queryByText(/Advanced\. When set/)).toBeNull()
     expect(screen.queryByPlaceholderText(/git worktree add --no-checkout/)).toBeNull()
   })
@@ -128,9 +129,10 @@ describe('ProjectSettingsDialog', () => {
 
     await waitFor(() => expect(projectApiMocks.detectSetupSuggestions).toHaveBeenCalled())
 
-    expect(
-      screen.getByRole('button', { name: /worktree create script/i })
-    ).toHaveProperty('ariaExpanded', 'true')
+    expect(screen.getByRole('button', { name: /worktree create script/i })).toHaveProperty(
+      'ariaExpanded',
+      'true'
+    )
     expect(screen.getByDisplayValue('echo custom-create')).toBeTruthy()
   })
 
@@ -142,9 +144,10 @@ describe('ProjectSettingsDialog', () => {
 
     await user.click(screen.getByRole('button', { name: /worktree create script/i }))
 
-    expect(
-      screen.getByRole('button', { name: /worktree create script/i })
-    ).toHaveProperty('ariaExpanded', 'true')
+    expect(screen.getByRole('button', { name: /worktree create script/i })).toHaveProperty(
+      'ariaExpanded',
+      'true'
+    )
     expect(screen.getByPlaceholderText(/git worktree add --no-checkout/)).toBeTruthy()
   })
 
@@ -182,5 +185,115 @@ describe('ProjectSettingsDialog', () => {
         'Changing Kanban storage mode is only supported for projects with no cards.'
       )
     ).toBeTruthy()
+    expect(mocks.loadProjects).not.toHaveBeenCalled()
+  })
+
+  it('does not reset Kanban mode when saved project fields echo back into the open dialog', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const view = renderDialog({}, onOpenChange)
+
+    await waitFor(() => expect(projectApiMocks.detectSetupSuggestions).toHaveBeenCalled())
+    await user.click(screen.getByRole('button', { name: 'Markdown' }))
+
+    view.rerender(
+      <ProjectSettingsDialog
+        project={{ ...baseProject, custom_commands: [] }}
+        open={true}
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Markdown' })).toHaveClass('bg-primary')
+    expect(screen.getByRole('button', { name: 'Choose Kanban folder' })).toBeTruthy()
+    expect(kanbanApiMocks.config.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('reloads projects only after a Kanban mode save succeeds', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    renderDialog({}, onOpenChange)
+
+    await waitFor(() => expect(projectApiMocks.detectSetupSuggestions).toHaveBeenCalled())
+    await user.click(screen.getByRole('button', { name: 'Markdown' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+
+    expect(kanbanApiMocks.config.update).toHaveBeenCalledWith(
+      'project-1',
+      expect.objectContaining({ layout: 'single-folder' })
+    )
+    expect(kanbanApiMocks.config.setMode).toHaveBeenCalledWith('project-1', 'markdown')
+    expect(mocks.loadProjects).toHaveBeenCalledTimes(1)
+    expect(mocks.loadProjects.mock.invocationCallOrder[0]).toBeGreaterThan(
+      kanbanApiMocks.config.setMode.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('keeps Markdown selected and shows create-folder warning when activation folders are missing', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    kanbanApiMocks.config.setMode.mockResolvedValue({
+      success: false,
+      error: "ENOENT: no such file or directory, realpath '/tmp/hive/docs/kanban'"
+    })
+
+    renderDialog({}, onOpenChange)
+
+    await waitFor(() => expect(projectApiMocks.detectSetupSuggestions).toHaveBeenCalled())
+    await user.click(screen.getByRole('button', { name: 'Markdown' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(kanbanApiMocks.config.update).toHaveBeenCalledWith(
+      'project-1',
+      expect.objectContaining({
+        layout: 'single-folder',
+        singleFolder: 'docs/kanban'
+      })
+    )
+    expect(kanbanApiMocks.config.setMode).toHaveBeenCalledWith('project-1', 'markdown')
+    expect(await screen.findByTestId('kanban-missing-folders-state')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Markdown' })).toHaveClass('bg-primary')
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    expect(mocks.loadProjects).not.toHaveBeenCalled()
+  })
+
+  it('falls back to default Markdown folders when loaded config fields are missing', async () => {
+    const user = userEvent.setup()
+    kanbanApiMocks.config.get.mockResolvedValue({
+      mode: 'markdown',
+      markdown: {
+        layout: 'single-folder',
+        statusFolders: {
+          todo: undefined,
+          in_progress: undefined,
+          review: undefined,
+          done: undefined
+        }
+      }
+    })
+
+    renderDialog({ kanban_storage_mode: 'markdown' })
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('docs/kanban')).toBeTruthy()
+    })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(kanbanApiMocks.config.update).toHaveBeenCalledWith('project-1', {
+        layout: 'single-folder',
+        singleFolder: 'docs/kanban',
+        statusFolders: {
+          todo: 'docs/kanban/todo',
+          in_progress: 'docs/kanban/in-progress',
+          review: 'docs/kanban/review',
+          done: 'docs/kanban/done'
+        }
+      })
+    })
+    expect(screen.queryByText(/Cannot read properties of undefined/)).toBeNull()
   })
 })

--- a/src/renderer/src/components/projects/ProjectSettingsDialog.tsx
+++ b/src/renderer/src/components/projects/ProjectSettingsDialog.tsx
@@ -285,7 +285,7 @@ export function ProjectSettingsDialog({
         }
 
   const isMissingFolderError = (message: string): boolean =>
-    /ENOENT|no such file|cannot find|not found/i.test(message)
+    /ENOENT|no such file or directory/i.test(message)
 
   const extractMissingFolderPath = (message: string): string => {
     const quotedPath = message.match(/'([^']+)'/)?.[1]
@@ -299,6 +299,7 @@ export function ProjectSettingsDialog({
     setSaving(true)
     setKanbanConfigError(null)
     setCanCreateKanbanFolders(false)
+    let projectFieldsSaved = false
     try {
       try {
         const success = await updateProject(project.id, {
@@ -316,6 +317,7 @@ export function ProjectSettingsDialog({
           toast.error('Failed to save project settings')
           return
         }
+        projectFieldsSaved = true
       } catch {
         toast.error('Failed to save project settings')
         return
@@ -329,6 +331,7 @@ export function ProjectSettingsDialog({
         const message = modeResult.error ?? 'Kanban storage mode could not be changed'
         setKanbanConfigError(message)
         setCanCreateKanbanFolders(kanbanMode === 'markdown' && isMissingFolderError(message))
+        await loadProjects()
         return
       }
 
@@ -340,6 +343,9 @@ export function ProjectSettingsDialog({
       const message = error instanceof Error ? error.message : 'Failed to save Kanban settings'
       setKanbanConfigError(message)
       setCanCreateKanbanFolders(kanbanMode === 'markdown' && isMissingFolderError(message))
+      if (projectFieldsSaved) {
+        await loadProjects()
+      }
     } finally {
       setSaving(false)
     }

--- a/src/renderer/src/components/projects/ProjectSettingsDialog.tsx
+++ b/src/renderer/src/components/projects/ProjectSettingsDialog.tsx
@@ -56,6 +56,20 @@ type MarkdownConfig =
       statusFolders: { todo: string; in_progress: string; review: string; done: string }
     }
 
+const DEFAULT_MARKDOWN_FOLDERS = {
+  singleFolder: 'docs/kanban',
+  todo: 'docs/kanban/todo',
+  inProgress: 'docs/kanban/in-progress',
+  review: 'docs/kanban/review',
+  done: 'docs/kanban/done'
+}
+
+const folderOrDefault = (value: unknown, fallback: string): string => {
+  if (typeof value !== 'string') return fallback
+  const trimmed = value.trim()
+  return trimmed || fallback
+}
+
 interface ProjectSettingsDialogProps {
   project: Project
   open: boolean
@@ -91,88 +105,98 @@ export function ProjectSettingsDialog({
   const [pickingIcon, setPickingIcon] = useState(false)
   const [suggestions, setSuggestions] = useState<SuggestionItem[]>([])
   const [suggestionsOpen, setSuggestionsOpen] = useState(false)
+  const [initializedProjectId, setInitializedProjectId] = useState<string | null>(null)
+  const [initialProject, setInitialProject] = useState<Project | null>(null)
 
-  // Load current values when dialog opens
   useEffect(() => {
-    if (open) {
-      setSetupScript(project.setup_script ?? '')
-      setRunScript(project.run_script ?? '')
-      setArchiveScript(project.archive_script ?? '')
-      setWorktreeCreateScript(project.worktree_create_script ?? '')
-      setWorktreeCreateScriptExpanded((project.worktree_create_script ?? '').trim().length > 0)
-      setCustomIcon(project.custom_icon ?? null)
-      setCustomCommands(project.custom_commands ?? [])
-      setAutoAssignPort(project.auto_assign_port ?? false)
-      setKanbanMode(project.kanban_storage_mode ?? 'internal')
-      setKanbanConfigError(null)
-      setCanCreateKanbanFolders(false)
+    if (!open) {
+      setInitializedProjectId(null)
+      setInitialProject(null)
+      setSuggestions([])
       setSuggestionsOpen(false)
+      return
+    }
 
-      kanbanApi.config
-        .get<{ mode: 'internal' | 'markdown'; markdown: MarkdownConfig }>(project.id)
-        .then((config) => {
-          setKanbanMode(config.mode)
-          setKanbanLayout(config.markdown.layout)
-          setSingleFolder(
-            config.markdown.layout === 'single-folder'
-              ? config.markdown.singleFolder
-              : 'docs/kanban'
-          )
-          const statusFolders = config.markdown.statusFolders ?? {
-            todo: 'docs/kanban/todo',
-            in_progress: 'docs/kanban/in-progress',
-            review: 'docs/kanban/review',
-            done: 'docs/kanban/done'
-          }
-          setTodoFolder(statusFolders.todo)
-          setInProgressFolder(statusFolders.in_progress)
-          setReviewFolder(statusFolders.review)
-          setDoneFolder(statusFolders.done)
-        })
-        .catch(() => {
-          setKanbanConfigError('Failed to load Kanban storage settings')
-        })
+    if (initializedProjectId !== project.id) {
+      setInitializedProjectId(project.id)
+      setInitialProject(project)
+    }
+  }, [open, project, initializedProjectId])
 
-      if (project.is_remote === true) {
-        setSuggestions([])
-        return
-      }
+  // Load current values once per dialog-open/project combination. Later save echoes should not
+  // reset in-progress edits while the same project remains open.
+  useEffect(() => {
+    if (!open || !initialProject || initializedProjectId !== initialProject.id) {
+      return undefined
+    }
 
-      let cancelled = false
-      projectApi
-        .detectSetupSuggestions(project.path)
-        .then((items) => {
-          if (!cancelled) {
-            setSuggestions(items)
-          }
-        })
-        .catch(() => {
-          if (!cancelled) {
-            setSuggestions([])
-          }
-        })
+    let cancelled = false
+    setSetupScript(initialProject.setup_script ?? '')
+    setRunScript(initialProject.run_script ?? '')
+    setArchiveScript(initialProject.archive_script ?? '')
+    setWorktreeCreateScript(initialProject.worktree_create_script ?? '')
+    setWorktreeCreateScriptExpanded((initialProject.worktree_create_script ?? '').trim().length > 0)
+    setCustomIcon(initialProject.custom_icon ?? null)
+    setCustomCommands(initialProject.custom_commands ?? [])
+    setAutoAssignPort(initialProject.auto_assign_port ?? false)
+    setKanbanMode(initialProject.kanban_storage_mode ?? 'internal')
+    setKanbanConfigError(null)
+    setCanCreateKanbanFolders(false)
+    setSuggestionsOpen(false)
 
+    kanbanApi.config
+      .get<{ mode: 'internal' | 'markdown'; markdown: MarkdownConfig }>(initialProject.id)
+      .then((config) => {
+        if (cancelled) return
+        setKanbanMode(config.mode)
+        setKanbanLayout(config.markdown.layout)
+        setSingleFolder(
+          config.markdown.layout === 'single-folder'
+            ? folderOrDefault(config.markdown.singleFolder, DEFAULT_MARKDOWN_FOLDERS.singleFolder)
+            : DEFAULT_MARKDOWN_FOLDERS.singleFolder
+        )
+        const statusFolders = config.markdown.statusFolders ?? {
+          todo: DEFAULT_MARKDOWN_FOLDERS.todo,
+          in_progress: DEFAULT_MARKDOWN_FOLDERS.inProgress,
+          review: DEFAULT_MARKDOWN_FOLDERS.review,
+          done: DEFAULT_MARKDOWN_FOLDERS.done
+        }
+        setTodoFolder(folderOrDefault(statusFolders.todo, DEFAULT_MARKDOWN_FOLDERS.todo))
+        setInProgressFolder(
+          folderOrDefault(statusFolders.in_progress, DEFAULT_MARKDOWN_FOLDERS.inProgress)
+        )
+        setReviewFolder(folderOrDefault(statusFolders.review, DEFAULT_MARKDOWN_FOLDERS.review))
+        setDoneFolder(folderOrDefault(statusFolders.done, DEFAULT_MARKDOWN_FOLDERS.done))
+      })
+      .catch(() => {
+        if (cancelled) return
+        setKanbanConfigError('Failed to load Kanban storage settings')
+      })
+
+    if (initialProject.is_remote === true) {
+      setSuggestions([])
       return () => {
         cancelled = true
       }
     }
-    setSuggestions([])
-    setSuggestionsOpen(false)
-    return undefined
-  }, [
-    open,
-    project.id,
-    project.path,
-    project.is_remote,
-    project.setup_script,
-    project.run_script,
-    project.archive_script,
-    project.worktree_create_script,
-    project.custom_icon,
-    project.custom_commands,
-    project.auto_assign_port,
-    project.kanban_storage_mode
-  ])
+
+    projectApi
+      .detectSetupSuggestions(initialProject.path)
+      .then((items) => {
+        if (!cancelled) {
+          setSuggestions(items)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSuggestions([])
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [open, initializedProjectId, initialProject])
 
   const handlePickIcon = async (): Promise<void> => {
     setPickingIcon(true)
@@ -241,22 +265,22 @@ export function ProjectSettingsDialog({
     kanbanLayout === 'single-folder'
       ? {
           layout: 'single-folder' as const,
-          singleFolder: singleFolder.trim() || 'docs/kanban',
+          singleFolder: folderOrDefault(singleFolder, DEFAULT_MARKDOWN_FOLDERS.singleFolder),
           statusFolders: {
-            todo: todoFolder.trim() || 'docs/kanban/todo',
-            in_progress: inProgressFolder.trim() || 'docs/kanban/in-progress',
-            review: reviewFolder.trim() || 'docs/kanban/review',
-            done: doneFolder.trim() || 'docs/kanban/done'
+            todo: folderOrDefault(todoFolder, DEFAULT_MARKDOWN_FOLDERS.todo),
+            in_progress: folderOrDefault(inProgressFolder, DEFAULT_MARKDOWN_FOLDERS.inProgress),
+            review: folderOrDefault(reviewFolder, DEFAULT_MARKDOWN_FOLDERS.review),
+            done: folderOrDefault(doneFolder, DEFAULT_MARKDOWN_FOLDERS.done)
           }
         }
       : {
           layout: 'status-folders' as const,
-          singleFolder: singleFolder.trim() || 'docs/kanban',
+          singleFolder: folderOrDefault(singleFolder, DEFAULT_MARKDOWN_FOLDERS.singleFolder),
           statusFolders: {
-            todo: todoFolder.trim() || 'docs/kanban/todo',
-            in_progress: inProgressFolder.trim() || 'docs/kanban/in-progress',
-            review: reviewFolder.trim() || 'docs/kanban/review',
-            done: doneFolder.trim() || 'docs/kanban/done'
+            todo: folderOrDefault(todoFolder, DEFAULT_MARKDOWN_FOLDERS.todo),
+            in_progress: folderOrDefault(inProgressFolder, DEFAULT_MARKDOWN_FOLDERS.inProgress),
+            review: folderOrDefault(reviewFolder, DEFAULT_MARKDOWN_FOLDERS.review),
+            done: folderOrDefault(doneFolder, DEFAULT_MARKDOWN_FOLDERS.done)
           }
         }
 
@@ -292,8 +316,6 @@ export function ProjectSettingsDialog({
           toast.error('Failed to save project settings')
           return
         }
-
-        await loadProjects()
       } catch {
         toast.error('Failed to save project settings')
         return
@@ -304,10 +326,13 @@ export function ProjectSettingsDialog({
       }
       const modeResult = await kanbanApi.config.setMode(project.id, kanbanMode)
       if (!modeResult.success) {
-        setKanbanConfigError(modeResult.error ?? 'Kanban storage mode could not be changed')
+        const message = modeResult.error ?? 'Kanban storage mode could not be changed'
+        setKanbanConfigError(message)
+        setCanCreateKanbanFolders(kanbanMode === 'markdown' && isMissingFolderError(message))
         return
       }
 
+      await loadProjects()
       await useKanbanStore.getState().loadTickets(project.id)
       toast.success('Project settings saved')
       onOpenChange(false)

--- a/test/kanban/markdown-adoption-repair.test.ts
+++ b/test/kanban/markdown-adoption-repair.test.ts
@@ -183,6 +183,23 @@ describe('markdown kanban adoption repair', () => {
     expect(mockDatabase.updateProjectKanbanStorageMode).not.toHaveBeenCalled()
   })
 
+  test('switching to markdown explains a singular active internal card blocker', async () => {
+    const { setKanbanStorageMode } = await import('../../src/main/services/kanban-backend')
+    mockDatabase.getKanbanTicketsByProject.mockReturnValueOnce([
+      { title: 'Visible ENOENT realpath blocker', archived_at: null }
+    ])
+
+    const result = await setKanbanStorageMode('proj-adopt', 'markdown')
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'Markdown mode cannot be enabled because this project still has 1 active internal card. Remove the internal card before switching storage.'
+    })
+    expect(result.error).not.toContain('Visible ENOENT realpath blocker')
+    expect(mockDatabase.updateProjectKanbanStorageMode).not.toHaveBeenCalled()
+  })
+
   test('switching to markdown explains active and archived internal card blockers', async () => {
     const { setKanbanStorageMode } = await import('../../src/main/services/kanban-backend')
     mockDatabase.getKanbanTicketsByProject.mockReturnValueOnce([
@@ -195,8 +212,10 @@ describe('markdown kanban adoption repair', () => {
     expect(result).toEqual({
       success: false,
       error:
-        'Markdown mode cannot be enabled because this project still has 1 active internal card and 1 archived internal card. Active blocker: "Visible blocker". To find archived cards, turn on the archive toggle in the Done column, unarchive them, then remove the remaining internal cards before switching storage.'
+        'Markdown mode cannot be enabled because this project still has 1 active internal card and 1 archived internal card. To find archived cards, turn on the archive toggle in the Done column, unarchive them, then remove the remaining internal cards before switching storage.'
     })
+    expect(result.error).not.toContain('Visible blocker')
+    expect(result.error).not.toContain('Archived blocker')
     expect(mockDatabase.updateProjectKanbanStorageMode).not.toHaveBeenCalled()
   })
 })

--- a/test/kanban/markdown-adoption-repair.test.ts
+++ b/test/kanban/markdown-adoption-repair.test.ts
@@ -145,4 +145,58 @@ describe('markdown kanban adoption repair', () => {
     expect(await readFile(join(cardsPath, 'duplicate-a.md'), 'utf-8')).toBe(duplicateA)
     expect(await readFile(join(cardsPath, 'duplicate-b.md'), 'utf-8')).toBe(duplicateB)
   })
+
+  test('switching to markdown rejects missing configured folders without changing mode', async () => {
+    const { setKanbanStorageMode } = await import('../../src/main/services/kanban-backend')
+    mockState.project = {
+      ...mockState.project!,
+      kanban_markdown_config: JSON.stringify({
+        layout: 'single-folder',
+        singleFolder: 'missing-cards'
+      })
+    }
+
+    const result = await setKanbanStorageMode('proj-adopt', 'markdown')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/ENOENT|no such file|not found/i)
+    expect(mockDatabase.updateProjectKanbanStorageMode).not.toHaveBeenCalled()
+    expect(mockState.project?.kanban_storage_mode).toBe('internal')
+  })
+
+  test('switching to markdown explains archived internal card blockers', async () => {
+    const { setKanbanStorageMode } = await import('../../src/main/services/kanban-backend')
+    mockDatabase.getKanbanTicketsByProject.mockReturnValueOnce([
+      {
+        title: 'Audit remaining Dutch Java parity',
+        archived_at: '2026-06-01T12:00:19.043Z'
+      }
+    ])
+
+    const result = await setKanbanStorageMode('proj-adopt', 'markdown')
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'Markdown mode cannot be enabled because this project still has 1 archived internal card. To find archived cards, turn on the archive toggle in the Done column, unarchive them, then remove the remaining internal cards before switching storage.'
+    })
+    expect(mockDatabase.updateProjectKanbanStorageMode).not.toHaveBeenCalled()
+  })
+
+  test('switching to markdown explains active and archived internal card blockers', async () => {
+    const { setKanbanStorageMode } = await import('../../src/main/services/kanban-backend')
+    mockDatabase.getKanbanTicketsByProject.mockReturnValueOnce([
+      { title: 'Visible blocker', archived_at: null },
+      { title: 'Archived blocker', archived_at: '2026-06-01T12:00:19.043Z' }
+    ])
+
+    const result = await setKanbanStorageMode('proj-adopt', 'markdown')
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'Markdown mode cannot be enabled because this project still has 1 active internal card and 1 archived internal card. Active blocker: "Visible blocker". To find archived cards, turn on the archive toggle in the Done column, unarchive them, then remove the remaining internal cards before switching storage.'
+    })
+    expect(mockDatabase.updateProjectKanbanStorageMode).not.toHaveBeenCalled()
+  })
 })

--- a/test/kanban/markdown-diagnostics-cache.test.ts
+++ b/test/kanban/markdown-diagnostics-cache.test.ts
@@ -627,9 +627,31 @@ describe('markdown diagnostics cache', () => {
     })
   })
 
-  test('saving markdown config does not create missing folders', async () => {
+  test('saving inactive markdown config persists missing folders without creating them', async () => {
     const { updateKanbanMarkdownConfig } = await import('../../src/main/services/kanban-backend')
     const missingFolder = join(tempRoot!, 'missing-cards')
+    mockState.project = {
+      ...mockState.project!,
+      kanban_storage_mode: 'internal'
+    }
+
+    await updateKanbanMarkdownConfig('proj-cache', {
+      layout: 'single-folder',
+      singleFolder: 'missing-cards'
+    })
+
+    await expect(access(missingFolder)).rejects.toThrow()
+    expect(mockDatabase.updateProjectKanbanMarkdownConfig).toHaveBeenCalledWith(
+      'proj-cache',
+      JSON.stringify({
+        layout: 'single-folder',
+        singleFolder: 'missing-cards'
+      })
+    )
+  })
+
+  test('saving active markdown config rejects missing folders', async () => {
+    const { updateKanbanMarkdownConfig } = await import('../../src/main/services/kanban-backend')
 
     await expect(
       updateKanbanMarkdownConfig('proj-cache', {
@@ -638,7 +660,6 @@ describe('markdown diagnostics cache', () => {
       })
     ).rejects.toThrow()
 
-    await expect(access(missingFolder)).rejects.toThrow()
     expect(mockDatabase.updateProjectKanbanMarkdownConfig).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Description
Fixes the Markdown Kanban storage settings flow so users can safely configure Markdown folders before the folders exist, while keeping Internal mode active until Markdown mode can be validated.

This also improves the settings dialog behavior so it no longer snaps back to Internal after saving, and makes storage-mode blocker messages explain archived-card cases clearly.

## Related Issue
N/A

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] ♻️ Code refactoring
- [x] 🧪 Test improvement
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Changes Made
- Allow inactive Markdown Kanban config to persist as draft settings without requiring folders to already exist.
- Keep Markdown mode activation guarded by folder validation and existing internal-card checks.
- Prevent the Project Settings dialog from reinitializing Kanban form state when saved project fields echo back into the open dialog.
- Improve internal-card blocker messages, including guidance for archived cards hidden behind the Done column archive toggle.
- Add regression coverage for missing-folder config saves, mode activation blockers, dialog state reset prevention, and malformed folder config defaults.

## Screenshots
No screenshots needed.

## Testing

### Test Configuration
- **OS**: macOS 26.5.1
- **Node Version**: v25.8.1
- **Test Type**: Unit/Integration

### Test Steps
1. Ran focused Project Settings dialog tests.
2. Ran Markdown Kanban backend tests covering config persistence and mode activation.
3. Ran ESLint on the touched files.
4. Manually verified the Markdown Kanban settings flow in the app.

### Test Results
- [x] All existing focused tests pass
- [x] New tests added
- [x] Manual testing completed

Commands run:

```bash
npm test -- src/renderer/src/components/projects/ProjectSettingsDialog.test.tsx
npm test -- test/kanban/markdown-adoption-repair.test.ts test/kanban/markdown-diagnostics-cache.test.ts
npx eslint src/renderer/src/components/projects/ProjectSettingsDialog.tsx src/main/services/kanban-backend.ts test/kanban/markdown-adoption-repair.test.ts test/kanban/markdown-diagnostics-cache.test.ts
```

Note: ESLint reports one unrelated pre-existing warning in `src/main/services/kanban-backend.ts`.

## Checklist
- [x] My code follows the project's code style
- [ ] I have run `pnpm lint` and fixed any issues
- [x] I have run formatting on touched files
- [x] I have run focused tests and all pass
- [x] I have added tests that prove my fix works
- [ ] I have updated the documentation (if needed)
- [ ] I have added comments to complex code sections
- [x] I have checked for any console errors
- [x] I have tested on macOS (required)
- [ ] I have updated documentation (for significant changes)

## Performance Impact
- [x] No performance impact
- [ ] Improves performance
- [ ] May affect performance (please explain)

## Breaking Changes
- [x] No breaking changes

## Additional Notes
This PR intentionally uses the existing `kanban_markdown_config` field as draft storage and does not introduce new entities or database schema changes.

## Post-Merge Tasks
- [ ] Update documentation site
- [ ] Notify users of breaking changes
- [ ] Update README examples
- [ ] Other:
