### PR TITLE
Defer Claude CLI completion until background subagents finish

### DIFF
--- a/src/main/services/__tests__/claude-cli-interaction-ledger.test.ts
+++ b/src/main/services/__tests__/claude-cli-interaction-ledger.test.ts
@@ -18,6 +18,7 @@ interface HookStep {
   id?: string
   status: SessionStatusType | null
   plan?: string
+  prompt?: string
 }
 
 function buildHook(step: HookStep): ParsedClaudeHook {
@@ -25,6 +26,7 @@ function buildHook(step: HookStep): ParsedClaudeHook {
   if (step.tool) hook.tool_name = step.tool
   if (step.id) hook.tool_use_id = step.id
   if (step.plan) hook.tool_input = { plan: step.plan }
+  if (step.prompt !== undefined) hook.prompt = step.prompt
   return hook
 }
 
@@ -269,6 +271,32 @@ describe('plan_ready latch', () => {
 
     const released = process({ event: 'PostToolUse', tool: 'Bash', status: 'working' })
     expect(statuses(released)).toEqual(['working', 'plan_ready'])
+  })
+})
+
+describe('task-notification resume does not reset a latched interaction', () => {
+  it('keeps a latch alive across a task-notification UserPromptSubmit but a plain prompt clears it', () => {
+    expect(
+      statuses(process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' }))
+    ).toEqual(['answering'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+
+    // A background-subagent resume turn is not a user turn boundary: the
+    // latch must survive it, and its own publish is suppressed while pending.
+    expect(
+      process({
+        event: 'UserPromptSubmit',
+        status: 'working',
+        prompt: '<task-notification>\n<task-id>a</task-id>\n</task-notification>'
+      })
+    ).toEqual([])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+
+    // A real user turn still resets normally.
+    expect(
+      statuses(process({ event: 'UserPromptSubmit', status: 'working', prompt: 'please continue' }))
+    ).toEqual(['working'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
   })
 })
 

--- a/src/main/services/__tests__/claude-cli-subagent-tracker.test.ts
+++ b/src/main/services/__tests__/claude-cli-subagent-tracker.test.ts
@@ -1,0 +1,393 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  clearAllClaudeCliSubagentTracking,
+  clearClaudeCliSubagentTracking,
+  hasPendingClaudeCliSubagentWork,
+  isClaudeCliCompletionDeferred,
+  parseTaskNotificationIds,
+  processClaudeCliSubagentHook,
+  setClaudeCliDeferredCompletionHandler,
+  SUBAGENT_RESUME_TIMEOUT_MS,
+  SUBAGENT_WATCHDOG_TIMEOUT_MS,
+  type ClaudeCliBackgroundTask,
+  type ClaudeCliTrackedHook,
+  type SubagentGateResult
+} from '../claude-cli-subagent-tracker'
+import type { ClaudeCliStatusPayload } from '../claude-hook-server'
+
+const SESSION = 'hive-session-1'
+
+function bgTask(id: string, overrides: Partial<ClaudeCliBackgroundTask> = {}): ClaudeCliBackgroundTask {
+  return { id, type: 'subagent', status: 'running', ...overrides }
+}
+
+interface HookInput {
+  event: string
+  agentId?: string
+  backgroundTasks?: ClaudeCliBackgroundTask[]
+  prompt?: unknown
+  lastAssistantMessage?: string
+}
+
+function buildHook(input: HookInput): ClaudeCliTrackedHook {
+  const hook: ClaudeCliTrackedHook = { hook_event_name: input.event }
+  if (input.agentId) hook.agent_id = input.agentId
+  if (input.backgroundTasks) hook.background_tasks = input.backgroundTasks
+  if (input.prompt !== undefined) hook.prompt = input.prompt
+  if (input.lastAssistantMessage) hook.last_assistant_message = input.lastAssistantMessage
+  return hook
+}
+
+function buildMapped(sessionId: string, status: ClaudeCliStatusPayload['status']): ClaudeCliStatusPayload {
+  return { sessionId, status, metadata: { hookEventName: 'Stop' } }
+}
+
+function process(
+  input: HookInput,
+  mapped: ClaudeCliStatusPayload | null = null,
+  sessionId = SESSION
+): SubagentGateResult {
+  return processClaudeCliSubagentHook(sessionId, buildHook(input), mapped)
+}
+
+function notificationPrompt(...ids: string[]): string {
+  return `<task-notification>${ids.map((id) => `<task-id>${id}</task-id>`).join('')}</task-notification>`
+}
+
+afterEach(() => {
+  clearAllClaudeCliSubagentTracking()
+  setClaudeCliDeferredCompletionHandler(null)
+  vi.useRealTimers()
+})
+
+describe('pass-through with no background work', () => {
+  it('Stop with no background_tasks and nothing pending passes', () => {
+    expect(process({ event: 'Stop', backgroundTasks: [] })).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+  })
+})
+
+describe('deferring a Stop with running background subagents', () => {
+  it('defers and stays deferred across repeated Stops, overwriting the payload handed to the watchdog', () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockReturnValue(true)
+    setClaudeCliDeferredCompletionHandler(handler)
+
+    expect(process({ event: 'Stop', backgroundTasks: [bgTask('a')] }, buildMapped(SESSION, 'completed'))).toEqual({
+      kind: 'defer_stop'
+    })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+
+    const secondPayload: ClaudeCliStatusPayload = {
+      sessionId: SESSION,
+      status: 'completed',
+      metadata: { hookEventName: 'Stop', reason: 'second' }
+    }
+    expect(process({ event: 'Stop', backgroundTasks: [bgTask('a')] }, secondPayload)).toEqual({
+      kind: 'defer_stop'
+    })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(SESSION, secondPayload, undefined)
+  })
+})
+
+describe('full happy path (real trace replay)', () => {
+  it('defers, drains via notification, then completes on a clean Stop', () => {
+    expect(
+      process({ event: 'Stop', backgroundTasks: [bgTask('a'), bgTask('b')] }, buildMapped(SESSION, 'completed'))
+    ).toEqual({ kind: 'defer_stop' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+
+    expect(
+      process({ event: 'SubagentStop', agentId: 'a', backgroundTasks: [bgTask('a')] })
+    ).toEqual({ kind: 'pass' })
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(true)
+
+    expect(
+      process({ event: 'UserPromptSubmit', prompt: notificationPrompt('a') }, buildMapped(SESSION, 'working'))
+    ).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(false)
+
+    expect(process({ event: 'Stop', backgroundTasks: [] })).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(false)
+  })
+})
+
+describe('queued-notification gap', () => {
+  it('defers a clean Stop when a notification is still pending, then completes once drained', () => {
+    // Subagent finishes mid-turn, self-listed, before the main Stop fires.
+    expect(
+      process({ event: 'SubagentStop', agentId: 'a', backgroundTasks: [bgTask('a')] })
+    ).toEqual({ kind: 'pass' })
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(true)
+
+    // The main Stop reports nothing running, but the notification hasn't arrived yet.
+    expect(process({ event: 'Stop', backgroundTasks: [] })).toEqual({ kind: 'defer_stop' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+
+    expect(
+      process({ event: 'UserPromptSubmit', prompt: notificationPrompt('a') }, buildMapped(SESSION, 'working'))
+    ).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+
+    expect(process({ event: 'Stop', backgroundTasks: [] })).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(false)
+  })
+})
+
+describe('foreground subagents', () => {
+  it('a SubagentStop not self-listed in background_tasks leaves nothing pending', () => {
+    expect(
+      process({ event: 'SubagentStop', agentId: 'a', backgroundTasks: [] })
+    ).toEqual({ kind: 'pass' })
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(false)
+
+    expect(process({ event: 'Stop', backgroundTasks: [] })).toEqual({ kind: 'pass' })
+  })
+})
+
+describe('ephemeral internal agents', () => {
+  it('a not-self-listed SubagentStop after a passing Stop creates no state and has no effect', () => {
+    expect(process({ event: 'Stop', backgroundTasks: [] })).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+
+    expect(
+      process({ event: 'SubagentStop', agentId: 'x', backgroundTasks: [] })
+    ).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(false)
+
+    expect(process({ event: 'Stop', backgroundTasks: [] })).toEqual({ kind: 'pass' })
+  })
+})
+
+describe('Stop scoped to a subagent (agent_id present)', () => {
+  it('is never a session completion and creates no deferral', () => {
+    expect(process({ event: 'Stop', agentId: 'a', backgroundTasks: [] })).toEqual({
+      kind: 'subagent_scoped'
+    })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(false)
+  })
+
+  it('does not clear or complete an already-deferred session, only re-arms its timer', () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockReturnValue(true)
+    setClaudeCliDeferredCompletionHandler(handler)
+
+    process({ event: 'Stop', backgroundTasks: [bgTask('a')] })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS - 1)
+    expect(process({ event: 'Stop', agentId: 'b', backgroundTasks: [] })).toEqual({
+      kind: 'subagent_scoped'
+    })
+    // Still deferred — a subagent-scoped Stop must not complete or clear it.
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+    expect(handler).not.toHaveBeenCalled()
+
+    // The subagent-scoped Stop re-armed the countdown from scratch.
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS - 1)
+    expect(handler).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('non-notification UserPromptSubmit', () => {
+  it('clears the deferral but keeps pendingNotifications', () => {
+    process({ event: 'SubagentStop', agentId: 'a', backgroundTasks: [bgTask('a')] })
+    process({ event: 'Stop', backgroundTasks: [] })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+
+    expect(process({ event: 'UserPromptSubmit', prompt: 'please continue' })).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(true)
+
+    expect(process({ event: 'Stop', backgroundTasks: [] })).toEqual({ kind: 'defer_stop' })
+  })
+})
+
+describe('SessionStart / SessionEnd', () => {
+  it.each(['SessionStart', 'SessionEnd'])('%s clears all tracking and disarms timers', (event) => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockReturnValue(true)
+    setClaudeCliDeferredCompletionHandler(handler)
+
+    process({ event: 'Stop', backgroundTasks: [bgTask('a')] })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+
+    expect(process({ event })).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(false)
+
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS + SUBAGENT_RESUME_TIMEOUT_MS + 1000)
+    expect(handler).not.toHaveBeenCalled()
+  })
+})
+
+describe('timer duration by state', () => {
+  it('running-nonempty deferral fires at the watchdog duration, not before', () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockReturnValue(true)
+    setClaudeCliDeferredCompletionHandler(handler)
+
+    process({ event: 'Stop', backgroundTasks: [bgTask('a')] })
+
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS - 1)
+    expect(handler).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('pending-only deferral (running empty) fires at the shorter resume duration', () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockReturnValue(true)
+    setClaudeCliDeferredCompletionHandler(handler)
+
+    process({ event: 'SubagentStop', agentId: 'a', backgroundTasks: [bgTask('a')] })
+    process({ event: 'Stop', backgroundTasks: [] })
+
+    vi.advanceTimersByTime(SUBAGENT_RESUME_TIMEOUT_MS - 1)
+    expect(handler).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('draining the last running id via self-listed SubagentStop re-arms to the short duration', () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockReturnValue(true)
+    setClaudeCliDeferredCompletionHandler(handler)
+
+    process({ event: 'Stop', backgroundTasks: [bgTask('a')] })
+    // Still within the long watchdog window.
+    vi.advanceTimersByTime(SUBAGENT_RESUME_TIMEOUT_MS + 1000)
+    expect(handler).not.toHaveBeenCalled()
+
+    // 'a' drains from running (moves to pendingNotifications) -> should now be armed short.
+    process({ event: 'SubagentStop', agentId: 'a', backgroundTasks: [bgTask('a')] })
+
+    vi.advanceTimersByTime(SUBAGENT_RESUME_TIMEOUT_MS - 1)
+    expect(handler).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('re-arm on activity', () => {
+  it('any unrelated hook while deferred resets the countdown', () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockReturnValue(true)
+    setClaudeCliDeferredCompletionHandler(handler)
+
+    process({ event: 'Stop', backgroundTasks: [bgTask('a')] })
+
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS - 1)
+    expect(handler).not.toHaveBeenCalled()
+
+    process({ event: 'PostToolUse' })
+
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS - 1)
+    expect(handler).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('deferred completion handler', () => {
+  it('is called with the original payload and lastAssistantMessage; true clears state', () => {
+    vi.useFakeTimers()
+    const originalPayload = buildMapped(SESSION, 'completed')
+    const handler = vi.fn().mockReturnValue(true)
+    setClaudeCliDeferredCompletionHandler(handler)
+
+    process(
+      { event: 'Stop', backgroundTasks: [bgTask('a')], lastAssistantMessage: 'All done.' },
+      originalPayload
+    )
+
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(SESSION, originalPayload, 'All done.')
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+  })
+
+  it('false keeps the deferral and fires again after the watchdog duration', () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockReturnValue(false)
+    setClaudeCliDeferredCompletionHandler(handler)
+
+    process({ event: 'Stop', backgroundTasks: [bgTask('a')] })
+
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS - 1)
+    expect(handler).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(1)
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('manual clears', () => {
+  it('clearClaudeCliSubagentTracking cancels the timer so the handler is never called', () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockReturnValue(true)
+    setClaudeCliDeferredCompletionHandler(handler)
+
+    process({ event: 'Stop', backgroundTasks: [bgTask('a')] })
+    clearClaudeCliSubagentTracking(SESSION)
+
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS + 1000)
+    expect(handler).not.toHaveBeenCalled()
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+  })
+})
+
+describe('session isolation', () => {
+  it('deferring one session does not affect another', () => {
+    const OTHER = 'other-session'
+    expect(process({ event: 'Stop', backgroundTasks: [bgTask('a')] }, null, SESSION)).toEqual({
+      kind: 'defer_stop'
+    })
+    expect(process({ event: 'Stop', backgroundTasks: [] }, null, OTHER)).toEqual({ kind: 'pass' })
+
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+    expect(isClaudeCliCompletionDeferred(OTHER)).toBe(false)
+  })
+})
+
+describe('parseTaskNotificationIds', () => {
+  it('returns [] for non-string prompts', () => {
+    expect(parseTaskNotificationIds(undefined)).toEqual([])
+    expect(parseTaskNotificationIds(null)).toEqual([])
+    expect(parseTaskNotificationIds({ text: 'hi' })).toEqual([])
+  })
+
+  it('returns [] for an ordinary user prompt', () => {
+    expect(parseTaskNotificationIds('please fix the bug')).toEqual([])
+  })
+
+  it('returns the id for a single notification block', () => {
+    expect(parseTaskNotificationIds(notificationPrompt('abc123'))).toEqual(['abc123'])
+  })
+
+  it('returns all ids for two concatenated notification blocks', () => {
+    expect(parseTaskNotificationIds(notificationPrompt('abc123', 'def456'))).toEqual(['abc123', 'def456'])
+  })
+
+  it('tolerates leading whitespace before the tag', () => {
+    expect(parseTaskNotificationIds(`   \n${notificationPrompt('abc123')}`)).toEqual(['abc123'])
+  })
+})

--- a/src/main/services/__tests__/claude-cli-subagent-tracker.test.ts
+++ b/src/main/services/__tests__/claude-cli-subagent-tracker.test.ts
@@ -6,6 +6,7 @@ import {
   clearClaudeCliSubagentTracking,
   hasPendingClaudeCliSubagentWork,
   isClaudeCliCompletionDeferred,
+  isTaskNotificationPrompt,
   parseTaskNotificationIds,
   processClaudeCliSubagentHook,
   setClaudeCliDeferredCompletionHandler,
@@ -147,6 +148,21 @@ describe('foreground subagents', () => {
   it('a SubagentStop not self-listed in background_tasks leaves nothing pending', () => {
     expect(
       process({ event: 'SubagentStop', agentId: 'a', backgroundTasks: [] })
+    ).toEqual({ kind: 'pass' })
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(false)
+
+    expect(process({ event: 'Stop', backgroundTasks: [] })).toEqual({ kind: 'pass' })
+  })
+})
+
+describe('isSelfListed requires a running status', () => {
+  it('a SubagentStop whose self-entry is already completed does not add a pending notification', () => {
+    expect(
+      process({
+        event: 'SubagentStop',
+        agentId: 'a',
+        backgroundTasks: [bgTask('a', { status: 'completed' })]
+      })
     ).toEqual({ kind: 'pass' })
     expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(false)
 
@@ -389,5 +405,26 @@ describe('parseTaskNotificationIds', () => {
 
   it('tolerates leading whitespace before the tag', () => {
     expect(parseTaskNotificationIds(`   \n${notificationPrompt('abc123')}`)).toEqual(['abc123'])
+  })
+})
+
+describe('isTaskNotificationPrompt', () => {
+  it('returns false for non-string prompts', () => {
+    expect(isTaskNotificationPrompt(undefined)).toBe(false)
+    expect(isTaskNotificationPrompt(null)).toBe(false)
+    expect(isTaskNotificationPrompt({ text: 'hi' })).toBe(false)
+  })
+
+  it('returns false for an ordinary user prompt', () => {
+    expect(isTaskNotificationPrompt('please fix the bug')).toBe(false)
+  })
+
+  it('returns true for a marker-prefixed prompt even with zero parseable task-id blocks', () => {
+    expect(isTaskNotificationPrompt('<task-notification></task-notification>')).toBe(true)
+    expect(parseTaskNotificationIds('<task-notification></task-notification>')).toEqual([])
+  })
+
+  it('tolerates leading whitespace before the tag', () => {
+    expect(isTaskNotificationPrompt(`   \n${notificationPrompt('abc123')}`)).toBe(true)
   })
 })

--- a/src/main/services/__tests__/claude-cli-telegram-bridge.test.ts
+++ b/src/main/services/__tests__/claude-cli-telegram-bridge.test.ts
@@ -217,6 +217,37 @@ describe('claudeCliTelegramBridge Stop + busy bridging (private channel)', () =>
     expect(events.some((e) => e.type === 'session.busy')).toBe(true)
     unsub()
   })
+
+  it('does not emit idle on Stop when ctx.suppressIdle is set', () => {
+    const events: OpenCodeStreamEvent[] = []
+    const unsub = claudeCliTelegramBridge.subscribe((e) => events.push(e))
+    claudeCliTelegramBridge.register(SESSION)
+
+    claudeCliTelegramBridge.onHook(
+      SESSION,
+      { hook_event_name: 'Stop', last_assistant_message: 'All done.' },
+      makeRes(),
+      { suppressIdle: true }
+    )
+
+    expect(events.some((e) => e.type === 'message.updated')).toBe(false)
+    expect(events.some((e) => e.type === 'session.idle')).toBe(false)
+    unsub()
+  })
+
+  it('notifySessionIdle delegates to the core and emits message.updated + session.idle', () => {
+    const events: OpenCodeStreamEvent[] = []
+    const unsub = claudeCliTelegramBridge.subscribe((e) => events.push(e))
+    claudeCliTelegramBridge.register(SESSION)
+
+    claudeCliTelegramBridge.notifySessionIdle(SESSION, 'Background work complete.')
+
+    const msg = events.find((e) => e.type === 'message.updated')
+    expect((msg!.data as { content: string }).content).toBe('Background work complete.')
+    expect(events.some((e) => e.type === 'session.idle')).toBe(true)
+    expect(publishedEvents).toHaveLength(0) // never reaches the renderer
+    unsub()
+  })
 })
 
 describe('claudeCliTelegramBridge teardown', () => {

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -1,8 +1,13 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OPENCODE_STREAM_CHANNEL } from '@shared/opencode-events'
 
 const backendManagerMocks = vi.hoisted(() => ({
   publishDesktopBackendEvent: vi.fn()
+}))
+
+const telemetryMocks = vi.hoisted(() => ({
+  handleClaudeCliHiveTelemetryHook: vi.fn().mockResolvedValue(undefined)
 }))
 
 vi.mock('../logger', () => ({
@@ -18,19 +23,30 @@ vi.mock('../../desktop/backend-event-publisher', () => ({
   publishDesktopBackendEvent: backendManagerMocks.publishDesktopBackendEvent
 }))
 
+vi.mock('../hive-enterprise-claude-cli-telemetry', () => ({
+  handleClaudeCliHiveTelemetryHook: telemetryMocks.handleClaudeCliHiveTelemetryHook
+}))
+
 import {
   buildClaudeCliHookSettings,
   closeClaudeHookServer,
   getClaudeHookServer,
   mapHookEventToStatus,
   publishClaudeCliStatus,
+  subscribeClaudeCliStatus,
   type ParsedClaudeHook
 } from '../claude-hook-server'
+import { hasBlockingClaudeCliInteraction } from '../claude-cli-interaction-ledger'
+import {
+  processClaudeCliSubagentHook,
+  SUBAGENT_WATCHDOG_TIMEOUT_MS
+} from '../claude-cli-subagent-tracker'
+import { cliHookTransportRouter } from '../cli-hook-transport-router'
 
 async function postHook(
   port: number,
   sessionId: string,
-  path: 'session' | 'start' | 'stop' | 'tool' | 'permission',
+  path: 'session' | 'start' | 'stop' | 'tool' | 'permission' | 'subagent',
   body: Record<string, unknown> | string
 ): Promise<{ status: number; text: string }> {
   const response = await fetch(`http://127.0.0.1:${port}/hook/${sessionId}/${path}`, {
@@ -121,7 +137,8 @@ describe('mapHookEventToStatus', () => {
       'unmatched PreToolUse events are ignored',
       { hook_event_name: 'PreToolUse', tool_name: 'Read' },
       null
-    ]
+    ],
+    ['SubagentStop maps to null', { hook_event_name: 'SubagentStop' }, null]
   ])('%s', (_name, hook, expected) => {
     expect(mapHookEventToStatus(hook)).toBe(expected)
   })
@@ -173,6 +190,16 @@ describe('buildClaudeCliHookSettings', () => {
             ]
           }
         ],
+        SubagentStop: [
+          {
+            hooks: [
+              {
+                type: 'http',
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/subagent'
+              }
+            ]
+          }
+        ],
         PreToolUse: [
           {
             matcher: 'ExitPlanMode|AskUserQuestion',
@@ -207,6 +234,8 @@ describe('buildClaudeCliHookSettings', () => {
             ]
           }
         ],
+        // SubagentStart is intentionally not registered: only completion of a
+        // background subagent (SubagentStop) is needed by the tracker.
         PermissionRequest: [
           {
             matcher: '*',
@@ -220,6 +249,7 @@ describe('buildClaudeCliHookSettings', () => {
         ]
       }
     })
+    expect(settings.hooks).not.toHaveProperty('SubagentStart')
   })
 })
 
@@ -579,5 +609,342 @@ describe('ClaudeHookServer HTTP round-trip', () => {
 
     expect(response).toEqual({ status: 405, text: '{}' })
     expect(backendManagerMocks.publishDesktopBackendEvent).not.toHaveBeenCalled()
+  })
+})
+
+function completedCalls(): unknown[] {
+  return backendManagerMocks.publishDesktopBackendEvent.mock.calls.filter(
+    ([channel, payload]) =>
+      channel === 'claude-cli:status' &&
+      (payload as { status?: string } | undefined)?.status === 'completed'
+  )
+}
+
+describe('background subagent deferral (HTTP round-trip)', () => {
+  it('defers session completion while a background subagent runs, then completes once the notification resume ends cleanly', async () => {
+    const { port } = await getClaudeHookServer()
+
+    // (No leading "real" UserPromptSubmit here: publishClaudeCliStatus dedupes
+    // on status alone, so an initial 'working' would swallow the resume's
+    // identically-'working' publish below and hide the very metadata this
+    // test is verifying. Starting from the deferred Stop keeps the dedup
+    // cache empty going into the assertions that matter.)
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'Stop',
+      background_tasks: [{ id: 'a', type: 'subagent', status: 'running' }]
+    })
+    expect(completedCalls()).toHaveLength(0)
+
+    // Self-listed SubagentStop: the subagent finished but the resume turn
+    // hasn't started yet — still no completion.
+    await postHook(port, 'hive-session-1', 'subagent', {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'a',
+      background_tasks: [{ id: 'a', type: 'subagent', status: 'running' }]
+    })
+    expect(completedCalls()).toHaveLength(0)
+
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default',
+      prompt: '<task-notification>\n<task-id>a</task-id>\n</task-notification>'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:status',
+        expect.objectContaining({
+          status: 'working',
+          metadata: expect.objectContaining({ taskNotification: true })
+        })
+      )
+    })
+    expect(completedCalls()).toHaveLength(0)
+
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'Stop',
+      background_tasks: []
+    })
+
+    await vi.waitFor(() => {
+      expect(completedCalls()).toHaveLength(1)
+    })
+    const [, completedPayload] = completedCalls()[0] as [string, { metadata?: { hookEventName?: string } }]
+    expect(completedPayload.metadata?.hookEventName).toBe('Stop')
+  })
+
+  it('queued-notification gap: a clean Stop still defers when the notification has not arrived yet', async () => {
+    const { port } = await getClaudeHookServer()
+
+    // Subagent finishes mid-turn, self-listed, before the main Stop fires.
+    await postHook(port, 'hive-session-1', 'subagent', {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'a',
+      background_tasks: [{ id: 'a', type: 'subagent', status: 'running' }]
+    })
+
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'Stop',
+      background_tasks: []
+    })
+    expect(completedCalls()).toHaveLength(0)
+
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default',
+      prompt: '<task-notification>\n<task-id>a</task-id>\n</task-notification>'
+    })
+    expect(completedCalls()).toHaveLength(0)
+
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'Stop',
+      background_tasks: []
+    })
+
+    await vi.waitFor(() => {
+      expect(completedCalls()).toHaveLength(1)
+    })
+  })
+
+  it('foreground subagent: a not-self-listed SubagentStop lets the following Stop complete immediately', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'subagent', {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'a',
+      background_tasks: []
+    })
+    expect(completedCalls()).toHaveLength(0)
+
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'Stop',
+      background_tasks: []
+    })
+
+    await vi.waitFor(() => {
+      expect(completedCalls()).toHaveLength(1)
+    })
+  })
+})
+
+describe('ledger survival across a deferred Stop', () => {
+  it('keeps a latched question surfaced through a deferring Stop and a task-notification resume, but a plain prompt clears it', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:status',
+        expect.objectContaining({ status: 'answering' })
+      )
+    })
+    expect(hasBlockingClaudeCliInteraction('hive-session-1')).toBe(true)
+
+    // A deferred Stop (background subagent still running) must never reach
+    // the ledger — its RESET would otherwise clobber the latched question.
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'Stop',
+      background_tasks: [{ id: 'a', type: 'subagent', status: 'running' }]
+    })
+    expect(hasBlockingClaudeCliInteraction('hive-session-1')).toBe(true)
+
+    const callsBeforeUnrelated = backendManagerMocks.publishDesktopBackendEvent.mock.calls.length
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Read'
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent.mock.calls.length).toBe(callsBeforeUnrelated)
+    expect(hasBlockingClaudeCliInteraction('hive-session-1')).toBe(true)
+
+    // A task-notification resume is not a user turn boundary either.
+    const callsBeforeNotification = backendManagerMocks.publishDesktopBackendEvent.mock.calls.length
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default',
+      prompt: '<task-notification>\n<task-id>a</task-id>\n</task-notification>'
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent.mock.calls.length).toBe(callsBeforeNotification)
+    expect(hasBlockingClaudeCliInteraction('hive-session-1')).toBe(true)
+
+    // A plain user prompt still resets it.
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default',
+      prompt: 'please continue'
+    })
+    expect(hasBlockingClaudeCliInteraction('hive-session-1')).toBe(false)
+  })
+})
+
+describe('telemetry gating for deferred Stops', () => {
+  it('does not record telemetry for a deferred Stop but does for a passing one', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'Stop',
+      background_tasks: [{ id: 'a', type: 'subagent', status: 'running' }]
+    })
+    expect(telemetryMocks.handleClaudeCliHiveTelemetryHook).not.toHaveBeenCalled()
+
+    await postHook(port, 'hive-session-1', 'subagent', {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'a',
+      background_tasks: [{ id: 'a', type: 'subagent', status: 'running' }]
+    })
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default',
+      prompt: '<task-notification>\n<task-id>a</task-id>\n</task-notification>'
+    })
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'Stop',
+      background_tasks: []
+    })
+
+    expect(telemetryMocks.handleClaudeCliHiveTelemetryHook).toHaveBeenCalledWith(
+      'hive-session-1',
+      expect.objectContaining({ hook_event_name: 'Stop' })
+    )
+  })
+})
+
+describe('transport ctx suppressIdle', () => {
+  it('passes suppressIdle true for a deferred Stop and false for a passing hook', async () => {
+    const { port } = await getClaudeHookServer()
+    const routeHookSpy = vi.spyOn(cliHookTransportRouter, 'routeHook')
+
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'Stop',
+      background_tasks: [{ id: 'a', type: 'subagent', status: 'running' }]
+    })
+    expect(routeHookSpy).toHaveBeenLastCalledWith(
+      'hive-session-1',
+      expect.objectContaining({ hook_event_name: 'Stop' }),
+      expect.anything(),
+      { suppressIdle: true }
+    )
+
+    await postHook(port, 'hive-session-1', 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default'
+    })
+    expect(routeHookSpy).toHaveBeenLastCalledWith(
+      'hive-session-1',
+      expect.objectContaining({ hook_event_name: 'UserPromptSubmit' }),
+      expect.anything(),
+      { suppressIdle: false }
+    )
+
+    routeHookSpy.mockRestore()
+  })
+})
+
+describe('deferred-completion watchdog handler', () => {
+  afterEach(() => {
+    // Must run before the top-level afterEach's closeClaudeHookServer(), so
+    // the server close (real socket I/O) happens under real timers.
+    vi.useRealTimers()
+  })
+
+  it('completes via the watchdog handler after the timeout and notifies transport idle', async () => {
+    await getClaudeHookServer()
+    const statusListener = vi.fn()
+    const unsubscribe = subscribeClaudeCliStatus(statusListener)
+    const notifyIdleSpy = vi.spyOn(cliHookTransportRouter, 'notifySessionIdle')
+
+    vi.useFakeTimers()
+    try {
+      const gate = processClaudeCliSubagentHook(
+        'hive-session-1',
+        { hook_event_name: 'Stop', background_tasks: [{ id: 'a', type: 'subagent', status: 'running' }] },
+        { sessionId: 'hive-session-1', status: 'completed', metadata: { hookEventName: 'Stop' } }
+      )
+      expect(gate).toEqual({ kind: 'defer_stop' })
+
+      vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS)
+
+      expect(statusListener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 'hive-session-1',
+          status: 'completed',
+          metadata: expect.objectContaining({ reason: 'deferred_completion_watchdog' })
+        })
+      )
+      expect(notifyIdleSpy).toHaveBeenCalledWith('hive-session-1', undefined)
+    } finally {
+      unsubscribe()
+      notifyIdleSpy.mockRestore()
+    }
+  })
+
+  it('does not complete via the watchdog while a blocking interaction is pending', async () => {
+    const { port } = await getClaudeHookServer()
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+
+    const statusListener = vi.fn()
+    const unsubscribe = subscribeClaudeCliStatus(statusListener)
+    const notifyIdleSpy = vi.spyOn(cliHookTransportRouter, 'notifySessionIdle')
+
+    vi.useFakeTimers()
+    try {
+      const gate = processClaudeCliSubagentHook(
+        'hive-session-1',
+        { hook_event_name: 'Stop', background_tasks: [{ id: 'a', type: 'subagent', status: 'running' }] },
+        { sessionId: 'hive-session-1', status: 'completed', metadata: { hookEventName: 'Stop' } }
+      )
+      expect(gate).toEqual({ kind: 'defer_stop' })
+
+      vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS)
+
+      expect(statusListener).not.toHaveBeenCalled()
+      expect(notifyIdleSpy).not.toHaveBeenCalled()
+    } finally {
+      unsubscribe()
+      notifyIdleSpy.mockRestore()
+    }
+  })
+})
+
+describe('first-prompt detection with task notifications', () => {
+  // A dedicated session id: `firstPromptAnnounced` is a module-level Set that
+  // closeClaudeHookServer() never clears (by design — a session must announce
+  // at most once for the lifetime of the app, even across hook-server
+  // restarts), so reusing 'hive-session-1' here would flake depending on
+  // whether an earlier test in this file already sent it a real prompt.
+  const SESSION = 'hive-session-first-prompt'
+
+  it('does not treat a task-notification resume as the first prompt, but a later real prompt still announces', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, SESSION, 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default',
+      prompt: '<task-notification>\n<task-id>a</task-id>\n</task-notification>'
+    })
+    expect(backendManagerMocks.publishDesktopBackendEvent).not.toHaveBeenCalledWith(
+      OPENCODE_STREAM_CHANNEL,
+      expect.objectContaining({ type: 'claude-cli.first-prompt-detected' })
+    )
+
+    await postHook(port, SESSION, 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      permission_mode: 'default',
+      prompt: 'please fix the bug'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        OPENCODE_STREAM_CHANNEL,
+        {
+          type: 'claude-cli.first-prompt-detected',
+          sessionId: SESSION,
+          data: { promptText: 'please fix the bug' }
+        }
+      )
+    })
   })
 })

