### PR TITLE
last-modified-time

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -1364,6 +1364,18 @@ export class DatabaseService {
     values.push(id)
     db.prepare(`UPDATE worktrees SET ${updates.join(', ')} WHERE id = ?`).run(...values)
 
+    // Keep the project's default (main, no-worktree) row at least as recent as
+    // any worktree bump, so the project retains its recency for sorting even
+    // after the worktree is archived or deleted. MAX guards against regressing
+    // the default row when older timestamps are re-persisted (e.g. hydration).
+    if (data.last_message_at !== undefined && data.last_message_at !== null && !existing.is_default) {
+      db.prepare(
+        `UPDATE worktrees
+         SET last_message_at = MAX(COALESCE(last_message_at, 0), ?)
+         WHERE project_id = ? AND is_default = 1`
+      ).run(data.last_message_at, existing.project_id)
+    }
+
     return this.getWorktree(id)
   }
 

--- a/src/main/db/last-message-fanout.test.ts
+++ b/src/main/db/last-message-fanout.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { DatabaseService } from './database'
+
+const tempDirs: string[] = []
+let databaseLoadError: Error | null = null
+
+const canRunDatabaseTests = (): boolean => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require('better-sqlite3')
+    const db = new Database(':memory:')
+    db.close()
+    return true
+  } catch (error) {
+    databaseLoadError = error as Error
+    return false
+  }
+}
+
+const describeIf = canRunDatabaseTests() ? describe : describe.skip
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function setupProject(): {
+  db: DatabaseService
+  projectId: string
+  defaultWorktreeId: string
+  featureWorktreeId: string
+} {
+  const dir = mkdtempSync(join(tmpdir(), 'hive-last-message-db-'))
+  tempDirs.push(dir)
+  const db = new DatabaseService(join(dir, 'state.sqlite'))
+  db.init()
+
+  const project = db.createProject({ name: 'repo', path: join(dir, 'repo') })
+  const defaultWorktree = db.createWorktree({
+    project_id: project.id,
+    name: 'main',
+    branch_name: 'main',
+    path: join(dir, 'repo'),
+    is_default: true
+  })
+  const featureWorktree = db.createWorktree({
+    project_id: project.id,
+    name: 'feature',
+    branch_name: 'feature',
+    path: join(dir, 'repo-feature')
+  })
+
+  return {
+    db,
+    projectId: project.id,
+    defaultWorktreeId: defaultWorktree.id,
+    featureWorktreeId: featureWorktree.id
+  }
+}
+
+describeIf('worktree last_message_at fan-out to default worktree', () => {
+  if (databaseLoadError) {
+    it('skips when better-sqlite3 is not available for this Node runtime', () => {
+      expect(databaseLoadError?.message).toBeTruthy()
+    })
+  }
+
+  it('bumping a worktree also bumps the project default worktree', () => {
+    const { db, defaultWorktreeId, featureWorktreeId } = setupProject()
+
+    const now = Date.now()
+    db.updateWorktree(featureWorktreeId, { last_message_at: now })
+
+    expect(db.getWorktree(featureWorktreeId)?.last_message_at).toBe(now)
+    expect(db.getWorktree(defaultWorktreeId)?.last_message_at).toBe(now)
+  })
+
+  it('keeps the project recency after the worktree is archived', () => {
+    const { db, defaultWorktreeId, featureWorktreeId } = setupProject()
+
+    const now = Date.now()
+    db.updateWorktree(featureWorktreeId, { last_message_at: now })
+    db.archiveWorktree(featureWorktreeId)
+    db.deleteWorktree(featureWorktreeId)
+
+    expect(db.getWorktree(defaultWorktreeId)?.last_message_at).toBe(now)
+  })
+
+  it('does not regress the default worktree when an older timestamp is persisted', () => {
+    const { db, defaultWorktreeId, featureWorktreeId } = setupProject()
+
+    const newer = Date.now()
+    const older = newer - 60_000
+    db.updateWorktree(defaultWorktreeId, { last_message_at: newer })
+    db.updateWorktree(featureWorktreeId, { last_message_at: older })
+
+    expect(db.getWorktree(defaultWorktreeId)?.last_message_at).toBe(newer)
+    expect(db.getWorktree(featureWorktreeId)?.last_message_at).toBe(older)
+  })
+
+  it('updating the default worktree itself does not loop or affect others', () => {
+    const { db, defaultWorktreeId, featureWorktreeId } = setupProject()
+
+    const now = Date.now()
+    db.updateWorktree(defaultWorktreeId, { last_message_at: now })
+
+    expect(db.getWorktree(defaultWorktreeId)?.last_message_at).toBe(now)
+    expect(db.getWorktree(featureWorktreeId)?.last_message_at).toBeNull()
+  })
+
+  it('clearing last_message_at (null) does not touch the default worktree', () => {
+    const { db, defaultWorktreeId, featureWorktreeId } = setupProject()
+
+    const now = Date.now()
+    db.updateWorktree(featureWorktreeId, { last_message_at: now })
+    db.updateWorktree(featureWorktreeId, { last_message_at: null })
+
+    expect(db.getWorktree(featureWorktreeId)?.last_message_at).toBeNull()
+    expect(db.getWorktree(defaultWorktreeId)?.last_message_at).toBe(now)
+  })
+
+  it('does not bump default worktrees of other projects', () => {
+    const { db, featureWorktreeId } = setupProject()
+    const otherDir = mkdtempSync(join(tmpdir(), 'hive-last-message-db-other-'))
+    tempDirs.push(otherDir)
+    const otherProject = db.createProject({ name: 'other', path: join(otherDir, 'other') })
+    const otherDefault = db.createWorktree({
+      project_id: otherProject.id,
+      name: 'main',
+      branch_name: 'main',
+      path: join(otherDir, 'other'),
+      is_default: true
+    })
+
+    db.updateWorktree(featureWorktreeId, { last_message_at: Date.now() })
+
+    expect(db.getWorktree(otherDefault.id)?.last_message_at).toBeNull()
+  })
+})

