### PR TITLE
Per-Card Markdown Kanban Migration

### DIFF
--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -1,5 +1,15 @@
 import { randomBytes, randomUUID } from 'node:crypto'
-import { copyFile, readFile, readdir, rename, rm, stat, unlink, writeFile } from 'node:fs/promises'
+import {
+  copyFile,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  stat,
+  unlink,
+  writeFile
+} from 'node:fs/promises'
 import { basename, dirname, extname, join } from 'node:path'
 import YAML from 'yaml'
 
@@ -116,6 +126,12 @@ interface MarkdownRuntimeCleanupRow {
   card_id: string
   last_seen_path: string | null
   orphaned_at: string | null
+}
+
+interface ConfiguredMarkdownFileMatch {
+  filePath: string
+  indexFilePath: string
+  column: KanbanTicketColumn | null
 }
 
 function emptyRuntimeState(): MarkdownRuntimeState {
@@ -1141,6 +1157,67 @@ class MarkdownKanbanBackend implements KanbanBackend {
     return { created, updated, dependencyCount, ignoredDependencyCount }
   }
 
+  async convertMarkdownFileToCard(projectId: string, filePath: string): Promise<KanbanTicket> {
+    if (getProjectStorageMode(projectId) !== 'markdown') {
+      throw new Error('Project is not using Markdown Kanban storage.')
+    }
+    if (!isMarkdownCandidate(basename(filePath))) {
+      throw new Error('File is not a Markdown Kanban candidate.')
+    }
+
+    const project = requireProject(projectId)
+    const config = parseMarkdownConfig(project)
+    const match = await this.requireConfiguredMarkdownFile(project, config, filePath)
+    const canonicalFilePath = match.filePath
+    const indexFilePath = match.indexFilePath
+    const fileStat = await stat(canonicalFilePath)
+    if (!fileStat.isFile()) throw new Error('Markdown Kanban candidate is not a file.')
+    if (fileStat.size > CARD_FILE_SIZE_LIMIT_BYTES) {
+      throw new Error('Markdown card exceeds 1 MB limit')
+    }
+
+    const raw = await readFile(canonicalFilePath, 'utf-8')
+    const parsed = parseMarkdown(raw)
+    const frontmatter = parsed.frontmatter
+    const existingId = asString(frontmatter.id)
+    const removeFields = blankConversionRemoveFields(frontmatter)
+    const frontmatterForValidation = withoutBlankConversionFields(frontmatter)
+    validateKnownFrontmatter(frontmatterForValidation, existingId)
+
+    const title =
+      asString(frontmatter.title) ??
+      titleFromBody(parsed.body) ??
+      basename(canonicalFilePath, extname(canonicalFilePath))
+    const id = existingId ?? generateTicketId(title)
+    const column = asColumn(frontmatter.column) ?? match.column ?? 'todo'
+    const index = await this.reloadIndex(projectId)
+    this.assertCardIdAvailableForFile(index, id, indexFilePath)
+
+    const now = new Date().toISOString()
+    const updates: Frontmatter = {}
+    if (!existingId) updates.id = id
+    if (!hasUsableStringFrontmatter(frontmatter, 'title')) updates.title = title
+    if (!hasUsableStringFrontmatter(frontmatter, 'column')) updates.column = column
+    if (!hasUsableNullableModeFrontmatter(frontmatter)) updates.mode = 'build'
+    if (!hasOwnFrontmatter(frontmatter, 'archived_at')) updates.archived_at = null
+    if (!hasUsableStringFrontmatter(frontmatter, 'created_at')) {
+      updates.created_at = createdAtFromStat(fileStat, now)
+    }
+    if (!hasUsableNumberFrontmatter(frontmatter, 'sort_order')) {
+      updates.sort_order = nextSortOrderFromIndex(index, column, id)
+    }
+
+    if (Object.keys(updates).length > 0 || removeFields.length > 0) {
+      await rewriteCard(canonicalFilePath, updates, undefined, removeFields)
+      suppressMarkdownWrites(projectId, canonicalFilePath)
+      this.invalidate(projectId)
+    }
+
+    const ticket = await this.get(projectId, id)
+    if (!ticket) throw new Error('Converted markdown ticket could not be loaded')
+    return ticket
+  }
+
   async hasAnyCardLikeFiles(projectId: string): Promise<boolean> {
     const project = requireProject(projectId)
     const config = parseMarkdownConfig(project)
@@ -1454,6 +1531,52 @@ class MarkdownKanbanBackend implements KanbanBackend {
         `Cannot create markdown ticket "${ticketId}" because that card id already exists.`
       )
     }
+  }
+
+  private assertCardIdAvailableForFile(
+    index: MarkdownIndex,
+    ticketId: string,
+    filePath: string
+  ): void {
+    const paths = index.pathsById.get(ticketId) ?? []
+    const diagnosticPaths = index.diagnostics
+      .filter((diagnostic) => diagnostic.ticketId === ticketId && diagnostic.blocking)
+      .map((diagnostic) => diagnostic.filePath)
+    const conflictingPaths = [...paths, ...diagnosticPaths].filter((path) => path !== filePath)
+    if (conflictingPaths.length > 0) {
+      throw new Error(
+        `Cannot convert markdown file because card id "${ticketId}" already exists.`
+      )
+    }
+  }
+
+  private async requireConfiguredMarkdownFile(
+    project: Project,
+    config: KanbanMarkdownConfig,
+    filePath: string
+  ): Promise<ConfiguredMarkdownFileMatch> {
+    const canonicalFilePath = await realpath(filePath)
+    const canonicalFileFolder = await realpath(dirname(canonicalFilePath))
+    const folders =
+      config.layout === 'single-folder'
+        ? [{ folder: resolveProjectPath(project.path, config.singleFolder), column: null }]
+        : (Object.entries(config.statusFolders) as Array<[KanbanTicketColumn, string]>).map(
+            ([column, folder]) => ({
+              folder: resolveProjectPath(project.path, folder),
+              column
+            })
+          )
+    for (const candidate of folders) {
+      const canonicalFolder = await realpath(candidate.folder).catch(() => null)
+      if (canonicalFolder === canonicalFileFolder) {
+        return {
+          filePath: canonicalFilePath,
+          indexFilePath: join(candidate.folder, basename(filePath)),
+          column: candidate.column
+        }
+      }
+    }
+    throw new Error('File is outside configured Markdown Kanban folders.')
   }
 
   private readRuntime(projectId: string, cardId: string): MarkdownRuntimeState {
@@ -2007,6 +2130,41 @@ function hasOwnFrontmatter(frontmatter: Frontmatter, field: string): boolean {
   return Object.prototype.hasOwnProperty.call(frontmatter, field)
 }
 
+function withoutBlankConversionFields(frontmatter: Frontmatter): Frontmatter {
+  const next = { ...frontmatter }
+  for (const field of ['id', 'title', 'column', 'sort_order', 'created_at']) {
+    if (isBlankFrontmatterValue(next[field])) delete next[field]
+  }
+  for (const field of blankConversionRemoveFields(frontmatter)) delete next[field]
+  if (typeof next.mode === 'string' && next.mode.trim() === '') delete next.mode
+  return next
+}
+
+function blankConversionRemoveFields(frontmatter: Frontmatter): string[] {
+  return ['dependencies', 'depends_on'].filter((field) =>
+    isBlankFrontmatterValue(frontmatter[field])
+  )
+}
+
+function isBlankFrontmatterValue(value: unknown): boolean {
+  return value === null || value === undefined || (typeof value === 'string' && value.trim() === '')
+}
+
+function hasUsableStringFrontmatter(frontmatter: Frontmatter, field: string): boolean {
+  return hasOwnFrontmatter(frontmatter, field) && !isBlankFrontmatterValue(frontmatter[field])
+}
+
+function hasUsableNumberFrontmatter(frontmatter: Frontmatter, field: string): boolean {
+  return hasOwnFrontmatter(frontmatter, field) && asNumber(frontmatter[field]) !== null
+}
+
+function hasUsableNullableModeFrontmatter(frontmatter: Frontmatter): boolean {
+  return (
+    hasOwnFrontmatter(frontmatter, 'mode') &&
+    (frontmatter.mode === null || asMode(frontmatter.mode) !== null)
+  )
+}
+
 function createdAtFromStat(
   fileStat: { birthtime: Date; birthtimeMs: number },
   fallback: string
@@ -2150,6 +2308,20 @@ function suppressMarkdownWrites(projectId: string, paths: string | string[]): vo
   const pathList = Array.isArray(paths) ? paths : [paths]
   if (pathList.length === 0) return
   suppressMarkdownKanbanWatch(projectId, pathList)
+}
+
+function nextSortOrderFromIndex(
+  index: MarkdownIndex,
+  column: KanbanTicketColumn,
+  excludeTicketId?: string
+): number {
+  const max = Math.max(
+    -1,
+    ...index.tickets
+      .filter((ticket) => ticket.column === column && ticket.id !== excludeTicketId)
+      .map((ticket) => ticket.sort_order)
+  )
+  return max + 1
 }
 
 function mergeFrontmatter(

--- a/src/renderer/src/api/__tests__/kanban-api.test.ts
+++ b/src/renderer/src/api/__tests__/kanban-api.test.ts
@@ -600,4 +600,36 @@ describe('kanbanApi', () => {
     expect(request).toHaveBeenNthCalledWith(2, 'kanban.watch.start', { projectId: 'project-1' })
     expect(request).toHaveBeenNthCalledWith(3, 'kanban.watch.stop', { projectId: 'project-1' })
   })
+
+  it('routes markdown file conversion through the renderer RPC client', async () => {
+    const ticket = {
+      id: 'converted-card',
+      project_id: 'project-1',
+      title: 'Converted Card',
+      description: 'Body',
+      attachments: [],
+      column: 'todo',
+      sort_order: 0,
+      current_session_id: null,
+      worktree_id: null,
+      mode: 'build',
+      plan_ready: false,
+      created_at: '2026-06-21T00:00:00.000Z',
+      updated_at: '2026-06-21T00:00:00.000Z',
+      archived_at: null
+    }
+    const request = vi.fn().mockResolvedValueOnce(ticket)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(
+      kanbanApi.markdown.convertFileToCard('/project-1', '/tmp/cards/doc.md')
+    ).resolves.toEqual(ticket)
+
+    expect(request).toHaveBeenCalledWith('kanban.markdown.convertFileToCard', {
+      projectId: '/project-1',
+      filePath: '/tmp/cards/doc.md'
+    })
+  })
 })