--- a/src/main/services/__tests__/cli-hook-hold-core.test.ts
+++ b/src/main/services/__tests__/cli-hook-hold-core.test.ts
@@ -143,4 +143,65 @@ describe('CliHookHoldCore', () => {
     expect(core.hasPendingQuestion(requestId)).toBe(false)
     expect(shared.some((event) => event.type === 'question.rejected')).toBe(true)
   })
+
+  it('Stop with ctx.suppressIdle emits neither message.updated nor session.idle', () => {
+    const { core, transport } = makeCore()
+    core.register(SESSION)
+    const res = makeRes()
+
+    const owned = core.onHook(
+      SESSION,
+      { hook_event_name: 'Stop', last_assistant_message: 'All done.' },
+      res,
+      { suppressIdle: true }
+    )
+
+    expect(owned).toBe(false)
+    expect(transport.some((event) => event.type === 'message.updated')).toBe(false)
+    expect(transport.some((event) => event.type === 'session.idle')).toBe(false)
+  })
+
+  it('Stop with no ctx / suppressIdle: false emits idle unchanged (regression)', () => {
+    const { core, transport } = makeCore()
+    core.register(SESSION)
+    const res = makeRes()
+
+    core.onHook(SESSION, { hook_event_name: 'Stop', last_assistant_message: 'All done.' }, res)
+
+    expect(transport.find((event) => event.type === 'message.updated')).toBeTruthy()
+    expect(transport.some((event) => event.type === 'session.idle')).toBe(true)
+
+    const { core: core2, transport: transport2 } = makeCore()
+    core2.register(SESSION)
+    const res2 = makeRes()
+    core2.onHook(SESSION, { hook_event_name: 'Stop', last_assistant_message: 'All done.' }, res2, {
+      suppressIdle: false
+    })
+
+    expect(transport2.find((event) => event.type === 'message.updated')).toBeTruthy()
+    expect(transport2.some((event) => event.type === 'session.idle')).toBe(true)
+  })
+
+  it('emitSessionIdle(sessionId, text) emits message.updated then session.idle', () => {
+    const { core, transport } = makeCore()
+
+    core.emitSessionIdle(SESSION, 'Finished the task.')
+
+    expect(transport).toHaveLength(2)
+    expect(transport[0]).toMatchObject({
+      type: 'message.updated',
+      sessionId: SESSION,
+      data: { role: 'assistant', content: 'Finished the task.' }
+    })
+    expect(transport[1]).toMatchObject({ type: 'session.idle', sessionId: SESSION })
+  })
+
+  it('emitSessionIdle(sessionId) with no text emits only session.idle', () => {
+    const { core, transport } = makeCore()
+
+    core.emitSessionIdle(SESSION)
+
+    expect(transport).toHaveLength(1)
+    expect(transport[0]).toMatchObject({ type: 'session.idle', sessionId: SESSION })
+  })
 })

