### PR TITLE
Auto-create plan files for oversized goal prompts

### DIFF
--- a/src/main/services/file-ops.create-file.test.ts
+++ b/src/main/services/file-ops.create-file.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createFile } from './file-ops'
+
+describe('createFile', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'hive-file-ops-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('creates a new file with the given content', () => {
+    const filePath = join(dir, 'PLAN_test.md')
+    const result = createFile(filePath, '# Plan\n\ncontent')
+
+    expect(result).toEqual({ success: true })
+    expect(readFileSync(filePath, 'utf-8')).toBe('# Plan\n\ncontent')
+  })
+
+  it('fails when the file already exists and keeps the original content', () => {
+    const filePath = join(dir, 'existing.md')
+    writeFileSync(filePath, 'original', 'utf-8')
+
+    const result = createFile(filePath, 'replacement')
+
+    expect(result.success).toBe(false)
+    expect(readFileSync(filePath, 'utf-8')).toBe('original')
+  })
+
+  it('fails when the parent directory does not exist', () => {
+    const result = createFile(join(dir, 'missing-dir', 'PLAN_test.md'), 'content')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeTruthy()
+  })
+
+  it('rejects an empty file path', () => {
+    expect(createFile('', 'content')).toEqual({ success: false, error: 'Invalid file path' })
+  })
+})

--- a/src/main/services/file-ops.ts
+++ b/src/main/services/file-ops.ts
@@ -1,5 +1,4 @@
 import { readFileSync, writeFileSync, existsSync, statSync } from 'fs'
-import { join } from 'path'
 import { getImageMimeType } from '@shared/types/file-utils'
 
 const MAX_FILE_SIZE = 1024 * 1024 // 1MB
@@ -76,6 +75,22 @@ export function writeFile(filePath: string, content: string): { success: boolean
       return { success: false, error: 'Path is a directory' }
     }
     writeFileSync(filePath, content, 'utf-8')
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+  }
+}
+
+export function createFile(filePath: string, content: string): { success: boolean; error?: string } {
+  try {
+    if (!filePath || typeof filePath !== 'string') {
+      return { success: false, error: 'Invalid file path' }
+    }
+    if (typeof content !== 'string') {
+      return { success: false, error: 'Invalid content' }
+    }
+    // 'wx' fails with EEXIST if the file already exists — create-only semantics
+    writeFileSync(filePath, content, { encoding: 'utf-8', flag: 'wx' })
     return { success: true }
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }

--- a/src/renderer/src/api/file-api.ts
+++ b/src/renderer/src/api/file-api.ts
@@ -70,5 +70,12 @@ export const fileApi = {
         filePath,
         content
       })
+    ),
+  createFile: (filePath: string, content: string): Promise<Envelope<null>> =>
+    toEnvelope(
+      getRendererRpcClient().request<null>('fileOps.createFile', {
+        filePath,
+        content
+      })
     )
 }

