### PR TITLE
Add plan export to markdown files

### DIFF
--- a/src/main/services/file-ops.ts
+++ b/src/main/services/file-ops.ts
@@ -81,3 +81,49 @@ export function writeFile(filePath: string, content: string): { success: boolean
     return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
   }
 }
+
+export function createFile(
+  directoryPath: string,
+  fileName: string,
+  content: string,
+  overwrite: boolean
+): { success: boolean; error?: string; code?: string } {
+  try {
+    if (!directoryPath || typeof directoryPath !== 'string') {
+      return { success: false, error: 'Invalid directory path', code: 'DirectoryNotFound' }
+    }
+    if (typeof content !== 'string') {
+      return { success: false, error: 'Invalid content', code: 'InvalidContent' }
+    }
+    if (
+      !fileName ||
+      typeof fileName !== 'string' ||
+      fileName.includes('/') ||
+      fileName.includes('\\') ||
+      fileName === '.' ||
+      fileName === '..'
+    ) {
+      return { success: false, error: 'Invalid file name', code: 'InvalidFileName' }
+    }
+    if (!existsSync(directoryPath) || !statSync(directoryPath).isDirectory()) {
+      return { success: false, error: 'Directory does not exist', code: 'DirectoryNotFound' }
+    }
+    const filePath = join(directoryPath, fileName)
+    if (existsSync(filePath)) {
+      if (statSync(filePath).isDirectory()) {
+        return {
+          success: false,
+          error: 'A directory with this name exists',
+          code: 'InvalidFileName'
+        }
+      }
+      if (!overwrite) {
+        return { success: false, error: 'File already exists', code: 'FileAlreadyExists' }
+      }
+    }
+    writeFileSync(filePath, content, 'utf-8')
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+  }
+}

--- a/src/renderer/src/api/__tests__/file-api.test.ts
+++ b/src/renderer/src/api/__tests__/file-api.test.ts
@@ -85,4 +85,41 @@ describe('fileApi', () => {
       content: '# Hive'
     })
   })
+
+  it('routes createFile through the renderer RPC client', async () => {
+    const request = vi.fn().mockResolvedValue(null)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(
+      fileApi.createFile('/tmp/hive', 'PLAN_feature.md', '# Plan', false)
+    ).resolves.toEqual({
+      success: true,
+      value: null
+    })
+    expect(request).toHaveBeenCalledWith('fileOps.createFile', {
+      directoryPath: '/tmp/hive',
+      fileName: 'PLAN_feature.md',
+      content: '# Plan',
+      overwrite: false
+    })
+  })
+
+  it('surfaces the RPC error code when createFile rejects', async () => {
+    const error = new Error('File already exists')
+    error.name = 'FileAlreadyExists'
+    const request = vi.fn().mockRejectedValue(error)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(
+      fileApi.createFile('/tmp/hive', 'PLAN_feature.md', '# Plan', false)
+    ).resolves.toEqual({
+      success: false,
+      errorCode: 'FileAlreadyExists',
+      error: 'File already exists'
+    })
+  })
 })

--- a/src/renderer/src/api/file-api.ts
+++ b/src/renderer/src/api/file-api.ts
@@ -70,5 +70,19 @@ export const fileApi = {
         filePath,
         content
       })
+    ),
+  createFile: (
+    directoryPath: string,
+    fileName: string,
+    content: string,
+    overwrite: boolean
+  ): Promise<Envelope<null>> =>
+    toEnvelope(
+      getRendererRpcClient().request<null>('fileOps.createFile', {
+        directoryPath,
+        fileName,
+        content,
+        overwrite
+      })
     )
 }

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -15,6 +15,7 @@ import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalCont
 import { QuestionPrompt } from './QuestionPrompt'
 import { ClaudeCliEndedOverlay } from './ClaudeCliEndedOverlay'
 import { HandoffSplitButton } from './HandoffSplitButton'
+import { SavePlanAsFileModal } from './SavePlanAsFileModal'
 import { buildHandoffPrompt, type HandoffSelectionOverride } from '@/lib/handoffSelection'
 import { lastSendMode } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
