### PR TITLE
Fix macOS Ghostty config access prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "pnpm run build && electron-builder --dir",
     "build:win": "pnpm run build && electron-builder --win",
-    "build:mac": "test -f .env.signing && . ./.env.signing; pnpm run build && electron-builder --mac",
+    "build:mac": "test -f .env.signing || { echo 'ERROR: .env.signing not found; a signed+notarized build requires it (see .env.signing.example). Use build:mac:unsigned for ad-hoc builds.' >&2; exit 1; }; . ./.env.signing && pnpm run build && electron-builder --mac",
     "build:mac:unsigned": "CSC_IDENTITY_AUTO_DISCOVERY=false pnpm run build && electron-builder --mac",
     "build:linux": "pnpm run build && electron-builder --linux",
     "lint": "eslint . --ext .ts,.tsx",

--- a/src/main/desktop/backend-manager.ts
+++ b/src/main/desktop/backend-manager.ts
@@ -55,6 +55,7 @@ import {
 import { scriptRunner } from '../services/script-runner'
 import { ptyService } from '../services/pty-service'
 import { ghosttyService } from '../services/ghostty-service'
+import { getGhosttyConfigPathOnce } from '../services/ghostty-config-store'
 import { startFileTreeWatcher, stopFileTreeWatcher } from '../services/file-tree-watcher'
 import {
   createClaudeCliTerminal,
@@ -2892,7 +2893,9 @@ const handleDesktopBackendCommand = (
 
   if (message.command === 'terminalGhosttyInit') {
     try {
-      const value = ghosttyService.init()
+      // Path was resolved once at app launch; re-using the memo avoids
+      // touching Ghostty's TCC-protected dir mid-flow.
+      const value = ghosttyService.init(getGhosttyConfigPathOnce())
       sendDesktopBackendCommandResult(
         child,
         makeDesktopCommandResult(message.id, { ok: true, value }),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -57,6 +57,7 @@ import { perfDiagnostics } from './services/perf-diagnostics'
 import { configure as configureCodexDebugLogger } from './services/codex-debug-logger'
 import { ptyService } from './services/pty-service'
 import { ghosttyService } from './services/ghostty-service'
+import { getGhosttyConfigPathOnce } from './services/ghostty-config-store'
 import { closeClaudeHookServer } from './services/claude-hook-server'
 import { scriptRunner } from './services/script-runner'
 import { cleanupScripts } from './services/script-cleanup'
@@ -489,6 +490,13 @@ app
     // Load full shell environment for macOS when launched from Finder/Dock/Spotlight.
     // Must run before any child process spawning (opencode, scripts, Claude Code SDK).
     loadShellEnv()
+
+    // Resolve the Ghostty config path now: its dir is TCC-protected on macOS,
+    // so the one "access data from other apps" prompt happens at launch, not
+    // mid-flow when the first Ghostty terminal surface initializes.
+    if (process.platform === 'darwin') {
+      getGhosttyConfigPathOnce()
+    }
 
     // Resolve system-wide Claude binary (must run after loadShellEnv)
     const claudeBinaryPath = resolveClaudeBinaryPath()

--- a/src/main/services/__tests__/ghostty-config-paths.test.ts
+++ b/src/main/services/__tests__/ghostty-config-paths.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { parseGhosttyConfig, resolveGhosttyConfigPath } from '../ghostty-config'
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn()
+}))
+
+vi.mock('os', () => ({
+  homedir: vi.fn(() => '/Users/test')
+}))
+
+vi.mock('../logger', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }))
+}))
+
+const HOME = '/Users/test'
+const APP_SUPPORT_DIR = join(HOME, 'Library', 'Application Support', 'com.mitchellh.ghostty')
+const XDG_CONFIG = join(HOME, '.config', 'ghostty', 'config')
+
+const existsSyncMock = vi.mocked(existsSync)
+const readFileSyncMock = vi.mocked(readFileSync)
+
+describe('ghostty config path resolution (TCC gating)', () => {
+  let savedXdgConfigHome: string | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    savedXdgConfigHome = process.env.XDG_CONFIG_HOME
+    delete process.env.XDG_CONFIG_HOME
+  })
+
+  afterEach(() => {
+    if (savedXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME
+    } else {
+      process.env.XDG_CONFIG_HOME = savedXdgConfigHome
+    }
+  })
+
+  it('never touches the Application Support dir by default, even when only it has a config', () => {
+    // Simulate a machine where the only Ghostty config lives in App Support.
+    existsSyncMock.mockImplementation((path) => String(path).startsWith(APP_SUPPORT_DIR))
+
+    const config = parseGhosttyConfig()
+
+    expect(config).toEqual({})
+    for (const call of existsSyncMock.mock.calls) {
+      expect(String(call[0])).not.toContain('com.mitchellh.ghostty')
+    }
+    expect(readFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('finds and parses the XDG config in default mode', () => {
+    existsSyncMock.mockImplementation((path) => path === XDG_CONFIG)
+    readFileSyncMock.mockReturnValue('font-size = 13\nbackground = #1e1e2e')
+
+    const config = parseGhosttyConfig()
+
+    expect(config.fontSize).toBe(13)
+    expect(config.background).toBe('#1e1e2e')
+    expect(readFileSyncMock).toHaveBeenCalledWith(XDG_CONFIG, 'utf-8')
+  })
+
+  it('honors XDG_CONFIG_HOME in default mode', () => {
+    process.env.XDG_CONFIG_HOME = '/custom/xdg'
+    const customPath = join('/custom/xdg', 'ghostty', 'config')
+    existsSyncMock.mockImplementation((path) => path === customPath)
+    readFileSyncMock.mockReturnValue('font-size = 11')
+
+    const config = parseGhosttyConfig()
+
+    expect(config.fontSize).toBe(11)
+    expect(readFileSyncMock).toHaveBeenCalledWith(customPath, 'utf-8')
+  })
+
+  it('prefers the Application Support config when includeAppSupport is set', () => {
+    const appSupportConfig = join(APP_SUPPORT_DIR, 'config.ghostty')
+    existsSyncMock.mockImplementation(
+      (path) => path === appSupportConfig || path === XDG_CONFIG
+    )
+
+    const resolved = resolveGhosttyConfigPath({ includeAppSupport: true })
+
+    expect(resolved).toBe(appSupportConfig)
+  })
+
+  it('falls back through App Support candidates in order when opted in', () => {
+    const appSupportPlain = join(APP_SUPPORT_DIR, 'config')
+    existsSyncMock.mockImplementation((path) => path === appSupportPlain)
+
+    const resolved = resolveGhosttyConfigPath({ includeAppSupport: true })
+
+    expect(resolved).toBe(appSupportPlain)
+  })
+
+  it('resolves nothing (empty config) when no candidate exists', () => {
+    existsSyncMock.mockReturnValue(false)
+
+    expect(resolveGhosttyConfigPath({ includeAppSupport: true })).toBeUndefined()
+    expect(parseGhosttyConfig({ includeAppSupport: true })).toEqual({})
+  })
+})

--- a/src/main/services/__tests__/ghostty-config-store.test.ts
+++ b/src/main/services/__tests__/ghostty-config-store.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { parseGhosttyConfig, resolveGhosttyConfigPath } from '../ghostty-config'
+import {
+  clearGhosttyConfigMemo,
+  getGhosttyConfigPathOnce,
+  getGhosttyTerminalConfig,
+  warmUpGhosttyConfig
+} from '../ghostty-config-store'
+
+vi.mock('../ghostty-config', () => ({
+  parseGhosttyConfig: vi.fn(() => ({})),
+  resolveGhosttyConfigPath: vi.fn(() => undefined)
+}))
+
+const parseGhosttyConfigMock = vi.mocked(parseGhosttyConfig)
+const resolveGhosttyConfigPathMock = vi.mocked(resolveGhosttyConfigPath)
+
+describe('ghostty config store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearGhosttyConfigMemo()
+  })
+
+  it('reads from disk once and serves the memo afterwards', () => {
+    parseGhosttyConfigMock.mockReturnValue({ fontFamily: 'TX-02' })
+
+    const first = getGhosttyTerminalConfig()
+    const second = getGhosttyTerminalConfig()
+
+    expect(first).toEqual({ fontFamily: 'TX-02' })
+    expect(second).toEqual({ fontFamily: 'TX-02' })
+    expect(parseGhosttyConfigMock).toHaveBeenCalledTimes(1)
+    expect(parseGhosttyConfigMock).toHaveBeenCalledWith({ includeAppSupport: true })
+  })
+
+  it('re-reads from disk on refresh and updates the memo', () => {
+    parseGhosttyConfigMock.mockReturnValueOnce({ fontSize: 10 })
+    getGhosttyTerminalConfig()
+
+    parseGhosttyConfigMock.mockReturnValueOnce({ fontSize: 15 })
+    const refreshed = getGhosttyTerminalConfig({ refresh: true })
+
+    expect(refreshed).toEqual({ fontSize: 15 })
+    expect(parseGhosttyConfigMock).toHaveBeenCalledTimes(2)
+
+    // Subsequent non-refresh calls serve the refreshed memo.
+    expect(getGhosttyTerminalConfig()).toEqual({ fontSize: 15 })
+    expect(parseGhosttyConfigMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves the config path once, even when it is undefined', () => {
+    resolveGhosttyConfigPathMock.mockReturnValue(undefined)
+
+    expect(getGhosttyConfigPathOnce()).toBeUndefined()
+    expect(getGhosttyConfigPathOnce()).toBeUndefined()
+
+    expect(resolveGhosttyConfigPathMock).toHaveBeenCalledTimes(1)
+    expect(resolveGhosttyConfigPathMock).toHaveBeenCalledWith({ includeAppSupport: true })
+  })
+
+  it('re-resolves the config path on refresh', () => {
+    resolveGhosttyConfigPathMock.mockReturnValueOnce('/old/config')
+    expect(getGhosttyConfigPathOnce()).toBe('/old/config')
+
+    resolveGhosttyConfigPathMock.mockReturnValueOnce('/new/config')
+    expect(getGhosttyConfigPathOnce({ refresh: true })).toBe('/new/config')
+    expect(getGhosttyConfigPathOnce()).toBe('/new/config')
+    expect(resolveGhosttyConfigPathMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('warms up both the path and config memos so later calls never hit disk', () => {
+    parseGhosttyConfigMock.mockReturnValue({ background: '#1e1e2e' })
+    resolveGhosttyConfigPathMock.mockReturnValue('/path/config')
+
+    warmUpGhosttyConfig()
+
+    parseGhosttyConfigMock.mockClear()
+    resolveGhosttyConfigPathMock.mockClear()
+
+    expect(getGhosttyTerminalConfig()).toEqual({ background: '#1e1e2e' })
+    expect(getGhosttyConfigPathOnce()).toBe('/path/config')
+    expect(parseGhosttyConfigMock).not.toHaveBeenCalled()
+    expect(resolveGhosttyConfigPathMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/services/ghostty-config-store.ts
+++ b/src/main/services/ghostty-config-store.ts
@@ -1,0 +1,60 @@
+import {
+  parseGhosttyConfig,
+  resolveGhosttyConfigPath,
+  type GhosttyConfig
+} from './ghostty-config'
+
+/**
+ * Launch-time cache for the user's Ghostty config.
+ *
+ * The config may live in Ghostty's Application Support dir, which macOS TCC
+ * guards with the "access data from other apps" prompt. To keep that prompt
+ * from appearing mid-flow, the protected dir is touched exactly once — at app
+ * launch (warmUpGhosttyConfig) — and every later consumer is served from the
+ * in-memory memo. There is deliberately no mtime-based freshness check (even a
+ * stat re-triggers TCC); the only mid-run re-reads are explicit user re-syncs.
+ */
+
+let configMemo: GhosttyConfig | null = null
+let pathMemo: string | undefined
+let pathResolved = false
+
+/** Test hook: reset the module-level memos between test cases. */
+export function clearGhosttyConfigMemo(): void {
+  configMemo = null
+  pathMemo = undefined
+  pathResolved = false
+}
+
+/**
+ * Parse the Ghostty config, reading from disk only on the first call (app
+ * launch) or when `refresh` is set (explicit user re-sync).
+ */
+export function getGhosttyTerminalConfig(opts?: { refresh?: boolean }): GhosttyConfig {
+  if (!opts?.refresh && configMemo) {
+    return configMemo
+  }
+  configMemo = parseGhosttyConfig({ includeAppSupport: true })
+  return configMemo
+}
+
+/**
+ * Resolve the Ghostty config file path, stat-ing the candidates only on the
+ * first call. Used by the native ghostty runtime init in the main process.
+ */
+export function getGhosttyConfigPathOnce(opts?: { refresh?: boolean }): string | undefined {
+  if (!pathResolved || opts?.refresh) {
+    pathMemo = resolveGhosttyConfigPath({ includeAppSupport: true })
+    pathResolved = true
+  }
+  return pathMemo
+}
+
+/**
+ * Launch-time warm-up: perform the one TCC-relevant disk read now, so any
+ * macOS permission prompt appears at app launch rather than mid-flow.
+ */
+export function warmUpGhosttyConfig(): void {
+  getGhosttyConfigPathOnce()
+  getGhosttyTerminalConfig()
+}

--- a/src/main/services/ghostty-config.ts
+++ b/src/main/services/ghostty-config.ts
@@ -37,14 +37,24 @@ const CURSOR_STYLE_MAP: Record<string, GhosttyConfig['cursorStyle']> = {
 /**
  * Config file search order matching Ghostty's own resolution.
  * Returns the first config file path that exists, or undefined.
+ *
+ * The `~/Library/Application Support/com.mitchellh.ghostty` candidates live in
+ * another app's data container: on macOS 14+ even an existsSync/stat there
+ * triggers the TCC "access data from other apps" prompt attributed to Hive.
+ * Callers must opt into them (includeAppSupport) — the ghostty-config-store
+ * does so only at app launch and on explicit re-sync, never mid-flow.
  */
-function findConfigFile(): string | undefined {
+function findConfigFile(includeAppSupport: boolean): string | undefined {
   const home = homedir()
   const xdgConfig = process.env.XDG_CONFIG_HOME || join(home, '.config')
 
   const candidates = [
-    join(home, 'Library', 'Application Support', 'com.mitchellh.ghostty', 'config.ghostty'),
-    join(home, 'Library', 'Application Support', 'com.mitchellh.ghostty', 'config'),
+    ...(includeAppSupport
+      ? [
+          join(home, 'Library', 'Application Support', 'com.mitchellh.ghostty', 'config.ghostty'),
+          join(home, 'Library', 'Application Support', 'com.mitchellh.ghostty', 'config')
+        ]
+      : []),
     join(xdgConfig, 'ghostty', 'config.ghostty'),
     join(xdgConfig, 'ghostty', 'config'),
     join(home, '.config', 'ghostty', 'config'),
@@ -60,6 +70,16 @@ function findConfigFile(): string | undefined {
   }
 
   return undefined
+}
+
+/**
+ * Resolve the Ghostty config file path without parsing it.
+ * Used by the native ghostty runtime init, which loads the file itself.
+ */
+export function resolveGhosttyConfigPath(opts: {
+  includeAppSupport: boolean
+}): string | undefined {
+  return findConfigFile(opts.includeAppSupport)
 }
 
 /**
@@ -284,9 +304,10 @@ function createIncludeResolver(baseConfigDir: string): (includePath: string) => 
 /**
  * Parse the user's Ghostty config file.
  * Searches standard locations, returns parsed config or empty defaults.
+ * AppSupport (TCC-protected) locations are skipped unless includeAppSupport is set.
  */
-export function parseGhosttyConfig(): GhosttyConfig {
-  const configPath = findConfigFile()
+export function parseGhosttyConfig(opts?: { includeAppSupport?: boolean }): GhosttyConfig {
+  const configPath = findConfigFile(opts?.includeAppSupport ?? false)
 
   if (!configPath) {
     log.info('No Ghostty config file found, using defaults')

--- a/src/main/services/ghostty-service.ts
+++ b/src/main/services/ghostty-service.ts
@@ -6,7 +6,7 @@ const log = createLogger({ component: 'GhosttyService' })
 
 // Types matching the N-API addon exports
 interface GhosttyAddon {
-  ghosttyInit(): boolean
+  ghosttyInit(configPath?: string): boolean
   ghosttyGetVersion(): string
   ghosttyCreateSurface(
     windowHandle: Buffer,
@@ -157,8 +157,11 @@ class GhosttyService {
   /**
    * Initialize the Ghostty runtime. Must be called once before creating surfaces.
    * Automatically loads the addon if not already loaded.
+   * configPath: explicit Ghostty config file for the runtime to load; omitted
+   * means built-in defaults (the runtime never reads Ghostty's own
+   * TCC-protected default locations).
    */
-  init(): { success: boolean; version?: string; error?: string } {
+  init(configPath?: string): { success: boolean; version?: string; error?: string } {
     if (this.initialized) {
       return { success: true, version: this.getVersion() }
     }
@@ -168,7 +171,7 @@ class GhosttyService {
     }
 
     try {
-      const result = this.addon!.ghosttyInit()
+      const result = this.addon!.ghosttyInit(configPath)
       if (!result) {
         return { success: false, error: 'ghostty_init() returned false' }
       }

--- a/src/native/src/addon.mm
+++ b/src/native/src/addon.mm
@@ -1,7 +1,7 @@
 // addon.mm — N-API addon entry point for the Ghostty native module
 //
 // Exposes the following functions to Node.js:
-//   ghosttyInit()                    → boolean
+//   ghosttyInit(configPath?)         → boolean
 //   ghosttyGetVersion()              → string
 //   ghosttyCreateSurface(handle, rect, opts) → number (surface ID)
 //   ghosttySetFrame(surfaceId, rect) → void
@@ -22,11 +22,15 @@
 using namespace ghostty;
 
 // ---------------------------------------------------------------------------
-// ghosttyInit() → boolean
+// ghosttyInit(configPath?: string) → boolean
 // ---------------------------------------------------------------------------
 Napi::Value GhosttyInit(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  bool result = GhosttyBridge::instance().init();
+  std::string configPath;
+  if (info.Length() > 0 && info[0].IsString()) {
+    configPath = info[0].As<Napi::String>().Utf8Value();
+  }
+  bool result = GhosttyBridge::instance().init(configPath.empty() ? nullptr : configPath.c_str());
   return Napi::Boolean::New(env, result);
 }
 

--- a/src/native/src/ghostty_bridge.h
+++ b/src/native/src/ghostty_bridge.h
@@ -52,7 +52,11 @@ public:
   // Initialize the Ghostty runtime. Must be called once before any other
   // operations. Returns true on success, false if already initialized or
   // if ghostty_init() fails.
-  bool init();
+  // configPath: explicit config file to load; null/empty loads no user
+  // config (libghostty built-in defaults). Never reads the default config
+  // locations — Ghostty's Application Support dir is TCC-protected and
+  // reading it triggers the macOS "access data from other apps" prompt.
+  bool init(const char* configPath = nullptr);
 
   // Check if the runtime has been initialized
   bool isInitialized() const;

--- a/src/native/src/ghostty_bridge.mm
+++ b/src/native/src/ghostty_bridge.mm
@@ -48,7 +48,7 @@ GhosttyBridge::~GhosttyBridge() {
 // Lifecycle
 // ---------------------------------------------------------------------------
 
-bool GhosttyBridge::init() {
+bool GhosttyBridge::init(const char* configPath) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   if (initialized_) {
@@ -63,14 +63,19 @@ bool GhosttyBridge::init() {
     return false;
   }
 
-  // Create and load config from user's default files
   config_ = ghostty_config_new();
   if (!config_) {
     fprintf(stderr, "[ghostty_bridge] ghostty_config_new failed\n");
     return false;
   }
 
-  ghostty_config_load_default_files(config_);
+  // Load only an explicitly provided config file. Never
+  // ghostty_config_load_default_files: that reads Ghostty's own
+  // Application Support container, which macOS TCC guards with the
+  // "access data from other apps" prompt attributed to this app.
+  if (configPath && configPath[0] != '\0') {
+    ghostty_config_load_file(config_, configPath);
+  }
   ghostty_config_finalize(config_);
 
   // Check for config diagnostics

--- a/src/renderer/src/api/terminal-api.ts
+++ b/src/renderer/src/api/terminal-api.ts
@@ -154,6 +154,14 @@ export const terminalApi = {
     )
     return { success: true, value: config }
   },
+  /** Force a fresh read of the Ghostty config (used by the settings "Sync from Ghostty" toggle). */
+  resyncGhosttyConfig: async (): Promise<Envelope<GhosttyTerminalConfig>> => {
+    const config = await getRendererRpcClient().request<GhosttyTerminalConfig>(
+      'terminalOps.resyncGhosttyConfig',
+      {}
+    )
+    return { success: true, value: config }
+  },
   /**
    * Fire-and-forget: persist renderer-side terminal diagnostics (font
    * resolution, renderer fallback, fitted dimensions) into the main-process

--- a/src/renderer/src/components/settings/SettingsTerminal.tsx
+++ b/src/renderer/src/components/settings/SettingsTerminal.tsx
@@ -98,6 +98,18 @@ export function SettingsTerminal(): React.JSX.Element {
   const [isDetecting, setIsDetecting] = useState(true)
   const [ghosttyAvailable, setGhosttyAvailable] = useState<boolean | null>(null)
   const [isMac, setIsMac] = useState(false)
+  const [isSyncingGhosttyConfig, setIsSyncingGhosttyConfig] = useState(false)
+
+  const resyncGhosttyConfig = async (): Promise<void> => {
+    setIsSyncingGhosttyConfig(true)
+    try {
+      await terminalApi.resyncGhosttyConfig()
+    } catch {
+      // Non-fatal: terminals fall back to defaults until the next re-sync.
+    } finally {
+      setIsSyncingGhosttyConfig(false)
+    }
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -246,7 +258,8 @@ export function SettingsTerminal(): React.JSX.Element {
               <Info className="h-3.5 w-3.5 text-blue-500 shrink-0 mt-0.5" />
               <p className="text-muted-foreground">
                 Ghostty renders via Metal for native performance. The terminal will restart when
-                switching backends. Colors and cursor style are read from your Ghostty config.
+                switching backends. Colors and cursor style are read from your Ghostty config once
+                at app launch.
               </p>
             </div>
 
@@ -275,6 +288,36 @@ export function SettingsTerminal(): React.JSX.Element {
               </p>
             </div>
           </>
+        )}
+
+        {isMac && (
+          <div className="mt-4 space-y-2">
+            <div>
+              <label className="text-sm font-medium">Ghostty config</label>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Fonts, colors, and shell are read from your Ghostty config once at app launch.
+                Edited your config? Re-sync to apply it without restarting.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => void resyncGhosttyConfig()}
+                disabled={isSyncingGhosttyConfig}
+                data-testid="ghostty-config-resync"
+                className={cn(
+                  'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs border border-border hover:bg-accent/50 transition-colors',
+                  isSyncingGhosttyConfig && 'opacity-50 cursor-not-allowed'
+                )}
+              >
+                {isSyncingGhosttyConfig && <Loader2 className="h-3 w-3 animate-spin" />}
+                Re-sync now
+              </button>
+              <span className="text-xs text-muted-foreground">
+                Applies to newly opened terminals; the Ghostty backend picks it up after an app
+                restart.
+              </span>
+            </div>
+          </div>
         )}
       </div>
 

--- a/src/server/__tests__/terminal-ops.test.ts
+++ b/src/server/__tests__/terminal-ops.test.ts
@@ -14,9 +14,11 @@ const ptyServiceMocks = vi.hoisted(() => ({
   resize: vi.fn()
 }))
 
-vi.mock('../../main/services/ghostty-config', () => ({
-  parseGhosttyConfig: vi.fn(() => ({}))
+const ghosttyConfigStoreMocks = vi.hoisted(() => ({
+  getGhosttyTerminalConfig: vi.fn(() => ({}))
 }))
+
+vi.mock('../../main/services/ghostty-config-store', () => ghosttyConfigStoreMocks)
 
 const loggerMocks = vi.hoisted(() => ({
   debug: vi.fn(),
@@ -83,6 +85,28 @@ describe('terminal ops RPC live service', () => {
     ])
     expect(removeData).toHaveBeenCalledTimes(1)
     expect(removeExit).toHaveBeenCalledTimes(1)
+  })
+
+  it('serves getConfig from the ghostty config store without forcing a refresh', async () => {
+    ghosttyConfigStoreMocks.getGhosttyTerminalConfig.mockReturnValue({ fontFamily: 'TX-02' })
+    const service = makeLiveTerminalOpsRpcService()
+
+    const result = await Effect.runPromise(service.getConfig())
+
+    expect(result).toEqual({ fontFamily: 'TX-02' })
+    expect(ghosttyConfigStoreMocks.getGhosttyTerminalConfig).toHaveBeenCalledWith()
+  })
+
+  it('forces a fresh read through the resyncGhosttyConfig RPC', async () => {
+    ghosttyConfigStoreMocks.getGhosttyTerminalConfig.mockReturnValue({ fontSize: 13 })
+    const service = makeLiveTerminalOpsRpcService()
+
+    const result = await Effect.runPromise(service.resyncGhosttyConfig!())
+
+    expect(result).toEqual({ fontSize: 13 })
+    expect(ghosttyConfigStoreMocks.getGhosttyTerminalConfig).toHaveBeenCalledWith({
+      refresh: true
+    })
   })
 
   it('persists client diagnostics through the logDiagnostics RPC', async () => {

--- a/src/server/rpc/domains/terminal-ops.ts
+++ b/src/server/rpc/domains/terminal-ops.ts
@@ -1,7 +1,7 @@
 import { Effect } from 'effect'
 import { z } from 'zod'
 import type { EventBus } from '../../events/event-bus'
-import { parseGhosttyConfig } from '../../../main/services/ghostty-config'
+import { getGhosttyTerminalConfig } from '../../../main/services/ghostty-config-store'
 import { createLogger } from '../../../main/services/logger'
 import { ptyService } from '../../../main/services/pty-service'
 import {
@@ -20,6 +20,8 @@ import type { RpcHandler } from '../router'
 
 export interface TerminalOpsRpcService {
   readonly getConfig: () => Effect.Effect<GhosttyTerminalConfig, unknown, never>
+  /** Force a re-read of the Ghostty config from disk (user-initiated; may touch the TCC-protected dir). */
+  readonly resyncGhosttyConfig?: () => Effect.Effect<GhosttyTerminalConfig, unknown>
   readonly logDiagnostics?: (
     event: string,
     data: Record<string, unknown>
@@ -1299,7 +1301,15 @@ export const makeLiveTerminalOpsRpcService = (eventBus?: EventBus): TerminalOpsR
   getConfig: () =>
     Effect.sync(() => {
       try {
-        return parseGhosttyConfig()
+        return getGhosttyTerminalConfig()
+      } catch {
+        return {}
+      }
+    }),
+  resyncGhosttyConfig: () =>
+    Effect.sync(() => {
+      try {
+        return getGhosttyTerminalConfig({ refresh: true })
       } catch {
         return {}
       }
@@ -1456,6 +1466,17 @@ export const makeTerminalOpsRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.getConfig()
+        })
+    ],
+    [
+      'terminalOps.resyncGhosttyConfig',
+      (params) =>
+        Effect.gen(function* () {
+          yield* Effect.try({
+            try: () => emptyParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* (service.resyncGhosttyConfig?.() ?? service.getConfig())
         })
     ],
     [

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -10,6 +10,7 @@ import { attachWebSocketRpcServer } from './rpc/ws-server'
 import { resolveStaticFile, serveStaticFile } from './static'
 import { isDesktopBackendEventMessage } from '../shared/desktop-command'
 import { cleanupBranchWatchers } from '../main/services/branch-watcher'
+import { warmUpGhosttyConfig } from '../main/services/ghostty-config-store'
 import { setGitEventPublisher } from '../main/services/git-events'
 import { setWorktreeEventPublisher } from '../main/services/worktree-events'
 import { cleanupWorktreeWatchers } from '../main/services/worktree-watcher'
@@ -40,6 +41,10 @@ export const startHiveServer = (
   Effect.gen(function* () {
     const config = yield* resolveServerConfig(input)
     getDatabase().init()
+    // Read the Ghostty config once at boot so the macOS "access data from
+    // other apps" prompt (its dir is TCC-protected) appears at app launch,
+    // never mid-flow when a terminal mounts.
+    warmUpGhosttyConfig()
     const eventBus = makeEventBus()
 
     if (desktopBackendEventForwarder) {

--- a/test/terminal/ghostty-config.test.ts
+++ b/test/terminal/ghostty-config.test.ts
@@ -366,14 +366,28 @@ palette = 15=#a6adc8
       expect(config).toEqual({})
     })
 
-    test('reads from first found config path', () => {
-      // Simulate that the macOS Application Support path exists
+    test('skips the TCC-protected Application Support path by default', () => {
+      // Simulate that only the macOS Application Support path exists
       existsSyncMock.mockImplementation((path: unknown) => {
         return String(path).includes('com.mitchellh.ghostty/config.ghostty')
       })
       readFileSyncMock.mockReturnValue('font-size = 16')
 
       const config = parseGhosttyConfig()
+      expect(config).toEqual({})
+      // The protected dir must not even be stat'd (existsSync triggers TCC too)
+      for (const call of existsSyncMock.mock.calls) {
+        expect(String(call[0])).not.toContain('com.mitchellh.ghostty')
+      }
+    })
+
+    test('reads the Application Support path first when includeAppSupport is set', () => {
+      existsSyncMock.mockImplementation((path: unknown) => {
+        return String(path).includes('com.mitchellh.ghostty/config.ghostty')
+      })
+      readFileSyncMock.mockReturnValue('font-size = 16')
+
+      const config = parseGhosttyConfig({ includeAppSupport: true })
       expect(config.fontSize).toBe(16)
     })
 


### PR DESCRIPTION
## Summary
- Move Ghostty config resolution and loading out of the protected Application Support path by default on macOS.
- Warm the Ghostty config at app launch and memoize both the config contents and resolved path to avoid mid-flow TCC prompts.
- Add an explicit Ghostty config re-sync action in Settings for user-initiated refreshes.
- Update the native Ghostty bridge to accept an explicit config path instead of loading default files.
- Tighten `build:mac` so signed notarized builds fail fast when `.env.signing` is missing.

## Testing
- Added unit coverage for Ghostty config path resolution, including default XDG lookup and opt-in Application Support lookup.
- Added unit coverage for Ghostty config memoization, refresh behavior, and path caching.
- Updated terminal ops RPC tests to verify cached config reads and explicit refresh handling.
- Updated terminal config tests to verify Application Support is skipped by default and only read when explicitly enabled.
- Not run locally in this session.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS TCC-sensitive filesystem paths and native Ghostty init; wrong gating could miss user config or show prompts at the wrong time, but behavior is covered by new tests and explicit opt-in refresh.
> 
> **Overview**
> Stops macOS **“access data from other apps”** prompts from appearing when the first embedded Ghostty terminal opens, by controlling when Hive reads Ghostty’s config (including its TCC-protected Application Support paths).
> 
> **Ghostty config access** now skips `~/Library/Application Support/com.mitchellh.ghostty` unless callers pass `includeAppSupport`. A new **`ghostty-config-store`** warms and memoizes the resolved path and parsed config at app/server boot; `terminalGhosttyInit` passes the memoized path into the native runtime instead of re-statting mid-flow. The native bridge no longer calls `ghostty_config_load_default_files` and only loads an **explicit config file** passed to `ghosttyInit(configPath?)`.
> 
> **User-facing behavior**: terminal settings explain config is read once at launch; macOS gets a **Re-sync now** control wired through `terminalOps.resyncGhosttyConfig` (`refresh: true`). **`build:mac`** fails fast if `.env.signing` is missing (unsigned builds use `build:mac:unsigned`). Tests cover TCC gating, memoization, and RPC refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32259d5be0b0b42dd65263888f27352c7da32cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->