### PR TITLE
Latch Claude CLI blocking statuses across sub-agent hooks

### DIFF
--- a/src/main/services/__tests__/claude-cli-interaction-ledger.test.ts
+++ b/src/main/services/__tests__/claude-cli-interaction-ledger.test.ts
@@ -1,0 +1,321 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  clearAllClaudeCliInteractions,
+  clearClaudeCliInteractions,
+  hasBlockingClaudeCliInteraction,
+  processClaudeCliHook
+} from '../claude-cli-interaction-ledger'
+import type { ClaudeCliStatusPayload, ParsedClaudeHook } from '../claude-hook-server'
+import type { SessionStatusType } from '@shared/types/session-status'
+
+const SESSION = 'hive-session-1'
+
+interface HookStep {
+  event: string
+  tool?: string
+  id?: string
+  status: SessionStatusType | null
+  plan?: string
+}
+
+function buildHook(step: HookStep): ParsedClaudeHook {
+  const hook: ParsedClaudeHook = { hook_event_name: step.event }
+  if (step.tool) hook.tool_name = step.tool
+  if (step.id) hook.tool_use_id = step.id
+  if (step.plan) hook.tool_input = { plan: step.plan }
+  return hook
+}
+
+function buildMapped(sessionId: string, step: HookStep): ClaudeCliStatusPayload | null {
+  if (!step.status) return null
+  const metadata: NonNullable<ClaudeCliStatusPayload['metadata']> = {
+    hookEventName: step.event,
+    hookPath: 'tool'
+  }
+  if (step.tool) metadata.toolName = step.tool
+  if (step.plan) metadata.plan = step.plan
+  return { sessionId, status: step.status, metadata }
+}
+
+function process(step: HookStep, sessionId = SESSION): ClaudeCliStatusPayload[] {
+  return processClaudeCliHook(sessionId, buildHook(step), buildMapped(sessionId, step))
+}
+
+function statuses(payloads: ClaudeCliStatusPayload[]): (SessionStatusType | undefined)[] {
+  return payloads.map((p) => p.status)
+}
+
+afterEach(() => {
+  clearAllClaudeCliInteractions()
+})
+
+describe('passthrough when no interactions pending', () => {
+  it('publishes non-blocking statuses unchanged', () => {
+    expect(statuses(process({ event: 'UserPromptSubmit', status: 'working' }))).toEqual(['working'])
+    expect(statuses(process({ event: 'PostToolUse', tool: 'Read', status: 'working' }))).toEqual([
+      'working'
+    ])
+    expect(statuses(process({ event: 'Stop', status: 'completed' }))).toEqual(['completed'])
+  })
+
+  it('publishes nothing for unmapped hooks', () => {
+    expect(process({ event: 'BogusEvent', status: null })).toEqual([])
+  })
+
+  it('passes a stray AskUserQuestion resolution through when nothing is latched', () => {
+    expect(
+      statuses(process({ event: 'PostToolUse', tool: 'AskUserQuestion', status: 'working' }))
+    ).toEqual(['working'])
+  })
+})
+
+describe('answering latch (the ticket bug)', () => {
+  it('suppresses unrelated tool completions while a question is pending', () => {
+    expect(
+      statuses(process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' }))
+    ).toEqual(['answering'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+
+    // Parallel sub-agent activity must not clobber the question alert.
+    expect(process({ event: 'PostToolUse', tool: 'Read', status: 'working' })).toEqual([])
+    expect(process({ event: 'PostToolUseFailure', tool: 'Bash', status: 'working' })).toEqual([])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+  })
+
+  it('releases on PostToolUse(AskUserQuestion) and resumes publishing', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+
+    const released = process({ event: 'PostToolUse', tool: 'AskUserQuestion', status: 'working' })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+
+    expect(statuses(process({ event: 'PostToolUse', tool: 'Read', status: 'working' }))).toEqual([
+      'working'
+    ])
+  })
+
+  it('releases on PostToolUseFailure(AskUserQuestion) (question escaped)', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+
+    const released = process({
+      event: 'PostToolUseFailure',
+      tool: 'AskUserQuestion',
+      status: 'working'
+    })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('keeps the latch while another question with a distinct tool_use_id is outstanding', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', id: 'q1', status: 'answering' })
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', id: 'q2', status: 'answering' })
+
+    const first = process({
+      event: 'PostToolUse',
+      tool: 'AskUserQuestion',
+      id: 'q1',
+      status: 'working'
+    })
+    // Resolution publishes, then the still-pending question re-surfaces.
+    expect(statuses(first)).toEqual(['working', 'answering'])
+    expect(first[1].metadata?.reason).toBe('interaction_resurfaced')
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+
+    const second = process({
+      event: 'PostToolUse',
+      tool: 'AskUserQuestion',
+      id: 'q2',
+      status: 'working'
+    })
+    expect(statuses(second)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('deduplicates PreToolUse + PermissionRequest firing for the same question call', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', id: 'q1', status: 'answering' })
+    process({ event: 'PermissionRequest', tool: 'AskUserQuestion', id: 'q1', status: 'answering' })
+
+    const released = process({
+      event: 'PostToolUse',
+      tool: 'AskUserQuestion',
+      id: 'q1',
+      status: 'working'
+    })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('deduplicates the real-world sequence: PreToolUse with id + PermissionRequest without id', () => {
+    // Empirically, PreToolUse carries tool_use_id but the paired
+    // PermissionRequest for the same question does not.
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', id: 'q1', status: 'answering' })
+    process({ event: 'PermissionRequest', tool: 'AskUserQuestion', status: 'answering' })
+
+    const released = process({
+      event: 'PostToolUse',
+      tool: 'AskUserQuestion',
+      id: 'q1',
+      status: 'working'
+    })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('deduplicates PreToolUse + PermissionRequest double-fire without tool_use_ids', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+    process({ event: 'PermissionRequest', tool: 'AskUserQuestion', status: 'answering' })
+
+    const released = process({
+      event: 'PostToolUse',
+      tool: 'AskUserQuestion',
+      status: 'working'
+    })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+})
+
+describe('permission latch and the pending-interaction queue', () => {
+  it('holds a permission request behind a pending question, then re-surfaces it', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+
+    // Permission fires while the question is still shown: registered, not published.
+    expect(process({ event: 'PermissionRequest', tool: 'Bash', status: 'permission' })).toEqual([])
+
+    const released = process({ event: 'PostToolUse', tool: 'AskUserQuestion', status: 'working' })
+    expect(statuses(released)).toEqual(['working', 'permission'])
+    expect(released[1].metadata?.toolName).toBe('Bash')
+    expect(released[1].metadata?.reason).toBe('interaction_resurfaced')
+
+    expect(statuses(process({ event: 'PostToolUse', tool: 'Bash', status: 'working' }))).toEqual([
+      'working'
+    ])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('publishes a permission immediately when it is the top pending interaction', () => {
+    expect(
+      statuses(process({ event: 'PermissionRequest', tool: 'Bash', status: 'permission' }))
+    ).toEqual(['permission'])
+  })
+
+  it('does not release a permission on an unrelated same-tool completion (tool_use_id mismatch)', () => {
+    process({ event: 'PermissionRequest', tool: 'Bash', id: 'p1', status: 'permission' })
+
+    // A parallel sub-agent's Bash call (different id) completes — still latched.
+    expect(process({ event: 'PostToolUse', tool: 'Bash', id: 'x9', status: 'working' })).toEqual([])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+
+    const released = process({ event: 'PostToolUse', tool: 'Bash', id: 'p1', status: 'working' })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('falls back to counting when the release hook lacks a tool_use_id', () => {
+    process({ event: 'PermissionRequest', tool: 'Bash', id: 'p1', status: 'permission' })
+
+    const released = process({ event: 'PostToolUse', tool: 'Bash', status: 'working' })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+})
+
+describe('plan_ready latch', () => {
+  it('keeps plan_ready surfaced through sub-agent completions until the plan resolves', () => {
+    expect(
+      statuses(
+        process({ event: 'PreToolUse', tool: 'ExitPlanMode', status: 'plan_ready', plan: '# Plan' })
+      )
+    ).toEqual(['plan_ready'])
+
+    expect(process({ event: 'PostToolUse', tool: 'Task', status: 'working' })).toEqual([])
+
+    const approved = process({ event: 'PostToolUse', tool: 'ExitPlanMode', status: 'working' })
+    expect(statuses(approved)).toEqual(['working'])
+    expect(approved[0].metadata?.toolName).toBe('ExitPlanMode')
+  })
+
+  it('publishes the rejection payload on PostToolUseFailure(ExitPlanMode)', () => {
+    process({ event: 'PreToolUse', tool: 'ExitPlanMode', status: 'plan_ready' })
+
+    const rejected = process({
+      event: 'PostToolUseFailure',
+      tool: 'ExitPlanMode',
+      status: 'planning'
+    })
+    expect(statuses(rejected)).toEqual(['planning'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('holds a plan registered behind a question and re-surfaces it with its plan text', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+    expect(
+      process({ event: 'PreToolUse', tool: 'ExitPlanMode', status: 'plan_ready', plan: '# P' })
+    ).toEqual([])
+
+    const released = process({ event: 'PostToolUse', tool: 'AskUserQuestion', status: 'working' })
+    expect(statuses(released)).toEqual(['working', 'plan_ready'])
+    expect(released[1].metadata?.plan).toBe('# P')
+  })
+
+  it('lets a higher-priority permission surface over a latched plan_ready, then restores it', () => {
+    process({ event: 'PreToolUse', tool: 'ExitPlanMode', status: 'plan_ready', plan: '# P' })
+
+    expect(
+      statuses(process({ event: 'PermissionRequest', tool: 'Bash', status: 'permission' }))
+    ).toEqual(['permission'])
+
+    const released = process({ event: 'PostToolUse', tool: 'Bash', status: 'working' })
+    expect(statuses(released)).toEqual(['working', 'plan_ready'])
+  })
+})
+
+describe('fail-safe clears', () => {
+  it.each(['UserPromptSubmit', 'Stop', 'SessionStart', 'SessionEnd'])(
+    '%s clears all pending interactions and publishes its own status',
+    (event) => {
+      process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+      process({ event: 'PermissionRequest', tool: 'Bash', status: 'permission' })
+
+      const cleared = process({ event, status: event === 'UserPromptSubmit' ? 'working' : 'completed' })
+      expect(statuses(cleared)).toEqual([event === 'UserPromptSubmit' ? 'working' : 'completed'])
+      expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+
+      expect(statuses(process({ event: 'PostToolUse', tool: 'Read', status: 'working' }))).toEqual([
+        'working'
+      ])
+    }
+  )
+})
+
+describe('manual clears and session isolation', () => {
+  it('clearClaudeCliInteractions drops only the given session', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' }, 'other-session')
+
+    clearClaudeCliInteractions(SESSION)
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+    expect(hasBlockingClaudeCliInteraction('other-session')).toBe(true)
+  })
+
+  it('clearAllClaudeCliInteractions drops everything', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' }, 'other-session')
+
+    clearAllClaudeCliInteractions()
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+    expect(hasBlockingClaudeCliInteraction('other-session')).toBe(false)
+  })
+
+  it('keeps sessions independent: a latch in one session never suppresses another', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+
+    expect(
+      statuses(
+        process({ event: 'PostToolUse', tool: 'Read', status: 'working' }, 'other-session')
+      )
+    ).toEqual(['working'])
+  })
+})

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -374,6 +374,184 @@ describe('ClaudeHookServer HTTP round-trip', () => {
     )
   })
 
+  it('keeps a pending question surfaced through unrelated sub-agent hooks until answered', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:status',
+        expect.objectContaining({ sessionId: 'hive-session-1', status: 'answering' })
+      )
+    })
+
+    // Parallel sub-agent tool completions must not clobber the question.
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Read'
+    })
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'Bash'
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(1)
+
+    // Answering the question resolves the latch and publishes working.
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(2)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenLastCalledWith(
+      'claude-cli:status',
+      {
+        sessionId: 'hive-session-1',
+        status: 'working',
+        metadata: {
+          hookEventName: 'PostToolUse',
+          hookPath: 'tool',
+          toolName: 'AskUserQuestion'
+        }
+      }
+    )
+  })
+
+  it('re-surfaces a queued permission request after the question is answered', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    // Permission arrives while the question is pending: queued, not published.
+    await postHook(port, 'hive-session-1', 'permission', {
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(1)
+    })
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(3)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenNthCalledWith(
+      2,
+      'claude-cli:status',
+      expect.objectContaining({ sessionId: 'hive-session-1', status: 'working' })
+    )
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenNthCalledWith(
+      3,
+      'claude-cli:status',
+      {
+        sessionId: 'hive-session-1',
+        status: 'permission',
+        metadata: {
+          hookEventName: 'PermissionRequest',
+          hookPath: 'permission',
+          toolName: 'Bash',
+          reason: 'interaction_resurfaced'
+        }
+      }
+    )
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(4)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenLastCalledWith(
+      'claude-cli:status',
+      expect.objectContaining({ sessionId: 'hive-session-1', status: 'working' })
+    )
+  })
+
+  it('keeps plan_ready surfaced through sub-agent completions until the plan resolves', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'ExitPlanMode',
+      tool_input: { plan: '# Plan' }
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:status',
+        expect.objectContaining({ sessionId: 'hive-session-1', status: 'plan_ready' })
+      )
+    })
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Task'
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(1)
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'ExitPlanMode'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(2)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenLastCalledWith(
+      'claude-cli:status',
+      {
+        sessionId: 'hive-session-1',
+        status: 'working',
+        metadata: {
+          hookEventName: 'PostToolUse',
+          hookPath: 'tool',
+          toolName: 'ExitPlanMode'
+        }
+      }
+    )
+  })
+
+  it('clears pending interactions on turn boundaries so later hooks publish normally', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(2)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenLastCalledWith(
+      'claude-cli:status',
+      expect.objectContaining({ sessionId: 'hive-session-1', status: 'working' })
+    )
+
+    // The abandoned question no longer suppresses later publishes.
+    await postHook(port, 'hive-session-1', 'permission', {
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(3)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenLastCalledWith(
+      'claude-cli:status',
+      expect.objectContaining({ sessionId: 'hive-session-1', status: 'permission' })
+    )
+  })
+
   it('ignores unknown event names without publishing status events', async () => {
     const { port } = await getClaudeHookServer()
 

--- a/src/main/services/claude-cli-interaction-ledger.ts
+++ b/src/main/services/claude-cli-interaction-ledger.ts
@@ -1,0 +1,197 @@
+import { STATUS_PRIORITY, type SessionStatusType } from '@shared/types/session-status'
+// Type-only import: claude-hook-server imports this module at runtime, so a
+// runtime import back would create a cycle.
+import type { ClaudeCliStatusPayload, ParsedClaudeHook } from './claude-hook-server'
+
+/**
+ * Per-session ledger of blocking interactions (questions, permission prompts,
+ * plan approvals) raised by Claude CLI hooks. Sub-agents share the parent's
+ * hive session id, so their PostToolUse hooks would otherwise overwrite an
+ * unanswered question's status (last-write-wins). The ledger latches blocking
+ * statuses until the hook that actually resolves them arrives, suppresses
+ * unrelated status publishes in between, and re-surfaces the next pending
+ * interaction once the current one resolves.
+ *
+ * This must run before publishClaudeCliStatus's dedup: the resolution hook
+ * (PostToolUse → 'working') often carries the same status as a suppressed
+ * intermediate publish, and would be dedup-swallowed if the latch lived
+ * downstream (e.g. in the renderer store).
+ */
+
+type BlockingKind = 'answering' | 'permission' | 'plan_ready'
+
+const KIND_STATUS: Record<BlockingKind, SessionStatusType> = {
+  answering: 'answering',
+  permission: 'permission',
+  plan_ready: 'plan_ready'
+}
+
+interface BlockingEntry {
+  kind: BlockingKind
+  // Outstanding requests tracked precisely by tool_use_id when hooks carry it…
+  toolUseIds: Set<string>
+  // …and by count for hooks that don't.
+  count: number
+  // Latest register payload, re-published when this entry re-surfaces.
+  payload: ClaudeCliStatusPayload
+}
+
+// sessionId → entry key ('answering' | 'plan_ready' | 'permission:<tool>') → entry
+const ledgers = new Map<string, Map<string, BlockingEntry>>()
+
+// Turn boundaries: a new prompt or a finished/started session invalidates any
+// interaction the hooks failed to resolve explicitly (e.g. a permission denied
+// in the TUI, which fires no per-tool hook).
+const RESET_EVENTS = new Set(['UserPromptSubmit', 'Stop', 'SessionStart', 'SessionEnd'])
+
+function entrySize(entry: BlockingEntry): number {
+  return entry.toolUseIds.size + entry.count
+}
+
+function classify(toolName: string | undefined): { kind: BlockingKind; key: string } {
+  if (toolName === 'AskUserQuestion') return { kind: 'answering', key: 'answering' }
+  if (toolName === 'ExitPlanMode') return { kind: 'plan_ready', key: 'plan_ready' }
+  return { kind: 'permission', key: `permission:${toolName ?? ''}` }
+}
+
+function topEntry(session: Map<string, BlockingEntry> | undefined): BlockingEntry | null {
+  if (!session) return null
+  let best: BlockingEntry | null = null
+  for (const entry of session.values()) {
+    if (!best || STATUS_PRIORITY[KIND_STATUS[entry.kind]] > STATUS_PRIORITY[KIND_STATUS[best.kind]]) {
+      best = entry
+    }
+  }
+  return best
+}
+
+function resurfacedPayload(entry: BlockingEntry): ClaudeCliStatusPayload {
+  return {
+    ...entry.payload,
+    metadata: { ...entry.payload.metadata, reason: 'interaction_resurfaced' }
+  }
+}
+
+function registerInteraction(
+  sessionId: string,
+  hook: ParsedClaudeHook,
+  mapped: ClaudeCliStatusPayload,
+  kind: BlockingKind,
+  key: string
+): ClaudeCliStatusPayload[] {
+  let session = ledgers.get(sessionId)
+  if (!session) {
+    session = new Map()
+    ledgers.set(sessionId, session)
+  }
+
+  let entry = session.get(key)
+  if (!entry) {
+    entry = { kind, toolUseIds: new Set(), count: 0, payload: mapped }
+    session.set(key, entry)
+  }
+  entry.payload = mapped
+
+  if (hook.tool_use_id) {
+    // Set semantics also dedupe PreToolUse + PermissionRequest firing for the
+    // same tool call.
+    entry.toolUseIds.add(hook.tool_use_id)
+  } else if (hook.hook_event_name === 'PermissionRequest' && kind !== 'permission') {
+    // PreToolUse already fires for AskUserQuestion/ExitPlanMode; a paired
+    // PermissionRequest must not double-count the same interaction.
+    if (entrySize(entry) === 0) entry.count = 1
+  } else {
+    entry.count += 1
+  }
+
+  return topEntry(session) === entry ? [mapped] : []
+}
+
+/**
+ * Release one outstanding unit from the entry. Returns false when the hook's
+ * tool_use_id does not match any outstanding request — i.e. an unrelated
+ * parallel call of the same tool completed, which must not lift the latch.
+ */
+function releaseOne(entry: BlockingEntry, toolUseId: string | undefined): boolean {
+  if (toolUseId) {
+    if (entry.toolUseIds.delete(toolUseId)) return true
+    if (entry.count > 0) {
+      entry.count -= 1
+      return true
+    }
+    return false
+  }
+
+  if (entry.count > 0) {
+    entry.count -= 1
+    return true
+  }
+  const first = entry.toolUseIds.values().next()
+  if (!first.done) {
+    entry.toolUseIds.delete(first.value)
+    return true
+  }
+  return false
+}
+
+/**
+ * Apply a hook to the session's interaction ledger and return the status
+ * payloads to publish, in order (0, 1, or 2 — a resolution followed by the
+ * re-surfaced next pending interaction).
+ */
+export function processClaudeCliHook(
+  sessionId: string,
+  hook: ParsedClaudeHook,
+  mapped: ClaudeCliStatusPayload | null
+): ClaudeCliStatusPayload[] {
+  const event = hook.hook_event_name ?? ''
+
+  if (RESET_EVENTS.has(event)) {
+    ledgers.delete(sessionId)
+    return mapped ? [mapped] : []
+  }
+
+  const session = ledgers.get(sessionId)
+
+  if (mapped && (event === 'PreToolUse' || event === 'PermissionRequest')) {
+    const { kind, key } = classify(hook.tool_name)
+    // PreToolUse hooks are only configured for AskUserQuestion/ExitPlanMode;
+    // anything else that slips through is not a blocking interaction.
+    if (event === 'PermissionRequest' || kind !== 'permission') {
+      return registerInteraction(sessionId, hook, mapped, kind, key)
+    }
+  }
+
+  if (event === 'PostToolUse' || event === 'PostToolUseFailure') {
+    const { key } = classify(hook.tool_name)
+    const entry = session?.get(key)
+    if (session && entry) {
+      if (!releaseOne(entry, hook.tool_use_id)) return []
+      if (entrySize(entry) === 0) {
+        session.delete(key)
+        if (session.size === 0) ledgers.delete(sessionId)
+      }
+      const publishes = mapped ? [mapped] : []
+      const top = topEntry(session)
+      if (top) publishes.push(resurfacedPayload(top))
+      return publishes
+    }
+  }
+
+  // While any interaction is pending, unrelated hooks neither register nor
+  // release — suppress their status so the alert stays surfaced.
+  if (session && session.size > 0) return []
+  return mapped ? [mapped] : []
+}
+
+export function clearClaudeCliInteractions(sessionId: string): void {
+  ledgers.delete(sessionId)
+}
+
+export function clearAllClaudeCliInteractions(): void {
+  ledgers.clear()
+}
+
+export function hasBlockingClaudeCliInteraction(sessionId: string): boolean {
+  return (ledgers.get(sessionId)?.size ?? 0) > 0
+}

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -5,10 +5,15 @@ import { createLogger } from './logger'
 import { cliHookTransportRouter } from './cli-hook-transport-router'
 import { handleClaudeCliHiveTelemetryHook } from './hive-enterprise-claude-cli-telemetry'
 import { publishDesktopBackendEvent } from '../desktop/backend-event-publisher'
+import {
+  clearAllClaudeCliInteractions,
+  processClaudeCliHook
+} from './claude-cli-interaction-ledger'
 
 export interface ParsedClaudeHook {
   hook_event_name?: string
   tool_name?: string
+  tool_use_id?: string
   permission_mode?: string
   prompt?: unknown
   transcript_path?: unknown
@@ -164,11 +169,9 @@ export function publishClaudeCliStatus(payload: ClaudeCliStatusPayload): void {
   for (const subscriber of statusSubscribers) {
     subscriber(payload)
   }
-  void import('../desktop/backend-event-publisher')
-    .then(({ publishDesktopBackendEvent }) =>
-      publishDesktopBackendEvent('claude-cli:status', payload)
-    )
-    .catch(() => undefined)
+  void Promise.resolve(publishDesktopBackendEvent('claude-cli:status', payload)).catch(
+    () => undefined
+  )
 }
 
 /**
@@ -253,12 +256,18 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
     const body = JSON.parse(rawBody || '{}') as ParsedClaudeHook
     if (route) {
       const status = mapHookEventToStatus(body)
-      if (status) {
-        publishClaudeCliStatus({
-          sessionId: route.sessionId,
-          status,
-          metadata: buildStatusMetadata(body, route.hookPath)
-        })
+      const mapped: ClaudeCliStatusPayload | null = status
+        ? {
+            sessionId: route.sessionId,
+            status,
+            metadata: buildStatusMetadata(body, route.hookPath)
+          }
+        : null
+      // The interaction ledger latches blocking statuses (question/permission/
+      // plan approval) so parallel sub-agent hooks can't clobber them, and
+      // re-surfaces queued interactions as each one resolves.
+      for (const payload of processClaudeCliHook(route.sessionId, body, mapped)) {
+        publishClaudeCliStatus(payload)
       }
       void handleClaudeCliHiveTelemetryHook(route.sessionId, body)
       // First user prompt of this CLI session → tell the renderer so it can
@@ -361,6 +370,7 @@ export async function closeClaudeHookServer(): Promise<void> {
     startingPromise = null
     lastStatusBySession.clear()
     statusSubscribers.clear()
+    clearAllClaudeCliInteractions()
     return
   }
 
@@ -379,4 +389,5 @@ export async function closeClaudeHookServer(): Promise<void> {
   startingPromise = null
   lastStatusBySession.clear()
   statusSubscribers.clear()
+  clearAllClaudeCliInteractions()
 }

--- a/src/main/services/terminal-pty-bridge.claude-cli.test.ts
+++ b/src/main/services/terminal-pty-bridge.claude-cli.test.ts
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => {
     getLastClaudeCliStatus: vi.fn(),
     publishClaudeCliStatus: vi.fn(),
     subscribeClaudeCliStatus: vi.fn(() => vi.fn()),
+    clearClaudeCliInteractions: vi.fn(),
+    clearAllClaudeCliInteractions: vi.fn(),
     ptyService: {
       has: vi.fn(() => false),
       create: vi.fn(() => ({ cols: 120, rows: 40 })),
@@ -120,6 +122,11 @@ vi.mock('./claude-hook-server', () => ({
 
 vi.mock('../desktop/backend-event-publisher', () => ({
   publishDesktopBackendEvent: mocks.publishDesktopBackendEvent
+}))
+
+vi.mock('./claude-cli-interaction-ledger', () => ({
+  clearClaudeCliInteractions: mocks.clearClaudeCliInteractions,
+  clearAllClaudeCliInteractions: mocks.clearAllClaudeCliInteractions
 }))
 
 import type { Session } from '../db/types'
@@ -484,7 +491,7 @@ describe('Claude CLI terminal hook status wiring', () => {
       }
     )
 
-    it.each(['planning', 'permission'])(
+    it.each(['planning', 'permission', 'answering'])(
       'publishes completed when Escape is typed while %s',
       async (status) => {
         await createClaudeCliTerminal('hive-session-1', {})
@@ -522,7 +529,7 @@ describe('Claude CLI terminal hook status wiring', () => {
       }
     )
 
-    it.each(['completed', 'plan_ready', 'answering', undefined])(
+    it.each(['completed', 'plan_ready', undefined])(
       'ignores Escape when the last published status is %s',
       async (status) => {
         await createClaudeCliTerminal('hive-session-1', {})
@@ -534,6 +541,64 @@ describe('Claude CLI terminal hook status wiring', () => {
         expect(mocks.publishClaudeCliStatus).not.toHaveBeenCalled()
       }
     )
+  })
+
+  describe('interaction ledger clears', () => {
+    it('clears the session ledger when a Claude CLI PTY starts, so restarts never inherit a stale latch', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+
+      expect(mocks.clearClaudeCliInteractions).toHaveBeenCalledWith('hive-session-1')
+    })
+
+    it.each(['\x1b', '\x03'])(
+      'clears the session ledger on user interrupt %j so a phantom permission cannot re-surface',
+      async (key) => {
+        await createClaudeCliTerminal('hive-session-1', {})
+        mocks.getLastClaudeCliStatus.mockReturnValue('permission')
+        mocks.clearClaudeCliInteractions.mockClear()
+
+        handleClaudeCliTerminalInput('hive-session-1', key)
+
+        expect(mocks.clearClaudeCliInteractions).toHaveBeenCalledWith('hive-session-1')
+      }
+    )
+
+    it('clears the ledger on Escape while answering — no hook fires for an escaped question', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.getLastClaudeCliStatus.mockReturnValue('answering')
+      mocks.clearClaudeCliInteractions.mockClear()
+
+      handleClaudeCliTerminalInput('hive-session-1', '\x1b')
+
+      expect(mocks.clearClaudeCliInteractions).toHaveBeenCalledWith('hive-session-1')
+    })
+
+    it('clears the session ledger when the tracked PTY exits', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.clearClaudeCliInteractions.mockClear()
+
+      mocks.exitCallbacks.get('hive-session-1')?.(9)
+
+      expect(mocks.clearClaudeCliInteractions).toHaveBeenCalledWith('hive-session-1')
+    })
+
+    it('clears the session ledger when the terminal is destroyed', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.clearClaudeCliInteractions.mockClear()
+
+      destroyNodePtyTerminal('hive-session-1')
+
+      expect(mocks.clearClaudeCliInteractions).toHaveBeenCalledWith('hive-session-1')
+    })
+
+    it('clears all ledgers on cleanupTerminals', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.clearAllClaudeCliInteractions.mockClear()
+
+      cleanupTerminals()
+
+      expect(mocks.clearAllClaudeCliInteractions).toHaveBeenCalled()
+    })
   })
 
   it('removes the Claude CLI PTY-exit safety net when the terminal is destroyed', async () => {

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -8,6 +8,10 @@ import {
   subscribeClaudeCliStatus,
   type ClaudeCliStatusPayload
 } from './claude-hook-server'
+import {
+  clearAllClaudeCliInteractions,
+  clearClaudeCliInteractions
+} from './claude-cli-interaction-ledger'
 import { logClaudeBinaryVersion, resolveClaudeBinaryPath } from './claude-binary-resolver'
 import { buildClaudeCliPtySpawn } from './claude-cli-spawner'
 import { externalizeGoalHandoffPlan } from './claude-cli-plan-handoff'
@@ -57,6 +61,8 @@ function armClaudePlanFollowupWatcher(sessionId: string): void {
     sessionId,
     watchForClaudePlanFollowup(source.worktreePath, source.claudeSessionId, () => {
       closeClaudePlanFollowupWatcher(sessionId)
+      // Bypasses the interaction ledger deliberately: a plan followup implies a
+      // user prompt, whose UserPromptSubmit hook clears the ledger anyway.
       publishClaudeCliStatus({
         sessionId,
         status: 'planning',
@@ -100,21 +106,25 @@ function ensureClaudeCliStatusSubscription(): void {
 // Lone Escape / Ctrl+C. A bare Escape keypress arrives as exactly '\x1b';
 // multi-byte sequences (arrow keys, bracketed pastes) never match exactly.
 const INTERRUPT_KEYS = new Set(['\x1b', '\x03'])
-const INTERRUPTIBLE_STATUSES = new Set(['working', 'planning', 'permission'])
+const INTERRUPTIBLE_STATUSES = new Set(['working', 'planning', 'permission', 'answering'])
 
 /**
  * Claude Code never fires its Stop hook when the user interrupts a running
  * turn with Escape/Ctrl+C, and the CLI keeps running so the pty_exit fallback
  * never fires either — the session would stay stuck on 'working'. Mirror the
- * keypress itself into a status update instead. plan_ready/answering are
- * excluded: escaping those dialogs fires PostToolUseFailure hooks that the
- * existing pipeline already handles.
+ * keypress itself into a status update instead. Escaping a question or
+ * permission dialog fires no hook at all (verified empirically), so those
+ * statuses are interruptible too; plan_ready is excluded because rejecting a
+ * plan fires PostToolUseFailure(ExitPlanMode), which the pipeline handles.
  */
 export function handleClaudeCliTerminalInput(terminalId: string, data: string): void {
   if (!claudeCliSessions.has(terminalId)) return
   if (!INTERRUPT_KEYS.has(data)) return
   const last = getLastClaudeCliStatus(terminalId)
   if (!last || !INTERRUPTIBLE_STATUSES.has(last)) return
+  // No hook fires for an interrupted/denied interaction — drop any pending
+  // latch so the next hook cannot re-surface a phantom permission.
+  clearClaudeCliInteractions(terminalId)
   publishClaudeCliStatus({
     sessionId: terminalId,
     status: 'completed',
@@ -134,6 +144,7 @@ export function destroyNodePtyTerminal(terminalId: string): void {
   claudeWatchers.get(terminalId)?.close()
   claudeWatchers.delete(terminalId)
   closeClaudePlanFollowupWatcher(terminalId)
+  clearClaudeCliInteractions(terminalId)
   claudeCliSessions.delete(terminalId)
   claudeCliWorktreeBasenames.delete(terminalId)
   claudeCliTranscriptSources.delete(terminalId)
@@ -199,6 +210,7 @@ function attachNodePtyListeners(terminalId: string): void {
     claudeWatchers.delete(terminalId)
     closeClaudePlanFollowupWatcher(terminalId)
     if (claudeCliSessions.has(terminalId)) {
+      clearClaudeCliInteractions(terminalId)
       publishClaudeCliStatus({
         sessionId: terminalId,
         status: 'completed',
@@ -329,6 +341,8 @@ export async function createClaudeCliTerminal(
       })
     }
     claudeCliSessions.add(sessionId)
+    // A restarted session must never inherit a stale interaction latch.
+    clearClaudeCliInteractions(sessionId)
     claudeCliWorktreeBasenames.set(sessionId, path.basename(worktreePath))
     if (!pendingPrompt) {
       publishClaudeCliStatus({
@@ -377,6 +391,7 @@ export function cleanupTerminals(): void {
   claudeCliWorktreeBasenames.clear()
   claudeCliTranscriptSources.clear()
   claudeCliLastStatus.clear()
+  clearAllClaudeCliInteractions()
   unsubscribeClaudeCliStatus?.()
   unsubscribeClaudeCliStatus = null
   resetAllClaudeCliTitleState()

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -24,6 +24,7 @@ import {
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { checkAutoApprove } from '@/lib/permissionUtils'
 import { isPlanLike } from '@/lib/constants'
+import { shouldPreserveBlockingSessionStatus } from '@/lib/session-status-guards'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import {
@@ -561,12 +562,16 @@ export function useOpenCodeGlobalListener(): void {
         // Don't overwrite plan_ready — session is blocked waiting for plan approval
         if (useSessionStore.getState().getPendingPlan(sessionId)) return
 
-        // Don't overwrite command_approval — session is blocked waiting for command approval
+        // Don't overwrite blocking statuses (command approval, permission, or a
+        // still-pending question) — the session is waiting on the user.
         const currentStatus = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-        if (currentStatus?.status === 'command_approval') return
-
-        // Don't overwrite permission — session is blocked waiting for permission approval
-        if (currentStatus?.status === 'permission') return
+        if (
+          shouldPreserveBlockingSessionStatus(
+            currentStatus?.status,
+            useQuestionStore.getState().getQuestions(sessionId).length > 0
+          )
+        )
+          return
 
         if (sessionId !== activeId) {
           const currentMode = useSessionStore.getState().getSessionMode(sessionId)
@@ -642,12 +647,16 @@ export function useOpenCodeGlobalListener(): void {
       // Don't overwrite plan_ready — session is blocked waiting for plan approval
       if (useSessionStore.getState().getPendingPlan(sessionId)) return
 
-      // Don't overwrite command_approval — session is blocked waiting for command approval
+      // Don't overwrite blocking statuses (command approval, permission, or a
+      // still-pending question) — the session is waiting on the user.
       const statusForIdle = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-      if (statusForIdle?.status === 'command_approval') return
-
-      // Don't overwrite permission — session is blocked waiting for permission approval
-      if (statusForIdle?.status === 'permission') return
+      if (
+        shouldPreserveBlockingSessionStatus(
+          statusForIdle?.status,
+          useQuestionStore.getState().getQuestions(sessionId).length > 0
+        )
+      )
+        return
 
       // Active session is handled by SessionView.
       if (sessionId === activeId) return
@@ -657,7 +666,10 @@ export function useOpenCodeGlobalListener(): void {
         isBlocked: () => {
           if (useSessionStore.getState().getPendingPlan(sessionId)) return true
           const current = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-          return current?.status === 'command_approval' || current?.status === 'permission'
+          return shouldPreserveBlockingSessionStatus(
+            current?.status,
+            useQuestionStore.getState().getQuestions(sessionId).length > 0
+          )
         },
         dequeueFollowUp: () => useSessionStore.getState().dequeueFollowUpMessage(sessionId),
         requeueFollowUp: (message) =>

--- a/src/renderer/src/lib/__tests__/session-status-guards.test.ts
+++ b/src/renderer/src/lib/__tests__/session-status-guards.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldPreserveBlockingSessionStatus } from '../session-status-guards'
+
+describe('shouldPreserveBlockingSessionStatus', () => {
+  it('preserves command_approval and permission unconditionally, matching the existing guards', () => {
+    expect(shouldPreserveBlockingSessionStatus('command_approval', false)).toBe(true)
+    expect(shouldPreserveBlockingSessionStatus('permission', false)).toBe(true)
+  })
+
+  it('preserves answering while a question is still pending', () => {
+    expect(shouldPreserveBlockingSessionStatus('answering', true)).toBe(true)
+  })
+
+  it('does not preserve a stale answering status with no pending question', () => {
+    expect(shouldPreserveBlockingSessionStatus('answering', false)).toBe(false)
+  })
+
+  it('does not preserve non-blocking statuses', () => {
+    expect(shouldPreserveBlockingSessionStatus('working', true)).toBe(false)
+    expect(shouldPreserveBlockingSessionStatus('planning', false)).toBe(false)
+    expect(shouldPreserveBlockingSessionStatus('completed', false)).toBe(false)
+    expect(shouldPreserveBlockingSessionStatus(null, true)).toBe(false)
+    expect(shouldPreserveBlockingSessionStatus(undefined, true)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/pet-status-aggregator.ts
+++ b/src/renderer/src/lib/pet-status-aggregator.ts
@@ -1,16 +1,6 @@
 import type { PetState, PetStatusPayload } from '@shared/types/pet'
 import type { SessionStatusEntry, SessionStatusType } from '@/stores/useWorktreeStatusStore'
-
-const STATUS_PRIORITY: Record<SessionStatusType, number> = {
-  answering: 8,
-  command_approval: 7,
-  permission: 6,
-  planning: 5,
-  working: 4,
-  plan_ready: 3,
-  completed: 2,
-  unread: 1
-}
+import { STATUS_PRIORITY } from '@shared/types/session-status'
 
 const PET_STATE_BY_STATUS: Record<SessionStatusType, PetState> = {
   answering: 'question',

--- a/src/renderer/src/lib/session-status-guards.ts
+++ b/src/renderer/src/lib/session-status-guards.ts
@@ -1,0 +1,16 @@
+import type { SessionStatusType } from '@shared/types/session-status'
+
+/**
+ * Whether a session's current status represents a blocking interaction that a
+ * busy/idle stream event must not overwrite. command_approval and permission
+ * are preserved unconditionally (their prompts stay mounted until replied);
+ * answering is preserved only while a question is actually pending, so a stale
+ * status can't stick after the question store has drained.
+ */
+export function shouldPreserveBlockingSessionStatus(
+  currentStatus: SessionStatusType | null | undefined,
+  hasPendingQuestion: boolean
+): boolean {
+  if (currentStatus === 'command_approval' || currentStatus === 'permission') return true
+  return currentStatus === 'answering' && hasPendingQuestion
+}

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -4,7 +4,7 @@ import { useConnectionStore } from './useConnectionStore'
 import { lastSendMode } from '@/lib/message-send-times'
 import { notifyKanbanSessionSync } from './store-coordination'
 import { dbApi } from '@/api/db-api'
-import type { SessionStatusType } from '@shared/types/session-status'
+import { higherPriority, type SessionStatusType } from '@shared/types/session-status'
 
 // Re-exported from the shared definition so existing importers keep working.
 export type { SessionStatusType }
@@ -73,27 +73,6 @@ interface WorktreeStatusState {
   setMergeConflictFlow: (worktreeId: string, flow: MergeConflictFlow | null) => void
   setMergeConflictWorktreeForTicket: (ticketId: string, worktreeId: string | null) => void
   isWorktreeBeingReviewed: (worktreeId: string) => boolean
-}
-
-// Priority ranking for status aggregation (higher number = higher priority)
-const STATUS_PRIORITY: Record<SessionStatusType, number> = {
-  answering: 8,
-  command_approval: 7,
-  permission: 6,
-  planning: 5,
-  working: 4,
-  plan_ready: 3,
-  completed: 2,
-  unread: 1
-}
-
-function higherPriority(
-  a: SessionStatusType | null,
-  b: SessionStatusType | null
-): SessionStatusType | null {
-  if (!a) return b
-  if (!b) return a
-  return STATUS_PRIORITY[a] >= STATUS_PRIORITY[b] ? a : b
 }
 
 export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => ({

--- a/src/shared/types/session-status.ts
+++ b/src/shared/types/session-status.ts
@@ -13,3 +13,24 @@ export type SessionStatusType =
   | 'unread'
   | 'completed'
   | 'plan_ready'
+
+// Priority ranking for status aggregation (higher number = higher priority)
+export const STATUS_PRIORITY: Record<SessionStatusType, number> = {
+  answering: 8,
+  command_approval: 7,
+  permission: 6,
+  planning: 5,
+  working: 4,
+  plan_ready: 3,
+  completed: 2,
+  unread: 1
+}
+
+export function higherPriority(
+  a: SessionStatusType | null,
+  b: SessionStatusType | null
+): SessionStatusType | null {
+  if (!a) return b
+  if (!b) return a
+  return STATUS_PRIORITY[a] >= STATUS_PRIORITY[b] ? a : b
+}


### PR DESCRIPTION
## Summary
- Add a session-scoped interaction ledger to keep `answering`, `permission`, and `plan_ready` statuses latched until the matching resolving hook arrives.
- Suppress unrelated Claude CLI hook publishes while a blocking interaction is pending, then re-surface queued interactions in priority order.
- Clear pending interaction state on turn boundaries, PTY lifecycle events, and user interrupts so stale latches do not leak across sessions.
- Update renderer status guards to preserve blocking session states when questions or approvals are still active.
- Extend test coverage for hook sequencing, session isolation, interrupt handling, and renderer status preservation.

## Testing
- Added unit tests for the new interaction ledger covering question, permission, and plan approval flows.
- Added Claude hook server tests for queued/resurfaced statuses across unrelated sub-agent hooks.
- Added PTY bridge tests for clearing interaction state on start, interrupt, destroy, and cleanup paths.
- Added renderer guard tests for preserving blocking statuses when a session still has pending interactions.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Claude CLI status publishing and session badge logic; incorrect latch/clear timing could hide prompts or leave stale blocking states, but behavior is heavily covered by new tests.
> 
> **Overview**
> Fixes Claude CLI session badges being overwritten when sub-agents emit unrelated tool hooks while a question, permission, or plan approval is still open.
> 
> **Main process:** Adds `claude-cli-interaction-ledger` to latch `answering`, `permission`, and `plan_ready` per session, suppress unrelated hook publishes until the matching resolve hook arrives, queue lower-priority interactions, and re-publish them with `interaction_resurfaced`. `claude-hook-server` routes mapped hooks through `processClaudeCliHook` before deduped publish; `ParsedClaudeHook` gains `tool_use_id`. PTY bridge clears ledger on start, Escape/Ctrl+C (including `answering`), exit, destroy, and global cleanup so stale latches cannot leak.
> 
> **Renderer:** `shouldPreserveBlockingSessionStatus` centralizes guards so busy/idle stream events do not clobber blocking UI when questions are still pending. `STATUS_PRIORITY` / `higherPriority` move to `@shared/types/session-status` for shared aggregation.
> 
> **Tests:** Ledger unit tests, hook-server integration scenarios, PTY clear behavior, and renderer guard tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e7a12c2f48e38367ebb9f5b393fcd3d548873d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->