@@ -26,7 +27,7 @@ import {
 } from '@/lib/hive-enterprise-telemetry'
 import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
-import { extractPlanTitle } from '@shared/types/branch-utils'
+import { extractPlanTitle, normalizeFilename } from '@shared/types/branch-utils'
 import { supportsGoalMode } from '@shared/types/agent-sdk'
 import '@xterm/xterm/css/xterm.css'
 import '@/styles/xterm.css'
@@ -129,6 +130,7 @@ interface ClaudeCliPlanReadyCardProps {
   worktreeId?: string
   onHandoff: (override: HandoffSelectionOverride) => void
   onSaveAsTicket: () => void
+  onSaveAsFile: () => void
   savedAsTicket: boolean
 }
 
@@ -137,6 +139,7 @@ function ClaudeCliPlanReadyCard({
   worktreeId,
   onHandoff,
   onSaveAsTicket,
+  onSaveAsFile,
   savedAsTicket
 }: ClaudeCliPlanReadyCardProps): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -272,6 +275,17 @@ function ClaudeCliPlanReadyCard({
           >
             {savedAsTicket ? 'Saved as ticket' : 'Save as ticket'}
           </button>
+          <button
+            type="button"
+            onClick={onSaveAsFile}
+            className={cn(
+              'h-8 rounded-full border border-border bg-muted/80 px-3 text-xs font-medium',
+              'text-foreground shadow-md transition-colors hover:bg-muted'
+            )}
+            data-testid="claude-cli-plan-ready-save-file"
+          >
+            Save as md file
+          </button>
         </div>
       </div>
     </div>
@@ -286,6 +300,11 @@ export function ClaudeCliSessionView({
   const [terminalKey, setTerminalKey] = useState(0)
   const [ended, setEnded] = useState(false)
   const [planSavedAsTicket, setPlanSavedAsTicket] = useState(false)
+  // Captured at click time so the modal survives pendingPlan being cleared
+  const [savePlanFile, setSavePlanFile] = useState<{
+    planContent: string
+    directoryPath: string
+  } | null>(null)
   const pendingPlan = useSessionStore((state) => state.pendingPlans.get(sessionId) ?? null)
   const { getTarget, revision: portalRevision } = useClaudeCliSessionPortal()
   void portalRevision
@@ -482,6 +501,26 @@ export function ClaudeCliSessionView({
     }
   }, [pendingPlan?.planContent, sessionRecord?.project_id])
 
+  const handlePlanReadySaveAsFile = useCallback(() => {
+    const planContent = pendingPlan?.planContent
+    if (!planContent) {
+      toast.error('No plan content found')
+      return
+    }
+
+    const directoryPath = sessionRecord?.worktree_id
+      ? findWorktreePathById(sessionRecord.worktree_id)
+      : sessionRecord?.connection_id
+        ? findConnectionPathById(sessionRecord.connection_id)
+        : null
+    if (!directoryPath) {
+      toast.error('No worktree path for this session')
+      return
+    }
+
+    setSavePlanFile({ planContent, directoryPath })
+  }, [pendingPlan?.planContent, sessionRecord?.worktree_id, sessionRecord?.connection_id])
+
   const resolveQuestionPath = useCallback((): string | undefined => {
     if (sessionRecord?.worktree_id) {
       return findWorktreePathById(sessionRecord.worktree_id) ?? undefined
@@ -549,7 +588,19 @@ export function ClaudeCliSessionView({
             worktreeId={sessionRecord?.worktree_id ?? undefined}
             onHandoff={handlePlanReadyHandoff}
             onSaveAsTicket={handlePlanReadySaveAsTicket}
+            onSaveAsFile={handlePlanReadySaveAsFile}
             savedAsTicket={planSavedAsTicket}
+          />
+        )}
+        {savePlanFile && (
+          <SavePlanAsFileModal
+            open
+            onOpenChange={(o) => {
+              if (!o) setSavePlanFile(null)
+            }}
+            planContent={savePlanFile.planContent}
+            directoryPath={savePlanFile.directoryPath}
+            defaultFileName={`PLAN_${normalizeFilename(extractPlanTitle(savePlanFile.planContent) ?? '') || 'plan'}.md`}
           />
         )}
         {/* In the ticket modal the modal renders its own question sidebar, so only

--- a/src/renderer/src/components/sessions/PlanReadyImplementFab.tsx
+++ b/src/renderer/src/components/sessions/PlanReadyImplementFab.tsx
@@ -27,6 +27,7 @@ interface PlanReadyImplementFabProps {
   superpowersAvailable?: boolean
   isConnectionSession?: boolean
   onSaveAsTicket?: () => void
+  onSaveAsFile?: () => void
   worktreeId?: string
 }
 
@@ -40,6 +41,7 @@ export function PlanReadyImplementFab({
   superpowersAvailable,
   isConnectionSession,
   onSaveAsTicket,
+  onSaveAsFile,
   worktreeId
 }: PlanReadyImplementFabProps): React.JSX.Element {
   const vimModeEnabled = useSettingsStore((s) => s.vimModeEnabled)
@@ -68,6 +70,27 @@ export function PlanReadyImplementFab({
           data-testid="plan-ready-save-ticket-fab"
         >
           {vimModeEnabled ? <MnemonicLabel letter="s" label="Save as ticket" /> : 'Save as ticket'}
+        </button>
+      )}
+      {onSaveAsFile && (
+        <button
+          onClick={onSaveAsFile}
+          className={cn(
+            'h-8 rounded-full px-3',
+            'text-xs font-medium',
+            'bg-muted/80 text-foreground border border-border',
+            'shadow-md hover:bg-muted transition-colors duration-200',
+            'cursor-pointer',
+            visible ? 'opacity-100' : 'opacity-0'
+          )}
+          aria-label="Save plan as md file"
+          data-testid="plan-ready-save-file-fab"
+        >
+          {vimModeEnabled ? (
+            <MnemonicLabel letter="f" label="Save as md file" />
+          ) : (
+            'Save as md file'
+          )}
         </button>
       )}
       <button

--- a/src/renderer/src/components/sessions/SavePlanAsFileModal.tsx
+++ b/src/renderer/src/components/sessions/SavePlanAsFileModal.tsx
@@ -1,0 +1,168 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { toast } from '@/lib/toast'
+import { fileApi } from '@/api/file-api'
+
+interface SavePlanAsFileModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  planContent: string
+  directoryPath: string
+  defaultFileName: string
+}
+
+export function SavePlanAsFileModal({
+  open,
+  onOpenChange,
+  planContent,
+  directoryPath,
+  defaultFileName
+}: SavePlanAsFileModalProps): React.JSX.Element {
+  const [fileName, setFileName] = useState(defaultFileName)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [confirmingOverwrite, setConfirmingOverwrite] = useState(false)
+
+  const fileNameInputRef = useRef<HTMLInputElement>(null)
+
+  // Reset form when modal opens
+  useEffect(() => {
+    if (open) {
+      setFileName(defaultFileName)
+      setErrorMessage(null)
+      setIsSaving(false)
+      setConfirmingOverwrite(false)
+      // Auto-focus the input after dialog animation
+      setTimeout(() => {
+        fileNameInputRef.current?.focus()
+        fileNameInputRef.current?.select()
+      }, 50)
+    }
+  }, [open, defaultFileName])
+
+  const handleSave = useCallback(
+    async (overwrite: boolean) => {
+      const trimmed = fileName.trim()
+      if (!trimmed || isSaving) return
+      if (trimmed.includes('/') || trimmed.includes('\\')) {
+        setErrorMessage('File name cannot contain slashes')
+        return
+      }
+      const finalName = trimmed.toLowerCase().endsWith('.md') ? trimmed : `${trimmed}.md`
+
+      setIsSaving(true)
+      setErrorMessage(null)
+      try {
+        const envelope = await fileApi.createFile(directoryPath, finalName, planContent, overwrite)
+        if (envelope.success) {
+          toast.success(`Saved ${finalName}`)
+          onOpenChange(false)
+          return
+        }
+        if (envelope.errorCode === 'FileAlreadyExists') {
+          setConfirmingOverwrite(true)
+          return
+        }
+        toast.error(envelope.error ?? 'Failed to save plan file')
+      } catch {
+        toast.error('Failed to save plan file')
+      } finally {
+        setIsSaving(false)
+      }
+    },
+    [fileName, isSaving, directoryPath, planContent, onOpenChange]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && fileName.trim()) {
+        e.preventDefault()
+        handleSave(confirmingOverwrite)
+      }
+    },
+    [handleSave, fileName, confirmingOverwrite]
+  )
+
+  const isFileNameEmpty = !fileName.trim()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        data-testid="save-plan-file-modal"
+        className="sm:max-w-md"
+        onKeyDown={handleKeyDown}
+      >
+        <DialogHeader>
+          <DialogTitle>Save plan as md file</DialogTitle>
+          <DialogDescription>
+            The plan will be saved in the worktree root directory.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1.5">
+          <label htmlFor="save-plan-file-name" className="text-sm font-medium text-foreground">
+            File name
+          </label>
+          <Input
+            id="save-plan-file-name"
+            ref={fileNameInputRef}
+            data-testid="save-plan-file-input"
+            value={fileName}
+            onChange={(e) => {
+              setFileName(e.target.value)
+              setErrorMessage(null)
+              setConfirmingOverwrite(false)
+            }}
+            autoFocus
+          />
+          {errorMessage && <p className="text-xs text-destructive">{errorMessage}</p>}
+          {confirmingOverwrite && (
+            <p className="text-xs text-destructive" data-testid="save-plan-file-overwrite-warning">
+              A file with this name already exists. Overwrite it?
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            data-testid="save-plan-file-cancel-btn"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          {confirmingOverwrite ? (
+            <Button
+              type="button"
+              variant="destructive"
+              data-testid="save-plan-file-overwrite-btn"
+              disabled={isFileNameEmpty || isSaving}
+              onClick={() => handleSave(true)}
+            >
+              Overwrite
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              data-testid="save-plan-file-ok-btn"
+              disabled={isFileNameEmpty || isSaving}
+              onClick={() => handleSave(false)}
+            >
+              Ok
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -43,6 +43,7 @@ import { SlashCommandPopover } from './SlashCommandPopover'
 import { FileMentionPopover } from './FileMentionPopover'
 import { ScrollToBottomFab } from './ScrollToBottomFab'
 import { PlanReadyImplementFab } from './PlanReadyImplementFab'
+import { SavePlanAsFileModal } from './SavePlanAsFileModal'
 import { IndeterminateProgressBar } from './IndeterminateProgressBar'
 import { TaskListWidget } from './TaskListWidget'
 import { GoalStatusWidget } from './GoalStatusWidget'
@@ -58,7 +59,11 @@ import type { CodexThreadGoal } from '@/stores/useSessionStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useContextStore } from '@/stores/useContextStore'
 import { maybeExtractJsonTitle } from '@shared/title-utils'
-import { canonicalizeTicketTitle, extractPlanTitle } from '@shared/types/branch-utils'
+import {
+  canonicalizeTicketTitle,
+  extractPlanTitle,
+  normalizeFilename
+} from '@shared/types/branch-utils'
 import { supportsGoalMode } from '@shared/types/agent-sdk'
 import type { TokenInfo, SessionModelRef } from '@/stores/useContextStore'
 import {
@@ -89,10 +94,7 @@ import { COMPLETION_WORDS } from '@/lib/format-utils'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline, computeTokenDelta } from '@/lib/token-baselines'
-import {
-  notifyKanbanSessionSync,
-  notifyKanbanAutoCreateTicket
-} from '@/stores/store-coordination'
+import { notifyKanbanSessionSync, notifyKanbanAutoCreateTicket } from '@/stores/store-coordination'
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
@@ -712,6 +714,11 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
   const [sessionErrorStderr, setSessionErrorStderr] = useState<string | null>(null)
   const [retryTickMs, setRetryTickMs] = useState<number>(Date.now())
   const [planSavedAsTicket, setPlanSavedAsTicket] = useState(false)
+  // Captured at click time so the modal survives pendingPlan being cleared
+  const [savePlanFile, setSavePlanFile] = useState<{
+    planContent: string
+    directoryPath: string
+  } | null>(null)
 
   // Prompt history key: works for both worktree and connection sessions
   const historyKey = worktreeId ?? connectionId
@@ -5375,6 +5382,25 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
     }
   }, [messages, pendingPlan, sessionRecord?.project_id])
 
+  const handlePlanReadySaveAsFile = useCallback(() => {
+    if (!worktreePath) {
+      toast.error('No worktree path for this session')
+      return
+    }
+
+    const planContent =
+      pendingPlan?.planContent ??
+      [...messages].reverse().find((m) => m.role === 'assistant' && m.content.trim().length > 0)
+        ?.content
+
+    if (!planContent) {
+      toast.error('No plan content found')
+      return
+    }
+
+    setSavePlanFile({ planContent, directoryPath: worktreePath })
+  }, [messages, pendingPlan, worktreePath])
+
   // Abort streaming
   const handleAbort = useCallback(async () => {
     if (isBashRunning) {
@@ -6182,6 +6208,7 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
               ? handlePlanReadySaveAsTicket
               : undefined
           }
+          onSaveAsFile={worktreePath ? handlePlanReadySaveAsFile : undefined}
         />
         {/* Scroll-to-bottom FAB */}
         <ScrollToBottomFab
@@ -6473,6 +6500,19 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
           open={ticketPickerOpen}
           onOpenChange={setTicketPickerOpen}
           onSelectTickets={handleTicketPickerSelect}
+        />
+      )}
+
+      {/* Save plan as md file modal */}
+      {savePlanFile && (
+        <SavePlanAsFileModal
+          open
+          onOpenChange={(o) => {
+            if (!o) setSavePlanFile(null)
+          }}
+          planContent={savePlanFile.planContent}
+          directoryPath={savePlanFile.directoryPath}
+          defaultFileName={`PLAN_${normalizeFilename(extractPlanTitle(savePlanFile.planContent) ?? '') || 'plan'}.md`}
         />
       )}
     </div>

--- a/src/renderer/src/hooks/useVimNavigation.ts
+++ b/src/renderer/src/hooks/useVimNavigation.ts
@@ -70,7 +70,8 @@ export function useVimNavigation(): void {
         A: 'plan-ready-handoff-chevron',
         u: 'plan-ready-supercharge-fab',
         o: 'plan-ready-supercharge-local-fab',
-        s: 'plan-ready-save-ticket-fab'
+        s: 'plan-ready-save-ticket-fab',
+        f: 'plan-ready-save-file-fab'
       }
       const testId = keyToTestId[key]
       if (!testId) return false
@@ -193,7 +194,8 @@ export function useVimNavigation(): void {
         event.key === 'o' ||
         event.key === 'a' ||
         event.key === 'A' ||
-        event.key === 's'
+        event.key === 's' ||
+        event.key === 'f'
       ) {
         if (clickPlanFabButton(event.key)) {
           event.preventDefault()

--- a/src/server/__tests__/file-rpc.mock-provider.test.ts
+++ b/src/server/__tests__/file-rpc.mock-provider.test.ts
@@ -108,6 +108,64 @@ describe('file ops RPC mocked provider', () => {
     })
   })
 
+  it('routes fileOps.createFile to the injected provider service', async () => {
+    const createFile = vi.fn(() => Effect.succeed(null))
+    const service = { createFile } as unknown as FileOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      fileOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'file-create-file-1',
+        method: 'fileOps.createFile',
+        params: {
+          directoryPath: '/tmp/hive',
+          fileName: 'PLAN_feature.md',
+          content: '# Plan',
+          overwrite: true
+        }
+      })
+    )
+
+    expect(createFile).toHaveBeenCalledWith('/tmp/hive', 'PLAN_feature.md', '# Plan', true)
+    expect(response).toEqual({
+      id: 'file-create-file-1',
+      ok: true,
+      value: null
+    })
+  })
+
+  it('validates fileOps.createFile params before calling the provider service', async () => {
+    const createFile = vi.fn(() => Effect.succeed(null))
+    const service = { createFile } as unknown as FileOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      fileOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'file-create-file-invalid',
+        method: 'fileOps.createFile',
+        params: {
+          directoryPath: '/tmp/hive',
+          fileName: '',
+          content: '# Plan',
+          overwrite: false
+        }
+      })
+    )
+
+    expect(createFile).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      id: 'file-create-file-invalid',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
+
   it('routes fileOps.readImageAsBase64 to the injected provider service', async () => {
     const result = { data: 'aGVsbG8=', mimeType: 'image/png' }
     const readImageAsBase64 = vi.fn(() => Effect.succeed(result))

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -2987,6 +2987,7 @@ describe('rpc router', () => {
             return { success: true, content: 'hello from http' }
           }),
         writeFile: () => Effect.succeed(null),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: () => Effect.succeed({ data: 'unused' })
       }
     })
