### PR TITLE
Add ultracode support for Claude CLI models

### DIFF
--- a/src/main/services/__tests__/claude-cli-spawner.test.ts
+++ b/src/main/services/__tests__/claude-cli-spawner.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { Session } from '../../db/types'
-import { buildClaudeCliPtySpawn, normalizeClaudeCliModel } from '../claude-cli-spawner'
+import {
+  buildClaudeCliPtySpawn,
+  isUltracodeEffort,
+  normalizeClaudeCliModel
+} from '../claude-cli-spawner'
 
 function makeSession(overrides: Partial<Session> = {}): Session {
   return {
@@ -168,5 +172,50 @@ describe('buildClaudeCliPtySpawn', () => {
 
     expect(spawn.args).not.toContain('--settings')
     expect(spawn.args.at(-1)).toBe('Say hi')
+  })
+
+  it('recognizes the ultracode effort case-insensitively', () => {
+    expect(isUltracodeEffort('ultracode')).toBe(true)
+    expect(isUltracodeEffort('UltraCode')).toBe(true)
+    expect(isUltracodeEffort('xhigh')).toBe(false)
+    expect(isUltracodeEffort(null)).toBe(false)
+    expect(isUltracodeEffort(undefined)).toBe(false)
+  })
+
+  it('enables ultracode via the settings flag, preserves hooks, and omits --effort', () => {
+    const hookSettingsJson = '{"hooks":{"Stop":[{"id":1}]}}'
+    const spawn = buildClaudeCliPtySpawn({
+      session: makeSession({ model_id: 'opus', model_variant: 'ultracode' }),
+      worktreePath: '/repo/worktree',
+      pendingPrompt: 'Go',
+      claudeBinary: 'claude',
+      hookSettingsJson
+    })
+
+    // ultracode rides in --settings; it is never passed as a --effort value.
+    expect(spawn.args).not.toContain('--effort')
+    // model is still forwarded as usual.
+    expect(spawn.args).toContain('--model')
+    expect(spawn.args).toContain('opus')
+
+    const settingsIndex = spawn.args.indexOf('--settings')
+    expect(settingsIndex).toBeGreaterThanOrEqual(0)
+    const settings = JSON.parse(spawn.args[settingsIndex + 1])
+    expect(settings.ultracode).toBe(true)
+    expect(settings.hooks).toEqual({ Stop: [{ id: 1 }] })
+  })
+
+  it('passes ultracode settings even when no hook settings are provided', () => {
+    const spawn = buildClaudeCliPtySpawn({
+      session: makeSession({ model_id: 'opus', model_variant: 'ultracode' }),
+      worktreePath: '/repo/worktree',
+      pendingPrompt: null,
+      claudeBinary: 'claude'
+    })
+
+    expect(spawn.args).not.toContain('--effort')
+    const settingsIndex = spawn.args.indexOf('--settings')
+    expect(settingsIndex).toBeGreaterThanOrEqual(0)
+    expect(JSON.parse(spawn.args[settingsIndex + 1])).toEqual({ ultracode: true })
   })
 })

