### PR TITLE
Fix finished sessions not moving to review

### DIFF
--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -20,7 +20,9 @@ vi.mock('./useSettingsStore', () => ({
 }))
 
 import { useKanbanStore } from './useKanbanStore'
+import { useWorktreeStatusStore } from './useWorktreeStatusStore'
 import { kanbanApi } from '@/api/kanban-api'
+import type { SessionStatusType } from '@shared/types/session-status'
 
 const SESSION_ID = 'sess-1'
 const PROJECT_ID = 'proj-1'
@@ -70,13 +72,21 @@ function columnOf(ticketId: string): KanbanTicketColumn | undefined {
 
 const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
 
+function setSessionStatus(sessionId: string, status: SessionStatusType | null): void {
+  useWorktreeStatusStore.setState({
+    sessionStatuses: status ? { [sessionId]: { status, timestamp: 0 } } : {}
+  })
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   useKanbanStore.setState({ tickets: new Map() })
+  useWorktreeStatusStore.setState({ sessionStatuses: {} })
 })
 
 afterEach(() => {
   useKanbanStore.setState({ tickets: new Map() })
+  useWorktreeStatusStore.setState({ sessionStatuses: {} })
 })
 
 describe('syncTicketWithSession — done is terminal', () => {
@@ -149,5 +159,91 @@ describe('syncTicketWithSession — non-done paths unchanged', () => {
 
     expect(columnOf('ticket-1')).toBe('in_progress')
     expect(kanbanApi.ticket.move).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', 'in_progress', 0)
+  })
+})
+
+describe('syncTicketWithSession — finish moves to review regardless of mode/plan state', () => {
+  it('moves an in_progress ticket with mode null to review on session_completed', async () => {
+    seed(makeTicket({ column: 'in_progress', mode: null }))
+
+    useKanbanStore.getState().syncTicketWithSession(SESSION_ID, {
+      type: 'session_completed',
+      sessionMode: undefined
+    })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('review')
+    expect(kanbanApi.ticket.move).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', 'review', 0)
+  })
+
+  it('moves an in_progress plan ticket to review on session_completed even when plan_ready is already true', async () => {
+    seed(makeTicket({ column: 'in_progress', mode: 'plan', plan_ready: true }))
+
+    useKanbanStore.getState().syncTicketWithSession(SESSION_ID, {
+      type: 'session_completed',
+      sessionMode: 'plan'
+    })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('review')
+    expect(kanbanApi.ticket.move).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', 'review', 0)
+  })
+
+  it('moves an in_progress build ticket to review on a misrouted plan_ready event', async () => {
+    // A build session's completion can be rerouted to the plan_ready event by a
+    // stale lastSendMode; the move must not be gated on mode.
+    seed(makeTicket({ column: 'in_progress', mode: 'build', plan_ready: false }))
+
+    useKanbanStore.getState().syncTicketWithSession(SESSION_ID, { type: 'plan_ready' })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('review')
+    expect(kanbanApi.ticket.move).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', 'review', 0)
+  })
+})
+
+describe('reconcileFinishedSessions — recovers dropped finish moves on load', () => {
+  it('moves an in_progress ticket to review when its session status is completed', async () => {
+    seed(makeTicket({ column: 'in_progress', mode: 'build' }))
+    setSessionStatus(SESSION_ID, 'completed')
+
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('review')
+    expect(kanbanApi.ticket.move).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', 'review', 0)
+  })
+
+  it('moves an in_progress plan ticket to review when its session status is plan_ready', async () => {
+    seed(makeTicket({ column: 'in_progress', mode: 'plan', plan_ready: false }))
+    setSessionStatus(SESSION_ID, 'plan_ready')
+
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('review')
+    expect(kanbanApi.ticket.move).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', 'review', 0)
+  })
+
+  it('does not move when the session has no status', async () => {
+    seed(makeTicket({ column: 'in_progress', mode: 'build' }))
+    setSessionStatus(SESSION_ID, null)
+
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+
+  it('does not move when the session is still working', async () => {
+    seed(makeTicket({ column: 'in_progress', mode: 'build' }))
+    setSessionStatus(SESSION_ID, 'working')
+
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -216,6 +216,7 @@ interface KanbanState {
   clearBoardTelegramTarget: () => void
   loadTickets: (projectId: string) => Promise<void>
   loadTicketsWithArchiveVisibility: (projectId: string, includeArchived: boolean) => Promise<void>
+  reconcileFinishedSessions: (projectId: string) => void
   createTicket: (projectId: string, data: KanbanTicketCreate) => Promise<KanbanTicket>
   convertMarkdownPlaceholder: (projectId: string, filePath: string) => Promise<KanbanTicket>
   updateTicket: (ticketId: string, projectId: string, data: KanbanTicketUpdate) => Promise<void>
@@ -366,6 +367,8 @@ export const useKanbanStore = create<KanbanState>()(
           })
           // Load dependencies for this project
           get().loadDependencies(projectId)
+          // Recover any finished-session moves dropped before this load
+          get().reconcileFinishedSessions(projectId)
         } catch {
           set({ isLoading: false })
         }
@@ -396,8 +399,32 @@ export const useKanbanStore = create<KanbanState>()(
             }
           })
           get().loadDependencies(projectId)
+          get().reconcileFinishedSessions(projectId)
         } catch {
           set({ isLoading: false })
+        }
+      },
+
+      // ── reconcileFinishedSessions ────────────────────────────────
+      // Safety net for session_completed/plan_ready events that were dropped
+      // because this project's tickets weren't loaded when the event fired (e.g.
+      // on app relaunch the idle→completed replay can beat the board load). Run
+      // after tickets load: any in_progress ticket whose linked session is in a
+      // concrete "finished" status is advanced to review.
+      reconcileFinishedSessions: (projectId: string) => {
+        const tickets = get().tickets.get(projectId) ?? []
+        const statuses = useWorktreeStatusStore.getState().sessionStatuses
+        for (const ticket of tickets) {
+          if (ticket.column !== 'in_progress' || !ticket.current_session_id) continue
+          const status = statuses[ticket.current_session_id]?.status ?? null
+          // Only act on positive "finished" evidence — never on progressing/asking/
+          // no-status, so we don't yank not-yet-started or actively-running sessions
+          // out of in_progress.
+          if (status !== 'completed' && status !== 'plan_ready') continue
+          if (isPlanLike(ticket.mode) && !ticket.plan_ready) {
+            get().updateTicket(ticket.id, projectId, { plan_ready: true }).catch(() => {})
+          }
+          get().moveTicket(ticket.id, projectId, 'review', ticket.sort_order).catch(() => {})
         }
       },
 
@@ -430,6 +457,7 @@ export const useKanbanStore = create<KanbanState>()(
             }
           })
           get().loadDependencies(projectId)