@@ -3013,6 +3014,7 @@ describe('rpc router', () => {
       fileOps: {
         readFile: () => Effect.succeed({ success: false, error: 'should not run' }),
         writeFile: () => Effect.succeed(null),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: () => Effect.succeed({ data: 'unused' })
       }
     })
@@ -3043,6 +3045,7 @@ describe('rpc router', () => {
             calls.push({ filePath, content })
             return null
           }),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: () => Effect.succeed({ data: 'unused' })
       }
     })
@@ -3069,6 +3072,7 @@ describe('rpc router', () => {
       fileOps: {
         readFile: () => Effect.succeed({ success: false, error: 'unused' }),
         writeFile: () => Effect.succeed(null),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: () => Effect.succeed({ data: 'unused' })
       }
     })
@@ -3088,6 +3092,81 @@ describe('rpc router', () => {
     })
   })
 
+  it('handles fileOps.createFile through the file ops RPC domain', async () => {
+    const calls: Array<{
+      directoryPath: string
+      fileName: string
+      content: string
+      overwrite: boolean
+    }> = []
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      fileOps: {
+        readFile: () => Effect.succeed({ success: false, error: 'unused' }),
+        writeFile: () => Effect.succeed(null),
+        createFile: (directoryPath, fileName, content, overwrite) =>
+          Effect.sync(() => {
+            calls.push({ directoryPath, fileName, content, overwrite })
+            return null
+          }),
+        readImageAsBase64: () => Effect.succeed({ data: 'unused' })
+      }
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'file-ops-create-file-1',
+        method: 'fileOps.createFile',
+        params: {
+          directoryPath: '/tmp/hive',
+          fileName: 'PLAN_feature.md',
+          content: '# Plan',
+          overwrite: false
+        }
+      })
+    )
+
+    expect(response).toEqual({
+      id: 'file-ops-create-file-1',
+      ok: true,
+      value: null
+    })
+    expect(calls).toEqual([
+      {
+        directoryPath: '/tmp/hive',
+        fileName: 'PLAN_feature.md',
+        content: '# Plan',
+        overwrite: false
+      }
+    ])
+  })
+
+  it('validates fileOps.createFile params', async () => {
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      fileOps: {
+        readFile: () => Effect.succeed({ success: false, error: 'unused' }),
+        writeFile: () => Effect.succeed(null),
+        createFile: () => Effect.succeed(null),
+        readImageAsBase64: () => Effect.succeed({ data: 'unused' })
+      }
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'file-ops-create-file-2',
+        method: 'fileOps.createFile',
+        params: { directoryPath: '/tmp/hive', fileName: 'PLAN_feature.md', content: '# Plan' }
+      })
+    )
+
+    expect(response).toMatchObject({
+      id: 'file-ops-create-file-2',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
+
   it('handles fileOps.readImageAsBase64 through the file ops RPC domain', async () => {
     const calls: string[] = []
     const router = makeRpcRouter({
@@ -3095,6 +3174,7 @@ describe('rpc router', () => {
       fileOps: {
         readFile: () => Effect.succeed({ success: false, error: 'unused' }),
         writeFile: () => Effect.succeed(null),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: (filePath) =>
           Effect.sync(() => {
             calls.push(filePath)
@@ -3125,6 +3205,7 @@ describe('rpc router', () => {
       fileOps: {
         readFile: () => Effect.succeed({ success: false, error: 'unused' }),
         writeFile: () => Effect.succeed(null),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: () => Effect.succeed({ data: 'unused' })
       }
     })

--- a/src/server/rpc/domains/file-ops.ts
+++ b/src/server/rpc/domains/file-ops.ts
@@ -1,6 +1,6 @@
 import { Effect } from 'effect'
 import { z } from 'zod'
-import { readFile, readFileAsBase64, writeFile } from '../../../main/services/file-ops'
+import { createFile, readFile, readFileAsBase64, writeFile } from '../../../main/services/file-ops'
 import { RpcRouteError } from '../../../shared/rpc/errors'
 import type { RpcHandler } from '../router'
 
@@ -18,6 +18,12 @@ export interface FileImageReadResult {
 export interface FileOpsRpcService {
   readonly readFile: (filePath: string) => Effect.Effect<FileReadResult, unknown, never>
   readonly writeFile: (filePath: string, content: string) => Effect.Effect<null, unknown, never>
+  readonly createFile: (
+    directoryPath: string,
+    fileName: string,
+    content: string,
+    overwrite: boolean
+  ) => Effect.Effect<null, unknown, never>
   readonly readImageAsBase64: (
     filePath: string
   ) => Effect.Effect<FileImageReadResult, unknown, never>
@@ -26,6 +32,14 @@ export interface FileOpsRpcService {
 const readFileParamsSchema = z.object({ filePath: z.string().min(1) }).strict()
 const writeFileParamsSchema = z
   .object({ filePath: z.string().min(1), content: z.string() })
+  .strict()
+const createFileParamsSchema = z
+  .object({
+    directoryPath: z.string().min(1),
+    fileName: z.string().min(1),
+    content: z.string(),
+    overwrite: z.boolean()
+  })
   .strict()
 const readImageAsBase64ParamsSchema = z.object({ filePath: z.string().min(1) }).strict()
 
@@ -39,6 +53,17 @@ export const makeLiveFileOpsRpcService = (): FileOpsRpcService => ({
       const result = writeFile(filePath, content)
       if (result.success) return Effect.succeed(null)
       return Effect.fail(new Error(result.error ?? 'Unknown error'))
+    }),
+  createFile: (directoryPath, fileName, content, overwrite) =>
+    Effect.suspend(() => {
+      const result = createFile(directoryPath, fileName, content, overwrite)
+      if (result.success) return Effect.succeed(null)
+      return Effect.fail(
+        new RpcRouteError(result.code ?? 'FileCreateFailed', result.error ?? 'Unknown error', {
+          directoryPath,
+          fileName
+        })
+      )
     }),
   readImageAsBase64: (filePath) =>
     Effect.suspend(() => {
@@ -79,6 +104,17 @@ export const makeFileOpsRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.writeFile(filePath, content)
+        })
+    ],
+    [
+      'fileOps.createFile',
+      (params) =>
+        Effect.gen(function* () {
+          const { directoryPath, fileName, content, overwrite } = yield* Effect.try({
+            try: () => createFileParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.createFile(directoryPath, fileName, content, overwrite)
         })
     ],
     [

--- a/src/shared/__tests__/branch-utils.test.ts
+++ b/src/shared/__tests__/branch-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeFilename } from '../types/branch-utils'
+
+describe('normalizeFilename', () => {
+  it('converts spaces to underscores', () => {
+    expect(normalizeFilename('save plan as md file')).toBe('save_plan_as_md_file')
+  })
+
+  it('preserves case', () => {
+    expect(normalizeFilename('Save Plan As MD File')).toBe('Save_Plan_As_MD_File')
+  })
+
+  it('strips filesystem-unsafe characters', () => {
+    expect(normalizeFilename('fix: auth/login (v2)!')).toBe('fix_authlogin_v2')
+  })
+
+  it('collapses consecutive underscores', () => {
+    expect(normalizeFilename('a  -  b')).toBe('a_-_b')
+    expect(normalizeFilename('a __ b')).toBe('a_b')
+  })
+
+  it('strips leading and trailing separators', () => {
+    expect(normalizeFilename('...plan title...')).toBe('plan_title')
+    expect(normalizeFilename('__plan__')).toBe('plan')
+  })
+
+  it('caps length at 64 characters without trailing separators', () => {
+    const long = 'word '.repeat(20).trim()
+    const result = normalizeFilename(long)
+    expect(result.length).toBeLessThanOrEqual(64)
+    expect(result).not.toMatch(/[._-]$/)
+  })
+
+  it('returns an empty string for all-unsafe input', () => {
+    expect(normalizeFilename('!@#$%^&*()')).toBe('')
+    expect(normalizeFilename('   ')).toBe('')
+  })
+})

--- a/src/shared/types/branch-utils.ts
+++ b/src/shared/types/branch-utils.ts
@@ -22,6 +22,23 @@ export function canonicalizeTicketTitle(title: string): string {
     .replace(/-+$/, '') // strip trailing dashes after truncation
 }
 
+/**
+ * Convert a plan title into a filesystem-safe filename fragment.
+ * Unlike canonicalizeTicketTitle (lowercase, 32-char cap for Windows
+ * worktree paths), this preserves case and keeps more of the title since
+ * the result is a user-visible, user-editable filename.
+ */
+export function normalizeFilename(title: string): string {
+  return title
+    .trim()
+    .replace(/\s+/g, '_') // underscore style matches the PLAN_ prefix
+    .replace(/[^A-Za-z0-9._-]/g, '') // strip filesystem-unsafe chars
+    .replace(/_{2,}/g, '_')
+    .replace(/^[._-]+|[._-]+$/g, '')
+    .slice(0, 64)
+    .replace(/[._-]+$/, '')
+}
+
 function normalizePlanTitle(title: string): string {
   const trimmed = title.trim()
   const withoutPrefix = trimmed.replace(/^plan\s*[:\-–—]\s*/i, '').trim()


### PR DESCRIPTION
## Summary
- Adds a new “Save as md file” flow for ready plans in both session views and the plan-ready FAB.
- Introduces a `SavePlanAsFileModal` that captures a filename, validates overwrite behavior, and writes the plan into the worktree root.
- Adds renderer, server RPC, and main-process file creation support for `fileOps.createFile`.
- Adds shared filename normalization for plan-derived markdown filenames and covers it with tests.

## Testing
- Added unit tests for `fileApi.createFile` request routing and error mapping.
- Added RPC router tests for `fileOps.createFile` happy path and validation failures.
- Added mocked-provider tests to verify `fileOps.createFile` reaches the injected service.
- Added shared utility tests for `normalizeFilename` edge cases.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces filesystem writes from the UI with overwrite support; validation limits writes to a single filename under a known session directory, but mistaken overwrites are still possible.
> 
> **Overview**
> Adds **Save as md file** alongside the existing plan-ready actions in `SessionView`, `ClaudeCliSessionView`, and `PlanReadyImplementFab`, with vim shortcut **f** on the plan FAB.
> 
> A new **`SavePlanAsFileModal`** lets users edit the filename (default `PLAN_<title>.md` via new **`normalizeFilename`**), appends `.md` when needed, and prompts to overwrite when the file already exists. Plan content and directory are captured at click time so the modal still works if `pendingPlan` clears.
> 
> End-to-end file creation is wired through **`fileApi.createFile`** → **`fileOps.createFile`** RPC → main **`createFile`**, which validates directory and basename (no path segments), supports optional overwrite, and returns structured error codes such as **`FileAlreadyExists`**. Unlike **`writeFile`**, this path can create new files under an existing directory.
> 
> Tests cover renderer RPC routing/error mapping, RPC router validation and dispatch, and **`normalizeFilename`** edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d8482f371f621e97d3bd10b678973342f477945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->