--- a/src/renderer/src/api/kanban-api.ts
+++ b/src/renderer/src/api/kanban-api.ts
@@ -201,6 +201,13 @@ export const kanbanApi = {
     get: async <TResult>(projectId: string): Promise<TResult[]> =>
       getRendererRpcClient().request<TResult[]>('kanban.diagnostics.get', { projectId })
   },
+  markdown: {
+    convertFileToCard: async <TResult>(projectId: string, filePath: string): Promise<TResult> =>
+      getRendererRpcClient().request<TResult>('kanban.markdown.convertFileToCard', {
+        projectId,
+        filePath
+      })
+  },
   watch: {
     start: async (projectId: string): Promise<{ success: boolean; error?: string }> =>
       getRendererRpcClient().request<{ success: boolean; error?: string }>('kanban.watch.start', {

--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -72,24 +72,61 @@ function fileNameFromPath(filePath: string): string {
 }
 
 function MarkdownInvalidCardPlaceholder({ placeholder }: { placeholder: MarkdownCardPlaceholder }) {
+  const [isConverting, setIsConverting] = useState(false)
+
+  const handleConvert = useCallback(async () => {
+    setIsConverting(true)
+    try {
+      const ticket = await useKanbanStore
+        .getState()
+        .convertMarkdownPlaceholder(placeholder.projectId, placeholder.filePath)
+      toast.success(`Converted "${ticket.title}" to a kanban card`)
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Failed to convert markdown file to kanban card'
+      )
+    } finally {
+      setIsConverting(false)
+    }
+  }, [placeholder.filePath, placeholder.projectId])
+
   return (
-    <div
-      data-testid="kanban-invalid-card-placeholder"
-      className="rounded-md border border-destructive/35 bg-destructive/5 p-2 text-sm shadow-sm"
-      title={`${placeholder.filePath}\n${placeholder.message}`}
-    >
-      <div className="flex items-start gap-2">
-        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
-        <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 items-center gap-1.5 font-medium text-destructive">
-            <FileText className="h-3.5 w-3.5 shrink-0" />
-            <span className="truncate">{fileNameFromPath(placeholder.filePath)}</span>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          data-testid="kanban-invalid-card-placeholder"
+          className="rounded-md border border-destructive/35 bg-destructive/5 p-2 text-sm shadow-sm"
+          title={`${placeholder.filePath}\n${placeholder.message}`}
+        >
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-1.5 font-medium text-destructive">
+                <FileText className="h-3.5 w-3.5 shrink-0" />
+                <span className="truncate">{fileNameFromPath(placeholder.filePath)}</span>
+              </div>
+              <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                {placeholder.message}
+              </p>
+              <p className="mt-1 truncate text-[10px] text-muted-foreground/70">
+                {placeholder.filePath}
+              </p>
+            </div>
           </div>
-          <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{placeholder.message}</p>
-          <p className="mt-1 truncate text-[10px] text-muted-foreground/70">{placeholder.filePath}</p>
         </div>
-      </div>
-    </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem
+          data-testid="ctx-convert-markdown-card"
+          disabled={isConverting}
+          onClick={handleConvert}
+          className="gap-2"
+        >
+          <FileText className="h-3.5 w-3.5" />
+          {isConverting ? 'Converting...' : 'Convert to kanban card'}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }
 

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -170,6 +170,17 @@ function placeholdersFromDiagnostics(
     }))
 }
 