--- a/src/main/services/__tests__/cli-hook-transport-router.test.ts
+++ b/src/main/services/__tests__/cli-hook-transport-router.test.ts
@@ -7,6 +7,7 @@ const makeTransport = (name: string, registered: boolean): CliHookTransport => (
   name,
   isRegistered: vi.fn(() => registered),
   onHook: vi.fn(() => true),
+  notifySessionIdle: vi.fn(),
   cancelAll: vi.fn()
 })
 
@@ -20,7 +21,7 @@ describe('CliHookTransportRouter', () => {
 
     expect(router.routeHook('session-1', body, res)).toBe(true)
 
-    expect(first.onHook).toHaveBeenCalledWith('session-1', body, res)
+    expect(first.onHook).toHaveBeenCalledWith('session-1', body, res, undefined)
     expect(second.onHook).not.toHaveBeenCalled()
   })
 
@@ -41,5 +42,38 @@ describe('CliHookTransportRouter', () => {
 
     expect(first.cancelAll).toHaveBeenCalledTimes(1)
     expect(second.cancelAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards ctx to the matched transport', () => {
+    const first = makeTransport('first', true)
+    const second = makeTransport('second', true)
+    const router = new CliHookTransportRouter([first, second])
+    const res = {} as ServerResponse
+    const body = { hook_event_name: 'Stop' }
+    const ctx = { suppressIdle: true }
+
+    router.routeHook('session-1', body, res, ctx)
+
+    expect(first.onHook).toHaveBeenCalledWith('session-1', body, res, ctx)
+    expect(second.onHook).not.toHaveBeenCalled()
+  })
+
+  it('notifySessionIdle dispatches to the registered transport with the given args', () => {
+    const first = makeTransport('first', false)
+    const second = makeTransport('second', true)
+    const router = new CliHookTransportRouter([first, second])
+
+    router.notifySessionIdle('session-1', 'All done.')
+
+    expect(second.notifySessionIdle).toHaveBeenCalledWith('session-1', 'All done.')
+    expect(first.notifySessionIdle).not.toHaveBeenCalled()
+  })
+
+  it('notifySessionIdle no-ops without throwing when no transport is registered', () => {
+    const transport = makeTransport('none', false)
+    const router = new CliHookTransportRouter([transport])
+
+    expect(() => router.notifySessionIdle('session-1')).not.toThrow()
+    expect(transport.notifySessionIdle).not.toHaveBeenCalled()
   })
 })