--- a/src/renderer/src/components/kanban/WorktreePickerModal.goal-plan-file.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.goal-plan-file.test.tsx
@@ -1,0 +1,622 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorktreePickerModal, _resetLastSourceBranch } from './WorktreePickerModal'
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { opencodeApi } from '@/api/opencode-api'
+import { toast } from '@/lib/toast'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useUsageStore } from '@/stores/useUsageStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket, Session, Worktree } from '../../../../main/db/types'
+
+vi.mock('@/api/hive-enterprise/client', () => ({
+  isHiveTelemetryEnabled: vi.fn(() => false),
+  recordHivePromptStart: vi.fn(),
+  recordHivePromptIdle: vi.fn(),
+  recordHiveQuestionsAnswered: vi.fn()
+}))
+
+vi.mock('@/components/sessions/ModelSelector', () => ({
+  ModelSelector: () => <div data-testid="model-selector" />
+}))
+
+vi.mock('@/components/sessions/CodexFastToggle', () => ({
+  CodexFastToggle: () => <div data-testid="codex-fast-toggle" />
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@/api/settings-api', () => ({
+  settingsApi: {
+    detectEditors: vi.fn(),
+    detectTerminals: vi.fn(),
+    loadCustomCommandsFile: vi.fn().mockResolvedValue({ commands: [] }),
+    onSettingsUpdated: vi.fn(() => vi.fn()),
+    openWithTerminal: vi.fn()
+  }
+}))
+
+vi.mock('@/api/pet-api', () => ({
+  petApi: {
+    updateSettings: vi.fn().mockResolvedValue({
+      success: true,
+      value: { enabled: true, size: 'md', position: { x: 0, y: 0 }, hatched: true }
+    })
+  }
+}))
+
+vi.mock('@/api/opencode-api', () => ({
+  opencodeApi: {
+    connect: vi.fn(),
+    prompt: vi.fn()
+  }
+}))
+
+const initialSettingsState = useSettingsStore.getState()
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+const initialConnectionState = useConnectionStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialUsageState = useUsageStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
+
+// Long enough that the built prompt (prefix + <ticket> XML) exceeds 3k chars.
+const LONG_DESCRIPTION = 'Implement all the things. '.repeat(150)
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'project-1',
+    title: 'Goal ticket',
+    description: 'Short description',
+    column: 'todo',
+    sort_order: 0,
+    worktree_id: null,
+    current_session_id: null,
+    mode: 'build',
+    plan_ready: false,
+    goal_mode: false,
+    goal_success_criteria: null,
+    pending_launch_config: null,
+    created_from_session: false,
+    attachments: [],
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    note: null,
+    total_tokens: 0,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'worktree-1',
+    project_id: 'project-1',
+    name: 'Feature',
+    branch_name: 'feature',
+    path: '/repo/feature',
+    status: 'active',
+    is_default: false,
+    branch_renamed: 0,
+    last_message_at: null,
+    session_titles: '[]',
+    last_model_provider_id: null,
+    last_model_id: null,
+    last_model_variant: null,
+    attachments: '[]',
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_accessed_at: '2026-01-01T00:00:00.000Z',
+    github_pr_number: null,
+    github_pr_url: null,
+    ...overrides
+  } as Worktree
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    pinned_to_board: false,
+    ...overrides
+  }
+}
+
+function setupStores(): void {
+  const createSession = vi.fn(
+    async (
+      worktreeId: string,
+      projectId: string,
+      sdk: Session['agent_sdk'] = 'opencode',
+      mode: Session['mode'] = 'build'
+    ) => ({
+      success: true,
+      session: makeSession({
+        worktree_id: worktreeId,
+        project_id: projectId,
+        agent_sdk: sdk,
+        mode: mode === 'super-plan' ? 'plan' : mode
+      })
+    })
+  )
+  const createConnectionSession = vi.fn(
+    async (connectionId: string, sdk: Session['agent_sdk'] = 'opencode') => ({
+      success: true,
+      session: makeSession({
+        id: 'connection-session-1',
+        worktree_id: null,
+        connection_id: connectionId,
+        agent_sdk: sdk
+      })
+    })
+  )
+
+  useSettingsStore.setState({
+    availableAgentSdks: { opencode: true, claude: true, codex: true },
+    defaultAgentSdk: 'opencode',
+    selectedModel: null,
+    selectedModelByProvider: {},
+    defaultModels: null,
+    codexFastMode: false,
+    codexFastModeAccepted: true,
+    boardMode: 'toggle'
+  })
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '/repo',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        worktree_create_script: null,
+        custom_commands: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        last_accessed_at: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([['project-1', [makeWorktree()]]]),
+    worktreeOrderByProject: new Map(),
+    syncWorktrees: vi.fn(),
+    createWorktreeFromBranch: vi.fn()
+  })
+  useConnectionStore.setState({
+    connections: [
+      {
+        id: 'connection-1',
+        name: 'Feature connection',
+        custom_name: null,
+        status: 'active',
+        path: '/repo/connection',
+        color: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        members: []
+      }
+    ],
+    loaded: true
+  })
+  useKanbanStore.setState({
+    tickets: new Map([['project-1', []]]),
+    updateTicket: vi.fn(async () => undefined),
+    computeSortOrder: vi.fn(() => 1),
+    getTicketsByColumn: vi.fn(() => []),
+    getTicketsByColumnForConnection: vi.fn(() => [])
+  })
+  useSessionStore.setState({
+    sessionsByWorktree: new Map(),
+    sessionsByConnection: new Map(),
+    modeBySession: new Map(),
+    createSession,
+    createConnectionSession,
+    setSessionModel: vi.fn(async () => undefined),
+    setSessionMode: vi.fn(async () => undefined),
+    setOpenCodeSessionId: vi.fn(),
+    setActiveSession: vi.fn(),
+    dequeuePendingMessage: vi.fn()
+  })
+  useWorktreeStatusStore.setState({
+    setSessionStatus: vi.fn(),
+    setLastMessageTime: vi.fn()
+  })
+  useUsageStore.setState({
+    fetchUsageForProvider: vi.fn()
+  })
+}
+
+async function enableGoalMode(criteria = 'Tests pass'): Promise<void> {
+  await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+  await userEvent.click(screen.getByTestId('goal-mode-toggle'))
+  await userEvent.type(screen.getByTestId('goal-success-criteria'), criteria)
+}
+
+function findRpcCall(
+  request: ReturnType<typeof vi.fn>,
+  method: string
+): unknown[] | undefined {
+  return request.mock.calls.find(([m]) => m === method)
+}
+
+describe('WorktreePickerModal goal plan-file conversion', () => {
+  let request: ReturnType<typeof vi.fn>
+
+  beforeAll(async () => {
+    // useSettingsStore schedules a one-shot 200ms timer on module import that
+    // reloads settings and re-detects agent SDKs; with the mocked RPC client it
+    // sets availableAgentSdks to null, unmounting the SDK toggle mid-test. Let
+    // it fire (against a mock client) before any test renders.
+    const bootRequest: ReturnType<typeof vi.fn> = vi.fn(async () => null)
+    setRendererRpcClient({ request: bootRequest, subscribe: vi.fn() })
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    resetRendererRpcClientForTests()
+  })
+
+  beforeEach(() => {
+    _resetLastSourceBranch()
+    vi.clearAllMocks()
+    resetRendererRpcClientForTests()
+    request = vi.fn(async (method: string) => {
+      if (method === 'terminalOps.createClaudeCli') return { success: true }
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    setupStores()
+    vi.mocked(opencodeApi.connect).mockResolvedValue({
+      success: true,
+      value: { success: true, sessionId: 'opc-1' }
+    })
+    vi.mocked(opencodeApi.prompt).mockResolvedValue({
+      success: true,
+      value: { success: true }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useSettingsStore.setState(initialSettingsState, true)
+    useSessionStore.setState(initialSessionState, true)
+    useWorktreeStore.setState(initialWorktreeState, true)
+    useConnectionStore.setState(initialConnectionState, true)
+    useKanbanStore.setState(initialKanbanState, true)
+    useProjectStore.setState(initialProjectState, true)
+    useUsageStore.setState(initialUsageState, true)
+    useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
+    resetRendererRpcClientForTests()
+  })
+
+  it('shows the conversion notice when goal mode is on and the prompt exceeds 3k characters', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={makeTicket({ description: LONG_DESCRIPTION })}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('goal-plan-file-notice')).toBeNull()
+
+    await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+    await userEvent.click(screen.getByTestId('goal-mode-toggle'))
+
+    expect(screen.getByTestId('goal-plan-file-notice').textContent).toContain(
+      'Will be converted to an md file for implementation (>3k characters)'
+    )
+  })
+
+  it('hides the notice for prompts under the limit', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={makeTicket()}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+    await userEvent.click(screen.getByTestId('goal-mode-toggle'))
+
+    expect(screen.queryByTestId('goal-plan-file-notice')).toBeNull()
+  })
+
+  it('writes a plan file into the worktree root and sends a slim goal prompt (Claude CLI)', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={makeTicket({ description: LONG_DESCRIPTION })}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+      />
+    )
+
+    await enableGoalMode()
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', expect.any(Object))
+    )
+
+    const createFileCall = findRpcCall(request, 'fileOps.createFile')
+    expect(createFileCall).toBeDefined()
+    const { filePath, content } = createFileCall![1] as { filePath: string; content: string }
+    expect(filePath).toMatch(/^\/repo\/feature\/PLAN_[0-9a-f-]{36}\.md$/)
+    expect(content).toContain('<ticket title="Goal ticket">')
+    expect(content).toContain(LONG_DESCRIPTION.trim())
+
+    const fileName = filePath.replace('/repo/feature/', '')
+    const cliCall = findRpcCall(request, 'terminalOps.createClaudeCli')
+    const pendingPrompt = (cliCall![1] as { opts: { pendingPrompt: string } }).opts.pendingPrompt
+    expect(pendingPrompt).toBe(`/goal Implement ${fileName}. Goal success criteria: Tests pass`)
+
+    // The plan file must be written before the CLI spawns to read it
+    const methods = request.mock.calls.map(([m]) => m)
+    expect(methods.indexOf('fileOps.createFile')).toBeLessThan(
+      methods.indexOf('terminalOps.createClaudeCli')
+    )
+  })
+
+  it('aborts the send when the plan-file write fails', async () => {
+    request.mockImplementation(async (method: string) => {
+      if (method === 'fileOps.createFile') throw new Error('read-only worktree')
+      if (method === 'terminalOps.createClaudeCli') return { success: true }
+      return null
+    })
+    const createSession = useSessionStore.getState().createSession
+
+    render(
+      <WorktreePickerModal
+        ticket={makeTicket({ description: LONG_DESCRIPTION })}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+      />
+    )
+
+    await enableGoalMode()
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() =>
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+        'Failed to create plan file: read-only worktree'
+      )
+    )
+    expect(createSession).not.toHaveBeenCalled()
+    expect(findRpcCall(request, 'terminalOps.createClaudeCli')).toBeUndefined()
+  })
+
+  it('creates the plan file in a newly created worktree root', async () => {
+    const newWorktree = makeWorktree({
+      id: 'worktree-2',
+      name: 'goal-ticket',
+      branch_name: 'goal-ticket',
+      path: '/repo/goal-ticket'
+    })
+    const createWorktreeFromBranch = vi.fn(async () => {
+      useWorktreeStore.setState((state) => {
+        const map = new Map(state.worktreesByProject)
+        map.set('project-1', [newWorktree, ...(map.get('project-1') ?? [])])
+        return { worktreesByProject: map }
+      })
+      return { success: true, worktree: newWorktree }
+    })
+    useWorktreeStore.setState({ createWorktreeFromBranch })
+
+    render(
+      <WorktreePickerModal
+        ticket={makeTicket({ description: LONG_DESCRIPTION })}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+      />
+    )
+
+    await enableGoalMode()
+    // Default selection is "New worktree" — send without picking an existing one
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', expect.any(Object))
+    )
+    expect(createWorktreeFromBranch).toHaveBeenCalled()
+
+    const createFileCall = findRpcCall(request, 'fileOps.createFile')
+    expect(createFileCall).toBeDefined()
+    const { filePath } = createFileCall![1] as { filePath: string }
+    expect(filePath).toMatch(/^\/repo\/goal-ticket\/PLAN_[0-9a-f-]{36}\.md$/)
+  })
+
+  it('writes the plan file to the connection root in connection mode', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={makeTicket({ description: LONG_DESCRIPTION })}
+        projectId="project-1"
+        connectionId="connection-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+      />
+    )
+
+    await enableGoalMode()
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', expect.any(Object))
+    )
+
+    const createFileCall = findRpcCall(request, 'fileOps.createFile')
+    expect(createFileCall).toBeDefined()
+    const { filePath } = createFileCall![1] as { filePath: string }
+    expect(filePath).toMatch(/^\/repo\/connection\/PLAN_[0-9a-f-]{36}\.md$/)
+
+    const fileName = filePath.replace('/repo/connection/', '')
+    const cliCall = findRpcCall(request, 'terminalOps.createClaudeCli')
+    const pendingPrompt = (cliCall![1] as { opts: { pendingPrompt: string } }).opts.pendingPrompt
+    expect(pendingPrompt).toBe(`/goal Implement ${fileName}. Goal success criteria: Tests pass`)
+  })
+
+  it('converts oversized codex goal prompts sent through OpenCode', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={makeTicket({ description: LONG_DESCRIPTION })}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    await userEvent.click(screen.getByTestId('goal-mode-toggle'))
+    await userEvent.type(screen.getByTestId('goal-success-criteria'), 'Tests pass')
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(opencodeApi.prompt).toHaveBeenCalled())
+
+    const createFileCall = findRpcCall(request, 'fileOps.createFile')
+    expect(createFileCall).toBeDefined()
+    const { filePath } = createFileCall![1] as { filePath: string }
+    expect(filePath).toMatch(/^\/repo\/feature\/PLAN_[0-9a-f-]{36}\.md$/)
+
+    const fileName = filePath.replace('/repo/feature/', '')
+    const [, , parts] = vi.mocked(opencodeApi.prompt).mock.calls[0]
+    expect(parts).toEqual([
+      { type: 'text', text: `/goal Implement ${fileName}. Goal success criteria: Tests pass` }
+    ])
+
+    // The plan file must be written before the prompt referencing it is sent
+    const createFileIdx = request.mock.calls.findIndex(([m]) => m === 'fileOps.createFile')
+    expect(request.mock.invocationCallOrder[createFileIdx]).toBeLessThan(
+      vi.mocked(opencodeApi.prompt).mock.invocationCallOrder[0]
+    )
+  })
+
+  it('converts oversized codex goal prompts in connection mode through OpenCode', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={makeTicket({ description: LONG_DESCRIPTION })}
+        projectId="project-1"
+        connectionId="connection-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    await userEvent.click(screen.getByTestId('goal-mode-toggle'))
+    await userEvent.type(screen.getByTestId('goal-success-criteria'), 'Tests pass')
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(opencodeApi.prompt).toHaveBeenCalled())
+
+    const createFileCall = findRpcCall(request, 'fileOps.createFile')
+    expect(createFileCall).toBeDefined()
+    const { filePath } = createFileCall![1] as { filePath: string }
+    expect(filePath).toMatch(/^\/repo\/connection\/PLAN_[0-9a-f-]{36}\.md$/)
+
+    const fileName = filePath.replace('/repo/connection/', '')
+    const [promptPath, , parts] = vi.mocked(opencodeApi.prompt).mock.calls[0]
+    expect(promptPath).toBe('/repo/connection')
+    expect(parts).toEqual([
+      { type: 'text', text: `/goal Implement ${fileName}. Goal success criteria: Tests pass` }
+    ])
+  })
+
+  it('sends the full goal prompt without a plan file when under the limit', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={makeTicket()}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+      />
+    )
+
+    await enableGoalMode()
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', expect.any(Object))
+    )
+    expect(findRpcCall(request, 'fileOps.createFile')).toBeUndefined()
+
+    const cliCall = findRpcCall(request, 'terminalOps.createClaudeCli')
+    const pendingPrompt = (cliCall![1] as { opts: { pendingPrompt: string } }).opts.pendingPrompt
+    expect(pendingPrompt).toContain('<ticket title="Goal ticket">')
+    expect(pendingPrompt).toContain('Goal success criteria: Tests pass')
+  })
+
+  it('does not create a plan file for oversized prompts when goal mode is off', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={makeTicket({ description: LONG_DESCRIPTION })}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', expect.any(Object))
+    )
+    expect(findRpcCall(request, 'fileOps.createFile')).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -39,6 +39,7 @@ import { startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
 import type { KanbanTicket, Session } from '../../../../main/db/types'
 import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
 import { supportsGoalMode } from '@shared/types/agent-sdk'
+import { createPlanFile, exceedsGoalPromptLimit, planFilePrompt } from '@/lib/goal-plan-file'
 
 // Stable empty array to avoid referential-inequality loops in Zustand selectors
 const EMPTY_ARRAY: readonly never[] = []
@@ -157,6 +158,21 @@ function composePromptForSdk(
   return goalMode && goalCriteria.trim()
     ? wrapGoalPrompt(fullPrompt, goalCriteria.trim())
     : fullPrompt
+}
+
+// Oversized goal prompts get rejected by the CLI. When the composed goal prompt
+// exceeds the limit, persist the full ticket prompt as PLAN_{uuid}.md in the
+// session root and swap the prompt body for "Implement PLAN_{uuid}.md" — the
+// /goal wrapper and success criteria stay as-is. Returns the prompt text to
+// compose the outbound prompt from.
+async function convertOversizedGoalPrompt(
+  promptText: string,
+  composedGoalPrompt: string | null,
+  rootPath: string | null | undefined
+): Promise<string> {
+  if (!exceedsGoalPromptLimit(composedGoalPrompt) || !rootPath) return promptText
+  const fileName = await createPlanFile(rootPath, promptText.trim())
+  return planFilePrompt(fileName)
 }
 
 // Strip a SelectedModel down to the shape the prompt RPC accepts. The renderer's
@@ -443,6 +459,16 @@ export function WorktreePickerModal({
       ? !isSending
       : (selectedWorktreeId !== null || isNewWorktree) && !isSending) && goalCriteriaValid
 
+  // The goal prompt as it would go out. Goal mode is build-only, so the mode
+  // prefix is empty and this matches the outbound prompt for every SDK.
+  const composedGoalPrompt = useMemo(() => {
+    if (!goalMode || !goalAvailable) return null
+    return composePromptForSdk(mode, agentSdk, promptText, goalMode, goalCriteria, {
+      claudeCli: agentSdk === 'claude-code-cli'
+    })
+  }, [goalMode, goalAvailable, mode, agentSdk, promptText, goalCriteria])
+  const willUsePlanFile = exceedsGoalPromptLimit(composedGoalPrompt)
+
   const handleSend = useCallback(async () => {
     if (!canSend) return
     setIsSending(true)
@@ -450,13 +476,22 @@ export function WorktreePickerModal({
     // ── Connection mode path ──────────────────────────────────────
     if (isConnectionMode && connectionId) {
       try {
+        const connectionPath = useConnectionStore
+          .getState()
+          .connections.find((c) => c.id === connectionId)?.path
+        const effectivePromptText = await convertOversizedGoalPrompt(
+          promptText,
+          composedGoalPrompt,
+          connectionPath
+        )
+
         // Create connection session
         const createConnectionSession = useSessionStore.getState().createConnectionSession
         const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
         const modelOverride = effectiveModel ? { ...effectiveModel, agentSdk } : undefined
         const cliPendingPrompt =
           agentSdk === 'claude-code-cli'
-            ? composePromptForSdk(mode, agentSdk, promptText, goalMode, goalCriteria, {
+            ? composePromptForSdk(mode, agentSdk, effectivePromptText, goalMode, goalCriteria, {
                 claudeCli: true
               })
             : null
@@ -529,7 +564,7 @@ export function WorktreePickerModal({
         if (sessionAgentSdk === 'claude-code-cli') {
           const outboundPrompt =
             cliPendingPrompt ??
-            composePromptForSdk(mode, sessionAgentSdk, promptText, goalMode, goalCriteria, {
+            composePromptForSdk(mode, sessionAgentSdk, effectivePromptText, goalMode, goalCriteria, {
               claudeCli: true
             })
 
@@ -552,9 +587,6 @@ export function WorktreePickerModal({
         }
 
         // Connect to opencode using connection path
-        const connectionPath = useConnectionStore
-          .getState()
-          .connections.find((c) => c.id === connectionId)?.path
         if (!connectionPath) return
 
         const connectResult = unwrapEnvelope(await opencodeApi.connect(connectionPath, sessionId))
@@ -569,11 +601,11 @@ export function WorktreePickerModal({
         })
 
         // Send prompt
-        if (promptText.trim()) {
+        if (effectivePromptText.trim()) {
           const outboundPrompt = composePromptForSdk(
             mode,
             sessionAgentSdk,
-            promptText,
+            effectivePromptText,
             goalMode,
             goalCriteria,
             { claudeCli: false }
@@ -733,12 +765,26 @@ export function WorktreePickerModal({
         return
       }
 
+      // Resolve the worktree record once — needed for plan-file creation and
+      // the OpenCode connect below. Newly created worktrees are already in the
+      // store at this point.
+      const allWorktrees = Array.from(
+        useWorktreeStore.getState().worktreesByProject.values()
+      ).flat()
+      const worktree = allWorktrees.find((w) => w.id === worktreeId)
+
+      const effectivePromptText = await convertOversizedGoalPrompt(
+        promptText,
+        composedGoalPrompt,
+        worktree?.path
+      )
+
       // Create session in the selected worktree
       const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
       const modelOverride = effectiveModel ? { ...effectiveModel, agentSdk } : undefined
       const cliPendingPrompt =
         agentSdk === 'claude-code-cli'
-          ? composePromptForSdk(mode, agentSdk, promptText, goalMode, goalCriteria, {
+          ? composePromptForSdk(mode, agentSdk, effectivePromptText, goalMode, goalCriteria, {
               claudeCli: true
             })
           : null
@@ -813,7 +859,7 @@ export function WorktreePickerModal({
       if (sessionAgentSdk === 'claude-code-cli') {
         const outboundPrompt =
           cliPendingPrompt ??
-          composePromptForSdk(mode, sessionAgentSdk, promptText, goalMode, goalCriteria, {
+          composePromptForSdk(mode, sessionAgentSdk, effectivePromptText, goalMode, goalCriteria, {
             claudeCli: true
           })
 
@@ -836,11 +882,6 @@ export function WorktreePickerModal({
       }
 
       // ── Start the OpenCode session in the background ──────────
-      // Resolve worktree path from the store
-      const allWorktrees = Array.from(
-        useWorktreeStore.getState().worktreesByProject.values()
-      ).flat()
-      const worktree = allWorktrees.find((w) => w.id === worktreeId)
       if (!worktree?.path) return
 
       // Connect to OpenCode to create the AI session
@@ -857,11 +898,11 @@ export function WorktreePickerModal({
       })
 
       // Send the prompt — apply plan mode prefix for opencode SDK
-      if (promptText.trim()) {
+      if (effectivePromptText.trim()) {
         const outboundPrompt = composePromptForSdk(
           mode,
           sessionAgentSdk,
-          promptText,
+          effectivePromptText,
           goalMode,
           goalCriteria,
           { claudeCli: false }
@@ -927,6 +968,7 @@ export function WorktreePickerModal({
     codexFastMode,
     goalMode,
     goalCriteria,
+    composedGoalPrompt,
     isConnectionMode,
     connectionId
   ])
@@ -1309,6 +1351,15 @@ export function WorktreePickerModal({
             </div>
           )}
         </div>
+
+        {willUsePlanFile && (
+          <div
+            data-testid="goal-plan-file-notice"
+            className="w-full rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400"
+          >
+            Will be converted to an md file for implementation (&gt;3k characters)
+          </div>
+        )}
 
         <DialogFooter className="pt-1">
           <Button

--- a/src/renderer/src/lib/__tests__/goal-plan-file.test.ts
+++ b/src/renderer/src/lib/__tests__/goal-plan-file.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import {
+  GOAL_PROMPT_MAX_LENGTH,
+  createPlanFile,
+  exceedsGoalPromptLimit,
+  planFilePrompt
+} from '../goal-plan-file'
+
+describe('exceedsGoalPromptLimit', () => {
+  it('is false for null, empty, and prompts at the limit', () => {
+    expect(exceedsGoalPromptLimit(null)).toBe(false)
+    expect(exceedsGoalPromptLimit(undefined)).toBe(false)
+    expect(exceedsGoalPromptLimit('')).toBe(false)
+    expect(exceedsGoalPromptLimit('x'.repeat(GOAL_PROMPT_MAX_LENGTH))).toBe(false)
+  })
+
+  it('is true just past the limit', () => {
+    expect(exceedsGoalPromptLimit('x'.repeat(GOAL_PROMPT_MAX_LENGTH + 1))).toBe(true)
+  })
+})
+
+describe('planFilePrompt', () => {
+  it('builds the slimmed implementation prompt', () => {
+    expect(planFilePrompt('PLAN_abc.md')).toBe('Implement PLAN_abc.md')
+  })
+})
+
+describe('createPlanFile', () => {
+  let request: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    resetRendererRpcClientForTests()
+    request = vi.fn(async () => null)
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+  })
+
+  it('writes a PLAN_{uuid}.md into the root path and returns the file name', async () => {
+    const fileName = await createPlanFile('/repo/feature', 'ticket body')
+
+    expect(fileName).toMatch(/^PLAN_[0-9a-f-]{36}\.md$/)
+    expect(request).toHaveBeenCalledWith('fileOps.createFile', {
+      filePath: `/repo/feature/${fileName}`,
+      content: 'ticket body'
+    })
+  })
+
+  it('throws when the write fails', async () => {
+    request.mockRejectedValueOnce(new Error('disk full'))
+
+    await expect(createPlanFile('/repo/feature', 'ticket body')).rejects.toThrow(
+      'Failed to create plan file: disk full'
+    )
+  })
+})

--- a/src/renderer/src/lib/auto-launch.goal-plan-file.test.ts
+++ b/src/renderer/src/lib/auto-launch.goal-plan-file.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { autoLaunchTicket } from './auto-launch'
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { opencodeApi } from '@/api/opencode-api'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useUsageStore } from '@/stores/useUsageStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { Session, Worktree } from '../../../main/db/types'
+
+vi.mock('@/api/settings-api', () => ({
+  settingsApi: {
+    detectEditors: vi.fn(),
+    detectTerminals: vi.fn(),
+    onSettingsUpdated: vi.fn(() => vi.fn()),
+    openWithTerminal: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@/api/opencode-api', () => ({
+  opencodeApi: {
+    connect: vi.fn(),
+    prompt: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/hive-enterprise-telemetry', () => ({
+  startHivePromptTelemetry: vi.fn()
+}))
+
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialUsageState = useUsageStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
+
+const LONG_PROMPT = 'Implement all the things. '.repeat(150)
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    pinned_to_board: false,
+    ...overrides
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'worktree-1',
+    project_id: 'project-1',
+    name: 'Feature',
+    branch_name: 'feature',
+    path: '/repo/feature',
+    status: 'active',
+    is_default: false,
+    branch_renamed: 0,
+    last_message_at: null,
+    session_titles: '[]',
+    last_model_provider_id: null,
+    last_model_id: null,
+    last_model_variant: null,
+    attachments: '[]',
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_accessed_at: '2026-01-01T00:00:00.000Z',
+    github_pr_number: null,
+    github_pr_url: null,
+    ...overrides
+  } as Worktree
+}
+
+function setupStores(): void {
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '/repo',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        worktree_create_script: null,
+        custom_commands: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        last_accessed_at: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([['project-1', [makeWorktree()]]])
+  })
+  useKanbanStore.setState({ updateTicket: vi.fn(async () => undefined) })
+  useSessionStore.setState({
+    createSession: vi.fn(
+      async (
+        worktreeId: string,
+        projectId: string,
+        sdk?: Session['agent_sdk'],
+        mode?: Session['mode']
+      ) => ({
+        success: true,
+        session: makeSession({
+          worktree_id: worktreeId,
+          project_id: projectId,
+          agent_sdk: sdk ?? 'opencode',
+          mode: mode ?? 'build'
+        })
+      })
+    ),
+    setSessionModel: vi.fn(async () => undefined),
+    setOpenCodeSessionId: vi.fn(),
+    setSessionMode: vi.fn(async () => undefined),
+    dequeuePendingMessage: vi.fn()
+  })
+  useWorktreeStatusStore.setState({
+    setSessionStatus: vi.fn(),
+    setLastMessageTime: vi.fn()
+  })
+  useUsageStore.setState({
+    fetchUsageForProvider: vi.fn()
+  })
+}
+
+function makeConfig(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    worktree: { type: 'existing', worktreeId: 'worktree-1' },
+    prompt: LONG_PROMPT,
+    mode: 'build',
+    model: null,
+    sdk: 'claude-code-cli',
+    codexFastMode: false,
+    goalMode: true,
+    goalSuccessCriteria: 'Tests pass',
+    ...overrides
+  })
+}
+
+function findRpcCall(
+  request: ReturnType<typeof vi.fn>,
+  method: string
+): unknown[] | undefined {
+  return request.mock.calls.find(([m]) => m === method)
+}
+
+describe('autoLaunchTicket goal plan-file conversion', () => {
+  let request: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetRendererRpcClientForTests()
+    request = vi.fn(async (method: string) => {
+      if (method === 'terminalOps.createClaudeCli') return { success: true }
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    setupStores()
+    vi.mocked(opencodeApi.connect).mockResolvedValue({
+      success: true,
+      value: { success: true, sessionId: 'opc-1' }
+    })
+    vi.mocked(opencodeApi.prompt).mockResolvedValue({
+      success: true,
+      value: { success: true }
+    })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+    useSessionStore.setState(initialSessionState, true)
+    useWorktreeStore.setState(initialWorktreeState, true)
+    useKanbanStore.setState(initialKanbanState, true)
+    useProjectStore.setState(initialProjectState, true)
+    useUsageStore.setState(initialUsageState, true)
+    useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
+  })
+
+  it('converts an oversized goal prompt to a plan file before spawning Claude CLI', async () => {
+    await autoLaunchTicket({
+      id: 'ticket-1',
+      project_id: 'project-1',
+      title: 'Launch Claude CLI',
+      pending_launch_config: makeConfig()
+    })
+
+    const createFileCall = findRpcCall(request, 'fileOps.createFile')
+    expect(createFileCall).toBeDefined()
+    const { filePath, content } = createFileCall![1] as { filePath: string; content: string }
+    expect(filePath).toMatch(/^\/repo\/feature\/PLAN_[0-9a-f-]{36}\.md$/)
+    expect(content).toBe(LONG_PROMPT.trim())
+
+    const fileName = filePath.replace('/repo/feature/', '')
+    expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', {
+      sessionId: 'session-1',
+      opts: {
+        pendingPrompt: `/goal Implement ${fileName}. Goal success criteria: Tests pass`
+      }
+    })
+
+    // The plan file must be written before the CLI spawns to read it
+    const methods = request.mock.calls.map(([m]) => m)
+    expect(methods.indexOf('fileOps.createFile')).toBeLessThan(
+      methods.indexOf('terminalOps.createClaudeCli')
+    )
+  })
+
+  it('aborts the launch when the plan-file write fails', async () => {
+    request.mockImplementation(async (method: string) => {
+      if (method === 'fileOps.createFile') throw new Error('read-only worktree')
+      if (method === 'terminalOps.createClaudeCli') return { success: true }
+      return null
+    })
+    const createSession = useSessionStore.getState().createSession
+
+    await autoLaunchTicket({
+      id: 'ticket-1',
+      project_id: 'project-1',
+      title: 'Launch Claude CLI',
+      pending_launch_config: makeConfig()
+    })
+
+    expect(createSession).not.toHaveBeenCalled()
+    expect(findRpcCall(request, 'terminalOps.createClaudeCli')).toBeUndefined()
+  })
+
+  it('creates the plan file in the root of a newly created worktree', async () => {
+    const newWorktree = makeWorktree({
+      id: 'worktree-2',
+      name: 'goal-ticket',
+      branch_name: 'goal-ticket',
+      path: '/repo/goal-ticket'
+    })
+    const createWorktreeFromBranch = vi.fn(async () => {
+      useWorktreeStore.setState((state) => {
+        const map = new Map(state.worktreesByProject)
+        map.set('project-1', [newWorktree, ...(map.get('project-1') ?? [])])
+        return { worktreesByProject: map }
+      })
+      return { success: true, worktree: newWorktree }
+    })
+    useWorktreeStore.setState({ createWorktreeFromBranch })
+
+    await autoLaunchTicket({
+      id: 'ticket-1',
+      project_id: 'project-1',
+      title: 'Goal ticket',
+      pending_launch_config: makeConfig({
+        worktree: { type: 'new', sourceBranch: 'main' },
+        sdk: 'codex'
+      })
+    })
+
+    expect(createWorktreeFromBranch).toHaveBeenCalled()
+    const createFileCall = findRpcCall(request, 'fileOps.createFile')
+    expect(createFileCall).toBeDefined()
+    const { filePath } = createFileCall![1] as { filePath: string }
+    expect(filePath).toMatch(/^\/repo\/goal-ticket\/PLAN_[0-9a-f-]{36}\.md$/)
+
+    const fileName = filePath.replace('/repo/goal-ticket/', '')
+    expect(opencodeApi.prompt).toHaveBeenCalledWith(
+      '/repo/goal-ticket',
+      'opc-1',
+      [{ type: 'text', text: `/goal Implement ${fileName}. Goal success criteria: Tests pass` }],
+      undefined,
+      { codexFastMode: false }
+    )
+  })
+
+  it('leaves goal prompts under the limit untouched', async () => {
+    await autoLaunchTicket({
+      id: 'ticket-1',
+      project_id: 'project-1',
+      title: 'Launch Claude CLI',
+      pending_launch_config: makeConfig({ prompt: 'Implement the ticket' })
+    })
+
+    expect(findRpcCall(request, 'fileOps.createFile')).toBeUndefined()
+    expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', {
+      sessionId: 'session-1',
+      opts: {
+        pendingPrompt: '/goal Implement the ticket. Goal success criteria: Tests pass'
+      }
+    })
+  })
+
+  it('leaves oversized prompts untouched when goal mode is off', async () => {
+    await autoLaunchTicket({
+      id: 'ticket-1',
+      project_id: 'project-1',
+      title: 'Launch Claude CLI',
+      pending_launch_config: makeConfig({ goalMode: false, goalSuccessCriteria: null })
+    })
+
+    expect(findRpcCall(request, 'fileOps.createFile')).toBeUndefined()
+    expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', {
+      sessionId: 'session-1',
+      opts: { pendingPrompt: LONG_PROMPT.trim() }
+    })
+  })
+})

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -16,6 +16,7 @@ import { dbApi } from '@/api/db-api'
 import { terminalApi } from '@/api/terminal-api'
 import { startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
 import { autoPinBaseWorktree } from '@/lib/auto-pin'
+import { createPlanFile, exceedsGoalPromptLimit, planFilePrompt } from '@/lib/goal-plan-file'
 
 type AutoLaunchMode = 'build' | 'plan' | 'super-plan'
 
@@ -114,6 +115,37 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
       worktreeId = config.worktree.worktreeId
     }
 
+    // Resolve the worktree record once — needed for plan-file creation and the
+    // OpenCode connect below. Newly created worktrees are already in the store.
+    const findWorktree = (): { path: string } | undefined =>
+      Array.from(useWorktreeStore.getState().worktreesByProject.values())
+        .flat()
+        .find((w) => w.id === worktreeId)
+    let worktree = findWorktree()
+    if (!worktree) {
+      // The project's worktrees may not be loaded yet (e.g. auto-launch firing
+      // from a store subscription shortly after startup)
+      await useWorktreeStore.getState().loadWorktrees(ticket.project_id)
+      worktree = findWorktree()
+    }
+
+    // Oversized goal prompts get rejected by the CLI — persist the full ticket
+    // prompt as PLAN_{uuid}.md in the worktree root and send a short
+    // "Implement PLAN_{uuid}.md" goal prompt instead (the /goal wrapper stays).
+    if (configGoalMode && configGoalSuccessCriteria && worktree?.path) {
+      const composed = composeAutoLaunchPrompt(
+        config,
+        config.sdk,
+        configGoalMode,
+        configGoalSuccessCriteria,
+        { claudeCli: config.sdk === 'claude-code-cli' }
+      )
+      if (exceedsGoalPromptLimit(composed)) {
+        const fileName = await createPlanFile(worktree.path, config.prompt.trim())
+        config = { ...config, prompt: planFilePrompt(fileName) }
+      }
+    }
+
     // 2. Create session
     const modelOverride = config.model ? { ...config.model, agentSdk: config.sdk } : undefined
     const cliPendingPrompt =
@@ -201,8 +233,6 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
     }
 
     // 8. Connect to OpenCode and send prompt
-    const allWorktrees = Array.from(useWorktreeStore.getState().worktreesByProject.values()).flat()
-    const worktree = allWorktrees.find((w) => w.id === worktreeId)
     if (!worktree?.path) return
 
     const connectResult = unwrapEnvelope(await opencodeApi.connect(worktree.path, sessionId))

--- a/src/renderer/src/lib/goal-plan-file.ts
+++ b/src/renderer/src/lib/goal-plan-file.ts
@@ -1,0 +1,31 @@
+import { fileApi } from '@/api/file-api'
+
+/**
+ * Goal prompts (`/goal ...`) longer than this get rejected by the CLI, so
+ * oversized ticket prompts are written to a PLAN_{uuid}.md file and the goal
+ * prompt is slimmed down to "Implement PLAN_{uuid}.md" instead.
+ */
+export const GOAL_PROMPT_MAX_LENGTH = 3000
+
+export function exceedsGoalPromptLimit(prompt: string | null | undefined): boolean {
+  return !!prompt && prompt.length > GOAL_PROMPT_MAX_LENGTH
+}
+
+/** The prompt body that replaces the full ticket description in the goal prompt. */
+export function planFilePrompt(fileName: string): string {
+  return `Implement ${fileName}`
+}
+
+/**
+ * Write the full ticket prompt to a PLAN_{uuid}.md in the session root
+ * (worktree or connection path) so the agent can read it from disk.
+ * Returns the created file name; throws when the write fails.
+ */
+export async function createPlanFile(rootPath: string, content: string): Promise<string> {
+  const fileName = `PLAN_${crypto.randomUUID()}.md`
+  const result = await fileApi.createFile(`${rootPath}/${fileName}`, content)
+  if (!result.success) {
+    throw new Error(`Failed to create plan file: ${result.error ?? 'Unknown error'}`)
+  }
+  return fileName
+}

--- a/src/server/__tests__/file-rpc.mock-provider.test.ts
+++ b/src/server/__tests__/file-rpc.mock-provider.test.ts
@@ -108,6 +108,60 @@ describe('file ops RPC mocked provider', () => {
     })
   })
 
+  it('routes fileOps.createFile to the injected provider service', async () => {
+    const createFile = vi.fn(() => Effect.succeed(null))
+    const service = { createFile } as unknown as FileOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      fileOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'file-create-file-1',
+        method: 'fileOps.createFile',
+        params: {
+          filePath: '/tmp/hive/PLAN_123.md',
+          content: 'plan body'
+        }
+      })
+    )
+
+    expect(createFile).toHaveBeenCalledWith('/tmp/hive/PLAN_123.md', 'plan body')
+    expect(response).toEqual({
+      id: 'file-create-file-1',
+      ok: true,
+      value: null
+    })
+  })
+
+  it('validates fileOps.createFile params before calling the provider service', async () => {
+    const createFile = vi.fn(() => Effect.succeed(null))
+    const service = { createFile } as unknown as FileOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      fileOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'file-create-file-invalid',
+        method: 'fileOps.createFile',
+        params: {
+          filePath: '',
+          content: 'plan body'
+        }
+      })
+    )
+
+    expect(createFile).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      id: 'file-create-file-invalid',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
+
   it('routes fileOps.readImageAsBase64 to the injected provider service', async () => {
     const result = { data: 'aGVsbG8=', mimeType: 'image/png' }
     const readImageAsBase64 = vi.fn(() => Effect.succeed(result))

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -2987,6 +2987,7 @@ describe('rpc router', () => {
             return { success: true, content: 'hello from http' }
           }),
         writeFile: () => Effect.succeed(null),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: () => Effect.succeed({ data: 'unused' })
       }
     })
@@ -3013,6 +3014,7 @@ describe('rpc router', () => {
       fileOps: {
         readFile: () => Effect.succeed({ success: false, error: 'should not run' }),
         writeFile: () => Effect.succeed(null),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: () => Effect.succeed({ data: 'unused' })
       }
     })
@@ -3043,6 +3045,7 @@ describe('rpc router', () => {
             calls.push({ filePath, content })
             return null
           }),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: () => Effect.succeed({ data: 'unused' })
       }
     })
@@ -3069,6 +3072,7 @@ describe('rpc router', () => {
       fileOps: {
         readFile: () => Effect.succeed({ success: false, error: 'unused' }),
         writeFile: () => Effect.succeed(null),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: () => Effect.succeed({ data: 'unused' })
       }
     })
@@ -3095,6 +3099,7 @@ describe('rpc router', () => {
       fileOps: {
         readFile: () => Effect.succeed({ success: false, error: 'unused' }),
         writeFile: () => Effect.succeed(null),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: (filePath) =>
           Effect.sync(() => {
             calls.push(filePath)
@@ -3125,6 +3130,7 @@ describe('rpc router', () => {
       fileOps: {
         readFile: () => Effect.succeed({ success: false, error: 'unused' }),
         writeFile: () => Effect.succeed(null),
+        createFile: () => Effect.succeed(null),
         readImageAsBase64: () => Effect.succeed({ data: 'unused' })
       }
     })

--- a/src/server/rpc/domains/file-ops.ts
+++ b/src/server/rpc/domains/file-ops.ts
@@ -1,6 +1,6 @@
 import { Effect } from 'effect'
 import { z } from 'zod'
-import { readFile, readFileAsBase64, writeFile } from '../../../main/services/file-ops'
+import { createFile, readFile, readFileAsBase64, writeFile } from '../../../main/services/file-ops'
 import { RpcRouteError } from '../../../shared/rpc/errors'
 import type { RpcHandler } from '../router'
 
@@ -18,6 +18,7 @@ export interface FileImageReadResult {
 export interface FileOpsRpcService {
   readonly readFile: (filePath: string) => Effect.Effect<FileReadResult, unknown, never>
   readonly writeFile: (filePath: string, content: string) => Effect.Effect<null, unknown, never>
+  readonly createFile: (filePath: string, content: string) => Effect.Effect<null, unknown, never>
   readonly readImageAsBase64: (
     filePath: string
   ) => Effect.Effect<FileImageReadResult, unknown, never>
@@ -37,6 +38,12 @@ export const makeLiveFileOpsRpcService = (): FileOpsRpcService => ({
   writeFile: (filePath, content) =>
     Effect.suspend(() => {
       const result = writeFile(filePath, content)
+      if (result.success) return Effect.succeed(null)
+      return Effect.fail(new Error(result.error ?? 'Unknown error'))
+    }),
+  createFile: (filePath, content) =>
+    Effect.suspend(() => {
+      const result = createFile(filePath, content)
       if (result.success) return Effect.succeed(null)
       return Effect.fail(new Error(result.error ?? 'Unknown error'))
     }),
@@ -79,6 +86,17 @@ export const makeFileOpsRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.writeFile(filePath, content)
+        })
+    ],
+    [
+      'fileOps.createFile',
+      (params) =>
+        Effect.gen(function* () {
+          const { filePath, content } = yield* Effect.try({
+            try: () => writeFileParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.createFile(filePath, content)
         })
     ],
     [

--- a/test/phase-12/renderer-api-cleanup.test.ts
+++ b/test/phase-12/renderer-api-cleanup.test.ts
@@ -20263,9 +20263,9 @@ describe('renderer API cleanup', () => {
     expect(worktreeSource).toContain('await dbApi.session.update<Session>(sessionId, {')
     expect(worktreeSource).toContain('opencode_session_id: connectResult.sessionId')
     expect(worktreeSource).not.toContain('await db.session.update(sessionId, {')
-    expect(worktreeSource).toContain(
-      'const worktree = allWorktrees.find((w) => w.id === worktreeId)'
-    )
+    // The store-based worktree lookup is hoisted above session creation so the
+    // goal plan-file conversion can reuse it
+    expect(source).toContain('const worktree = allWorktrees.find((w) => w.id === worktreeId)')
     expect(worktreeSource).not.toContain('window.opencodeOps.connect')
   })
 


### PR DESCRIPTION
## Summary
- Add create-only file creation support in the main process and expose it through the renderer file API.
- Detect oversized goal prompts and convert them into `PLAN_{uuid}.md` files in the target worktree or connection root.
- Update worktree picker and auto-launch flows to send slim `/goal Implement PLAN_*.md` prompts after creating the plan file.
- Show a UI notice when a goal prompt will be converted to a plan file.
- Add coverage for file creation, prompt conversion helpers, and the end-to-end worktree picker/auto-launch behavior.

## Testing
- `vitest` coverage added for `createFile` in the main process.
- Renderer unit tests added for `goal-plan-file` helpers.
- Worktree picker modal tests cover long-goal conversion, failure handling, new worktree roots, and connection mode.
- Auto-launch tests cover oversized goal prompt conversion paths.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session start and auto-launch prompt handling and writes new files into user repo paths; behavior is gated on goal mode and length with abort-on-failure, plus broad test coverage.
> 
> **Overview**
> Adds **create-only** file creation (`writeFileSync` with `wx`) in the main process, exposed as `fileOps.createFile` through RPC and `fileApi.createFile`.
> 
> When **goal mode** is on and the fully composed `/goal` prompt exceeds **3000 characters**, `WorktreePickerModal` and `autoLaunchTicket` persist the full ticket prompt as `PLAN_{uuid}.md` under the worktree or connection root, then send a slim body (`Implement PLAN_….md`) while keeping goal success criteria. The picker shows an amber notice when conversion will happen; a failed write aborts launch/send (toast, no session/CLI).
> 
> Conversion runs for Claude CLI and OpenCode/Codex paths, including new worktrees and connection mode. Prompts under the limit or non-goal mode are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 577f19bdabcc23ecea86cec7b26ac4e32c1668e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->