### PR TITLE
Add connection-mode PR flow

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: verify
+description: Build, launch, and drive this worktree's Hive app over CDP to verify a change end-to-end with playwright-cli
+---
+
+# Verifying Hive changes end-to-end
+
+## Build & launch (verified 2026-07-03)
+
+```bash
+pnpm exec electron-vite build && pnpm run build:server
+env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_EXECPATH \
+    -u CLAUDE_CODE_NEW_INIT -u CLAUDE_CODE_SESSION_ID -u CLAUDECODE \
+    HIVE_SERVER_ENTRY_PATH=$PWD/out/main/server.js HIVE_DESKTOP_BACKEND_PORT=51000 \
+    pnpm exec electron . --remote-debugging-port=9223   # background
+playwright-cli -s=<unique-session> attach --cdp=http://127.0.0.1:9223
+playwright-cli -s=<s> tab-select 1   # tab 0 is the pet overlay, tab 1 is the main window
+```
+
+- Port 9222 is usually the user's own Chrome — always use 9223.
+- Without `HIVE_SERVER_ENTRY_PATH` the app dies ~30s in ("Fatal error during app startup").
+- The `env -u CLAUDE_CODE_*` strip is required or spawned claude TUIs become child sessions.
+- Confirm you're driving YOUR build: the page URL is `file://<this worktree>/out/renderer/index.html`.
+
+## Data & test targets
+
+- Dev shares the real `~/.hive/hive.db` with the installed app — only exercise the
+  **test-python** (GitHub remote) and **ct-test** (no remote) projects.
+- Inspect state read-only: `sqlite3 -readonly ~/.hive/hive.db "..."` (projects, worktrees,
+  connections, connection_members tables).
+- Create worktrees via the sidebar "+" button on a project row; connections via
+  right-click worktree → "Connect to..." → check other worktrees → Connect.
+
+## Gotchas
+
+- Snapshot refs vanish (all elements ref-less) while a context-menu/focus state is
+  active — `playwright-cli press Escape`, then re-snapshot.
+- Open React context menus by dispatching a `contextmenu` MouseEvent via `eval` on the row ref.
+- Quit the dev app with `osascript -e 'tell application "Electron" to quit'`
+  (production app is named "Hive", dev is "Electron").
+- Clean up after PR tests: `gh pr close <n> --repo morapelker/test-python --delete-branch`,
+  archive test worktrees via the sidebar context menu ("Archive Delete branch").
+- App logs: `~/.hive/logs/hive-YYYY-MM-DD.log` (all Hive processes write there; filter by pid).

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -24,6 +24,7 @@ import { useKeepAwake } from '@/hooks/useKeepAwake'
 import { useSleepWhenIdle } from '@/hooks/useSleepWhenIdle'
 import { ErrorBoundary, ErrorFallback } from '@/components/error'
 import { CreatePRModal } from '@/components/pr/CreatePRModal'
+import { ConnectionPRModal } from '@/components/pr/ConnectionPRModal'
 import { ProjectSettingsDialog } from '@/components/projects/ProjectSettingsDialog'
 import { TerminalPortalProvider, useTerminalPortal } from '@/contexts/TerminalPortalContext'
 import { ClaudeCliSessionPortalProvider } from '@/contexts/ClaudeCliSessionPortalContext'
@@ -244,6 +245,7 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
 
   const createPRWorktreeId = useGitStore((s) => s.createPRWorktreeId)
   const createPRWorktreePath = useGitStore((s) => s.createPRWorktreePath)