--- a/src/main/effect/db/repos/worktrees.ts
+++ b/src/main/effect/db/repos/worktrees.ts
@@ -174,6 +174,20 @@ const update = (
     const db = yield* Db
     values.push(id)
     yield* db.exec(`UPDATE worktrees SET ${updates.join(', ')} WHERE id = ?`, values)
+
+    // Keep the project's default (main, no-worktree) row at least as recent as
+    // any worktree bump, so the project retains its recency for sorting even
+    // after the worktree is archived or deleted. MAX guards against regressing
+    // the default row when older timestamps are re-persisted (e.g. hydration).
+    if (data.last_message_at !== undefined && data.last_message_at !== null && !existing.is_default) {
+      yield* db.exec(
+        `UPDATE worktrees
+         SET last_message_at = MAX(COALESCE(last_message_at, 0), ?)
+         WHERE project_id = ? AND is_default = 1`,
+        [data.last_message_at, existing.project_id]
+      )
+    }
+
     return yield* get(id)
   })
 

--- a/src/renderer/src/lib/last-message-utils.test.ts
+++ b/src/renderer/src/lib/last-message-utils.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// setLastMessageTime persists via dbApi; stub it so tests stay in-memory.
+vi.mock('@/api/db-api', () => ({
+  dbApi: {
+    worktree: {
+      update: vi.fn().mockResolvedValue(null)
+    }
+  }
+}))
+
+import { bumpWorktreeLastMessage } from './last-message-utils'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+const PROJECT_ID = 'proj-1'
+const DEFAULT_WT = 'wt-default'
+const FEATURE_WT = 'wt-feature'
+
+function makeWorktree(id: string, isDefault: boolean): Record<string, unknown> {
+  return {
+    id,
+    project_id: PROJECT_ID,
+    name: id,
+    branch_name: id,
+    path: `/tmp/${id}`,
+    status: 'active',
+    is_default: isDefault,
+    branch_renamed: 0,
+    last_message_at: null,
+    session_titles: '[]',
+    last_model_provider_id: null,
+    last_model_id: null,
+    last_model_variant: null,
+    attachments: '[]',
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_accessed_at: '2026-01-01T00:00:00.000Z',
+    github_pr_number: null,
+    github_pr_url: null
+  }
+}
+
+beforeEach(() => {
+  type WorktreesByProject = ReturnType<typeof useWorktreeStore.getState>['worktreesByProject']
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([
+      [PROJECT_ID, [makeWorktree(DEFAULT_WT, true), makeWorktree(FEATURE_WT, false)]]
+    ]) as unknown as WorktreesByProject
+  })
+  useWorktreeStatusStore.setState({ lastMessageTimeByWorktree: {} })
+})
+
+describe('bumpWorktreeLastMessage default-worktree fan-out', () => {
+  it('bumping a worktree also bumps the project default worktree', () => {
+    const ts = 1_750_000_000_000
+    bumpWorktreeLastMessage({ worktreeId: FEATURE_WT, timestamp: ts })
+
+    const times = useWorktreeStatusStore.getState().lastMessageTimeByWorktree
+    expect(times[FEATURE_WT]).toBe(ts)
+    expect(times[DEFAULT_WT]).toBe(ts)
+  })
+
+  it('bumping the default worktree itself only bumps once', () => {
+    const ts = 1_750_000_000_000
+    bumpWorktreeLastMessage({ worktreeId: DEFAULT_WT, timestamp: ts })
+
+    const times = useWorktreeStatusStore.getState().lastMessageTimeByWorktree
+    expect(times[DEFAULT_WT]).toBe(ts)
+    expect(times[FEATURE_WT]).toBeUndefined()
+  })
+
+  it('connection bumps fan out to each member project default', () => {
+    const ts = 1_750_000_000_000
+    useConnectionStore.setState({
+      connections: [
+        {
+          id: 'conn-1',
+          members: [{ worktree_id: FEATURE_WT, project_id: PROJECT_ID }]
+        }
+      ] as unknown as ReturnType<typeof useConnectionStore.getState>['connections']
+    })
+
+    bumpWorktreeLastMessage({ connectionId: 'conn-1', timestamp: ts })
+
+    const times = useWorktreeStatusStore.getState().lastMessageTimeByWorktree
+    expect(times[FEATURE_WT]).toBe(ts)
+    expect(times[DEFAULT_WT]).toBe(ts)
+  })
+})

