### PR TITLE
Add recent connection notes and filtering

### DIFF
--- a/src/main/db/connection-history.test.ts
+++ b/src/main/db/connection-history.test.ts
@@ -104,6 +104,73 @@ describeIf('connection_history', () => {
     db.close()
   })
 
+  it('creates the note column defaulting to NULL on fresh databases', () => {
+    const db = new DatabaseService(makeDbPath())
+    db.init()
+
+    const columns = db.getRawDb().pragma('table_info(connection_history)') as { name: string }[]
+    expect(columns.map((c) => c.name)).toContain('note')
+
+    const entry = db.upsertConnectionHistory(['project-a', 'project-b'])
+    expect(entry?.note).toBeNull()
+
+    db.close()
+  })
+
+  it('adds the note column to a pre-existing table missing it (repair path)', () => {
+    const dbPath = makeDbPath()
+    const first = new DatabaseService(dbPath)
+    first.init()
+    // Simulate a database created before the note column existed.
+    first.getRawDb().exec('ALTER TABLE connection_history DROP COLUMN note')
+    first.close()
+
+    const second = new DatabaseService(dbPath)
+    second.init()
+    const columns = second.getRawDb().pragma('table_info(connection_history)') as {
+      name: string
+    }[]
+    expect(columns.map((c) => c.name)).toContain('note')
+
+    second.close()
+  })
+
+  it('setConnectionHistoryNote sets and clears the note, and reports unknown ids', () => {
+    const db = new DatabaseService(makeDbPath())
+    db.init()
+
+    const entry = db.upsertConnectionHistory(['project-a', 'project-b'])
+    expect(entry).not.toBeNull()
+
+    expect(db.setConnectionHistoryNote(entry!.id, 'urgent client work')).toBe(true)
+    let rows = db.getRecentConnectionHistory()
+    expect(rows[0].note).toBe('urgent client work')
+
+    expect(db.setConnectionHistoryNote(entry!.id, null)).toBe(true)
+    rows = db.getRecentConnectionHistory()
+    expect(rows[0].note).toBeNull()
+
+    expect(db.setConnectionHistoryNote('missing-id', 'nope')).toBe(false)
+
+    db.close()
+  })
+
+  it('preserves an existing note when the same project set is upserted again', () => {
+    const db = new DatabaseService(makeDbPath())
+    db.init()
+
+    const entry = db.upsertConnectionHistory(['project-a', 'project-b'])
+    expect(entry).not.toBeNull()
+    expect(db.setConnectionHistoryNote(entry!.id, 'keep me')).toBe(true)
+
+    const again = db.upsertConnectionHistory(['project-b', 'project-a'])
+    expect(again?.id).toBe(entry?.id)
+    expect(again?.use_count).toBe(2)
+    expect(again?.note).toBe('keep me')
+
+    db.close()
+  })
+
   it('getRecentConnectionHistory orders by recency and respects the limit', async () => {
     const db = new DatabaseService(makeDbPath())
     db.init()

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -640,11 +640,14 @@ export class DatabaseService {
         project_ids TEXT NOT NULL,
         last_used_at TEXT NOT NULL,
         use_count INTEGER NOT NULL DEFAULT 1,
-        created_at TEXT NOT NULL
+        created_at TEXT NOT NULL,
+        note TEXT DEFAULT NULL
       );
       CREATE INDEX IF NOT EXISTS idx_connection_history_last_used
         ON connection_history(last_used_at DESC);
     `)
+
+    this.safeAddColumn('connection_history', 'note', 'TEXT DEFAULT NULL')
 
     this.safeAddColumn(
       'sessions',
@@ -2256,6 +2259,12 @@ export class DatabaseService {
     return db
       .prepare('SELECT * FROM connection_history WHERE project_set_key = ?')
       .get(key) as ConnectionHistoryEntry
+  }
+
+  setConnectionHistoryNote(id: string, note: string | null): boolean {
+    const db = this.getDb()
+    const result = db.prepare('UPDATE connection_history SET note = ? WHERE id = ?').run(note, id)
+    return result.changes > 0
   }
 
   getRecentConnectionHistory(limit = 50): ConnectionHistoryEntry[] {

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 36
+export const CURRENT_SCHEMA_VERSION = 37
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -649,5 +649,12 @@ DROP TABLE IF EXISTS diff_comments;`
       DROP INDEX IF EXISTS idx_connection_history_last_used;
       DROP TABLE IF EXISTS connection_history;
     `
+  },
+  {
+    version: 37,
+    name: 'add_connection_history_note',
+    up: `-- NOTE: ALTER TABLE for connection_history.note is handled idempotently by
+         -- ensureConnectionTables() in database.ts to avoid "duplicate column" errors.`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -461,6 +461,7 @@ export interface ConnectionHistoryEntry {
   last_used_at: string
   use_count: number
   created_at: string
+  note: string | null
 }
 
 // Database response types for queries

--- a/src/main/services/__tests__/claude-cli-interaction-ledger.test.ts
+++ b/src/main/services/__tests__/claude-cli-interaction-ledger.test.ts
@@ -1,0 +1,321 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  clearAllClaudeCliInteractions,
+  clearClaudeCliInteractions,
+  hasBlockingClaudeCliInteraction,
+  processClaudeCliHook
+} from '../claude-cli-interaction-ledger'
+import type { ClaudeCliStatusPayload, ParsedClaudeHook } from '../claude-hook-server'
+import type { SessionStatusType } from '@shared/types/session-status'
+
+const SESSION = 'hive-session-1'
+
+interface HookStep {
+  event: string
+  tool?: string
+  id?: string
+  status: SessionStatusType | null
+  plan?: string
+}
+
+function buildHook(step: HookStep): ParsedClaudeHook {
+  const hook: ParsedClaudeHook = { hook_event_name: step.event }
+  if (step.tool) hook.tool_name = step.tool
+  if (step.id) hook.tool_use_id = step.id
+  if (step.plan) hook.tool_input = { plan: step.plan }
+  return hook
+}
+
+function buildMapped(sessionId: string, step: HookStep): ClaudeCliStatusPayload | null {
+  if (!step.status) return null
+  const metadata: NonNullable<ClaudeCliStatusPayload['metadata']> = {
+    hookEventName: step.event,
+    hookPath: 'tool'
+  }
+  if (step.tool) metadata.toolName = step.tool
+  if (step.plan) metadata.plan = step.plan
+  return { sessionId, status: step.status, metadata }
+}
+
+function process(step: HookStep, sessionId = SESSION): ClaudeCliStatusPayload[] {
+  return processClaudeCliHook(sessionId, buildHook(step), buildMapped(sessionId, step))
+}
+
+function statuses(payloads: ClaudeCliStatusPayload[]): (SessionStatusType | undefined)[] {
+  return payloads.map((p) => p.status)
+}
+
+afterEach(() => {
+  clearAllClaudeCliInteractions()
+})
+
+describe('passthrough when no interactions pending', () => {
+  it('publishes non-blocking statuses unchanged', () => {
+    expect(statuses(process({ event: 'UserPromptSubmit', status: 'working' }))).toEqual(['working'])
+    expect(statuses(process({ event: 'PostToolUse', tool: 'Read', status: 'working' }))).toEqual([
+      'working'
+    ])
+    expect(statuses(process({ event: 'Stop', status: 'completed' }))).toEqual(['completed'])
+  })
+
+  it('publishes nothing for unmapped hooks', () => {
+    expect(process({ event: 'BogusEvent', status: null })).toEqual([])
+  })
+
+  it('passes a stray AskUserQuestion resolution through when nothing is latched', () => {
+    expect(
+      statuses(process({ event: 'PostToolUse', tool: 'AskUserQuestion', status: 'working' }))
+    ).toEqual(['working'])
+  })
+})
+
+describe('answering latch (the ticket bug)', () => {
+  it('suppresses unrelated tool completions while a question is pending', () => {
+    expect(
+      statuses(process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' }))
+    ).toEqual(['answering'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+
+    // Parallel sub-agent activity must not clobber the question alert.
+    expect(process({ event: 'PostToolUse', tool: 'Read', status: 'working' })).toEqual([])
+    expect(process({ event: 'PostToolUseFailure', tool: 'Bash', status: 'working' })).toEqual([])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+  })
+
+  it('releases on PostToolUse(AskUserQuestion) and resumes publishing', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+
+    const released = process({ event: 'PostToolUse', tool: 'AskUserQuestion', status: 'working' })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+
+    expect(statuses(process({ event: 'PostToolUse', tool: 'Read', status: 'working' }))).toEqual([
+      'working'
+    ])
+  })
+
+  it('releases on PostToolUseFailure(AskUserQuestion) (question escaped)', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+
+    const released = process({
+      event: 'PostToolUseFailure',
+      tool: 'AskUserQuestion',
+      status: 'working'
+    })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('keeps the latch while another question with a distinct tool_use_id is outstanding', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', id: 'q1', status: 'answering' })
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', id: 'q2', status: 'answering' })
+
+    const first = process({
+      event: 'PostToolUse',
+      tool: 'AskUserQuestion',
+      id: 'q1',
+      status: 'working'
+    })
+    // Resolution publishes, then the still-pending question re-surfaces.
+    expect(statuses(first)).toEqual(['working', 'answering'])
+    expect(first[1].metadata?.reason).toBe('interaction_resurfaced')
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+
+    const second = process({
+      event: 'PostToolUse',
+      tool: 'AskUserQuestion',
+      id: 'q2',
+      status: 'working'
+    })
+    expect(statuses(second)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('deduplicates PreToolUse + PermissionRequest firing for the same question call', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', id: 'q1', status: 'answering' })
+    process({ event: 'PermissionRequest', tool: 'AskUserQuestion', id: 'q1', status: 'answering' })
+
+    const released = process({
+      event: 'PostToolUse',
+      tool: 'AskUserQuestion',
+      id: 'q1',
+      status: 'working'
+    })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('deduplicates the real-world sequence: PreToolUse with id + PermissionRequest without id', () => {
+    // Empirically, PreToolUse carries tool_use_id but the paired
+    // PermissionRequest for the same question does not.
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', id: 'q1', status: 'answering' })
+    process({ event: 'PermissionRequest', tool: 'AskUserQuestion', status: 'answering' })
+
+    const released = process({
+      event: 'PostToolUse',
+      tool: 'AskUserQuestion',
+      id: 'q1',
+      status: 'working'
+    })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('deduplicates PreToolUse + PermissionRequest double-fire without tool_use_ids', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+    process({ event: 'PermissionRequest', tool: 'AskUserQuestion', status: 'answering' })
+
+    const released = process({
+      event: 'PostToolUse',
+      tool: 'AskUserQuestion',
+      status: 'working'
+    })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+})
+
+describe('permission latch and the pending-interaction queue', () => {
+  it('holds a permission request behind a pending question, then re-surfaces it', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+
+    // Permission fires while the question is still shown: registered, not published.
+    expect(process({ event: 'PermissionRequest', tool: 'Bash', status: 'permission' })).toEqual([])
+
+    const released = process({ event: 'PostToolUse', tool: 'AskUserQuestion', status: 'working' })
+    expect(statuses(released)).toEqual(['working', 'permission'])
+    expect(released[1].metadata?.toolName).toBe('Bash')
+    expect(released[1].metadata?.reason).toBe('interaction_resurfaced')
+
+    expect(statuses(process({ event: 'PostToolUse', tool: 'Bash', status: 'working' }))).toEqual([
+      'working'
+    ])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('publishes a permission immediately when it is the top pending interaction', () => {
+    expect(
+      statuses(process({ event: 'PermissionRequest', tool: 'Bash', status: 'permission' }))
+    ).toEqual(['permission'])
+  })
+
+  it('does not release a permission on an unrelated same-tool completion (tool_use_id mismatch)', () => {
+    process({ event: 'PermissionRequest', tool: 'Bash', id: 'p1', status: 'permission' })
+
+    // A parallel sub-agent's Bash call (different id) completes — still latched.
+    expect(process({ event: 'PostToolUse', tool: 'Bash', id: 'x9', status: 'working' })).toEqual([])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+
+    const released = process({ event: 'PostToolUse', tool: 'Bash', id: 'p1', status: 'working' })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('falls back to counting when the release hook lacks a tool_use_id', () => {
+    process({ event: 'PermissionRequest', tool: 'Bash', id: 'p1', status: 'permission' })
+
+    const released = process({ event: 'PostToolUse', tool: 'Bash', status: 'working' })
+    expect(statuses(released)).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+})
+
+describe('plan_ready latch', () => {
+  it('keeps plan_ready surfaced through sub-agent completions until the plan resolves', () => {
+    expect(
+      statuses(
+        process({ event: 'PreToolUse', tool: 'ExitPlanMode', status: 'plan_ready', plan: '# Plan' })
+      )
+    ).toEqual(['plan_ready'])
+
+    expect(process({ event: 'PostToolUse', tool: 'Task', status: 'working' })).toEqual([])
+
+    const approved = process({ event: 'PostToolUse', tool: 'ExitPlanMode', status: 'working' })
+    expect(statuses(approved)).toEqual(['working'])
+    expect(approved[0].metadata?.toolName).toBe('ExitPlanMode')
+  })
+
+  it('publishes the rejection payload on PostToolUseFailure(ExitPlanMode)', () => {
+    process({ event: 'PreToolUse', tool: 'ExitPlanMode', status: 'plan_ready' })
+
+    const rejected = process({
+      event: 'PostToolUseFailure',
+      tool: 'ExitPlanMode',
+      status: 'planning'
+    })
+    expect(statuses(rejected)).toEqual(['planning'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('holds a plan registered behind a question and re-surfaces it with its plan text', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+    expect(
+      process({ event: 'PreToolUse', tool: 'ExitPlanMode', status: 'plan_ready', plan: '# P' })
+    ).toEqual([])
+
+    const released = process({ event: 'PostToolUse', tool: 'AskUserQuestion', status: 'working' })
+    expect(statuses(released)).toEqual(['working', 'plan_ready'])
+    expect(released[1].metadata?.plan).toBe('# P')
+  })
+
+  it('lets a higher-priority permission surface over a latched plan_ready, then restores it', () => {
+    process({ event: 'PreToolUse', tool: 'ExitPlanMode', status: 'plan_ready', plan: '# P' })
+
+    expect(
+      statuses(process({ event: 'PermissionRequest', tool: 'Bash', status: 'permission' }))
+    ).toEqual(['permission'])
+
+    const released = process({ event: 'PostToolUse', tool: 'Bash', status: 'working' })
+    expect(statuses(released)).toEqual(['working', 'plan_ready'])
+  })
+})
+
+describe('fail-safe clears', () => {
+  it.each(['UserPromptSubmit', 'Stop', 'SessionStart', 'SessionEnd'])(
+    '%s clears all pending interactions and publishes its own status',
+    (event) => {
+      process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+      process({ event: 'PermissionRequest', tool: 'Bash', status: 'permission' })
+
+      const cleared = process({ event, status: event === 'UserPromptSubmit' ? 'working' : 'completed' })
+      expect(statuses(cleared)).toEqual([event === 'UserPromptSubmit' ? 'working' : 'completed'])
+      expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+
+      expect(statuses(process({ event: 'PostToolUse', tool: 'Read', status: 'working' }))).toEqual([
+        'working'
+      ])
+    }
+  )
+})
+
+describe('manual clears and session isolation', () => {
+  it('clearClaudeCliInteractions drops only the given session', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' }, 'other-session')
+
+    clearClaudeCliInteractions(SESSION)
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+    expect(hasBlockingClaudeCliInteraction('other-session')).toBe(true)
+  })
+
+  it('clearAllClaudeCliInteractions drops everything', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' }, 'other-session')
+
+    clearAllClaudeCliInteractions()
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+    expect(hasBlockingClaudeCliInteraction('other-session')).toBe(false)
+  })
+
+  it('keeps sessions independent: a latch in one session never suppresses another', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+
+    expect(
+      statuses(
+        process({ event: 'PostToolUse', tool: 'Read', status: 'working' }, 'other-session')
+      )
+    ).toEqual(['working'])
+  })
+})

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -374,6 +374,184 @@ describe('ClaudeHookServer HTTP round-trip', () => {
     )
   })
 
+  it('keeps a pending question surfaced through unrelated sub-agent hooks until answered', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:status',
+        expect.objectContaining({ sessionId: 'hive-session-1', status: 'answering' })
+      )
+    })
+
+    // Parallel sub-agent tool completions must not clobber the question.
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Read'
+    })
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'Bash'
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(1)
+
+    // Answering the question resolves the latch and publishes working.
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(2)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenLastCalledWith(
+      'claude-cli:status',
+      {
+        sessionId: 'hive-session-1',
+        status: 'working',
+        metadata: {
+          hookEventName: 'PostToolUse',
+          hookPath: 'tool',
+          toolName: 'AskUserQuestion'
+        }
+      }
+    )
+  })
+
+  it('re-surfaces a queued permission request after the question is answered', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    // Permission arrives while the question is pending: queued, not published.
+    await postHook(port, 'hive-session-1', 'permission', {
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(1)
+    })
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(3)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenNthCalledWith(
+      2,
+      'claude-cli:status',
+      expect.objectContaining({ sessionId: 'hive-session-1', status: 'working' })
+    )
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenNthCalledWith(
+      3,
+      'claude-cli:status',
+      {
+        sessionId: 'hive-session-1',
+        status: 'permission',
+        metadata: {
+          hookEventName: 'PermissionRequest',
+          hookPath: 'permission',
+          toolName: 'Bash',
+          reason: 'interaction_resurfaced'
+        }
+      }
+    )
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(4)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenLastCalledWith(
+      'claude-cli:status',
+      expect.objectContaining({ sessionId: 'hive-session-1', status: 'working' })
+    )
+  })
+
+  it('keeps plan_ready surfaced through sub-agent completions until the plan resolves', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'ExitPlanMode',
+      tool_input: { plan: '# Plan' }
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:status',
+        expect.objectContaining({ sessionId: 'hive-session-1', status: 'plan_ready' })
+      )
+    })
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Task'
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(1)
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'ExitPlanMode'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(2)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenLastCalledWith(
+      'claude-cli:status',
+      {
+        sessionId: 'hive-session-1',
+        status: 'working',
+        metadata: {
+          hookEventName: 'PostToolUse',
+          hookPath: 'tool',
+          toolName: 'ExitPlanMode'
+        }
+      }
+    )
+  })
+
+  it('clears pending interactions on turn boundaries so later hooks publish normally', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(2)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenLastCalledWith(
+      'claude-cli:status',
+      expect.objectContaining({ sessionId: 'hive-session-1', status: 'working' })
+    )
+
+    // The abandoned question no longer suppresses later publishes.
+    await postHook(port, 'hive-session-1', 'permission', {
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledTimes(3)
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenLastCalledWith(
+      'claude-cli:status',
+      expect.objectContaining({ sessionId: 'hive-session-1', status: 'permission' })
+    )
+  })
+
   it('ignores unknown event names without publishing status events', async () => {
     const { port } = await getClaudeHookServer()
 

--- a/src/main/services/claude-cli-interaction-ledger.ts
+++ b/src/main/services/claude-cli-interaction-ledger.ts
@@ -1,0 +1,197 @@
+import { STATUS_PRIORITY, type SessionStatusType } from '@shared/types/session-status'
+// Type-only import: claude-hook-server imports this module at runtime, so a
+// runtime import back would create a cycle.
+import type { ClaudeCliStatusPayload, ParsedClaudeHook } from './claude-hook-server'
+
+/**
+ * Per-session ledger of blocking interactions (questions, permission prompts,
+ * plan approvals) raised by Claude CLI hooks. Sub-agents share the parent's
+ * hive session id, so their PostToolUse hooks would otherwise overwrite an
+ * unanswered question's status (last-write-wins). The ledger latches blocking
+ * statuses until the hook that actually resolves them arrives, suppresses
+ * unrelated status publishes in between, and re-surfaces the next pending
+ * interaction once the current one resolves.
+ *
+ * This must run before publishClaudeCliStatus's dedup: the resolution hook
+ * (PostToolUse → 'working') often carries the same status as a suppressed
+ * intermediate publish, and would be dedup-swallowed if the latch lived
+ * downstream (e.g. in the renderer store).
+ */
+
+type BlockingKind = 'answering' | 'permission' | 'plan_ready'
+
+const KIND_STATUS: Record<BlockingKind, SessionStatusType> = {
+  answering: 'answering',
+  permission: 'permission',
+  plan_ready: 'plan_ready'
+}
+
+interface BlockingEntry {
+  kind: BlockingKind
+  // Outstanding requests tracked precisely by tool_use_id when hooks carry it…
+  toolUseIds: Set<string>
+  // …and by count for hooks that don't.
+  count: number
+  // Latest register payload, re-published when this entry re-surfaces.
+  payload: ClaudeCliStatusPayload
+}
+
+// sessionId → entry key ('answering' | 'plan_ready' | 'permission:<tool>') → entry
+const ledgers = new Map<string, Map<string, BlockingEntry>>()
+
+// Turn boundaries: a new prompt or a finished/started session invalidates any
+// interaction the hooks failed to resolve explicitly (e.g. a permission denied
+// in the TUI, which fires no per-tool hook).
+const RESET_EVENTS = new Set(['UserPromptSubmit', 'Stop', 'SessionStart', 'SessionEnd'])
+
+function entrySize(entry: BlockingEntry): number {
+  return entry.toolUseIds.size + entry.count
+}
+
+function classify(toolName: string | undefined): { kind: BlockingKind; key: string } {
+  if (toolName === 'AskUserQuestion') return { kind: 'answering', key: 'answering' }
+  if (toolName === 'ExitPlanMode') return { kind: 'plan_ready', key: 'plan_ready' }
+  return { kind: 'permission', key: `permission:${toolName ?? ''}` }
+}
+
+function topEntry(session: Map<string, BlockingEntry> | undefined): BlockingEntry | null {
+  if (!session) return null
+  let best: BlockingEntry | null = null
+  for (const entry of session.values()) {
+    if (!best || STATUS_PRIORITY[KIND_STATUS[entry.kind]] > STATUS_PRIORITY[KIND_STATUS[best.kind]]) {
+      best = entry
+    }
+  }
+  return best
+}
+
+function resurfacedPayload(entry: BlockingEntry): ClaudeCliStatusPayload {
+  return {
+    ...entry.payload,
+    metadata: { ...entry.payload.metadata, reason: 'interaction_resurfaced' }
+  }
+}
+
+function registerInteraction(
+  sessionId: string,
+  hook: ParsedClaudeHook,
+  mapped: ClaudeCliStatusPayload,
+  kind: BlockingKind,
+  key: string
+): ClaudeCliStatusPayload[] {
+  let session = ledgers.get(sessionId)
+  if (!session) {
+    session = new Map()
+    ledgers.set(sessionId, session)
+  }
+
+  let entry = session.get(key)
+  if (!entry) {
+    entry = { kind, toolUseIds: new Set(), count: 0, payload: mapped }
+    session.set(key, entry)
+  }
+  entry.payload = mapped
+
+  if (hook.tool_use_id) {
+    // Set semantics also dedupe PreToolUse + PermissionRequest firing for the
+    // same tool call.
+    entry.toolUseIds.add(hook.tool_use_id)
+  } else if (hook.hook_event_name === 'PermissionRequest' && kind !== 'permission') {
+    // PreToolUse already fires for AskUserQuestion/ExitPlanMode; a paired
+    // PermissionRequest must not double-count the same interaction.
+    if (entrySize(entry) === 0) entry.count = 1
+  } else {
+    entry.count += 1
+  }
+
+  return topEntry(session) === entry ? [mapped] : []
+}
+
+/**
+ * Release one outstanding unit from the entry. Returns false when the hook's
+ * tool_use_id does not match any outstanding request — i.e. an unrelated
+ * parallel call of the same tool completed, which must not lift the latch.
+ */
+function releaseOne(entry: BlockingEntry, toolUseId: string | undefined): boolean {
+  if (toolUseId) {
+    if (entry.toolUseIds.delete(toolUseId)) return true
+    if (entry.count > 0) {
+      entry.count -= 1
+      return true
+    }
+    return false
+  }
+
+  if (entry.count > 0) {
+    entry.count -= 1
+    return true
+  }
+  const first = entry.toolUseIds.values().next()
+  if (!first.done) {
+    entry.toolUseIds.delete(first.value)
+    return true
+  }
+  return false
+}
+
+/**
+ * Apply a hook to the session's interaction ledger and return the status
+ * payloads to publish, in order (0, 1, or 2 — a resolution followed by the
+ * re-surfaced next pending interaction).
+ */
+export function processClaudeCliHook(
+  sessionId: string,
+  hook: ParsedClaudeHook,
+  mapped: ClaudeCliStatusPayload | null
+): ClaudeCliStatusPayload[] {
+  const event = hook.hook_event_name ?? ''
+
+  if (RESET_EVENTS.has(event)) {
+    ledgers.delete(sessionId)
+    return mapped ? [mapped] : []
+  }
+
+  const session = ledgers.get(sessionId)
+
+  if (mapped && (event === 'PreToolUse' || event === 'PermissionRequest')) {
+    const { kind, key } = classify(hook.tool_name)
+    // PreToolUse hooks are only configured for AskUserQuestion/ExitPlanMode;
+    // anything else that slips through is not a blocking interaction.
+    if (event === 'PermissionRequest' || kind !== 'permission') {
+      return registerInteraction(sessionId, hook, mapped, kind, key)
+    }
+  }
+
+  if (event === 'PostToolUse' || event === 'PostToolUseFailure') {
+    const { key } = classify(hook.tool_name)
+    const entry = session?.get(key)
+    if (session && entry) {
+      if (!releaseOne(entry, hook.tool_use_id)) return []
+      if (entrySize(entry) === 0) {
+        session.delete(key)
+        if (session.size === 0) ledgers.delete(sessionId)
+      }
+      const publishes = mapped ? [mapped] : []
+      const top = topEntry(session)
+      if (top) publishes.push(resurfacedPayload(top))
+      return publishes
+    }
+  }
+
+  // While any interaction is pending, unrelated hooks neither register nor
+  // release — suppress their status so the alert stays surfaced.
+  if (session && session.size > 0) return []
+  return mapped ? [mapped] : []
+}
+
+export function clearClaudeCliInteractions(sessionId: string): void {
+  ledgers.delete(sessionId)
+}
+
+export function clearAllClaudeCliInteractions(): void {
+  ledgers.clear()
+}
+
+export function hasBlockingClaudeCliInteraction(sessionId: string): boolean {
+  return (ledgers.get(sessionId)?.size ?? 0) > 0
+}

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -5,10 +5,15 @@ import { createLogger } from './logger'
 import { cliHookTransportRouter } from './cli-hook-transport-router'
 import { handleClaudeCliHiveTelemetryHook } from './hive-enterprise-claude-cli-telemetry'
 import { publishDesktopBackendEvent } from '../desktop/backend-event-publisher'
+import {
+  clearAllClaudeCliInteractions,
+  processClaudeCliHook
+} from './claude-cli-interaction-ledger'
 
 export interface ParsedClaudeHook {
   hook_event_name?: string
   tool_name?: string
+  tool_use_id?: string
   permission_mode?: string
   prompt?: unknown
   transcript_path?: unknown
@@ -164,11 +169,9 @@ export function publishClaudeCliStatus(payload: ClaudeCliStatusPayload): void {
   for (const subscriber of statusSubscribers) {
     subscriber(payload)
   }
-  void import('../desktop/backend-event-publisher')
-    .then(({ publishDesktopBackendEvent }) =>
-      publishDesktopBackendEvent('claude-cli:status', payload)
-    )
-    .catch(() => undefined)
+  void Promise.resolve(publishDesktopBackendEvent('claude-cli:status', payload)).catch(
+    () => undefined
+  )
 }
 
 /**
@@ -253,12 +256,18 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
     const body = JSON.parse(rawBody || '{}') as ParsedClaudeHook
     if (route) {
       const status = mapHookEventToStatus(body)
-      if (status) {
-        publishClaudeCliStatus({
-          sessionId: route.sessionId,
-          status,
-          metadata: buildStatusMetadata(body, route.hookPath)
-        })
+      const mapped: ClaudeCliStatusPayload | null = status
+        ? {
+            sessionId: route.sessionId,
+            status,
+            metadata: buildStatusMetadata(body, route.hookPath)
+          }
+        : null
+      // The interaction ledger latches blocking statuses (question/permission/
+      // plan approval) so parallel sub-agent hooks can't clobber them, and
+      // re-surfaces queued interactions as each one resolves.
+      for (const payload of processClaudeCliHook(route.sessionId, body, mapped)) {
+        publishClaudeCliStatus(payload)
       }
       void handleClaudeCliHiveTelemetryHook(route.sessionId, body)
       // First user prompt of this CLI session → tell the renderer so it can
@@ -361,6 +370,7 @@ export async function closeClaudeHookServer(): Promise<void> {
     startingPromise = null
     lastStatusBySession.clear()
     statusSubscribers.clear()
+    clearAllClaudeCliInteractions()
     return
   }
 
@@ -379,4 +389,5 @@ export async function closeClaudeHookServer(): Promise<void> {
   startingPromise = null
   lastStatusBySession.clear()
   statusSubscribers.clear()
+  clearAllClaudeCliInteractions()
 }

--- a/src/main/services/connection-ops.history.test.ts
+++ b/src/main/services/connection-ops.history.test.ts
@@ -18,6 +18,7 @@ import {
   createConnectionOp,
   getRecentConnectionsOp,
   recordConnectionHistory,
+  setRecentConnectionNoteOp,
   updateConnectionMembersOp
 } from './connection-ops'
 
@@ -290,6 +291,57 @@ describeIf('connection-ops history recording', () => {
         )
       }
     }
+
+    db.close()
+  })
+
+  it('getRecentConnectionsOp surfaces the stored note on entries (null when unset)', async () => {
+    stubHome()
+    const db = makeDb()
+
+    const projectA = seedProject(db, 'proja')
+    const projectB = seedProject(db, 'projb')
+    const worktreeA = seedWorktree(db, projectA, 'main')
+    const worktreeB = seedWorktree(db, projectB, 'main')
+    await createConnectionOp(db, [worktreeA.id, worktreeB.id])
+
+    let result = getRecentConnectionsOp(db)
+    expect(result.success).toBe(true)
+    expect(result.entries![0].note).toBeNull()
+
+    const row = db.getRecentConnectionHistory()[0]
+    expect(db.setConnectionHistoryNote(row.id, 'urgent client work')).toBe(true)
+
+    result = getRecentConnectionsOp(db)
+    expect(result.entries![0].note).toBe('urgent client work')
+
+    db.close()
+  })
+
+  it('setRecentConnectionNoteOp trims, clears on empty, and reports missing entries', async () => {
+    stubHome()
+    const db = makeDb()
+
+    const projectA = seedProject(db, 'proja')
+    const projectB = seedProject(db, 'projb')
+    const worktreeA = seedWorktree(db, projectA, 'main')
+    const worktreeB = seedWorktree(db, projectB, 'main')
+    await createConnectionOp(db, [worktreeA.id, worktreeB.id])
+    const row = db.getRecentConnectionHistory()[0]
+
+    expect(setRecentConnectionNoteOp(db, row.id, '  my note  ')).toEqual({ success: true })
+    expect(db.getRecentConnectionHistory()[0].note).toBe('my note')
+
+    expect(setRecentConnectionNoteOp(db, row.id, '   ')).toEqual({ success: true })
+    expect(db.getRecentConnectionHistory()[0].note).toBeNull()
+
+    expect(setRecentConnectionNoteOp(db, row.id, null)).toEqual({ success: true })
+    expect(db.getRecentConnectionHistory()[0].note).toBeNull()
+
+    expect(setRecentConnectionNoteOp(db, 'missing-id', 'x')).toEqual({
+      success: false,
+      error: 'Recent connection not found'
+    })
 
     db.close()
   })

--- a/src/main/services/connection-ops.ts
+++ b/src/main/services/connection-ops.ts
@@ -526,7 +526,8 @@ export function getRecentConnectionsOp(db: DatabaseService): {
         project_set_key: row.project_set_key,
         projects,
         last_used_at: row.last_used_at,
-        use_count: row.use_count
+        use_count: row.use_count,
+        note: row.note ?? null
       })
     }
 
@@ -534,6 +535,32 @@ export function getRecentConnectionsOp(db: DatabaseService): {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     log.error('Get recent connections failed', error instanceof Error ? error : new Error(message))
+    return { success: false, error: message }
+  }
+}
+
+/**
+ * Set or clear the note on a recent-connection history entry. Empty or
+ * whitespace-only notes are normalized to null (clears the note).
+ */
+export function setRecentConnectionNoteOp(
+  db: DatabaseService,
+  entryId: string,
+  note: string | null
+): { success: boolean; error?: string } {
+  log.info('Setting recent connection note', { entryId })
+  try {
+    const normalized = note && note.trim() ? note.trim() : null
+    if (!db.setConnectionHistoryNote(entryId, normalized)) {
+      return { success: false, error: 'Recent connection not found' }
+    }
+    return { success: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log.error(
+      'Set recent connection note failed',
+      error instanceof Error ? error : new Error(message)
+    )
     return { success: false, error: message }
   }
 }

--- a/src/main/services/terminal-pty-bridge.claude-cli.test.ts
+++ b/src/main/services/terminal-pty-bridge.claude-cli.test.ts
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => {
     getLastClaudeCliStatus: vi.fn(),
     publishClaudeCliStatus: vi.fn(),
     subscribeClaudeCliStatus: vi.fn(() => vi.fn()),
+    clearClaudeCliInteractions: vi.fn(),
+    clearAllClaudeCliInteractions: vi.fn(),
     ptyService: {
       has: vi.fn(() => false),
       create: vi.fn(() => ({ cols: 120, rows: 40 })),
@@ -120,6 +122,11 @@ vi.mock('./claude-hook-server', () => ({
 
 vi.mock('../desktop/backend-event-publisher', () => ({
   publishDesktopBackendEvent: mocks.publishDesktopBackendEvent
+}))
+
+vi.mock('./claude-cli-interaction-ledger', () => ({
+  clearClaudeCliInteractions: mocks.clearClaudeCliInteractions,
+  clearAllClaudeCliInteractions: mocks.clearAllClaudeCliInteractions
 }))
 
 import type { Session } from '../db/types'
@@ -484,7 +491,7 @@ describe('Claude CLI terminal hook status wiring', () => {
       }
     )
 
-    it.each(['planning', 'permission'])(
+    it.each(['planning', 'permission', 'answering'])(
       'publishes completed when Escape is typed while %s',
       async (status) => {
         await createClaudeCliTerminal('hive-session-1', {})
@@ -522,7 +529,7 @@ describe('Claude CLI terminal hook status wiring', () => {
       }
     )
 
-    it.each(['completed', 'plan_ready', 'answering', undefined])(
+    it.each(['completed', 'plan_ready', undefined])(
       'ignores Escape when the last published status is %s',
       async (status) => {
         await createClaudeCliTerminal('hive-session-1', {})
@@ -534,6 +541,64 @@ describe('Claude CLI terminal hook status wiring', () => {
         expect(mocks.publishClaudeCliStatus).not.toHaveBeenCalled()
       }
     )
+  })
+
+  describe('interaction ledger clears', () => {
+    it('clears the session ledger when a Claude CLI PTY starts, so restarts never inherit a stale latch', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+
+      expect(mocks.clearClaudeCliInteractions).toHaveBeenCalledWith('hive-session-1')
+    })
+
+    it.each(['\x1b', '\x03'])(
+      'clears the session ledger on user interrupt %j so a phantom permission cannot re-surface',
+      async (key) => {
+        await createClaudeCliTerminal('hive-session-1', {})
+        mocks.getLastClaudeCliStatus.mockReturnValue('permission')
+        mocks.clearClaudeCliInteractions.mockClear()
+
+        handleClaudeCliTerminalInput('hive-session-1', key)
+
+        expect(mocks.clearClaudeCliInteractions).toHaveBeenCalledWith('hive-session-1')
+      }
+    )
+
+    it('clears the ledger on Escape while answering — no hook fires for an escaped question', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.getLastClaudeCliStatus.mockReturnValue('answering')
+      mocks.clearClaudeCliInteractions.mockClear()
+
+      handleClaudeCliTerminalInput('hive-session-1', '\x1b')
+
+      expect(mocks.clearClaudeCliInteractions).toHaveBeenCalledWith('hive-session-1')
+    })
+
+    it('clears the session ledger when the tracked PTY exits', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.clearClaudeCliInteractions.mockClear()
+
+      mocks.exitCallbacks.get('hive-session-1')?.(9)
+
+      expect(mocks.clearClaudeCliInteractions).toHaveBeenCalledWith('hive-session-1')
+    })
+
+    it('clears the session ledger when the terminal is destroyed', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.clearClaudeCliInteractions.mockClear()
+
+      destroyNodePtyTerminal('hive-session-1')
+
+      expect(mocks.clearClaudeCliInteractions).toHaveBeenCalledWith('hive-session-1')
+    })
+
+    it('clears all ledgers on cleanupTerminals', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.clearAllClaudeCliInteractions.mockClear()
+
+      cleanupTerminals()
+
+      expect(mocks.clearAllClaudeCliInteractions).toHaveBeenCalled()
+    })
   })
 
   it('removes the Claude CLI PTY-exit safety net when the terminal is destroyed', async () => {

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -8,6 +8,10 @@ import {
   subscribeClaudeCliStatus,
   type ClaudeCliStatusPayload
 } from './claude-hook-server'
+import {
+  clearAllClaudeCliInteractions,
+  clearClaudeCliInteractions
+} from './claude-cli-interaction-ledger'
 import { logClaudeBinaryVersion, resolveClaudeBinaryPath } from './claude-binary-resolver'
 import { buildClaudeCliPtySpawn } from './claude-cli-spawner'
 import { externalizeGoalHandoffPlan } from './claude-cli-plan-handoff'
@@ -57,6 +61,8 @@ function armClaudePlanFollowupWatcher(sessionId: string): void {
     sessionId,
     watchForClaudePlanFollowup(source.worktreePath, source.claudeSessionId, () => {
       closeClaudePlanFollowupWatcher(sessionId)
+      // Bypasses the interaction ledger deliberately: a plan followup implies a
+      // user prompt, whose UserPromptSubmit hook clears the ledger anyway.
       publishClaudeCliStatus({
         sessionId,
         status: 'planning',
@@ -100,21 +106,25 @@ function ensureClaudeCliStatusSubscription(): void {
 // Lone Escape / Ctrl+C. A bare Escape keypress arrives as exactly '\x1b';
 // multi-byte sequences (arrow keys, bracketed pastes) never match exactly.
 const INTERRUPT_KEYS = new Set(['\x1b', '\x03'])
-const INTERRUPTIBLE_STATUSES = new Set(['working', 'planning', 'permission'])
+const INTERRUPTIBLE_STATUSES = new Set(['working', 'planning', 'permission', 'answering'])
 
 /**
  * Claude Code never fires its Stop hook when the user interrupts a running
  * turn with Escape/Ctrl+C, and the CLI keeps running so the pty_exit fallback
  * never fires either — the session would stay stuck on 'working'. Mirror the
- * keypress itself into a status update instead. plan_ready/answering are
- * excluded: escaping those dialogs fires PostToolUseFailure hooks that the
- * existing pipeline already handles.
+ * keypress itself into a status update instead. Escaping a question or
+ * permission dialog fires no hook at all (verified empirically), so those
+ * statuses are interruptible too; plan_ready is excluded because rejecting a
+ * plan fires PostToolUseFailure(ExitPlanMode), which the pipeline handles.
  */
 export function handleClaudeCliTerminalInput(terminalId: string, data: string): void {
   if (!claudeCliSessions.has(terminalId)) return
   if (!INTERRUPT_KEYS.has(data)) return
   const last = getLastClaudeCliStatus(terminalId)
   if (!last || !INTERRUPTIBLE_STATUSES.has(last)) return
+  // No hook fires for an interrupted/denied interaction — drop any pending
+  // latch so the next hook cannot re-surface a phantom permission.
+  clearClaudeCliInteractions(terminalId)
   publishClaudeCliStatus({
     sessionId: terminalId,
     status: 'completed',
@@ -134,6 +144,7 @@ export function destroyNodePtyTerminal(terminalId: string): void {
   claudeWatchers.get(terminalId)?.close()
   claudeWatchers.delete(terminalId)
   closeClaudePlanFollowupWatcher(terminalId)
+  clearClaudeCliInteractions(terminalId)
   claudeCliSessions.delete(terminalId)
   claudeCliWorktreeBasenames.delete(terminalId)
   claudeCliTranscriptSources.delete(terminalId)
@@ -199,6 +210,7 @@ function attachNodePtyListeners(terminalId: string): void {
     claudeWatchers.delete(terminalId)
     closeClaudePlanFollowupWatcher(terminalId)
     if (claudeCliSessions.has(terminalId)) {
+      clearClaudeCliInteractions(terminalId)
       publishClaudeCliStatus({
         sessionId: terminalId,
         status: 'completed',
@@ -329,6 +341,8 @@ export async function createClaudeCliTerminal(
       })
     }
     claudeCliSessions.add(sessionId)
+    // A restarted session must never inherit a stale interaction latch.
+    clearClaudeCliInteractions(sessionId)
     claudeCliWorktreeBasenames.set(sessionId, path.basename(worktreePath))
     if (!pendingPrompt) {
       publishClaudeCliStatus({
@@ -377,6 +391,7 @@ export function cleanupTerminals(): void {
   claudeCliWorktreeBasenames.clear()
   claudeCliTranscriptSources.clear()
   claudeCliLastStatus.clear()
+  clearAllClaudeCliInteractions()
   unsubscribeClaudeCliStatus?.()
   unsubscribeClaudeCliStatus = null
   resetAllClaudeCliTitleState()

--- a/src/renderer/src/api/__tests__/connection-api.test.ts
+++ b/src/renderer/src/api/__tests__/connection-api.test.ts
@@ -317,7 +317,8 @@ describe('connectionApi', () => {
             { id: 'project-2', name: 'Project 2', path: '/tmp/project-2' }
           ],
           last_used_at: '2026-05-28T00:00:00.000Z',
-          use_count: 3
+          use_count: 3,
+          note: null
         }
       ]
     }
@@ -328,5 +329,27 @@ describe('connectionApi', () => {
 
     await expect(connectionApi.getRecentConnections()).resolves.toBe(result)
     expect(request).toHaveBeenCalledWith('connectionOps.getRecentConnections', {})
+  })
+
+  it('routes setRecentConnectionNote through the renderer RPC client', async () => {
+    const result = { success: true }
+    const request = vi.fn().mockResolvedValue(result)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(connectionApi.setRecentConnectionNote('recent-1', 'my note')).resolves.toBe(
+      result
+    )
+    expect(request).toHaveBeenCalledWith('connectionOps.setRecentConnectionNote', {
+      entryId: 'recent-1',
+      note: 'my note'
+    })
+
+    await expect(connectionApi.setRecentConnectionNote('recent-1', null)).resolves.toBe(result)
+    expect(request).toHaveBeenCalledWith('connectionOps.setRecentConnectionNote', {
+      entryId: 'recent-1',
+      note: null
+    })
   })
 })

--- a/src/renderer/src/api/connection-api.ts
+++ b/src/renderer/src/api/connection-api.ts
@@ -116,6 +116,14 @@ export const connectionApi = {
       'connectionOps.setPinned',
       { connectionId, pinned }
     ),
+  setRecentConnectionNote: async (
+    entryId: string,
+    note: string | null
+  ): Promise<ConnectionMutationResult> =>
+    getRendererRpcClient().request<ConnectionMutationResult>(
+      'connectionOps.setRecentConnectionNote',
+      { entryId, note }
+    ),
   updateMembers: async (
     connectionId: string,
     worktreeIds: string[]

--- a/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
+++ b/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react'
-import { Loader2, Link } from 'lucide-react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { Loader2, Link, Search, StickyNote, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   Dialog,
@@ -10,8 +10,16 @@ import {
   DialogFooter
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
 import { useConnectionStore } from '@/stores'
 import { connectionApi } from '@/api/connection-api'
+import { toast } from '@/lib/toast'
 import { formatRelativeTime } from '@/lib/format-utils'
 import type { RecentConnectionEntry } from '@shared/types/connection'
 
@@ -31,6 +39,15 @@ export function RecentConnectionsDialog({
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [isCreating, setIsCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState('')
+
+  // Inline note edit state
+  const [editingNoteId, setEditingNoteId] = useState<string | null>(null)
+  const [noteInput, setNoteInput] = useState('')
+  const noteInputRef = useRef<HTMLInputElement>(null)
+  const noteBlurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const noteIntentionalCloseRef = useRef(false)
+  const noteEditStartRef = useRef(0)
 
   useEffect(() => {
     if (!open) return
@@ -40,6 +57,8 @@ export function RecentConnectionsDialog({
     setError(null)
     setEntries([])
     setIsLoading(true)
+    setFilter('')
+    setEditingNoteId(null)
 
     connectionApi
       .getRecentConnections()
@@ -60,6 +79,41 @@ export function RecentConnectionsDialog({
       })
   }, [open])
 
+  const filteredEntries = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    if (!q) return entries
+    return entries.filter((entry) =>
+      `${entry.projects.map((p) => p.name).join(' + ')} ${entry.note ?? ''}`
+        .toLowerCase()
+        .includes(q)
+    )
+  }, [entries, filter])
+
+  // The Create handler resolves against `entries`, so a selected row hidden by
+  // the filter would still be creatable invisibly -- drop the selection instead.
+  useEffect(() => {
+    if (selectedId && !filteredEntries.some((entry) => entry.id === selectedId)) {
+      setSelectedId(null)
+    }
+  }, [filteredEntries, selectedId])
+
+  // Focus the note input when it appears (deferred to run after the context menu closes)
+  useEffect(() => {
+    if (!editingNoteId) return
+    requestAnimationFrame(() => {
+      if (noteInputRef.current && document.activeElement !== noteInputRef.current) {
+        noteInputRef.current.focus()
+        noteInputRef.current.select()
+      }
+    })
+  }, [editingNoteId])
+
+  useEffect(() => {
+    return () => {
+      if (noteBlurTimerRef.current) clearTimeout(noteBlurTimerRef.current)
+    }
+  }, [])
+
   const handleCreate = useCallback(async () => {
     const entry = entries.find((e) => e.id === selectedId)
     if (!entry) return
@@ -75,6 +129,86 @@ export function RecentConnectionsDialog({
     }
   }, [entries, selectedId, quickCreateConnection, onOpenChange])
 
+  const persistNote = useCallback(async (entryId: string, raw: string | null) => {
+    const normalized = raw && raw.trim() ? raw.trim() : null
+    try {
+      const result = await connectionApi.setRecentConnectionNote(entryId, normalized)
+      if (result.success) {
+        setEntries((prev) =>
+          prev.map((entry) => (entry.id === entryId ? { ...entry, note: normalized } : entry))
+        )
+      } else {
+        toast.error(result.error || 'Failed to save note')
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save note')
+    }
+  }, [])
+
+  const handleStartNoteEdit = useCallback((entry: RecentConnectionEntry) => {
+    noteIntentionalCloseRef.current = false
+    if (noteBlurTimerRef.current) clearTimeout(noteBlurTimerRef.current)
+    noteEditStartRef.current = Date.now()
+    setNoteInput(entry.note ?? '')
+    setEditingNoteId(entry.id)
+  }, [])
+
+  const handleSaveNote = useCallback(async () => {
+    if (!editingNoteId) return
+    noteIntentionalCloseRef.current = true
+    if (noteBlurTimerRef.current) clearTimeout(noteBlurTimerRef.current)
+    try {
+      await persistNote(editingNoteId, noteInput)
+    } finally {
+      setEditingNoteId(null)
+    }
+  }, [editingNoteId, noteInput, persistNote])
+
+  const handleNoteKeyDown = useCallback(
+    (e: React.KeyboardEvent): void => {
+      // Keep Enter/Escape inside the row edit -- Escape would otherwise close the dialog.
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        e.stopPropagation()
+        handleSaveNote()
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        noteIntentionalCloseRef.current = true
+        if (noteBlurTimerRef.current) clearTimeout(noteBlurTimerRef.current)
+        setEditingNoteId(null)
+      }
+    },
+    [handleSaveNote]
+  )
+
+  const handleNoteBlur = useCallback(() => {
+    if (noteIntentionalCloseRef.current) {
+      noteIntentionalCloseRef.current = false
+      return
+    }
+    // The closing context menu steals focus right after the input mounts --
+    // refocus instead of cancelling during that window.
+    const timeSinceStart = Date.now() - noteEditStartRef.current
+    if (timeSinceStart < 500) {
+      setTimeout(() => {
+        if (noteInputRef.current && document.activeElement !== noteInputRef.current) {
+          noteInputRef.current.focus()
+          noteInputRef.current.select()
+        }
+      }, 0)
+      return
+    }
+
+    if (noteBlurTimerRef.current) clearTimeout(noteBlurTimerRef.current)
+    noteBlurTimerRef.current = setTimeout(() => {
+      noteBlurTimerRef.current = null
+      if (document.activeElement !== noteInputRef.current) {
+        setEditingNoteId(null)
+      }
+    }, 100)
+  }, [])
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md" data-testid="recent-connections-dialog">
@@ -87,6 +221,18 @@ export function RecentConnectionsDialog({
             Recreate a connection with fresh worktrees in each project.
           </DialogDescription>
         </DialogHeader>
+
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Filter by project or note..."
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className="pl-9"
+            autoFocus
+            data-testid="recent-connections-filter"
+          />
+        </div>
 
         <div className="max-h-[300px] overflow-y-auto border rounded-md">
           {error ? (
@@ -111,25 +257,78 @@ export function RecentConnectionsDialog({
               No recent connections yet. Create one by right-clicking a worktree and choosing
               Connect to…
             </div>
+          ) : filteredEntries.length === 0 ? (
+            <div
+              className="px-4 py-8 text-center text-sm text-muted-foreground"
+              data-testid="recent-connections-no-match"
+            >
+              No connections match your filter
+            </div>
           ) : (
             <div className="py-1">
-              {entries.map((entry) => (
-                <button
-                  key={entry.id}
-                  className={cn(
-                    'flex flex-col w-full px-3 py-2 text-sm text-left',
-                    'hover:bg-accent/50 transition-colors',
-                    selectedId === entry.id && 'bg-accent/30'
-                  )}
-                  onClick={() => setSelectedId(entry.id)}
-                  data-testid={`recent-connection-row-${entry.id}`}
-                >
-                  <span className="truncate">{entry.projects.map((p) => p.name).join(' + ')}</span>
-                  <span className="text-xs text-muted-foreground truncate">
-                    {formatRelativeTime(Date.parse(entry.last_used_at))}
-                  </span>
-                </button>
-              ))}
+              {filteredEntries.map((entry) =>
+                editingNoteId === entry.id ? (
+                  <div key={entry.id} className="flex flex-col w-full px-3 py-2 text-sm text-left">
+                    <input
+                      ref={noteInputRef}
+                      autoFocus
+                      value={noteInput}
+                      onChange={(e) => setNoteInput(e.target.value)}
+                      onKeyDown={handleNoteKeyDown}
+                      onBlur={handleNoteBlur}
+                      onClick={(e) => e.stopPropagation()}
+                      className="bg-background border border-border rounded px-1.5 py-0.5 text-sm w-full focus:outline-none focus:ring-1 focus:ring-ring"
+                      placeholder="Add a note..."
+                      data-testid="recent-connection-note-input"
+                    />
+                    <span className="text-xs text-muted-foreground truncate">
+                      {formatRelativeTime(Date.parse(entry.last_used_at))}
+                    </span>
+                  </div>
+                ) : (
+                  <ContextMenu key={entry.id}>
+                    <ContextMenuTrigger asChild>
+                      <button
+                        className={cn(
+                          'flex flex-col w-full px-3 py-2 text-sm text-left',
+                          'hover:bg-accent/50 transition-colors',
+                          selectedId === entry.id && 'bg-accent/30'
+                        )}
+                        onClick={() => setSelectedId(entry.id)}
+                        data-testid={`recent-connection-row-${entry.id}`}
+                      >
+                        <span className="truncate">
+                          {entry.note && (
+                            <span
+                              className="italic text-primary"
+                              data-testid={`recent-connection-note-${entry.id}`}
+                            >
+                              {entry.note}
+                              {' — '}
+                            </span>
+                          )}
+                          {entry.projects.map((p) => p.name).join(' + ')}
+                        </span>
+                        <span className="text-xs text-muted-foreground truncate">
+                          {formatRelativeTime(Date.parse(entry.last_used_at))}
+                        </span>
+                      </button>
+                    </ContextMenuTrigger>
+                    <ContextMenuContent className="w-52">
+                      <ContextMenuItem onClick={() => handleStartNoteEdit(entry)}>
+                        <StickyNote className="h-4 w-4 mr-2" />
+                        {entry.note ? 'Edit note' : 'Add note'}
+                      </ContextMenuItem>
+                      {entry.note && (
+                        <ContextMenuItem onClick={() => void persistNote(entry.id, null)}>
+                          <Trash2 className="h-4 w-4 mr-2" />
+                          Remove note
+                        </ContextMenuItem>
+                      )}
+                    </ContextMenuContent>
+                  </ContextMenu>
+                )
+              )}
             </div>
           )}
         </div>

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -24,6 +24,7 @@ import {
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { checkAutoApprove } from '@/lib/permissionUtils'
 import { isPlanLike } from '@/lib/constants'
+import { shouldPreserveBlockingSessionStatus } from '@/lib/session-status-guards'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import {
@@ -561,12 +562,16 @@ export function useOpenCodeGlobalListener(): void {
         // Don't overwrite plan_ready — session is blocked waiting for plan approval
         if (useSessionStore.getState().getPendingPlan(sessionId)) return
 
-        // Don't overwrite command_approval — session is blocked waiting for command approval
+        // Don't overwrite blocking statuses (command approval, permission, or a
+        // still-pending question) — the session is waiting on the user.
         const currentStatus = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-        if (currentStatus?.status === 'command_approval') return
-
-        // Don't overwrite permission — session is blocked waiting for permission approval
-        if (currentStatus?.status === 'permission') return
+        if (
+          shouldPreserveBlockingSessionStatus(
+            currentStatus?.status,
+            useQuestionStore.getState().getQuestions(sessionId).length > 0
+          )
+        )
+          return
 
         if (sessionId !== activeId) {
           const currentMode = useSessionStore.getState().getSessionMode(sessionId)
@@ -642,12 +647,16 @@ export function useOpenCodeGlobalListener(): void {
       // Don't overwrite plan_ready — session is blocked waiting for plan approval
       if (useSessionStore.getState().getPendingPlan(sessionId)) return
 
-      // Don't overwrite command_approval — session is blocked waiting for command approval
+      // Don't overwrite blocking statuses (command approval, permission, or a
+      // still-pending question) — the session is waiting on the user.
       const statusForIdle = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-      if (statusForIdle?.status === 'command_approval') return
-
-      // Don't overwrite permission — session is blocked waiting for permission approval
-      if (statusForIdle?.status === 'permission') return
+      if (
+        shouldPreserveBlockingSessionStatus(
+          statusForIdle?.status,
+          useQuestionStore.getState().getQuestions(sessionId).length > 0
+        )
+      )
+        return
 
       // Active session is handled by SessionView.
       if (sessionId === activeId) return
@@ -657,7 +666,10 @@ export function useOpenCodeGlobalListener(): void {
         isBlocked: () => {
           if (useSessionStore.getState().getPendingPlan(sessionId)) return true
           const current = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-          return current?.status === 'command_approval' || current?.status === 'permission'
+          return shouldPreserveBlockingSessionStatus(
+            current?.status,
+            useQuestionStore.getState().getQuestions(sessionId).length > 0
+          )
         },
         dequeueFollowUp: () => useSessionStore.getState().dequeueFollowUpMessage(sessionId),
         requeueFollowUp: (message) =>

--- a/src/renderer/src/lib/__tests__/session-status-guards.test.ts
+++ b/src/renderer/src/lib/__tests__/session-status-guards.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldPreserveBlockingSessionStatus } from '../session-status-guards'
+
+describe('shouldPreserveBlockingSessionStatus', () => {
+  it('preserves command_approval and permission unconditionally, matching the existing guards', () => {
+    expect(shouldPreserveBlockingSessionStatus('command_approval', false)).toBe(true)
+    expect(shouldPreserveBlockingSessionStatus('permission', false)).toBe(true)
+  })
+
+  it('preserves answering while a question is still pending', () => {
+    expect(shouldPreserveBlockingSessionStatus('answering', true)).toBe(true)
+  })
+
+  it('does not preserve a stale answering status with no pending question', () => {
+    expect(shouldPreserveBlockingSessionStatus('answering', false)).toBe(false)
+  })
+
+  it('does not preserve non-blocking statuses', () => {
+    expect(shouldPreserveBlockingSessionStatus('working', true)).toBe(false)
+    expect(shouldPreserveBlockingSessionStatus('planning', false)).toBe(false)
+    expect(shouldPreserveBlockingSessionStatus('completed', false)).toBe(false)
+    expect(shouldPreserveBlockingSessionStatus(null, true)).toBe(false)
+    expect(shouldPreserveBlockingSessionStatus(undefined, true)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/pet-status-aggregator.ts
+++ b/src/renderer/src/lib/pet-status-aggregator.ts
@@ -1,16 +1,6 @@
 import type { PetState, PetStatusPayload } from '@shared/types/pet'
 import type { SessionStatusEntry, SessionStatusType } from '@/stores/useWorktreeStatusStore'
-
-const STATUS_PRIORITY: Record<SessionStatusType, number> = {
-  answering: 8,
-  command_approval: 7,
-  permission: 6,
-  planning: 5,
-  working: 4,
-  plan_ready: 3,
-  completed: 2,
-  unread: 1
-}
+import { STATUS_PRIORITY } from '@shared/types/session-status'
 
 const PET_STATE_BY_STATUS: Record<SessionStatusType, PetState> = {
   answering: 'question',

--- a/src/renderer/src/lib/session-status-guards.ts
+++ b/src/renderer/src/lib/session-status-guards.ts
@@ -1,0 +1,16 @@
+import type { SessionStatusType } from '@shared/types/session-status'
+
+/**
+ * Whether a session's current status represents a blocking interaction that a
+ * busy/idle stream event must not overwrite. command_approval and permission
+ * are preserved unconditionally (their prompts stay mounted until replied);
+ * answering is preserved only while a question is actually pending, so a stale
+ * status can't stick after the question store has drained.
+ */
+export function shouldPreserveBlockingSessionStatus(
+  currentStatus: SessionStatusType | null | undefined,
+  hasPendingQuestion: boolean
+): boolean {
+  if (currentStatus === 'command_approval' || currentStatus === 'permission') return true
+  return currentStatus === 'answering' && hasPendingQuestion
+}

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -4,7 +4,7 @@ import { useConnectionStore } from './useConnectionStore'
 import { lastSendMode } from '@/lib/message-send-times'
 import { notifyKanbanSessionSync } from './store-coordination'
 import { dbApi } from '@/api/db-api'
-import type { SessionStatusType } from '@shared/types/session-status'
+import { higherPriority, type SessionStatusType } from '@shared/types/session-status'
 
 // Re-exported from the shared definition so existing importers keep working.
 export type { SessionStatusType }
@@ -73,27 +73,6 @@ interface WorktreeStatusState {
   setMergeConflictFlow: (worktreeId: string, flow: MergeConflictFlow | null) => void
   setMergeConflictWorktreeForTicket: (ticketId: string, worktreeId: string | null) => void
   isWorktreeBeingReviewed: (worktreeId: string) => boolean
-}
-
-// Priority ranking for status aggregation (higher number = higher priority)
-const STATUS_PRIORITY: Record<SessionStatusType, number> = {
-  answering: 8,
-  command_approval: 7,
-  permission: 6,
-  planning: 5,
-  working: 4,
-  plan_ready: 3,
-  completed: 2,
-  unread: 1
-}
-
-function higherPriority(
-  a: SessionStatusType | null,
-  b: SessionStatusType | null
-): SessionStatusType | null {
-  if (!a) return b
-  if (!b) return a
-  return STATUS_PRIORITY[a] >= STATUS_PRIORITY[b] ? a : b
 }
 
 export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => ({

--- a/src/server/__tests__/connection-rpc.mock-provider.test.ts
+++ b/src/server/__tests__/connection-rpc.mock-provider.test.ts
@@ -813,7 +813,8 @@ describe('connection ops RPC mocked provider', () => {
             { id: 'project-2', name: 'Other', path: '/tmp/other' }
           ],
           last_used_at: '2026-05-26T00:00:00.000Z',
-          use_count: 3
+          use_count: 3,
+          note: 'demo note'
         }
       ]
     }
@@ -862,5 +863,89 @@ describe('connection ops RPC mocked provider', () => {
       ok: false,
       error: { code: 'VALIDATION_FAILED' }
     })
+  })
+
+  it('routes connectionOps.setRecentConnectionNote to the injected provider service', async () => {
+    const result = { success: true }
+    const setRecentConnectionNote = vi.fn(() => Effect.succeed(result))
+    const service = { setRecentConnectionNote } as unknown as ConnectionOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      connectionOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'connection-set-recent-note-1',
+        method: 'connectionOps.setRecentConnectionNote',
+        params: { entryId: 'history-1', note: 'my note' }
+      })
+    )
+
+    expect(setRecentConnectionNote).toHaveBeenCalledWith('history-1', 'my note')
+    expect(response).toEqual({
+      id: 'connection-set-recent-note-1',
+      ok: true,
+      value: result
+    })
+  })
+
+  it('routes connectionOps.setRecentConnectionNote with a null note (clear)', async () => {
+    const result = { success: true }
+    const setRecentConnectionNote = vi.fn(() => Effect.succeed(result))
+    const service = { setRecentConnectionNote } as unknown as ConnectionOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      connectionOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'connection-set-recent-note-clear',
+        method: 'connectionOps.setRecentConnectionNote',
+        params: { entryId: 'history-1', note: null }
+      })
+    )
+
+    expect(setRecentConnectionNote).toHaveBeenCalledWith('history-1', null)
+    expect(response).toEqual({
+      id: 'connection-set-recent-note-clear',
+      ok: true,
+      value: result
+    })
+  })
+
+  it('validates connectionOps.setRecentConnectionNote params before calling the provider service', async () => {
+    const setRecentConnectionNote = vi.fn(() => Effect.succeed({ success: true }))
+    const service = { setRecentConnectionNote } as unknown as ConnectionOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      connectionOps: service
+    })
+
+    const invalidParams = [
+      { note: 'missing entry id' },
+      { entryId: '', note: 'empty entry id' },
+      { entryId: 'history-1', note: 42 },
+      { entryId: 'history-1', note: 'extra key', extra: true }
+    ]
+
+    for (const [index, params] of invalidParams.entries()) {
+      const response = await Effect.runPromise(
+        router.handle({
+          id: `connection-set-recent-note-invalid-${index}`,
+          method: 'connectionOps.setRecentConnectionNote',
+          params
+        })
+      )
+
+      expect(response).toMatchObject({
+        id: `connection-set-recent-note-invalid-${index}`,
+        ok: false,
+        error: { code: 'VALIDATION_FAILED' }
+      })
+    }
+
+    expect(setRecentConnectionNote).not.toHaveBeenCalled()
   })
 })

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -3380,7 +3380,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3422,7 +3423,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3476,7 +3478,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3518,7 +3521,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3560,7 +3564,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3602,7 +3607,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3644,7 +3650,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3686,7 +3693,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3728,7 +3736,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3770,7 +3779,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3812,7 +3822,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3854,7 +3865,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3908,7 +3920,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3950,7 +3963,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -3992,7 +4006,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -4034,7 +4049,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -4103,7 +4119,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -4145,7 +4162,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -4214,7 +4232,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -4251,7 +4270,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'unused' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -4317,7 +4337,8 @@ describe('rpc router', () => {
           }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -4354,7 +4375,8 @@ describe('rpc router', () => {
         get: () => Effect.succeed({ success: false, error: 'should not run' }),
         delete: () => Effect.succeed({ success: false, error: 'unused' }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -4395,7 +4417,8 @@ describe('rpc router', () => {
             return { success: true }
           }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 
@@ -4437,7 +4460,8 @@ describe('rpc router', () => {
             return { success: true }
           }),
         updateMembers: () => Effect.succeed({ success: false, error: 'unused' }),
-        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' })
+        getRecentConnections: () => Effect.succeed({ success: false, error: 'unused' }),
+        setRecentConnectionNote: () => Effect.succeed({ success: false, error: 'unused' })
       }
     })
 

--- a/src/server/rpc/domains/connection-ops.ts
+++ b/src/server/rpc/domains/connection-ops.ts
@@ -13,6 +13,7 @@ import {
   removeWorktreeFromAllConnectionsOp,
   renameConnectionOp,
   setConnectionPinnedOp,
+  setRecentConnectionNoteOp,
   updateConnectionMembersOp
 } from '../../../main/services/connection-ops'
 import { telemetryService } from '../../../main/services/telemetry-service'
@@ -93,6 +94,11 @@ export interface ConnectionOpsGetRecentResult {
   readonly error?: string
 }
 
+export interface ConnectionOpsSetRecentNoteResult {
+  readonly success: boolean
+  readonly error?: string
+}
+
 export interface ConnectionOpsRpcService {
   readonly create: (
     worktreeIds: string[]
@@ -133,6 +139,10 @@ export interface ConnectionOpsRpcService {
     worktreeIds: string[]
   ) => Effect.Effect<ConnectionOpsUpdateMembersResult, unknown, never>
   readonly getRecentConnections: () => Effect.Effect<ConnectionOpsGetRecentResult, unknown, never>
+  readonly setRecentConnectionNote: (
+    entryId: string,
+    note: string | null
+  ) => Effect.Effect<ConnectionOpsSetRecentNoteResult, unknown, never>
 }
 
 const emptyParamsSchema = z.union([z.object({}).strict(), z.undefined(), z.null()])
@@ -162,6 +172,12 @@ const updateMembersParamsSchema = z
   .object({
     connectionId: z.string().min(1),
     worktreeIds: z.array(z.string().min(1)).min(1)
+  })
+  .strict()
+const setRecentNoteParamsSchema = z
+  .object({
+    entryId: z.string().min(1),
+    note: z.string().nullable()
   })
   .strict()
 
@@ -267,6 +283,11 @@ export const makeLiveConnectionOpsRpcService = (): ConnectionOpsRpcService => ({
   getRecentConnections: () =>
     Effect.try({
       try: () => getRecentConnectionsOp(getDatabase()),
+      catch: (cause) => cause
+    }),
+  setRecentConnectionNote: (entryId, note) =>
+    Effect.try({
+      try: () => setRecentConnectionNoteOp(getDatabase(), entryId, note),
       catch: (cause) => cause
     })
 })
@@ -427,6 +448,17 @@ export const makeConnectionOpsRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.getRecentConnections()
+        })
+    ],
+    [
+      'connectionOps.setRecentConnectionNote',
+      (params) =>
+        Effect.gen(function* () {
+          const { entryId, note } = yield* Effect.try({
+            try: () => setRecentNoteParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.setRecentConnectionNote(entryId, note)
         })
     ]
   ])

--- a/src/shared/types/connection.ts
+++ b/src/shared/types/connection.ts
@@ -40,4 +40,5 @@ export interface RecentConnectionEntry {
   projects: RecentConnectionProject[]
   last_used_at: string
   use_count: number
+  note: string | null
 }

--- a/src/shared/types/session-status.ts
+++ b/src/shared/types/session-status.ts
@@ -13,3 +13,24 @@ export type SessionStatusType =
   | 'unread'
   | 'completed'
   | 'plan_ready'
+
+// Priority ranking for status aggregation (higher number = higher priority)
+export const STATUS_PRIORITY: Record<SessionStatusType, number> = {
+  answering: 8,
+  command_approval: 7,
+  permission: 6,
+  planning: 5,
+  working: 4,
+  plan_ready: 3,
+  completed: 2,
+  unread: 1
+}
+
+export function higherPriority(
+  a: SessionStatusType | null,
+  b: SessionStatusType | null
+): SessionStatusType | null {
+  if (!a) return b
+  if (!b) return a
+  return STATUS_PRIORITY[a] >= STATUS_PRIORITY[b] ? a : b
+}

--- a/test/worktree-connection/recent-connections/recent-connections-dialog.test.tsx
+++ b/test/worktree-connection/recent-connections/recent-connections-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { act } from '@testing-library/react'
 import { RecentConnectionsDialog } from '../../../src/renderer/src/components/connections/RecentConnectionsDialog'
@@ -8,7 +8,8 @@ import type { RecentConnectionEntry } from '../../../src/shared/types/connection
 
 const apiMocks = vi.hoisted(() => ({
   connectionApi: {
-    getRecentConnections: vi.fn()
+    getRecentConnections: vi.fn(),
+    setRecentConnectionNote: vi.fn()
   }
 }))
 
@@ -38,8 +39,27 @@ function makeEntry(overrides: Partial<RecentConnectionEntry> = {}): RecentConnec
     ],
     last_used_at: new Date(Date.now() - 5 * 60000).toISOString(),
     use_count: 3,
+    note: null,
     ...overrides
   }
+}
+
+function makeSecondEntry(overrides: Partial<RecentConnectionEntry> = {}): RecentConnectionEntry {
+  return makeEntry({
+    id: 'hist-2',
+    project_set_key: 'proj-3,proj-4',
+    projects: [
+      { id: 'proj-3', name: 'Api', path: '/repos/api' },
+      { id: 'proj-4', name: 'Docs', path: '/repos/docs' }
+    ],
+    ...overrides
+  })
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 10))
+  })
 }
 
 describe('Recent Connections Dialog', () => {
@@ -202,5 +222,164 @@ describe('Recent Connections Dialog', () => {
 
     expect(quickCreateConnection).toHaveBeenCalledWith(entry.projects)
     expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  test('filter input narrows rows by project name, case-insensitively', async () => {
+    const user = userEvent.setup()
+    const entryA = makeEntry()
+    const entryB = makeSecondEntry()
+    mockConnectionApi.getRecentConnections.mockResolvedValue({
+      success: true,
+      entries: [entryA, entryB]
+    })
+
+    render(<RecentConnectionsDialog open={true} onOpenChange={vi.fn()} />)
+    await flush()
+
+    expect(screen.getByTestId('recent-connection-row-hist-1')).toBeInTheDocument()
+    expect(screen.getByTestId('recent-connection-row-hist-2')).toBeInTheDocument()
+
+    await user.type(screen.getByTestId('recent-connections-filter'), 'FRONT')
+
+    expect(screen.getByTestId('recent-connection-row-hist-1')).toBeInTheDocument()
+    expect(screen.queryByTestId('recent-connection-row-hist-2')).not.toBeInTheDocument()
+
+    await user.clear(screen.getByTestId('recent-connections-filter'))
+
+    expect(screen.getByTestId('recent-connection-row-hist-1')).toBeInTheDocument()
+    expect(screen.getByTestId('recent-connection-row-hist-2')).toBeInTheDocument()
+  })
+
+  test('shows a no-match state when the filter matches nothing', async () => {
+    const user = userEvent.setup()
+    mockConnectionApi.getRecentConnections.mockResolvedValue({
+      success: true,
+      entries: [makeEntry()]
+    })
+
+    render(<RecentConnectionsDialog open={true} onOpenChange={vi.fn()} />)
+    await flush()
+
+    await user.type(screen.getByTestId('recent-connections-filter'), 'zzz-no-match')
+
+    expect(screen.getByTestId('recent-connections-no-match')).toBeInTheDocument()
+    expect(screen.queryByTestId('recent-connections-empty')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('recent-connection-row-hist-1')).not.toBeInTheDocument()
+  })
+
+  test('filter matches the note text', async () => {
+    const user = userEvent.setup()
+    const entryA = makeEntry()
+    const entryB = makeSecondEntry({ note: 'urgent hotfix' })
+    mockConnectionApi.getRecentConnections.mockResolvedValue({
+      success: true,
+      entries: [entryA, entryB]
+    })
+
+    render(<RecentConnectionsDialog open={true} onOpenChange={vi.fn()} />)
+    await flush()
+
+    await user.type(screen.getByTestId('recent-connections-filter'), 'urgent')
+
+    expect(screen.queryByTestId('recent-connection-row-hist-1')).not.toBeInTheDocument()
+    expect(screen.getByTestId('recent-connection-row-hist-2')).toBeInTheDocument()
+  })
+
+  test('filtering out the selected row disables Create', async () => {
+    const user = userEvent.setup()
+    const entryA = makeEntry()
+    const entryB = makeSecondEntry()
+    mockConnectionApi.getRecentConnections.mockResolvedValue({
+      success: true,
+      entries: [entryA, entryB]
+    })
+
+    render(<RecentConnectionsDialog open={true} onOpenChange={vi.fn()} />)
+    await flush()
+
+    await user.click(screen.getByTestId('recent-connection-row-hist-1'))
+    const createButton = screen.getByTestId('recent-connections-create-button')
+    expect(createButton).not.toBeDisabled()
+
+    await user.type(screen.getByTestId('recent-connections-filter'), 'api')
+
+    expect(screen.queryByTestId('recent-connection-row-hist-1')).not.toBeInTheDocument()
+    expect(createButton).toBeDisabled()
+  })
+
+  test('renders the note as a styled prefix only when present', async () => {
+    const entryA = makeEntry({ note: 'urgent' })
+    const entryB = makeSecondEntry()
+    mockConnectionApi.getRecentConnections.mockResolvedValue({
+      success: true,
+      entries: [entryA, entryB]
+    })
+
+    render(<RecentConnectionsDialog open={true} onOpenChange={vi.fn()} />)
+    await flush()
+
+    expect(screen.getByTestId('recent-connection-note-hist-1')).toHaveTextContent('urgent')
+    expect(screen.queryByTestId('recent-connection-note-hist-2')).not.toBeInTheDocument()
+  })
+
+  test('right-click, Add note, then Enter saves via the API and shows the prefix', async () => {
+    const user = userEvent.setup()
+    const entry = makeEntry()
+    mockConnectionApi.getRecentConnections.mockResolvedValue({ success: true, entries: [entry] })
+    mockConnectionApi.setRecentConnectionNote.mockResolvedValue({ success: true })
+
+    render(<RecentConnectionsDialog open={true} onOpenChange={vi.fn()} />)
+    await flush()
+
+    fireEvent.contextMenu(screen.getByTestId('recent-connection-row-hist-1'))
+    await user.click(await screen.findByText('Add note'))
+
+    const input = await screen.findByTestId('recent-connection-note-input')
+    await user.type(input, 'ship it{Enter}')
+    await flush()
+
+    expect(mockConnectionApi.setRecentConnectionNote).toHaveBeenCalledWith('hist-1', 'ship it')
+    expect(screen.queryByTestId('recent-connection-note-input')).not.toBeInTheDocument()
+    expect(screen.getByTestId('recent-connection-note-hist-1')).toHaveTextContent('ship it')
+  })
+
+  test('Escape cancels the note edit without calling the API', async () => {
+    const user = userEvent.setup()
+    const entry = makeEntry()
+    mockConnectionApi.getRecentConnections.mockResolvedValue({ success: true, entries: [entry] })
+
+    render(<RecentConnectionsDialog open={true} onOpenChange={vi.fn()} />)
+    await flush()
+
+    fireEvent.contextMenu(screen.getByTestId('recent-connection-row-hist-1'))
+    await user.click(await screen.findByText('Add note'))
+
+    const input = await screen.findByTestId('recent-connection-note-input')
+    await user.type(input, 'discard me{Escape}')
+    await flush()
+
+    expect(mockConnectionApi.setRecentConnectionNote).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('recent-connection-note-input')).not.toBeInTheDocument()
+    // The dialog itself stays open.
+    expect(screen.getByTestId('recent-connections-dialog')).toBeInTheDocument()
+  })
+
+  test('Remove note is offered for noted entries and clears via the API', async () => {
+    const user = userEvent.setup()
+    const entry = makeEntry({ note: 'stale note' })
+    mockConnectionApi.getRecentConnections.mockResolvedValue({ success: true, entries: [entry] })
+    mockConnectionApi.setRecentConnectionNote.mockResolvedValue({ success: true })
+
+    render(<RecentConnectionsDialog open={true} onOpenChange={vi.fn()} />)
+    await flush()
+
+    fireEvent.contextMenu(screen.getByTestId('recent-connection-row-hist-1'))
+    // A noted entry offers Edit (not Add) alongside Remove.
+    expect(await screen.findByText('Edit note')).toBeInTheDocument()
+    await user.click(screen.getByText('Remove note'))
+    await flush()
+
+    expect(mockConnectionApi.setRecentConnectionNote).toHaveBeenCalledWith('hist-1', null)
+    expect(screen.queryByTestId('recent-connection-note-hist-1')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Adds a `note` field to recent connection history, including schema migration/repair handling and persistence support.
- Exposes note updates through the connection ops service, RPC layer, and renderer API.
- Updates the Recent Connections dialog to support filtering by project or note, display notes inline, and add a context menu for add/edit/remove note actions.
- Expands test coverage across database, service, RPC, API, and dialog behavior.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DB migration, local file creation in worktree/connection roots, and session launch ordering; mistakes could break goal sends or overwrite files, but paths are validated and failures abort the launch.
> 
> **Overview**
> Adds **persistent notes** on recent connection history (schema v37, idempotent `note` column repair, notes preserved on upsert) and wires **`setRecentConnectionNote`** through DB, connection ops, RPC, and the renderer API. **Recent Connections** gains search/filter (project or note), inline note display, and context-menu add/edit/remove with optimistic UI updates.
> 
> Also introduces **`fileOps.createFile`** (validated single-file create with optional overwrite) and **`normalizeFilename`** for safe default plan names.
> 
> **Goal mode** prompts over **3k characters** are written to `PLAN_{uuid}.md` in the worktree/connection root before send; the outbound `/goal` prompt becomes `Implement PLAN_….md` (worktree picker, auto-launch, Claude CLI, and OpenCode/Codex paths), with UI notice and abort-on-write-failure. **Plan-ready** flows add **Save as md file** via `SavePlanAsFileModal` (SessionView, Claude CLI plan card, plan FAB + vim `f`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba9ba798d7c925012682c1f38cdaaab0951a6fa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->