+  const connectionPRConnectionId = useGitStore((s) => s.connectionPRConnectionId)
 
   // Ensure remote info + branch info are loaded for PR modal worktree (may differ from sidebar)
   useEffect(() => {
@@ -306,6 +308,11 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
           {createPRWorktreeId && createPRWorktreePath && (
             <ErrorBoundary componentName="CreatePRModal" fallback={null}>
               <CreatePRModal worktreeId={createPRWorktreeId} worktreePath={createPRWorktreePath} />
+            </ErrorBoundary>
+          )}
+          {connectionPRConnectionId && (
+            <ErrorBoundary componentName="ConnectionPRModal" fallback={null}>
+              <ConnectionPRModal connectionId={connectionPRConnectionId} />
             </ErrorBoundary>
           )}
           <AgentSetupGuard />

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -143,6 +143,23 @@ export function Header(): React.JSX.Element {
   )
   const isConnectionMode = !!selectedConnectionId && !selectedWorktreeId
 
+  // Pre-warm GitHub remote detection for connection members so the PR button
+  // can appear as soon as a connection is selected
+  useEffect(() => {
+    if (!isConnectionMode || !selectedConnection) return
+    for (const member of selectedConnection.members) {
+      if (!useGitStore.getState().remoteInfo.has(member.worktree_id)) {
+        void useGitStore.getState().checkRemoteInfo(member.worktree_id, member.worktree_path)
+      }
+    }
+  }, [isConnectionMode, selectedConnection])
+
+  const connectionHasGitHubMember = useGitStore((s) =>
+    isConnectionMode && selectedConnection
+      ? selectedConnection.members.some((m) => s.remoteInfo.get(m.worktree_id)?.isGitHub)
+      : false
+  )
+
   const hasConflicts = useGitStore(
     (state) =>
       (selectedWorktree?.path ? state.conflictsByWorktree[selectedWorktree.path] : false) ?? false
@@ -339,6 +356,24 @@ export function Header(): React.JSX.Element {
         className="flex items-center gap-2"
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
+        {/* Connection PR button — creates one PR per connected project with changes */}
+        {isConnectionMode && connectionHasGitHubMember && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 text-xs"
+            onClick={() => {
+              if (selectedConnectionId) {
+                useGitStore.getState().setConnectionPRModalOpen(true, selectedConnectionId)
+              }
+            }}
+            title="Create pull requests for the connected projects"
+            data-testid="connection-pr-button"
+          >
+            <GitPullRequest className="h-3.5 w-3.5 mr-1" />
+            PR
+          </Button>
+        )}
         {!isConnectionMode &&
           isGitHub &&
           hasAttachedPR &&

--- a/src/renderer/src/components/pr/ConnectionPRModal.tsx
+++ b/src/renderer/src/components/pr/ConnectionPRModal.tsx
@@ -1,0 +1,741 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import {
+  GitPullRequest,
+  GitBranch,
+  Check,
+  Loader2,
+  AlertCircle,
+  ChevronDown,
+  Plus,
+  Inbox
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { toast } from '@/lib/toast'
+import { resolvePRContentProvider } from '@/lib/pr-content-provider'
+import {
+  assessConnectionMembers,
+  commitConnectionMembers,
+  createConnectionPRs,
+  emitArchivePrompts,
+  isPRWorthy,
+  type MemberAssessment
+} from '@/lib/connection-pr'
+import { useGitStore, type GitFileStatus } from '@/stores/useGitStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { gitApi } from '@/api/git-api'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ModalPhase = 'loading' | 'empty' | 'commit' | 'form'
+
+interface ConnectionPRModalProps {
+  connectionId: string
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): React.JSX.Element {
+  const open = useGitStore((s) => s.connectionPRModalOpen)
+  const setOpen = useGitStore((s) => s.setConnectionPRModalOpen)
+  const fileStatusesByWorktree = useGitStore((s) => s.fileStatusesByWorktree)
+  const isCommitting = useGitStore((s) => s.isCommitting)
+  const loadFileStatuses = useGitStore((s) => s.loadFileStatuses)
+  const stageAll = useGitStore((s) => s.stageAll)
+  const defaultAgentSdk = useSettingsStore((s) => s.defaultAgentSdk) ?? 'claude-code'
+  const availableAgentSdks = useSettingsStore((s) => s.availableAgentSdks)
+
+  // ── Phase & assessment state ────────────────────────────────────
+  const [phase, setPhase] = useState<ModalPhase>('loading')
+  const [assessments, setAssessments] = useState<MemberAssessment[]>([])
+
+  // ── Commit phase state ──────────────────────────────────────────
+  const [commitSummary, setCommitSummary] = useState('')
+  const [commitDescription, setCommitDescription] = useState('')
+  const [commitErrors, setCommitErrors] = useState<Map<string, string>>(new Map())
+  const [stagingWorktreeId, setStagingWorktreeId] = useState<string | null>(null)
+
+  // ── Form phase state ────────────────────────────────────────────
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [includeByWorktree, setIncludeByWorktree] = useState<Map<string, boolean>>(new Map())
+  const [baseBranchByWorktree, setBaseBranchByWorktree] = useState<Map<string, string>>(new Map())
+  const [remoteBranchesByWorktree, setRemoteBranchesByWorktree] = useState<Map<string, string[]>>(
+    new Map()
+  )
+  const [openBranchDropdown, setOpenBranchDropdown] = useState<string | null>(null)
+
+  const eligible = useMemo(() => assessments.filter(isPRWorthy), [assessments])
+  const ineligible = useMemo(() => assessments.filter((a) => !isPRWorthy(a)), [assessments])
+
+  // ── Shared commit message pre-fill from member session titles ───
+  const sessionTitles: string[] = useMemo(() => {
+    const memberIds = new Set(
+      useConnectionStore
+        .getState()
+        .connections.find((c) => c.id === connectionId)
+        ?.members.map((m) => m.worktree_id) ?? []
+    )
+    const titles: string[] = []
+    for (const worktrees of useWorktreeStore.getState().worktreesByProject.values()) {
+      for (const wt of worktrees) {
+        if (!memberIds.has(wt.id) || !wt.session_titles) continue
+        try {
+          for (const t of JSON.parse(wt.session_titles) as string[]) {
+            if (!titles.includes(t)) titles.push(t)
+          }
+        } catch {
+          // Ignore malformed session titles
+        }
+      }
+    }
+    return titles
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connectionId, open])
+
+  // ── Assessment helpers ──────────────────────────────────────────
+  const seedSelections = useCallback((results: MemberAssessment[]) => {
+    const worthy = results.filter(isPRWorthy)
+    setIncludeByWorktree((prev) => {
+      const next = new Map(prev)
+      for (const a of worthy) {
+        if (!next.has(a.worktreeId)) next.set(a.worktreeId, a.isGitHub)
+      }
+      return next
+    })
+    setBaseBranchByWorktree((prev) => {
+      const next = new Map(prev)
+      for (const a of worthy) {
+        if (!next.has(a.worktreeId)) next.set(a.worktreeId, a.defaultBase)
+      }
+      return next
+    })
+  }, [])
+
+  const refreshAssessments = useCallback(async (): Promise<MemberAssessment[]> => {
+    const connection = useConnectionStore.getState().connections.find((c) => c.id === connectionId)
+    if (!connection) return []
+    const results = await assessConnectionMembers(connection.members)
+    setAssessments(results)
+    seedSelections(results)
+    return results
+  }, [connectionId, seedSelections])
+
+  // ── Evaluate on open ────────────────────────────────────────────
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+
+    setPhase('loading')
+    setAssessments([])
+    setTitle('')
+    setBody('')
+    setCommitErrors(new Map())
+    setIncludeByWorktree(new Map())
+    setBaseBranchByWorktree(new Map())
+    setRemoteBranchesByWorktree(new Map())
+
+    const connection = useConnectionStore.getState().connections.find((c) => c.id === connectionId)
+    if (!connection) {
+      setOpen(false)
+      return
+    }
+
+    // Pre-fill the shared commit message like GitCommitForm does
+    setCommitSummary(sessionTitles[0] ?? '')
+    setCommitDescription(
+      sessionTitles.length > 1 ? sessionTitles.map((t) => `- ${t}`).join('\n') : ''
+    )
+
+    assessConnectionMembers(connection.members)
+      .then((results) => {
+        if (cancelled) return
+        setAssessments(results)
+        seedSelections(results)
+        const worthy = results.filter(isPRWorthy)
+        if (worthy.length === 0) {
+          // Nothing to PR anywhere — prompt to archive the clean worktrees
+          emitArchivePrompts(results)
+          setPhase('empty')
+        } else if (worthy.some((a) => a.hasUncommitted)) {
+          setPhase('commit')
+        } else {
+          setPhase('form')
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setPhase('empty')
+      })
+
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, connectionId])
+
+  // ── Lazily fetch remote branches when the form phase opens ──────
+  useEffect(() => {
+    if (phase !== 'form') return
+    for (const assessment of eligible) {
+      if (!assessment.isGitHub) continue
+      if (remoteBranchesByWorktree.has(assessment.worktreeId)) continue
+      gitApi
+        .listBranchesWithStatus(assessment.worktreePath)
+        .then((result) => {
+          if (!result.success) return
+          const seen = new Set<string>()
+          const names: string[] = []
+          for (const b of result.branches.filter((b) => b.isRemote)) {
+            const name = b.name.replace(/^origin\//, '')
+            if (!seen.has(name)) {
+              seen.add(name)
+              names.push(name)
+            }
+          }
+          setRemoteBranchesByWorktree((prev) => new Map(prev).set(assessment.worktreeId, names))
+        })
+        .catch(() => {
+          // Non-critical
+        })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, eligible])
+
+  // ── Commit phase handlers ───────────────────────────────────────
+  const handleStageAll = useCallback(
+    async (assessment: MemberAssessment) => {
+      setStagingWorktreeId(assessment.worktreeId)
+      try {
+        const success = await stageAll(assessment.worktreePath)
+        if (success) {
+          await loadFileStatuses(assessment.worktreePath)
+        } else {
+          toast.error(`Failed to stage files in ${assessment.projectName}`)
+        }
+      } finally {
+        setStagingWorktreeId(null)
+      }
+    },
+    [stageAll, loadFileStatuses]
+  )
+
+  const handleToggleFile = useCallback(
+    async (worktreePath: string, file: GitFileStatus) => {
+      if (file.staged) {
+        await useGitStore.getState().unstageFile(worktreePath, file.relativePath)
+      } else {
+        await useGitStore.getState().stageFile(worktreePath, file.relativePath)
+      }
+      await loadFileStatuses(worktreePath)
+    },
+    [loadFileStatuses]
+  )
+
+  const membersWithStagedFiles = useMemo(
+    () =>
+      eligible.filter((a) =>
+        (fileStatusesByWorktree.get(a.worktreePath) ?? []).some((f) => f.staged)
+      ),
+    [eligible, fileStatusesByWorktree]
+  )
+
+  const handleCommitAndContinue = useCallback(async () => {
+    if (!commitSummary.trim() || membersWithStagedFiles.length === 0) return
+    setCommitErrors(new Map())
+
+    const message = commitDescription.trim()
+      ? `${commitSummary.trim()}\n\n${commitDescription.trim()}`
+      : commitSummary.trim()
+
+    const results = await commitConnectionMembers(membersWithStagedFiles, message)
+    const errors = new Map<string, string>()
+    for (const [worktreeId, result] of results) {
+      if (!result.success) errors.set(worktreeId, result.error ?? 'Commit failed')
+    }
+
+    if (errors.size > 0) {
+      setCommitErrors(errors)
+      await refreshAssessments()
+      return
+    }
+
+    toast.success(
+      `Committed ${results.size} project${results.size !== 1 ? 's' : ''}`
+    )
+    await refreshAssessments()
+    setPhase('form')
+  }, [commitSummary, commitDescription, membersWithStagedFiles, refreshAssessments])
+
+  const handleSkipCommit = useCallback(async () => {
+    await refreshAssessments()
+    setPhase('form')
+  }, [refreshAssessments])
+
+  // ── Create PRs (background — closes modal immediately) ──────────
+  const includedCount = useMemo(
+    () =>
+      eligible.filter((a) => a.isGitHub && (includeByWorktree.get(a.worktreeId) ?? a.isGitHub))
+        .length,
+    [eligible, includeByWorktree]
+  )
+
+  const handleCreate = useCallback(() => {
+    const provider = resolvePRContentProvider(defaultAgentSdk, availableAgentSdks)
+    const gitStore = useGitStore.getState()
+
+    const plans = eligible.map((assessment) => ({
+      assessment,
+      baseBranch: baseBranchByWorktree.get(assessment.worktreeId) ?? assessment.defaultBase,
+      include: includeByWorktree.get(assessment.worktreeId) ?? assessment.isGitHub
+    }))
+
+    // Persist the selected target branches like the single-worktree flow
+    for (const plan of plans) {
+      if (!plan.include || !plan.assessment.isGitHub) continue
+      const normalized = plan.baseBranch.startsWith('origin/')
+        ? plan.baseBranch
+        : `origin/${plan.baseBranch}`
+      gitStore.setPrTargetBranch(plan.assessment.worktreeId, normalized)
+      if (!gitStore.reviewTargetBranch.get(plan.assessment.worktreeId)) {
+        gitStore.setReviewTargetBranch(plan.assessment.worktreeId, normalized)
+      }
+    }
+
+    setOpen(false)
+
+    void createConnectionPRs({
+      plans,
+      ineligible,
+      title: title.trim(),
+      body: body.trim(),
+      provider
+    })
+  }, [
+    eligible,
+    ineligible,
+    baseBranchByWorktree,
+    includeByWorktree,
+    title,
+    body,
+    defaultAgentSdk,
+    availableAgentSdks,
+    setOpen
+  ])
+
+  const handleCancel = useCallback(() => {
+    setOpen(false)
+  }, [setOpen])
+
+  // ── Render: Loading ─────────────────────────────────────────────
+  const renderLoading = (): React.JSX.Element => (
+    <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+      <Loader2 className="h-4 w-4 animate-spin" />
+      Checking connected worktrees...
+    </div>
+  )
+
+  // ── Render: Empty ───────────────────────────────────────────────
+  const renderEmpty = (): React.JSX.Element => (
+    <div className="flex flex-col items-center gap-2 py-8 text-center">
+      <Inbox className="h-8 w-8 text-muted-foreground/60" />
+      <p className="text-sm font-medium text-foreground">Nothing to PR</p>
+      <p className="text-xs text-muted-foreground max-w-[360px]">
+        All connected worktrees are clean — no uncommitted changes and no commits ahead of their
+        base branches.
+      </p>
+    </div>
+  )
+
+  // ── Render: Commit phase ────────────────────────────────────────
+  const renderCommitSection = (assessment: MemberAssessment): React.JSX.Element | null => {
+    const files = fileStatusesByWorktree.get(assessment.worktreePath) ?? []
+    if (files.length === 0) return null
+    const stagedCount = files.filter((f) => f.staged).length
+    const commitError = commitErrors.get(assessment.worktreeId)
+
+    return (
+      <div
+        key={assessment.worktreeId}
+        className="border rounded-md overflow-hidden"
+        data-testid={`connection-pr-section-${assessment.worktreeId}`}
+      >
+        <div className="flex items-center justify-between px-3 py-1.5 bg-muted/30 border-b">
+          <span className="flex items-center gap-2 min-w-0 text-xs font-medium">
+            <span className="truncate">{assessment.projectName}</span>
+            <span className="flex items-center gap-1 text-muted-foreground font-normal shrink-0">
+              <GitBranch className="h-3 w-3" />
+              {assessment.branchName}
+            </span>
+            <span className="text-muted-foreground font-normal shrink-0">
+              {files.length} file{files.length !== 1 ? 's' : ''}
+              {stagedCount > 0 && ` · ${stagedCount} staged`}
+            </span>
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs"
+            onClick={() => handleStageAll(assessment)}
+            disabled={stagingWorktreeId !== null || isCommitting}
+          >
+            {stagingWorktreeId === assessment.worktreeId ? (
+              <Loader2 className="h-3 w-3 animate-spin mr-1" />
+            ) : (
+              <Plus className="h-3 w-3 mr-1" />
+            )}
+            Stage All
+          </Button>
+        </div>
+        <div className="max-h-[120px] overflow-y-auto">
+          {files.map((file) => (
+            <div
+              key={file.relativePath}
+              className="flex items-center gap-2 px-3 py-1 text-xs hover:bg-accent/30"
+            >
+              <Checkbox
+                checked={file.staged}
+                onCheckedChange={() => handleToggleFile(assessment.worktreePath, file)}
+                className="h-3.5 w-3.5"
+              />
+              <span
+                className={cn(
+                  'font-mono w-3 text-center shrink-0',
+                  file.status === 'M' && 'text-yellow-500',
+                  file.status === 'A' && 'text-green-500',
+                  file.status === 'D' && 'text-red-500',
+                  file.status === '?' && 'text-muted-foreground'
+                )}
+              >
+                {file.status}
+              </span>
+              <span className="truncate">{file.relativePath}</span>
+            </div>
+          ))}
+        </div>
+        {commitError && (
+          <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-destructive border-t">
+            <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{commitError}</span>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  const renderCommit = (): React.JSX.Element => (
+    <>
+      <p className="text-sm text-muted-foreground">
+        You have uncommitted changes in {eligible.filter((a) => a.hasUncommitted).length} connected
+        project
+        {eligible.filter((a) => a.hasUncommitted).length !== 1 ? 's' : ''}. Commit them with one
+        shared message, or skip to continue with what&apos;s already committed.
+      </p>
+
+      {/* Per-project file sections */}
+      <div className="space-y-2 max-h-[280px] overflow-y-auto pr-1">
+        {eligible.map((assessment) => renderCommitSection(assessment))}
+      </div>
+
+      {/* Shared commit message */}
+      <div className="space-y-2">
+        <div className="relative">
+          <Input
+            value={commitSummary}
+            onChange={(e) => setCommitSummary(e.target.value)}
+            placeholder="Commit summary (applied to every project)"
+            className={cn(
+              'pr-12',
+              commitSummary.length > 72 && 'border-red-500 focus-visible:ring-red-500',
+              commitSummary.length > 50 &&
+                commitSummary.length <= 72 &&
+                'border-yellow-500 focus-visible:ring-yellow-500'
+            )}
+            disabled={isCommitting}
+          />
+          <span
+            className={cn(
+              'absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-mono',
+              commitSummary.length > 72 && 'text-red-500',
+              commitSummary.length > 50 && commitSummary.length <= 72 && 'text-yellow-500',
+              commitSummary.length <= 50 && 'text-muted-foreground'
+            )}
+          >
+            {commitSummary.length}/72
+          </span>
+        </div>
+        <Textarea
+          value={commitDescription}
+          onChange={(e) => setCommitDescription(e.target.value)}
+          placeholder="Extended description (optional)"
+          rows={2}
+          disabled={isCommitting}
+        />
+      </div>
+
+      {membersWithStagedFiles.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          Will commit in {membersWithStagedFiles.map((a) => a.projectName).join(', ')}
+        </p>
+      )}
+    </>
+  )
+
+  // ── Render: Form phase ──────────────────────────────────────────
+  const renderFormRow = (assessment: MemberAssessment): React.JSX.Element => {
+    const included = includeByWorktree.get(assessment.worktreeId) ?? assessment.isGitHub
+    const baseBranch = baseBranchByWorktree.get(assessment.worktreeId) ?? assessment.defaultBase
+    const rawOptions = remoteBranchesByWorktree.get(assessment.worktreeId) ?? []
+    const options = rawOptions.includes(baseBranch) ? rawOptions : [baseBranch, ...rawOptions]
+    const sortedOptions = [...options].sort((a, b) => {
+      if (a === assessment.defaultBase) return -1
+      if (b === assessment.defaultBase) return 1
+      return a.localeCompare(b)
+    })
+
+    return (
+      <div
+        key={assessment.worktreeId}
+        className="border rounded-md px-3 py-2 space-y-1.5"
+        data-testid={`connection-pr-row-${assessment.worktreeId}`}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <Checkbox
+            checked={included}
+            disabled={!assessment.isGitHub}
+            onCheckedChange={(checked) =>
+              setIncludeByWorktree((prev) =>
+                new Map(prev).set(assessment.worktreeId, checked === true)
+              )
+            }
+            className="h-3.5 w-3.5"
+          />
+          <span className="text-sm font-medium truncate">{assessment.projectName}</span>
+          <span className="flex items-center gap-1 text-xs text-muted-foreground min-w-0">
+            <GitBranch className="h-3 w-3 shrink-0" />
+            <span className="truncate">{assessment.branchName}</span>
+          </span>
+          <span className="ml-auto text-xs text-muted-foreground shrink-0">
+            {assessment.commitsAhead} commit{assessment.commitsAhead !== 1 ? 's' : ''} ahead
+          </span>
+        </div>
+
+        {!assessment.isGitHub ? (
+          <p className="text-xs text-amber-500">No GitHub remote — PR will be skipped</p>
+        ) : assessment.attachedPR ? (
+          <p className="text-xs text-blue-400">
+            PR #{assessment.attachedPR.number} attached — will push updates
+          </p>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground shrink-0">Base</span>
+            <Popover
+              open={openBranchDropdown === assessment.worktreeId}
+              onOpenChange={(isOpen) =>
+                setOpenBranchDropdown(isOpen ? assessment.worktreeId : null)
+              }
+            >
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className={cn(
+                    'flex items-center justify-between flex-1 min-w-0 px-2 py-1 text-xs border rounded-md',
+                    'bg-background hover:bg-accent/50 transition-colors text-left'
+                  )}
+                  disabled={!included}
+                >
+                  <span className="flex items-center gap-1.5 min-w-0">
+                    <GitBranch className="h-3 w-3 text-muted-foreground shrink-0" />
+                    <span className="truncate">{baseBranch}</span>
+                  </span>
+                  <ChevronDown
+                    className={cn(
+                      'h-3 w-3 text-muted-foreground transition-transform',
+                      openBranchDropdown === assessment.worktreeId && 'rotate-180'
+                    )}
+                  />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+                <div className="max-h-[180px] overflow-y-auto">
+                  {sortedOptions.map((name) => (
+                    <button
+                      key={name}
+                      type="button"
+                      className={cn(
+                        'flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left',
+                        'hover:bg-accent transition-colors',
+                        name === baseBranch && 'bg-accent'
+                      )}
+                      onClick={() => {
+                        setBaseBranchByWorktree((prev) =>
+                          new Map(prev).set(assessment.worktreeId, name)
+                        )
+                        setOpenBranchDropdown(null)
+                      }}
+                    >
+                      <GitBranch className="h-3 w-3 text-muted-foreground shrink-0" />
+                      <span className="truncate">{name}</span>
+                      {name === baseBranch && (
+                        <Check className="h-3 w-3 ml-auto text-primary shrink-0" />
+                      )}
+                    </button>
+                  ))}
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  const renderForm = (): React.JSX.Element => (
+    <>
+      {/* Per-project rows */}
+      <div className="space-y-2 max-h-[260px] overflow-y-auto pr-1">
+        {eligible.map((assessment) => renderFormRow(assessment))}
+      </div>
+
+      {/* Shared title */}
+      <div className="space-y-1.5">
+        <label htmlFor="connection-pr-title" className="text-sm font-medium text-foreground">
+          Title
+        </label>
+        <Input
+          id="connection-pr-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Leave empty to auto-generate per repository"
+        />
+      </div>
+
+      {/* Shared description */}
+      <div className="space-y-1.5">
+        <label htmlFor="connection-pr-description" className="text-sm font-medium text-foreground">
+          Description
+        </label>
+        <Textarea
+          id="connection-pr-description"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Leave empty to auto-generate per repository"
+          rows={3}
+        />
+      </div>
+    </>
+  )
+
+  // ── Render: Footer ──────────────────────────────────────────────
+  const renderFooter = (): React.JSX.Element => {
+    switch (phase) {
+      case 'loading':
+        return <></>
+      case 'empty':
+        return (
+          <DialogFooter>
+            <Button variant="ghost" onClick={handleCancel}>
+              Close
+            </Button>
+          </DialogFooter>
+        )
+      case 'commit':
+        return (
+          <DialogFooter>
+            <Button variant="ghost" onClick={handleSkipCommit} disabled={isCommitting}>
+              Skip
+            </Button>
+            <Button
+              onClick={handleCommitAndContinue}
+              disabled={
+                !commitSummary.trim() || membersWithStagedFiles.length === 0 || isCommitting
+              }
+              data-testid="connection-pr-commit-button"
+            >
+              {isCommitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+                  Committing...
+                </>
+              ) : (
+                <>
+                  <Check className="h-4 w-4 mr-1.5" />
+                  Commit & Continue
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        )
+      case 'form':
+        return (
+          <DialogFooter>
+            <Button variant="ghost" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={includedCount === 0}
+              data-testid="connection-pr-create-button"
+            >
+              <GitPullRequest className="h-4 w-4 mr-1.5" />
+              Create {includedCount} Pull Request{includedCount !== 1 ? 's' : ''}
+            </Button>
+          </DialogFooter>
+        )
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => setOpen(isOpen, isOpen ? connectionId : undefined)}>
+      <DialogContent className="sm:max-w-xl" data-testid="connection-pr-modal">
+        <DialogHeader>
+          <DialogTitle>
+            <span className="flex items-center gap-2">
+              <GitPullRequest className="h-5 w-5" />
+              Create Pull Requests
+            </span>
+          </DialogTitle>
+          {phase === 'commit' && (
+            <DialogDescription>
+              Commit your changes across the connected projects before creating pull requests.
+            </DialogDescription>
+          )}
+          {phase === 'form' && (
+            <DialogDescription>
+              One pull request will be created per connected project with changes.
+            </DialogDescription>
+          )}
+          {(phase === 'loading' || phase === 'empty') && (
+            <DialogDescription>
+              Create pull requests for the projects in this connection.
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        {phase === 'loading' && renderLoading()}
+        {phase === 'empty' && renderEmpty()}
+        {phase === 'commit' && renderCommit()}
+        {phase === 'form' && renderForm()}
+
+        {renderFooter()}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/pr/CreatePRModal.tsx
+++ b/src/renderer/src/components/pr/CreatePRModal.tsx
@@ -24,6 +24,7 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { toast } from '@/lib/toast'
 import { resolvePRContentProvider } from '@/lib/pr-content-provider'
+import { runCreatePRPipeline } from '@/lib/pr-pipeline'
 import { useGitStore, type GitFileStatus } from '@/stores/useGitStore'
 import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
@@ -55,8 +56,6 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
   const prTargetBranch = useGitStore((s) =>
     worktreeId ? s.prTargetBranch.get(worktreeId) : undefined
   )
-  const attachPR = useGitStore((s) => s.attachPR)
-  const setCreatingPR = useGitStore((s) => s.setCreatingPR)
   const fileStatusesByWorktree = useGitStore((s) => s.fileStatusesByWorktree)
   const isCommitting = useGitStore((s) => s.isCommitting)
   const loadFileStatuses = useGitStore((s) => s.loadFileStatuses)
@@ -278,166 +277,33 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
 
     // Close modal — PR creation continues in background via notification
     setOpen(false)
-    setCreatingPR(worktreeId, true)
 
-    const { show, update } = usePRNotificationStore.getState()
-    const notifId = show({
+    const notifId = usePRNotificationStore.getState().show({
       status: 'loading',
       message: 'Creating pull request...',
       worktreeId
     })
 
-    let finalTitle = prTitle
-    let finalBody = prBody
-
-    try {
-      // Step 1: Push if needed
-      let willPush = false
-      try {
-        willPush = await gitApi.needsPush(worktreePath)
-      } catch {
-        // Assume no push needed
+    // Resolve the project path for the already-exists title lookup
+    let projectPath: string | null = null
+    for (const [pid, worktrees] of useWorktreeStore.getState().worktreesByProject) {
+      if (worktrees.some((w) => w.id === worktreeId)) {
+        projectPath = useProjectStore.getState().projects.find((p) => p.id === pid)?.path ?? null
+        break
       }
-
-      if (willPush) {
-        update(notifId, { message: 'Pushing branch...' })
-        const pushResult = await gitApi.push(worktreePath)
-        if (!pushResult.success) {
-          throw new Error(pushResult.error ?? 'Push failed')
-        }
-      }
-
-      // Step 2: Generate content if needed (best-effort — failure should not block PR creation)
-      const needsGenerate = !finalTitle || !finalBody
-      let usedFallbackContent = false
-      let generationFailureReason: string | null = null
-      if (needsGenerate) {
-        update(notifId, { message: 'Generating PR content...' })
-        if (!provider) {
-          usedFallbackContent = true
-          generationFailureReason =
-            'No AI provider available for PR content generation. Using default title and description.'
-        } else {
-          try {
-            const genResult = await gitApi.generatePRContent(worktreePath, targetBase, provider)
-            if (genResult.success) {
-              if (!finalTitle && genResult.title) finalTitle = genResult.title
-              if (!finalBody && genResult.body) finalBody = genResult.body
-            } else {
-              console.warn('PR content generation failed, using fallback:', genResult.error)
-              generationFailureReason =
-                genResult.error ??
-                'AI content generation failed — you may want to edit the title and description'
-              usedFallbackContent = true
-            }
-          } catch (err) {
-            console.warn('PR content generation threw, using fallback:', err)
-            generationFailureReason = err instanceof Error ? err.message : String(err)
-            usedFallbackContent = true
-          }
-        }
-        // Fallback if generation failed or returned empty
-        if (!finalTitle) finalTitle = branchName
-        if (!finalBody) finalBody = ''
-      }
-
-      // Step 3: Create PR
-      update(notifId, { message: 'Creating pull request...' })
-      const createResult = await gitApi.createPR(worktreePath, targetBase, finalTitle, finalBody)
-
-      if (!createResult.success) {
-        // The backend populates url/number even on failure when a PR already
-        // exists — use that structured data first, regex fallback second.
-        let existingNumber = createResult.number
-        let existingUrl = createResult.url
-
-        if (!existingNumber) {
-          // Fallback: parse the error message ([\s\S] to match across newlines)
-          const errMsg = createResult.error ?? ''
-          const alreadyExistsMatch = errMsg.match(
-            /already exists[\s\S]*?\/pull\/(\d+)|pull request.*?#(\d+).*?already/i
-          )
-          if (alreadyExistsMatch) {
-            existingNumber = parseInt(alreadyExistsMatch[1] || alreadyExistsMatch[2], 10)
-            if (!existingUrl) {
-              const urlMatch = errMsg.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/)
-              existingUrl = urlMatch?.[0] ?? `https://github.com/unknown/pull/${existingNumber}`
-            }
-          }
-        }
-
-        if (existingNumber) {
-          existingUrl = existingUrl ?? `https://github.com/unknown/pull/${existingNumber}`
-
-          // Auto-attach the existing PR
-          await attachPR(worktreeId, existingNumber, existingUrl)
-
-          let existingTitle: string | undefined
-          try {
-            const worktreeStore = useWorktreeStore.getState()
-            let projectId: string | null = null
-            for (const [pid, worktrees] of worktreeStore.worktreesByProject) {
-              if (worktrees.some((w) => w.id === worktreeId)) {
-                projectId = pid
-                break
-              }
-            }
-
-            const projectPath = projectId
-              ? useProjectStore.getState().projects.find((p) => p.id === projectId)?.path
-              : undefined
-            if (projectPath) {
-              const state = await gitApi.getPRState(projectPath, existingNumber)
-              if (state.success) existingTitle = state.title
-            }
-          } catch {
-            // Best-effort: existing PR notification still works without a title.
-          }
-
-          update(notifId, {
-            status: 'info',
-            message: `PR #${existingNumber} already exists`,
-            description: 'Attached to workspace',
-            prUrl: existingUrl,
-            prNumber: existingNumber,
-            prTitle: existingTitle,
-            worktreeId
-          })
-          return
-        }
-
-        throw new Error(createResult.error ?? 'PR creation failed')
-      }
-
-      // Attach the new PR
-      const prUrl = createResult.url ?? ''
-      const prNumber = createResult.number ?? 0
-      await attachPR(worktreeId, prNumber, prUrl)
-
-      update(notifId, {
-        status: usedFallbackContent ? 'warning' : 'success',
-        message: usedFallbackContent
-          ? `PR #${prNumber} created with default content`
-          : `Pull request #${prNumber} created`,
-        description: usedFallbackContent
-          ? (generationFailureReason ??
-            'AI content generation failed — you may want to edit the title and description')
-          : undefined,
-        prUrl,
-        prNumber,
-        prTitle: finalTitle,
-        worktreeId
-      })
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      update(notifId, {
-        status: 'error',
-        message: 'Failed to create pull request',
-        description: msg
-      })
-    } finally {
-      setCreatingPR(worktreeId, false)
     }
+
+    await runCreatePRPipeline({
+      worktreeId,
+      worktreePath,
+      projectPath,
+      baseBranch: targetBase,
+      title: prTitle,
+      body: prBody,
+      fallbackTitle: branchName,
+      provider,
+      notifId
+    })
   }, [
     worktreePath,
     worktreeId,
@@ -447,9 +313,7 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
     defaultAgentSdk,
     availableAgentSdks,
     branchInfo,
-    attachPR,
-    setOpen,
-    setCreatingPR
+    setOpen
   ])
 
   // ── Cancel handler ──────────────────────────────────────────────

--- a/src/renderer/src/components/pr/PRNotificationStack.tsx
+++ b/src/renderer/src/components/pr/PRNotificationStack.tsx
@@ -42,7 +42,7 @@ function StatusIcon({ status }: { status: string }): React.JSX.Element {
 // Single notification card
 // ---------------------------------------------------------------------------
 
-type MergePhase = 'idle' | 'merging' | 'merged' | 'archiving'
+type MergePhase = 'idle' | 'merging' | 'merged'
 
 function PRNotificationCard({
   id,
@@ -52,7 +52,8 @@ function PRNotificationCard({
   prTitle,
   prUrl,
   prNumber,
-  worktreeId
+  worktreeId,
+  showArchiveButton
 }: {
   id: string
   status: string
@@ -62,13 +63,16 @@ function PRNotificationCard({
   prUrl?: string
   prNumber?: number
   worktreeId?: string
+  showArchiveButton?: boolean
 }): React.JSX.Element {
   const dismiss = usePRNotificationStore((s) => s.dismiss)
   const isDone =
     status === 'success' || status === 'error' || status === 'info' || status === 'warning'
 
   const [mergePhase, setMergePhase] = useState<MergePhase>('idle')
+  const [isArchiving, setIsArchiving] = useState(false)
   const showMergeButton = !!(prNumber && worktreeId && (status === 'success' || status === 'info'))
+  const showArchivePrompt = !!(showArchiveButton && worktreeId && isDone && mergePhase === 'idle')
 
   const handleClose = useCallback(() => {
     dismiss(id)
@@ -134,7 +138,7 @@ function PRNotificationCard({
       return
     }
 
-    setMergePhase('archiving')
+    setIsArchiving(true)
     try {
       const result = await worktreeStore.archiveWorktree(
         worktreeId,
@@ -146,13 +150,41 @@ function PRNotificationCard({
         dismiss(id)
       } else {
         toast.error(result.error || 'Archive failed')
-        setMergePhase('merged')
+        setIsArchiving(false)
       }
     } catch {
       toast.error('Failed to archive worktree')
-      setMergePhase('merged')
+      setIsArchiving(false)
     }
   }, [worktreeId, id, dismiss])
+
+  const archiveButton = isArchiving ? (
+    <button
+      type="button"
+      disabled
+      className={cn(
+        'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium',
+        'bg-secondary text-secondary-foreground',
+        'opacity-60 cursor-not-allowed'
+      )}
+    >
+      <Loader2 className="h-3 w-3 animate-spin" />
+      Archiving...
+    </button>
+  ) : (
+    <button
+      type="button"
+      onClick={handleArchive}
+      className={cn(
+        'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium',
+        'bg-secondary text-secondary-foreground',
+        'hover:bg-secondary/80 transition-colors'
+      )}
+    >
+      <Archive className="h-3 w-3" />
+      Archive
+    </button>
+  )
 
   return (
     <div
@@ -232,36 +264,10 @@ function PRNotificationCard({
                 Merging...
               </button>
             )}
-            {mergePhase === 'merged' && (
-              <button
-                type="button"
-                onClick={handleArchive}
-                className={cn(
-                  'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium',
-                  'bg-secondary text-secondary-foreground',
-                  'hover:bg-secondary/80 transition-colors'
-                )}
-              >
-                <Archive className="h-3 w-3" />
-                Archive
-              </button>
-            )}
-            {mergePhase === 'archiving' && (
-              <button
-                type="button"
-                disabled
-                className={cn(
-                  'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium',
-                  'bg-secondary text-secondary-foreground',
-                  'opacity-60 cursor-not-allowed'
-                )}
-              >
-                <Loader2 className="h-3 w-3 animate-spin" />
-                Archiving...
-              </button>
-            )}
+            {mergePhase === 'merged' && archiveButton}
           </div>
         )}
+        {showArchivePrompt && <div className="mt-1.5">{archiveButton}</div>}
       </div>
 
       {/* Close button — always rendered but only visible when done */}
@@ -307,6 +313,7 @@ export function PRNotificationStack(): React.JSX.Element | null {
           prUrl={n.prUrl}
           prNumber={n.prNumber}
           worktreeId={n.worktreeId}
+          showArchiveButton={n.showArchiveButton}
         />
       ))}
     </div>

--- a/src/renderer/src/components/pr/__tests__/ConnectionPRModal.test.tsx
+++ b/src/renderer/src/components/pr/__tests__/ConnectionPRModal.test.tsx
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '../../../api/rpc-client'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useGitStore } from '@/stores/useGitStore'
+import { ConnectionPRModal } from '../ConnectionPRModal'
+
+const connection = {
+  id: 'conn-1',
+  name: 'alpha + beta',
+  custom_name: null,
+  status: 'active' as const,
+  path: '/connections/conn-1',
+  color: null,
+  created_at: '',
+  updated_at: '',
+  members: [
+    {
+      id: 'cm-1',
+      connection_id: 'conn-1',
+      worktree_id: 'wt-a',
+      project_id: 'proj-a',
+      symlink_name: 'alpha',
+      added_at: '',
+      worktree_name: 'wt-a',
+      worktree_branch: 'feat-a',
+      worktree_path: '/repo/a',
+      project_name: 'alpha'
+    },
+    {
+      id: 'cm-2',
+      connection_id: 'conn-1',
+      worktree_id: 'wt-b',
+      project_id: 'proj-b',
+      symlink_name: 'beta',
+      added_at: '',
+      worktree_name: 'wt-b',
+      worktree_branch: 'feat-b',
+      worktree_path: '/repo/b',
+      project_name: 'beta'
+    }
+  ]
+}
+
+let request: ReturnType<typeof vi.fn>
+
+function mockResponses(spec: {
+  hasUncommitted?: Record<string, boolean>
+  commitCount?: Record<string, number>
+  files?: Record<string, unknown[]>
+}): void {
+  request.mockImplementation((method: string, params: Record<string, unknown>) => {
+    const path = params?.worktreePath as string
+    switch (method) {
+      case 'gitOps.getRemoteUrl':
+        return Promise.resolve({ success: true, url: 'https://github.com/acme/x.git' })
+      case 'gitOps.hasUncommittedChanges':
+        return Promise.resolve(spec.hasUncommitted?.[path] ?? false)
+      case 'gitOps.getRangeDiff':
+        return Promise.resolve({
+          commitSummary: '',
+          diffSummary: '',
+          diffPatch: '',
+          commitCount: spec.commitCount?.[path] ?? 0
+        })
+      case 'gitOps.getBranchInfo':
+        return Promise.resolve({
+          success: true,
+          branch: { name: 'feat', tracking: null, ahead: 0, behind: 0 }
+        })
+      case 'gitOps.getFileStatuses':
+        return Promise.resolve({ success: true, files: spec.files?.[path] ?? [] })
+      case 'gitOps.listBranchesWithStatus':
+        return Promise.resolve({
+          success: true,
+          branches: [{ name: 'origin/main', isRemote: true }]
+        })
+      default:
+        return Promise.resolve([])
+    }
+  })
+}
+
+describe('ConnectionPRModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    request = vi.fn().mockResolvedValue([])
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    useConnectionStore.setState({ connections: [connection] } as never)
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        [
+          'proj-a',
+          [
+            { id: 'wt-a-default', path: '/proj/a', branch_name: 'main', is_default: true },
+            { id: 'wt-a', path: '/repo/a', branch_name: 'feat-a', is_default: false }
+          ]
+        ],
+        [
+          'proj-b',
+          [
+            { id: 'wt-b-default', path: '/proj/b', branch_name: 'main', is_default: true },
+            { id: 'wt-b', path: '/repo/b', branch_name: 'feat-b', is_default: false }
+          ]
+        ]
+      ])
+    } as never)
+    useProjectStore.setState({
+      projects: [
+        { id: 'proj-a', path: '/proj/a' },
+        { id: 'proj-b', path: '/proj/b' }
+      ]
+    } as never)
+    useGitStore.setState({
+      fileStatusesByWorktree: new Map(),
+      branchInfoByWorktree: new Map(),
+      remoteInfo: new Map(),
+      prTargetBranch: new Map(),
+      attachedPR: new Map(),
+      creatingPRByWorktreeId: new Map(),
+      connectionPRModalOpen: true,
+      connectionPRConnectionId: 'conn-1'
+    })
+    usePRNotificationStore.setState({ notifications: [] })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+  })
+
+  it('shows a commit section only for members with changes', async () => {
+    mockResponses({
+      hasUncommitted: { '/repo/a': true },
+      files: {
+        '/repo/a': [
+          { path: '/repo/a/src/x.ts', relativePath: 'src/x.ts', status: 'M', staged: false }
+        ]
+      }
+    })
+
+    render(<ConnectionPRModal connectionId="conn-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('connection-pr-section-wt-a')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('connection-pr-section-wt-b')).not.toBeInTheDocument()
+    expect(screen.getByText('src/x.ts')).toBeInTheDocument()
+  })
+
+  it('shows the form phase directly when changes are already committed', async () => {
+    mockResponses({ commitCount: { '/repo/a': 2 } })
+
+    render(<ConnectionPRModal connectionId="conn-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('connection-pr-row-wt-a')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('connection-pr-row-wt-b')).not.toBeInTheDocument()
+    expect(screen.getByText(/2 commits ahead/)).toBeInTheDocument()
+  })
+
+  it('closes with archive prompts when every member is clean', async () => {
+    mockResponses({})
+
+    render(<ConnectionPRModal connectionId="conn-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/nothing to PR/i)).toBeInTheDocument()
+    })
+    const prompts = usePRNotificationStore.getState().notifications
+    expect(prompts).toHaveLength(2)
+    expect(prompts.every((n) => n.showArchiveButton)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/pr/__tests__/PRNotificationStack.archive-prompt.test.tsx
+++ b/src/renderer/src/components/pr/__tests__/PRNotificationStack.archive-prompt.test.tsx
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { PRNotificationStack } from '../PRNotificationStack'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+
+const worktree = {
+  id: 'wt-1',
+  path: '/repo/wt-1',
+  branch_name: 'feature-x'
+}
+
+describe('PRNotificationStack archive prompt', () => {
+  beforeEach(() => {
+    usePRNotificationStore.setState({ notifications: [] })
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([['proj-1', [worktree]]])
+    } as never)
+    useProjectStore.setState({
+      projects: [{ id: 'proj-1', path: '/projects/one' }]
+    } as never)
+  })
+
+  it('renders an Archive button for archive-prompt notifications', () => {
+    usePRNotificationStore.getState().show({
+      status: 'info',
+      message: 'Nothing to PR in one',
+      worktreeId: 'wt-1',
+      showArchiveButton: true
+    })
+
+    render(<PRNotificationStack />)
+
+    expect(screen.getByRole('button', { name: /archive/i })).toBeInTheDocument()
+  })
+
+  it('does not render an Archive button without the flag', () => {
+    usePRNotificationStore.getState().show({
+      status: 'info',
+      message: 'PR #7 already exists',
+      worktreeId: 'wt-1'
+    })
+
+    render(<PRNotificationStack />)
+
+    expect(screen.queryByRole('button', { name: /archive/i })).not.toBeInTheDocument()
+  })
+
+  it('archives the worktree and dismisses the card on click', async () => {
+    const archiveWorktree = vi.fn().mockResolvedValue({ success: true })
+    useWorktreeStore.setState({ archiveWorktree } as never)
+
+    usePRNotificationStore.getState().show({
+      status: 'info',
+      message: 'Nothing to PR in one',
+      worktreeId: 'wt-1',
+      showArchiveButton: true
+    })
+
+    render(<PRNotificationStack />)
+    await userEvent.click(screen.getByRole('button', { name: /archive/i }))
+
+    expect(archiveWorktree).toHaveBeenCalledWith(
+      'wt-1',
+      '/repo/wt-1',
+      'feature-x',
+      '/projects/one'
+    )
+    await waitFor(() => {
+      expect(usePRNotificationStore.getState().notifications).toHaveLength(0)
+    })
+  })
+})

--- a/src/renderer/src/lib/__tests__/connection-pr.test.ts
+++ b/src/renderer/src/lib/__tests__/connection-pr.test.ts
@@ -1,0 +1,463 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '../../api/rpc-client'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+
+import type { MemberAssessment } from '../connection-pr'
+
+let request: ReturnType<typeof vi.fn>
+let useGitStore: typeof import('@/stores/useGitStore').useGitStore
+let connectionPr: typeof import('../connection-pr')
+
+const memberA = {
+  worktree_id: 'wt-a',
+  project_id: 'proj-a',
+  project_name: 'alpha',
+  worktree_path: '/repo/a',
+  worktree_branch: 'feat-a'
+}
+const memberB = {
+  worktree_id: 'wt-b',
+  project_id: 'proj-b',
+  project_name: 'beta',
+  worktree_path: '/repo/b',
+  worktree_branch: 'feat-b'
+}
+const memberC = {
+  worktree_id: 'wt-c',
+  project_id: 'proj-c',
+  project_name: 'gamma',
+  worktree_path: '/repo/c',
+  worktree_branch: 'feat-c'
+}
+
+function seedStores(): void {
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([
+      [
+        'proj-a',
+        [
+          { id: 'wt-a-default', path: '/proj/a', branch_name: 'main', is_default: true },
+          { id: 'wt-a', path: '/repo/a', branch_name: 'feat-a', is_default: false }
+        ]
+      ],
+      [
+        'proj-b',
+        [
+          { id: 'wt-b-default', path: '/proj/b', branch_name: 'develop', is_default: true },
+          { id: 'wt-b', path: '/repo/b', branch_name: 'feat-b', is_default: false }
+        ]
+      ],
+      [
+        'proj-c',
+        [
+          { id: 'wt-c-default', path: '/proj/c', branch_name: 'main', is_default: true },
+          { id: 'wt-c', path: '/repo/c', branch_name: 'feat-c', is_default: false }
+        ]
+      ]
+    ])
+  } as never)
+  useProjectStore.setState({
+    projects: [
+      { id: 'proj-a', path: '/proj/a' },
+      { id: 'proj-b', path: '/proj/b' },
+      { id: 'proj-c', path: '/proj/c' }
+    ]
+  } as never)
+}
+
+interface MockSpec {
+  hasUncommitted?: Record<string, boolean>
+  commitCount?: Record<string, number>
+  branchAhead?: Record<string, number>
+  overrides?: Record<string, unknown | ((params: Record<string, unknown>) => unknown)>
+}
+
+function mockResponses(spec: MockSpec = {}): void {
+  request.mockImplementation((method: string, params: Record<string, unknown>) => {
+    const path = params?.worktreePath as string
+    const override = spec.overrides?.[method]
+    if (override !== undefined) {
+      const value = typeof override === 'function' ? override(params) : override
+      if (value instanceof Error) return Promise.reject(value)
+      return Promise.resolve(value)
+    }
+    switch (method) {
+      case 'gitOps.getRemoteUrl':
+        return Promise.resolve({ success: true, url: 'https://github.com/acme/x.git' })
+      case 'gitOps.hasUncommittedChanges':
+        return Promise.resolve(spec.hasUncommitted?.[path] ?? false)
+      case 'gitOps.getRangeDiff':
+        return Promise.resolve({
+          commitSummary: '',
+          diffSummary: '',
+          diffPatch: '',
+          commitCount: spec.commitCount?.[path] ?? 0
+        })
+      case 'gitOps.getBranchInfo':
+        return Promise.resolve({
+          success: true,
+          branch: {
+            name: 'feat',
+            tracking: null,
+            ahead: spec.branchAhead?.[path] ?? 0,
+            behind: 0
+          }
+        })
+      case 'gitOps.getFileStatuses':
+        return Promise.resolve({ success: true, files: [] })
+      case 'gitOps.needsPush':
+        return Promise.resolve(true)
+      case 'gitOps.push':
+        return Promise.resolve({ success: true, pushed: true })
+      case 'gitOps.generatePRContent':
+        return Promise.resolve({ success: true, title: 'AI title', body: 'AI body' })
+      case 'gitOps.createPR':
+        return Promise.resolve({
+          success: true,
+          url: `https://github.com/acme/x/pull/42`,
+          number: 42
+        })
+      case 'gitOps.commit':
+        return Promise.resolve({ success: true, commitHash: 'abc1234' })
+      case 'db.worktree.attachPR':
+      case 'kanban.ticket.syncPR':
+        return Promise.resolve({ success: true })
+      default:
+        return Promise.resolve([])
+    }
+  })
+}
+
+function callsTo(method: string): unknown[][] {
+  return request.mock.calls.filter(([m]) => m === method)
+}
+
+function notifications(): Array<Record<string, unknown>> {
+  return usePRNotificationStore.getState().notifications as unknown as Array<
+    Record<string, unknown>
+  >
+}
+
+function makeAssessment(overrides: Partial<MemberAssessment> = {}): MemberAssessment {
+  return {
+    worktreeId: 'wt-a',
+    worktreePath: '/repo/a',
+    projectId: 'proj-a',
+    projectName: 'alpha',
+    projectPath: '/proj/a',
+    branchName: 'feat-a',
+    isDefaultWorktree: false,
+    isGitHub: true,
+    hasUncommitted: false,
+    commitsAhead: 1,
+    trackingAhead: 0,
+    defaultBase: 'main',
+    attachedPR: null,
+    assessmentFailed: false,
+    ...overrides
+  }
+}
+
+describe('connection-pr', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    request = vi.fn().mockResolvedValue([])
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    ;({ useGitStore } = await import('@/stores/useGitStore'))
+    connectionPr = await import('../connection-pr')
+    useGitStore.setState({
+      fileStatusesByWorktree: new Map(),
+      branchInfoByWorktree: new Map(),
+      remoteInfo: new Map(),
+      prTargetBranch: new Map(),
+      attachedPR: new Map(),
+      creatingPRByWorktreeId: new Map(),
+      isCommitting: false
+    })
+    usePRNotificationStore.setState({ notifications: [] })
+    seedStores()
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+  })
+
+  describe('assessConnectionMembers', () => {
+    it('classifies members by changes and commits ahead', async () => {
+      mockResponses({
+        hasUncommitted: { '/repo/a': true },
+        commitCount: { '/repo/b': 2 }
+      })
+
+      const assessments = await connectionPr.assessConnectionMembers([memberA, memberB, memberC])
+      const byId = new Map(assessments.map((a) => [a.worktreeId, a]))
+
+      const a = byId.get('wt-a')!
+      const b = byId.get('wt-b')!
+      const c = byId.get('wt-c')!
+
+      expect(connectionPr.isPRWorthy(a)).toBe(true)
+      expect(connectionPr.isArchivePromptable(a)).toBe(false)
+      expect(connectionPr.isPRWorthy(b)).toBe(true)
+      expect(connectionPr.isPRWorthy(c)).toBe(false)
+      expect(connectionPr.isArchivePromptable(c)).toBe(true)
+      expect(a.isGitHub).toBe(true)
+      expect(b.defaultBase).toBe('develop')
+      expect(b.projectPath).toBe('/proj/b')
+    })
+
+    it('never marks default worktrees as archive promptable', async () => {
+      mockResponses()
+
+      const assessments = await connectionPr.assessConnectionMembers([
+        {
+          worktree_id: 'wt-a-default',
+          project_id: 'proj-a',
+          project_name: 'alpha',
+          worktree_path: '/proj/a',
+          worktree_branch: 'main'
+        }
+      ])
+
+      expect(assessments[0].isDefaultWorktree).toBe(true)
+      expect(connectionPr.isArchivePromptable(assessments[0])).toBe(false)
+    })
+
+    it('blocks archive prompts when the tracking branch is ahead despite a zero range diff', async () => {
+      mockResponses({ branchAhead: { '/repo/c': 3 } })
+
+      const assessments = await connectionPr.assessConnectionMembers([memberC])
+
+      expect(assessments[0].commitsAhead).toBe(0)
+      expect(assessments[0].trackingAhead).toBe(3)
+      expect(connectionPr.isArchivePromptable(assessments[0])).toBe(false)
+    })
+
+    it('prefers the persisted PR target branch as the default base', async () => {
+      mockResponses()
+      useGitStore.setState({ prTargetBranch: new Map([['wt-a', 'origin/release']]) })
+
+      const assessments = await connectionPr.assessConnectionMembers([memberA])
+
+      expect(assessments[0].defaultBase).toBe('release')
+      expect(request).toHaveBeenCalledWith('gitOps.getRangeDiff', {
+        worktreePath: '/repo/a',
+        baseBranch: 'release'
+      })
+    })
+
+    it('marks members whose assessment fails without prompting them', async () => {
+      mockResponses({
+        overrides: {
+          'gitOps.getRangeDiff': (params) =>
+            params.worktreePath === '/repo/c' ? new Error('git blew up') : undefined
+        }
+      })
+      // Fall through to defaults for other members
+      const assessments = await connectionPr.assessConnectionMembers([memberC])
+
+      expect(assessments[0].assessmentFailed).toBe(true)
+      expect(connectionPr.isPRWorthy(assessments[0])).toBe(false)
+      expect(connectionPr.isArchivePromptable(assessments[0])).toBe(false)
+    })
+  })
+
+  describe('commitConnectionMembers', () => {
+    it('commits each member and isolates failures', async () => {
+      mockResponses({
+        overrides: {
+          'gitOps.commit': (params) =>
+            params.worktreePath === '/repo/a'
+              ? { success: false, error: 'boom' }
+              : { success: true, commitHash: 'def5678' }
+        }
+      })
+
+      const results = await connectionPr.commitConnectionMembers(
+        [makeAssessment(), makeAssessment({ worktreeId: 'wt-b', worktreePath: '/repo/b' })],
+        'shared message'
+      )
+
+      expect(callsTo('gitOps.commit')).toHaveLength(2)
+      expect(results.get('wt-a')).toMatchObject({ success: false, error: 'boom' })
+      expect(results.get('wt-b')).toMatchObject({ success: true })
+    })
+  })
+
+  describe('createConnectionPRs', () => {
+    it('creates a PR per included member with the project name as prefix', async () => {
+      mockResponses()
+
+      await connectionPr.createConnectionPRs({
+        plans: [{ assessment: makeAssessment(), baseBranch: 'main', include: true }],
+        ineligible: [],
+        title: '',
+        body: '',
+        provider: 'claude-code'
+      })
+
+      expect(request).toHaveBeenCalledWith('gitOps.createPR', {
+        worktreePath: '/repo/a',
+        baseBranch: 'main',
+        title: 'AI title',
+        body: 'AI body'
+      })
+      expect(notifications()).toHaveLength(1)
+      expect(notifications()[0]).toMatchObject({
+        status: 'success',
+        message: 'alpha: Pull request #42 created',
+        worktreeId: 'wt-a'
+      })
+    })
+
+    it('isolates a failing member from the others', async () => {
+      mockResponses({
+        overrides: {
+          'gitOps.push': (params) =>
+            params.worktreePath === '/repo/a'
+              ? { success: false, error: 'no upstream' }
+              : { success: true, pushed: true }
+        }
+      })
+
+      await connectionPr.createConnectionPRs({
+        plans: [
+          { assessment: makeAssessment(), baseBranch: 'main', include: true },
+          {
+            assessment: makeAssessment({
+              worktreeId: 'wt-b',
+              worktreePath: '/repo/b',
+              projectName: 'beta',
+              projectPath: '/proj/b'
+            }),
+            baseBranch: 'develop',
+            include: true
+          }
+        ],
+        ineligible: [],
+        title: '',
+        body: '',
+        provider: 'claude-code'
+      })
+
+      expect(callsTo('gitOps.createPR')).toHaveLength(1)
+      const byWorktree = new Map(notifications().map((n) => [n.worktreeId, n]))
+      expect(byWorktree.get('wt-a')).toMatchObject({ status: 'error' })
+      expect(byWorktree.get('wt-b')).toMatchObject({ status: 'success' })
+    })
+
+    it('pushes updates instead of creating for members with an attached PR', async () => {
+      mockResponses()
+
+      await connectionPr.createConnectionPRs({
+        plans: [
+          {
+            assessment: makeAssessment({
+              attachedPR: { number: 7, url: 'https://github.com/acme/x/pull/7' }
+            }),
+            baseBranch: 'main',
+            include: true
+          }
+        ],
+        ineligible: [],
+        title: '',
+        body: '',
+        provider: 'claude-code'
+      })
+
+      expect(callsTo('gitOps.createPR')).toHaveLength(0)
+      expect(callsTo('gitOps.push')).toHaveLength(1)
+      expect(notifications()[0]).toMatchObject({
+        status: 'info',
+        message: 'alpha: Pushed updates to PR #7',
+        prNumber: 7,
+        prUrl: 'https://github.com/acme/x/pull/7'
+      })
+    })
+
+    it('skips non-GitHub members with an informational card', async () => {
+      mockResponses()
+
+      await connectionPr.createConnectionPRs({
+        plans: [
+          {
+            assessment: makeAssessment({ isGitHub: false, hasUncommitted: true }),
+            baseBranch: 'main',
+            include: false
+          }
+        ],
+        ineligible: [],
+        title: '',
+        body: '',
+        provider: 'claude-code'
+      })
+
+      expect(callsTo('gitOps.createPR')).toHaveLength(0)
+      expect(callsTo('gitOps.push')).toHaveLength(0)
+      expect(notifications()[0]).toMatchObject({ status: 'info', worktreeId: 'wt-a' })
+      expect(String(notifications()[0].message)).toContain('no GitHub remote')
+    })
+
+    it('does nothing for members the user excluded', async () => {
+      mockResponses()
+
+      await connectionPr.createConnectionPRs({
+        plans: [{ assessment: makeAssessment(), baseBranch: 'main', include: false }],
+        ineligible: [],
+        title: '',
+        body: '',
+        provider: 'claude-code'
+      })
+
+      expect(callsTo('gitOps.createPR')).toHaveLength(0)
+      expect(notifications()).toHaveLength(0)
+    })
+
+    it('warns for included members that ended up with no commits ahead', async () => {
+      mockResponses()
+
+      await connectionPr.createConnectionPRs({
+        plans: [
+          { assessment: makeAssessment({ commitsAhead: 0 }), baseBranch: 'main', include: true }
+        ],
+        ineligible: [],
+        title: '',
+        body: '',
+        provider: 'claude-code'
+      })
+
+      expect(callsTo('gitOps.createPR')).toHaveLength(0)
+      expect(notifications()[0]).toMatchObject({ status: 'warning', worktreeId: 'wt-a' })
+    })
+
+    it('emits archive prompts for clean members after the batch settles', async () => {
+      mockResponses()
+
+      await connectionPr.createConnectionPRs({
+        plans: [{ assessment: makeAssessment(), baseBranch: 'main', include: true }],
+        ineligible: [
+          makeAssessment({
+            worktreeId: 'wt-c',
+            worktreePath: '/repo/c',
+            projectName: 'gamma',
+            hasUncommitted: false,
+            commitsAhead: 0
+          })
+        ],
+        title: '',
+        body: '',
+        provider: 'claude-code'
+      })
+
+      const prompt = notifications().find((n) => n.worktreeId === 'wt-c')
+      expect(prompt).toMatchObject({
+        status: 'info',
+        message: 'Nothing to PR in gamma',
+        showArchiveButton: true
+      })
+    })
+  })
+})

--- a/src/renderer/src/lib/__tests__/pr-pipeline.test.ts
+++ b/src/renderer/src/lib/__tests__/pr-pipeline.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '../../api/rpc-client'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
+
+let request: ReturnType<typeof vi.fn>
+let useGitStore: typeof import('@/stores/useGitStore').useGitStore
+let runCreatePRPipeline: typeof import('../pr-pipeline').runCreatePRPipeline
+
+const baseOptions = {
+  worktreeId: 'wt-1',
+  worktreePath: '/repo/wt-1',
+  projectPath: '/projects/one',
+  baseBranch: 'main',
+  title: '',
+  body: '',
+  fallbackTitle: 'feature-x',
+  provider: 'claude-code' as const
+}
+
+function mockResponses(overrides: Record<string, unknown> = {}): void {
+  const defaults: Record<string, unknown> = {
+    'gitOps.needsPush': true,
+    'gitOps.push': { success: true, pushed: true },
+    'gitOps.generatePRContent': { success: true, title: 'AI title', body: 'AI body' },
+    'gitOps.createPR': {
+      success: true,
+      url: 'https://github.com/acme/repo/pull/42',
+      number: 42
+    },
+    'gitOps.getPRState': { success: true, state: 'OPEN', title: 'Existing PR title' },
+    'db.worktree.attachPR': { success: true },
+    'kanban.ticket.syncPR': { success: true }
+  }
+  const responses = { ...defaults, ...overrides }
+  request.mockImplementation((method: string) => {
+    if (method in responses) {
+      const value = responses[method]
+      if (value instanceof Error) return Promise.reject(value)
+      return Promise.resolve(value)
+    }
+    return Promise.resolve([])
+  })
+}
+
+function callsTo(method: string): unknown[][] {
+  return request.mock.calls.filter(([m]) => m === method)
+}
+
+function lastNotification(): Record<string, unknown> {
+  const notifications = usePRNotificationStore.getState().notifications
+  return notifications[notifications.length - 1] as unknown as Record<string, unknown>
+}
+
+describe('runCreatePRPipeline', () => {
+  let notifId: string
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    request = vi.fn().mockResolvedValue([])
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    ;({ useGitStore } = await import('@/stores/useGitStore'))
+    ;({ runCreatePRPipeline } = await import('../pr-pipeline'))
+    useGitStore.setState({
+      attachedPR: new Map(),
+      creatingPRByWorktreeId: new Map()
+    })
+    usePRNotificationStore.setState({ notifications: [] })
+    notifId = usePRNotificationStore.getState().show({
+      status: 'loading',
+      message: 'Creating pull request...',
+      worktreeId: 'wt-1'
+    })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+  })
+
+  it('pushes when needed, generates content, creates and attaches the PR', async () => {
+    mockResponses()
+
+    const result = await runCreatePRPipeline({ ...baseOptions, notifId })
+
+    expect(callsTo('gitOps.push')).toHaveLength(1)
+    expect(request).toHaveBeenCalledWith('gitOps.generatePRContent', {
+      worktreePath: '/repo/wt-1',
+      baseBranch: 'main',
+      provider: 'claude-code'
+    })
+    expect(request).toHaveBeenCalledWith('gitOps.createPR', {
+      worktreePath: '/repo/wt-1',
+      baseBranch: 'main',
+      title: 'AI title',
+      body: 'AI body'
+    })
+    expect(request).toHaveBeenCalledWith('db.worktree.attachPR', {
+      worktreeId: 'wt-1',
+      prNumber: 42,
+      prUrl: 'https://github.com/acme/repo/pull/42'
+    })
+    expect(result).toEqual({
+      ok: true,
+      prNumber: 42,
+      prUrl: 'https://github.com/acme/repo/pull/42'
+    })
+    expect(lastNotification()).toMatchObject({
+      status: 'success',
+      message: 'Pull request #42 created',
+      prNumber: 42,
+      prUrl: 'https://github.com/acme/repo/pull/42'
+    })
+    expect(useGitStore.getState().creatingPRByWorktreeId.has('wt-1')).toBe(false)
+  })
+
+  it('skips push and generation when nothing to push and content is provided', async () => {
+    mockResponses({ 'gitOps.needsPush': false })
+
+    await runCreatePRPipeline({
+      ...baseOptions,
+      title: 'My title',
+      body: 'My body',
+      notifId
+    })
+
+    expect(callsTo('gitOps.push')).toHaveLength(0)
+    expect(callsTo('gitOps.generatePRContent')).toHaveLength(0)
+    expect(request).toHaveBeenCalledWith('gitOps.createPR', {
+      worktreePath: '/repo/wt-1',
+      baseBranch: 'main',
+      title: 'My title',
+      body: 'My body'
+    })
+  })
+
+  it('falls back to the branch name with a warning when generation fails', async () => {
+    mockResponses({
+      'gitOps.needsPush': false,
+      'gitOps.generatePRContent': { success: false, error: 'model unavailable' }
+    })
+
+    const result = await runCreatePRPipeline({ ...baseOptions, notifId })
+
+    expect(request).toHaveBeenCalledWith('gitOps.createPR', {
+      worktreePath: '/repo/wt-1',
+      baseBranch: 'main',
+      title: 'feature-x',
+      body: ''
+    })
+    expect(result.ok).toBe(true)
+    expect(lastNotification()).toMatchObject({
+      status: 'warning',
+      message: 'PR #42 created with default content',
+      description: 'model unavailable'
+    })
+  })
+
+  it('attaches an existing PR from the structured already-exists result', async () => {
+    mockResponses({
+      'gitOps.needsPush': false,
+      'gitOps.createPR': {
+        success: false,
+        error: 'a pull request already exists',
+        number: 7,
+        url: 'https://github.com/acme/repo/pull/7'
+      }
+    })
+
+    const result = await runCreatePRPipeline({ ...baseOptions, notifId })
+
+    expect(request).toHaveBeenCalledWith('db.worktree.attachPR', {
+      worktreeId: 'wt-1',
+      prNumber: 7,
+      prUrl: 'https://github.com/acme/repo/pull/7'
+    })
+    expect(request).toHaveBeenCalledWith('gitOps.getPRState', {
+      projectPath: '/projects/one',
+      prNumber: 7
+    })
+    expect(result).toMatchObject({ ok: true, existing: true, prNumber: 7 })
+    expect(lastNotification()).toMatchObject({
+      status: 'info',
+      message: 'PR #7 already exists',
+      description: 'Attached to workspace',
+      prTitle: 'Existing PR title'
+    })
+  })
+
+  it('recovers the existing PR from the error message when unstructured', async () => {
+    mockResponses({
+      'gitOps.needsPush': false,
+      'gitOps.createPR': {
+        success: false,
+        error:
+          'a pull request for branch "feature-x" already exists:\nhttps://github.com/acme/repo/pull/12'
+      }
+    })
+
+    const result = await runCreatePRPipeline({ ...baseOptions, notifId })
+
+    expect(request).toHaveBeenCalledWith('db.worktree.attachPR', {
+      worktreeId: 'wt-1',
+      prNumber: 12,
+      prUrl: 'https://github.com/acme/repo/pull/12'
+    })
+    expect(result).toMatchObject({ ok: true, existing: true, prNumber: 12 })
+  })
+
+  it('reports an error notification when the push fails', async () => {
+    mockResponses({ 'gitOps.push': { success: false, error: 'no upstream' } })
+
+    const result = await runCreatePRPipeline({ ...baseOptions, notifId })
+
+    expect(result.ok).toBe(false)
+    expect(callsTo('gitOps.createPR')).toHaveLength(0)
+    expect(lastNotification()).toMatchObject({
+      status: 'error',
+      message: 'Failed to create pull request',
+      description: 'no upstream'
+    })
+    expect(useGitStore.getState().creatingPRByWorktreeId.has('wt-1')).toBe(false)
+  })
+
+  it('prefixes notification messages with the label prefix', async () => {
+    mockResponses({ 'gitOps.needsPush': false })
+
+    await runCreatePRPipeline({ ...baseOptions, notifId, labelPrefix: 'web: ' })
+
+    expect(lastNotification()).toMatchObject({
+      status: 'success',
+      message: 'web: Pull request #42 created'
+    })
+  })
+})

--- a/src/renderer/src/lib/connection-pr.ts
+++ b/src/renderer/src/lib/connection-pr.ts
@@ -1,0 +1,290 @@
+import { gitApi } from '@/api/git-api'
+import { runCreatePRPipeline } from '@/lib/pr-pipeline'
+import type { PRContentProvider } from '@/lib/pr-content-provider'
+import { useGitStore } from '@/stores/useGitStore'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The slice of a connection member the PR flow needs */
+export interface ConnectionPRMember {
+  worktree_id: string
+  project_id: string
+  project_name: string
+  worktree_path: string
+  worktree_branch: string
+}
+
+export interface MemberAssessment {
+  worktreeId: string
+  worktreePath: string
+  projectId: string
+  projectName: string
+  projectPath: string | null
+  branchName: string
+  isDefaultWorktree: boolean
+  isGitHub: boolean
+  hasUncommitted: boolean
+  /** Commits ahead of defaultBase (`getRangeDiff`) — 0 on backend errors */
+  commitsAhead: number
+  /** Commits ahead of the tracking branch — guards against false 0s above */
+  trackingAhead: number
+  /** Base branch without remote prefix, e.g. 'main' */
+  defaultBase: string
+  attachedPR: { number: number; url: string } | null
+  assessmentFailed: boolean
+}
+
+export interface MemberPRPlan {
+  assessment: MemberAssessment
+  baseBranch: string
+  include: boolean
+}
+
+export interface CreateConnectionPRsOptions {
+  plans: MemberPRPlan[]
+  /** Members hidden from the modal — archive prompts fire for the clean ones */
+  ineligible: MemberAssessment[]
+  title: string
+  body: string
+  provider: PRContentProvider | null
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+export function isPRWorthy(assessment: MemberAssessment): boolean {
+  return !assessment.assessmentFailed && (assessment.hasUncommitted || assessment.commitsAhead > 0)
+}
+
+export function isArchivePromptable(assessment: MemberAssessment): boolean {
+  return (
+    !assessment.assessmentFailed &&
+    !assessment.hasUncommitted &&
+    assessment.commitsAhead === 0 &&
+    assessment.trackingAhead === 0 &&
+    !assessment.isDefaultWorktree
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Assessment
+// ---------------------------------------------------------------------------
+
+async function assessMember(member: ConnectionPRMember): Promise<MemberAssessment> {
+  const gitStore = useGitStore.getState()
+  const worktrees = useWorktreeStore.getState().worktreesByProject.get(member.project_id) ?? []
+  const projectPath =
+    useProjectStore.getState().projects.find((p) => p.id === member.project_id)?.path ?? null
+  const isDefaultWorktree = worktrees.find((w) => w.id === member.worktree_id)?.is_default ?? false
+  const persistedBase = gitStore.prTargetBranch.get(member.worktree_id)
+  const defaultBase =
+    persistedBase?.replace(/^origin\//, '') ??
+    worktrees.find((w) => w.is_default)?.branch_name ??
+    'main'
+
+  const base: MemberAssessment = {
+    worktreeId: member.worktree_id,
+    worktreePath: member.worktree_path,
+    projectId: member.project_id,
+    projectName: member.project_name,
+    projectPath,
+    branchName: member.worktree_branch,
+    isDefaultWorktree,
+    isGitHub: false,
+    hasUncommitted: false,
+    commitsAhead: 0,
+    trackingAhead: 0,
+    defaultBase,
+    attachedPR: gitStore.attachedPR.get(member.worktree_id) ?? null,
+    assessmentFailed: false
+  }
+
+  try {
+    if (!gitStore.remoteInfo.get(member.worktree_id)) {
+      await gitStore.checkRemoteInfo(member.worktree_id, member.worktree_path)
+    }
+    const isGitHub = useGitStore.getState().remoteInfo.get(member.worktree_id)?.isGitHub ?? false
+
+    const [hasUncommitted, rangeDiff] = await Promise.all([
+      gitApi.hasUncommittedChanges(member.worktree_path),
+      gitApi.getRangeDiff(member.worktree_path, defaultBase),
+      gitStore.loadFileStatuses(member.worktree_path, { force: true }),
+      gitStore.loadBranchInfo(member.worktree_path, { force: true })
+    ])
+    const trackingAhead =
+      useGitStore.getState().branchInfoByWorktree.get(member.worktree_path)?.ahead ?? 0
+
+    return {
+      ...base,
+      isGitHub,
+      hasUncommitted,
+      commitsAhead: rangeDiff.commitCount,
+      trackingAhead
+    }
+  } catch {
+    // Failed members are neither shown in the modal nor archive-prompted
+    return { ...base, assessmentFailed: true }
+  }
+}
+
+export async function assessConnectionMembers(
+  members: ConnectionPRMember[]
+): Promise<MemberAssessment[]> {
+  return Promise.all(members.map(assessMember))
+}
+
+// ---------------------------------------------------------------------------
+// Commit
+// ---------------------------------------------------------------------------
+
+/**
+ * Commit the shared message in each member, sequentially so the global
+ * isCommitting flag and per-path status refreshes don't race.
+ */
+export async function commitConnectionMembers(
+  members: MemberAssessment[],
+  message: string
+): Promise<Map<string, { success: boolean; error?: string }>> {
+  const results = new Map<string, { success: boolean; error?: string }>()
+  for (const member of members) {
+    try {
+      const result = await useGitStore.getState().commit(member.worktreePath, message)
+      results.set(member.worktreeId, { success: result.success, error: result.error })
+    } catch (err) {
+      results.set(member.worktreeId, {
+        success: false,
+        error: err instanceof Error ? err.message : String(err)
+      })
+    }
+  }
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// PR creation
+// ---------------------------------------------------------------------------
+
+export function emitArchivePrompts(assessments: MemberAssessment[]): void {
+  const { show } = usePRNotificationStore.getState()
+  for (const assessment of assessments.filter(isArchivePromptable)) {
+    show({
+      status: 'info',
+      message: `Nothing to PR in ${assessment.projectName}`,
+      description: 'No changes and no commits ahead — you can archive this worktree',
+      worktreeId: assessment.worktreeId,
+      showArchiveButton: true
+    })
+  }
+}
+
+async function pushAttachedPRUpdates(assessment: MemberAssessment, prefix: string): Promise<void> {
+  const { show, update } = usePRNotificationStore.getState()
+  const pr = assessment.attachedPR
+  if (!pr) return
+
+  const notifId = show({
+    status: 'loading',
+    message: `${prefix}Pushing updates to PR #${pr.number}...`,
+    worktreeId: assessment.worktreeId
+  })
+  try {
+    let willPush = false
+    try {
+      willPush = await gitApi.needsPush(assessment.worktreePath)
+    } catch {
+      // Assume no push needed
+    }
+    if (willPush) {
+      const pushResult = await gitApi.push(assessment.worktreePath)
+      if (!pushResult.success) {
+        throw new Error(pushResult.error ?? 'Push failed')
+      }
+    }
+    update(notifId, {
+      status: 'info',
+      message: willPush
+        ? `${prefix}Pushed updates to PR #${pr.number}`
+        : `${prefix}PR #${pr.number} is up to date`,
+      prUrl: pr.url,
+      prNumber: pr.number,
+      worktreeId: assessment.worktreeId
+    })
+  } catch (err) {
+    update(notifId, {
+      status: 'error',
+      message: `${prefix}Failed to push updates to PR #${pr.number}`,
+      description: err instanceof Error ? err.message : String(err)
+    })
+  }
+}
+
+/**
+ * Create a PR for every included member, one notification card each.
+ * Members fail independently; clean ineligible members get archive prompts
+ * once the whole batch settles.
+ */
+export async function createConnectionPRs(options: CreateConnectionPRsOptions): Promise<void> {
+  const { plans, ineligible, title, body, provider } = options
+  const { show } = usePRNotificationStore.getState()
+
+  await Promise.allSettled(
+    plans.map(async (plan) => {
+      const assessment = plan.assessment
+      const prefix = `${assessment.projectName}: `
+
+      if (!assessment.isGitHub) {
+        // Committed in the commit phase, but there is no remote to PR against
+        if (assessment.hasUncommitted || assessment.commitsAhead > 0) {
+          show({
+            status: 'info',
+            message: `${prefix}committed — no GitHub remote, PR skipped`,
+            worktreeId: assessment.worktreeId
+          })
+        }
+        return
+      }
+
+      if (!plan.include) return
+
+      if (assessment.attachedPR) {
+        await pushAttachedPRUpdates(assessment, prefix)
+        return
+      }
+
+      if (assessment.commitsAhead <= 0) {
+        show({
+          status: 'warning',
+          message: `${prefix}skipped — no commits ahead of ${plan.baseBranch}`,
+          worktreeId: assessment.worktreeId
+        })
+        return
+      }
+
+      const notifId = show({
+        status: 'loading',
+        message: `${prefix}Creating pull request...`,
+        worktreeId: assessment.worktreeId
+      })
+      await runCreatePRPipeline({
+        worktreeId: assessment.worktreeId,
+        worktreePath: assessment.worktreePath,
+        projectPath: assessment.projectPath,
+        baseBranch: plan.baseBranch,
+        title,
+        body,
+        fallbackTitle: assessment.branchName,
+        provider,
+        notifId,
+        labelPrefix: prefix
+      })
+    })
+  )
+
+  emitArchivePrompts(ineligible)
+}

--- a/src/renderer/src/lib/pr-pipeline.ts
+++ b/src/renderer/src/lib/pr-pipeline.ts
@@ -1,0 +1,198 @@
+import { gitApi } from '@/api/git-api'
+import { useGitStore } from '@/stores/useGitStore'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
+import type { PRContentProvider } from '@/lib/pr-content-provider'
+
+export interface CreatePRPipelineOptions {
+  worktreeId: string
+  worktreePath: string
+  /** Project root path — used to look up the PR title in the already-exists flow */
+  projectPath: string | null
+  /** Base branch without a remote prefix, e.g. 'main' */
+  baseBranch: string
+  /** Empty string means auto-generate */
+  title: string
+  /** Empty string means auto-generate */
+  body: string
+  /** Used as the PR title when generation fails or is unavailable */
+  fallbackTitle: string
+  provider: PRContentProvider | null
+  /** Pre-created notification card driven through the pipeline's states */
+  notifId: string
+  /** Prepended to every notification message, e.g. 'my-project: ' */
+  labelPrefix?: string
+}
+
+export interface CreatePRPipelineResult {
+  ok: boolean
+  prNumber?: number
+  prUrl?: string
+  existing?: boolean
+  error?: string
+}
+
+/**
+ * Push (if needed) → generate PR content (if needed) → create the PR via
+ * `gh pr create` → attach it to the worktree, driving a PR notification card
+ * through the whole flow. Recovers gracefully when the PR already exists.
+ */
+export async function runCreatePRPipeline(
+  options: CreatePRPipelineOptions
+): Promise<CreatePRPipelineResult> {
+  const {
+    worktreeId,
+    worktreePath,
+    projectPath,
+    baseBranch,
+    fallbackTitle,
+    provider,
+    notifId,
+    labelPrefix = ''
+  } = options
+
+  const { update } = usePRNotificationStore.getState()
+  const { attachPR, setCreatingPR } = useGitStore.getState()
+  setCreatingPR(worktreeId, true)
+
+  let finalTitle = options.title
+  let finalBody = options.body
+
+  try {
+    // Step 1: Push if needed
+    let willPush = false
+    try {
+      willPush = await gitApi.needsPush(worktreePath)
+    } catch {
+      // Assume no push needed
+    }
+
+    if (willPush) {
+      update(notifId, { message: `${labelPrefix}Pushing branch...` })
+      const pushResult = await gitApi.push(worktreePath)
+      if (!pushResult.success) {
+        throw new Error(pushResult.error ?? 'Push failed')
+      }
+    }
+
+    // Step 2: Generate content if needed (best-effort — failure should not block PR creation)
+    const needsGenerate = !finalTitle || !finalBody
+    let usedFallbackContent = false
+    let generationFailureReason: string | null = null
+    if (needsGenerate) {
+      update(notifId, { message: `${labelPrefix}Generating PR content...` })
+      if (!provider) {
+        usedFallbackContent = true
+        generationFailureReason =
+          'No AI provider available for PR content generation. Using default title and description.'
+      } else {
+        try {
+          const genResult = await gitApi.generatePRContent(worktreePath, baseBranch, provider)
+          if (genResult.success) {
+            if (!finalTitle && genResult.title) finalTitle = genResult.title
+            if (!finalBody && genResult.body) finalBody = genResult.body
+          } else {
+            console.warn('PR content generation failed, using fallback:', genResult.error)
+            generationFailureReason =
+              genResult.error ??
+              'AI content generation failed — you may want to edit the title and description'
+            usedFallbackContent = true
+          }
+        } catch (err) {
+          console.warn('PR content generation threw, using fallback:', err)
+          generationFailureReason = err instanceof Error ? err.message : String(err)
+          usedFallbackContent = true
+        }
+      }
+      // Fallback if generation failed or returned empty
+      if (!finalTitle) finalTitle = fallbackTitle
+      if (!finalBody) finalBody = ''
+    }
+
+    // Step 3: Create PR
+    update(notifId, { message: `${labelPrefix}Creating pull request...` })
+    const createResult = await gitApi.createPR(worktreePath, baseBranch, finalTitle, finalBody)
+
+    if (!createResult.success) {
+      // The backend populates url/number even on failure when a PR already
+      // exists — use that structured data first, regex fallback second.
+      let existingNumber = createResult.number
+      let existingUrl = createResult.url
+
+      if (!existingNumber) {
+        // Fallback: parse the error message ([\s\S] to match across newlines)
+        const errMsg = createResult.error ?? ''
+        const alreadyExistsMatch = errMsg.match(
+          /already exists[\s\S]*?\/pull\/(\d+)|pull request.*?#(\d+).*?already/i
+        )
+        if (alreadyExistsMatch) {
+          existingNumber = parseInt(alreadyExistsMatch[1] || alreadyExistsMatch[2], 10)
+          if (!existingUrl) {
+            const urlMatch = errMsg.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/)
+            existingUrl = urlMatch?.[0] ?? `https://github.com/unknown/pull/${existingNumber}`
+          }
+        }
+      }
+
+      if (existingNumber) {
+        existingUrl = existingUrl ?? `https://github.com/unknown/pull/${existingNumber}`
+
+        // Auto-attach the existing PR
+        await attachPR(worktreeId, existingNumber, existingUrl)
+
+        let existingTitle: string | undefined
+        try {
+          if (projectPath) {
+            const state = await gitApi.getPRState(projectPath, existingNumber)
+            if (state.success) existingTitle = state.title
+          }
+        } catch {
+          // Best-effort: existing PR notification still works without a title.
+        }
+
+        update(notifId, {
+          status: 'info',
+          message: `${labelPrefix}PR #${existingNumber} already exists`,
+          description: 'Attached to workspace',
+          prUrl: existingUrl,
+          prNumber: existingNumber,
+          prTitle: existingTitle,
+          worktreeId
+        })
+        return { ok: true, existing: true, prNumber: existingNumber, prUrl: existingUrl }
+      }
+
+      throw new Error(createResult.error ?? 'PR creation failed')
+    }
+
+    // Attach the new PR
+    const prUrl = createResult.url ?? ''
+    const prNumber = createResult.number ?? 0
+    await attachPR(worktreeId, prNumber, prUrl)
+
+    update(notifId, {
+      status: usedFallbackContent ? 'warning' : 'success',
+      message: usedFallbackContent
+        ? `${labelPrefix}PR #${prNumber} created with default content`
+        : `${labelPrefix}Pull request #${prNumber} created`,
+      description: usedFallbackContent
+        ? (generationFailureReason ??
+          'AI content generation failed — you may want to edit the title and description')
+        : undefined,
+      prUrl,
+      prNumber,
+      prTitle: finalTitle,
+      worktreeId
+    })
+    return { ok: true, prNumber, prUrl }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    update(notifId, {
+      status: 'error',
+      message: `${labelPrefix}Failed to create pull request`,
+      description: msg
+    })
+    return { ok: false, error: msg }
+  } finally {
+    setCreatingPR(worktreeId, false)
+  }
+}

--- a/src/renderer/src/stores/__tests__/useGitStore.connection-pr-modal.test.ts
+++ b/src/renderer/src/stores/__tests__/useGitStore.connection-pr-modal.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '../../api/rpc-client'
+
+let request: ReturnType<typeof vi.fn>
+let useGitStore: typeof import('../useGitStore').useGitStore
+
+describe('useGitStore connection PR modal state', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    request = vi.fn().mockResolvedValue([])
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    ;({ useGitStore } = await import('../useGitStore'))
+    useGitStore.setState({
+      createPRModalOpen: false,
+      createPRWorktreeId: null,
+      createPRWorktreePath: null,
+      connectionPRModalOpen: false,
+      connectionPRConnectionId: null
+    })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+  })
+
+  it('opens the connection PR modal with a connection id', () => {
+    useGitStore.getState().setConnectionPRModalOpen(true, 'conn-1')
+
+    expect(useGitStore.getState().connectionPRModalOpen).toBe(true)
+    expect(useGitStore.getState().connectionPRConnectionId).toBe('conn-1')
+  })
+
+  it('ignores opening without a connection id', () => {
+    useGitStore.getState().setConnectionPRModalOpen(true)
+
+    expect(useGitStore.getState().connectionPRModalOpen).toBe(false)
+    expect(useGitStore.getState().connectionPRConnectionId).toBeNull()
+  })
+
+  it('clears the connection id on close', () => {
+    useGitStore.getState().setConnectionPRModalOpen(true, 'conn-1')
+    useGitStore.getState().setConnectionPRModalOpen(false)
+
+    expect(useGitStore.getState().connectionPRModalOpen).toBe(false)
+    expect(useGitStore.getState().connectionPRConnectionId).toBeNull()
+  })
+
+  it('keeps the single-worktree modal state independent', () => {
+    useGitStore.getState().setCreatePRModalOpen(true, {
+      worktreeId: 'wt-1',
+      worktreePath: '/repo/wt-1'
+    })
+    useGitStore.getState().setConnectionPRModalOpen(true, 'conn-1')
+    useGitStore.getState().setConnectionPRModalOpen(false)
+
+    expect(useGitStore.getState().createPRModalOpen).toBe(true)
+    expect(useGitStore.getState().createPRWorktreeId).toBe('wt-1')
+  })
+})

--- a/src/renderer/src/stores/useGitStore.ts
+++ b/src/renderer/src/stores/useGitStore.ts
@@ -84,6 +84,10 @@ interface GitStoreState {
   createPRWorktreeId: string | null
   createPRWorktreePath: string | null
 
+  // Connection PR modal
+  connectionPRModalOpen: boolean
+  connectionPRConnectionId: string | null
+
   // Actions
   loadFileStatuses: (worktreePath: string, opts?: { force?: boolean }) => Promise<void>
   loadBranchInfo: (worktreePath: string, opts?: { force?: boolean }) => Promise<void>
@@ -126,6 +130,9 @@ interface GitStoreState {
     open: boolean,
     context?: { worktreeId: string; worktreePath: string }
   ) => void
+
+  // Connection PR modal actions
+  setConnectionPRModalOpen: (open: boolean, connectionId?: string) => void
 
   // Commit, Push, Pull actions
   commit: (
@@ -182,6 +189,10 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
   createPRModalOpen: false,
   createPRWorktreeId: null,
   createPRWorktreePath: null,
+
+  // Connection PR modal
+  connectionPRModalOpen: false,
+  connectionPRConnectionId: null,
 
   // Load file statuses for a worktree
   loadFileStatuses: async (worktreePath: string, opts?: { force?: boolean }) => {
@@ -633,6 +644,16 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
       })
     }
     // Opening without context is a no-op (all callers must provide context)
+  },
+
+  // Open/close connection PR modal
+  setConnectionPRModalOpen: (open: boolean, connectionId?: string) => {
+    if (open && connectionId) {
+      set({ connectionPRModalOpen: true, connectionPRConnectionId: connectionId })
+    } else if (!open) {
+      set({ connectionPRModalOpen: false, connectionPRConnectionId: null })
+    }
+    // Opening without a connection id is a no-op (all callers must provide one)
   },
 
   setCreatingPR: (worktreeId: string, creating: boolean) => {

--- a/src/renderer/src/stores/usePRNotificationStore.ts
+++ b/src/renderer/src/stores/usePRNotificationStore.ts
@@ -15,6 +15,8 @@ interface PRNotification {
   prNumber?: number
   prTitle?: string
   worktreeId?: string
+  /** Render an Archive button for worktrees with nothing to PR */
+  showArchiveButton?: boolean
 }
 
 interface PRNotificationState {


### PR DESCRIPTION
## Summary
- Adds a new connection PR modal that can create one pull request per eligible connected worktree.
- Adds connection-mode PR entry points in the header and app layout, with preloading of GitHub remote info for connection members.
- Refactors single-worktree PR creation to use a shared PR pipeline, and adds new connection PR helpers plus tests.
- Updates notification behavior to support the new connection PR flow.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-worktree git commit, push, and GitHub PR creation with partial failure isolation; behavior is refactored but still operationally sensitive.
> 
> **Overview**
> Adds **connection-mode PR creation**: when a connection (not a single worktree) is selected, the header shows a **PR** button (after pre-warming GitHub remote info for members) that opens a new **`ConnectionPRModal`**.
> 
> The modal assesses each connected worktree, then walks through **commit** (shared message across repos), **form** (per-project include/base branch, shared title/body), or **empty** states. Background work uses new **`connection-pr`** helpers (`assessConnectionMembers`, `commitConnectionMembers`, `createConnectionPRs`) with per-member isolation, attached-PR push-only paths, and **archive prompts** for clean non-default members.
> 
> **`CreatePRModal`** no longer embeds push/generate/create logic; it delegates to shared **`runCreatePRPipeline`** in **`pr-pipeline`**. **`useGitStore`** gains connection modal state; **`PRNotificationStack`** can show an **Archive** action via `showArchiveButton` on notifications.
> 
> Also adds a **verify** Claude skill doc for E2E testing and broad unit tests for the new flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 789a9e5066b6a39dd811467974f618cb1f72472a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->