### PR TITLE
Add one-shot auto-approve for Claude plan mode

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -362,7 +362,8 @@ export class DatabaseService {
       goal_mode: row.goal_mode === 1,
       goal_success_criteria: (row.goal_success_criteria as string) ?? null,
       note: (row.note as string) ?? null,
-      created_from_session: row.created_from_session === 1
+      created_from_session: row.created_from_session === 1,
+      auto_approve_plan: row.auto_approve_plan === 1
     }
   }
 
@@ -679,6 +680,7 @@ export class DatabaseService {
     this.safeAddColumn('kanban_tickets', 'goal_mode', 'INTEGER NOT NULL DEFAULT 0')
     this.safeAddColumn('kanban_tickets', 'goal_success_criteria', 'TEXT DEFAULT NULL')
     this.safeAddColumn('kanban_tickets', 'created_from_session', 'INTEGER NOT NULL DEFAULT 0')
+    this.safeAddColumn('kanban_tickets', 'auto_approve_plan', 'INTEGER NOT NULL DEFAULT 0')
     this.safeAddColumn('sessions', 'session_type', "TEXT NOT NULL DEFAULT 'default'")
     this.safeAddColumn(
       'discord_resources',
@@ -786,6 +788,7 @@ export class DatabaseService {
     this.safeAddColumn('markdown_kanban_card_state', 'pending_launch_config', 'TEXT DEFAULT NULL')
     this.safeAddColumn('markdown_kanban_card_state', 'last_seen_path', 'TEXT DEFAULT NULL')
     this.safeAddColumn('markdown_kanban_card_state', 'orphaned_at', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('markdown_kanban_card_state', 'auto_approve_plan', 'INTEGER NOT NULL DEFAULT 0')
   }
 
   // Settings operations
@@ -2780,6 +2783,10 @@ export class DatabaseService {
     if (data.note !== undefined) {
       updates.push('note = ?')
       values.push(data.note)
+    }
+    if (data.auto_approve_plan !== undefined) {
+      updates.push('auto_approve_plan = ?')
+      values.push(data.auto_approve_plan ? 1 : 0)
     }
 
     if (updates.length === 1) return existing // Only updated_at, nothing meaningful changed

--- a/src/main/db/migration-safety.test.ts
+++ b/src/main/db/migration-safety.test.ts
@@ -178,6 +178,30 @@ describeIf('database migration safety', () => {
     db.close()
   })
 
+  it('supports the kanban auto_approve_plan flag end-to-end on a fresh database', () => {
+    const db = new DatabaseService(makeDbPath())
+    db.init()
+
+    expect(columnNames(db, 'kanban_tickets')).toEqual(expect.arrayContaining(['auto_approve_plan']))
+    expect(columnNames(db, 'markdown_kanban_card_state')).toEqual(
+      expect.arrayContaining(['auto_approve_plan'])
+    )
+
+    const project = db.createProject({ name: 'Project', path: makeDbPath() })
+    const ticket = db.createKanbanTicket({ project_id: project.id, title: 'Ticket', mode: 'plan' })
+    expect(ticket.auto_approve_plan).toBe(false)
+
+    expect(db.updateKanbanTicket(ticket.id, { auto_approve_plan: true })?.auto_approve_plan).toBe(
+      true
+    )
+    expect(db.getKanbanTicket(ticket.id)?.auto_approve_plan).toBe(true)
+    expect(db.updateKanbanTicket(ticket.id, { auto_approve_plan: false })?.auto_approve_plan).toBe(
+      false
+    )
+
+    db.close()
+  })
+
   it('upgrades an origin/main v31-shaped database to v34 without losing existing worktrees', () => {
     const dbPath = makeDbPath()
     seedOriginMainVersion31Shape(dbPath)

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 37
+export const CURRENT_SCHEMA_VERSION = 38
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -655,6 +655,14 @@ DROP TABLE IF EXISTS diff_comments;`
     name: 'add_connection_history_note',
     up: `-- NOTE: ALTER TABLE for connection_history.note is handled idempotently by
          -- ensureConnectionTables() in database.ts to avoid "duplicate column" errors.`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 38,
+    name: 'add_ticket_auto_approve_plan',
+    up: `-- NOTE: ALTER TABLE for kanban_tickets.auto_approve_plan and
+         -- markdown_kanban_card_state.auto_approve_plan is handled idempotently by
+         -- safeAddColumn() in database.ts to avoid "duplicate column" errors.`,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -514,6 +514,8 @@ export interface KanbanTicket {
   note: string | null
   /** True when auto-created by the "automatically create ticket" setting on a session's first message. */
   created_from_session: boolean
+  /** One-shot: auto-approve the next claude-cli ExitPlanMode plan, then self-clears. */
+  auto_approve_plan: boolean
 }
 
 export interface KanbanTicketCreate {
@@ -555,6 +557,7 @@ export interface KanbanTicketUpdate {
   goal_mode?: boolean
   goal_success_criteria?: string | null
   note?: string | null
+  auto_approve_plan?: boolean
 }
 
 export interface BoardAssistantDraft {

--- a/src/main/desktop/backend-manager.test.ts
+++ b/src/main/desktop/backend-manager.test.ts
@@ -233,6 +233,7 @@ import {
   waitForBackendReady
 } from './backend-manager'
 import { publishDesktopBackendEvent } from './backend-event-publisher'
+import { isClaudeCliPlanAutoApproveArmed } from '../services/claude-cli-plan-auto-approve'
 
 class FakeChildProcess extends EventEmitter {
   stdout = new PassThrough()
@@ -3677,6 +3678,54 @@ describe('desktop backend manager', () => {
       }),
       expect.any(Function)
     )
+  })
+
+  it('applies backend terminalSetClaudeCliPlanAutoApprove commands to the armed registry', async () => {
+    const child = new FakeChildProcess()
+
+    await startDesktopBackend(
+      {
+        executablePath: '/electron',
+        entryPath: '/app/server.js',
+        cwd: '/app',
+        baseDir: mkdtempSync(join(tmpdir(), 'hive-backend-manager-')),
+        port: 0
+      },
+      {
+        spawnProcess: vi.fn(() => child as never),
+        fetch: vi.fn(async () => new Response('{}', { status: 200 })),
+        logger: makeLogger()
+      }
+    )
+
+    child.emit(
+      'message',
+      makeDesktopCommandRequest('plan-auto-approve-1', 'terminalSetClaudeCliPlanAutoApprove', {
+        sessionId: 'session-armed',
+        enabled: true
+      })
+    )
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(isClaudeCliPlanAutoApproveArmed('session-armed')).toBe(true)
+    expect(child.send).toHaveBeenCalledWith(
+      makeDesktopCommandResult('plan-auto-approve-1', {
+        ok: true,
+        value: { success: true }
+      }),
+      expect.any(Function)
+    )
+
+    child.emit(
+      'message',
+      makeDesktopCommandRequest('plan-auto-approve-2', 'terminalSetClaudeCliPlanAutoApprove', {
+        sessionId: 'session-armed',
+        enabled: false
+      })
+    )
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(isClaudeCliPlanAutoApproveArmed('session-armed')).toBe(false)
   })
 
   it('forwards backend terminalGhosttyInit commands to the Ghostty service', async () => {

--- a/src/main/desktop/backend-manager.ts
+++ b/src/main/desktop/backend-manager.ts
@@ -63,6 +63,7 @@ import {
   handleClaudeCliTerminalInput
 } from '../services/terminal-pty-bridge'
 import { claudeCliTelegramBridge } from '../services/claude-cli-telegram-bridge'
+import { setClaudeCliPlanAutoApprove } from '../services/claude-cli-plan-auto-approve'
 import { openPathWithEditor, openPathWithTerminal } from '../services/settings-openers'
 import {
   beginPetPointerInteraction,
@@ -747,6 +748,16 @@ const handleDesktopBackendCommand = (
 
   if (message.command === 'telegramClaudeCliCancel') {
     claudeCliTelegramBridge.cancelSession(message.payload.sessionId)
+    sendDesktopBackendCommandResult(
+      child,
+      makeDesktopCommandResult(message.id, { ok: true, value: { success: true } }),
+      log
+    )
+    return
+  }
+
+  if (message.command === 'terminalSetClaudeCliPlanAutoApprove') {
+    setClaudeCliPlanAutoApprove(message.payload.sessionId, message.payload.enabled)
     sendDesktopBackendCommandResult(
       child,
       makeDesktopCommandResult(message.id, { ok: true, value: { success: true } }),

--- a/src/main/services/__tests__/claude-cli-plan-auto-approve.test.ts
+++ b/src/main/services/__tests__/claude-cli-plan-auto-approve.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearAllClaudeCliPlanAutoApprove,
+  consumeClaudeCliPlanAutoApprove,
+  isClaudeCliPlanAutoApproveArmed,
+  setClaudeCliPlanAutoApprove
+} from '../claude-cli-plan-auto-approve'
+
+describe('claude-cli-plan-auto-approve registry', () => {
+  beforeEach(() => {
+    clearAllClaudeCliPlanAutoApprove()
+  })
+
+  it('arms and disarms a session', () => {
+    expect(isClaudeCliPlanAutoApproveArmed('s1')).toBe(false)
+
+    setClaudeCliPlanAutoApprove('s1', true)
+    expect(isClaudeCliPlanAutoApproveArmed('s1')).toBe(true)
+    expect(isClaudeCliPlanAutoApproveArmed('s2')).toBe(false)
+
+    setClaudeCliPlanAutoApprove('s1', false)
+    expect(isClaudeCliPlanAutoApproveArmed('s1')).toBe(false)
+  })
+
+  it('consume is one-shot: returns true once and unregisters', () => {
+    setClaudeCliPlanAutoApprove('s1', true)
+
+    expect(consumeClaudeCliPlanAutoApprove('s1')).toBe(true)
+    expect(isClaudeCliPlanAutoApproveArmed('s1')).toBe(false)
+    expect(consumeClaudeCliPlanAutoApprove('s1')).toBe(false)
+  })
+
+  it('consume on an unarmed session returns false', () => {
+    expect(consumeClaudeCliPlanAutoApprove('never-armed')).toBe(false)
+  })
+
+  it('clearAll disarms every session', () => {
+    setClaudeCliPlanAutoApprove('s1', true)
+    setClaudeCliPlanAutoApprove('s2', true)
+
+    clearAllClaudeCliPlanAutoApprove()
+
+    expect(isClaudeCliPlanAutoApproveArmed('s1')).toBe(false)
+    expect(isClaudeCliPlanAutoApproveArmed('s2')).toBe(false)
+  })
+})

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -10,6 +10,15 @@ const telemetryMocks = vi.hoisted(() => ({
   handleClaudeCliHiveTelemetryHook: vi.fn().mockResolvedValue(undefined)
 }))
 
+const ptyServiceMocks = vi.hoisted(() => ({
+  has: vi.fn(() => true),
+  write: vi.fn()
+}))
+
+vi.mock('../pty-service', () => ({
+  ptyService: ptyServiceMocks
+}))
+
 vi.mock('../logger', () => ({
   createLogger: () => ({
     debug: vi.fn(),
@@ -42,6 +51,10 @@ import {
   SUBAGENT_WATCHDOG_TIMEOUT_MS
 } from '../claude-cli-subagent-tracker'
 import { cliHookTransportRouter } from '../cli-hook-transport-router'
+import {
+  isClaudeCliPlanAutoApproveArmed,
+  setClaudeCliPlanAutoApprove
+} from '../claude-cli-plan-auto-approve'
 
 async function postHook(
   port: number,
@@ -946,5 +959,119 @@ describe('first-prompt detection with task notifications', () => {
         }
       )
     })
+  })
+})
+
+describe('plan auto-approve', () => {
+  const exitPlanPermissionRequest = {
+    hook_event_name: 'PermissionRequest',
+    tool_name: 'ExitPlanMode',
+    tool_input: { plan: 'The plan' }
+  }
+
+  it('approves an armed ExitPlanMode plan by pressing "1" on the dialog, one-shot', async () => {
+    const { port } = await getClaudeHookServer()
+    const statusListener = vi.fn()
+    const unsubscribe = subscribeClaudeCliStatus(statusListener)
+    setClaudeCliPlanAutoApprove('hive-session-1', true)
+
+    try {
+      const response = await postHook(port, 'hive-session-1', 'permission', exitPlanPermissionRequest)
+
+      // The hook reply stays '{}' so claude renders its native plan dialog;
+      // hook decisions do not approve the plan dialog on current claude
+      // (verified empirically on v2.1.201). The approval is the delayed "1"
+      // keystroke below ("Yes, and bypass permissions").
+      expect(response.text).toBe('{}')
+      await vi.waitFor(() => {
+        expect(ptyServiceMocks.write).toHaveBeenCalledWith('hive-session-1', '1')
+      })
+      // plan_ready still flashes through to the in-app status flow.
+      expect(statusListener).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'hive-session-1', status: 'plan_ready' })
+      )
+      // One-shot: consumed on approval, a second plan is not auto-answered.
+      expect(isClaudeCliPlanAutoApproveArmed('hive-session-1')).toBe(false)
+      ptyServiceMocks.write.mockClear()
+      const second = await postHook(port, 'hive-session-1', 'permission', exitPlanPermissionRequest)
+      expect(second.text).toBe('{}')
+      await new Promise((resolve) => setTimeout(resolve, 700))
+      expect(ptyServiceMocks.write).not.toHaveBeenCalled()
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('does not auto-answer non-ExitPlanMode PermissionRequests on an armed session', async () => {
+    const { port } = await getClaudeHookServer()
+    setClaudeCliPlanAutoApprove('hive-session-1', true)
+
+    const response = await postHook(port, 'hive-session-1', 'permission', {
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' }
+    })
+
+    expect(response.text).toBe('{}')
+    expect(isClaudeCliPlanAutoApproveArmed('hive-session-1')).toBe(true)
+  })
+
+  it('does not auto-answer a subagent-scoped ExitPlanMode PermissionRequest', async () => {
+    const { port } = await getClaudeHookServer()
+    setClaudeCliPlanAutoApprove('hive-session-1', true)
+
+    const response = await postHook(port, 'hive-session-1', 'permission', {
+      ...exitPlanPermissionRequest,
+      agent_id: 'subagent-1'
+    })
+
+    expect(response.text).toBe('{}')
+    expect(isClaudeCliPlanAutoApproveArmed('hive-session-1')).toBe(true)
+  })
+
+  it('bypasses transport routing for armed ExitPlanMode PreToolUse, but routes when unarmed', async () => {
+    const { port } = await getClaudeHookServer()
+    const routeHookSpy = vi.spyOn(cliHookTransportRouter, 'routeHook')
+    setClaudeCliPlanAutoApprove('hive-session-1', true)
+
+    try {
+      const armedResponse = await postHook(port, 'hive-session-1', 'tool', {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'ExitPlanMode',
+        tool_input: { plan: 'The plan' }
+      })
+      expect(armedResponse.text).toBe('{}')
+      expect(routeHookSpy).not.toHaveBeenCalled()
+      // PreToolUse does not consume the arm; only the PermissionRequest answer does.
+      expect(isClaudeCliPlanAutoApproveArmed('hive-session-1')).toBe(true)
+
+      setClaudeCliPlanAutoApprove('hive-session-1', false)
+      await postHook(port, 'hive-session-1', 'tool', {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'ExitPlanMode',
+        tool_input: { plan: 'The plan' }
+      })
+      expect(routeHookSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      routeHookSpy.mockRestore()
+    }
+  })
+
+  it('disarms on SessionEnd', async () => {
+    const { port } = await getClaudeHookServer()
+    setClaudeCliPlanAutoApprove('hive-session-1', true)
+
+    await postHook(port, 'hive-session-1', 'session', { hook_event_name: 'SessionEnd' })
+
+    expect(isClaudeCliPlanAutoApproveArmed('hive-session-1')).toBe(false)
+  })
+
+  it('clears armed sessions when the hook server closes', async () => {
+    await getClaudeHookServer()
+    setClaudeCliPlanAutoApprove('hive-session-close', true)
+
+    await closeClaudeHookServer()
+
+    expect(isClaudeCliPlanAutoApproveArmed('hive-session-close')).toBe(false)
   })
 })

--- a/src/main/services/claude-cli-plan-auto-approve.ts
+++ b/src/main/services/claude-cli-plan-auto-approve.ts
@@ -1,0 +1,23 @@
+// In-memory registry of claude-cli sessions armed for one-shot plan
+// auto-approval. The durable flag lives on the kanban ticket
+// (auto_approve_plan); the renderer mirrors it here so the hook server can
+// answer the ExitPlanMode PermissionRequest without a DB lookup.
+const armedSessions = new Set<string>()
+
+export function setClaudeCliPlanAutoApprove(sessionId: string, enabled: boolean): void {
+  if (enabled) armedSessions.add(sessionId)
+  else armedSessions.delete(sessionId)
+}
+
+export function isClaudeCliPlanAutoApproveArmed(sessionId: string): boolean {
+  return armedSessions.has(sessionId)
+}
+
+/** One-shot consume: disarms the session and reports whether it was armed. */
+export function consumeClaudeCliPlanAutoApprove(sessionId: string): boolean {
+  return armedSessions.delete(sessionId)
+}
+
+export function clearAllClaudeCliPlanAutoApprove(): void {
+  armedSessions.clear()
+}

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -18,6 +18,18 @@ import {
   setClaudeCliDeferredCompletionHandler,
   type ClaudeCliBackgroundTask
 } from './claude-cli-subagent-tracker'
+import {
+  clearAllClaudeCliPlanAutoApprove,
+  consumeClaudeCliPlanAutoApprove,
+  isClaudeCliPlanAutoApproveArmed,
+  setClaudeCliPlanAutoApprove
+} from './claude-cli-plan-auto-approve'
+import { ptyService } from './pty-service'
+
+// Delay between replying to the ExitPlanMode PermissionRequest hook and
+// pressing "1" on the PTY: claude renders its plan dialog only after the hook
+// response lands, and the keypress must hit the dialog, not the composer.
+const PLAN_AUTO_APPROVE_KEYSTROKE_DELAY_MS = 500
 
 export interface ParsedClaudeHook {
   hook_event_name?: string
@@ -327,13 +339,61 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
           data: { promptText: body.prompt }
         })
       }
+      // Plan auto-approve: an armed session's ExitPlanMode is answered here
+      // instead of by the user. The setMode permission is only honored on the
+      // PermissionRequest hook (not PreToolUse), so the PreToolUse must fall
+      // through unheld — which also means transports (Telegram/Discord) must
+      // not grab it, or the plan would go to the phone instead. Subagent
+      // ExitPlanMode hooks (agent_id set) never consume the main plan's arm.
+      const autoApproveExitPlan =
+        body.tool_name === 'ExitPlanMode' &&
+        !body.agent_id &&
+        isClaudeCliPlanAutoApproveArmed(route.sessionId)
+      const bypassTransport =
+        autoApproveExitPlan &&
+        (body.hook_event_name === 'PreToolUse' || body.hook_event_name === 'PermissionRequest')
+
       // For forwarded CLI sessions a transport may take ownership of the
       // response (held open until answered). Otherwise behavior is unchanged.
       // suppressIdle keeps a deferred/subagent-scoped Stop from telling the
       // transport the session went idle while background work is in flight.
-      owned = cliHookTransportRouter.routeHook(route.sessionId, body, res, {
-        suppressIdle: gate.kind !== 'pass'
-      })
+      if (!bypassTransport) {
+        owned = cliHookTransportRouter.routeHook(route.sessionId, body, res, {
+          suppressIdle: gate.kind !== 'pass'
+        })
+      }
+
+      if (
+        autoApproveExitPlan &&
+        body.hook_event_name === 'PermissionRequest' &&
+        !res.writableEnded
+      ) {
+        // Hook responses cannot approve the plan dialog: on claude v2.1.201 a
+        // PermissionRequest hookSpecificOutput.decision (allow + setMode) is
+        // accepted but the interactive dialog is shown anyway (verified
+        // empirically — claude-playground keeps a keystroke fallback for the
+        // same reason). So reply '{}' to let the dialog render, then press "1"
+        // ("Yes, and bypass permissions") on the PTY — approval and
+        // bypassPermissions in the same stroke, exactly like a manual approve.
+        const approvedSessionId = route.sessionId
+        consumeClaudeCliPlanAutoApprove(approvedSessionId)
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end('{}')
+        setTimeout(() => {
+          if (!ptyService.has(approvedSessionId)) {
+            log.warn('Plan auto-approve keystroke skipped: PTY is gone', {
+              sessionId: approvedSessionId
+            })
+            return
+          }
+          ptyService.write(approvedSessionId, '1')
+          log.info('Auto-approved ExitPlanMode plan', { sessionId: approvedSessionId })
+        }, PLAN_AUTO_APPROVE_KEYSTROKE_DELAY_MS)
+      }
+
+      if (body.hook_event_name === 'SessionEnd') {
+        setClaudeCliPlanAutoApprove(route.sessionId, false)
+      }
     }
   } catch (error) {
     log.warn('Failed to parse Claude hook payload', {
@@ -437,6 +497,7 @@ export async function closeClaudeHookServer(): Promise<void> {
     statusSubscribers.clear()
     clearAllClaudeCliInteractions()
     clearAllClaudeCliSubagentTracking()
+    clearAllClaudeCliPlanAutoApprove()
     setClaudeCliDeferredCompletionHandler(null)
     return
   }
@@ -458,5 +519,6 @@ export async function closeClaudeHookServer(): Promise<void> {
   statusSubscribers.clear()
   clearAllClaudeCliInteractions()
   clearAllClaudeCliSubagentTracking()
+  clearAllClaudeCliPlanAutoApprove()
   setClaudeCliDeferredCompletionHandler(null)
 }

--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -117,6 +117,7 @@ interface MarkdownRuntimeState {
   note: string | null
   attachments: unknown[]
   plan_ready: boolean
+  auto_approve_plan: boolean
   total_tokens: number
   pending_launch_config: string | null
   updated_at: string | null
@@ -141,6 +142,7 @@ function emptyRuntimeState(): MarkdownRuntimeState {
     note: null,
     attachments: [],
     plan_ready: false,
+    auto_approve_plan: false,
     total_tokens: 0,
     pending_launch_config: null,
     updated_at: null
@@ -690,6 +692,8 @@ class MarkdownKanbanBackend implements KanbanBackend {
       runtimeUpdates.current_session_id = data.current_session_id
     if (data.worktree_id !== undefined) runtimeUpdates.worktree_id = data.worktree_id
     if (data.plan_ready !== undefined) runtimeUpdates.plan_ready = data.plan_ready
+    if (data.auto_approve_plan !== undefined)
+      runtimeUpdates.auto_approve_plan = data.auto_approve_plan
     if (data.pending_launch_config !== undefined)
       runtimeUpdates.pending_launch_config = data.pending_launch_config
     if (data.note !== undefined) runtimeUpdates.note = data.note
@@ -1480,7 +1484,8 @@ class MarkdownKanbanBackend implements KanbanBackend {
       pending_launch_config: runtime.pending_launch_config,
       goal_mode: asBoolean(frontmatter.goal_mode) ?? false,
       goal_success_criteria: nullableString(frontmatter.goal_success_criteria),
-      note: runtime.note
+      note: runtime.note,
+      auto_approve_plan: runtime.auto_approve_plan
     }
 
     return { ticket, filePath, frontmatter }
@@ -1494,6 +1499,7 @@ class MarkdownKanbanBackend implements KanbanBackend {
       current_session_id: runtime.current_session_id,
       worktree_id: runtime.worktree_id,
       plan_ready: runtime.plan_ready,
+      auto_approve_plan: runtime.auto_approve_plan,
       total_tokens: runtime.total_tokens,
       pending_launch_config: runtime.pending_launch_config,
       note: runtime.note,
@@ -1590,6 +1596,7 @@ class MarkdownKanbanBackend implements KanbanBackend {
           note: string | null
           attachments: string | null
           plan_ready: number
+          auto_approve_plan: number
           total_tokens: number
           pending_launch_config: string | null
           updated_at: string | null
@@ -1604,6 +1611,7 @@ class MarkdownKanbanBackend implements KanbanBackend {
       note: row.note,
       attachments: parseJsonArray(row.attachments),
       plan_ready: row.plan_ready === 1,
+      auto_approve_plan: row.auto_approve_plan === 1,
       total_tokens: row.total_tokens ?? 0,
       pending_launch_config: row.pending_launch_config,
       updated_at: row.updated_at
@@ -1650,6 +1658,10 @@ class MarkdownKanbanBackend implements KanbanBackend {
     if (data.plan_ready !== undefined) {
       updates.push('plan_ready = ?')
       values.push(data.plan_ready ? 1 : 0)
+    }
+    if (data.auto_approve_plan !== undefined) {
+      updates.push('auto_approve_plan = ?')
+      values.push(data.auto_approve_plan ? 1 : 0)
     }
     if (data.pending_launch_config !== undefined) {
       updates.push('pending_launch_config = ?')
@@ -1760,6 +1772,7 @@ export async function moveKanbanTicketToProject(
     if (!moved) return null
     return internalBackend.update(targetProjectId, ticketId, {
       plan_ready: false,
+      auto_approve_plan: false,
       pending_launch_config: null
     })
   }

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -16,6 +16,7 @@ import {
   clearAllClaudeCliSubagentTracking,
   clearClaudeCliSubagentTracking
 } from './claude-cli-subagent-tracker'
+import { setClaudeCliPlanAutoApprove } from './claude-cli-plan-auto-approve'
 import { logClaudeBinaryVersion, resolveClaudeBinaryPath } from './claude-binary-resolver'
 import { buildClaudeCliPtySpawn } from './claude-cli-spawner'
 import { externalizeGoalHandoffPlan } from './claude-cli-plan-handoff'
@@ -218,6 +219,7 @@ function attachNodePtyListeners(terminalId: string): void {
     if (claudeCliSessions.has(terminalId)) {
       clearClaudeCliInteractions(terminalId)
       clearClaudeCliSubagentTracking(terminalId)
+      setClaudeCliPlanAutoApprove(terminalId, false)
       publishClaudeCliStatus({
         sessionId: terminalId,
         status: 'completed',

--- a/src/renderer/src/api/terminal-api.ts
+++ b/src/renderer/src/api/terminal-api.ts
@@ -85,6 +85,16 @@ export const terminalApi = {
     }>('terminalOps.createClaudeCli', { sessionId, opts })
     return { success: true, value: result }
   },
+  setClaudeCliPlanAutoApprove: async (
+    sessionId: string,
+    enabled: boolean
+  ): Promise<Envelope<{ success: boolean; error?: string }>> => {
+    const result = await getRendererRpcClient().request<{
+      success: boolean
+      error?: string
+    }>('terminalOps.setClaudeCliPlanAutoApprove', { sessionId, enabled })
+    return { success: true, value: result }
+  },
   sendClaudeCliPrompt: async (
     sessionId: string,
     prompt: string

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -29,7 +29,8 @@ import {
   ChevronDown,
   Hammer,
   Map as MapIcon,
-  FolderInput
+  FolderInput,
+  FastForward
 } from 'lucide-react'
 import { CheckeredFlagIcon } from './CheckeredFlagIcon'
 import { UpdateStatusModal } from './UpdateStatusModal'
@@ -95,6 +96,9 @@ import { useSessionTimer } from '@/hooks/useSessionTimer'
 import { useSessionTokenDelta } from '@/hooks/useSessionTokenDelta'
 import { useConflictFixFlow } from '@/hooks/useConflictFixFlow'
 import { formatTokenCount } from '@/lib/format-utils'
+import { canToggleAutoApprovePlan } from '@/lib/plan-auto-approve'
+import { isClaudeCli } from '@shared/types/agent-sdk'
+import { terminalApi } from '@/api/terminal-api'
 import type { KanbanTicket, TicketMark } from '../../../../main/db/types'
 
 // ── Project tag color palette ──────────────────────────────────────
@@ -366,6 +370,24 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       (state) => {
         if (!ticket.current_session_id) return null
         return state.codexGoalsBySession.get(ticket.current_session_id)?.status ?? null
+      },
+      [ticket.current_session_id]
+    )
+  )
+
+  const linkedSessionAgentSdk = useSessionStore(
+    useCallback(
+      (state) => {
+        if (!ticket.current_session_id) return null
+        for (const sessions of state.sessionsByWorktree.values()) {
+          const found = sessions.find((s) => s.id === ticket.current_session_id)
+          if (found) return found.agent_sdk
+        }
+        for (const sessions of state.sessionsByConnection.values()) {
+          const found = sessions.find((s) => s.id === ticket.current_session_id)
+          if (found) return found.agent_sdk
+        }
+        return null
       },
       [ticket.current_session_id]
     )
@@ -823,6 +845,32 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     }
   }, [ticket.id, ticket.project_id])
 
+  const canToggleAutoApprove =
+    !isArchived && !blockingDiagnostic && canToggleAutoApprovePlan(ticket, linkedSessionAgentSdk)
+
+  const handleToggleAutoApprove = useCallback(async () => {
+    const next = !ticket.auto_approve_plan
+    try {
+      await useKanbanStore.getState().updateTicket(ticket.id, ticket.project_id, {
+        auto_approve_plan: next
+      })
+      // Mirror the durable flag into the hook server's in-memory armed registry
+      // when a claude-cli session is already live; sessions armed before they
+      // exist are registered by the status listener on their first planning turn.
+      if (ticket.current_session_id && isClaudeCli(linkedSessionAgentSdk)) {
+        await terminalApi.setClaudeCliPlanAutoApprove(ticket.current_session_id, next)
+      }
+    } catch {
+      toast.error('Failed to toggle auto approve')
+    }
+  }, [
+    ticket.id,
+    ticket.project_id,
+    ticket.auto_approve_plan,
+    ticket.current_session_id,
+    linkedSessionAgentSdk
+  ])
+
   const handleSaveNote = useCallback(async (note: string | null) => {
     try {
       await useKanbanStore.getState().updateTicket(ticket.id, ticket.project_id, { note })
@@ -906,7 +954,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || blockingDiagnostic || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode) && (
+            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || blockingDiagnostic || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode || ticket.auto_approve_plan) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
@@ -1016,6 +1064,23 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                   <span className="inline-flex items-center rounded-full bg-violet-500/10 border border-violet-500/30 px-2 py-0.5 text-[11px] font-medium text-violet-500">
                     Plan ready
                   </span>
+                )}
+
+                {/* Auto-approve plan badge */}
+                {ticket.auto_approve_plan && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        data-testid="kanban-ticket-auto-approve"
+                        className="inline-flex items-center rounded-full bg-violet-500/10 border border-violet-500/30 px-1.5 py-0.5 text-violet-500 cursor-help"
+                      >
+                        <FastForward className="h-3 w-3" />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Auto approve plan: implementation starts automatically when the plan is ready
+                    </TooltipContent>
+                  </Tooltip>
                 )}
 
                 {/* Error badge */}
@@ -1377,6 +1442,17 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             <ContextMenuItem onClick={() => handleSaveNote(null)} className="gap-2">
               <X className="h-3.5 w-3.5" />
               Remove note
+            </ContextMenuItem>
+          )}
+
+          {canToggleAutoApprove && (
+            <ContextMenuItem
+              data-testid="ctx-toggle-auto-approve"
+              onClick={() => void handleToggleAutoApprove()}
+              className="gap-2"
+            >
+              <FastForward className="h-3.5 w-3.5" />
+              {ticket.auto_approve_plan ? 'Disable auto approve' : 'Auto approve'}
             </ContextMenuItem>
           )}
 

--- a/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
@@ -232,7 +232,8 @@ const ticket: KanbanTicket = {
   goal_mode: false,
   goal_success_criteria: null,
   note: null,
-  created_from_session: false
+  created_from_session: false,
+  auto_approve_plan: false
 }
 
 const worktree: Worktree = {

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -111,6 +111,7 @@ const baseTicket: KanbanTicket = {
   goal_success_criteria: null,
   pending_launch_config: null,
   created_from_session: false,
+  auto_approve_plan: false,
   attachments: [],
   archived_at: null,
   external_provider: null,

--- a/src/renderer/src/components/kanban/WorktreePickerModal.goal-plan-file.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.goal-plan-file.test.tsx
@@ -91,6 +91,7 @@ function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
     goal_success_criteria: null,
     pending_launch_config: null,
     created_from_session: false,
+    auto_approve_plan: false,
     attachments: [],
     archived_at: null,
     external_provider: null,

--- a/src/renderer/src/components/kanban/WorktreePickerModal.ultracode.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.ultracode.test.tsx
@@ -93,6 +93,7 @@ const baseTicket: KanbanTicket = {
   goal_success_criteria: null,
   pending_launch_config: null,
   created_from_session: false,
+  auto_approve_plan: false,
   attachments: [],
   archived_at: null,
   external_provider: null,

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   onClaudeCliStatus: vi.fn(),
+  setClaudeCliPlanAutoApprove: vi.fn().mockResolvedValue({ success: true }),
   setSessionStatus: vi.fn(),
   setPendingPlan: vi.fn(),
   clearPendingPlan: vi.fn(),
@@ -13,7 +14,16 @@ const mocks = vi.hoisted(() => ({
   sessionStatuses: {} as Record<string, { status: string } | null>,
   kanbanState: {
     selectedTicketId: null as string | null,
-    tickets: new Map<string, Array<{ id: string; current_session_id: string | null }>>()
+    tickets: new Map<
+      string,
+      Array<{
+        id: string
+        current_session_id: string | null
+        auto_approve_plan?: boolean
+        mode?: 'build' | 'plan' | 'super-plan' | null
+        goal_mode?: boolean
+      }>
+    >()
   }
 }))
 
@@ -38,7 +48,8 @@ vi.mock('@/stores/useSessionStore', () => ({
 
 vi.mock('@/api/terminal-api', () => ({
   terminalApi: {
-    onClaudeCliStatus: mocks.onClaudeCliStatus
+    onClaudeCliStatus: mocks.onClaudeCliStatus,
+    setClaudeCliPlanAutoApprove: mocks.setClaudeCliPlanAutoApprove
   }
 }))
 
@@ -97,6 +108,7 @@ describe('useClaudeCliStatusListener', () => {
       return unsubscribe
     })
     unsubscribe.mockClear()
+    mocks.setClaudeCliPlanAutoApprove.mockClear()
     mocks.setSessionStatus.mockClear()
     mocks.setPendingPlan.mockClear()
     mocks.clearPendingPlan.mockClear()
@@ -403,5 +415,111 @@ describe('useClaudeCliStatusListener', () => {
       expect(mocks.notifyKanbanSessionSync).not.toHaveBeenCalled()
       expect(mocks.setSessionStatus).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe('useClaudeCliStatusListener — plan auto-approve arming', () => {
+  let subscribedCallbackForAutoApprove: ((payload: SubscribedPayload) => void) | null = null
+
+  beforeEach(() => {
+    subscribedCallbackForAutoApprove = null
+    mocks.setClaudeCliPlanAutoApprove.mockClear()
+    mocks.sessionStatuses = {}
+    mocks.kanbanState = { selectedTicketId: null, tickets: new Map() }
+    mocks.onClaudeCliStatus.mockReset()
+    mocks.onClaudeCliStatus.mockImplementation((callback: (payload: SubscribedPayload) => void) => {
+      subscribedCallbackForAutoApprove = callback
+      return vi.fn()
+    })
+  })
+
+  it('re-asserts server-side arming on planning for an armed plan-like ticket', () => {
+    mocks.kanbanState.tickets = new Map([
+      [
+        'proj-1',
+        [
+          {
+            id: 'ticket-1',
+            current_session_id: 'hive-session-1',
+            auto_approve_plan: true,
+            mode: 'plan',
+            goal_mode: false
+          }
+        ]
+      ]
+    ])
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallbackForAutoApprove?.({
+      sessionId: 'hive-session-1',
+      status: 'planning',
+      metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start' }
+    })
+
+    expect(mocks.setClaudeCliPlanAutoApprove).toHaveBeenCalledWith('hive-session-1', true)
+  })
+
+  it('does not arm on planning when the linked ticket is not flagged', () => {
+    mocks.kanbanState.tickets = new Map([
+      [
+        'proj-1',
+        [
+          {
+            id: 'ticket-1',
+            current_session_id: 'hive-session-1',
+            auto_approve_plan: false,
+            mode: 'plan',
+            goal_mode: false
+          }
+        ]
+      ]
+    ])
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallbackForAutoApprove?.({
+      sessionId: 'hive-session-1',
+      status: 'planning',
+      metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start' }
+    })
+
+    expect(mocks.setClaudeCliPlanAutoApprove).not.toHaveBeenCalled()
+  })
+
+  it('does not arm on planning for a goal-mode ticket', () => {
+    mocks.kanbanState.tickets = new Map([
+      [
+        'proj-1',
+        [
+          {
+            id: 'ticket-1',
+            current_session_id: 'hive-session-1',
+            auto_approve_plan: true,
+            mode: 'plan',
+            goal_mode: true
+          }
+        ]
+      ]
+    ])
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallbackForAutoApprove?.({
+      sessionId: 'hive-session-1',
+      status: 'planning',
+      metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start' }
+    })
+
+    expect(mocks.setClaudeCliPlanAutoApprove).not.toHaveBeenCalled()
+  })
+
+  it('disarms server-side on PostToolUse ExitPlanMode (any plan approval)', () => {
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallbackForAutoApprove?.({
+      sessionId: 'hive-session-1',
+      status: 'working',
+      metadata: { hookEventName: 'PostToolUse', hookPath: 'tool', toolName: 'ExitPlanMode' }
+    })
+
+    expect(mocks.setClaudeCliPlanAutoApprove).toHaveBeenCalledWith('hive-session-1', false)
   })
 })

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -31,6 +31,22 @@ function closeLinkedTicketModal(sessionId: string): void {
   }
 }
 
+// The hook server's armed registry is in-memory (desktop process), while the
+// durable auto_approve_plan flag lives on the ticket. Re-asserting on every
+// 'planning' publish keeps the two in sync across all spawn paths, --resume,
+// and app restarts, and is a no-op for non-armed tickets.
+function reassertPlanAutoApprove(sessionId: string): void {
+  for (const projectTickets of useKanbanStore.getState().tickets.values()) {
+    for (const ticket of projectTickets) {
+      if (ticket.current_session_id !== sessionId) continue
+      if (ticket.auto_approve_plan && isPlanLike(ticket.mode) && !ticket.goal_mode) {
+        void terminalApi.setClaudeCliPlanAutoApprove(sessionId, true).catch(() => undefined)
+      }
+      return
+    }
+  }
+}
+
 export function useClaudeCliStatusListener(): void {
   useEffect(() => {
     const handlePlanFollowup = (
@@ -67,8 +83,15 @@ export function useClaudeCliStatusListener(): void {
         return
       }
 
+      if (status === 'planning') {
+        reassertPlanAutoApprove(sessionId)
+      }
+
       if (metadata?.hookEventName === 'PostToolUse' && metadata.toolName === 'ExitPlanMode') {
         // User approved ExitPlanMode from the terminal, matching the in-app implement action.
+        // Any approval consumes the one-shot auto-approve arm (no-op if the hook
+        // server already consumed it when auto-approving).
+        void terminalApi.setClaudeCliPlanAutoApprove(sessionId, false).catch(() => undefined)
         sessionStore.clearPendingPlan(sessionId)
         notifyKanbanSessionSync(sessionId, { type: 'implement' })
         closeLinkedTicketModal(sessionId)
@@ -116,6 +139,7 @@ export function useClaudeCliStatusListener(): void {
         metadata?.hookEventName === 'UserPromptSubmit' &&
         isPlanLike(currentMode)
       ) {
+        reassertPlanAutoApprove(sessionId)
         lastSendMode.set(sessionId, 'plan')
         worktreeStatus.setSessionStatus(sessionId, 'planning', metadata)
         return

--- a/src/renderer/src/lib/__tests__/plan-auto-approve.test.ts
+++ b/src/renderer/src/lib/__tests__/plan-auto-approve.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { canToggleAutoApprovePlan } from '../plan-auto-approve'
+
+function ticket(
+  overrides: Partial<Parameters<typeof canToggleAutoApprovePlan>[0]> = {}
+): Parameters<typeof canToggleAutoApprovePlan>[0] {
+  return {
+    mode: 'plan',
+    goal_mode: false,
+    plan_ready: false,
+    current_session_id: null,
+    ...overrides
+  }
+}
+
+describe('canToggleAutoApprovePlan', () => {
+  it('allows a plan-mode ticket with no session yet (pre-arming)', () => {
+    expect(canToggleAutoApprovePlan(ticket(), null)).toBe(true)
+  })
+
+  it('allows a plan-mode ticket with a live claude-cli session', () => {
+    expect(
+      canToggleAutoApprovePlan(ticket({ current_session_id: 's1' }), 'claude-code-cli')
+    ).toBe(true)
+  })
+
+  it('allows super-plan mode', () => {
+    expect(canToggleAutoApprovePlan(ticket({ mode: 'super-plan' }), null)).toBe(true)
+  })
+
+  it('rejects build mode and null mode', () => {
+    expect(canToggleAutoApprovePlan(ticket({ mode: 'build' }), null)).toBe(false)
+    expect(canToggleAutoApprovePlan(ticket({ mode: null }), null)).toBe(false)
+  })
+
+  it('rejects goal-mode tickets (they have their own handoff flow)', () => {
+    expect(canToggleAutoApprovePlan(ticket({ goal_mode: true }), null)).toBe(false)
+  })
+
+  it('rejects when a plan is already awaiting approval', () => {
+    expect(canToggleAutoApprovePlan(ticket({ plan_ready: true }), null)).toBe(false)
+  })
+
+  it('rejects a session linked to a non-claude-cli SDK', () => {
+    expect(canToggleAutoApprovePlan(ticket({ current_session_id: 's1' }), 'opencode')).toBe(false)
+    expect(canToggleAutoApprovePlan(ticket({ current_session_id: 's1' }), 'claude-code')).toBe(
+      false
+    )
+    expect(canToggleAutoApprovePlan(ticket({ current_session_id: 's1' }), null)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/plan-auto-approve.ts
+++ b/src/renderer/src/lib/plan-auto-approve.ts
@@ -1,0 +1,20 @@
+import { isClaudeCli } from '@shared/types/agent-sdk'
+import { isPlanLike } from './constants'
+import type { KanbanTicket } from '../../../main/db/types'
+
+/**
+ * Whether the "Auto approve" toggle applies to this ticket: a plan/super-plan
+ * claude-cli ticket (or one with no session yet, so it can be pre-armed) whose
+ * plan is not already awaiting approval. Goal-mode tickets keep their own
+ * plan→implementor handoff flow and are excluded.
+ */
+export function canToggleAutoApprovePlan(
+  ticket: Pick<KanbanTicket, 'mode' | 'goal_mode' | 'plan_ready' | 'current_session_id'>,
+  linkedSessionAgentSdk: string | null
+): boolean {
+  if (!isPlanLike(ticket.mode)) return false
+  if (ticket.goal_mode) return false
+  if (ticket.plan_ready) return false
+  if (ticket.current_session_id && !isClaudeCli(linkedSessionAgentSdk)) return false
+  return true
+}

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -55,6 +55,7 @@ function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
     goal_success_criteria: null,
     note: null,
     created_from_session: true,
+    auto_approve_plan: false,
     ...overrides
   }
 }
@@ -245,5 +246,42 @@ describe('reconcileFinishedSessions — recovers dropped finish moves on load', 
 
     expect(columnOf('ticket-1')).toBe('in_progress')
     expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+})
+
+describe('syncTicketWithSession — implement consumes auto-approve', () => {
+  it('clears auto_approve_plan alongside plan_ready and mode on implement', async () => {
+    seed(
+      makeTicket({ column: 'in_progress', mode: 'plan', plan_ready: true, auto_approve_plan: true })
+    )
+
+    useKanbanStore.getState().syncTicketWithSession(SESSION_ID, { type: 'implement' })
+    await flush()
+
+    expect(kanbanApi.ticket.update).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', {
+      plan_ready: false,
+      mode: 'build',
+      auto_approve_plan: false
+    })
+  })
+
+  it('clears a lingering auto_approve_plan on implement even for a build ticket', async () => {
+    seed(
+      makeTicket({
+        column: 'in_progress',
+        mode: 'build',
+        plan_ready: false,
+        auto_approve_plan: true
+      })
+    )
+
+    useKanbanStore.getState().syncTicketWithSession(SESSION_ID, { type: 'implement' })
+    await flush()
+
+    expect(kanbanApi.ticket.update).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', {
+      plan_ready: false,
+      mode: 'build',
+      auto_approve_plan: false
+    })
   })
 })

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -1020,10 +1020,15 @@ export const useKanbanStore = create<KanbanState>()(
               }
 
               case 'implement': {
-                // Plan approved from session view — clear plan_ready, set mode to build
-                if (ticket.plan_ready || ticket.mode !== 'build') {
+                // Plan approved from session view — clear plan_ready, set mode to
+                // build, and consume the one-shot auto-approve flag.
+                if (ticket.plan_ready || ticket.mode !== 'build' || ticket.auto_approve_plan) {
                   get()
-                    .updateTicket(ticket.id, projectId, { plan_ready: false, mode: 'build' })
+                    .updateTicket(ticket.id, projectId, {
+                      plan_ready: false,
+                      mode: 'build',
+                      auto_approve_plan: false
+                    })
                     .catch(() => {})
                 }
                 break

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -160,7 +160,8 @@ describe('rpc router', () => {
       goal_mode: false,
       goal_success_criteria: null,
       note: null,
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const calls: unknown[] = []
     const router = makeRpcRouter({
@@ -266,7 +267,8 @@ describe('rpc router', () => {
       goal_mode: false,
       goal_success_criteria: null,
       note: null,
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const secondTicket = {
       ...firstTicket,
@@ -397,7 +399,8 @@ describe('rpc router', () => {
       goal_mode: false,
       goal_success_criteria: null,
       note: null,
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const calls: Array<{ projectId: string; id: string }> = []
     const router = makeRpcRouter({
@@ -495,7 +498,8 @@ describe('rpc router', () => {
       goal_mode: false,
       goal_success_criteria: null,
       note: null,
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const calls: Array<{ projectId: string; includeArchived: boolean | undefined }> = []
     const router = makeRpcRouter({
@@ -594,7 +598,8 @@ describe('rpc router', () => {
       goal_mode: true,
       goal_success_criteria: 'Build passes',
       note: 'Keep private',
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const calls: Array<{ projectId: string; id: string; data: unknown }> = []
     const router = makeRpcRouter({
@@ -629,7 +634,7 @@ describe('rpc router', () => {
       goal_mode: true,
       goal_success_criteria: 'Build passes',
       note: 'Keep private',
-      created_from_session: false
+      auto_approve_plan: false
     }
     const response = await Effect.runPromise(
       router.handle({
@@ -776,7 +781,8 @@ describe('rpc router', () => {
       goal_mode: false,
       goal_success_criteria: null,
       note: null,
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const calls: Array<{ projectId: string; id: string }> = []
     const router = makeRpcRouter({
@@ -946,7 +952,8 @@ describe('rpc router', () => {
       goal_mode: false,
       goal_success_criteria: null,
       note: null,
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const calls: Array<{ projectId: string; ticketId: string }> = []
     const router = makeRpcRouter({
@@ -1045,7 +1052,8 @@ describe('rpc router', () => {
       goal_mode: false,
       goal_success_criteria: null,
       note: null,
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const calls: Array<{ projectId: string; id: string; column: string; sortOrder: number }> = []
     const router = makeRpcRouter({
@@ -1319,7 +1327,8 @@ describe('rpc router', () => {
       goal_mode: false,
       goal_success_criteria: null,
       note: null,
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const calls: string[] = []
     const router = makeRpcRouter({
@@ -1420,7 +1429,8 @@ describe('rpc router', () => {
       goal_mode: false,
       goal_success_criteria: null,
       note: null,
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const calls: Array<{ projectId: string; id: string; tokens: number }> = []
     const router = makeRpcRouter({
@@ -2186,7 +2196,8 @@ describe('rpc router', () => {
       goal_mode: false,
       goal_success_criteria: null,
       note: null,
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const calls: string[] = []
     const router = makeRpcRouter({
@@ -2298,7 +2309,8 @@ describe('rpc router', () => {
       goal_mode: false,
       goal_success_criteria: null,
       note: null,
-      created_from_session: false
+      created_from_session: false,
+      auto_approve_plan: false
     }
     const calls: Array<{ projectId: string; ticketId: string }> = []
     const router = makeRpcRouter({
@@ -6451,6 +6463,7 @@ describe('rpc router', () => {
           }),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -6491,6 +6504,7 @@ describe('rpc router', () => {
           }),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -6532,6 +6546,7 @@ describe('rpc router', () => {
             return result
           }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -6572,6 +6587,7 @@ describe('rpc router', () => {
             return { success: true, cols: 80, rows: 24 }
           }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -6613,6 +6629,7 @@ describe('rpc router', () => {
             calls.push({ sessionId, opts })
             return result
           }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -6641,6 +6658,57 @@ describe('rpc router', () => {
     expect(calls).toEqual([{ sessionId: 'session-1', opts: { pendingPrompt: 'continue' } }])
   })
 
+  it('handles terminalOps.setClaudeCliPlanAutoApprove through the terminal ops RPC domain', async () => {
+    const calls: Array<{ sessionId: string; enabled: boolean }> = []
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      terminalOps: {
+        getConfig: () => Effect.succeed({}),
+        create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: (sessionId, enabled) =>
+          Effect.sync(() => {
+            calls.push({ sessionId, enabled })
+            return { success: true }
+          }),
+        ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
+        ghosttyIsAvailable: () =>
+          Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
+        ghosttyCreateSurface: () => Effect.succeed({ success: true, surfaceId: 1 }),
+        ghosttySetFrame: () => Effect.succeed(undefined),
+        ghosttySetSize: () => Effect.succeed(undefined),
+        write: () => Effect.succeed(undefined),
+        resize: () => Effect.succeed(undefined),
+        destroy: () => Effect.succeed(undefined)
+      }
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'terminal-plan-auto-approve-1',
+        method: 'terminalOps.setClaudeCliPlanAutoApprove',
+        params: { sessionId: 'session-1', enabled: true }
+      })
+    )
+
+    expect(response).toEqual({
+      id: 'terminal-plan-auto-approve-1',
+      ok: true,
+      value: { success: true }
+    })
+    expect(calls).toEqual([{ sessionId: 'session-1', enabled: true }])
+
+    const invalid = await Effect.runPromise(
+      router.handle({
+        id: 'terminal-plan-auto-approve-2',
+        method: 'terminalOps.setClaudeCliPlanAutoApprove',
+        params: { sessionId: 'session-1', enabled: true, extra: 'nope' }
+      })
+    )
+    expect(invalid.ok).toBe(false)
+    expect(calls).toHaveLength(1)
+  })
+
   it('validates terminalOps.createClaudeCli params', async () => {
     const calls: string[] = []
     const router = makeRpcRouter({
@@ -6653,6 +6721,7 @@ describe('rpc router', () => {
             calls.push('createClaudeCli')
             return { success: true, cols: 80, rows: 24 }
           }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -6690,6 +6759,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () =>
           Effect.sync(() => {
             calls.push('ghosttyInit')
@@ -6730,6 +6800,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () =>
           Effect.sync(() => {
             calls.push('ghosttyInit')
@@ -6771,6 +6842,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.sync(() => {
@@ -6810,6 +6882,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.sync(() => {
@@ -6856,6 +6929,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -6896,6 +6970,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -6952,6 +7027,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -6991,6 +7067,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7042,6 +7119,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7081,6 +7159,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7152,6 +7231,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7194,6 +7274,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7248,6 +7329,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7289,6 +7371,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7342,6 +7425,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7384,6 +7468,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7438,6 +7523,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7481,6 +7567,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7536,6 +7623,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7580,6 +7668,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7636,6 +7725,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7681,6 +7771,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7747,6 +7838,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7789,6 +7881,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7836,6 +7929,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7883,6 +7977,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7930,6 +8025,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -7978,6 +8074,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -8026,6 +8123,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -8065,6 +8163,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -8104,6 +8203,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -8143,6 +8243,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -8182,6 +8283,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
@@ -8221,6 +8323,7 @@ describe('rpc router', () => {
         getConfig: () => Effect.succeed({}),
         create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
         createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
         ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
         ghosttyIsAvailable: () =>
           Effect.succeed({ available: false, initialized: false, platform: 'linux' }),

--- a/src/server/rpc/domains/kanban.ts
+++ b/src/server/rpc/domains/kanban.ts
@@ -258,7 +258,8 @@ const kanbanTicketUpdateSchema = z
     goal_mode: z.boolean().optional(),
     goal_success_criteria: z.string().nullable().optional(),
     note: z.string().nullable().optional(),
-    archived_at: z.string().nullable().optional()
+    archived_at: z.string().nullable().optional(),
+    auto_approve_plan: z.boolean().optional()
   })
   .strict() satisfies z.ZodType<KanbanTicketUpdate>
 const ticketIdProjectParamsSchema = z

--- a/src/server/rpc/domains/terminal-ops.ts
+++ b/src/server/rpc/domains/terminal-ops.ts
@@ -35,6 +35,10 @@ export interface TerminalOpsRpcService {
     sessionId: string,
     opts?: { pendingPrompt?: string | null }
   ) => Effect.Effect<TerminalCreateResult, unknown>
+  readonly setClaudeCliPlanAutoApprove: (
+    sessionId: string,
+    enabled: boolean
+  ) => Effect.Effect<TerminalPlanAutoApproveResult, unknown>
   readonly ghosttyInit: () => Effect.Effect<TerminalGhosttyInitResult, unknown>
   readonly ghosttyIsAvailable: () => Effect.Effect<TerminalGhosttyAvailabilityResult, unknown>
   readonly ghosttyCreateSurface: (
@@ -113,6 +117,12 @@ const createClaudeCliParamsSchema = z
         pendingPrompt: z.string().nullable().optional()
       })
       .optional()
+  })
+  .strict()
+const setClaudeCliPlanAutoApproveParamsSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    enabled: z.boolean()
   })
   .strict()
 const ghosttyRectSchema = z
@@ -238,6 +248,7 @@ interface TerminalCreateResult {
 
 type TerminalDestroyResult = TerminalResizeResult
 type TerminalWriteResult = TerminalResizeResult
+type TerminalPlanAutoApproveResult = TerminalResizeResult
 
 const listenerCleanups = new Map<string, { removeData: () => void; removeExit: () => void }>()
 const dataBuffers = new Map<string, string>()
@@ -1138,6 +1149,58 @@ const requestDesktopTerminalCreateClaudeCli = (
   })
 }
 
+const requestDesktopTerminalSetClaudeCliPlanAutoApprove = (
+  sessionId: string,
+  enabled: boolean
+): Promise<TerminalPlanAutoApproveResult> => {
+  const send = process.send
+  // No desktop transport → single-process mode; the local registration in the
+  // service impl already took effect.
+  if (!send) return Promise.resolve({ success: true })
+
+  const id = `terminal-plan-auto-approve-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const command = 'terminalSetClaudeCliPlanAutoApprove'
+
+  return new Promise<TerminalPlanAutoApproveResult>((resolve) => {
+    let settled = false
+    const cleanup = (): void => {
+      clearTimeout(timeout)
+      process.off('message', onMessage)
+    }
+    const finish = (value: TerminalPlanAutoApproveResult): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(value)
+    }
+    const timeout = setTimeout(() => {
+      finish({
+        success: false,
+        error: `Timed out waiting for desktop command response: ${command}`
+      })
+    }, 5_000)
+
+    const onMessage = (message: unknown): void => {
+      if (!isDesktopCommandResult(message) || message.id !== id) return
+      if (!message.ok) {
+        finish({ success: false, error: message.error ?? `Desktop command failed: ${command}` })
+        return
+      }
+      if (isTerminalCommandResult(message.value)) {
+        finish(message.value)
+        return
+      }
+      finish({ success: false, error: `Invalid desktop command response for ${command}` })
+    }
+
+    process.on('message', onMessage)
+    send.call(process, makeDesktopCommandRequest(id, command, { sessionId, enabled }), (error) => {
+      if (!error) return
+      finish({ success: false, error: error.message })
+    })
+  })
+}
+
 const requestDesktopTerminalResize = (
   terminalId: string,
   cols: number,
@@ -1341,6 +1404,21 @@ export const makeLiveTerminalOpsRpcService = (eventBus?: EventBus): TerminalOpsR
       try: () => requestDesktopTerminalCreateClaudeCli(sessionId, opts),
       catch: (cause) => cause
     }),
+  setClaudeCliPlanAutoApprove: (sessionId, enabled) =>
+    Effect.tryPromise({
+      try: async () => {
+        // Dual registration (telegram-forwarding-service pattern): in
+        // single-process mode the hook server shares this process, so register
+        // locally; in desktop mode it lives in the Electron main process, so
+        // also forward over the command bridge. The unused one is a no-op.
+        const { setClaudeCliPlanAutoApprove } = await import(
+          '../../../main/services/claude-cli-plan-auto-approve'
+        )
+        setClaudeCliPlanAutoApprove(sessionId, enabled)
+        return requestDesktopTerminalSetClaudeCliPlanAutoApprove(sessionId, enabled)
+      },
+      catch: (cause) => cause
+    }),
   ghosttyInit: () =>
     Effect.tryPromise({
       try: () => requestDesktopTerminalGhosttyInit(),
@@ -1511,6 +1589,17 @@ export const makeTerminalOpsRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.createClaudeCli(parsed.sessionId, parsed.opts)
+        })
+    ],
+    [
+      'terminalOps.setClaudeCliPlanAutoApprove',
+      (params) =>
+        Effect.gen(function* () {
+          const parsed = yield* Effect.try({
+            try: () => setClaudeCliPlanAutoApproveParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.setClaudeCliPlanAutoApprove(parsed.sessionId, parsed.enabled)
         })
     ],
     [

--- a/src/shared/desktop-command.ts
+++ b/src/shared/desktop-command.ts
@@ -106,6 +106,7 @@ export type DesktopCommandName =
   | 'telegramClaudeCliQuestionReply'
   | 'telegramClaudeCliQuestionReject'
   | 'telegramClaudeCliPlanReply'
+  | 'terminalSetClaudeCliPlanAutoApprove'
 
 export interface OpenInAppPayload {
   readonly appName: string
@@ -345,6 +346,11 @@ export interface TerminalCreateResult {
 
 export interface TelegramClaudeCliSessionPayload {
   readonly sessionId: string
+}
+
+export interface TerminalClaudeCliPlanAutoApprovePayload {
+  readonly sessionId: string
+  readonly enabled: boolean
 }
 
 export interface TelegramClaudeCliQuestionReplyPayload {
@@ -944,6 +950,7 @@ export type DesktopCommandRequest =
   | TelegramClaudeCliQuestionReplyDesktopCommandRequest
   | TelegramClaudeCliQuestionRejectDesktopCommandRequest
   | TelegramClaudeCliPlanReplyDesktopCommandRequest
+  | TerminalSetClaudeCliPlanAutoApproveDesktopCommandRequest
 
 export interface QuitAppDesktopCommandRequest {
   readonly type: typeof DESKTOP_COMMAND_REQUEST_TYPE
@@ -1609,6 +1616,13 @@ export interface TelegramClaudeCliCancelDesktopCommandRequest {
   readonly payload: TelegramClaudeCliSessionPayload
 }
 
+export interface TerminalSetClaudeCliPlanAutoApproveDesktopCommandRequest {
+  readonly type: typeof DESKTOP_COMMAND_REQUEST_TYPE
+  readonly id: string
+  readonly command: 'terminalSetClaudeCliPlanAutoApprove'
+  readonly payload: TerminalClaudeCliPlanAutoApprovePayload
+}
+
 export interface TelegramClaudeCliQuestionReplyDesktopCommandRequest {
   readonly type: typeof DESKTOP_COMMAND_REQUEST_TYPE
   readonly id: string
@@ -2121,6 +2135,11 @@ export function makeDesktopCommandRequest(
   command: 'telegramClaudeCliPlanReply',
   payload: TelegramClaudeCliPlanReplyPayload
 ): TelegramClaudeCliPlanReplyDesktopCommandRequest
+export function makeDesktopCommandRequest(
+  id: string,
+  command: 'terminalSetClaudeCliPlanAutoApprove',
+  payload: TerminalClaudeCliPlanAutoApprovePayload
+): TerminalSetClaudeCliPlanAutoApproveDesktopCommandRequest
 export function makeDesktopCommandRequest(
   id: string,
   command: DesktopCommandName,
@@ -3298,6 +3317,19 @@ export function makeDesktopCommandRequest(
     } as TelegramClaudeCliPlanReplyDesktopCommandRequest
   }
 
+  if (command === 'terminalSetClaudeCliPlanAutoApprove') {
+    if (!payload) {
+      throw new Error('Missing terminalSetClaudeCliPlanAutoApprove payload')
+    }
+
+    return {
+      type: DESKTOP_COMMAND_REQUEST_TYPE,
+      id,
+      command,
+      payload
+    } as TerminalSetClaudeCliPlanAutoApproveDesktopCommandRequest
+  }
+
   return {
     type: DESKTOP_COMMAND_REQUEST_TYPE,
     id,
@@ -3452,7 +3484,9 @@ export const isDesktopCommandRequest = (value: unknown): value is DesktopCommand
       (value.command === 'telegramClaudeCliQuestionReject' &&
         isTelegramClaudeCliQuestionRejectPayload(value.payload)) ||
       (value.command === 'telegramClaudeCliPlanReply' &&
-        isTelegramClaudeCliPlanReplyPayload(value.payload)))
+        isTelegramClaudeCliPlanReplyPayload(value.payload)) ||
+      (value.command === 'terminalSetClaudeCliPlanAutoApprove' &&
+        isTerminalClaudeCliPlanAutoApprovePayload(value.payload)))
   )
 }
 
@@ -3993,3 +4027,8 @@ const isTelegramClaudeCliPlanReplyPayload = (
   typeof value.requestId === 'string' &&
   typeof value.approve === 'boolean' &&
   (value.feedback === undefined || typeof value.feedback === 'string')
+
+const isTerminalClaudeCliPlanAutoApprovePayload = (
+  value: unknown
+): value is TerminalClaudeCliPlanAutoApprovePayload =>
+  isRecord(value) && typeof value.sessionId === 'string' && typeof value.enabled === 'boolean'


### PR DESCRIPTION
## Summary
- Adds a new `auto_approve_plan` flag to kanban tickets and markdown-backed kanban state, with schema and migration support.
- Introduces an in-memory arm/consume registry in the main process so live Claude CLI sessions can be auto-approved once for `ExitPlanMode`.
- Wires the hook server, PTY bridge, backend manager, and renderer status listener to arm, consume, and clear the flag at the right lifecycle points.
- Updates the kanban ticket card UI with a badge and context menu action to toggle auto-approve plan.
- Expands test coverage across database migrations, hook handling, backend routing, and renderer state synchronization.

## Testing
- `Not run`
- Added/updated unit and integration tests covering the new auto-approve flag, hook server behavior, backend command handling, and renderer listener sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Claude CLI permission hooks and automated PTY input (bypass-permissions path), which is security-sensitive but scoped to one-shot, user-opt-in plan tickets and excludes subagents/goal mode.
> 
> **Overview**
> Adds a **one-shot `auto_approve_plan`** option on plan/super-plan kanban tickets (internal DB and markdown kanban runtime) so the next Claude CLI `ExitPlanMode` can move to implementation without manual approval.
> 
> The renderer exposes a context-menu toggle and badge; toggling updates the ticket and mirrors into an **in-memory armed-session registry** via new `terminalOps.setClaudeCliPlanAutoApprove` / desktop `terminalSetClaudeCliPlanAutoApprove`. `useClaudeCliStatusListener` re-arms on planning when the ticket flag is set.
> 
> When armed, the **hook server** skips Telegram/Discord routing for main-session `ExitPlanMode`, replies `{}` to the permission hook, then after a short delay sends **`1`** on the PTY (dialog cannot be approved via hook JSON alone). The arm is consumed once; it clears on session end, PTY exit, hook server shutdown, manual/other approval (`PostToolUse ExitPlanMode`), and kanban **implement** sync (which also clears the durable flag). Schema bumps to **v38** with migration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccd1fe96faac2499f0f069b6e210ff82a7f44ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->