--- a/src/main/services/claude-cli-spawner.ts
+++ b/src/main/services/claude-cli-spawner.ts
@@ -25,6 +25,39 @@ export interface ClaudeCliPtySpawn {
 const VALID_MODELS = new Set(['fable', 'opus', 'sonnet', 'haiku'])
 const VALID_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh', 'max'])
 
+/**
+ * "ultracode" is not a valid claude `--effort` value. It is enabled through the
+ * `ultracode` setting (xhigh effort plus standing dynamic-workflow
+ * orchestration) injected into the `--settings` JSON instead of via `--effort`.
+ */
+const ULTRACODE = 'ultracode'
+
+export function isUltracodeEffort(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.toLowerCase() === ULTRACODE
+}
+
+/**
+ * Merge `{ ultracode: true }` into the existing claude `--settings` JSON,
+ * preserving the hook config already in it. Falls back to a fresh object when
+ * there is no prior settings string or it cannot be parsed, so a malformed blob
+ * never breaks spawning.
+ */
+function withUltracodeSetting(hookSettingsJson: string | null | undefined): string {
+  let settings: Record<string, unknown> = {}
+  if (hookSettingsJson) {
+    try {
+      const parsed = JSON.parse(hookSettingsJson)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        settings = parsed as Record<string, unknown>
+      }
+    } catch {
+      settings = {}
+    }
+  }
+  settings[ULTRACODE] = true
+  return JSON.stringify(settings)
+}
+
 export function normalizeClaudeCliModel(modelId: string | null | undefined): string | null {
   if (!modelId) return null
   const lower = modelId.toLowerCase()
@@ -54,6 +87,7 @@ export function buildClaudeCliPtySpawn(input: ClaudeCliPtySpawnInput): ClaudeCli
     args.push('--model', model)
   }
 
+  const ultracode = isUltracodeEffort(input.session.model_variant)
   const effort = normalizeClaudeCliEffort(input.session.model_variant)
   if (effort) {
     args.push('--effort', effort)
@@ -64,7 +98,12 @@ export function buildClaudeCliPtySpawn(input: ClaudeCliPtySpawnInput): ClaudeCli
     args.push('--resume', resumeId)
   }
 