+async function loadProjectTicketsSnapshot(
+  projectId: string,
+  includeArchived: boolean
+): Promise<{ tickets: KanbanTicket[]; diagnostics: MarkdownCardDiagnostic[] }> {
+  const tickets = await kanban.ticket.getByProject<KanbanTicket>(projectId, includeArchived)
+  const diagnostics = await kanban.diagnostics
+    .get<MarkdownCardDiagnostic>(projectId)
+    .catch(() => [])
+  return { tickets, diagnostics }
+}
+
 // ── State interface ────────────────────────────────────────────────────
 interface KanbanState {
   /** Tickets keyed by project ID */
@@ -204,7 +215,9 @@ interface KanbanState {
   setBoardTelegramTarget: (target: BoardTelegramTarget | null) => void
   clearBoardTelegramTarget: () => void
   loadTickets: (projectId: string) => Promise<void>
+  loadTicketsWithArchiveVisibility: (projectId: string, includeArchived: boolean) => Promise<void>
   createTicket: (projectId: string, data: KanbanTicketCreate) => Promise<KanbanTicket>
+  convertMarkdownPlaceholder: (projectId: string, filePath: string) => Promise<KanbanTicket>
   updateTicket: (ticketId: string, projectId: string, data: KanbanTicketUpdate) => Promise<void>
   deleteTicket: (ticketId: string, projectId: string) => Promise<void>
   moveTicketToProject: (
@@ -330,13 +343,10 @@ export const useKanbanStore = create<KanbanState>()(
         set({ isLoading: true })
         try {
           const includeArchived = get().showArchivedByProject[projectId] ?? false
-          const tickets = await kanban.ticket.getByProject<KanbanTicket>(
+          const { tickets, diagnostics } = await loadProjectTicketsSnapshot(
             projectId,
             includeArchived
           )
-          const diagnostics = await kanban.diagnostics
-            .get<MarkdownCardDiagnostic>(projectId)
-            .catch(() => [])
           set((state) => {
             const next = new Map(state.tickets)
             const nextDiagnostics = new Map(state.markdownDiagnostics)
@@ -355,6 +365,36 @@ export const useKanbanStore = create<KanbanState>()(
             }
           })
           // Load dependencies for this project
+          get().loadDependencies(projectId)
+        } catch {
+          set({ isLoading: false })
+        }
+      },
+
+      loadTicketsWithArchiveVisibility: async (projectId: string, includeArchived: boolean) => {
+        set({ isLoading: true })
+        try {
+          const { tickets, diagnostics } = await loadProjectTicketsSnapshot(
+            projectId,
+            includeArchived
+          )
+          set((state) => {
+            const next = new Map(state.tickets)
+            const nextDiagnostics = new Map(state.markdownDiagnostics)
+            const nextPlaceholders = new Map(state.markdownPlaceholders)
+            next.set(projectId, tickets)
+            nextDiagnostics.set(projectId, diagnostics)
+            nextPlaceholders.set(
+              projectId,
+              placeholdersFromDiagnostics(projectId, diagnostics, tickets)
+            )
+            return {
+              tickets: next,
+              markdownDiagnostics: nextDiagnostics,
+              markdownPlaceholders: nextPlaceholders,
+              isLoading: false
+            }
+          })
           get().loadDependencies(projectId)
         } catch {
           set({ isLoading: false })
@@ -407,6 +447,14 @@ export const useKanbanStore = create<KanbanState>()(
           next.set(projectId, [...existing, ticket])
           return { tickets: next }
         })
+        return ticket
+      },
+
+      convertMarkdownPlaceholder: async (projectId: string, filePath: string) => {
+        const ticket = await kanban.markdown.convertFileToCard<KanbanTicket>(projectId, filePath)
+        const includeArchived =
+          get().showArchivedByProject[projectId] ?? get().showArchivedByProject[''] ?? false
+        await get().loadTicketsWithArchiveVisibility(projectId, includeArchived)
         return ticket
       },
 

--- a/src/server/__tests__/kanban-rpc.mock-provider.test.ts
+++ b/src/server/__tests__/kanban-rpc.mock-provider.test.ts
@@ -108,6 +108,57 @@ describe('kanban RPC mocked provider', () => {
     })
   })
 
+  it('routes kanban.markdown.convertFileToCard to the injected provider service', async () => {
+    const ticket = {
+      id: 'converted-card',
+      project_id: 'project-1',
+      title: 'Converted Card',
+      description: 'Body',
+      attachments: [],
+      column: 'todo' as const,
+      sort_order: 0,
+      current_session_id: null,
+      worktree_id: null,
+      mode: 'build' as const,
+      plan_ready: false,
+      created_at: '2026-06-21T00:00:00.000Z',
+      updated_at: '2026-06-21T00:00:00.000Z',
+      archived_at: null,
+      external_provider: null,
+      external_id: null,
+      external_url: null,
+      github_pr_number: null,
+      github_pr_url: null,
+      mark: null,
+      total_tokens: 0,
+      pending_launch_config: null,
+      goal_mode: false,
+      goal_success_criteria: null,
+      note: null
+    }
+    const convertMarkdownFileToCard = vi.fn(() => Effect.succeed(ticket))
+    const service = { convertMarkdownFileToCard } as unknown as KanbanRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      kanban: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'kanban-markdown-convert-1',
+        method: 'kanban.markdown.convertFileToCard',
+        params: { projectId: 'project-1', filePath: '/tmp/cards/doc.md' }
+      })
+    )
+
+    expect(convertMarkdownFileToCard).toHaveBeenCalledWith('project-1', '/tmp/cards/doc.md')
+    expect(response).toEqual({
+      id: 'kanban-markdown-convert-1',
+      ok: true,
+      value: ticket
+    })
+  })
+
   it('routes kanban.ticket.createBatch to the injected provider service', async () => {
     const payload = {
       drafts: [

--- a/src/server/rpc/domains/kanban.ts
+++ b/src/server/rpc/domains/kanban.ts
@@ -181,6 +181,10 @@ export interface KanbanRpcService {
   readonly getDiagnostics?: (
     projectId: string
   ) => Effect.Effect<MarkdownCardDiagnostic[], unknown, never>
+  readonly convertMarkdownFileToCard?: (
+    projectId: string,
+    filePath: string
+  ) => Effect.Effect<KanbanTicket, unknown, never>
   readonly startWatch?: (
     projectId: string
   ) => Effect.Effect<{ success: boolean; error?: string }, unknown, never>
@@ -270,6 +274,12 @@ const getTicketsByProjectParamsSchema = z
   })
   .strict()
 const projectIdParamsSchema = z.object({ projectId: z.string() }).strict()
+const markdownFileParamsSchema = z
+  .object({
+    projectId: z.string(),
+    filePath: z.string()
+  })
+  .strict()
 const updateTicketParamsSchema = z
   .object({
     projectId: z.string(),
@@ -823,6 +833,14 @@ export const makeLiveKanbanRpcService = (): KanbanRpcService => ({
         )
         if (getKanbanStorageConfig(projectId).mode !== 'markdown') return []
         return getMarkdownKanbanBackend().getDiagnostics(projectId)
+      },
+      catch: (cause) => cause
+    }),
+  convertMarkdownFileToCard: (projectId, filePath) =>
+    Effect.tryPromise({
+      try: async () => {
+        const { getMarkdownKanbanBackend } = await import('../../../main/services/kanban-backend')
+        return getMarkdownKanbanBackend().convertMarkdownFileToCard(projectId, filePath)
       },
       catch: (cause) => cause
     }),
@@ -1448,6 +1466,22 @@ export const makeKanbanRpcHandlers = (
             )
           }
           return yield* service.getDiagnostics(projectId)
+        })
+    ],
+    [
+      'kanban.markdown.convertFileToCard',
+      (params) =>
+        Effect.gen(function* () {
+          const { projectId, filePath } = yield* Effect.try({
+            try: () => markdownFileParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          if (!service.convertMarkdownFileToCard) {
+            return yield* Effect.die(
+              new Error('kanban.markdown.convertFileToCard service is not implemented')
+            )
+          }
+          return yield* service.convertMarkdownFileToCard(projectId, filePath)
         })
     ],
     [

--- a/test/kanban/duplicate-card-identity.test.tsx
+++ b/test/kanban/duplicate-card-identity.test.tsx
@@ -15,6 +15,9 @@ const kanbanApiMock = vi.hoisted(() => ({
   diagnostics: {
     get: vi.fn()
   },
+  markdown: {
+    convertFileToCard: vi.fn()
+  },
   dependency: {
     getForProject: vi.fn()
   }
@@ -163,6 +166,7 @@ describe('duplicate markdown card renderer identity', () => {
     reorderTicket.mockReset()
     kanbanApiMock.ticket.getByProject.mockReset()
     kanbanApiMock.diagnostics.get.mockReset()
+    kanbanApiMock.markdown.convertFileToCard.mockReset()
     kanbanApiMock.dependency.getForProject.mockReset()
     kanbanApiMock.dependency.getForProject.mockResolvedValue([])
     vi.stubGlobal(
@@ -373,6 +377,102 @@ describe('duplicate markdown card renderer identity', () => {
     expect(getByTestId('kanban-invalid-card-placeholder')).toHaveTextContent(
       'Invalid markdown frontmatter'
     )
+  })
+
+  test('placeholder context menu converts the selected markdown file', async () => {
+    const converted = makeTicket({
+      id: 'converted-card',
+      title: 'Converted Card'
+    })
+    kanbanApiMock.markdown.convertFileToCard.mockResolvedValueOnce(converted)
+    kanbanApiMock.ticket.getByProject.mockResolvedValueOnce([converted])
+    kanbanApiMock.diagnostics.get.mockResolvedValueOnce([])
+    useKanbanStore.setState({
+      loadTickets: useKanbanStore.getInitialState().loadTickets,
+      convertMarkdownPlaceholder: useKanbanStore.getInitialState().convertMarkdownPlaceholder,
+      tickets: new Map([['proj-1', []]]),
+      markdownPlaceholders: new Map([
+        [
+          'proj-1',
+          [
+            {
+              projectId: 'proj-1',
+              filePath: '/tmp/project/cards/broken.md',
+              kind: 'invalid_frontmatter',
+              message: 'Invalid markdown frontmatter',
+              blocking: true
+            }
+          ]
+        ]
+      ])
+    })
+
+    const { getByTestId } = render(
+      <TooltipProvider>
+        <KanbanBoard projectId="proj-1" />
+      </TooltipProvider>
+    )
+
+    fireEvent.contextMenu(getByTestId('kanban-invalid-card-placeholder'))
+    fireEvent.click(getByTestId('ctx-convert-markdown-card'))
+
+    await waitFor(() => {
+      expect(kanbanApiMock.markdown.convertFileToCard).toHaveBeenCalledWith(
+        'proj-1',
+        '/tmp/project/cards/broken.md'
+      )
+    })
+    await waitFor(() => {
+      expect(useKanbanStore.getState().tickets.get('proj-1')).toEqual([converted])
+      expect(useKanbanStore.getState().markdownPlaceholders.get('proj-1')).toEqual([])
+    })
+  })
+
+  test('failed placeholder conversion does not reload the board', async () => {
+    const loadTickets = vi.fn().mockResolvedValue(undefined)
+    kanbanApiMock.markdown.convertFileToCard.mockRejectedValueOnce(new Error('Duplicate id'))
+    useKanbanStore.setState({
+      loadTickets,
+      convertMarkdownPlaceholder: useKanbanStore.getInitialState().convertMarkdownPlaceholder
+    })
+
+    await expect(
+      useKanbanStore
+        .getState()
+        .convertMarkdownPlaceholder('proj-1', '/tmp/project/cards/duplicate.md')
+    ).rejects.toThrow('Duplicate id')
+
+    expect(loadTickets).not.toHaveBeenCalled()
+  })
+
+  test('placeholder conversion reload preserves aggregate archive visibility', async () => {
+    const converted = makeTicket({
+      id: 'converted-card',
+      title: 'Converted Card'
+    })
+    const archived = makeTicket({
+      id: 'archived-card',
+      title: 'Archived Card',
+      archived_at: '2026-06-21T00:00:00.000Z'
+    })
+    kanbanApiMock.markdown.convertFileToCard.mockResolvedValueOnce(converted)
+    kanbanApiMock.ticket.getByProject.mockResolvedValueOnce([converted, archived])
+    kanbanApiMock.diagnostics.get.mockResolvedValueOnce([])
+    useKanbanStore.setState({
+      convertMarkdownPlaceholder: useKanbanStore.getInitialState().convertMarkdownPlaceholder,
+      loadTicketsWithArchiveVisibility:
+        useKanbanStore.getInitialState().loadTicketsWithArchiveVisibility,
+      showArchivedByProject: { '': true },
+      tickets: new Map([['proj-1', []]]),
+      markdownPlaceholders: new Map()
+    })
+
+    await useKanbanStore
+      .getState()
+      .convertMarkdownPlaceholder('proj-1', '/tmp/project/cards/broken.md')
+
+    expect(kanbanApiMock.ticket.getByProject).toHaveBeenCalledWith('proj-1', true)
+    expect(useKanbanStore.getState().tickets.get('proj-1')).toEqual([converted, archived])
   })
 
   test('loadTickets creates placeholders for id-bearing invalid markdown diagnostics', async () => {

--- a/test/kanban/markdown-diagnostics-cache.test.ts
+++ b/test/kanban/markdown-diagnostics-cache.test.ts
@@ -7,6 +7,7 @@ import {
   readFile,
   rm,
   stat,
+  symlink,
   writeFile
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -121,6 +122,11 @@ function frontmatterOf(raw: string): Record<string, unknown> {
   const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/)
   if (!match) return {}
   return (YAML.parse(match[1]) ?? {}) as Record<string, unknown>
+}
+
+function bodyOf(raw: string): string {
+  const match = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?([\s\S]*)$/)
+  return match ? match[1] : raw
 }
 
 function dependencyBlockersOf(frontmatter: Record<string, unknown>): string[] {
@@ -460,6 +466,308 @@ describe('markdown diagnostics cache', () => {
       message: expect.stringContaining('missing required frontmatter field "id"'),
       blocking: true
     })
+  })
+
+  test('converting a placeholder markdown file preserves body and writes kanban frontmatter', async () => {
+    const backend = (
+      await import('../../src/main/services/kanban-backend')
+    ).getMarkdownKanbanBackend()
+    const cardsPath = join(tempRoot!, 'cards')
+    const existingPath = join(cardsPath, 'existing.md')
+    const cardPath = join(cardsPath, 'needs-migration.md')
+    const body = '# Migrated From Docs\n\nKeep this body exactly.\n'
+    await writeFile(
+      existingPath,
+      [
+        '---',
+        'id: existing-card',
+        'title: Existing Card',
+        'column: todo',
+        'sort_order: 7',
+        'mode: build',
+        'archived_at: null',
+        'created_at: "2026-06-01T00:00:00.000Z"',
+        '---',
+        'Existing body'
+      ].join('\n'),
+      'utf-8'
+    )
+    await writeFile(
+      cardPath,
+      ['---', 'reviewer: keep-me', '---', body].join('\n'),
+      'utf-8'
+    )
+    backend.invalidate('proj-cache')
+
+    const ticket = await backend.convertMarkdownFileToCard('proj-cache', cardPath)
+    const raw = await readFile(cardPath, 'utf-8')
+    const frontmatter = frontmatterOf(raw)
+
+    expect(ticket.id).toMatch(/^migrated-from-docs-[a-z0-9]+$/)
+    expect(ticket.title).toBe('Migrated From Docs')
+    expect(ticket.column).toBe('todo')
+    expect(ticket.sort_order).toBe(8)
+    expect(frontmatter.id).toBe(ticket.id)
+    expect(frontmatter.title).toBe('Migrated From Docs')
+    expect(frontmatter.column).toBe('todo')
+    expect(frontmatter.sort_order).toBe(8)
+    expect(frontmatter.mode).toBe('build')
+    expect(frontmatter.archived_at).toBeNull()
+    expect(typeof frontmatter.created_at).toBe('string')
+    expect(frontmatter.reviewer).toBe('keep-me')
+    expect(bodyOf(raw)).toBe(body)
+  })
+
+  test('converting treats blank id frontmatter as missing', async () => {
+    const backend = (
+      await import('../../src/main/services/kanban-backend')
+    ).getMarkdownKanbanBackend()
+    const cardPath = join(tempRoot!, 'cards', 'blank-id.md')
+    const body = '# Blank ID Template\n\nBody\n'
+    await writeFile(
+      cardPath,
+      ['---', "id: ''", 'title: Blank ID Template', '---', body].join('\n'),
+      'utf-8'
+    )
+    backend.invalidate('proj-cache')
+
+    const ticket = await backend.convertMarkdownFileToCard('proj-cache', cardPath)
+    const frontmatter = frontmatterOf(await readFile(cardPath, 'utf-8'))
+
+    expect(ticket.id).toMatch(/^blank-id-template-[a-z0-9]+$/)
+    expect(frontmatter.id).toBe(ticket.id)
+    expect(frontmatter.title).toBe('Blank ID Template')
+  })
+
+  test('converting treats blank title and column frontmatter as missing', async () => {
+    const backend = (
+      await import('../../src/main/services/kanban-backend')
+    ).getMarkdownKanbanBackend()
+    const cardPath = join(tempRoot!, 'cards', 'blank-fields.md')
+    await writeFile(
+      cardPath,
+      ['---', "title: ''", 'column:', '---', '# Heading Title', 'Body'].join('\n'),
+      'utf-8'
+    )
+    backend.invalidate('proj-cache')
+
+    const ticket = await backend.convertMarkdownFileToCard('proj-cache', cardPath)
+    const frontmatter = frontmatterOf(await readFile(cardPath, 'utf-8'))
+
+    expect(ticket.title).toBe('Heading Title')
+    expect(ticket.column).toBe('todo')
+    expect(frontmatter.title).toBe('Heading Title')
+    expect(frontmatter.column).toBe('todo')
+  })
+
+  test('converting treats blank generated metadata as missing', async () => {
+    const backend = (
+      await import('../../src/main/services/kanban-backend')
+    ).getMarkdownKanbanBackend()
+    const cardPath = join(tempRoot!, 'cards', 'blank-generated.md')
+    await writeFile(
+      cardPath,
+      [
+        '---',
+        'sort_order:',
+        'created_at:',
+        '---',
+        '# Blank Generated Metadata',
+        'Body'
+      ].join('\n'),
+      'utf-8'
+    )
+    backend.invalidate('proj-cache')
+
+    const ticket = await backend.convertMarkdownFileToCard('proj-cache', cardPath)
+    const frontmatter = frontmatterOf(await readFile(cardPath, 'utf-8'))
+
+    expect(ticket.sort_order).toBe(0)
+    expect(typeof ticket.created_at).toBe('string')
+    expect(frontmatter.sort_order).toBe(0)
+    expect(typeof frontmatter.created_at).toBe('string')
+  })
+
+  test('converting removes blank dependency skeleton fields', async () => {
+    const backend = (
+      await import('../../src/main/services/kanban-backend')
+    ).getMarkdownKanbanBackend()
+    const cardPath = join(tempRoot!, 'cards', 'blank-dependencies.md')
+    await writeFile(
+      cardPath,
+      [
+        '---',
+        'id: blank-dependencies',
+        'title: Blank Dependencies',
+        'column: todo',
+        'dependencies:',
+        'depends_on:',
+        'mode: build',
+        'archived_at: null',
+        'created_at: 2026-06-17T20:36:08.965Z',
+        'sort_order: 2',
+        '---',
+        'Body'
+      ].join('\n'),
+      'utf-8'
+    )
+    backend.invalidate('proj-cache')
+
+    const ticket = await backend.convertMarkdownFileToCard('proj-cache', cardPath)
+    const frontmatter = frontmatterOf(await readFile(cardPath, 'utf-8'))
+
+    expect(ticket.id).toBe('blank-dependencies')
+    expect(frontmatter.dependencies).toBeUndefined()
+    expect(frontmatter.depends_on).toBeUndefined()
+  })
+
+  test('converting preserves explicit null markdown ticket mode', async () => {
+    const backend = (
+      await import('../../src/main/services/kanban-backend')
+    ).getMarkdownKanbanBackend()
+    const cardPath = join(tempRoot!, 'cards', 'null-mode-placeholder.md')
+    await writeFile(
+      cardPath,
+      ['---', 'mode: null', '---', '# Null Mode Placeholder', 'Body'].join('\n'),
+      'utf-8'
+    )
+    backend.invalidate('proj-cache')
+
+    const ticket = await backend.convertMarkdownFileToCard('proj-cache', cardPath)
+    const frontmatter = frontmatterOf(await readFile(cardPath, 'utf-8'))
+
+    expect(ticket.mode).toBeNull()
+    expect(frontmatter.mode).toBeNull()
+  })
+
+  test('converting a status-folder placeholder infers the folder column', async () => {
+    const backend = (
+      await import('../../src/main/services/kanban-backend')
+    ).getMarkdownKanbanBackend()
+    mockState.project = {
+      ...mockState.project!,
+      kanban_markdown_config: JSON.stringify({
+        layout: 'status-folders',
+        statusFolders: {
+          todo: 'cards/todo',
+          in_progress: 'cards/in-progress',
+          review: 'cards/review',
+          done: 'cards/done'
+        }
+      })
+    }
+    await mkdir(join(tempRoot!, 'cards', 'todo'), { recursive: true })
+    await mkdir(join(tempRoot!, 'cards', 'in-progress'), { recursive: true })
+    await mkdir(join(tempRoot!, 'cards', 'review'), { recursive: true })
+    await mkdir(join(tempRoot!, 'cards', 'done'), { recursive: true })
+    await writeFile(
+      join(tempRoot!, 'cards', 'review', 'existing-review.md'),
+      [
+        '---',
+        'id: existing-review',
+        'title: Existing Review',
+        'column: review',
+        'sort_order: 2',
+        '---',
+        'Review body'
+      ].join('\n'),
+      'utf-8'
+    )
+    const cardPath = join(tempRoot!, 'cards', 'review', 'needs-review.md')
+    await writeFile(cardPath, '# Needs Review\n', 'utf-8')
+    backend.invalidate('proj-cache')
+
+    const ticket = await backend.convertMarkdownFileToCard('proj-cache', cardPath)
+    const frontmatter = frontmatterOf(await readFile(cardPath, 'utf-8'))
+
+    expect(ticket.column).toBe('review')
+    expect(ticket.sort_order).toBe(3)
+    expect(frontmatter.column).toBe('review')
+    expect(frontmatter.sort_order).toBe(3)
+  })
+
+  test('converting unsafe markdown files fails without rewriting them', async () => {
+    const backend = (
+      await import('../../src/main/services/kanban-backend')
+    ).getMarkdownKanbanBackend()
+    const cardsPath = join(tempRoot!, 'cards')
+    const existingPath = join(cardsPath, 'existing.md')
+    const duplicatePath = join(cardsPath, 'duplicate.md')
+    const malformedPath = join(cardsPath, 'malformed.md')
+    const existing = ['---', 'id: shared-card', 'title: Existing', '---', 'Existing'].join('\n')
+    const duplicate = ['---', 'id: shared-card', 'title: Duplicate', '---', 'Duplicate'].join('\n')
+    const malformed = ['---', 'title: [', '---', 'Malformed'].join('\n')
+    await writeFile(existingPath, existing, 'utf-8')
+    await writeFile(duplicatePath, duplicate, 'utf-8')
+    await writeFile(malformedPath, malformed, 'utf-8')
+    backend.invalidate('proj-cache')
+
+    await expect(
+      backend.convertMarkdownFileToCard('proj-cache', duplicatePath)
+    ).rejects.toThrow(/already exists/)
+    await expect(
+      backend.convertMarkdownFileToCard('proj-cache', malformedPath)
+    ).rejects.toThrow()
+
+    expect(await readFile(duplicatePath, 'utf-8')).toBe(duplicate)
+    expect(await readFile(malformedPath, 'utf-8')).toBe(malformed)
+  })
+
+  test('converting rejects ids already claimed by invalid same-id diagnostics', async () => {
+    const backend = (
+      await import('../../src/main/services/kanban-backend')
+    ).getMarkdownKanbanBackend()
+    const cardsPath = join(tempRoot!, 'cards')
+    const invalidPath = join(cardsPath, 'invalid-shared.md')
+    const convertiblePath = join(cardsPath, 'convertible-shared.md')
+    const invalid = ['---', 'id: shared-card', 'title: []', '---', 'Invalid'].join('\n')
+    const convertible = ['---', 'id: shared-card', '---', '# Convertible'].join('\n')
+    await writeFile(invalidPath, invalid, 'utf-8')
+    await writeFile(convertiblePath, convertible, 'utf-8')
+    backend.invalidate('proj-cache')
+
+    await expect(
+      backend.convertMarkdownFileToCard('proj-cache', convertiblePath)
+    ).rejects.toThrow(/already exists/)
+
+    expect(await readFile(convertiblePath, 'utf-8')).toBe(convertible)
+  })
+
+  test('converting id-bearing placeholders in symlinked folders ignores their own diagnostic', async () => {
+    const backend = (
+      await import('../../src/main/services/kanban-backend')
+    ).getMarkdownKanbanBackend()
+    const realCardsPath = join(tempRoot!, 'real-cards')
+    const linkedCardsPath = join(tempRoot!, 'linked-cards')
+    await mkdir(realCardsPath, { recursive: true })
+    await symlink(realCardsPath, linkedCardsPath, 'dir')
+    mockState.project = {
+      ...mockState.project!,
+      kanban_markdown_config: JSON.stringify({
+        layout: 'single-folder',
+        singleFolder: 'linked-cards'
+      })
+    }
+    const cardPath = join(linkedCardsPath, 'symlinked-placeholder.md')
+    await writeFile(
+      cardPath,
+      ['---', 'id: symlinked-card', "title: ''", '---', '# Symlinked Card'].join('\n'),
+      'utf-8'
+    )
+    backend.invalidate('proj-cache')
+
+    await expect(backend.getDiagnostics('proj-cache')).resolves.toContainEqual(
+      expect.objectContaining({
+        ticketId: 'symlinked-card',
+        filePath: cardPath,
+        kind: 'invalid_frontmatter'
+      })
+    )
+
+    const ticket = await backend.convertMarkdownFileToCard('proj-cache', cardPath)
+
+    expect(ticket.id).toBe('symlinked-card')
+    expect(ticket.title).toBe('Symlinked Card')
   })
 
   test.each([


### PR DESCRIPTION
## Description
Adds per-file migration for existing Markdown files in Markdown Kanban folders. Invalid placeholder cards can now be converted individually into valid Markdown Kanban cards via a context menu action.

## Related Issue
N/A

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] ♻️ Code refactoring
- [x] 🧪 Test improvement
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Changes Made
- Added backend support for converting one Markdown file into a Kanban card while preserving body content and unknown frontmatter.
- Exposed the migration through RPC, renderer API, store action, and invalid-placeholder context menu.
- Added coverage for backend migration behavior, RPC/API routing, and placeholder UI invocation.

## Screenshots
<img width="555" height="435" alt="Screenshot 2026-06-21 at 17 39 37" src="https://github.com/user-attachments/assets/549993bf-9f2d-4030-a0ec-4e994798dec4" />
<img width="559" height="431" alt="Screenshot 2026-06-21 at 17 39 43" src="https://github.com/user-attachments/assets/be3f8844-bb37-4392-95e6-85efb7a4e4d7" />


## Testing

### Test Configuration
- **OS**: macOS
- **Node Version**: local project default
- **Test Type**: Unit/Integration

### Test Steps
1. Ran focused markdown kanban, RPC, API, and renderer tests.
2. Ran targeted ESLint on touched files.
3. Ran `git diff --check`.

### Test Results
- [x] All existing targeted tests pass
- [x] New tests added
- [ ] Manual testing completed

## Checklist
- [x] My code follows the project's code style
- [ ] I have run `pnpm lint` and fixed any issues
- [ ] I have run `pnpm format` to format my code
- [x] I have run targeted tests and all tests pass
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation (if needed)
- [ ] I have added comments to complex code sections
- [ ] I have checked for any console errors
- [ ] I have tested on macOS (required)
- [ ] I have updated documentation (for significant changes)

## Performance Impact
- [x] No performance impact
- [ ] Improves performance
- [ ] May affect performance

## Breaking Changes
- [x] No breaking changes


## Additional Notes
Full `npm run lint` currently reports unrelated existing repo issues; targeted ESLint on touched files passes with one pre-existing warning in `kanban-backend.ts`.

## Post-Merge Tasks
- [ ] Update documentation site
- [ ] Notify users of breaking changes
- [ ] Update README examples
- [ ] Other:
