### PR TITLE
feat: add frameless title bar with window controls on Windows/Linux

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -397,6 +397,12 @@ function createWindow(backendBootstrap?: LocalEnvironmentBootstrap | null): void
 
   // Save window bounds on resize and move
   const createdWindow = mainWindow
+  const emitMaximizedChanged = (): void => {
+    if (createdWindow.isDestroyed()) return
+    createdWindow.webContents.send('window:maximized-changed', createdWindow.isMaximized())
+  }
+  mainWindow.on('maximize', emitMaximizedChanged)
+  mainWindow.on('unmaximize', emitMaximizedChanged)
   mainWindow.on('resize', () => saveWindowBounds(createdWindow))
   mainWindow.on('move', () => saveWindowBounds(createdWindow))
   mainWindow.on('close', () => saveWindowBounds(createdWindow))

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -300,21 +300,26 @@ function ensureDockVisible(reason: string): void {
 }
 
 function registerWindowControlHandlers(): void {
-  ipcMain.handle('window:minimize', () => {
-    mainWindow?.minimize()
+  ipcMain.handle('window:minimize', (event) => {
+    if (event.sender !== mainWindow?.webContents) return
+    mainWindow.minimize()
   })
-  ipcMain.handle('window:maximize', () => {
-    if (!mainWindow) return
+  ipcMain.handle('window:maximize', (event) => {
+    if (event.sender !== mainWindow?.webContents) return
     if (mainWindow.isMaximized()) {
       mainWindow.unmaximize()
     } else {
       mainWindow.maximize()
     }
   })
-  ipcMain.handle('window:close', () => {
-    mainWindow?.close()
+  ipcMain.handle('window:close', (event) => {
+    if (event.sender !== mainWindow?.webContents) return
+    mainWindow.close()
   })
-  ipcMain.handle('window:isMaximized', () => mainWindow?.isMaximized() ?? false)
+  ipcMain.handle('window:isMaximized', (event) => {
+    if (event.sender !== mainWindow?.webContents) return false
+    return mainWindow.isMaximized()
+  })
 }
 
 function createWindow(backendBootstrap?: LocalEnvironmentBootstrap | null): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 import { loadShellEnv } from './services/shell-env'
-import { app, shell, BrowserWindow, Menu, screen, webContents } from 'electron'
+import { app, shell, BrowserWindow, Menu, screen, webContents, ipcMain } from 'electron'
 import { join } from 'path'
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { electronApp, is } from '@electron-toolkit/utils'
@@ -299,6 +299,24 @@ function ensureDockVisible(reason: string): void {
   }
 }
 
+function registerWindowControlHandlers(): void {
+  ipcMain.handle('window:minimize', () => {
+    mainWindow?.minimize()
+  })
+  ipcMain.handle('window:maximize', () => {
+    if (!mainWindow) return
+    if (mainWindow.isMaximized()) {
+      mainWindow.unmaximize()
+    } else {
+      mainWindow.maximize()
+    }
+  })
+  ipcMain.handle('window:close', () => {
+    mainWindow?.close()
+  })
+  ipcMain.handle('window:isMaximized', () => mainWindow?.isMaximized() ?? false)
+}
+
 function createWindow(backendBootstrap?: LocalEnvironmentBootstrap | null): void {
   const savedBounds = loadWindowBounds()
 
@@ -316,7 +334,7 @@ function createWindow(backendBootstrap?: LocalEnvironmentBootstrap | null): void
           titleBarStyle: 'hiddenInset' as const,
           trafficLightPosition: { x: 15, y: 10 }
         }
-      : {}),
+      : { frame: false }),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       contextIsolation: true,
@@ -535,6 +553,7 @@ app
     // Register desktop-side integrations that back server desktop commands.
     log.info('Registering desktop integrations')
     registerDesktopBridgeHandlers()
+    registerWindowControlHandlers()
     configurePetWindow({ getMainWindow: () => mainWindow, headless: isHeadless })
     initTicketProviderManager([new GitHubProvider(), new JiraProvider()])
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -301,11 +301,11 @@ function ensureDockVisible(reason: string): void {
 
 function registerWindowControlHandlers(): void {
   ipcMain.handle('window:minimize', (event) => {
-    if (event.sender !== mainWindow?.webContents) return
+    if (!mainWindow || event.sender !== mainWindow.webContents) return
     mainWindow.minimize()
   })
   ipcMain.handle('window:maximize', (event) => {
-    if (event.sender !== mainWindow?.webContents) return
+    if (!mainWindow || event.sender !== mainWindow.webContents) return
     if (mainWindow.isMaximized()) {
       mainWindow.unmaximize()
     } else {
@@ -313,11 +313,11 @@ function registerWindowControlHandlers(): void {
     }
   })
   ipcMain.handle('window:close', (event) => {
-    if (event.sender !== mainWindow?.webContents) return
+    if (!mainWindow || event.sender !== mainWindow.webContents) return
     mainWindow.close()
   })
   ipcMain.handle('window:isMaximized', (event) => {
-    if (event.sender !== mainWindow?.webContents) return false
+    if (!mainWindow || event.sender !== mainWindow.webContents) return false
     return mainWindow.isMaximized()
   })
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -51,6 +51,10 @@ declare global {
       getLocalEnvironmentBootstrap: () => Promise<LocalEnvironmentBootstrap | null>
       getPathForFile: (file: File) => string
       startHiveEnterpriseLogin: (serverUrl: string) => Promise<{ token: string }>
+      windowMinimize: () => Promise<void>
+      windowMaximize: () => Promise<void>
+      windowClose: () => Promise<void>
+      windowIsMaximized: () => Promise<boolean>
     }
   }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -55,6 +55,7 @@ declare global {
       windowMaximize: () => Promise<void>
       windowClose: () => Promise<void>
       windowIsMaximized: () => Promise<boolean>
+      onWindowMaximizedChanged: (callback: (isMaximized: boolean) => void) => () => void
     }
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,7 +9,16 @@ const desktopBridge = {
   windowMinimize: (): Promise<void> => ipcRenderer.invoke('window:minimize'),
   windowMaximize: (): Promise<void> => ipcRenderer.invoke('window:maximize'),
   windowClose: (): Promise<void> => ipcRenderer.invoke('window:close'),
-  windowIsMaximized: (): Promise<boolean> => ipcRenderer.invoke('window:isMaximized')
+  windowIsMaximized: (): Promise<boolean> => ipcRenderer.invoke('window:isMaximized'),
+  onWindowMaximizedChanged: (callback: (isMaximized: boolean) => void): (() => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, isMaximized: boolean): void => {
+      callback(isMaximized)
+    }
+    ipcRenderer.on('window:maximized-changed', listener)
+    return () => {
+      ipcRenderer.removeListener('window:maximized-changed', listener)
+    }
+  }
 }
 
 // Force 100% zoom — Ghostty's native NSView overlay requires 1:1 CSS-to-AppKit

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,7 +5,11 @@ const desktopBridge = {
   getLocalEnvironmentBootstrap: async () => decodeLocalEnvironmentBootstrapArg(process.argv),
   getPathForFile: (file: File): string => webUtils.getPathForFile(file),
   startHiveEnterpriseLogin: (serverUrl: string): Promise<{ token: string }> =>
-    ipcRenderer.invoke('hive-enterprise:start-login', { serverUrl })
+    ipcRenderer.invoke('hive-enterprise:start-login', { serverUrl }),
+  windowMinimize: (): Promise<void> => ipcRenderer.invoke('window:minimize'),
+  windowMaximize: (): Promise<void> => ipcRenderer.invoke('window:maximize'),
+  windowClose: (): Promise<void> => ipcRenderer.invoke('window:close'),
+  windowIsMaximized: (): Promise<boolean> => ipcRenderer.invoke('window:isMaximized')
 }
 
 // Force 100% zoom — Ghostty's native NSView overlay requires 1:1 CSS-to-AppKit

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -135,6 +135,7 @@ export function Header(): React.JSX.Element {
   useEffect(() => {
     if (!windowControls) return
     void windowControls.windowIsMaximized().then(setIsMaximized)
+    return windowControls.onWindowMaximizedChanged(setIsMaximized)
   }, [windowControls])
 
   const hasProjects = projects.length > 0
@@ -797,12 +798,7 @@ export function Header(): React.JSX.Element {
               variant="ghost"
               size="icon"
               className="h-12 w-12 rounded-none"
-              onClick={() => {
-                void windowControls
-                  .windowMaximize()
-                  .then(() => windowControls.windowIsMaximized())
-                  .then(setIsMaximized)
-              }}
+              onClick={() => void windowControls.windowMaximize()}
               title={isMaximized ? 'Restore' : 'Maximize'}
               data-testid="window-maximize"
             >

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -19,7 +19,9 @@ import {
   Hammer,
   Map,
   Check,
-  MoonStar
+  MoonStar,
+  Minus,
+  Square
 } from 'lucide-react'
 import { KanbanIcon } from '@/components/kanban/KanbanIcon'
 import { Button } from '@/components/ui/button'
@@ -123,6 +125,12 @@ export function Header(): React.JSX.Element {
     }
     prevBoardActive.current = isBoardViewActive
   }, [isBoardViewActive])
+
+  const [isMaximized, setIsMaximized] = useState(false)
+  useEffect(() => {
+    if (isMac()) return
+    void window.desktopBridge.windowIsMaximized().then(setIsMaximized)
+  }, [])
 
   const hasProjects = projects.length > 0
 
@@ -765,6 +773,45 @@ export function Header(): React.JSX.Element {
             <PanelRightClose className="h-4 w-4" />
           )}
         </Button>
+        {!isMac() && (
+          <div
+            className="flex items-center -mr-4"
+            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+          >
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-12 w-12 rounded-none"
+              onClick={() => void window.desktopBridge.windowMinimize()}
+              title="Minimize"
+              data-testid="window-minimize"
+            >
+              <Minus className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-12 w-12 rounded-none"
+              onClick={() => {
+                void window.desktopBridge.windowMaximize().then(() => setIsMaximized((v) => !v))
+              }}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              data-testid="window-maximize"
+            >
+              {isMaximized ? <Copy className="h-3.5 w-3.5" /> : <Square className="h-3.5 w-3.5" />}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-12 w-12 rounded-none hover:bg-red-600 hover:text-white"
+              onClick={() => void window.desktopBridge.windowClose()}
+              title="Close"
+              data-testid="window-close"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
       </div>
     </header>
   )

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -126,11 +126,16 @@ export function Header(): React.JSX.Element {
     prevBoardActive.current = isBoardViewActive
   }, [isBoardViewActive])
 
+  const windowControls =
+    !isMac() && typeof window.desktopBridge?.windowMinimize === 'function'
+      ? window.desktopBridge
+      : null
+
   const [isMaximized, setIsMaximized] = useState(false)
   useEffect(() => {
-    if (isMac()) return
-    void window.desktopBridge.windowIsMaximized().then(setIsMaximized)
-  }, [])
+    if (!windowControls) return
+    void windowControls.windowIsMaximized().then(setIsMaximized)
+  }, [windowControls])
 
   const hasProjects = projects.length > 0
 
@@ -773,7 +778,7 @@ export function Header(): React.JSX.Element {
             <PanelRightClose className="h-4 w-4" />
           )}
         </Button>
-        {!isMac() && (
+        {windowControls && (
           <div
             className="flex items-center -mr-4"
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
@@ -782,7 +787,7 @@ export function Header(): React.JSX.Element {
               variant="ghost"
               size="icon"
               className="h-12 w-12 rounded-none"
-              onClick={() => void window.desktopBridge.windowMinimize()}
+              onClick={() => void windowControls.windowMinimize()}
               title="Minimize"
               data-testid="window-minimize"
             >
@@ -793,7 +798,10 @@ export function Header(): React.JSX.Element {
               size="icon"
               className="h-12 w-12 rounded-none"
               onClick={() => {
-                void window.desktopBridge.windowMaximize().then(() => setIsMaximized((v) => !v))
+                void windowControls
+                  .windowMaximize()
+                  .then(() => windowControls.windowIsMaximized())
+                  .then(setIsMaximized)
               }}
               title={isMaximized ? 'Restore' : 'Maximize'}
               data-testid="window-maximize"
@@ -804,7 +812,7 @@ export function Header(): React.JSX.Element {
               variant="ghost"
               size="icon"
               className="h-12 w-12 rounded-none hover:bg-red-600 hover:text-white"
-              onClick={() => void window.desktopBridge.windowClose()}
+              onClick={() => void windowControls.windowClose()}
               title="Close"
               data-testid="window-close"
             >


### PR DESCRIPTION
## Description

Frameless window on Windows/Linux: native title bar removed, minimize/maximize/close moved into the app header. macOS unchanged.

## Related Issue

N/A

## Type of Change

- [x] 🎨 UI/UX improvement

## Changes Made

- `frame: false` for main window on Windows/Linux
- IPC handlers for window minimize/maximize/close/isMaximized
- Window control buttons in `Header.tsx` (non-macOS only)

## Screenshots

<details>
<summary><img width="1754" height="174" alt="image" src="https://github.com/user-attachments/assets/1b766049-5631-419e-82d2-f0832d658621" /></summary>

<!-- Add before/after screenshots -->

</details>

## Testing

### Test Configuration
- **OS**: Windows 11
- **Test Type**: Manual

### Test Steps
1. Launch on Windows — single header, no native title bar
2. Drag header, resize edges, test _ □ X buttons
3. Ctrl+W closes session tab, not the window

### Test Results

- [x] Manual testing completed

## Checklist

- [x] My code follows the project's code style

## Performance Impact

- [x] No performance impact

## Breaking Changes

- [x] No breaking changes

## Additional Notes

Direct preload IPC for window controls (not backend RPC). No Windows 11 snap menu on maximize hover.

---

<!-- Thank you for contributing to Hive! 🚀 -->