-  if (input.hookSettingsJson) {
+  if (ultracode) {
+    // ultracode is enabled via the settings JSON, not `--effort`. Merge it into
+    // the hook settings (or a fresh object when there are none) so the flag is
+    // always present when selected.
+    args.push('--settings', withUltracodeSetting(input.hookSettingsJson))
+  } else if (input.hookSettingsJson) {
     args.push('--settings', input.hookSettingsJson)
   }
 

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -12,7 +12,7 @@ import type { DatabaseService } from '../db/database'
 import { readClaudeTranscript, translateEntry } from './claude-transcript-reader'
 import { getUserEnvironmentVariables } from './env-vars'
 import { generateSessionTitle } from './claude-session-title'
-import { normalizeClaudeCliModel } from './claude-cli-spawner'
+import { isUltracodeEffort, normalizeClaudeCliModel } from './claude-cli-spawner'
 import { autoRenameWorktreeBranch } from './git-service'
 import { Options, PermissionMode } from '@anthropic-ai/claude-agent-sdk'
 import { CommandFilterService, type CommandFilterSettings } from './command-filter-service'
@@ -500,10 +500,15 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       const requestedModel = modelOverride?.modelID ?? this.selectedModel
       const resolvedModel = normalizeClaudeCliModel(requestedModel) ?? requestedModel
       const modelDef = CLAUDE_MODELS.find((m) => m.id === resolvedModel)
-      const effortLevel = (modelOverride?.variant ??
-        this.selectedVariant ??
-        modelDef?.defaultVariant ??
-        'high') as Options['effort']
+      const requestedEffort =
+        modelOverride?.variant ?? this.selectedVariant ?? modelDef?.defaultVariant ?? 'high'
+      // `ultracode` is a CLI-only setting with no Agent SDK `effort` equivalent.
+      // It should never reach here (the picker only offers it for claude-code-cli),
+      // but if a stale default leaks it in, fall back to its xhigh equivalent so
+      // the SDK never receives an invalid effort value.
+      const effortLevel = (isUltracodeEffort(requestedEffort)
+        ? 'xhigh'
+        : requestedEffort) as Options['effort']
 
       // Build SDK query options
       const options: Options = {

--- a/src/renderer/src/components/kanban/WorktreePickerModal.ultracode.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.ultracode.test.tsx
@@ -1,0 +1,264 @@
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorktreePickerModal, _resetLastSourceBranch } from './WorktreePickerModal'
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useUsageStore } from '@/stores/useUsageStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket } from '../../../../main/db/types'
+
+// IMPORTANT: do NOT mock ModelSelector here — this test exercises the real
+// board-modal -> ModelSelector SDK-resolution path end to end.
+
+const PROVIDERS = [
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    models: {
+      opus: {
+        id: 'opus',
+        name: 'Opus 4.8',
+        variants: { low: {}, medium: {}, high: {}, xhigh: {}, max: {} }
+      },
+      sonnet: { id: 'sonnet', name: 'Sonnet 4.6', variants: { low: {}, medium: {}, high: {} } }
+    }
+  }
+]
+
+vi.mock('@/api/opencode-api', () => ({
+  opencodeApi: {
+    listModels: vi.fn(async () => ({ success: true, providers: PROVIDERS }))
+  }
+}))
+
+vi.mock('@/api/hive-enterprise/client', () => ({
+  isHiveTelemetryEnabled: vi.fn(() => false),
+  recordHivePromptStart: vi.fn(),
+  recordHivePromptIdle: vi.fn(),
+  recordHiveQuestionsAnswered: vi.fn()
+}))
+
+vi.mock('@/components/sessions/CodexFastToggle', () => ({
+  CodexFastToggle: () => <div data-testid="codex-fast-toggle" />
+}))
+
+vi.mock('@/lib/toast', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+vi.mock('@/api/settings-api', () => ({
+  settingsApi: {
+    detectEditors: vi.fn(),
+    detectTerminals: vi.fn(),
+    loadCustomCommandsFile: vi.fn().mockResolvedValue({ commands: [] }),
+    onSettingsUpdated: vi.fn(() => vi.fn()),
+    openWithTerminal: vi.fn()
+  }
+}))
+
+vi.mock('@/api/pet-api', () => ({
+  petApi: {
+    updateSettings: vi.fn().mockResolvedValue({
+      success: true,
+      value: { enabled: true, size: 'md', position: { x: 0, y: 0 }, hatched: true }
+    })
+  }
+}))
+
+const initialSettingsState = useSettingsStore.getState()
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+const initialConnectionState = useConnectionStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialUsageState = useUsageStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
+
+const baseTicket: KanbanTicket = {
+  id: 'ticket-1',
+  project_id: 'project-1',
+  title: 'Launch Claude CLI',
+  description: 'desc',
+  column: 'todo',
+  sort_order: 0,
+  worktree_id: null,
+  current_session_id: null,
+  mode: 'build',
+  plan_ready: false,
+  goal_mode: false,
+  goal_success_criteria: null,
+  pending_launch_config: null,
+  created_from_session: false,
+  attachments: [],
+  archived_at: null,
+  external_provider: null,
+  external_id: null,
+  external_url: null,
+  github_pr_number: null,
+  github_pr_url: null,
+  mark: null,
+  note: null,
+  total_tokens: 0,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z'
+}
+
+function setupStores(): void {
+  useSettingsStore.setState({
+    availableAgentSdks: { opencode: true, claude: true, codex: true },
+    defaultAgentSdk: 'codex',
+    selectedModel: null,
+    // Mirrors the real user's settings: the build-mode default is a claude-code-cli model.
+    selectedModelByProvider: {
+      'claude-code-cli': { providerID: 'claude-code', modelID: 'opus', variant: 'xhigh' }
+    },
+    defaultModels: {
+      build: { agentSdk: 'claude-code-cli', providerID: 'claude-code', modelID: 'opus', variant: 'high' },
+      plan: null,
+      ask: null,
+      review: null
+    },
+    codexFastMode: false,
+    codexFastModeAccepted: true,
+    boardMode: 'toggle',
+    showModelProvider: false,
+    favoriteModels: []
+  })
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        worktree_create_script: null,
+        custom_commands: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        last_accessed_at: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([
+      [
+        'project-1',
+        [
+          {
+            id: 'worktree-1',
+            project_id: 'project-1',
+            name: 'Feature',
+            branch_name: 'feature',
+            path: '/repo/feature',
+            status: 'active',
+            is_default: false,
+            branch_renamed: 0,
+            last_message_at: null,
+            session_titles: '[]',
+            last_model_provider_id: null,
+            last_model_id: null,
+            last_model_variant: null,
+            attachments: '[]',
+            created_at: '2026-01-01T00:00:00.000Z',
+            last_accessed_at: '2026-01-01T00:00:00.000Z',
+            github_pr_number: null,
+            github_pr_url: null
+          }
+        ]
+      ]
+    ]),
+    worktreeOrderByProject: new Map(),
+    syncWorktrees: vi.fn(),
+    createWorktreeFromBranch: vi.fn()
+  })
+  useConnectionStore.setState({ connections: [], loaded: true })
+  useKanbanStore.setState({
+    tickets: new Map([['project-1', [baseTicket]]]),
+    updateTicket: vi.fn(async () => undefined),
+    computeSortOrder: vi.fn(() => 1),
+    getTicketsByColumn: vi.fn(() => []),
+    getTicketsByColumnForConnection: vi.fn(() => [])
+  })
+  useSessionStore.setState({
+    sessionsByWorktree: new Map(),
+    sessionsByConnection: new Map(),
+    modeBySession: new Map(),
+    createSession: vi.fn(),
+    createConnectionSession: vi.fn(),
+    setSessionModel: vi.fn(),
+    setSessionMode: vi.fn(),
+    setOpenCodeSessionId: vi.fn(),
+    setActiveSession: vi.fn()
+  })
+  useWorktreeStatusStore.setState({ setSessionStatus: vi.fn(), setLastMessageTime: vi.fn() })
+  useUsageStore.setState({ fetchUsageForProvider: vi.fn() })
+}
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = vi.fn()
+  Element.prototype.releasePointerCapture = vi.fn()
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+beforeEach(() => {
+  _resetLastSourceBranch()
+  vi.clearAllMocks()
+  resetRendererRpcClientForTests()
+  setRendererRpcClient({
+    request: vi.fn(async () => null),
+    subscribe: vi.fn(() => () => {})
+  })
+  setupStores()
+})
+
+afterEach(() => {
+  cleanup()
+  useSettingsStore.setState(initialSettingsState, true)
+  useSessionStore.setState(initialSessionState, true)
+  useWorktreeStore.setState(initialWorktreeState, true)
+  useConnectionStore.setState(initialConnectionState, true)
+  useKanbanStore.setState(initialKanbanState, true)
+  useProjectStore.setState(initialProjectState, true)
+  useUsageStore.setState(initialUsageState, true)
+  useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
+  resetRendererRpcClientForTests()
+})
+
+describe('WorktreePickerModal ultracode chip (real ModelSelector)', () => {
+  it('shows ULTRACODE on Opus when Claude CLI is selected in the ticket modal', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={baseTicket}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+
+    // Open the model picker dropdown (the pill trigger).
+    await userEvent.click(await screen.findByTestId('model-selector'))
+
+    await waitFor(() => expect(screen.getByTestId('variant-chips-opus')).toBeInTheDocument())
+
+    const opusChips = screen.getByTestId('variant-chips-opus')
+    expect(within(opusChips).getByTestId('variant-chip-ultracode')).toBeInTheDocument()
+
+    const sonnetChips = screen.getByTestId('variant-chips-sonnet')
+    expect(within(sonnetChips).queryByTestId('variant-chip-ultracode')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -10,7 +10,9 @@ import {
   findModelInfo,
   getModelDisplayName,
   getModelVariantKeys,
+  getVariantKeysForSdk,
   parseProviders,
+  ULTRACODE_VARIANT,
   type ModelInfo,
   type ProviderModels
 } from '@/lib/parseProviders'
@@ -54,6 +56,27 @@ type SelectableProviderModels = Omit<ProviderModels, 'models'> & {
 type SdkFilterOption = {
   agentSdk: HandoffAgentSdk
   label: string
+}
+
+const ULTRACODE_TOOLTIP = 'xhigh effort + dynamic-workflow orchestration'
+
+/** Styling for a variant chip. ultracode gets a distinct accent so it reads as
+ * the special CLI-only mode it is, rather than just another effort level. */
+function variantChipClass(isActive: boolean, isUltracode: boolean): string {
+  if (isUltracode) {
+    return cn(
+      'text-[10px] px-1.5 py-0.5 rounded font-medium',
+      isActive
+        ? 'bg-violet-600 text-white'
+        : 'bg-violet-500/15 text-violet-600 dark:text-violet-300 hover:bg-violet-500/25'
+    )
+  }
+  return cn(
+    'text-[10px] px-1.5 py-0.5 rounded',
+    isActive
+      ? 'bg-primary text-primary-foreground'
+      : 'bg-muted text-muted-foreground hover:bg-accent'
+  )
 }
 
 export const ModelSelector = memo(function ModelSelector({
@@ -157,7 +180,7 @@ export const ModelSelector = memo(function ModelSelector({
       const currentSdkProviders = providers.filter((provider) => provider.agentSdk === agentSdk)
       const currentSdkModel = findModelInfo(currentSdkProviders, providerID, modelID)
       if (!currentSdkModel) return false
-      return !variant || getModelVariantKeys(currentSdkModel).includes(variant)
+      return !variant || getVariantKeysForSdk(currentSdkModel, agentSdk).includes(variant)
     },
     [providers, agentSdk]
   )
@@ -170,7 +193,7 @@ export const ModelSelector = memo(function ModelSelector({
         if (sdkProviders.length === 0) return false
         const sdkModel = findModelInfo(sdkProviders, providerID, modelID)
         if (!sdkModel) return false
-        return !variant || getModelVariantKeys(sdkModel).includes(variant)
+        return !variant || getVariantKeysForSdk(sdkModel, sdk).includes(variant)
       })
     },
     [providers, catalogAgentSdks]
@@ -248,7 +271,9 @@ export const ModelSelector = memo(function ModelSelector({
   }
 
   function handleSelectModel(model: SelectableModelInfo): void {
-    const variantKeys = getModelVariantKeys(model)
+    // SDK-aware so a remembered `ultracode` choice is honored on re-select.
+    // ultracode is appended last, so it never becomes the implicit [0] default.
+    const variantKeys = getVariantKeysForSdk(model, model.agentSdk)
     const remembered = useSettingsStore
       .getState()
       .getModelVariantDefault(model.providerID, model.id)
@@ -376,7 +401,7 @@ export const ModelSelector = memo(function ModelSelector({
   // Cycle thinking-level variant for Alt+T
   const cycleVariant = useCallback(() => {
     if (!currentModel) return
-    const variantKeys = getModelVariantKeys(currentModel)
+    const variantKeys = getVariantKeysForSdk(currentModel, currentModel.agentSdk)
     if (variantKeys.length <= 1) return
 
     const currentVariant = selectedModel?.variant
@@ -552,7 +577,12 @@ export const ModelSelector = memo(function ModelSelector({
             <span className="truncate max-w-[140px]">{isLoading ? 'Loading...' : displayName}</span>
             {hasVariants && selectedModel?.variant && (
               <span
-                className="text-[10px] font-semibold text-primary uppercase"
+                className={cn(
+                  'text-[10px] font-semibold uppercase',
+                  selectedModel.variant === ULTRACODE_VARIANT
+                    ? 'text-violet-600 dark:text-violet-300'
+                    : 'text-primary'
+                )}
                 data-testid="variant-indicator"
               >
                 {selectedModel.variant}
@@ -561,7 +591,7 @@ export const ModelSelector = memo(function ModelSelector({
             <ChevronDown className="h-3 w-3 shrink-0 opacity-50" />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-64 max-h-80 overflow-y-auto">
+        <DropdownMenuContent align="start" className="w-96 max-h-80 overflow-y-auto">
           <div className="flex items-center gap-1.5 px-2 pb-1.5 pt-1">
             <Search className="h-3 w-3 shrink-0 text-muted-foreground" />
             <input
@@ -581,7 +611,7 @@ export const ModelSelector = memo(function ModelSelector({
               </DropdownMenuLabel>
               {favoriteModelObjects.map((model) => {
                 const favActive = isActiveModel(model)
-                const favVariantKeys = getModelVariantKeys(model)
+                const favVariantKeys = getVariantKeysForSdk(model, model.agentSdk)
                 return (
                   <div key={`fav-${model.agentSdk}:${model.providerID}:${model.id}`}>
                     <DropdownMenuItem
@@ -599,18 +629,15 @@ export const ModelSelector = memo(function ModelSelector({
                       {favActive && <Check className="h-4 w-4 shrink-0 text-primary" />}
                     </DropdownMenuItem>
                     {favVariantKeys.length > 0 && (
-                      <div className="flex gap-1 pl-6 pb-1">
+                      <div className="flex flex-wrap gap-1 pl-6 pb-1">
                         {favVariantKeys.map((variant) => {
                           const isActiveVariant = favActive && selectedModel?.variant === variant
+                          const isUltracode = variant === ULTRACODE_VARIANT
                           return (
                             <button
                               key={variant}
-                              className={cn(
-                                'text-[10px] px-1.5 py-0.5 rounded',
-                                isActiveVariant
-                                  ? 'bg-primary text-primary-foreground'
-                                  : 'bg-muted text-muted-foreground hover:bg-accent'
-                              )}
+                              className={variantChipClass(isActiveVariant, isUltracode)}
+                              title={isUltracode ? ULTRACODE_TOOLTIP : undefined}
                               onClick={(e) => {
                                 e.stopPropagation()
                                 handleSelectVariant(model, variant)
@@ -638,7 +665,7 @@ export const ModelSelector = memo(function ModelSelector({
               </DropdownMenuLabel>
               {provider.models.map((model) => {
                 const active = isActiveModel(model)
-                const variantKeys = getModelVariantKeys(model)
+                const variantKeys = getVariantKeysForSdk(model, model.agentSdk)
                 return (
                   <div key={`${model.agentSdk}:${model.providerID}:${model.id}`}>
                     <DropdownMenuItem
@@ -660,20 +687,17 @@ export const ModelSelector = memo(function ModelSelector({
                     </DropdownMenuItem>
                     {variantKeys.length > 0 && (
                       <div
-                        className="flex gap-1 pl-6 pb-1"
+                        className="flex flex-wrap gap-1 pl-6 pb-1"
                         data-testid={`variant-chips-${model.id}`}
                       >
                         {variantKeys.map((variant) => {
                           const isActiveVariant = active && selectedModel?.variant === variant
+                          const isUltracode = variant === ULTRACODE_VARIANT
                           return (
                             <button
                               key={variant}
-                              className={cn(
-                                'text-[10px] px-1.5 py-0.5 rounded',
-                                isActiveVariant
-                                  ? 'bg-primary text-primary-foreground'
-                                  : 'bg-muted text-muted-foreground hover:bg-accent'
-                              )}
+                              className={variantChipClass(isActiveVariant, isUltracode)}
+                              title={isUltracode ? ULTRACODE_TOOLTIP : undefined}
                               onClick={(e) => {
                                 e.stopPropagation()
                                 handleSelectVariant(model, variant)

--- a/src/renderer/src/components/sessions/ModelSelector.ultracode.test.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.ultracode.test.tsx
@@ -1,0 +1,85 @@
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ModelSelector } from './ModelSelector'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+
+// Catalog returned by listModels for the claude-code provider (shared by the CLI).
+// Opus exposes xhigh (ultracode-eligible); Sonnet caps at high (not eligible).
+const PROVIDERS = [
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    models: {
+      opus: { id: 'opus', name: 'Opus 4.8', variants: { low: {}, medium: {}, high: {}, xhigh: {}, max: {} } },
+      sonnet: { id: 'sonnet', name: 'Sonnet 4.6', variants: { low: {}, medium: {}, high: {} } }
+    }
+  }
+]
+
+vi.mock('@/api/opencode-api', () => ({
+  opencodeApi: {
+    listModels: vi.fn(async () => ({ success: true, providers: PROVIDERS }))
+  }
+}))
+
+vi.mock('@/lib/toast', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+const initialSettingsState = useSettingsStore.getState()
+const initialSessionState = useSessionStore.getState()
+
+beforeAll(() => {
+  // Radix DropdownMenu relies on these in a real browser; jsdom lacks them.
+  Element.prototype.hasPointerCapture = vi.fn()
+  Element.prototype.releasePointerCapture = vi.fn()
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+beforeEach(() => {
+  useSettingsStore.setState({
+    defaultAgentSdk: 'codex',
+    availableAgentSdks: { opencode: true, claude: true, codex: true },
+    selectedModel: null,
+    selectedModelByProvider: {},
+    defaultModels: null,
+    showModelProvider: false,
+    favoriteModels: []
+  })
+  useSessionStore.setState({
+    sessionsByWorktree: new Map(),
+    sessionsByConnection: new Map()
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  useSettingsStore.setState(initialSettingsState, true)
+  useSessionStore.setState(initialSessionState, true)
+})
+
+async function openPicker(agentSdkOverride: 'claude-code' | 'claude-code-cli'): Promise<void> {
+  render(<ModelSelector agentSdkOverride={agentSdkOverride} />)
+  // Open the dropdown once models have loaded.
+  await userEvent.click(await screen.findByTestId('model-selector'))
+  await waitFor(() => expect(screen.getByTestId('variant-chips-opus')).toBeInTheDocument())
+}
+
+describe('ModelSelector ultracode chip', () => {
+  it('shows the ULTRACODE chip on Opus under claude-code-cli, but not on Sonnet', async () => {
+    await openPicker('claude-code-cli')
+
+    const opusChips = screen.getByTestId('variant-chips-opus')
+    expect(within(opusChips).getByTestId('variant-chip-ultracode')).toBeInTheDocument()
+
+    const sonnetChips = screen.getByTestId('variant-chips-sonnet')
+    expect(within(sonnetChips).queryByTestId('variant-chip-ultracode')).toBeNull()
+  })
+
+  it('does not show the ULTRACODE chip under the non-CLI claude-code SDK', async () => {
+    await openPicker('claude-code')
+
+    const opusChips = screen.getByTestId('variant-chips-opus')
+    expect(within(opusChips).queryByTestId('variant-chip-ultracode')).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/__tests__/parseProviders.test.ts
+++ b/src/renderer/src/lib/__tests__/parseProviders.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { getVariantKeysForSdk, ULTRACODE_VARIANT } from '../parseProviders'
+
+// Opus/Fable-tier models expose xhigh/max; Sonnet/Haiku cap at high.
+const opusLike = { variants: { low: {}, medium: {}, high: {}, xhigh: {}, max: {} } }
+const sonnetLike = { variants: { low: {}, medium: {}, high: {} } }
+
+describe('getVariantKeysForSdk', () => {
+  it('appends ultracode (last) for claude-code-cli high-tier models that expose xhigh', () => {
+    const keys = getVariantKeysForSdk(opusLike, 'claude-code-cli')
+    expect(keys).toContain(ULTRACODE_VARIANT)
+    expect(keys[keys.length - 1]).toBe(ULTRACODE_VARIANT)
+  })
+
+  it('does not offer ultracode for claude-code-cli models without xhigh (Sonnet/Haiku)', () => {
+    expect(getVariantKeysForSdk(sonnetLike, 'claude-code-cli')).not.toContain(ULTRACODE_VARIANT)
+  })
+
+  it('never offers ultracode for the non-CLI claude-code SDK', () => {
+    expect(getVariantKeysForSdk(opusLike, 'claude-code')).not.toContain(ULTRACODE_VARIANT)
+  })
+
+  it('never offers ultracode for other SDKs or when the SDK is unknown', () => {
+    expect(getVariantKeysForSdk(opusLike, 'opencode')).not.toContain(ULTRACODE_VARIANT)
+    expect(getVariantKeysForSdk(opusLike, 'codex')).not.toContain(ULTRACODE_VARIANT)
+    expect(getVariantKeysForSdk(opusLike, null)).not.toContain(ULTRACODE_VARIANT)
+  })
+
+  it('returns base variant keys unchanged when the model has no variants', () => {
+    expect(getVariantKeysForSdk({}, 'claude-code-cli')).toEqual([])
+  })
+})

--- a/src/renderer/src/lib/parseProviders.ts
+++ b/src/renderer/src/lib/parseProviders.ts
@@ -83,6 +83,26 @@ export function getModelVariantKeys(model: Pick<ModelInfo, 'variants'>): string[
   return Object.keys(model.variants)
 }
 
+/** CLI-only effort: enabled via the claude `--settings` JSON, not `--effort`. */
+export const ULTRACODE_VARIANT = 'ultracode'
+
+/**
+ * Variant keys to offer for a model under a given agent SDK. `claude-code-cli`
+ * additionally offers `ultracode` — a CLI-only `--settings` mode — but only for
+ * high-tier models, detected by whether the model already exposes `xhigh`
+ * (Opus/Fable). Other SDKs cannot honor ultracode, so it is never offered there.
+ */
+export function getVariantKeysForSdk(
+  model: Pick<ModelInfo, 'variants'>,
+  agentSdk: string | null | undefined
+): string[] {
+  const base = getModelVariantKeys(model)
+  if (agentSdk === 'claude-code-cli' && base.includes('xhigh')) {
+    return [...base, ULTRACODE_VARIANT]
+  }
+  return base
+}
+
 export function findModelInfo(
   providers: ProviderModels[],
   providerID: string,


### PR DESCRIPTION
## Summary
- Add `ultracode` handling in the Claude CLI spawner by mapping it to `--settings` instead of `--effort`.
- Preserve existing hook settings while injecting the `ultracode` flag, and avoid passing invalid effort values into the Agent SDK.
- Update model variant parsing and the UI to show `ultracode` only for Claude CLI high-tier models that support `xhigh`.
- Add renderer and main-process tests covering variant availability, selection behavior, and spawn argument construction.

## Testing
- `Not run`
- Added unit coverage for Claude CLI spawn args and ultracode detection.
- Added UI tests for `ModelSelector` and `WorktreePickerModal` variant visibility.
- Added parser tests for SDK-aware variant filtering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CLI spawn args and model-picker UX; SDK gets a safe xhigh fallback if ultracode leaks in. Malformed hook settings are handled when merging ultracode.
> 
> **Overview**
> Adds **ultracode** as a CLI-only model variant: xhigh-style effort plus dynamic-workflow orchestration, wired through Claude’s `--settings` JSON instead of `--effort`.
> 
> **Main process:** When `model_variant` is ultracode, `buildClaudeCliPtySpawn` merges `{ ultracode: true }` into `--settings` (keeping hook config) and skips `--effort`. The Agent SDK path maps a stray ultracode choice to `xhigh` so invalid effort never reaches the SDK.
> 
> **UI:** `getVariantKeysForSdk` exposes ultracode only for **claude-code-cli** on models that already have `xhigh` (e.g. Opus). `ModelSelector` shows a violet **ULTRACODE** chip with tooltip; variant cycling and portability checks use SDK-aware keys.
> 
> **Tests:** Spawner, `parseProviders`, `ModelSelector`, and `WorktreePickerModal` coverage for spawn args, chip visibility, and eligibility rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec9addec33f7f60a0258e479ac5190b97e0bd5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->