--- a/src/main/services/__tests__/hive-enterprise-claude-cli-telemetry.test.ts
+++ b/src/main/services/__tests__/hive-enterprise-claude-cli-telemetry.test.ts
@@ -457,6 +457,104 @@ describe('Claude CLI Hive Enterprise telemetry', () => {
     ])
   })
 
+  it('ignores a task-notification UserPromptSubmit, recording no active prompt', async () => {
+    const db = makeDb({
+      hiveEnterpriseServerUrl: 'https://enterprise.example.com',
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1'
+    })
+
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: '<task-notification>\n<task-id>a</task-id>\n</task-notification>'
+      },
+      { db, requestGraphql }
+    )
+
+    expect(requestGraphql).not.toHaveBeenCalled()
+
+    // With no active prompt recorded, the eventual Stop is a no-op too.
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      { hook_event_name: 'Stop' },
+      { db, requestGraphql }
+    )
+    expect(requestGraphql).not.toHaveBeenCalled()
+  })
+
+  it('keeps a real prompt active through a task-notification resume so the final Stop attributes usage to it', async () => {
+    const transcriptPath = makeTranscript(
+      `${assistantLine({ input: 100, output: 5, cacheRead: 20, cacheWrite: 7 })}\n`
+    )
+    const db = makeDb({
+      hiveEnterpriseServerUrl: 'https://enterprise.example.com',
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1'
+    })
+
+    // The real, user-authored prompt.
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'Do the real work',
+        transcript_path: transcriptPath
+      },
+      { db, requestGraphql }
+    )
+    expect(requestGraphql).toHaveBeenCalledTimes(1)
+
+    // A deferred Stop (background subagent still running) is skipped upstream
+    // by claude-hook-server and never reaches this module. The subagent's
+    // completion then resumes the session via a task-notification prompt,
+    // which must NOT clobber the real prompt's still-active record.
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: '<task-notification>\n<task-id>a</task-id>\n</task-notification>',
+        transcript_path: transcriptPath
+      },
+      { db, requestGraphql }
+    )
+    // No new recordPromptStart — the notification did not start a new prompt.
+    expect(requestGraphql).toHaveBeenCalledTimes(1)
+
+    writeFileSync(
+      transcriptPath,
+      [
+        assistantLine({ input: 100, output: 5, cacheRead: 20, cacheWrite: 7 }),
+        assistantLine({ input: 140, output: 30, cacheRead: 25, cacheWrite: 9 })
+      ].join('\n') + '\n'
+    )
+
+    // The final, passing Stop attributes the entire multi-turn usage delta to
+    // the real prompt's id and baseline.
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      { hook_event_name: 'Stop', transcript_path: transcriptPath },
+      { db, requestGraphql }
+    )
+
+    expect(requestGraphql).toHaveBeenCalledTimes(2)
+    expect(requestGraphql.mock.calls[1]).toEqual([
+      'https://enterprise.example.com/api/graphql',
+      'token-1',
+      expect.stringContaining('recordPromptIdle'),
+      {
+        input: {
+          promptId: SERVER_PROMPT_ID,
+          inputTokens: 140,
+          outputTokens: 30,
+          cacheReadTokens: 25,
+          cacheWriteTokens: 9
+        }
+      }
+    ])
+  })
+
   it('does not record hooks when Hive Enterprise organization settings are missing', async () => {
     const db = makeDb({
       hiveEnterpriseServerUrl: 'https://enterprise.example.com',

--- a/src/main/services/claude-cli-discord-bridge.ts
+++ b/src/main/services/claude-cli-discord-bridge.ts
@@ -2,7 +2,11 @@ import { EventEmitter } from 'node:events'
 import type { ServerResponse } from 'node:http'
 import type { OpenCodeStreamEvent } from '@shared/types/opencode'
 import { agentEventBus } from './agent-event-bus'
-import { CliHookHoldCore, type ClaudeHookBody } from './cli-hook-hold-core'
+import {
+  CliHookHoldCore,
+  type ClaudeHookBody,
+  type CliHookRouteContext
+} from './cli-hook-hold-core'
 
 class ClaudeCliDiscordBridge {
   readonly name = 'discord'
@@ -30,8 +34,17 @@ class ClaudeCliDiscordBridge {
     return () => this.emitter.off('event', listener)
   }
 
-  onHook(sessionId: string, body: ClaudeHookBody, res: ServerResponse): boolean {
-    return this.core.onHook(sessionId, body, res)
+  onHook(
+    sessionId: string,
+    body: ClaudeHookBody,
+    res: ServerResponse,
+    ctx?: CliHookRouteContext
+  ): boolean {
+    return this.core.onHook(sessionId, body, res, ctx)
+  }
+
+  notifySessionIdle(sessionId: string, lastAssistantMessage?: string): void {
+    this.core.emitSessionIdle(sessionId, lastAssistantMessage)
   }
 
   hasPendingQuestion(requestId: string): boolean {

--- a/src/main/services/claude-cli-interaction-ledger.ts
+++ b/src/main/services/claude-cli-interaction-ledger.ts
@@ -2,6 +2,9 @@ import { STATUS_PRIORITY, type SessionStatusType } from '@shared/types/session-s
 // Type-only import: claude-hook-server imports this module at runtime, so a
 // runtime import back would create a cycle.
 import type { ClaudeCliStatusPayload, ParsedClaudeHook } from './claude-hook-server'
+// Runtime import: claude-cli-subagent-tracker only *type*-imports from
+// claude-hook-server, so this does not create a cycle.
+import { parseTaskNotificationIds } from './claude-cli-subagent-tracker'
 
 /**
  * Per-session ledger of blocking interactions (questions, permission prompts,
@@ -145,8 +148,14 @@ export function processClaudeCliHook(
   mapped: ClaudeCliStatusPayload | null
 ): ClaudeCliStatusPayload[] {
   const event = hook.hook_event_name ?? ''
+  // A background-subagent task-notification resume is not a user turn
+  // boundary: it must not reset a latched question/permission/plan the way a
+  // real UserPromptSubmit would. It falls through to the normal non-reset
+  // flow below, which suppresses its publish while a latch is pending.
+  const isTaskNotificationResume =
+    event === 'UserPromptSubmit' && parseTaskNotificationIds(hook.prompt).length > 0
 
-  if (RESET_EVENTS.has(event)) {
+  if (RESET_EVENTS.has(event) && !isTaskNotificationResume) {
     ledgers.delete(sessionId)
     return mapped ? [mapped] : []
   }

--- a/src/main/services/claude-cli-interaction-ledger.ts
+++ b/src/main/services/claude-cli-interaction-ledger.ts
@@ -4,7 +4,7 @@ import { STATUS_PRIORITY, type SessionStatusType } from '@shared/types/session-s
 import type { ClaudeCliStatusPayload, ParsedClaudeHook } from './claude-hook-server'
 // Runtime import: claude-cli-subagent-tracker only *type*-imports from
 // claude-hook-server, so this does not create a cycle.
-import { parseTaskNotificationIds } from './claude-cli-subagent-tracker'
+import { isTaskNotificationPrompt } from './claude-cli-subagent-tracker'
 
 /**
  * Per-session ledger of blocking interactions (questions, permission prompts,
@@ -152,8 +152,7 @@ export function processClaudeCliHook(
   // boundary: it must not reset a latched question/permission/plan the way a
   // real UserPromptSubmit would. It falls through to the normal non-reset
   // flow below, which suppresses its publish while a latch is pending.
-  const isTaskNotificationResume =
-    event === 'UserPromptSubmit' && parseTaskNotificationIds(hook.prompt).length > 0
+  const isTaskNotificationResume = event === 'UserPromptSubmit' && isTaskNotificationPrompt(hook.prompt)
 
   if (RESET_EVENTS.has(event) && !isTaskNotificationResume) {
     ledgers.delete(sessionId)

--- a/src/main/services/claude-cli-subagent-tracker.ts
+++ b/src/main/services/claude-cli-subagent-tracker.ts
@@ -27,11 +27,10 @@ export interface ClaudeCliBackgroundTask {
   status?: string
 }
 
-export type ClaudeCliTrackedHook = ParsedClaudeHook & {
-  agent_id?: string
-  agent_type?: string
-  background_tasks?: ClaudeCliBackgroundTask[]
-}
+// `ParsedClaudeHook` already declares agent_id/agent_type/background_tasks
+// (claude-hook-server.ts), so this is just a local alias for readability at
+// this module's call sites — not a distinct shape.
+export type ClaudeCliTrackedHook = ParsedClaudeHook
 
 export const SUBAGENT_RESUME_TIMEOUT_MS = 90_000 // deferred with only pending notifications: resume should be near-immediate
 export const SUBAGENT_WATCHDOG_TIMEOUT_MS = 600_000 // deferred with running subagents: long tool calls can be hook-silent for minutes
@@ -60,6 +59,15 @@ interface SessionState {
 }
 
 // sessionId -> tracking state
+//
+// Accepted race: a hook can arrive after a PTY teardown has already cleared
+// this session (Esc/exit) and re-create bounded state for a now-dead session
+// — e.g. a pending-notification entry from a late SubagentStop, or a
+// deferring Stop that arms a timer whose eventual watchdog publish is simply
+// dedup-swallowed by publishClaudeCliStatus/SessionStart clears. This state
+// is bounded and self-heals on the next SessionStart (full clear) or PTY
+// restart, or expires on its own via the watchdog, so it is not worth
+// guarding against here.
 const sessions = new Map<string, SessionState>()
 
 let deferredCompletionHandler: DeferredCompletionHandler | null = null
@@ -72,17 +80,28 @@ export function setClaudeCliDeferredCompletionHandler(h: DeferredCompletionHandl
 }
 
 /**
+ * True iff `prompt` is a string whose trimmed start begins with the
+ * task-notification marker tag. This is the authoritative "is this a
+ * notification resume, not a user-authored prompt" check — it must stay true
+ * even for a marker-prefixed prompt with zero parseable `<task-id>` blocks,
+ * so callers gating turn-boundary behavior (ledger reset, first-prompt
+ * announce, status metadata) should use this rather than checking whether
+ * `parseTaskNotificationIds` returned anything.
+ */
+export function isTaskNotificationPrompt(prompt: unknown): boolean {
+  return typeof prompt === 'string' && prompt.trimStart().startsWith(TASK_NOTIFICATION_PREFIX)
+}
+
+/**
  * Pure parse of a Claude CLI background-task-resume prompt. Not a
  * notification unless the (trimmed) prompt starts with the marker tag; a
  * single resume can carry several `<task-id>` blocks (batch resume).
  */
 export function parseTaskNotificationIds(prompt: unknown): string[] {
-  if (typeof prompt !== 'string') return []
-  const trimmed = prompt.trimStart()
-  if (!trimmed.startsWith(TASK_NOTIFICATION_PREFIX)) return []
+  if (!isTaskNotificationPrompt(prompt)) return []
 
   const ids: string[] = []
-  for (const match of trimmed.matchAll(TASK_ID_PATTERN)) {
+  for (const match of (prompt as string).trimStart().matchAll(TASK_ID_PATTERN)) {
     ids.push(match[1])
   }
   return ids
@@ -150,7 +169,9 @@ function runningSubagentIds(backgroundTasks: ClaudeCliBackgroundTask[] | undefin
 }
 
 function isSelfListed(backgroundTasks: ClaudeCliBackgroundTask[] | undefined, agentId: string): boolean {
-  return (backgroundTasks ?? []).some((task) => task.id === agentId && task.type === 'subagent')
+  return (backgroundTasks ?? []).some(
+    (task) => task.id === agentId && task.type === 'subagent' && task.status === 'running'
+  )
 }
 
 /**

--- a/src/main/services/claude-cli-subagent-tracker.ts
+++ b/src/main/services/claude-cli-subagent-tracker.ts
@@ -1,0 +1,250 @@
+// Type-only import: claude-hook-server imports this module at runtime, so a
+// runtime import back would create a cycle.
+import type { ClaudeCliStatusPayload, ParsedClaudeHook } from './claude-hook-server'
+
+/**
+ * Since claude-cli v2.1.198, Task subagents can run in the background: the
+ * main agent's `Stop` hook can fire while subagents are still running, and
+ * claude-cli auto-resumes the session (as a fresh turn) once they finish.
+ * Naively mapping every main `Stop` to a 'completed' session status would
+ * flicker the UI/kanban to "done" mid-flight.
+ *
+ * This module tracks, per session, whether a `Stop` is truly final:
+ * - `background_tasks` on the Stop payload is the CLI's authoritative
+ *   snapshot of in-flight subagent work at stop time.
+ * - A background subagent's completion is delivered as a *separate* turn (a
+ *   `UserPromptSubmit` "task-notification" hook); `pendingNotifications`
+ *   covers the gap between a subagent finishing mid-turn and that
+ *   notification turn actually starting.
+ * - A deferred Stop is never resolved by mere inactivity — the resume turn
+ *   always ends with its own `Stop`, which re-evaluates. The timer/handler
+ *   here is purely a lost-event safety net.
+ */
+
+export interface ClaudeCliBackgroundTask {
+  id?: string
+  type?: string
+  status?: string
+}
+
+export type ClaudeCliTrackedHook = ParsedClaudeHook & {
+  agent_id?: string
+  agent_type?: string
+  background_tasks?: ClaudeCliBackgroundTask[]
+}
+
+export const SUBAGENT_RESUME_TIMEOUT_MS = 90_000 // deferred with only pending notifications: resume should be near-immediate
+export const SUBAGENT_WATCHDOG_TIMEOUT_MS = 600_000 // deferred with running subagents: long tool calls can be hook-silent for minutes
+
+export type SubagentGateResult =
+  | { kind: 'pass' } // hook proceeds through ledger + publish as today
+  | { kind: 'defer_stop' } // main Stop swallowed; session not done
+  | { kind: 'subagent_scoped' } // Stop carrying agent_id — never a session completion
+
+export type DeferredCompletionHandler = (
+  sessionId: string,
+  payload: ClaudeCliStatusPayload,
+  lastAssistantMessage?: string
+) => boolean // false ⇒ not safe to complete now (blocking interaction pending) ⇒ tracker re-arms
+
+interface DeferredCompletion {
+  payload: ClaudeCliStatusPayload
+  lastAssistantMessage?: string
+  running: Set<string> // running subagent task ids from the deferred Stop's background_tasks
+}
+
+interface SessionState {
+  pendingNotifications: Set<string> // background subagent ids whose results haven't been consumed by a resume yet
+  deferred: DeferredCompletion | null
+  timer: NodeJS.Timeout | null
+}
+
+// sessionId -> tracking state
+const sessions = new Map<string, SessionState>()
+
+let deferredCompletionHandler: DeferredCompletionHandler | null = null
+
+const TASK_NOTIFICATION_PREFIX = '<task-notification>'
+const TASK_ID_PATTERN = /<task-id>([^<]*)<\/task-id>/g
+
+export function setClaudeCliDeferredCompletionHandler(h: DeferredCompletionHandler | null): void {
+  deferredCompletionHandler = h
+}
+
+/**
+ * Pure parse of a Claude CLI background-task-resume prompt. Not a
+ * notification unless the (trimmed) prompt starts with the marker tag; a
+ * single resume can carry several `<task-id>` blocks (batch resume).
+ */
+export function parseTaskNotificationIds(prompt: unknown): string[] {
+  if (typeof prompt !== 'string') return []
+  const trimmed = prompt.trimStart()
+  if (!trimmed.startsWith(TASK_NOTIFICATION_PREFIX)) return []
+
+  const ids: string[] = []
+  for (const match of trimmed.matchAll(TASK_ID_PATTERN)) {
+    ids.push(match[1])
+  }
+  return ids
+}
+
+function getOrCreateState(sessionId: string): SessionState {
+  let state = sessions.get(sessionId)
+  if (!state) {
+    state = { pendingNotifications: new Set(), deferred: null, timer: null }
+    sessions.set(sessionId, state)
+  }
+  return state
+}
+
+function pruneIfEmpty(sessionId: string, state: SessionState): void {
+  if (state.pendingNotifications.size === 0 && state.deferred === null && state.timer === null) {
+    sessions.delete(sessionId)
+  }
+}
+
+/** Restart (or cancel) the deferral timer to match the current state. */
+function rearm(sessionId: string): void {
+  const state = sessions.get(sessionId)
+  if (!state) return
+
+  if (state.timer) {
+    clearTimeout(state.timer)
+    state.timer = null
+  }
+
+  if (state.deferred) {
+    const timeoutMs =
+      state.deferred.running.size > 0 ? SUBAGENT_WATCHDOG_TIMEOUT_MS : SUBAGENT_RESUME_TIMEOUT_MS
+    state.timer = setTimeout(() => onTimerFire(sessionId), timeoutMs)
+  }
+
+  pruneIfEmpty(sessionId, state)
+}
+
+function onTimerFire(sessionId: string): void {
+  const state = sessions.get(sessionId)
+  if (!state || !state.deferred) return
+
+  if (!deferredCompletionHandler) {
+    // No one registered to decide — safest is to stop holding the session open.
+    clearClaudeCliSubagentTracking(sessionId)
+    return
+  }
+
+  const { payload, lastAssistantMessage } = state.deferred
+  const safeToComplete = deferredCompletionHandler(sessionId, payload, lastAssistantMessage)
+  if (safeToComplete) {
+    clearClaudeCliSubagentTracking(sessionId)
+  } else {
+    state.timer = setTimeout(() => onTimerFire(sessionId), SUBAGENT_WATCHDOG_TIMEOUT_MS)
+  }
+}
+
+function runningSubagentIds(backgroundTasks: ClaudeCliBackgroundTask[] | undefined): Set<string> {
+  const ids = new Set<string>()
+  for (const task of backgroundTasks ?? []) {
+    if (task.type === 'subagent' && task.status === 'running' && task.id) ids.add(task.id)
+  }
+  return ids
+}
+
+function isSelfListed(backgroundTasks: ClaudeCliBackgroundTask[] | undefined, agentId: string): boolean {
+  return (backgroundTasks ?? []).some((task) => task.id === agentId && task.type === 'subagent')
+}
+
+/**
+ * Feed a Claude CLI hook through the subagent state machine and decide
+ * whether the caller should treat this as a normal hook (`pass`), swallow a
+ * `Stop` because background subagents are still in flight (`defer_stop`), or
+ * ignore a `Stop` scoped to a subagent turn (`subagent_scoped`).
+ */
+export function processClaudeCliSubagentHook(
+  sessionId: string,
+  hook: ClaudeCliTrackedHook,
+  mapped: ClaudeCliStatusPayload | null
+): SubagentGateResult {
+  const event = hook.hook_event_name ?? ''
+
+  if (event === 'SessionStart' || event === 'SessionEnd') {
+    clearClaudeCliSubagentTracking(sessionId)
+    return { kind: 'pass' }
+  }
+
+  if (event === 'UserPromptSubmit') {
+    const state = sessions.get(sessionId)
+    if (state) {
+      for (const id of parseTaskNotificationIds(hook.prompt)) {
+        state.pendingNotifications.delete(id)
+      }
+      state.deferred = null
+      if (state.timer) {
+        clearTimeout(state.timer)
+        state.timer = null
+      }
+      pruneIfEmpty(sessionId, state)
+    }
+    return { kind: 'pass' }
+  }
+
+  if (event === 'SubagentStop' && hook.agent_id) {
+    const agentId = hook.agent_id
+    if (isSelfListed(hook.background_tasks, agentId)) {
+      getOrCreateState(sessionId).pendingNotifications.add(agentId)
+    }
+    sessions.get(sessionId)?.deferred?.running.delete(agentId)
+    rearm(sessionId)
+    return { kind: 'pass' }
+  }
+
+  if (event === 'Stop' && hook.agent_id) {
+    rearm(sessionId)
+    return { kind: 'subagent_scoped' }
+  }
+
+  if (event === 'Stop') {
+    const running = runningSubagentIds(hook.background_tasks)
+    const pendingCount = sessions.get(sessionId)?.pendingNotifications.size ?? 0
+
+    if (running.size === 0 && pendingCount === 0) {
+      clearClaudeCliSubagentTracking(sessionId)
+      return { kind: 'pass' }
+    }
+
+    const state = getOrCreateState(sessionId)
+    state.deferred = {
+      payload: mapped ?? { sessionId, status: 'completed', metadata: { hookEventName: 'Stop' } },
+      lastAssistantMessage: hook.last_assistant_message ?? hook.assistant_message,
+      running
+    }
+    rearm(sessionId)
+    return { kind: 'defer_stop' }
+  }
+
+  // SubagentStart, SubagentStop without agent_id, or any other hook.
+  rearm(sessionId)
+  return { kind: 'pass' }
+}
+
+export function isClaudeCliCompletionDeferred(sessionId: string): boolean {
+  return sessions.get(sessionId)?.deferred != null
+}
+
+export function hasPendingClaudeCliSubagentWork(sessionId: string): boolean {
+  const state = sessions.get(sessionId)
+  if (!state) return false
+  return (state.deferred?.running.size ?? 0) > 0 || state.pendingNotifications.size > 0
+}
+
+export function clearClaudeCliSubagentTracking(sessionId: string): void {
+  const state = sessions.get(sessionId)
+  if (state?.timer) clearTimeout(state.timer)
+  sessions.delete(sessionId)
+}
+
+export function clearAllClaudeCliSubagentTracking(): void {
+  for (const state of sessions.values()) {
+    if (state.timer) clearTimeout(state.timer)
+  }
+  sessions.clear()
+}

--- a/src/main/services/claude-cli-telegram-bridge.ts
+++ b/src/main/services/claude-cli-telegram-bridge.ts
@@ -4,7 +4,11 @@ import type { OpenCodeStreamEvent } from '@shared/types/opencode'
 import { TELEGRAM_CLAUDE_CLI_EVENT_CHANNEL } from '@shared/telegram-events'
 import { agentEventBus } from './agent-event-bus'
 import { publishDesktopBackendEvent } from '../desktop/backend-event-publisher'
-import { CliHookHoldCore, type ClaudeHookBody } from './cli-hook-hold-core'
+import {
+  CliHookHoldCore,
+  type ClaudeHookBody,
+  type CliHookRouteContext
+} from './cli-hook-hold-core'
 
 export type { ClaudeHookBody } from './cli-hook-hold-core'
 
@@ -30,8 +34,17 @@ class ClaudeCliTelegramBridge {
     return () => this.emitter.off('event', listener)
   }
 
-  onHook(sessionId: string, body: ClaudeHookBody, res: ServerResponse): boolean {
-    return this.core.onHook(sessionId, body, res)
+  onHook(
+    sessionId: string,
+    body: ClaudeHookBody,
+    res: ServerResponse,
+    ctx?: CliHookRouteContext
+  ): boolean {
+    return this.core.onHook(sessionId, body, res, ctx)
+  }
+
+  notifySessionIdle(sessionId: string, lastAssistantMessage?: string): void {
+    this.core.emitSessionIdle(sessionId, lastAssistantMessage)
   }
 
   hasPendingQuestion(requestId: string): boolean {

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -7,8 +7,17 @@ import { handleClaudeCliHiveTelemetryHook } from './hive-enterprise-claude-cli-t
 import { publishDesktopBackendEvent } from '../desktop/backend-event-publisher'
 import {
   clearAllClaudeCliInteractions,
+  clearClaudeCliInteractions,
+  hasBlockingClaudeCliInteraction,
   processClaudeCliHook
 } from './claude-cli-interaction-ledger'
+import {
+  clearAllClaudeCliSubagentTracking,
+  parseTaskNotificationIds,
+  processClaudeCliSubagentHook,
+  setClaudeCliDeferredCompletionHandler,
+  type ClaudeCliBackgroundTask
+} from './claude-cli-subagent-tracker'
 
 export interface ParsedClaudeHook {
   hook_event_name?: string
@@ -24,6 +33,11 @@ export interface ParsedClaudeHook {
   /** Final assistant message of the turn (Stop hook). Read both spellings: */
   assistant_message?: string
   last_assistant_message?: string
+  /** Present on subagent-scoped hooks (SubagentStop, subagent-scoped Stop). */
+  agent_id?: string
+  agent_type?: string
+  /** Snapshot of in-flight background work at Stop/SubagentStop time. */
+  background_tasks?: ClaudeCliBackgroundTask[]
 }
 
 export interface ClaudeCliStatusPayload {
@@ -35,6 +49,7 @@ export interface ClaudeCliStatusPayload {
     hookPath?: string
     toolName?: string
     plan?: string
+    taskNotification?: boolean
   }
 }
 
@@ -76,6 +91,11 @@ export function buildClaudeCliHookSettings(port: number, hiveSessionId: string):
       Stop: [
         {
           hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'stop') }]
+        }
+      ],
+      SubagentStop: [
+        {
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'subagent') }]
         }
       ],
       PreToolUse: [
@@ -130,6 +150,8 @@ export function mapHookEventToStatus(hook: ParsedClaudeHook): SessionStatusType 
       if (hook.tool_name === 'ExitPlanMode') return 'plan_ready'
       if (hook.tool_name === 'AskUserQuestion') return 'answering'
       return 'permission'
+    case 'SubagentStop':
+      return null
     default:
       return null
   }
@@ -155,6 +177,10 @@ function buildStatusMetadata(
   const plan = extractPlanText(hook)
   if (plan !== undefined) {
     metadata.plan = plan
+  }
+
+  if (hook.hook_event_name === 'UserPromptSubmit' && parseTaskNotificationIds(hook.prompt).length > 0) {
+    metadata.taskNotification = true
   }
 
   return metadata
@@ -263,20 +289,35 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
             metadata: buildStatusMetadata(body, route.hookPath)
           }
         : null
-      // The interaction ledger latches blocking statuses (question/permission/
-      // plan approval) so parallel sub-agent hooks can't clobber them, and
-      // re-surfaces queued interactions as each one resolves.
-      for (const payload of processClaudeCliHook(route.sessionId, body, mapped)) {
-        publishClaudeCliStatus(payload)
+      // Background Task subagents can keep running after the main agent's
+      // Stop fires; the tracker decides whether this Stop is truly final
+      // ('pass'), must be swallowed because work is still in flight
+      // ('defer_stop'), or is scoped to a subagent turn and never a session
+      // completion ('subagent_scoped'). Only a 'pass' should reach the
+      // ledger/telemetry/status publish — a deferred Stop's RESET would
+      // otherwise clobber a subagent's latched question/permission.
+      const gate = processClaudeCliSubagentHook(route.sessionId, body, mapped)
+      if (gate.kind === 'pass') {
+        // The interaction ledger latches blocking statuses (question/permission/
+        // plan approval) so parallel sub-agent hooks can't clobber them, and
+        // re-surfaces queued interactions as each one resolves.
+        for (const payload of processClaudeCliHook(route.sessionId, body, mapped)) {
+          publishClaudeCliStatus(payload)
+        }
+        void handleClaudeCliHiveTelemetryHook(route.sessionId, body)
       }
-      void handleClaudeCliHiveTelemetryHook(route.sessionId, body)
       // First user prompt of this CLI session → tell the renderer so it can
       // auto-create a kanban ticket (if the setting is on). Fires for prompts
       // typed straight into the terminal as well as composer/handoff prompts.
+      // A task-notification resume is an auto-generated continuation turn,
+      // not a user-authored prompt, so it must never count as "first prompt"
+      // (and must not be recorded as announced — a later real prompt should
+      // still announce).
       if (
         body.hook_event_name === 'UserPromptSubmit' &&
         typeof body.prompt === 'string' &&
         body.prompt.trim().length > 0 &&
+        parseTaskNotificationIds(body.prompt).length === 0 &&
         !firstPromptAnnounced.has(route.sessionId)
       ) {
         firstPromptAnnounced.add(route.sessionId)
@@ -288,7 +329,11 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
       }
       // For forwarded CLI sessions a transport may take ownership of the
       // response (held open until answered). Otherwise behavior is unchanged.
-      owned = cliHookTransportRouter.routeHook(route.sessionId, body, res)
+      // suppressIdle keeps a deferred/subagent-scoped Stop from telling the
+      // transport the session went idle while background work is in flight.
+      owned = cliHookTransportRouter.routeHook(route.sessionId, body, res, {
+        suppressIdle: gate.kind !== 'pass'
+      })
     }
   } catch (error) {
     log.warn('Failed to parse Claude hook payload', {
@@ -303,6 +348,20 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
 }
 
 export async function getClaudeHookServer(): Promise<{ port: number }> {
+  // Re-registered on every call (the setter is idempotent) because
+  // closeClaudeHookServer clears it — a subsequent getClaudeHookServer() must
+  // restore it even when reusing an already-listening server.
+  setClaudeCliDeferredCompletionHandler((sessionId, payload, lastAssistantMessage) => {
+    if (hasBlockingClaudeCliInteraction(sessionId)) return false
+    clearClaudeCliInteractions(sessionId)
+    publishClaudeCliStatus({
+      ...payload,
+      metadata: { ...payload.metadata, reason: 'deferred_completion_watchdog' }
+    })
+    cliHookTransportRouter.notifySessionIdle(sessionId, lastAssistantMessage)
+    return true
+  })
+
   if (server && boundPort !== null) {
     return { port: boundPort }
   }
@@ -371,6 +430,8 @@ export async function closeClaudeHookServer(): Promise<void> {
     lastStatusBySession.clear()
     statusSubscribers.clear()
     clearAllClaudeCliInteractions()
+    clearAllClaudeCliSubagentTracking()
+    setClaudeCliDeferredCompletionHandler(null)
     return
   }
 
@@ -390,4 +451,6 @@ export async function closeClaudeHookServer(): Promise<void> {
   lastStatusBySession.clear()
   statusSubscribers.clear()
   clearAllClaudeCliInteractions()
+  clearAllClaudeCliSubagentTracking()
+  setClaudeCliDeferredCompletionHandler(null)
 }

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -13,7 +13,7 @@ import {
 } from './claude-cli-interaction-ledger'
 import {
   clearAllClaudeCliSubagentTracking,
-  parseTaskNotificationIds,
+  isTaskNotificationPrompt,
   processClaudeCliSubagentHook,
   setClaudeCliDeferredCompletionHandler,
   type ClaudeCliBackgroundTask
@@ -179,7 +179,7 @@ function buildStatusMetadata(
     metadata.plan = plan
   }
 
-  if (hook.hook_event_name === 'UserPromptSubmit' && parseTaskNotificationIds(hook.prompt).length > 0) {
+  if (hook.hook_event_name === 'UserPromptSubmit' && isTaskNotificationPrompt(hook.prompt)) {
     metadata.taskNotification = true
   }
 
@@ -317,7 +317,7 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
         body.hook_event_name === 'UserPromptSubmit' &&
         typeof body.prompt === 'string' &&
         body.prompt.trim().length > 0 &&
-        parseTaskNotificationIds(body.prompt).length === 0 &&
+        !isTaskNotificationPrompt(body.prompt) &&
         !firstPromptAnnounced.has(route.sessionId)
       ) {
         firstPromptAnnounced.add(route.sessionId)
@@ -354,6 +354,12 @@ export async function getClaudeHookServer(): Promise<{ port: number }> {
   setClaudeCliDeferredCompletionHandler((sessionId, payload, lastAssistantMessage) => {
     if (hasBlockingClaudeCliInteraction(sessionId)) return false
     clearClaudeCliInteractions(sessionId)
+    // Intentionally does not record telemetry idle here (no recordIdle call):
+    // this path fires when the resume turn's own Stop never showed up, so
+    // there is no matching hook payload to drive recordIdle off of. Known
+    // accepted gap: this can leave a dangling `activePromptBySession` entry
+    // in the telemetry module, which would inflate the *next* turn's usage
+    // delta with this turn's untallied tokens.
     publishClaudeCliStatus({
       ...payload,
       metadata: { ...payload.metadata, reason: 'deferred_completion_watchdog' }

--- a/src/main/services/cli-hook-hold-core.ts
+++ b/src/main/services/cli-hook-hold-core.ts
@@ -11,6 +11,11 @@ export interface ClaudeHookBody {
   tool_input?: { plan?: unknown; questions?: unknown }
   assistant_message?: string
   last_assistant_message?: string
+  agent_id?: string
+}
+
+export interface CliHookRouteContext {
+  suppressIdle?: boolean
 }
 
 type InteractionKind = 'question' | 'plan'
@@ -68,7 +73,12 @@ export class CliHookHoldCore {
     return this.registered.has(sessionId)
   }
 
-  onHook(sessionId: string, body: ClaudeHookBody, res: ServerResponse): boolean {
+  onHook(
+    sessionId: string,
+    body: ClaudeHookBody,
+    res: ServerResponse,
+    ctx?: CliHookRouteContext
+  ): boolean {
     if (!this.registered.has(sessionId)) return false
 
     const event = body.hook_event_name
@@ -79,7 +89,7 @@ export class CliHookHoldCore {
       return this.holdPlan(sessionId, body, res)
     }
     if (event === 'Stop') {
-      this.emitIdle(sessionId, body)
+      if (!ctx?.suppressIdle) this.emitIdle(sessionId, body)
       return false
     }
     if (
@@ -240,16 +250,20 @@ export class CliHookHoldCore {
     return requestId
   }
 
-  private emitIdle(sessionId: string, body: ClaudeHookBody): void {
-    const text = body.last_assistant_message ?? body.assistant_message
-    if (typeof text === 'string' && text.trim().length > 0) {
+  emitSessionIdle(sessionId: string, lastAssistantMessage?: string): void {
+    if (typeof lastAssistantMessage === 'string' && lastAssistantMessage.trim().length > 0) {
       this.events.emitTransport({
         type: 'message.updated',
         sessionId,
-        data: { role: 'assistant', content: text }
+        data: { role: 'assistant', content: lastAssistantMessage }
       })
     }
     this.events.emitTransport({ type: 'session.idle', sessionId, data: {} })
+  }
+
+  private emitIdle(sessionId: string, body: ClaudeHookBody): void {
+    const text = body.last_assistant_message ?? body.assistant_message
+    this.emitSessionIdle(sessionId, text)
   }
 
   private finalize(

--- a/src/main/services/cli-hook-transport-router.ts
+++ b/src/main/services/cli-hook-transport-router.ts
@@ -1,12 +1,18 @@
 import type { ServerResponse } from 'node:http'
-import type { ClaudeHookBody } from './cli-hook-hold-core'
+import type { ClaudeHookBody, CliHookRouteContext } from './cli-hook-hold-core'
 import { claudeCliDiscordBridge } from './claude-cli-discord-bridge'
 import { claudeCliTelegramBridge } from './claude-cli-telegram-bridge'
 
 export interface CliHookTransport {
   name: string
   isRegistered(sessionId: string): boolean
-  onHook(sessionId: string, body: ClaudeHookBody, res: ServerResponse): boolean
+  onHook(
+    sessionId: string,
+    body: ClaudeHookBody,
+    res: ServerResponse,
+    ctx?: CliHookRouteContext
+  ): boolean
+  notifySessionIdle(sessionId: string, lastAssistantMessage?: string): void
   cancelAll(): void
 }
 
@@ -17,9 +23,19 @@ export class CliHookTransportRouter {
     this.transports = transports
   }
 
-  routeHook(sessionId: string, body: ClaudeHookBody, res: ServerResponse): boolean {
+  routeHook(
+    sessionId: string,
+    body: ClaudeHookBody,
+    res: ServerResponse,
+    ctx?: CliHookRouteContext
+  ): boolean {
     const transport = this.transports.find((candidate) => candidate.isRegistered(sessionId))
-    return transport?.onHook(sessionId, body, res) ?? false
+    return transport?.onHook(sessionId, body, res, ctx) ?? false
+  }
+
+  notifySessionIdle(sessionId: string, lastAssistantMessage?: string): void {
+    const transport = this.transports.find((candidate) => candidate.isRegistered(sessionId))
+    transport?.notifySessionIdle(sessionId, lastAssistantMessage)
   }
 
   cancelAll(): void {

--- a/src/main/services/hive-enterprise-claude-cli-telemetry.ts
+++ b/src/main/services/hive-enterprise-claude-cli-telemetry.ts
@@ -5,6 +5,7 @@ import { getDatabase } from '../db'
 import type { Project } from '../db/types'
 import { GitService } from './git-service'
 import { createLogger } from './logger'
+import { isTaskNotificationPrompt } from './claude-cli-subagent-tracker'
 
 const RecordPromptStartDocument = /* GraphQL */ `
   mutation HiveEnterpriseRecordPromptStart($input: PromptStartInput!) {
@@ -432,6 +433,15 @@ export async function handleClaudeCliHiveTelemetryHook(
     }
 
     if (hook.hook_event_name === 'UserPromptSubmit') {
+      // A background-subagent task-notification resume is an auto-generated
+      // continuation turn, not a real user prompt. Since a deferred Stop
+      // already skips telemetry for the turn that triggered it, treating this
+      // resume as a new prompt start would overwrite (clobber) the real
+      // prompt's still-active record in `activePromptBySession`, orphaning it
+      // and mis-attributing the eventual recordIdle to a phantom
+      // `<task-notification>…` prompt. Skip it so the real prompt's record
+      // survives through to the final passing Stop.
+      if (isTaskNotificationPrompt(hook.prompt)) return
       await recordStart(sessionId, hook, resolvedDeps)
       return
     }

--- a/src/main/services/terminal-pty-bridge.claude-cli.test.ts
+++ b/src/main/services/terminal-pty-bridge.claude-cli.test.ts
@@ -23,6 +23,8 @@ const mocks = vi.hoisted(() => {
     subscribeClaudeCliStatus: vi.fn(() => vi.fn()),
     clearClaudeCliInteractions: vi.fn(),
     clearAllClaudeCliInteractions: vi.fn(),
+    clearClaudeCliSubagentTracking: vi.fn(),
+    clearAllClaudeCliSubagentTracking: vi.fn(),
     ptyService: {
       has: vi.fn(() => false),
       create: vi.fn(() => ({ cols: 120, rows: 40 })),
@@ -127,6 +129,11 @@ vi.mock('../desktop/backend-event-publisher', () => ({
 vi.mock('./claude-cli-interaction-ledger', () => ({
   clearClaudeCliInteractions: mocks.clearClaudeCliInteractions,
   clearAllClaudeCliInteractions: mocks.clearAllClaudeCliInteractions
+}))
+
+vi.mock('./claude-cli-subagent-tracker', () => ({
+  clearClaudeCliSubagentTracking: mocks.clearClaudeCliSubagentTracking,
+  clearAllClaudeCliSubagentTracking: mocks.clearAllClaudeCliSubagentTracking
 }))
 
 import type { Session } from '../db/types'
@@ -598,6 +605,58 @@ describe('Claude CLI terminal hook status wiring', () => {
       cleanupTerminals()
 
       expect(mocks.clearAllClaudeCliInteractions).toHaveBeenCalled()
+    })
+  })
+
+  describe('subagent tracker clears', () => {
+    it('clears subagent tracking when a Claude CLI PTY restarts, so a stale deferral cannot survive', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.clearClaudeCliSubagentTracking.mockClear()
+
+      mocks.ptyService.has.mockReturnValue(true)
+      await createClaudeCliTerminal('hive-session-1', {})
+
+      expect(mocks.clearClaudeCliSubagentTracking).toHaveBeenCalledWith('hive-session-1')
+    })
+
+    it.each(['\x1b', '\x03'])(
+      'clears subagent tracking on user interrupt %j',
+      async (key) => {
+        await createClaudeCliTerminal('hive-session-1', {})
+        mocks.getLastClaudeCliStatus.mockReturnValue('working')
+        mocks.clearClaudeCliSubagentTracking.mockClear()
+
+        handleClaudeCliTerminalInput('hive-session-1', key)
+
+        expect(mocks.clearClaudeCliSubagentTracking).toHaveBeenCalledWith('hive-session-1')
+      }
+    )
+
+    it('clears subagent tracking when the tracked PTY exits', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.clearClaudeCliSubagentTracking.mockClear()
+
+      mocks.exitCallbacks.get('hive-session-1')?.(9)
+
+      expect(mocks.clearClaudeCliSubagentTracking).toHaveBeenCalledWith('hive-session-1')
+    })
+
+    it('clears subagent tracking when the terminal is destroyed', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.clearClaudeCliSubagentTracking.mockClear()
+
+      destroyNodePtyTerminal('hive-session-1')
+
+      expect(mocks.clearClaudeCliSubagentTracking).toHaveBeenCalledWith('hive-session-1')
+    })
+
+    it('clears all subagent tracking on cleanupTerminals', async () => {
+      await createClaudeCliTerminal('hive-session-1', {})
+      mocks.clearAllClaudeCliSubagentTracking.mockClear()
+
+      cleanupTerminals()
+
+      expect(mocks.clearAllClaudeCliSubagentTracking).toHaveBeenCalled()
     })
   })
 

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -12,6 +12,10 @@ import {
   clearAllClaudeCliInteractions,
   clearClaudeCliInteractions
 } from './claude-cli-interaction-ledger'
+import {
+  clearAllClaudeCliSubagentTracking,
+  clearClaudeCliSubagentTracking
+} from './claude-cli-subagent-tracker'
 import { logClaudeBinaryVersion, resolveClaudeBinaryPath } from './claude-binary-resolver'
 import { buildClaudeCliPtySpawn } from './claude-cli-spawner'
 import { externalizeGoalHandoffPlan } from './claude-cli-plan-handoff'
@@ -125,6 +129,7 @@ export function handleClaudeCliTerminalInput(terminalId: string, data: string): 
   // No hook fires for an interrupted/denied interaction — drop any pending
   // latch so the next hook cannot re-surface a phantom permission.
   clearClaudeCliInteractions(terminalId)
+  clearClaudeCliSubagentTracking(terminalId)
   publishClaudeCliStatus({
     sessionId: terminalId,
     status: 'completed',
@@ -145,6 +150,7 @@ export function destroyNodePtyTerminal(terminalId: string): void {
   claudeWatchers.delete(terminalId)
   closeClaudePlanFollowupWatcher(terminalId)
   clearClaudeCliInteractions(terminalId)
+  clearClaudeCliSubagentTracking(terminalId)
   claudeCliSessions.delete(terminalId)
   claudeCliWorktreeBasenames.delete(terminalId)
   claudeCliTranscriptSources.delete(terminalId)
@@ -211,6 +217,7 @@ function attachNodePtyListeners(terminalId: string): void {
     closeClaudePlanFollowupWatcher(terminalId)
     if (claudeCliSessions.has(terminalId)) {
       clearClaudeCliInteractions(terminalId)
+      clearClaudeCliSubagentTracking(terminalId)
       publishClaudeCliStatus({
         sessionId: terminalId,
         status: 'completed',
@@ -343,6 +350,9 @@ export async function createClaudeCliTerminal(
     claudeCliSessions.add(sessionId)
     // A restarted session must never inherit a stale interaction latch.
     clearClaudeCliInteractions(sessionId)
+    // ...nor a stale subagent deferral/pending-notification set, which could
+    // otherwise swallow the next turn's Stop after a restart.
+    clearClaudeCliSubagentTracking(sessionId)
     claudeCliWorktreeBasenames.set(sessionId, path.basename(worktreePath))
     if (!pendingPrompt) {
       publishClaudeCliStatus({
@@ -392,6 +402,7 @@ export function cleanupTerminals(): void {
   claudeCliTranscriptSources.clear()
   claudeCliLastStatus.clear()
   clearAllClaudeCliInteractions()
+  clearAllClaudeCliSubagentTracking()
   unsubscribeClaudeCliStatus?.()
   unsubscribeClaudeCliStatus = null
   resetAllClaudeCliTitleState()

--- a/src/renderer/src/api/terminal-api.ts
+++ b/src/renderer/src/api/terminal-api.ts
@@ -31,6 +31,7 @@ export interface ClaudeCliStatusPayload {
     readonly hookPath?: string
     readonly toolName?: string
     readonly plan?: string
+    readonly taskNotification?: boolean
   }
 }
 

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -79,6 +79,7 @@ type SubscribedPayload = {
     hookPath?: string
     toolName?: string
     plan?: string
+    taskNotification?: boolean
   }
 }
 
@@ -319,6 +320,88 @@ describe('useClaudeCliStatusListener', () => {
       hookEventName: 'PostToolUseFailure',
       hookPath: 'tool',
       toolName: 'ExitPlanMode'
+    })
+  })
+
+  describe('background subagent auto-resume (task-notification) publishes', () => {
+    it('preserves plan_ready and does not clear the pending plan when a subagent resume arrives while plan_ready', () => {
+      mocks.sessionStatuses = { 'hive-session-1': { status: 'plan_ready' } }
+      renderHook(() => useClaudeCliStatusListener())
+
+      subscribedCallback?.({
+        sessionId: 'hive-session-1',
+        status: 'working',
+        metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start', taskNotification: true }
+      })
+
+      expect(mocks.clearPendingPlan).not.toHaveBeenCalled()
+      expect(mocks.lastSendMode.get('hive-session-1')).toBeUndefined()
+      expect(mocks.setSessionStatus).not.toHaveBeenCalled()
+    })
+
+    it('falls through to a plain working status when a subagent resume arrives while not plan_ready', () => {
+      mocks.sessionStatuses = { 'hive-session-1': { status: 'working' } }
+      renderHook(() => useClaudeCliStatusListener())
+
+      subscribedCallback?.({
+        sessionId: 'hive-session-1',
+        status: 'working',
+        metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start', taskNotification: true }
+      })
+
+      expect(mocks.setSessionStatus).toHaveBeenCalledWith('hive-session-1', 'working', {
+        hookEventName: 'UserPromptSubmit',
+        hookPath: 'start',
+        taskNotification: true
+      })
+    })
+
+    it('falls through to a plain working status when a subagent resume arrives with no prior status', () => {
+      renderHook(() => useClaudeCliStatusListener())
+
+      subscribedCallback?.({
+        sessionId: 'hive-session-1',
+        status: 'working',
+        metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start', taskNotification: true }
+      })
+
+      expect(mocks.setSessionStatus).toHaveBeenCalledWith('hive-session-1', 'working', {
+        hookEventName: 'UserPromptSubmit',
+        hookPath: 'start',
+        taskNotification: true
+      })
+    })
+
+    it('still performs the human plan-approval transition when a real UserPromptSubmit arrives while plan_ready', () => {
+      mocks.sessionStatuses = { 'hive-session-1': { status: 'plan_ready' } }
+      renderHook(() => useClaudeCliStatusListener())
+
+      subscribedCallback?.({
+        sessionId: 'hive-session-1',
+        status: 'working',
+        metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start' }
+      })
+
+      expect(mocks.lastSendMode.get('hive-session-1')).toBe('build')
+      expect(mocks.setSessionStatus).toHaveBeenCalledWith('hive-session-1', 'working', {
+        hookEventName: 'UserPromptSubmit',
+        hookPath: 'start'
+      })
+    })
+
+    it('does not trigger a plan followup for an auto-resume planning publish while plan_ready', () => {
+      mocks.sessionStatuses = { 'hive-session-1': { status: 'plan_ready' } }
+      renderHook(() => useClaudeCliStatusListener())
+
+      subscribedCallback?.({
+        sessionId: 'hive-session-1',
+        status: 'planning',
+        metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start', taskNotification: true }
+      })
+
+      expect(mocks.clearPendingPlan).not.toHaveBeenCalled()
+      expect(mocks.notifyKanbanSessionSync).not.toHaveBeenCalled()
+      expect(mocks.setSessionStatus).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -13,6 +13,7 @@ type ClaudeCliStatusMetadata = {
   hookPath?: string
   toolName?: string
   plan?: string
+  taskNotification?: boolean
 }
 
 function closeLinkedTicketModal(sessionId: string): void {
@@ -50,6 +51,21 @@ export function useClaudeCliStatusListener(): void {
       const sessionStore = useSessionStore.getState()
       const currentStatus = worktreeStatus.sessionStatuses[sessionId]?.status
       const currentMode = sessionStore.modeBySession.get(sessionId)
+
+      // Background subagents auto-resume the main agent via a UserPromptSubmit
+      // whose prompt is a <task-notification>; the hook server stamps those
+      // publishes with taskNotification: true. To the state machine below this
+      // looks exactly like a human sending a prompt, but it isn't one — it must
+      // not clear a pending plan or flip the send mode away from plan. If the
+      // session was sitting at plan_ready, leave it there (the eventual Stop
+      // re-derives plan_ready from lastSendMode === 'plan'); otherwise fall
+      // through to the default status write below so the UI still reflects the
+      // session genuinely working again.
+      if (metadata?.taskNotification === true) {
+        if (currentStatus === 'plan_ready') return
+        worktreeStatus.setSessionStatus(sessionId, status, metadata)
+        return
+      }
 
       if (metadata?.hookEventName === 'PostToolUse' && metadata.toolName === 'ExitPlanMode') {
         // User approved ExitPlanMode from the terminal, matching the in-app implement action.


### PR DESCRIPTION
## Summary
- Adds Claude CLI subagent tracking so `Stop` hooks can be deferred while background subagents are still running.
- Threads idle-suppression through hook transports and hold-core so deferred completion does not emit premature idle/status updates.
- Preserves interaction-ledger state across task-notification resume turns and avoids clobbering latched prompts.
- Updates telemetry, renderer status handling, and PTY teardown so deferred sessions clear cleanly and do not auto-resume incorrectly.
- Expands test coverage for subagent deferral, notification parsing, idle suppression, and watchdog completion behavior.

## Testing
- Added/updated unit tests for `claude-cli-subagent-tracker`, `claude-hook-server`, `cli-hook-hold-core`, `cli-hook-transport-router`, `claude-cli-interaction-ledger`, and bridge/status listener behavior.
- Added regression coverage for deferred `Stop` handling, task-notification resume parsing, watchdog timeout behavior, and session isolation.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Claude CLI hook pipeline (completion, idle, ledger, telemetry, kanban status); incorrect deferral could leave sessions stuck “working” or complete too early, though behavior is heavily test-covered.
> 
> **Overview**
> Fixes premature “session done” flicker when Claude CLI fires **`Stop`** while **background Task subagents** are still running or their **`<task-notification>`** resume turn has not finished.
> 
> Adds **`claude-cli-subagent-tracker`** to gate hooks: swallow main **`Stop`** when `background_tasks` or pending notifications remain, register **`SubagentStop`** HTTP hooks, and use **watchdog timers** (with a deferred-completion handler) as a safety net. **`claude-hook-server`** runs this gate **before** the interaction ledger so deferred stops never reset latched questions/permissions; deferred stops also skip telemetry and pass **`suppressIdle: true`** to transports.
> 
> **Task-notification** `UserPromptSubmit` prompts are detected via **`isTaskNotificationPrompt`** so they do **not** reset the interaction ledger, count as first user prompt, or start Hive Enterprise telemetry; status publishes can carry **`taskNotification: true`**. The renderer preserves **`plan_ready`** across auto-resume instead of treating it like a human prompt.
> 
> Hook transports gain **`CliHookRouteContext.suppressIdle`**, **`notifySessionIdle`**, and **`emitSessionIdle`** for deferred completion. PTY teardown/restart clears subagent tracking alongside existing ledger clears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3035b5ff6b190a6b4ae7dceeddf136e9e7e67236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->