### PR TITLE
Update Sonnet model label to 5

### DIFF
--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -53,7 +53,7 @@ const CLAUDE_MODELS = [
   },
   {
     id: 'sonnet',
-    name: 'Sonnet 4.6',
+    name: 'Sonnet 5',
     limit: { context: 200000, output: 16000 },
     variants: CLAUDE_EFFORT_VARIANTS,
     defaultVariant: 'high'

--- a/test/phase-21/session-6/claude-model-catalog.test.ts
+++ b/test/phase-21/session-6/claude-model-catalog.test.ts
@@ -83,7 +83,7 @@ describe('ClaudeCodeImplementer model catalog', () => {
     const info = await impl.getModelInfo('any', 'sonnet')
     expect(info).toEqual({
       id: 'sonnet',
-      name: 'Sonnet 4.6',
+      name: 'Sonnet 5',
       limit: { context: 200000, output: 16000 }
     })
   })


### PR DESCRIPTION
## Summary
- Updated the Claude model catalog entry for `sonnet` to display `Sonnet 5`.
- Aligned the corresponding model catalog test to the new label.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic catalog naming only; no routing, limits, or SDK model id behavior changes.
> 
> **Overview**
> Updates the **display label** for the `sonnet` entry in `CLAUDE_MODELS` from **Sonnet 4.6** to **Sonnet 5**. Model id, context/output limits, and variants are unchanged.
> 
> The model catalog test for `getModelInfo('sonnet')` is updated to expect the new name so metadata stays aligned with the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72d2f08593800c2d6744a96fda0a95fc20851903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->