+          get().reconcileFinishedSessions(projectId)
         } catch {
           set({ isLoading: false })
         }
@@ -891,25 +919,19 @@ export const useKanbanStore = create<KanbanState>()(
             // Each column-moving branch below guards on `column !== 'done'`.
             switch (event.type) {
               case 'session_completed': {
-                if (
-                  ticket.mode === 'build' &&
-                  ticket.column !== 'review' &&
-                  ticket.column !== 'done'
-                ) {
-                  // Auto-advance build ticket to review column (idempotent — skip if already there)
-                  get()
-                    .moveTicket(ticket.id, projectId, 'review', ticket.sort_order)
-                    .catch(() => {})
-                } else if (isPlanLike(ticket.mode) && !ticket.plan_ready) {
-                  // Plan finished — set plan_ready and move to review for user attention
+                // Plan tickets: surface the finished plan for the review UI.
+                if (isPlanLike(ticket.mode) && !ticket.plan_ready) {
                   get()
                     .updateTicket(ticket.id, projectId, { plan_ready: true })
                     .catch(() => {})
-                  if (ticket.column !== 'review' && ticket.column !== 'done') {
-                    get()
-                      .moveTicket(ticket.id, projectId, 'review', ticket.sort_order)
-                      .catch(() => {})
-                  }
+                }
+                // The session finished → its progress bar is gone. Any non-terminal
+                // ticket must advance to review regardless of mode/plan state (board
+                // invariant: in_progress ⇔ a running progress bar). Move is idempotent.
+                if (ticket.column !== 'review' && ticket.column !== 'done') {
+                  get()
+                    .moveTicket(ticket.id, projectId, 'review', ticket.sort_order)
+                    .catch(() => {})
                 }
                 // Accumulate token delta to ticket's persistent total
                 if (event.tokenDelta && event.tokenDelta > 0) {
@@ -933,16 +955,19 @@ export const useKanbanStore = create<KanbanState>()(
               }
 
               case 'plan_ready': {
-                // Explicit plan.ready event — set flag and move to review
+                // Explicit plan.ready event — set the flag for plan tickets...
                 if (isPlanLike(ticket.mode) && !ticket.plan_ready) {
                   get()
                     .updateTicket(ticket.id, projectId, { plan_ready: true })
                     .catch(() => {})
-                  if (ticket.column !== 'review' && ticket.column !== 'done') {
-                    get()
-                      .moveTicket(ticket.id, projectId, 'review', ticket.sort_order)
-                      .catch(() => {})
-                  }
+                }
+                // ...and move any non-terminal ticket to review. A build ticket can
+                // land here when its completion is rerouted to plan_ready by a stale
+                // lastSendMode, so the move must not be gated on mode.
+                if (ticket.column !== 'review' && ticket.column !== 'done') {
+                  get()
+                    .moveTicket(ticket.id, projectId, 'review', ticket.sort_order)
+                    .catch(() => {})
                 }
                 break
               }
@@ -1230,9 +1255,10 @@ export const useKanbanStore = create<KanbanState>()(
               markdownPlaceholders: newPlaceholders
             }
           })
-          // Load dependencies for each project
+          // Load dependencies + recover dropped finished-session moves per project
           for (const pid of projectIds) {
             get().loadDependencies(pid)
+            get().reconcileFinishedSessions(pid)
           }
         } catch (error) {
           console.error('Failed to load tickets for connection:', error)
@@ -1314,9 +1340,10 @@ export const useKanbanStore = create<KanbanState>()(
               markdownPlaceholders: newPlaceholders
             }
           })
-          // Load dependencies for each project
+          // Load dependencies + recover dropped finished-session moves per project
           for (const pid of projectIds) {
             get().loadDependencies(pid)
+            get().reconcileFinishedSessions(pid)
           }
         } catch (error) {
           console.error('Failed to load tickets for pinned projects:', error)


### PR DESCRIPTION
## Summary
- Move any non-terminal ticket to `review` when a linked session finishes, regardless of mode or plan state.
- Keep plan tickets in sync by setting `plan_ready` on `session_completed` and `plan_ready` events when needed.
- Add a reconciliation pass after ticket loads to recover missed finished-session moves on refresh or relaunch.
- Cover the new behavior with tests for session completion, misrouted plan-ready events, and load-time recovery.

## Testing
- `Not run`
- Added/updated unit tests in `useKanbanStore.session-sync.test.ts` for completed sessions, plan tickets, and reconciliation behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core kanban column automation on session lifecycle events and can auto-move tickets on every board load when session status says finished; behavior is guarded but affects workflow state.
> 
> **Overview**
> Fixes kanban tickets staying in **in_progress** after a linked session finishes when mode/plan gates blocked the move or finish events fired before tickets were loaded.
> 
> **`syncTicketWithSession`** now treats session finish as a board invariant: on `session_completed` and `plan_ready`, any ticket that is not already in `review` or `done` moves to **review**, independent of `mode` or `plan_ready`. Plan-like tickets still get `plan_ready: true` when appropriate, but the column move is no longer limited to build mode or tied to setting that flag first.
> 
> Adds **`reconcileFinishedSessions`**, run after project/connection/pinned ticket loads. It scans `in_progress` tickets whose `current_session_id` has worktree status `completed` or `plan_ready`, sets `plan_ready` for plan tickets if needed, and moves them to review—recovering moves missed on relaunch when status replay beats board load. It ignores missing or still-`working` statuses so active sessions are not pulled out of progress.
> 
> Unit tests cover broader finish paths, misrouted `plan_ready` on build tickets, and reconciliation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add2316b4890ca9bcf066b2b716a1dfb42db4867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->