--- a/src/renderer/src/lib/last-message-utils.ts
+++ b/src/renderer/src/lib/last-message-utils.ts
@@ -1,5 +1,6 @@
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
 
 /**
  * Bump worktree.last_message_at to "now" when a prompt is being sent.
@@ -7,6 +8,9 @@ import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
  * Worktree-bound sessions update their own worktree. Connection-bound sessions
  * fan out to every member worktree. Board-assistant sessions pass neither value
  * and intentionally become a no-op.
+ *
+ * Every bump also touches the project's default (main, no-worktree) row so the
+ * project keeps its recency for sorting even after the worktree is archived.
  */
 export function bumpWorktreeLastMessage(opts: {
   worktreeId?: string | null
@@ -16,8 +20,23 @@ export function bumpWorktreeLastMessage(opts: {
   const timestamp = opts.timestamp ?? Date.now()
   const setLastMessageTime = useWorktreeStatusStore.getState().setLastMessageTime
 
+  const bumpProjectDefault = (projectId: string, alreadyBumpedId: string): void => {
+    const defaultWorktree = useWorktreeStore.getState().getDefaultWorktree(projectId)
+    if (defaultWorktree && defaultWorktree.id !== alreadyBumpedId) {
+      setLastMessageTime(defaultWorktree.id, timestamp)
+    }
+  }
+
   if (opts.worktreeId) {
     setLastMessageTime(opts.worktreeId, timestamp)
+
+    const { worktreesByProject } = useWorktreeStore.getState()
+    for (const [projectId, worktrees] of worktreesByProject) {
+      if (worktrees.some((w) => w.id === opts.worktreeId)) {
+        bumpProjectDefault(projectId, opts.worktreeId)
+        break
+      }
+    }
     return
   }
 
@@ -29,6 +48,7 @@ export function bumpWorktreeLastMessage(opts: {
 
     for (const member of connection.members) {
       setLastMessageTime(member.worktree_id, timestamp)
+      bumpProjectDefault(member.project_id, member.worktree_id)
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized worktree timestamp logic with MAX guards and tests; no auth or schema changes.
> 
> **Overview**
> When activity updates `last_message_at` on a non-default worktree, the change now also raises the **project default** (`main`) worktree’s timestamp so project lists stay sorted by recent activity after that branch is archived or deleted.
> 
> **Persistence:** `updateWorktree` in both `DatabaseService` and the Effect worktree repo runs a follow-up `UPDATE` on the default row using `MAX(COALESCE(last_message_at, 0), ?)` so older re-persisted values (e.g. hydration) cannot move the default backward. Fan-out is skipped for default worktrees, `null` clears, and other projects’ defaults.
> 
> **UI:** `bumpWorktreeLastMessage` mirrors the same behavior in client state—worktree and connection session bumps also call `setLastMessageTime` on each affected project’s default worktree.
> 
> **Tests:** New Vitest coverage for DB fan-out edge cases and renderer bump behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04fd8c23652af771b03dd524e51a47804373140b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->