### PR TITLE
Add OAuth login and robust usage/account persistence

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,6 +13,13 @@ asarUnpack:
   - '**/*.node'
   - '**/better-sqlite3/**'
   - '**/node-pty/**'
+  # patchright (login-service.ts's dynamic `import('patchright')`) launches a
+  # real Chrome as a child process and needs real on-disk paths for its own
+  # driver/registry files — it cannot run from inside the ASAR archive.
+  # patchright-core is its actual implementation package (patchright itself is
+  # a thin re-export wrapper), pulled in transitively via pnpm's node_modules.
+  - '**/patchright/**'
+  - '**/patchright-core/**'
 
 # ── macOS ──────────────────────────────────────────────
 mac:

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "motion": "^12.38.0",
     "node-addon-api": "^8.6.0",
     "node-pty": "^1.1.0",
+    "patchright": "^1.61.1",
     "posthog-node": "^5.26.0",
     "qrcode-terminal": "^0.12.0",
     "radix-ui": "^1.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      patchright:
+        specifier: ^1.61.1
+        version: 1.61.1
       posthog-node:
         specifier: ^5.26.0
         version: 5.26.0
@@ -5802,6 +5805,16 @@ packages:
 
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+
+  patchright-core@1.61.1:
+    resolution: {integrity: sha512-d6Ju67DE6OzqlEX3WPvUX2SLEs6iMY1WERit//mpsrT98VHcztaUo0CBw2Lpxq25VdufVEiWEdcc0HnLwdiq6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  patchright@1.61.1:
+    resolution: {integrity: sha512-kZWNZ2tunsBMTBWtARFVWaNvB739GOybTlIPLT91eyx0YERjtUjESawomwO0hnOh6jt1L3Sru0PK62ylYOfqQw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -13809,6 +13822,14 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
+
+  patchright-core@1.61.1: {}
+
+  patchright@1.61.1:
+    dependencies:
+      patchright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   path-browserify@1.0.1: {}
 

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -937,6 +937,20 @@ export class DatabaseService {
     db.prepare(`UPDATE saved_usage_accounts SET credentials_json = '', updated_at = ?`).run(now)
   }
 
+  /**
+   * Blank a single row's credentials by id. Used by the one-time credentials
+   * migration so it can blank ONLY the rows it successfully migrated (or
+   * deliberately skipped), leaving a row whose keychain add hit a transient
+   * failure with its credentials intact for the next boot to retry.
+   */
+  clearSavedUsageAccountCredentialsById(id: string): void {
+    const db = this.getDb()
+    const now = new Date().toISOString()
+    db.prepare(
+      `UPDATE saved_usage_accounts SET credentials_json = '', updated_at = ? WHERE id = ?`
+    ).run(now, id)
+  }
+
   deleteSavedUsageAccount(id: string): boolean {
     const db = this.getDb()
     const result = db.prepare('DELETE FROM saved_usage_accounts WHERE id = ?').run(id)

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -813,56 +813,72 @@ export class DatabaseService {
   }
 
   // Saved usage account operations
+  //
+  // Emails are normalized to lowercase here, but legacy rows created before
+  // that normalization may still carry a mixed-case email. The
+  // (provider, email) unique index is case-sensitive (SQLite's default TEXT
+  // collation), so `INSERT ... ON CONFLICT(provider, email)` would not
+  // detect a case-variant match and would insert a duplicate row for the
+  // same account. To avoid that, look up any existing row
+  // case-insensitively first (via getSavedUsageAccountByProviderEmail) and
+  // update it directly when found, instead of relying on the unique index.
   upsertSavedUsageAccount(data: SavedUsageAccountUpsert): SavedUsageAccount {
     const db = this.getDb()
     const now = new Date().toISOString()
+    const email = data.email.toLowerCase()
     const hasLastUsage = data.last_usage_json !== undefined
     const hasStatus = data.status !== undefined
     const hasLastError = data.last_error !== undefined
 
-    db.prepare(
-      `INSERT INTO saved_usage_accounts (
-         id, provider, email, credentials_json, last_usage_json, last_fetched_at,
-         status, last_error, created_at, updated_at
-       )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(provider, email) DO UPDATE SET
-         credentials_json = excluded.credentials_json,
-         last_usage_json = CASE
-           WHEN ? THEN excluded.last_usage_json
-           ELSE saved_usage_accounts.last_usage_json
-         END,
-         last_fetched_at = CASE
-           WHEN ? THEN excluded.last_fetched_at
-           ELSE saved_usage_accounts.last_fetched_at
-         END,
-         status = CASE
-           WHEN ? THEN excluded.status
-           ELSE saved_usage_accounts.status
-         END,
-         last_error = CASE
-           WHEN ? THEN excluded.last_error
-           ELSE saved_usage_accounts.last_error
-         END,
-         updated_at = excluded.updated_at`
-    ).run(
-      randomUUID(),
-      data.provider,
-      data.email,
-      data.credentials_json,
-      data.last_usage_json ?? null,
-      hasLastUsage ? now : null,
-      data.status ?? 'ok',
-      data.last_error ?? null,
-      now,
-      now,
-      hasLastUsage ? 1 : 0,
-      hasLastUsage ? 1 : 0,
-      hasStatus ? 1 : 0,
-      hasLastError ? 1 : 0
-    )
+    const existing = this.getSavedUsageAccountByProviderEmail(data.provider, email)
 
-    const saved = this.getSavedUsageAccountByProviderEmail(data.provider, data.email)
+    if (existing) {
+      db.prepare(
+        `UPDATE saved_usage_accounts SET
+           email = ?,
+           credentials_json = ?,
+           last_usage_json = CASE WHEN ? THEN ? ELSE last_usage_json END,
+           last_fetched_at = CASE WHEN ? THEN ? ELSE last_fetched_at END,
+           status = CASE WHEN ? THEN ? ELSE status END,
+           last_error = CASE WHEN ? THEN ? ELSE last_error END,
+           updated_at = ?
+         WHERE id = ?`
+      ).run(
+        email,
+        data.credentials_json,
+        hasLastUsage ? 1 : 0,
+        data.last_usage_json ?? null,
+        hasLastUsage ? 1 : 0,
+        now,
+        hasStatus ? 1 : 0,
+        data.status ?? 'ok',
+        hasLastError ? 1 : 0,
+        data.last_error ?? null,
+        now,
+        existing.id
+      )
+    } else {
+      db.prepare(
+        `INSERT INTO saved_usage_accounts (
+           id, provider, email, credentials_json, last_usage_json, last_fetched_at,
+           status, last_error, created_at, updated_at
+         )
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        randomUUID(),
+        data.provider,
+        email,
+        data.credentials_json,
+        data.last_usage_json ?? null,
+        hasLastUsage ? now : null,
+        data.status ?? 'ok',
+        data.last_error ?? null,
+        now,
+        now
+      )
+    }
+
+    const saved = this.getSavedUsageAccountByProviderEmail(data.provider, email)
     if (!saved) {
       throw new Error('Failed to upsert saved usage account')
     }
@@ -900,8 +916,10 @@ export class DatabaseService {
     email: string
   ): SavedUsageAccount | null {
     const db = this.getDb()
+    // COLLATE NOCASE: legacy rows may carry a mixed-case email pre-dating
+    // lowercase normalization, so match case-insensitively.
     const row = db
-      .prepare('SELECT * FROM saved_usage_accounts WHERE provider = ? AND email = ?')
+      .prepare('SELECT * FROM saved_usage_accounts WHERE provider = ? AND email = ? COLLATE NOCASE')
       .get(provider, email) as SavedUsageAccount | undefined
     return row ?? null
   }

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -887,20 +887,6 @@ export class DatabaseService {
     return this.getSavedUsageAccountById(id)
   }
 
-  updateSavedUsageAccountCredentials(
-    id: string,
-    credentialsJson: string
-  ): SavedUsageAccount | null {
-    const db = this.getDb()
-    const now = new Date().toISOString()
-    db.prepare(
-      `UPDATE saved_usage_accounts
-       SET credentials_json = ?, updated_at = ?
-       WHERE id = ?`
-    ).run(credentialsJson, now, id)
-    return this.getSavedUsageAccountById(id)
-  }
-
   getSavedUsageAccountById(id: string): SavedUsageAccount | null {
     const db = this.getDb()
     const row = db.prepare('SELECT * FROM saved_usage_accounts WHERE id = ?').get(id) as

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -927,6 +927,12 @@ export class DatabaseService {
       .all(provider) as SavedUsageAccount[]
   }
 
+  clearSavedUsageAccountCredentials(): void {
+    const db = this.getDb()
+    const now = new Date().toISOString()
+    db.prepare(`UPDATE saved_usage_accounts SET credentials_json = '', updated_at = ?`).run(now)
+  }
+
   deleteSavedUsageAccount(id: string): boolean {
     const db = this.getDb()
     const result = db.prepare('DELETE FROM saved_usage_accounts WHERE id = ?').run(id)

--- a/src/main/services/__tests__/database-saved-usage-accounts.test.ts
+++ b/src/main/services/__tests__/database-saved-usage-accounts.test.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from 'crypto'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { DatabaseService } from '../../db/database'
+
+describe('saved_usage_accounts case-insensitive email handling', () => {
+  const tempDirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  const createService = (): DatabaseService => {
+    const dir = mkdtempSync(join(tmpdir(), 'hive-saved-usage-accounts-'))
+    tempDirs.push(dir)
+    const service = new DatabaseService(join(dir, 'hive.db'))
+    service.init()
+    return service
+  }
+
+  /** Insert a row directly via raw SQL, bypassing upsertSavedUsageAccount's
+   * own lowercasing, to model a legacy mixed-case row pre-dating normalization. */
+  function insertLegacyRow(
+    service: DatabaseService,
+    overrides: { provider: string; email: string }
+  ): string {
+    const db = service.getRawDb()
+    const id = randomUUID()
+    const now = new Date().toISOString()
+    db.prepare(
+      `INSERT INTO saved_usage_accounts (
+         id, provider, email, credentials_json, last_usage_json, last_fetched_at,
+         status, last_error, created_at, updated_at
+       ) VALUES (?, ?, ?, '', NULL, NULL, 'ok', NULL, ?, ?)`
+    ).run(id, overrides.provider, overrides.email, now, now)
+    return id
+  }
+
+  it('getSavedUsageAccountByProviderEmail matches an existing row regardless of casing', () => {
+    const service = createService()
+    const id = insertLegacyRow(service, { provider: 'anthropic', email: 'Mixed-Case@Example.com' })
+
+    expect(service.getSavedUsageAccountByProviderEmail('anthropic', 'mixed-case@example.com')?.id).toBe(
+      id
+    )
+    expect(service.getSavedUsageAccountByProviderEmail('anthropic', 'MIXED-CASE@EXAMPLE.COM')?.id).toBe(
+      id
+    )
+    expect(service.getSavedUsageAccountByProviderEmail('anthropic', 'Mixed-Case@Example.com')?.id).toBe(
+      id
+    )
+  })
+
+  it('upserting a case-variant email updates the same legacy row instead of inserting a duplicate', () => {
+    const service = createService()
+    const legacyId = insertLegacyRow(service, {
+      provider: 'anthropic',
+      email: 'Legacy-User@Example.com'
+    })
+
+    const result = service.upsertSavedUsageAccount({
+      provider: 'anthropic',
+      email: 'legacy-user@example.com',
+      credentials_json: '',
+      last_usage_json: JSON.stringify({ hello: 'world' }),
+      status: 'ok',
+      last_error: null
+    })
+
+    expect(result.id).toBe(legacyId)
+    expect(service.getSavedUsageAccountsByProvider('anthropic')).toHaveLength(1)
+
+    // Both casings resolve to the single, now-updated row.
+    const byLower = service.getSavedUsageAccountByProviderEmail('anthropic', 'legacy-user@example.com')
+    const byMixed = service.getSavedUsageAccountByProviderEmail('anthropic', 'Legacy-User@Example.com')
+    expect(byLower?.id).toBe(legacyId)
+    expect(byMixed?.id).toBe(legacyId)
+    expect(byLower?.last_usage_json).toBe(JSON.stringify({ hello: 'world' }))
+  })
+
+  it('a brand-new upsert normalizes the email to lowercase', () => {
+    const service = createService()
+
+    const result = service.upsertSavedUsageAccount({
+      provider: 'openai',
+      email: 'New-User@Example.com',
+      credentials_json: ''
+    })
+
+    expect(result.email).toBe('new-user@example.com')
+    expect(service.getSavedUsageAccountsByProvider('openai')).toHaveLength(1)
+  })
+
+  it('repeated upserts of the same case-variant email never create a second row', () => {
+    const service = createService()
+
+    service.upsertSavedUsageAccount({ provider: 'anthropic', email: 'A@B.com', credentials_json: '' })
+    service.upsertSavedUsageAccount({ provider: 'anthropic', email: 'a@b.com', credentials_json: '' })
+    service.upsertSavedUsageAccount({ provider: 'anthropic', email: 'A@B.COM', credentials_json: '' })
+
+    expect(service.getSavedUsageAccountsByProvider('anthropic')).toHaveLength(1)
+  })
+})

--- a/src/main/services/account-lock.ts
+++ b/src/main/services/account-lock.ts
@@ -1,0 +1,57 @@
+/**
+ * Per-account async mutex, shared across every code path that reads or rotates
+ * a single account's OAuth credentials.
+ *
+ * Several callers can race to refresh/rotate the SAME account's token
+ * concurrently: the 60s watcher, the boot/RPC mass refresh, a user-initiated
+ * live fetch, and an account switch. Refresh tokens are single-use and rotate
+ * on every refresh, so an overlapping second refresh would consume an
+ * already-rotated token and fail with invalid_grant even though the account
+ * has healthy, freshly-rotated credentials from the first refresh.
+ *
+ * Lives in its own module (rather than inside saved-usage-orchestrator.ts) so
+ * that the orchestrator's saved-account path AND usage-ops.ts's live path share
+ * ONE lock map keyed by `provider:email` — a left-click live fetch and a mass
+ * refresh/watcher tick for the same account then serialize instead of double-
+ * consuming the same single-use refresh token. Keeping it here also avoids an
+ * import cycle (usage-ops already imports from the orchestrator, but the
+ * orchestrator must not import from usage-ops).
+ */
+const accountLockTails = new Map<string, Promise<unknown>>()
+
+export function accountLockKey(provider: string, email: string): string {
+  return `${provider}:${email.toLowerCase()}`
+}
+
+/**
+ * Chain `fn` onto the tail promise for `key`, cleaning up the map entry once
+ * the chain drains so it never grows unbounded.
+ */
+export function withAccountLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prior = accountLockTails.get(key) ?? Promise.resolve()
+  const result = prior.then(fn, fn)
+  const tail = result.then(
+    () => undefined,
+    () => undefined
+  )
+  accountLockTails.set(key, tail)
+  void tail.finally(() => {
+    if (accountLockTails.get(key) === tail) accountLockTails.delete(key)
+  })
+  return result
+}
+
+/**
+ * Acquire several account locks at once (e.g. a switch touches both the
+ * outgoing-live and target accounts). Deduplicates and acquires in SORTED key
+ * order so two multi-lock callers can never deadlock by grabbing the same pair
+ * in opposite orders.
+ */
+export function withAccountLocks<T>(keys: string[], fn: () => Promise<T>): Promise<T> {
+  const ordered = [...new Set(keys)].sort()
+  const run = ordered.reduceRight<() => Promise<T>>(
+    (next, key) => () => withAccountLock(key, next),
+    fn
+  )
+  return run()
+}

--- a/src/main/services/account-maintenance.ts
+++ b/src/main/services/account-maintenance.ts
@@ -1,0 +1,195 @@
+/**
+ * Boot-time + background account maintenance for the ccswitch-compatible
+ * account stores: runs the one-time credentials migration, does a one-shot
+ * "launch mass refresh" of every managed account, then keeps tokens fresh
+ * with a low-frequency expiry watcher. Never launches a browser/login flow —
+ * a refresh that needs a human to log back in is left for the renderer
+ * (Phase 6) to notice via the cached account's `stale` status.
+ */
+import { listClaudeAccounts, readClaudeEffectiveBlob } from './account-store-claude'
+import { listCodexAccounts, readCodexEffectiveAuth } from './account-store-codex'
+import { migrateSavedCredentialsToStores } from './credentials-migration'
+import { createLogger } from './logger'
+import { refreshAllForProvider, refreshTokensForStoreAccount } from './saved-usage-orchestrator'
+
+const log = createLogger({ component: 'AccountMaintenance' })
+
+const TICK_INTERVAL_MS = 60_000
+const EXPIRY_THRESHOLD_MS = 120_000
+const BASE_ERROR_BACKOFF_MS = 5 * 60_000
+const MAX_ERROR_BACKOFF_MS = 30 * 60_000
+
+type BackoffState =
+  | { kind: 'needsLogin'; failingRefreshToken: string }
+  | { kind: 'error'; backoffMs: number; nextAttemptAt: number }
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isExpiringSoon(hasRefresh: boolean, expiresAtMs: number | null, now: number): boolean {
+  return hasRefresh && expiresAtMs !== null && expiresAtMs - now < EXPIRY_THRESHOLD_MS
+}
+
+/**
+ * Whether a candidate account should be attempted this tick, given its
+ * current backoff state and the CURRENT refresh token on record (used to
+ * detect that a previously-failing `needsLogin` token has since changed —
+ * e.g. the account was re-added or refreshed by another process).
+ */
+function shouldAttempt(
+  backoff: Map<string, BackoffState>,
+  key: string,
+  now: number,
+  currentRefreshToken: string | undefined
+): boolean {
+  const entry = backoff.get(key)
+  if (!entry) return true
+
+  if (entry.kind === 'needsLogin') {
+    if (currentRefreshToken !== undefined && currentRefreshToken !== entry.failingRefreshToken) {
+      backoff.delete(key)
+      return true
+    }
+    return false
+  }
+
+  return now >= entry.nextAttemptAt
+}
+
+function recordOutcome(
+  backoff: Map<string, BackoffState>,
+  key: string,
+  outcome: 'refreshed' | 'needsLogin' | 'error',
+  currentRefreshToken: string | undefined
+): void {
+  if (outcome === 'refreshed') {
+    backoff.delete(key)
+    return
+  }
+
+  if (outcome === 'needsLogin') {
+    backoff.set(key, { kind: 'needsLogin', failingRefreshToken: currentRefreshToken ?? '' })
+    return
+  }
+
+  const previous = backoff.get(key)
+  const previousBackoffMs = previous?.kind === 'error' ? previous.backoffMs : 0
+  const backoffMs =
+    previousBackoffMs === 0
+      ? BASE_ERROR_BACKOFF_MS
+      : Math.min(previousBackoffMs * 2, MAX_ERROR_BACKOFF_MS)
+  backoff.set(key, { kind: 'error', backoffMs, nextAttemptAt: Date.now() + backoffMs })
+}
+
+async function readCurrentClaudeRefreshToken(num: string, email: string): Promise<string | undefined> {
+  const effective = await readClaudeEffectiveBlob(num, email)
+  return effective?.parsed.refreshToken
+}
+
+async function readCurrentCodexRefreshToken(accountKey: string): Promise<string | undefined> {
+  const auth = await readCodexEffectiveAuth(accountKey)
+  return auth?.tokens?.refresh_token
+}
+
+async function tick(backoff: Map<string, BackoffState>): Promise<void> {
+  const now = Date.now()
+
+  const claudeAccounts = await listClaudeAccounts().catch((error) => {
+    log.warn('Failed to list Claude accounts for expiry check', { error: message(error) })
+    return []
+  })
+
+  for (const account of claudeAccounts) {
+    if (!isExpiringSoon(account.hasRefresh, account.expiresAtMs, now)) continue
+
+    const key = `anthropic:${account.num}`
+    const currentRefreshToken = await readCurrentClaudeRefreshToken(account.num, account.email)
+    if (!shouldAttempt(backoff, key, now, currentRefreshToken)) continue
+
+    log.info('Refreshing expiring Claude account token', { num: account.num, email: account.email })
+    const outcome = await refreshTokensForStoreAccount('anthropic', {
+      num: account.num,
+      email: account.email
+    }).catch((error) => {
+      log.warn('Claude token refresh threw', { num: account.num, error: message(error) })
+      return 'error' as const
+    })
+    recordOutcome(backoff, key, outcome, currentRefreshToken)
+    log[outcome === 'error' ? 'warn' : 'info']('Claude account refresh outcome', {
+      num: account.num,
+      email: account.email,
+      outcome
+    })
+  }
+
+  const codexAccounts = await listCodexAccounts().catch((error) => {
+    log.warn('Failed to list Codex accounts for expiry check', { error: message(error) })
+    return []
+  })
+
+  for (const account of codexAccounts) {
+    if (!isExpiringSoon(account.hasRefresh, account.expiresAtMs, now)) continue
+
+    const key = `openai:${account.accountKey}`
+    const currentRefreshToken = await readCurrentCodexRefreshToken(account.accountKey)
+    if (!shouldAttempt(backoff, key, now, currentRefreshToken)) continue
+
+    log.info('Refreshing expiring Codex account token', {
+      accountKey: account.accountKey,
+      email: account.email
+    })
+    const outcome = await refreshTokensForStoreAccount('openai', {
+      accountKey: account.accountKey
+    }).catch((error) => {
+      log.warn('Codex token refresh threw', { accountKey: account.accountKey, error: message(error) })
+      return 'error' as const
+    })
+    recordOutcome(backoff, key, outcome, currentRefreshToken)
+    log[outcome === 'error' ? 'warn' : 'info']('Codex account refresh outcome', {
+      accountKey: account.accountKey,
+      email: account.email,
+      outcome
+    })
+  }
+}
+
+async function runLaunchMassRefresh(): Promise<void> {
+  try {
+    await migrateSavedCredentialsToStores()
+  } catch (error) {
+    log.warn('Launch-time credentials migration failed', { error: message(error) })
+  }
+
+  try {
+    await refreshAllForProvider('anthropic')
+  } catch (error) {
+    log.warn('Launch-time mass refresh failed', { provider: 'anthropic', error: message(error) })
+  }
+
+  try {
+    await refreshAllForProvider('openai')
+  } catch (error) {
+    log.warn('Launch-time mass refresh failed', { provider: 'openai', error: message(error) })
+  }
+}
+
+/**
+ * Starts account maintenance: fires the one-shot migration + launch mass
+ * refresh (never blocking the caller), then a `setInterval` expiry watcher.
+ * Returns a cleanup function that stops the watcher.
+ */
+export function startAccountMaintenance(): () => void {
+  const backoff = new Map<string, BackoffState>()
+
+  void runLaunchMassRefresh()
+
+  const interval = setInterval(() => {
+    void tick(backoff).catch((error) => {
+      log.warn('Account maintenance tick failed', { error: message(error) })
+    })
+  }, TICK_INTERVAL_MS)
+  interval.unref?.()
+
+  return () => clearInterval(interval)
+}

--- a/src/main/services/account-maintenance.ts
+++ b/src/main/services/account-maintenance.ts
@@ -181,13 +181,23 @@ async function runLaunchMassRefresh(): Promise<void> {
  */
 export function startAccountMaintenance(): () => void {
   const backoff = new Map<string, BackoffState>()
+  let inTick = false
 
   void runLaunchMassRefresh()
 
   const interval = setInterval(() => {
-    void tick(backoff).catch((error) => {
-      log.warn('Account maintenance tick failed', { error: message(error) })
-    })
+    if (inTick) {
+      log.warn('Skipping account maintenance tick: previous tick is still running')
+      return
+    }
+    inTick = true
+    void tick(backoff)
+      .catch((error) => {
+        log.warn('Account maintenance tick failed', { error: message(error) })
+      })
+      .finally(() => {
+        inTick = false
+      })
   }, TICK_INTERVAL_MS)
   interval.unref?.()
 

--- a/src/main/services/account-service.ts
+++ b/src/main/services/account-service.ts
@@ -3,26 +3,11 @@ import { readFile } from 'fs/promises'
 import { join } from 'path'
 import { homedir } from 'os'
 import { createLogger } from './logger'
+import { decodeJwtPayload } from './jwt-utils'
 
 const log = createLogger({ component: 'AccountService' })
 
 const CODEX_HOME = process.env.CODEX_HOME || join(homedir(), '.codex')
-
-/**
- * Decode the payload section of a JWT token.
- */
-function decodeJwtPayload(token: string): Record<string, unknown> | null {
-  try {
-    const parts = token.split('.')
-    if (parts.length !== 3) return null
-    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
-    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
-    const json = Buffer.from(padded, 'base64').toString('utf-8')
-    return JSON.parse(json)
-  } catch {
-    return null
-  }
-}
 
 /**
  * Get the Claude account email from ~/.claude.json.

--- a/src/main/services/account-service.ts
+++ b/src/main/services/account-service.ts
@@ -4,34 +4,29 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { createLogger } from './logger'
 import { decodeJwtPayload } from './jwt-utils'
+import { readClaudeLiveIdentity } from './account-store-claude'
 
 const log = createLogger({ component: 'AccountService' })
 
 const CODEX_HOME = process.env.CODEX_HOME || join(homedir(), '.codex')
 
 /**
- * Get the Claude account email from ~/.claude.json.
- * Reads oauthAccount.emailAddress from the file.
+ * Get the currently-live Claude account email.
+ *
+ * Delegates to the account store's `readClaudeLiveIdentity()` so this uses the
+ * SAME identity seam as everything else: it prefers the nested
+ * `~/.claude/.claude.json` (ccswitch's primary, which `switchClaudeAccount`
+ * writes) over the top-level `~/.claude.json`. Lowercased so the renderer's
+ * Active-badge comparison against the lowercased DTO emails works even for
+ * mixed-case accounts. Reading only the verbatim top-level file (as this used
+ * to) left the badge stuck on the pre-switch account.
  */
 export async function getClaudeAccountEmail(): Promise<string | null> {
-  const claudePath = join(homedir(), '.claude.json')
-  if (!existsSync(claudePath)) {
+  const { email } = await readClaudeLiveIdentity()
+  if (typeof email !== 'string' || email.length === 0) {
     return null
   }
-  try {
-    const raw = await readFile(claudePath, 'utf-8')
-    const data = JSON.parse(raw)
-    const email = data?.oauthAccount?.emailAddress
-    if (typeof email !== 'string' || email.length === 0) {
-      log.warn('Claude account email missing or invalid in config file')
-      return null
-    }
-    return email
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    log.warn('Failed to read Claude account email', { error: message })
-    return null
-  }
+  return email.toLowerCase()
 }
 
 /**

--- a/src/main/services/account-store-claude.ts
+++ b/src/main/services/account-store-claude.ts
@@ -61,6 +61,28 @@ export interface ClaudeStoreAccount {
   active: boolean
 }
 
+/**
+ * Short TTL memo for `listClaudeAccounts()`. Every list call re-reads
+ * sequence.json plus every account's effective Keychain blob (a `security`
+ * execFile each, ~10-30ms) — callers like the saved-usage orchestrator's
+ * per-account mass refresh call it N+1 times in a row, so a short memo cuts
+ * that down to one real read. Invalidated synchronously by every mutating
+ * function in this module, and never populated from a rejected read.
+ */
+const LIST_CACHE_TTL_MS = 15_000
+let listCache: { value: ClaudeStoreAccount[]; expiresAt: number } | null = null
+
+function invalidateListCache(): void {
+  listCache = null
+}
+
+/** Test-only escape hatch: forces the next `listClaudeAccounts()` call to
+ * re-read, for tests that mutate the underlying fs/Keychain fixtures
+ * directly instead of going through this module's own mutators. */
+export function clearAccountStoreCacheForTests(): void {
+  invalidateListCache()
+}
+
 function backupDir(): string {
   return join(homedir(), '.claude-switch-backup')
 }
@@ -204,6 +226,10 @@ export async function readClaudeLiveIdentity(): Promise<{ email: string | null; 
 
 /** List all managed Claude accounts, in sequence.json's `sequence` order. */
 export async function listClaudeAccounts(): Promise<ClaudeStoreAccount[]> {
+  if (listCache !== null && listCache.expiresAt > Date.now()) {
+    return listCache.value
+  }
+
   const seq = await readSequence()
   const liveEmail = await readClaudeLiveEmail()
 
@@ -227,6 +253,7 @@ export async function listClaudeAccounts(): Promise<ClaudeStoreAccount[]> {
       active: liveEmail !== null && liveEmail === email
     })
   }
+  listCache = { value: out, expiresAt: Date.now() + LIST_CACHE_TTL_MS }
   return out
 }
 
@@ -241,6 +268,7 @@ export async function updateClaudeTokens(
   rotated: { accessToken: string; refreshToken: string; expiresAt: number },
   scope?: string
 ): Promise<void> {
+  invalidateListCache()
   const existingRaw = (await keychainRead(accountService(num, email))) ?? '{}'
   let full: ClaudeCredentialBlob
   try {
@@ -335,6 +363,8 @@ export async function persistRotatedLiveClaudeTokens(
     return 'skipped-race'
   }
 
+  invalidateListCache()
+
   const oauth: ClaudeOauthBlob = { ...(full.claudeAiOauth ?? {}) }
   oauth.accessToken = rotated.accessToken
   oauth.refreshToken = rotated.refreshToken
@@ -368,6 +398,7 @@ export async function persistRotatedLiveClaudeTokens(
 
 /** Port of ccswitch `switch_to`: makes `num`/`email` the live active Claude account. */
 export async function switchClaudeAccount(num: string, email: string): Promise<void> {
+  invalidateListCache()
   const seq = await readSequence()
 
   // 1) Preserve the outgoing account's freshest (live) credentials into its
@@ -429,6 +460,7 @@ export async function switchClaudeAccount(num: string, email: string): Promise<v
  * its account number). Returns the account number.
  */
 export async function addClaudeAccount(email: string, uuid: string, blobJson: string): Promise<string> {
+  invalidateListCache()
   // Normalized so this account's Keychain entry is always reachable by the
   // same (lowercased) email that listing/effective-blob lookups use.
   const normalizedEmail = email.toLowerCase()
@@ -459,6 +491,7 @@ export async function addClaudeAccount(email: string, uuid: string, blobJson: st
  * sequence.json bookkeeping.
  */
 export async function removeClaudeAccount(num: string, email: string): Promise<void> {
+  invalidateListCache()
   await keychainDelete(accountService(num, email))
 
   const seq = await readSequence()

--- a/src/main/services/account-store-claude.ts
+++ b/src/main/services/account-store-claude.ts
@@ -267,6 +267,93 @@ export async function updateClaudeTokens(
   }
 }
 
+interface LiveCredentialsSource {
+  kind: 'keychain' | 'file'
+  raw: string
+  filePath?: string
+}
+
+/** Re-read the live credentials from wherever usage-service.ts's `readFromFile`
+ * would find them: Keychain first, falling back to the legacy credentials
+ * file. Returns null when neither source has anything. */
+async function readLiveCredentialsSource(): Promise<LiveCredentialsSource | null> {
+  const keychainRaw = await keychainRead(LIVE_CLAUDE_KEYCHAIN_SERVICE)
+  if (keychainRaw !== null) return { kind: 'keychain', raw: keychainRaw }
+
+  const filePath = join(homedir(), '.claude', '.credentials.json')
+  if (!existsSync(filePath)) return null
+  try {
+    const raw = await readFile(filePath, 'utf-8')
+    return { kind: 'file', raw, filePath }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Persist rotated tokens for the LIVE Claude credentials (the ones the
+ * `claude` CLI itself reads/writes) after a Hive-initiated refresh.
+ *
+ * Guards against a race with the `claude` CLI rotating the very same
+ * refresh token concurrently: re-reads the live blob and only writes when
+ * its current refresh token still matches the one Hive used to obtain
+ * `rotated` — otherwise some other process already moved the live
+ * credentials forward, and writing here would clobber that newer rotation.
+ */
+export async function persistRotatedLiveClaudeTokens(
+  rotated: { accessToken: string; refreshToken: string; expiresAt: number },
+  usedRefreshToken: string,
+  scope?: string
+): Promise<'persisted' | 'skipped-race' | 'no-live'> {
+  const source = await readLiveCredentialsSource()
+  if (!source) return 'no-live'
+
+  let full: ClaudeCredentialBlob
+  try {
+    full = JSON.parse(source.raw) as ClaudeCredentialBlob
+  } catch (error) {
+    log.warn('Live Claude credentials blob is not valid JSON; refusing to patch', {
+      source: source.kind,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return 'no-live'
+  }
+
+  if ((full.claudeAiOauth?.refreshToken ?? undefined) !== usedRefreshToken) {
+    return 'skipped-race'
+  }
+
+  const oauth: ClaudeOauthBlob = { ...(full.claudeAiOauth ?? {}) }
+  oauth.accessToken = rotated.accessToken
+  oauth.refreshToken = rotated.refreshToken
+  oauth.expiresAt = rotated.expiresAt
+  if (scope !== undefined) {
+    oauth.scopes = scope.split(' ')
+  }
+  full.claudeAiOauth = oauth
+  const patchedRaw = JSON.stringify(full)
+
+  if (source.kind === 'keychain') {
+    await keychainWrite(LIVE_CLAUDE_KEYCHAIN_SERVICE, patchedRaw)
+  } else {
+    await atomicWriteJson(source.filePath!, full, { mode: 0o600 })
+  }
+
+  // Mirror to the managed account's backup slot, if the live email
+  // corresponds to one (same "keep the backup fresh" pattern as
+  // updateClaudeTokens/switchClaudeAccount).
+  const liveEmail = await readClaudeLiveEmail()
+  if (liveEmail !== null) {
+    const seq = await readSequence()
+    const num = findNumByEmail(seq, liveEmail)
+    if (num !== null) {
+      await keychainWrite(accountService(num, liveEmail), patchedRaw)
+    }
+  }
+
+  return 'persisted'
+}
+
 /** Port of ccswitch `switch_to`: makes `num`/`email` the live active Claude account. */
 export async function switchClaudeAccount(num: string, email: string): Promise<void> {
   const seq = await readSequence()

--- a/src/main/services/account-store-claude.ts
+++ b/src/main/services/account-store-claude.ts
@@ -1,0 +1,373 @@
+/**
+ * Claude account store — TypeScript port of ccswitch's `src/store/claude.rs`.
+ *
+ * This is the source of truth for managed Claude account identities and
+ * credentials. It interoperates on-disk/in-Keychain with the `ccswitch` CLI
+ * tool, so the file/Keychain shapes here must match it byte-for-byte:
+ *
+ * - Managed index:    ~/.claude-switch-backup/sequence.json
+ * - Per-account creds: macOS Keychain "Claude Code-Account-{num}-{email}"
+ * - Live active creds: macOS Keychain "Claude Code-credentials"
+ * - Live active oauth: ~/.claude/.claude.json (preferred) or ~/.claude.json
+ */
+import { existsSync } from 'fs'
+import { readFile } from 'fs/promises'
+import { homedir } from 'os'
+import { join } from 'path'
+import { keychainDelete, keychainRead, keychainWrite } from './keychain'
+import { atomicWriteJson, readJsonFile } from './atomic-json'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'AccountStoreClaude' })
+
+export const LIVE_CLAUDE_KEYCHAIN_SERVICE = 'Claude Code-credentials'
+
+/** The `claudeAiOauth` inner object, as stored in every Keychain credential blob. */
+export interface ClaudeOauthBlob {
+  accessToken?: string
+  refreshToken?: string
+  expiresAt?: number
+  scopes?: string[]
+  subscriptionType?: string
+  [key: string]: unknown
+}
+
+/** The full Keychain credential blob shape: `{ "claudeAiOauth": {...} }` plus unknown fields. */
+interface ClaudeCredentialBlob {
+  claudeAiOauth?: ClaudeOauthBlob
+  [key: string]: unknown
+}
+
+interface SequenceAccountEntry {
+  email: string
+  uuid: string
+  added: string
+}
+
+interface SequenceFile {
+  activeAccountNumber: number | null
+  lastUpdated: string
+  sequence: number[]
+  accounts: Record<string, SequenceAccountEntry>
+}
+
+export interface ClaudeStoreAccount {
+  num: string
+  email: string
+  uuid: string
+  expiresAtMs: number | null
+  hasRefresh: boolean
+  plan: string | null
+  active: boolean
+}
+
+function backupDir(): string {
+  return join(homedir(), '.claude-switch-backup')
+}
+
+function sequencePath(): string {
+  return join(backupDir(), 'sequence.json')
+}
+
+/** `~/.claude/.claude.json` when it exists, else `~/.claude.json`. */
+function claudeJsonPath(): string {
+  const nested = join(homedir(), '.claude', '.claude.json')
+  if (existsSync(nested)) return nested
+  return join(homedir(), '.claude.json')
+}
+
+function accountService(num: string, email: string): string {
+  return `Claude Code-Account-${num}-${email}`
+}
+
+function emptySequence(): SequenceFile {
+  return { activeAccountNumber: null, lastUpdated: new Date().toISOString(), sequence: [], accounts: {} }
+}
+
+/**
+ * Read sequence.json. Missing file => empty index. A file that exists but
+ * fails to parse throws (we never want to silently treat a corrupt index as
+ * "no accounts" and then overwrite it with an empty one).
+ */
+async function readSequence(): Promise<SequenceFile> {
+  const path = sequencePath()
+  if (!existsSync(path)) return emptySequence()
+
+  const raw = await readFile(path, 'utf-8')
+  let data: Partial<SequenceFile>
+  try {
+    data = JSON.parse(raw) as Partial<SequenceFile>
+  } catch (error) {
+    throw new Error(
+      `${path}: invalid JSON (${error instanceof Error ? error.message : String(error)})`
+    )
+  }
+
+  return {
+    activeAccountNumber: typeof data.activeAccountNumber === 'number' ? data.activeAccountNumber : null,
+    lastUpdated: typeof data.lastUpdated === 'string' ? data.lastUpdated : new Date().toISOString(),
+    sequence: Array.isArray(data.sequence) ? data.sequence : [],
+    accounts:
+      data.accounts && typeof data.accounts === 'object' && !Array.isArray(data.accounts)
+        ? data.accounts
+        : {}
+  }
+}
+
+async function writeSequence(seq: SequenceFile): Promise<void> {
+  await atomicWriteJson(sequencePath(), seq, { pretty: true })
+}
+
+function findNumByEmail(seq: SequenceFile, email: string): string | null {
+  const target = email.toLowerCase()
+  for (const [num, acct] of Object.entries(seq.accounts)) {
+    if ((acct.email ?? '').toLowerCase() === target) return num
+  }
+  return null
+}
+
+function nextNumber(seq: SequenceFile): number {
+  const nums = Object.keys(seq.accounts)
+    .map((k) => Number.parseInt(k, 10))
+    .filter((n) => Number.isFinite(n))
+  const max = nums.length > 0 ? Math.max(...nums) : 0
+  return max + 1
+}
+
+/** Read+parse a Keychain credential blob, tolerating a missing or corrupt entry (=> null). */
+async function readKeychainBlob(
+  service: string
+): Promise<{ raw: string; parsed: ClaudeOauthBlob } | null> {
+  const raw = await keychainRead(service)
+  if (raw === null) return null
+  try {
+    const full = JSON.parse(raw) as ClaudeCredentialBlob
+    return { raw, parsed: full.claudeAiOauth ?? {} }
+  } catch (error) {
+    log.warn('Failed to parse Claude Keychain credential blob', {
+      service,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return null
+  }
+}
+
+/** The currently-live Keychain credential blob ("Claude Code-credentials"). */
+async function readLiveBlob(): Promise<{ raw: string; parsed: ClaudeOauthBlob } | null> {
+  return readKeychainBlob(LIVE_CLAUDE_KEYCHAIN_SERVICE)
+}
+
+/** The per-account backup Keychain credential blob. */
+export async function readClaudeAccountBlob(
+  num: string,
+  email: string
+): Promise<{ raw: string; parsed: ClaudeOauthBlob } | null> {
+  return readKeychainBlob(accountService(num, email))
+}
+
+/**
+ * Effective credentials for an account: the live Keychain blob when this
+ * account is currently active (its real, freshest tokens live there),
+ * otherwise the per-account backup blob.
+ */
+export async function readClaudeEffectiveBlob(
+  num: string,
+  email: string
+): Promise<{ raw: string; parsed: ClaudeOauthBlob } | null> {
+  const liveEmail = await readClaudeLiveEmail()
+  if (liveEmail !== null && liveEmail === email.toLowerCase()) {
+    const live = await readLiveBlob()
+    if (live) return live
+  }
+  return readClaudeAccountBlob(num, email)
+}
+
+/** `oauthAccount.emailAddress` from the identity file, lowercased. Tolerant of missing/corrupt files. */
+export async function readClaudeLiveEmail(): Promise<string | null> {
+  const identity = await readClaudeLiveIdentity()
+  return identity.email !== null ? identity.email.toLowerCase() : null
+}
+
+/** `oauthAccount.{emailAddress,accountUuid}` from the identity file, as stored (no case change). */
+export async function readClaudeLiveIdentity(): Promise<{ email: string | null; uuid: string | null }> {
+  const data = await readJsonFile<Record<string, unknown>>(claudeJsonPath())
+  const oauthAccount =
+    data?.oauthAccount && typeof data.oauthAccount === 'object'
+      ? (data.oauthAccount as Record<string, unknown>)
+      : null
+  const email =
+    oauthAccount && typeof oauthAccount.emailAddress === 'string' ? oauthAccount.emailAddress : null
+  const uuid =
+    oauthAccount && typeof oauthAccount.accountUuid === 'string' ? oauthAccount.accountUuid : null
+  return { email, uuid }
+}
+
+/** List all managed Claude accounts, in sequence.json's `sequence` order. */
+export async function listClaudeAccounts(): Promise<ClaudeStoreAccount[]> {
+  const seq = await readSequence()
+  const liveEmail = await readClaudeLiveEmail()
+
+  const out: ClaudeStoreAccount[] = []
+  for (const numValue of seq.sequence) {
+    const num = String(numValue)
+    const entry = seq.accounts[num]
+    if (!entry) continue
+
+    const email = (entry.email ?? '').toLowerCase()
+    const effective = await readClaudeEffectiveBlob(num, email)
+    const parsed = effective?.parsed ?? null
+
+    out.push({
+      num,
+      email,
+      uuid: entry.uuid ?? '',
+      expiresAtMs: typeof parsed?.expiresAt === 'number' ? parsed.expiresAt : null,
+      hasRefresh: typeof parsed?.refreshToken === 'string' && parsed.refreshToken.length > 0,
+      plan: typeof parsed?.subscriptionType === 'string' ? parsed.subscriptionType : null,
+      active: liveEmail !== null && liveEmail === email
+    })
+  }
+  return out
+}
+
+/**
+ * Patch rotated tokens into an account's backup blob (preserving unknown
+ * fields), and mirror the patched blob to the live Keychain entry when this
+ * account is currently active.
+ */
+export async function updateClaudeTokens(
+  num: string,
+  email: string,
+  rotated: { accessToken: string; refreshToken: string; expiresAt: number },
+  scope?: string
+): Promise<void> {
+  const existingRaw = (await keychainRead(accountService(num, email))) ?? '{}'
+  let full: ClaudeCredentialBlob
+  try {
+    full = JSON.parse(existingRaw) as ClaudeCredentialBlob
+  } catch {
+    full = {}
+  }
+
+  const oauth: ClaudeOauthBlob = { ...(full.claudeAiOauth ?? {}) }
+  oauth.accessToken = rotated.accessToken
+  oauth.refreshToken = rotated.refreshToken
+  oauth.expiresAt = rotated.expiresAt
+  if (scope !== undefined) {
+    oauth.scopes = scope.split(' ')
+  }
+  full.claudeAiOauth = oauth
+
+  const raw = JSON.stringify(full)
+  await keychainWrite(accountService(num, email), raw)
+
+  const liveEmail = await readClaudeLiveEmail()
+  if (liveEmail !== null && liveEmail === email.toLowerCase()) {
+    await keychainWrite(LIVE_CLAUDE_KEYCHAIN_SERVICE, raw)
+  }
+}
+
+/** Port of ccswitch `switch_to`: makes `num`/`email` the live active Claude account. */
+export async function switchClaudeAccount(num: string, email: string): Promise<void> {
+  const seq = await readSequence()
+
+  // 1) Preserve the outgoing account's freshest (live) credentials into its
+  //    own backup slot before overwriting the live credential, so a
+  //    just-refreshed token isn't lost.
+  const currentLiveEmail = await readClaudeLiveEmail()
+  if (currentLiveEmail !== null && currentLiveEmail !== email.toLowerCase()) {
+    const outgoingNum = findNumByEmail(seq, currentLiveEmail)
+    if (outgoingNum !== null) {
+      const live = await readLiveBlob()
+      if (live) {
+        await keychainWrite(accountService(outgoingNum, currentLiveEmail), live.raw)
+      }
+    }
+  }
+
+  // 2) Write the target account's backup blob to the live Keychain entry.
+  const target = await readClaudeAccountBlob(num, email)
+  if (!target) {
+    throw new Error(`No stored Claude credentials for account ${num} (${email})`)
+  }
+  await keychainWrite(LIVE_CLAUDE_KEYCHAIN_SERVICE, target.raw)
+
+  // 3) Merge oauthAccount identity fields into the identity file, preserving
+  //    everything else. Never clobber a file we couldn't parse.
+  const path = claudeJsonPath()
+  let identity: Record<string, unknown> = {}
+  if (existsSync(path)) {
+    const raw = await readFile(path, 'utf-8')
+    try {
+      identity = JSON.parse(raw) as Record<string, unknown>
+    } catch (error) {
+      throw new Error(
+        `${path}: invalid JSON, refusing to overwrite (${error instanceof Error ? error.message : String(error)})`
+      )
+    }
+  }
+
+  const uuid = seq.accounts[num]?.uuid ?? ''
+  const oauthAccount: Record<string, unknown> =
+    identity.oauthAccount && typeof identity.oauthAccount === 'object'
+      ? { ...(identity.oauthAccount as Record<string, unknown>) }
+      : {}
+  oauthAccount.emailAddress = email
+  if (uuid !== '') {
+    oauthAccount.accountUuid = uuid
+  }
+  identity.oauthAccount = oauthAccount
+  await atomicWriteJson(path, identity, { pretty: true })
+
+  // 4) Update the active account number.
+  seq.activeAccountNumber = Number.parseInt(num, 10)
+  seq.lastUpdated = new Date().toISOString()
+  await writeSequence(seq)
+}
+
+/**
+ * Register a new managed account (or re-register an existing one, reusing
+ * its account number). Returns the account number.
+ */
+export async function addClaudeAccount(email: string, uuid: string, blobJson: string): Promise<string> {
+  // Normalized so this account's Keychain entry is always reachable by the
+  // same (lowercased) email that listing/effective-blob lookups use.
+  const normalizedEmail = email.toLowerCase()
+  const seq = await readSequence()
+  const existingNum = findNumByEmail(seq, normalizedEmail)
+  const num = existingNum ?? String(nextNumber(seq))
+
+  await keychainWrite(accountService(num, normalizedEmail), blobJson)
+
+  const prior = seq.accounts[num]
+  seq.accounts[num] = {
+    email: normalizedEmail,
+    uuid: uuid !== '' ? uuid : (prior?.uuid ?? ''),
+    added: prior?.added ?? new Date().toISOString()
+  }
+  if (existingNum === null) {
+    seq.sequence.push(Number.parseInt(num, 10))
+  }
+  seq.lastUpdated = new Date().toISOString()
+  await writeSequence(seq)
+
+  return num
+}
+
+/**
+ * Remove a managed account. Never touches the live Keychain entry or the
+ * identity file — only this account's backup Keychain entry and its
+ * sequence.json bookkeeping.
+ */
+export async function removeClaudeAccount(num: string, email: string): Promise<void> {
+  await keychainDelete(accountService(num, email))
+
+  const seq = await readSequence()
+  delete seq.accounts[num]
+  seq.sequence = seq.sequence.filter((n) => String(n) !== num)
+  if (seq.activeAccountNumber !== null && String(seq.activeAccountNumber) === num) {
+    seq.activeAccountNumber = null
+  }
+  seq.lastUpdated = new Date().toISOString()
+  await writeSequence(seq)
+}

--- a/src/main/services/account-store-claude.ts
+++ b/src/main/services/account-store-claude.ts
@@ -291,6 +291,18 @@ async function readLiveCredentialsSource(): Promise<LiveCredentialsSource | null
 }
 
 /**
+ * The raw (unparsed) live Claude credential blob JSON — Keychain first,
+ * falling back to the legacy `~/.claude/.credentials.json` file, matching
+ * `usage-service.ts`'s `readFromFile` fallback. Used to seed a brand-new
+ * managed account entry from whatever the `claude` CLI currently has live
+ * (see `captureLiveAccountFromFetch` in saved-usage-orchestrator.ts).
+ */
+export async function readClaudeLiveRawBlob(): Promise<string | null> {
+  const source = await readLiveCredentialsSource()
+  return source?.raw ?? null
+}
+
+/**
  * Persist rotated tokens for the LIVE Claude credentials (the ones the
  * `claude` CLI itself reads/writes) after a Hive-initiated refresh.
  *

--- a/src/main/services/account-store-codex.ts
+++ b/src/main/services/account-store-codex.ts
@@ -180,6 +180,21 @@ export async function listCodexAccounts(): Promise<CodexStoreAccount[]> {
 }
 
 /**
+ * Effective credentials for a managed account: live auth.json when this
+ * account is currently the registry's active account (its real, freshest
+ * tokens live there), otherwise its own snapshot. Mirrors
+ * `account-store-claude.ts`'s `readClaudeEffectiveBlob`.
+ */
+export async function readCodexEffectiveAuth(accountKey: string): Promise<CodexAuth | null> {
+  const registry = await readRegistry()
+  const live = await readCodexLive()
+  const derivedLiveKey = deriveAccountKey(live)
+  const liveAccountKey = derivedLiveKey ?? registry.active_account_key
+  if (accountKey === liveAccountKey && live) return live
+  return readCodexSnapshot(accountKey)
+}
+
+/**
  * Patch rotated tokens into a snapshot (access always; refresh/id only when
  * provided), and mirror the full patched snapshot to live auth.json when
  * this account is the registry's active account.

--- a/src/main/services/account-store-codex.ts
+++ b/src/main/services/account-store-codex.ts
@@ -63,6 +63,28 @@ interface CodexRegistry {
   [key: string]: unknown
 }
 
+/**
+ * Short TTL memo for `listCodexAccounts()`, mirroring
+ * `account-store-claude.ts`'s `listClaudeAccounts()` memo — every list call
+ * re-reads registry.json plus every account's effective snapshot file, and
+ * callers like the saved-usage orchestrator's per-account mass refresh call
+ * it N+1 times in a row. Invalidated synchronously by every mutating
+ * function in this module, and never populated from a rejected read.
+ */
+const LIST_CACHE_TTL_MS = 15_000
+let listCache: { value: CodexStoreAccount[]; expiresAt: number } | null = null
+
+function invalidateListCache(): void {
+  listCache = null
+}
+
+/** Test-only escape hatch: forces the next `listCodexAccounts()` call to
+ * re-read, for tests that mutate the underlying fs fixtures directly instead
+ * of going through this module's own mutators. */
+export function clearAccountStoreCacheForTests(): void {
+  invalidateListCache()
+}
+
 /** Same resolution as `openai-usage-service.ts`: env var first, else `~/.codex`. */
 function codexHome(): string {
   return process.env.CODEX_HOME || join(homedir(), '.codex')
@@ -150,6 +172,10 @@ export async function readCodexLive(): Promise<CodexAuth | null> {
 
 /** List all managed Codex accounts. */
 export async function listCodexAccounts(): Promise<CodexStoreAccount[]> {
+  if (listCache !== null && listCache.expiresAt > Date.now()) {
+    return listCache.value
+  }
+
   const registry = await readRegistry()
   const live = await readCodexLive()
   const derivedLiveKey = deriveAccountKey(live)
@@ -176,6 +202,7 @@ export async function listCodexAccounts(): Promise<CodexStoreAccount[]> {
       active
     })
   }
+  listCache = { value: out, expiresAt: Date.now() + LIST_CACHE_TTL_MS }
   return out
 }
 
@@ -207,6 +234,7 @@ export async function updateCodexTokens(
   if (!existing) {
     throw new Error(`No Codex snapshot for account ${accountKey}`)
   }
+  invalidateListCache()
 
   const existingTokens = existing.tokens
   const tokens = {
@@ -248,6 +276,7 @@ export async function persistRotatedLiveCodexTokens(
   if ((live.tokens?.refresh_token ?? undefined) !== usedRefreshToken) {
     return 'skipped-race'
   }
+  invalidateListCache()
 
   const existingTokens = live.tokens
   const tokens = {
@@ -277,6 +306,7 @@ export async function persistRotatedLiveCodexTokens(
 
 /** Port of ccswitch `switch_to`: makes `accountKey` the live active Codex account. */
 export async function switchCodexAccount(accountKey: string): Promise<void> {
+  invalidateListCache()
   const registry = await readRegistry()
   const live = await readCodexLive()
 
@@ -310,6 +340,7 @@ export async function addCodexAccount(
   if (!claims.userId || !claims.accountId) {
     throw new Error('Codex id_token is missing chatgpt_user_id or chatgpt_account_id')
   }
+  invalidateListCache()
   const accountKey = `${claims.userId}::${claims.accountId}`
   const email = claims.email ?? ''
 
@@ -364,6 +395,7 @@ export async function addCodexAccount(
 
 /** Remove a managed account. Never touches auth.json. */
 export async function removeCodexAccount(accountKey: string): Promise<void> {
+  invalidateListCache()
   try {
     await unlink(snapshotPath(accountKey))
   } catch (error) {

--- a/src/main/services/account-store-codex.ts
+++ b/src/main/services/account-store-codex.ts
@@ -1,0 +1,291 @@
+/**
+ * Codex (ChatGPT) account store — TypeScript port of ccswitch's
+ * `src/store/codex.rs`. Source of truth for managed Codex account identities
+ * and credentials. Interoperates on-disk with the `ccswitch` CLI tool and the
+ * Codex CLI, so the file shapes here must match them exactly:
+ *
+ * - Managed index:   ${CODEX_HOME}/accounts/registry.json  (schema_version 3)
+ * - Per-account snap: ${CODEX_HOME}/accounts/<base64(account_key)>.auth.json
+ * - Live active:      ${CODEX_HOME}/auth.json
+ */
+import { unlink } from 'fs/promises'
+import { existsSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import { atomicWriteJson, readJsonFile } from './atomic-json'
+import { jwtExpMs, parseCodexIdToken } from './jwt-utils'
+import { createLogger } from './logger'
+import type { CodexAuth } from './openai-usage-service'
+
+export type { CodexAuth }
+
+const log = createLogger({ component: 'AccountStoreCodex' })
+
+export interface CodexStoreAccount {
+  accountKey: string
+  email: string
+  plan: string | null
+  expiresAtMs: number | null
+  hasRefresh: boolean
+  active: boolean
+}
+
+interface CodexRegistryAccountEntry {
+  account_key: string
+  chatgpt_account_id: string
+  chatgpt_user_id: string
+  email: string
+  alias: string
+  account_name: string | null
+  plan: string | null
+  auth_mode: string
+  created_at: number
+  last_used_at: number | null
+}
+
+interface CodexRegistry {
+  schema_version: number
+  active_account_key: string | null
+  active_account_activated_at_ms?: number
+  accounts: CodexRegistryAccountEntry[]
+}
+
+/** Same resolution as `openai-usage-service.ts`: env var first, else `~/.codex`. */
+function codexHome(): string {
+  return process.env.CODEX_HOME || join(homedir(), '.codex')
+}
+
+function accountsDir(): string {
+  return join(codexHome(), 'accounts')
+}
+
+function registryPath(): string {
+  return join(accountsDir(), 'registry.json')
+}
+
+function liveAuthPath(): string {
+  return join(codexHome(), 'auth.json')
+}
+
+/** Standard base64 (`+`/`/` alphabet) of the account key, trailing `=` padding trimmed. */
+export function snapshotName(accountKey: string): string {
+  return Buffer.from(accountKey, 'utf-8').toString('base64').replace(/=+$/, '')
+}
+
+function snapshotPath(accountKey: string): string {
+  return join(accountsDir(), `${snapshotName(accountKey)}.auth.json`)
+}
+
+function emptyRegistry(): CodexRegistry {
+  return { schema_version: 3, active_account_key: null, accounts: [] }
+}
+
+/**
+ * Read registry.json. Missing file => empty registry. A file that exists but
+ * fails to parse throws (never silently treat a corrupt registry as empty
+ * and then overwrite it).
+ */
+async function readRegistry(): Promise<CodexRegistry> {
+  const path = registryPath()
+  if (!existsSync(path)) return emptyRegistry()
+
+  const data = await readJsonFile<Partial<CodexRegistry>>(path)
+  if (data === null) {
+    throw new Error(`${path}: invalid JSON`)
+  }
+
+  return {
+    schema_version: typeof data.schema_version === 'number' ? data.schema_version : 3,
+    active_account_key: typeof data.active_account_key === 'string' ? data.active_account_key : null,
+    active_account_activated_at_ms:
+      typeof data.active_account_activated_at_ms === 'number'
+        ? data.active_account_activated_at_ms
+        : undefined,
+    accounts: Array.isArray(data.accounts) ? data.accounts : []
+  }
+}
+
+async function writeRegistry(registry: CodexRegistry): Promise<void> {
+  await atomicWriteJson(registryPath(), registry, { pretty: true })
+}
+
+/** Derive `<chatgpt_user_id>::<chatgpt_account_id>` from an auth blob's id_token, if possible. */
+function deriveAccountKey(auth: CodexAuth | null): string | null {
+  const idToken = auth?.tokens?.id_token
+  if (typeof idToken !== 'string' || idToken.length === 0) return null
+  const claims = parseCodexIdToken(idToken)
+  if (!claims.userId || !claims.accountId) return null
+  return `${claims.userId}::${claims.accountId}`
+}
+
+export async function readCodexSnapshot(accountKey: string): Promise<CodexAuth | null> {
+  return readJsonFile<CodexAuth>(snapshotPath(accountKey))
+}
+
+export async function readCodexLive(): Promise<CodexAuth | null> {
+  return readJsonFile<CodexAuth>(liveAuthPath())
+}
+
+/** List all managed Codex accounts. */
+export async function listCodexAccounts(): Promise<CodexStoreAccount[]> {
+  const registry = await readRegistry()
+  const live = await readCodexLive()
+  const derivedLiveKey = deriveAccountKey(live)
+  const liveAccountKey = derivedLiveKey ?? registry.active_account_key
+
+  const out: CodexStoreAccount[] = []
+  for (const entry of registry.accounts) {
+    const accountKey = entry.account_key
+    if (!accountKey) continue
+
+    const active = accountKey === liveAccountKey
+    const snapshot = active && live ? live : await readCodexSnapshot(accountKey)
+    const accessToken = snapshot?.tokens?.access_token
+    const refreshToken = snapshot?.tokens?.refresh_token
+
+    out.push({
+      accountKey,
+      email: (entry.email ?? '').toLowerCase(),
+      plan: entry.plan ?? null,
+      expiresAtMs: typeof accessToken === 'string' ? jwtExpMs(accessToken) : null,
+      hasRefresh: typeof refreshToken === 'string' && refreshToken.length > 0,
+      active
+    })
+  }
+  return out
+}
+
+/**
+ * Patch rotated tokens into a snapshot (access always; refresh/id only when
+ * provided), and mirror the full patched snapshot to live auth.json when
+ * this account is the registry's active account.
+ */
+export async function updateCodexTokens(
+  accountKey: string,
+  rotated: { accessToken: string; refreshToken?: string; idToken?: string }
+): Promise<void> {
+  const existing = await readCodexSnapshot(accountKey)
+  if (!existing) {
+    throw new Error(`No Codex snapshot for account ${accountKey}`)
+  }
+
+  const existingTokens = existing.tokens
+  const tokens = {
+    id_token: existingTokens?.id_token,
+    access_token: existingTokens?.access_token ?? '',
+    refresh_token: existingTokens?.refresh_token ?? '',
+    account_id: existingTokens?.account_id ?? ''
+  }
+  tokens.access_token = rotated.accessToken
+  if (rotated.refreshToken !== undefined) tokens.refresh_token = rotated.refreshToken
+  if (rotated.idToken !== undefined) tokens.id_token = rotated.idToken
+
+  const patched: CodexAuth = { ...existing, tokens, last_refresh: new Date().toISOString() }
+  await atomicWriteJson(snapshotPath(accountKey), patched, { pretty: true })
+
+  const registry = await readRegistry()
+  if (registry.active_account_key === accountKey) {
+    await atomicWriteJson(liveAuthPath(), patched, { pretty: true })
+  }
+}
+
+/** Port of ccswitch `switch_to`: makes `accountKey` the live active Codex account. */
+export async function switchCodexAccount(accountKey: string): Promise<void> {
+  const registry = await readRegistry()
+  const live = await readCodexLive()
+
+  // 1) Preserve the outgoing account's live auth.json (which the Codex CLI
+  //    may have refreshed in place) into its own snapshot before overwriting.
+  const outgoingKey = deriveAccountKey(live)
+  if (outgoingKey !== null && outgoingKey !== accountKey && live !== null) {
+    await atomicWriteJson(snapshotPath(outgoingKey), live, { pretty: true })
+  }
+
+  // 2) Copy the target snapshot over live auth.json.
+  const target = await readCodexSnapshot(accountKey)
+  if (!target) {
+    throw new Error(`No Codex snapshot for account ${accountKey}`)
+  }
+  await atomicWriteJson(liveAuthPath(), target, { pretty: true })
+
+  // 3) Update the registry's active account.
+  registry.active_account_key = accountKey
+  registry.active_account_activated_at_ms = Date.now()
+  await writeRegistry(registry)
+}
+
+/** Register a new (or re-registered) Codex account from an interactive login. */
+export async function addCodexAccount(
+  idToken: string,
+  accessToken: string,
+  refreshToken: string
+): Promise<{ accountKey: string; email: string }> {
+  const claims = parseCodexIdToken(idToken)
+  if (!claims.userId || !claims.accountId) {
+    throw new Error('Codex id_token is missing chatgpt_user_id or chatgpt_account_id')
+  }
+  const accountKey = `${claims.userId}::${claims.accountId}`
+  const email = claims.email ?? ''
+
+  const auth: CodexAuth = {
+    OPENAI_API_KEY: null,
+    auth_mode: 'chatgpt',
+    tokens: {
+      id_token: idToken,
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      account_id: claims.accountId
+    },
+    last_refresh: new Date().toISOString()
+  }
+  await atomicWriteJson(snapshotPath(accountKey), auth, { pretty: true })
+
+  const registry = await readRegistry()
+  const existingIndex = registry.accounts.findIndex((a) => a.account_key === accountKey)
+  if (existingIndex >= 0) {
+    const existing = registry.accounts[existingIndex]
+    registry.accounts[existingIndex] = {
+      ...existing,
+      email,
+      plan: claims.plan ?? existing.plan ?? null
+    }
+  } else {
+    registry.accounts.push({
+      account_key: accountKey,
+      chatgpt_account_id: claims.accountId,
+      chatgpt_user_id: claims.userId,
+      email,
+      alias: '',
+      account_name: null,
+      plan: claims.plan ?? null,
+      auth_mode: 'chatgpt',
+      created_at: Date.now(),
+      last_used_at: null
+    })
+  }
+  await writeRegistry(registry)
+
+  return { accountKey, email }
+}
+
+/** Remove a managed account. Never touches auth.json. */
+export async function removeCodexAccount(accountKey: string): Promise<void> {
+  try {
+    await unlink(snapshotPath(accountKey))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      log.warn('Failed to delete Codex account snapshot', {
+        accountKey,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      throw error
+    }
+  }
+
+  const registry = await readRegistry()
+  registry.accounts = registry.accounts.filter((a) => a.account_key !== accountKey)
+  if (registry.active_account_key === accountKey) {
+    registry.active_account_key = null
+  }
+  await writeRegistry(registry)
+}

--- a/src/main/services/account-store-codex.ts
+++ b/src/main/services/account-store-codex.ts
@@ -213,6 +213,53 @@ export async function updateCodexTokens(
   }
 }
 
+/**
+ * Persist rotated tokens for the LIVE Codex credentials (`auth.json`, the
+ * file the Codex CLI itself reads/writes) after a Hive-initiated refresh.
+ *
+ * Guards against a race with the Codex CLI rotating the very same refresh
+ * token concurrently: re-reads live auth.json and only writes when its
+ * current refresh token still matches the one Hive used to obtain
+ * `rotated` — otherwise some other process already moved the live
+ * credentials forward, and writing here would clobber that newer rotation.
+ */
+export async function persistRotatedLiveCodexTokens(
+  rotated: { accessToken: string; refreshToken?: string; idToken?: string },
+  usedRefreshToken: string
+): Promise<'persisted' | 'skipped-race' | 'no-live'> {
+  const live = await readCodexLive()
+  if (!live) return 'no-live'
+
+  if ((live.tokens?.refresh_token ?? undefined) !== usedRefreshToken) {
+    return 'skipped-race'
+  }
+
+  const existingTokens = live.tokens
+  const tokens = {
+    id_token: existingTokens?.id_token,
+    access_token: existingTokens?.access_token ?? '',
+    refresh_token: existingTokens?.refresh_token ?? '',
+    account_id: existingTokens?.account_id ?? ''
+  }
+  tokens.access_token = rotated.accessToken
+  if (rotated.refreshToken !== undefined) tokens.refresh_token = rotated.refreshToken
+  if (rotated.idToken !== undefined) tokens.id_token = rotated.idToken
+
+  const patched: CodexAuth = { ...live, tokens, last_refresh: new Date().toISOString() }
+  await atomicWriteJson(liveAuthPath(), patched, { pretty: true })
+
+  // Mirror to the managed account's snapshot, if the live account_key is
+  // registered (same "keep the snapshot fresh" pattern as
+  // updateCodexTokens/switchCodexAccount).
+  const registry = await readRegistry()
+  const liveKey = deriveAccountKey(patched) ?? registry.active_account_key
+  if (liveKey !== null && registry.accounts.some((entry) => entry.account_key === liveKey)) {
+    await atomicWriteJson(snapshotPath(liveKey), patched, { pretty: true })
+  }
+
+  return 'persisted'
+}
+
 /** Port of ccswitch `switch_to`: makes `accountKey` the live active Codex account. */
 export async function switchCodexAccount(accountKey: string): Promise<void> {
   const registry = await readRegistry()

--- a/src/main/services/account-store-codex.ts
+++ b/src/main/services/account-store-codex.ts
@@ -41,6 +41,13 @@ interface CodexRegistryAccountEntry {
   auth_mode: string
   created_at: number
   last_used_at: number | null
+  /**
+   * ccswitch also carries `last_usage`, `last_usage_at`, `last_local_rollout`
+   * and possibly other fields we don't interpret. The index signature lets us
+   * round-trip them untouched (mirrors Rust mutating a raw serde_json::Value
+   * in place instead of reconstructing a typed struct).
+   */
+  [key: string]: unknown
 }
 
 interface CodexRegistry {
@@ -48,6 +55,12 @@ interface CodexRegistry {
   active_account_key: string | null
   active_account_activated_at_ms?: number
   accounts: CodexRegistryAccountEntry[]
+  /**
+   * ccswitch also carries top-level `api`/`auto_switch` settings (and
+   * possibly other fields) we don't interpret. The index signature lets us
+   * round-trip them untouched.
+   */
+  [key: string]: unknown
 }
 
 /** Same resolution as `openai-usage-service.ts`: env var first, else `~/.codex`. */
@@ -84,24 +97,33 @@ function emptyRegistry(): CodexRegistry {
  * Read registry.json. Missing file => empty registry. A file that exists but
  * fails to parse throws (never silently treat a corrupt registry as empty
  * and then overwrite it).
+ *
+ * The Rust implementation reads the registry as a raw `serde_json::Value` and
+ * mutates it in place, so unknown top-level keys (e.g. ccswitch's `api` /
+ * `auto_switch` settings) and unknown entry-level keys (e.g. `last_usage`)
+ * always round-trip untouched. To match that, we start from the raw parsed
+ * object (preserving every field, known or not) and only overlay the
+ * normalized/typed fields on top — never reconstruct the object from a
+ * fixed field list.
  */
 async function readRegistry(): Promise<CodexRegistry> {
   const path = registryPath()
   if (!existsSync(path)) return emptyRegistry()
 
-  const data = await readJsonFile<Partial<CodexRegistry>>(path)
+  const data = await readJsonFile<Record<string, unknown>>(path)
   if (data === null) {
     throw new Error(`${path}: invalid JSON`)
   }
 
   return {
+    ...data,
     schema_version: typeof data.schema_version === 'number' ? data.schema_version : 3,
     active_account_key: typeof data.active_account_key === 'string' ? data.active_account_key : null,
     active_account_activated_at_ms:
       typeof data.active_account_activated_at_ms === 'number'
         ? data.active_account_activated_at_ms
         : undefined,
-    accounts: Array.isArray(data.accounts) ? data.accounts : []
+    accounts: Array.isArray(data.accounts) ? (data.accounts as CodexRegistryAccountEntry[]) : []
   }
 }
 
@@ -146,7 +168,9 @@ export async function listCodexAccounts(): Promise<CodexStoreAccount[]> {
     out.push({
       accountKey,
       email: (entry.email ?? '').toLowerCase(),
-      plan: entry.plan ?? null,
+      // The file keeps `plan: ""` (ccswitch's unwrap_or_default) when the
+      // id_token has no plan claim; the DTO surfaces that as null instead.
+      plan: entry.plan ? entry.plan : null,
       expiresAtMs: typeof accessToken === 'string' ? jwtExpMs(accessToken) : null,
       hasRefresh: typeof refreshToken === 'string' && refreshToken.length > 0,
       active
@@ -243,11 +267,14 @@ export async function addCodexAccount(
   const registry = await readRegistry()
   const existingIndex = registry.accounts.findIndex((a) => a.account_key === accountKey)
   if (existingIndex >= 0) {
+    // Rust (codex.rs:246-253) patches only `email`, and `plan` only when the
+    // id_token claim is present — otherwise the existing value (and every
+    // other entry-level field, known or not) is left untouched.
     const existing = registry.accounts[existingIndex]
     registry.accounts[existingIndex] = {
       ...existing,
       email,
-      plan: claims.plan ?? existing.plan ?? null
+      ...(claims.plan !== null ? { plan: claims.plan } : {})
     }
   } else {
     registry.accounts.push({
@@ -257,10 +284,15 @@ export async function addCodexAccount(
       email,
       alias: '',
       account_name: null,
-      plan: claims.plan ?? null,
+      // Rust: `claims.plan.clone().unwrap_or_default()` — empty string, not null.
+      plan: claims.plan ?? '',
       auth_mode: 'chatgpt',
-      created_at: Date.now(),
-      last_used_at: null
+      // Rust: `chrono::Utc::now().timestamp()` — seconds, not milliseconds.
+      created_at: Math.floor(Date.now() / 1000),
+      last_used_at: null,
+      last_usage: null,
+      last_usage_at: null,
+      last_local_rollout: null
     })
   }
   await writeRegistry(registry)

--- a/src/main/services/atomic-json.ts
+++ b/src/main/services/atomic-json.ts
@@ -1,4 +1,4 @@
-import { mkdir, chmod, rename, readFile, writeFile } from 'fs/promises'
+import { mkdir, chmod, rename, readFile, unlink, writeFile } from 'fs/promises'
 import { dirname } from 'path'
 
 /**
@@ -18,9 +18,21 @@ export async function atomicWriteJson(
   await mkdir(dirname(path), { recursive: true })
 
   const tmpPath = `${path}.tmp.hive`
-  await writeFile(tmpPath, serialized, 'utf-8')
-  await chmod(tmpPath, opts?.mode ?? 0o600)
-  await rename(tmpPath, path)
+  const mode = opts?.mode ?? 0o600
+  try {
+    // Create the tmp file with the restrictive mode from the start — passing it
+    // to writeFile avoids the brief 0644 window that a create-then-chmod would
+    // open on a secrets file. The explicit chmod stays for exactness (writeFile
+    // honors the process umask, which could clear bits the caller asked for).
+    await writeFile(tmpPath, serialized, { encoding: 'utf-8', mode })
+    await chmod(tmpPath, mode)
+    await rename(tmpPath, path)
+  } catch (error) {
+    // Best-effort: don't leave a (potentially world-readable) partial secrets
+    // file behind if the chmod/rename failed.
+    await unlink(tmpPath).catch(() => {})
+    throw error
+  }
 }
 
 /**

--- a/src/main/services/atomic-json.ts
+++ b/src/main/services/atomic-json.ts
@@ -1,0 +1,37 @@
+import { mkdir, chmod, rename, readFile, writeFile } from 'fs/promises'
+import { dirname } from 'path'
+
+/**
+ * Write JSON to disk atomically: serialize, validate, write to a sibling
+ * `.tmp.hive` file, chmod it, then rename over the destination. The rename
+ * is atomic on POSIX filesystems, so readers never observe a partial write.
+ * Creates the parent directory (recursively) if it doesn't exist yet.
+ */
+export async function atomicWriteJson(
+  path: string,
+  value: unknown,
+  opts?: { mode?: number; pretty?: boolean }
+): Promise<void> {
+  const serialized = opts?.pretty ? JSON.stringify(value, null, 2) : JSON.stringify(value)
+  JSON.parse(serialized)
+
+  await mkdir(dirname(path), { recursive: true })
+
+  const tmpPath = `${path}.tmp.hive`
+  await writeFile(tmpPath, serialized, 'utf-8')
+  await chmod(tmpPath, opts?.mode ?? 0o600)
+  await rename(tmpPath, path)
+}
+
+/**
+ * Read and parse a JSON file. Returns null when the file is missing or its
+ * contents fail to parse.
+ */
+export async function readJsonFile<T>(path: string): Promise<T | null> {
+  try {
+    const raw = await readFile(path, 'utf-8')
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}

--- a/src/main/services/credentials-migration.ts
+++ b/src/main/services/credentials-migration.ts
@@ -36,17 +36,33 @@ interface StoredOpenAICredentials {
   email: string
 }
 
-async function migrateAnthropicRow(row: SavedUsageAccount): Promise<void> {
-  const parsed = JSON.parse(row.credentials_json) as Partial<StoredAnthropicCredentials>
+/**
+ * Per-row migration outcome. `migrated` and `skipped` (already-managed, or
+ * structurally unusable — no email / no idToken / unparseable blob) both mean
+ * "safe to blank this row's credentials". A THROW means a transient failure
+ * (e.g. a Keychain ACL denial) — the caller must leave the row's credentials
+ * intact and not mark the migration done, so the next boot retries.
+ */
+type RowOutcome = 'migrated' | 'skipped'
+
+async function migrateAnthropicRow(row: SavedUsageAccount): Promise<RowOutcome> {
+  let parsed: Partial<StoredAnthropicCredentials>
+  try {
+    parsed = JSON.parse(row.credentials_json) as Partial<StoredAnthropicCredentials>
+  } catch {
+    log.warn('Skipping saved Anthropic row with unparseable credentials_json', { id: row.id })
+    return 'skipped'
+  }
+
   const email = parsed.email
   if (!email) {
     log.warn('Skipping saved Anthropic row without an email', { id: row.id })
-    return
+    return 'skipped'
   }
 
   const managed = await listClaudeAccounts()
   if (managed.some((account) => account.email === email.toLowerCase())) {
-    return
+    return 'skipped'
   }
 
   const blobJson = JSON.stringify({
@@ -57,14 +73,24 @@ async function migrateAnthropicRow(row: SavedUsageAccount): Promise<void> {
       scopes: []
     }
   })
+  // A throw here (transient Keychain failure) propagates so the row is NOT
+  // blanked and the migration is retried on the next boot.
   await addClaudeAccount(email, '', blobJson)
+  return 'migrated'
 }
 
-async function migrateOpenAIRow(row: SavedUsageAccount): Promise<void> {
-  const parsed = JSON.parse(row.credentials_json) as Partial<StoredOpenAICredentials>
+async function migrateOpenAIRow(row: SavedUsageAccount): Promise<RowOutcome> {
+  let parsed: Partial<StoredOpenAICredentials>
+  try {
+    parsed = JSON.parse(row.credentials_json) as Partial<StoredOpenAICredentials>
+  } catch {
+    log.warn('Skipping saved OpenAI row with unparseable credentials_json', { id: row.id })
+    return 'skipped'
+  }
+
   if (!parsed.idToken) {
     log.warn('Skipping saved OpenAI row without an idToken', { id: row.id })
-    return
+    return 'skipped'
   }
 
   const claims = parseCodexIdToken(parsed.idToken)
@@ -72,22 +98,26 @@ async function migrateOpenAIRow(row: SavedUsageAccount): Promise<void> {
     log.warn('Skipping saved OpenAI row: id_token has no chatgpt_user_id/chatgpt_account_id', {
       id: row.id
     })
-    return
+    return 'skipped'
   }
 
   const accountKey = `${claims.userId}::${claims.accountId}`
   const managed = await listCodexAccounts()
   if (managed.some((account) => account.accountKey === accountKey)) {
-    return
+    return 'skipped'
   }
 
   await addCodexAccount(parsed.idToken, parsed.accessToken ?? '', parsed.refreshToken ?? '')
+  return 'migrated'
 }
 
 /**
  * Migrate every `saved_usage_accounts` row's credentials into the account
- * stores, then blank `credentials_json` for all rows. Idempotent: no-ops
- * immediately once the `saved_usage_credentials_migrated` setting is set.
+ * stores, blanking each row's `credentials_json` ONLY once it has been safely
+ * migrated (or deliberately skipped). Idempotent: no-ops immediately once the
+ * `saved_usage_credentials_migrated` setting is set. If any row hit a transient
+ * error, the setting is left unset so the next boot retries (store adds are
+ * idempotent, so already-migrated rows just skip).
  */
 export async function migrateSavedCredentialsToStores(): Promise<void> {
   const db = getDatabase()
@@ -96,30 +126,36 @@ export async function migrateSavedCredentialsToStores(): Promise<void> {
   const anthropicRows = db.getSavedUsageAccountsByProvider('anthropic')
   const openaiRows = db.getSavedUsageAccountsByProvider('openai')
 
-  for (const row of anthropicRows) {
-    if (!row.credentials_json) continue
-    try {
-      await migrateAnthropicRow(row)
-    } catch (error) {
-      log.warn('Failed to migrate saved Anthropic credentials', {
-        id: row.id,
-        error: error instanceof Error ? error.message : String(error)
-      })
+  let hadTransientError = false
+
+  const migrateRows = async (
+    rows: SavedUsageAccount[],
+    migrateRow: (row: SavedUsageAccount) => Promise<RowOutcome>
+  ): Promise<void> => {
+    for (const row of rows) {
+      if (!row.credentials_json) continue
+      try {
+        await migrateRow(row)
+        // Only blank a row we handled without throwing — a transient failure
+        // must NOT destroy the row's only surviving credentials.
+        db.clearSavedUsageAccountCredentialsById(row.id)
+      } catch (error) {
+        hadTransientError = true
+        log.warn('Failed to migrate saved credentials; leaving row intact for a retry', {
+          id: row.id,
+          provider: row.provider,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
     }
   }
 
-  for (const row of openaiRows) {
-    if (!row.credentials_json) continue
-    try {
-      await migrateOpenAIRow(row)
-    } catch (error) {
-      log.warn('Failed to migrate saved OpenAI credentials', {
-        id: row.id,
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-  }
+  await migrateRows(anthropicRows, migrateAnthropicRow)
+  await migrateRows(openaiRows, migrateOpenAIRow)
 
-  db.clearSavedUsageAccountCredentials()
-  db.setSetting(MIGRATION_SETTING_KEY, new Date().toISOString())
+  // Only mark the one-shot migration done when every row was fully handled;
+  // otherwise the next boot retries the rows still carrying credentials.
+  if (!hadTransientError) {
+    db.setSetting(MIGRATION_SETTING_KEY, new Date().toISOString())
+  }
 }

--- a/src/main/services/credentials-migration.ts
+++ b/src/main/services/credentials-migration.ts
@@ -1,0 +1,125 @@
+/**
+ * One-time migration of legacy `saved_usage_accounts.credentials_json` rows
+ * (SQLite-stored Anthropic/OpenAI tokens) into the ccswitch-compatible
+ * account stores (Keychain + ~/.claude-switch-backup / ~/.codex/accounts).
+ *
+ * After migration, `saved_usage_accounts` becomes a usage *cache* — this
+ * module blanks its `credentials_json` column so it stops being read as a
+ * credentials source elsewhere.
+ *
+ * This module is intentionally NOT wired into server boot yet; a later
+ * phase calls `migrateSavedCredentialsToStores()` during startup.
+ */
+import { getDatabase } from '../db'
+import type { SavedUsageAccount } from '../db/types'
+import { addClaudeAccount, listClaudeAccounts } from './account-store-claude'
+import { addCodexAccount, listCodexAccounts } from './account-store-codex'
+import { parseCodexIdToken } from './jwt-utils'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'CredentialsMigration' })
+
+const MIGRATION_SETTING_KEY = 'saved_usage_credentials_migrated'
+
+interface StoredAnthropicCredentials {
+  accessToken: string
+  refreshToken: string
+  expiresAt: number
+  email: string
+}
+
+interface StoredOpenAICredentials {
+  accessToken: string
+  refreshToken: string
+  accountId: string
+  idToken: string
+  email: string
+}
+
+async function migrateAnthropicRow(row: SavedUsageAccount): Promise<void> {
+  const parsed = JSON.parse(row.credentials_json) as Partial<StoredAnthropicCredentials>
+  const email = parsed.email
+  if (!email) {
+    log.warn('Skipping saved Anthropic row without an email', { id: row.id })
+    return
+  }
+
+  const managed = await listClaudeAccounts()
+  if (managed.some((account) => account.email === email.toLowerCase())) {
+    return
+  }
+
+  const blobJson = JSON.stringify({
+    claudeAiOauth: {
+      accessToken: parsed.accessToken,
+      refreshToken: parsed.refreshToken,
+      expiresAt: parsed.expiresAt,
+      scopes: []
+    }
+  })
+  await addClaudeAccount(email, '', blobJson)
+}
+
+async function migrateOpenAIRow(row: SavedUsageAccount): Promise<void> {
+  const parsed = JSON.parse(row.credentials_json) as Partial<StoredOpenAICredentials>
+  if (!parsed.idToken) {
+    log.warn('Skipping saved OpenAI row without an idToken', { id: row.id })
+    return
+  }
+
+  const claims = parseCodexIdToken(parsed.idToken)
+  if (!claims.userId || !claims.accountId) {
+    log.warn('Skipping saved OpenAI row: id_token has no chatgpt_user_id/chatgpt_account_id', {
+      id: row.id
+    })
+    return
+  }
+
+  const accountKey = `${claims.userId}::${claims.accountId}`
+  const managed = await listCodexAccounts()
+  if (managed.some((account) => account.accountKey === accountKey)) {
+    return
+  }
+
+  await addCodexAccount(parsed.idToken, parsed.accessToken ?? '', parsed.refreshToken ?? '')
+}
+
+/**
+ * Migrate every `saved_usage_accounts` row's credentials into the account
+ * stores, then blank `credentials_json` for all rows. Idempotent: no-ops
+ * immediately once the `saved_usage_credentials_migrated` setting is set.
+ */
+export async function migrateSavedCredentialsToStores(): Promise<void> {
+  const db = getDatabase()
+  if (db.getSetting(MIGRATION_SETTING_KEY)) return
+
+  const anthropicRows = db.getSavedUsageAccountsByProvider('anthropic')
+  const openaiRows = db.getSavedUsageAccountsByProvider('openai')
+
+  for (const row of anthropicRows) {
+    if (!row.credentials_json) continue
+    try {
+      await migrateAnthropicRow(row)
+    } catch (error) {
+      log.warn('Failed to migrate saved Anthropic credentials', {
+        id: row.id,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  for (const row of openaiRows) {
+    if (!row.credentials_json) continue
+    try {
+      await migrateOpenAIRow(row)
+    } catch (error) {
+      log.warn('Failed to migrate saved OpenAI credentials', {
+        id: row.id,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  db.clearSavedUsageAccountCredentials()
+  db.setSetting(MIGRATION_SETTING_KEY, new Date().toISOString())
+}

--- a/src/main/services/jwt-utils.ts
+++ b/src/main/services/jwt-utils.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared JWT helpers. Decodes the payload segment only — there is no
+ * signature verification, so these must never be used to authorize anything;
+ * they exist purely to read claims out of tokens we already trust (because we
+ * obtained them ourselves via OAuth or read them from local credential
+ * storage).
+ */
+
+const OPENAI_AUTH_CLAIM = 'https://api.openai.com/auth'
+
+/**
+ * Decode the payload (middle segment) of a JWT. Returns null on any failure
+ * (malformed token, invalid base64, invalid JSON).
+ */
+export function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split('.')
+    if (parts.length !== 3) return null
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+    const json = Buffer.from(padded, 'base64').toString('utf-8')
+    return JSON.parse(json)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Convert a JWT's `exp` claim (seconds since epoch) to milliseconds.
+ * Returns null when the claim is absent, non-numeric, or the token can't be
+ * decoded.
+ */
+export function jwtExpMs(token: string): number | null {
+  const payload = decodeJwtPayload(token)
+  const exp = payload?.exp
+  return typeof exp === 'number' && Number.isFinite(exp) ? exp * 1000 : null
+}
+
+export interface CodexIdTokenClaims {
+  email: string | null
+  accountId: string | null
+  userId: string | null
+  plan: string | null
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+/**
+ * Extract the account/user/plan claims Codex (ChatGPT) puts under the
+ * `https://api.openai.com/auth` custom claim of its id_token, plus the
+ * top-level `email` claim. Every field is null-safe: a malformed token or
+ * missing claim yields nulls rather than throwing.
+ */
+export function parseCodexIdToken(idToken: string): CodexIdTokenClaims {
+  const payload = decodeJwtPayload(idToken)
+  const email = asNonEmptyString(payload?.email)
+  const auth = asRecord(payload?.[OPENAI_AUTH_CLAIM])
+
+  let accountId = asNonEmptyString(auth?.chatgpt_account_id)
+  if (!accountId) {
+    const organizations = Array.isArray(auth?.organizations) ? auth.organizations : []
+    const orgRecords = organizations
+      .map((org) => asRecord(org))
+      .filter((org): org is Record<string, unknown> => org !== null)
+    const defaultOrg = orgRecords.find((org) => org.is_default === true)
+    const fallbackOrg = defaultOrg ?? orgRecords[0]
+    accountId = asNonEmptyString(fallbackOrg?.id)
+  }
+
+  const userId = asNonEmptyString(auth?.chatgpt_user_id) ?? asNonEmptyString(auth?.user_id)
+  const plan = asNonEmptyString(auth?.chatgpt_plan_type)
+
+  return { email, accountId, userId, plan }
+}

--- a/src/main/services/keychain.ts
+++ b/src/main/services/keychain.ts
@@ -1,0 +1,72 @@
+import { execFile } from 'child_process'
+import { platform, userInfo } from 'os'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'Keychain' })
+
+function isItemNotFoundError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /could not be found/i.test(message)
+}
+
+function runSecurity(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('security', args, { timeout: 5000 }, (error, stdout) => {
+      if (error) reject(error)
+      else resolve(stdout.trim())
+    })
+  })
+}
+
+/**
+ * Read a secret from the macOS Keychain's generic password store.
+ * Returns null when not on macOS, the item isn't found, or any other error
+ * occurs.
+ */
+export async function keychainRead(service: string): Promise<string | null> {
+  if (platform() !== 'darwin') return null
+  try {
+    const stdout = await runSecurity(['find-generic-password', '-s', service, '-w'])
+    return stdout || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Write (or overwrite) a secret in the macOS Keychain's generic password
+ * store. Throws on non-macOS platforms and when the underlying `security`
+ * CLI call fails.
+ */
+export async function keychainWrite(service: string, secret: string): Promise<void> {
+  if (platform() !== 'darwin') {
+    throw new Error('Keychain is only available on macOS')
+  }
+  const account = process.env.USER ?? userInfo().username
+  try {
+    await runSecurity(['add-generic-password', '-U', '-s', service, '-a', account, '-w', secret])
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log.warn('Keychain write failed', { service, error: message })
+    throw error
+  }
+}
+
+/**
+ * Delete a secret from the macOS Keychain's generic password store.
+ * Throws on non-macOS platforms. Deleting an item that doesn't exist is not
+ * treated as an error; other `security` CLI failures are re-thrown.
+ */
+export async function keychainDelete(service: string): Promise<void> {
+  if (platform() !== 'darwin') {
+    throw new Error('Keychain is only available on macOS')
+  }
+  try {
+    await runSecurity(['delete-generic-password', '-s', service])
+  } catch (error) {
+    if (isItemNotFoundError(error)) return
+    const message = error instanceof Error ? error.message : String(error)
+    log.warn('Keychain delete failed', { service, error: message })
+    throw error
+  }
+}

--- a/src/main/services/keychain.ts
+++ b/src/main/services/keychain.ts
@@ -20,10 +20,38 @@ function isItemNotFoundError(error: unknown): boolean {
 }
 
 function runSecurity(args: string[]): Promise<string> {
+  const subcommand = args[0] ?? 'security'
   return new Promise((resolve, reject) => {
-    execFile('security', args, { timeout: 5000 }, (error, stdout) => {
-      if (error) reject(error)
-      else resolve(stdout.trim())
+    // `-w <secret>` passes the secret as an argv element, so it is briefly
+    // visible in the process table. ccswitch does the same; this is an accepted
+    // tradeoff for Keychain-CLI parity (there is no stdin variant of
+    // `add-generic-password` that also does an in-place `-U` update).
+    //
+    // Critically, we MUST NOT surface execFile's raw ExecFileException: its
+    // `message` embeds the full command line — INCLUDING the `-w <secret>`
+    // credential. That message would otherwise propagate to log.warn, the
+    // saved_usage_accounts.last_error column, switchAccount error results, and
+    // renderer toasts. Reject instead with only the subcommand name, the exit
+    // code, and security's stderr (which never echoes `-w` values).
+    execFile('security', args, { timeout: 5000 }, (error, stdout, stderr) => {
+      if (error) {
+        const rawCode = (error as ExecFileException).code
+        const trimmedStderr = typeof stderr === 'string' ? stderr.trim() : ''
+        const notFound = isItemNotFoundError(error) || /could not be found/i.test(trimmedStderr)
+
+        const parts = [`security ${subcommand} failed`]
+        if (rawCode !== undefined) parts.push(`(exit ${rawCode})`)
+        if (trimmedStderr) parts.push(`- ${trimmedStderr}`)
+
+        const sanitized = new Error(parts.join(' ')) as Error & { code?: number | string }
+        // Preserve not-found detection: attach the exit code so the code-44
+        // check in isItemNotFoundError still fires on the sanitized error.
+        const resolvedCode = rawCode ?? (notFound ? ERR_SEC_ITEM_NOT_FOUND_CODE : undefined)
+        if (resolvedCode !== undefined) sanitized.code = resolvedCode
+        reject(sanitized)
+      } else {
+        resolve(stdout.trim())
+      }
     })
   })
 }

--- a/src/main/services/keychain.ts
+++ b/src/main/services/keychain.ts
@@ -1,10 +1,20 @@
-import { execFile } from 'child_process'
+import { execFile, type ExecFileException } from 'child_process'
 import { platform, userInfo } from 'os'
 import { createLogger } from './logger'
 
 const log = createLogger({ component: 'Keychain' })
 
+/**
+ * `security`'s documented exit code for errSecItemNotFound. Preferred over
+ * the message regex below, which is fragile to macOS wording drift across
+ * OS versions/locales.
+ */
+const ERR_SEC_ITEM_NOT_FOUND_CODE = 44
+
 function isItemNotFoundError(error: unknown): boolean {
+  const code = (error as ExecFileException | undefined)?.code
+  if (code === ERR_SEC_ITEM_NOT_FOUND_CODE) return true
+
   const message = error instanceof Error ? error.message : String(error)
   return /could not be found/i.test(message)
 }

--- a/src/main/services/login-service.ts
+++ b/src/main/services/login-service.ts
@@ -1,0 +1,476 @@
+/**
+ * Interactive OAuth login: launches a real Chrome instance (via patchright, a
+ * stealth-patched Playwright) with a persistent per-account profile, navigates
+ * to the provider's authorize URL, captures the resulting `code`/`state` from
+ * the redirect, exchanges it for tokens, and stores the account. TypeScript
+ * port of ccswitch's manual-login path (`login-sidecar/login.mjs` capture
+ * mechanics + `src/login.rs` orchestration) — no email autofill, no OTP
+ * control channel.
+ *
+ * Runs in-process (in the spawned server process) rather than as a sidecar.
+ * `patchright` is loaded via dynamic `import()` inside `loginStart` so that
+ * no other code path — and never the desktop-main bundle — pays for it.
+ *
+ * State machine (module-scope, one login at a time):
+ *   launching -> waiting -> exchanging -> done
+ *                        \-> failed
+ *   (any non-terminal state) -> cancelled
+ *
+ * Terminal sessions (`done`/`failed`/`cancelled`) are retained until the next
+ * `loginStart` (which replaces `currentSession`) or 5 minutes, whichever comes
+ * first, so a renderer's final status poll always lands.
+ */
+import { randomUUID } from 'crypto'
+import { mkdir } from 'fs/promises'
+import { homedir } from 'os'
+import { join } from 'path'
+import { getDatabase } from '../db'
+import { addClaudeAccount } from './account-store-claude'
+import { addCodexAccount } from './account-store-codex'
+import { createLogger } from './logger'
+import { buildAnthropicAuthorizeUrl, exchangeAnthropicCode } from './oauth-anthropic'
+import { buildOpenAIAuthorizeUrl, exchangeOpenAICode } from './oauth-openai'
+import { generatePkce, type Pkce } from './oauth-pkce'
+import { fetchForSavedAccount, listSavedAccounts } from './saved-usage-orchestrator'
+import type { LoginState, LoginStatusDTO, UsageProvider } from '@shared/types/usage'
+import type { SavedUsageProvider } from '../db/types'
+
+const log = createLogger({ component: 'LoginService' })
+
+const GC_DELAY_MS = 5 * 60 * 1000
+const LOGIN_TIMEOUT_MS = 30 * 60 * 1000
+const CLOSE_DELAY_MS = 1500
+
+// ─── Minimal browser-driver surface ──────────────────────────────────────
+//
+// Deliberately NOT patchright's real (huge) BrowserContext/Page types — just
+// the handful of members the login flow touches, so the fake driver used in
+// tests stays small and the real implementation is a thin adapter over it.
+
+export interface RouteRequestLike {
+  url: () => string
+}
+
+export interface RouteLike {
+  request: () => RouteRequestLike
+  fulfill: (options: { status: number; contentType: string; body: string }) => Promise<void>
+  continue: () => Promise<void>
+}
+
+export interface FrameLike {
+  url: () => string
+}
+
+export interface PageLike {
+  goto: (url: string) => Promise<unknown>
+  on: (event: 'framenavigated', handler: (frame: FrameLike) => void) => void
+  mainFrame: () => FrameLike
+}
+
+export interface BrowserContextLike {
+  pages: () => PageLike[]
+  newPage: () => Promise<PageLike>
+  route: (glob: string, handler: (route: RouteLike) => void | Promise<void>) => Promise<void>
+  on: (event: 'close', handler: () => void) => void
+  close: () => Promise<void>
+}
+
+export interface LaunchOptions {
+  channel: 'chrome'
+  headless: false
+  viewport: null
+  args: string[]
+}
+
+export type LoginBrowserLauncher = (
+  profileDir: string,
+  options: LaunchOptions
+) => Promise<BrowserContextLike>
+
+async function defaultLoginBrowserLauncher(
+  profileDir: string,
+  options: LaunchOptions
+): Promise<BrowserContextLike> {
+  const { chromium } = await import('patchright')
+  const context = await chromium.launchPersistentContext(profileDir, options)
+  return context as unknown as BrowserContextLike
+}
+
+let launchBrowser: LoginBrowserLauncher = defaultLoginBrowserLauncher
+
+/** Test-only seam: inject a fake browser driver, or pass `null` to restore the real one. */
+export function setLoginBrowserLauncherForTests(launcher: LoginBrowserLauncher | null): void {
+  launchBrowser = launcher ?? defaultLoginBrowserLauncher
+}
+
+// ─── Provider config ──────────────────────────────────────────────────────
+
+interface ProviderConfig {
+  /** ccswitch's `Provider::slug()` — MUST match exactly so profile dirs are reused. */
+  slug: 'claude' | 'codex'
+  matchGlob: string
+  redirectPrefix: string
+  buildAuthorizeUrl: (pkce: Pkce) => string
+}
+
+const PROVIDER_CONFIG: Record<UsageProvider, ProviderConfig> = {
+  anthropic: {
+    slug: 'claude',
+    matchGlob: '**/oauth/code/callback*',
+    redirectPrefix: 'https://console.anthropic.com/oauth/code/callback',
+    buildAuthorizeUrl: buildAnthropicAuthorizeUrl
+  },
+  openai: {
+    slug: 'codex',
+    matchGlob: '**/auth/callback*',
+    redirectPrefix: 'http://localhost:1455/auth/callback',
+    buildAuthorizeUrl: buildOpenAIAuthorizeUrl
+  }
+}
+
+/** Port of ccswitch's `login::profile_dir` — same slug + sanitization so existing profiles are reused. */
+function resolveProfileDir(provider: UsageProvider, emailHint?: string): string {
+  const safeEmail = (emailHint ?? '').replace(/[/\\:]/g, '_')
+  const tag = safeEmail.length > 0 ? safeEmail : 'new'
+  return join(homedir(), '.ccswitch', 'profiles', `${PROVIDER_CONFIG[provider].slug}-${tag}`)
+}
+
+const SIGNED_IN_HTML = `<!doctype html><html><head><meta charset="utf-8"><title>Hive</title>
+<style>body{font-family:-apple-system,system-ui,sans-serif;background:#0b0e14;color:#e6e6e6;
+display:flex;align-items:center;justify-content:center;height:100vh;margin:0}
+.card{text-align:center}h1{font-size:22px}p{color:#9aa5b1}</style></head>
+<body><div class="card"><h1>&#9989; Signed in</h1>
+<p>You can close this window and return to Hive.</p></div></body></html>`
+
+// ─── Session state ────────────────────────────────────────────────────────
+
+interface LoginSession {
+  loginId: string
+  provider: UsageProvider
+  state: LoginState
+  email: string | null
+  error: string | null
+  pkce: Pkce
+  context: BrowserContextLike | null
+  /** Guards the dual (route + framenavigated) capture so only the first hit wins. */
+  resolved: boolean
+  timeoutTimer: NodeJS.Timeout | null
+  closeTimer: NodeJS.Timeout | null
+  gcTimer: NodeJS.Timeout | null
+}
+
+let currentSession: LoginSession | null = null
+
+function isTerminal(state: LoginState): boolean {
+  return state === 'done' || state === 'failed' || state === 'cancelled'
+}
+
+function clearActiveTimers(session: LoginSession): void {
+  if (session.timeoutTimer) {
+    clearTimeout(session.timeoutTimer)
+    session.timeoutTimer = null
+  }
+  if (session.closeTimer) {
+    clearTimeout(session.closeTimer)
+    session.closeTimer = null
+  }
+}
+
+function scheduleGc(session: LoginSession): void {
+  if (session.gcTimer) clearTimeout(session.gcTimer)
+  const timer = setTimeout(() => {
+    if (currentSession === session) currentSession = null
+  }, GC_DELAY_MS)
+  timer.unref()
+  session.gcTimer = timer
+}
+
+function failSession(session: LoginSession, message: string): void {
+  if (isTerminal(session.state)) return
+  session.state = 'failed'
+  session.error = message
+  clearActiveTimers(session)
+  scheduleGc(session)
+  log.warn('Login failed', { loginId: session.loginId, provider: session.provider, error: message })
+}
+
+async function safeClose(context: BrowserContextLike | null): Promise<void> {
+  if (!context) return
+  try {
+    await context.close()
+  } catch (error) {
+    log.warn('Failed to close login browser context', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+function isChromeMissingError(message: string): boolean {
+  return /chrome/i.test(message) && (/is not found/i.test(message) || /not supported/i.test(message) || /doesn't exist/i.test(message))
+}
+
+function mapLaunchError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  if (isChromeMissingError(message)) {
+    return 'Google Chrome is required for sign-in. Please install Chrome and try again.'
+  }
+  return message
+}
+
+/** Public status snapshot for the renderer's poller. */
+export type LoginStatus = LoginStatusDTO
+
+export function isLoginActive(): boolean {
+  return currentSession !== null && !isTerminal(currentSession.state)
+}
+
+export function loginStatus(loginId: string): LoginStatusDTO {
+  if (!currentSession || currentSession.loginId !== loginId) {
+    throw new Error('login session not found')
+  }
+  const { provider, state, email, error } = currentSession
+  return { loginId, provider, state, email, error }
+}
+
+export async function loginCancel(loginId: string): Promise<boolean> {
+  const session = currentSession
+  if (!session || session.loginId !== loginId) return false
+  if (isTerminal(session.state)) return false
+
+  session.state = 'cancelled'
+  clearActiveTimers(session)
+  await safeClose(session.context)
+  scheduleGc(session)
+  return true
+}
+
+export async function loginStart(
+  provider: UsageProvider,
+  emailHint?: string
+): Promise<{ loginId: string }> {
+  if (process.platform !== 'darwin') {
+    throw new Error('Account sign-in is only supported on macOS')
+  }
+  if (currentSession && !isTerminal(currentSession.state)) {
+    throw new Error('A login is already in progress')
+  }
+
+  const session: LoginSession = {
+    loginId: randomUUID(),
+    provider,
+    state: 'launching',
+    email: emailHint ?? null,
+    error: null,
+    pkce: generatePkce(),
+    context: null,
+    resolved: false,
+    timeoutTimer: null,
+    closeTimer: null,
+    gcTimer: null
+  }
+  currentSession = session
+
+  // Fire-and-forget: the whole flow lives in the background so loginStart
+  // never blocks the RPC caller. Every failure lands in session.state — this
+  // never throws out of the background flow.
+  void runLoginFlow(session, emailHint).catch((error) => {
+    failSession(session, error instanceof Error ? error.message : String(error))
+  })
+
+  return { loginId: session.loginId }
+}
+
+// ─── Background flow ──────────────────────────────────────────────────────
+
+async function runLoginFlow(session: LoginSession, emailHint?: string): Promise<void> {
+  const config = PROVIDER_CONFIG[session.provider]
+  const authorizeUrl = config.buildAuthorizeUrl(session.pkce)
+  const profileDir = resolveProfileDir(session.provider, emailHint)
+  await mkdir(profileDir, { recursive: true })
+
+  let context: BrowserContextLike
+  try {
+    context = await launchBrowser(profileDir, {
+      channel: 'chrome',
+      headless: false,
+      viewport: null,
+      args: ['--no-first-run', '--no-default-browser-check']
+    })
+  } catch (error) {
+    failSession(session, mapLaunchError(error))
+    return
+  }
+
+  // A cancel could have landed while Chrome was still launching.
+  if (isTerminal(session.state)) {
+    await safeClose(context)
+    return
+  }
+
+  session.context = context
+  session.state = 'waiting'
+
+  context.on('close', () => {
+    if (!isTerminal(session.state)) {
+      failSession(session, 'Browser closed before login completed')
+    }
+  })
+
+  const timeoutTimer = setTimeout(() => {
+    failSession(session, 'Login timed out')
+    void safeClose(context)
+  }, LOGIN_TIMEOUT_MS)
+  timeoutTimer.unref()
+  session.timeoutTimer = timeoutTimer
+
+  await context.route(config.matchGlob, (route) => handleRoute(session, config, route))
+
+  let page: PageLike
+  try {
+    const pages = context.pages()
+    page = pages[0] ?? (await context.newPage())
+  } catch (error) {
+    failSession(session, error instanceof Error ? error.message : String(error))
+    return
+  }
+
+  page.on('framenavigated', (frame) => {
+    if (frame === page.mainFrame()) {
+      extractAndHandle(session, config, frame.url())
+    }
+  })
+
+  try {
+    await page.goto(authorizeUrl)
+  } catch (error) {
+    failSession(session, error instanceof Error ? error.message : String(error))
+  }
+}
+
+async function handleRoute(session: LoginSession, config: ProviderConfig, route: RouteLike): Promise<void> {
+  const url = route.request().url()
+  if (!url.startsWith(config.redirectPrefix)) {
+    try {
+      await route.continue()
+    } catch {
+      // best-effort — the page may already have navigated away
+    }
+    return
+  }
+
+  extractAndHandle(session, config, url)
+
+  try {
+    await route.fulfill({ status: 200, contentType: 'text/html', body: SIGNED_IN_HTML })
+  } catch {
+    try {
+      await route.continue()
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/** Shared capture logic for both the route interception and the framenavigated fallback. */
+function extractAndHandle(session: LoginSession, config: ProviderConfig, rawUrl: string): void {
+  if (session.resolved) return
+  if (!rawUrl.startsWith(config.redirectPrefix)) return
+
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return
+  }
+
+  const errorParam = parsed.searchParams.get('error')
+  if (errorParam) {
+    session.resolved = true
+    failSession(session, `Provider returned error: ${errorParam}`)
+    return
+  }
+
+  const code = parsed.searchParams.get('code')
+  if (!code) return
+
+  const state = parsed.searchParams.get('state')
+  session.resolved = true
+  void exchange(session, code, state)
+}
+
+async function exchange(session: LoginSession, code: string, state: string | null): Promise<void> {
+  session.state = 'exchanging'
+
+  if (state !== session.pkce.state) {
+    failSession(session, 'State mismatch — please retry')
+    await safeClose(session.context)
+    return
+  }
+
+  try {
+    const email =
+      session.provider === 'anthropic'
+        ? await exchangeAndStoreAnthropic(session, code)
+        : await exchangeAndStoreOpenAI(session, code)
+
+    if (email === null) return // failSession already called by the store helper
+
+    session.email = email
+    await refreshCacheForNewAccount(session.provider, email)
+
+    session.state = 'done'
+    clearActiveTimers(session) // the 30-min timeout no longer applies once we've succeeded
+    const closeTimer = setTimeout(() => {
+      void safeClose(session.context)
+    }, CLOSE_DELAY_MS)
+    closeTimer.unref()
+    session.closeTimer = closeTimer
+  } catch (error) {
+    failSession(session, error instanceof Error ? error.message : String(error))
+  }
+}
+
+/** Returns the stored account's email, or null if `failSession` was already called. */
+async function exchangeAndStoreAnthropic(session: LoginSession, code: string): Promise<string | null> {
+  const tokens = await exchangeAnthropicCode(code, session.pkce.state, session.pkce)
+  const email = tokens.account?.emailAddress?.toLowerCase()
+  if (!email) {
+    failSession(session, 'Login succeeded but no account email was returned')
+    return null
+  }
+  const uuid = tokens.account?.uuid ?? ''
+  const scopes = tokens.scope?.split(' ') ?? ['org:create_api_key', 'user:profile', 'user:inference']
+  const blob = JSON.stringify({
+    claudeAiOauth: {
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+      scopes
+    }
+  })
+  await addClaudeAccount(email, uuid, blob)
+  return email
+}
+
+async function exchangeAndStoreOpenAI(session: LoginSession, code: string): Promise<string | null> {
+  const tokens = await exchangeOpenAICode(code, session.pkce)
+  const { email } = await addCodexAccount(tokens.idToken, tokens.accessToken, tokens.refreshToken)
+  return email
+}
+
+/** Best-effort: populating the usage cache never blocks or fails a completed login. */
+async function refreshCacheForNewAccount(provider: UsageProvider, email: string): Promise<void> {
+  try {
+    await listSavedAccounts(provider)
+    const savedProvider: SavedUsageProvider = provider
+    const row = getDatabase().getSavedUsageAccountByProviderEmail(savedProvider, email)
+    if (row) {
+      void fetchForSavedAccount(row.id)
+    }
+  } catch (error) {
+    log.warn('Failed to refresh saved-account cache after login', {
+      provider,
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}

--- a/src/main/services/login-service.ts
+++ b/src/main/services/login-service.ts
@@ -418,8 +418,16 @@ async function exchange(session: LoginSession, code: string, state: string | nul
     session.email = email
     await refreshCacheForNewAccount(session.provider, email)
 
+    // A cancel could have landed while the exchange/store/cache-refresh above
+    // was in flight — don't clobber the terminal state it already set. The
+    // account may already be stored (the code was consumed; that's fine),
+    // but only loginCancel gets to decide the final state in that race, and
+    // it already closed the context and scheduled its own GC.
+    if (isTerminal(session.state)) return
+
     session.state = 'done'
     clearActiveTimers(session) // the 30-min timeout no longer applies once we've succeeded
+    scheduleGc(session)
     const closeTimer = setTimeout(() => {
       void safeClose(session.context)
     }, CLOSE_DELAY_MS)
@@ -463,9 +471,12 @@ async function refreshCacheForNewAccount(provider: UsageProvider, email: string)
   try {
     await listSavedAccounts(provider)
     const savedProvider: SavedUsageProvider = provider
-    const row = getDatabase().getSavedUsageAccountByProviderEmail(savedProvider, email)
+    // The orchestrator upserts rows with lowercased emails — match that here,
+    // since the email returned by the account-store helpers isn't guaranteed
+    // to be lowercased (e.g. Codex's id_token claim is verbatim).
+    const row = getDatabase().getSavedUsageAccountByProviderEmail(savedProvider, email.toLowerCase())
     if (row) {
-      void fetchForSavedAccount(row.id)
+      void fetchForSavedAccount(row.id).catch(() => {})
     }
   } catch (error) {
     log.warn('Failed to refresh saved-account cache after login', {

--- a/src/main/services/login-service.ts
+++ b/src/main/services/login-service.ts
@@ -270,6 +270,18 @@ export async function loginStart(
   }
   currentSession = session
 
+  // Start the overall timeout at session creation so it also covers the
+  // 'launching' state: a hung Chrome launch would otherwise leave a
+  // non-terminal 'launching' session forever, blocking every future login.
+  // `session.context` is read lazily at fire time, so it closes whatever
+  // context exists by then (possibly still null during launch).
+  const timeoutTimer = setTimeout(() => {
+    failSession(session, 'Login timed out')
+    void safeClose(session.context)
+  }, LOGIN_TIMEOUT_MS)
+  timeoutTimer.unref()
+  session.timeoutTimer = timeoutTimer
+
   // Fire-and-forget: the whole flow lives in the background so loginStart
   // never blocks the RPC caller. Every failure lands in session.state — this
   // never throws out of the background flow.
@@ -316,12 +328,8 @@ async function runLoginFlow(session: LoginSession, emailHint?: string): Promise<
     }
   })
 
-  const timeoutTimer = setTimeout(() => {
-    failSession(session, 'Login timed out')
-    void safeClose(context)
-  }, LOGIN_TIMEOUT_MS)
-  timeoutTimer.unref()
-  session.timeoutTimer = timeoutTimer
+  // The overall timeout timer was already armed in loginStart (it covers the
+  // 'launching' state too), so there's nothing to (re)start here.
 
   await context.route(config.matchGlob, (route) => handleRoute(session, config, route))
 
@@ -373,6 +381,11 @@ async function handleRoute(session: LoginSession, config: ProviderConfig, route:
 
 /** Shared capture logic for both the route interception and the framenavigated fallback. */
 function extractAndHandle(session: LoginSession, config: ProviderConfig, rawUrl: string): void {
+  // A route/framenavigated callback can still fire after the session went
+  // terminal (e.g. the user cancelled). `resolved` doesn't guard that — a
+  // cancel never sets it — so without this check a late callback could set
+  // 'exchanging' and complete to 'done' post-cancel.
+  if (isTerminal(session.state)) return
   if (session.resolved) return
   if (!rawUrl.startsWith(config.redirectPrefix)) return
 

--- a/src/main/services/oauth-anthropic.ts
+++ b/src/main/services/oauth-anthropic.ts
@@ -1,0 +1,181 @@
+/**
+ * Anthropic (Claude Code) OAuth: authorize-URL construction, refresh-token
+ * rotation, and authorization-code exchange. Port of ccswitch's
+ * `src/providers/anthropic.rs` OAuth surface (usage fetching stays in
+ * usage-service.ts).
+ */
+import type { Pkce } from './oauth-pkce'
+
+export const ANTHROPIC_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
+export const ANTHROPIC_TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token'
+export const ANTHROPIC_AUTHORIZE_URL = 'https://claude.ai/oauth/authorize'
+export const ANTHROPIC_REDIRECT_URI = 'https://console.anthropic.com/oauth/code/callback'
+export const ANTHROPIC_SCOPE = 'org:create_api_key user:profile user:inference'
+
+const REQUEST_TIMEOUT_MS = 10_000
+const BODY_SNIPPET_LENGTH = 500
+
+export function buildAnthropicAuthorizeUrl(pkce: Pkce): string {
+  const url = new URL(ANTHROPIC_AUTHORIZE_URL)
+  url.searchParams.set('code', 'true')
+  url.searchParams.set('client_id', ANTHROPIC_CLIENT_ID)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('redirect_uri', ANTHROPIC_REDIRECT_URI)
+  url.searchParams.set('scope', ANTHROPIC_SCOPE)
+  url.searchParams.set('code_challenge', pkce.challenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  url.searchParams.set('state', pkce.state)
+  return url.toString()
+}
+
+export type AnthropicRefreshOutcome =
+  | { ok: true; result: { accessToken: string; refreshToken: string; expiresAt: number }; scope?: string }
+  | { ok: false; needsLogin: true; error: string }
+
+async function readCappedBody(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 1024)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return `Failed to read response body: ${message}`
+  }
+}
+
+async function postJson(body: unknown): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    return await fetch(ANTHROPIC_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Anthropic token request timed out')
+    }
+    throw error
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/**
+ * Refresh an Anthropic OAuth access token. Rotates the refresh token
+ * (falling back to the input token when the response omits one). Returns a
+ * `needsLogin` outcome for 401/400 responses or a body containing
+ * `invalid_grant`; throws on any other failure (network error or other
+ * non-2xx status).
+ */
+export async function refreshAnthropicToken(refreshToken: string): Promise<AnthropicRefreshOutcome> {
+  const response = await postJson({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: ANTHROPIC_CLIENT_ID
+  })
+  const body = await readCappedBody(response)
+
+  if (response.status === 401 || response.status === 400 || body.includes('invalid_grant')) {
+    return {
+      ok: false,
+      needsLogin: true,
+      error: `Anthropic refresh needs login (${response.status}): ${body.slice(0, BODY_SNIPPET_LENGTH)}`
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(`Anthropic token refresh returned ${response.status}: ${body.slice(0, BODY_SNIPPET_LENGTH)}`)
+  }
+
+  const data = JSON.parse(body) as {
+    access_token?: unknown
+    refresh_token?: unknown
+    expires_in?: unknown
+    scope?: unknown
+  }
+
+  if (typeof data.access_token !== 'string' || data.access_token.length === 0) {
+    throw new Error('Anthropic token refresh: missing access_token in response')
+  }
+  if (typeof data.expires_in !== 'number' || !Number.isFinite(data.expires_in)) {
+    throw new Error('Anthropic token refresh: missing expires_in in response')
+  }
+
+  const rotatedRefreshToken =
+    typeof data.refresh_token === 'string' && data.refresh_token.length > 0 ? data.refresh_token : refreshToken
+
+  return {
+    ok: true,
+    result: {
+      accessToken: data.access_token,
+      refreshToken: rotatedRefreshToken,
+      expiresAt: Date.now() + data.expires_in * 1000
+    },
+    scope: typeof data.scope === 'string' ? data.scope : undefined
+  }
+}
+
+export interface AnthropicTokenExchange {
+  accessToken: string
+  refreshToken: string
+  expiresAt: number
+  scope?: string
+  account?: { uuid?: string; emailAddress?: string }
+}
+
+/** Exchange an authorization code (from the interactive login flow) for tokens. */
+export async function exchangeAnthropicCode(
+  code: string,
+  state: string,
+  pkce: Pkce
+): Promise<AnthropicTokenExchange> {
+  const response = await postJson({
+    grant_type: 'authorization_code',
+    code,
+    state,
+    redirect_uri: ANTHROPIC_REDIRECT_URI,
+    client_id: ANTHROPIC_CLIENT_ID,
+    code_verifier: pkce.verifier
+  })
+  const body = await readCappedBody(response)
+
+  if (!response.ok) {
+    throw new Error(`Anthropic token exchange returned ${response.status}: ${body.slice(0, BODY_SNIPPET_LENGTH)}`)
+  }
+
+  const data = JSON.parse(body) as {
+    access_token?: unknown
+    refresh_token?: unknown
+    expires_in?: unknown
+    scope?: unknown
+    account?: { uuid?: unknown; email_address?: unknown }
+  }
+
+  if (typeof data.access_token !== 'string' || data.access_token.length === 0) {
+    throw new Error('Anthropic token exchange: missing access_token in response')
+  }
+  if (typeof data.refresh_token !== 'string' || data.refresh_token.length === 0) {
+    throw new Error('Anthropic token exchange: missing refresh_token in response')
+  }
+  if (typeof data.expires_in !== 'number' || !Number.isFinite(data.expires_in)) {
+    throw new Error('Anthropic token exchange: missing expires_in in response')
+  }
+
+  const account =
+    data.account && typeof data.account === 'object'
+      ? {
+          uuid: typeof data.account.uuid === 'string' ? data.account.uuid : undefined,
+          emailAddress:
+            typeof data.account.email_address === 'string' ? data.account.email_address : undefined
+        }
+      : undefined
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+    scope: typeof data.scope === 'string' ? data.scope : undefined,
+    account
+  }
+}

--- a/src/main/services/oauth-openai.ts
+++ b/src/main/services/oauth-openai.ts
@@ -1,0 +1,169 @@
+/**
+ * OpenAI (Codex) OAuth: authorize-URL construction, refresh-token rotation,
+ * and authorization-code exchange. Port of ccswitch's
+ * `src/providers/openai.rs` OAuth surface (usage fetching stays in
+ * openai-usage-service.ts).
+ */
+import type { Pkce } from './oauth-pkce'
+
+export const OPENAI_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
+export const OPENAI_AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize'
+export const OPENAI_TOKEN_URL = 'https://auth.openai.com/oauth/token'
+export const OPENAI_REDIRECT_URI = 'http://localhost:1455/auth/callback'
+export const OPENAI_SCOPE = 'openid profile email offline_access'
+const OPENAI_ORIGINATOR = 'codex_cli_rs'
+
+const REQUEST_TIMEOUT_MS = 10_000
+const BODY_SNIPPET_LENGTH = 500
+
+export function buildOpenAIAuthorizeUrl(pkce: Pkce): string {
+  const url = new URL(OPENAI_AUTHORIZE_URL)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('client_id', OPENAI_CLIENT_ID)
+  url.searchParams.set('redirect_uri', OPENAI_REDIRECT_URI)
+  url.searchParams.set('scope', OPENAI_SCOPE)
+  url.searchParams.set('code_challenge', pkce.challenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  url.searchParams.set('id_token_add_organizations', 'true')
+  url.searchParams.set('codex_cli_simplified_flow', 'true')
+  url.searchParams.set('state', pkce.state)
+  url.searchParams.set('originator', OPENAI_ORIGINATOR)
+  return url.toString()
+}
+
+export type OpenAIRefreshOutcome =
+  | { ok: true; result: { accessToken: string; refreshToken?: string; idToken?: string } }
+  | { ok: false; needsLogin: true; error: string }
+
+async function readCappedBody(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 1024)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return `Failed to read response body: ${message}`
+  }
+}
+
+/**
+ * Refresh an OpenAI (Codex) OAuth access token. The refresh/id tokens only
+ * rotate when the response includes them — callers should fall back to
+ * whatever they already have on hand for the fields left `undefined` here.
+ * Returns a `needsLogin` outcome for 401/400 responses or a body containing
+ * `invalid_grant`; throws on any other failure (network error or other
+ * non-2xx status).
+ */
+export async function refreshOpenAIToken(refreshToken: string): Promise<OpenAIRefreshOutcome> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  let response: Response
+  try {
+    response = await fetch(OPENAI_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: OPENAI_CLIENT_ID,
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken
+      }),
+      signal: controller.signal
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('OpenAI token refresh timed out')
+    }
+    throw error
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  const body = await readCappedBody(response)
+
+  if (response.status === 401 || response.status === 400 || body.includes('invalid_grant')) {
+    return {
+      ok: false,
+      needsLogin: true,
+      error: `OpenAI refresh needs login (${response.status}): ${body.slice(0, BODY_SNIPPET_LENGTH)}`
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(`OpenAI token refresh returned ${response.status}: ${body.slice(0, BODY_SNIPPET_LENGTH)}`)
+  }
+
+  const data = JSON.parse(body) as {
+    id_token?: unknown
+    access_token?: unknown
+    refresh_token?: unknown
+  }
+
+  if (typeof data.access_token !== 'string' || data.access_token.length === 0) {
+    throw new Error('OpenAI token refresh: missing access_token in response')
+  }
+
+  return {
+    ok: true,
+    result: {
+      accessToken: data.access_token,
+      refreshToken:
+        typeof data.refresh_token === 'string' && data.refresh_token.length > 0 ? data.refresh_token : undefined,
+      idToken: typeof data.id_token === 'string' && data.id_token.length > 0 ? data.id_token : undefined
+    }
+  }
+}
+
+/** Exchange an authorization code (from the interactive login flow) for tokens. */
+export async function exchangeOpenAICode(
+  code: string,
+  pkce: Pkce
+): Promise<{ idToken: string; accessToken: string; refreshToken: string }> {
+  const form = new URLSearchParams()
+  form.set('grant_type', 'authorization_code')
+  form.set('code', code)
+  form.set('redirect_uri', OPENAI_REDIRECT_URI)
+  form.set('client_id', OPENAI_CLIENT_ID)
+  form.set('code_verifier', pkce.verifier)
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  let response: Response
+  try {
+    response = await fetch(OPENAI_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: form.toString(),
+      signal: controller.signal
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('OpenAI token exchange timed out')
+    }
+    throw error
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  const body = await readCappedBody(response)
+  if (!response.ok) {
+    throw new Error(`OpenAI token exchange returned ${response.status}: ${body.slice(0, BODY_SNIPPET_LENGTH)}`)
+  }
+
+  const data = JSON.parse(body) as {
+    id_token?: unknown
+    access_token?: unknown
+    refresh_token?: unknown
+  }
+
+  if (typeof data.id_token !== 'string' || data.id_token.length === 0) {
+    throw new Error('OpenAI token exchange: missing id_token in response')
+  }
+  if (typeof data.access_token !== 'string' || data.access_token.length === 0) {
+    throw new Error('OpenAI token exchange: missing access_token in response')
+  }
+  if (typeof data.refresh_token !== 'string' || data.refresh_token.length === 0) {
+    throw new Error('OpenAI token exchange: missing refresh_token in response')
+  }
+
+  return { idToken: data.id_token, accessToken: data.access_token, refreshToken: data.refresh_token }
+}

--- a/src/main/services/oauth-pkce.ts
+++ b/src/main/services/oauth-pkce.ts
@@ -1,0 +1,18 @@
+import { randomBytes, createHash } from 'crypto'
+
+export interface Pkce {
+  verifier: string
+  challenge: string
+  state: string
+}
+
+/**
+ * Generate an OAuth PKCE (RFC 7636, S256) verifier/challenge pair plus a
+ * random `state` value, all base64url-encoded (no padding, `-`/`_` alphabet).
+ */
+export function generatePkce(): Pkce {
+  const verifier = randomBytes(64).toString('base64url')
+  const challenge = createHash('sha256').update(verifier).digest('base64url')
+  const state = randomBytes(32).toString('base64url')
+  return { verifier, challenge, state }
+}

--- a/src/main/services/openai-usage-service.ts
+++ b/src/main/services/openai-usage-service.ts
@@ -1,10 +1,12 @@
 import { existsSync } from 'fs'
-import { readFile, writeFile } from 'fs/promises'
+import { readFile } from 'fs/promises'
 import { execFile } from 'child_process'
 import { join } from 'path'
 import { homedir, platform } from 'os'
 import { createLogger } from './logger'
 import { decodeJwtPayload } from './jwt-utils'
+import { refreshOpenAIToken } from './oauth-openai'
+import { NeedsLoginError } from './usage-service'
 import type { OpenAIUsageData, OpenAIUsageResult } from '@shared/types/usage'
 
 export type { OpenAIUsageData, OpenAIUsageResult }
@@ -14,8 +16,6 @@ const log = createLogger({ component: 'OpenAIUsageService' })
 const CODEX_HOME = process.env.CODEX_HOME || join(homedir(), '.codex')
 const AUTH_FILE = join(CODEX_HOME, 'auth.json')
 const USAGE_URL = 'https://chatgpt.com/backend-api/wham/usage'
-const TOKEN_URL = 'https://auth.openai.com/oauth/token'
-const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
 
 interface CodexAuthTokens {
   id_token: unknown
@@ -39,20 +39,12 @@ export interface OpenAIUsageOverride {
   email?: string
 }
 
-interface RefreshResponse {
-  id_token?: string
-  access_token?: string
-  refresh_token?: string
-}
-
 interface RefreshResult {
   accessToken: string
   refreshToken: string
   idToken?: string
 }
 
-/** Module-level promise to deduplicate concurrent refresh requests. */
-let refreshPromise: Promise<string> | null = null
 const inMemoryRefreshPromises = new Map<string, Promise<RefreshResult>>()
 
 /**
@@ -116,77 +108,11 @@ function isTokenExpired(accessToken: string): boolean {
 }
 
 /**
- * Refresh the access token using the given refresh token.
- */
-async function requestTokenRefresh(refreshToken: string): Promise<RefreshResponse> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 10_000)
-
-  try {
-    const response = await fetch(TOKEN_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        client_id: CLIENT_ID,
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken
-      }),
-      signal: controller.signal
-    })
-
-    clearTimeout(timeout)
-
-    if (!response.ok) {
-      const body = await response.text()
-      throw new Error(`Token refresh failed (${response.status}): ${body}`)
-    }
-
-    return (await response.json()) as RefreshResponse
-  } catch (error) {
-    clearTimeout(timeout)
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error('Token refresh timed out')
-    }
-    throw error
-  }
-}
-
-/**
- * Refresh the live access token and persist the updated auth.json.
- * Uses a module-level promise to deduplicate concurrent live refresh requests.
- */
-async function refreshAccessToken(auth: CodexAuth): Promise<string> {
-  if (refreshPromise) return refreshPromise
-
-  refreshPromise = (async () => {
-    if (!auth.tokens?.refresh_token) {
-      throw new Error('No refresh token available')
-    }
-
-    const data = await requestTokenRefresh(auth.tokens.refresh_token)
-
-    if (data.access_token) auth.tokens.access_token = data.access_token
-    if (data.refresh_token) auth.tokens.refresh_token = data.refresh_token
-    if (data.id_token) auth.tokens.id_token = data.id_token
-    auth.last_refresh = new Date().toISOString()
-
-    try {
-      await writeFile(AUTH_FILE, JSON.stringify(auth, null, 2), { mode: 0o600 })
-    } catch {
-      // persist failed, continue with in-memory token
-    }
-
-    return auth.tokens.access_token
-  })().finally(() => {
-    refreshPromise = null
-  })
-
-  return refreshPromise
-}
-
-/**
- * Refresh a saved account in memory only. Concurrent refreshes for the same
- * account share the same HTTP request; different accounts refresh independently.
+ * Refresh a Codex account's tokens in memory only — the live path and the
+ * saved-account (override) path both go through here; neither persists
+ * anything itself. Concurrent refreshes for the same account share the same
+ * HTTP request; different accounts refresh independently. Throws
+ * `NeedsLoginError` when the OAuth server rejects the refresh token itself.
  */
 export async function refreshAccessTokenInMemory(auth: CodexAuth): Promise<RefreshResult> {
   if (!auth.tokens?.refresh_token) {
@@ -201,10 +127,14 @@ export async function refreshAccessTokenInMemory(auth: CodexAuth): Promise<Refre
   if (existing) return existing
 
   const promise = (async () => {
-    const data = await requestTokenRefresh(auth.tokens!.refresh_token)
-    if (data.access_token) auth.tokens!.access_token = data.access_token
-    if (data.refresh_token) auth.tokens!.refresh_token = data.refresh_token
-    if (data.id_token) auth.tokens!.id_token = data.id_token
+    const outcome = await refreshOpenAIToken(auth.tokens!.refresh_token)
+    if (!outcome.ok) {
+      throw new NeedsLoginError(`Token refresh failed: invalid_grant (${outcome.error})`)
+    }
+
+    auth.tokens!.access_token = outcome.result.accessToken
+    if (outcome.result.refreshToken) auth.tokens!.refresh_token = outcome.result.refreshToken
+    if (outcome.result.idToken) auth.tokens!.id_token = outcome.result.idToken
     auth.last_refresh = new Date().toISOString()
 
     return {
@@ -284,16 +214,17 @@ export async function fetchOpenAIUsage(override?: OpenAIUsageOverride): Promise<
   const accountId = auth.tokens.account_id
   let rotated: RefreshResult | undefined
 
-  // Refresh if token is expired
+  // Refresh if token is expired. Both the live path (auth read from
+  // auth.json/Keychain) and the override (saved-account) path refresh in
+  // memory only — persistence is the caller's responsibility (usage-ops.ts).
   if (isTokenExpired(accessToken)) {
     try {
-      if (override) {
-        rotated = await refreshAccessTokenInMemory(auth)
-        accessToken = rotated.accessToken
-      } else {
-        accessToken = await refreshAccessToken(auth)
-      }
+      rotated = await refreshAccessTokenInMemory(auth)
+      accessToken = rotated.accessToken
     } catch (error) {
+      if (error instanceof NeedsLoginError) {
+        return { success: false, error: error.message, needsLogin: true }
+      }
       const message = error instanceof Error ? error.message : String(error)
       log.warn('Failed to refresh OpenAI access token', { error: message })
       return { success: false, error: message }
@@ -306,28 +237,38 @@ export async function fetchOpenAIUsage(override?: OpenAIUsageOverride): Promise<
     // Retry once on 401 after forcing a refresh
     if (result.status === 401) {
       try {
-        if (override) {
-          rotated = await refreshAccessTokenInMemory(auth)
-          accessToken = rotated.accessToken
-        } else {
-          accessToken = await refreshAccessToken(auth)
-        }
+        rotated = await refreshAccessTokenInMemory(auth)
+        accessToken = rotated.accessToken
         result = await fetchUsage(accessToken, accountId)
       } catch (error) {
+        if (error instanceof NeedsLoginError) {
+          return {
+            success: false,
+            error: error.message,
+            needsLogin: true,
+            ...(rotated ? { rotated } : {})
+          }
+        }
         const message = error instanceof Error ? error.message : String(error)
         log.warn('Failed to refresh OpenAI access token on 401 retry', { error: message })
         return { success: false, error: message }
       }
     }
 
+    if (result.status === 401 || result.status === 403) {
+      const message = `OpenAI Usage API returned ${result.status}: ${result.body || 'unknown error'}`
+      log.warn(message)
+      return { success: false, error: message, needsLogin: true, ...(rotated ? { rotated } : {}) }
+    }
+
     if (result.status !== 200) {
       const message = `OpenAI Usage API returned ${result.status}: ${result.body || 'unknown error'}`
       log.warn(message)
-      return { success: false, error: message }
+      return { success: false, error: message, ...(rotated ? { rotated } : {}) }
     }
 
     const data = result.data as OpenAIUsageData
-    return { success: true, data, rotated }
+    return { success: true, data, ...(rotated ? { rotated } : {}) }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     log.warn('Failed to fetch OpenAI usage', { error: message })

--- a/src/main/services/openai-usage-service.ts
+++ b/src/main/services/openai-usage-service.ts
@@ -43,6 +43,8 @@ interface RefreshResult {
   accessToken: string
   refreshToken: string
   idToken?: string
+  /** See `ClaudeRefreshResult.rotatedFrom` (usage.ts) — same rationale, Codex side. */
+  rotatedFrom: string
 }
 
 const inMemoryRefreshPromises = new Map<string, Promise<RefreshResult>>()
@@ -127,7 +129,11 @@ export async function refreshAccessTokenInMemory(auth: CodexAuth): Promise<Refre
   if (existing) return existing
 
   const promise = (async () => {
-    const outcome = await refreshOpenAIToken(auth.tokens!.refresh_token)
+    // Captured before the refresh call so it reflects the token this refresh
+    // was actually performed with, not whatever `auth.tokens.refresh_token`
+    // is mutated to afterward.
+    const usedRefreshToken = auth.tokens!.refresh_token
+    const outcome = await refreshOpenAIToken(usedRefreshToken)
     if (!outcome.ok) {
       throw new NeedsLoginError(`Token refresh failed: invalid_grant (${outcome.error})`)
     }
@@ -140,7 +146,8 @@ export async function refreshAccessTokenInMemory(auth: CodexAuth): Promise<Refre
     return {
       accessToken: auth.tokens!.access_token,
       refreshToken: auth.tokens!.refresh_token,
-      idToken: typeof auth.tokens!.id_token === 'string' ? auth.tokens!.id_token : undefined
+      idToken: typeof auth.tokens!.id_token === 'string' ? auth.tokens!.id_token : undefined,
+      rotatedFrom: usedRefreshToken
     }
   })().finally(() => {
     inMemoryRefreshPromises.delete(accountId)

--- a/src/main/services/openai-usage-service.ts
+++ b/src/main/services/openai-usage-service.ts
@@ -4,6 +4,7 @@ import { execFile } from 'child_process'
 import { join } from 'path'
 import { homedir, platform } from 'os'
 import { createLogger } from './logger'
+import { decodeJwtPayload } from './jwt-utils'
 import type { OpenAIUsageData, OpenAIUsageResult } from '@shared/types/usage'
 
 export type { OpenAIUsageData, OpenAIUsageResult }
@@ -102,22 +103,6 @@ export async function readCodexCredentials(): Promise<CodexAuth | null> {
   if (fromKeychain?.tokens?.access_token) return fromKeychain
 
   return null
-}
-
-/**
- * Decode the payload section of a JWT token.
- */
-function decodeJwtPayload(token: string): Record<string, unknown> | null {
-  try {
-    const parts = token.split('.')
-    if (parts.length !== 3) return null
-    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
-    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
-    const json = Buffer.from(padded, 'base64').toString('utf-8')
-    return JSON.parse(json)
-  } catch {
-    return null
-  }
 }
 
 /**

--- a/src/main/services/openai-usage-service.ts
+++ b/src/main/services/openai-usage-service.ts
@@ -279,6 +279,6 @@ export async function fetchOpenAIUsage(override?: OpenAIUsageOverride): Promise<
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     log.warn('Failed to fetch OpenAI usage', { error: message })
-    return { success: false, error: message }
+    return { success: false, error: message, ...(rotated ? { rotated } : {}) }
   }
 }

--- a/src/main/services/saved-usage-orchestrator.ts
+++ b/src/main/services/saved-usage-orchestrator.ts
@@ -56,7 +56,8 @@ export function toSavedAccountDTO(row: SavedUsageAccount): SavedAccountDTO {
     last_fetched_at: row.last_fetched_at,
     status: row.status,
     last_error: row.last_error,
-    created_at: row.created_at
+    created_at: row.created_at,
+    plan: null
   }
 }
 

--- a/src/main/services/saved-usage-orchestrator.ts
+++ b/src/main/services/saved-usage-orchestrator.ts
@@ -35,7 +35,7 @@ import {
   type ClaudeUsageFetchContext,
   type ClaudeUsageOverride
 } from './usage-service'
-import { parseCodexIdToken } from './jwt-utils'
+import { jwtExpMs, parseCodexIdToken } from './jwt-utils'
 import type {
   FetchForAccountResult,
   OpenAIUsageData,
@@ -47,6 +47,45 @@ import type {
 import type { SavedUsageAccount, SavedUsageProvider, SavedUsageStatus } from '../db/types'
 
 const log = createLogger({ component: 'SavedUsageOrchestrator' })
+
+/**
+ * Watcher expiry threshold (kept in sync with account-maintenance.ts's
+ * EXPIRY_THRESHOLD_MS by convention, not import, to avoid a cycle between the
+ * two modules). Used by refreshTokensForStoreAccount's post-lock recheck: if
+ * an earlier lock holder already refreshed the token past this threshold,
+ * there's no need to hit the network again.
+ */
+const REFRESH_RECHECK_THRESHOLD_MS = 120_000
+
+/**
+ * Per-account async mutex. Three callers can race to refresh the SAME
+ * account's OAuth token concurrently: the 60s watcher, the boot/RPC mass
+ * refresh, and a user-initiated fetch. Refresh tokens are single-use and
+ * rotate on every refresh, so an overlapping second refresh would consume an
+ * already-rotated token and fail with invalid_grant even though the account
+ * has healthy, freshly-rotated credentials from the first refresh. Chains
+ * each call onto the tail promise for its key, cleaning up the map entry once
+ * the chain drains so it never grows unbounded.
+ */
+const accountLockTails = new Map<string, Promise<unknown>>()
+
+function accountLockKey(provider: string, email: string): string {
+  return `${provider}:${email.toLowerCase()}`
+}
+
+function withAccountLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prior = accountLockTails.get(key) ?? Promise.resolve()
+  const result = prior.then(fn, fn)
+  const tail = result.then(
+    () => undefined,
+    () => undefined
+  )
+  accountLockTails.set(key, tail)
+  void tail.finally(() => {
+    if (accountLockTails.get(key) === tail) accountLockTails.delete(key)
+  })
+  return result
+}
 
 function safeParseJson(value: string): unknown {
   return JSON.parse(value)
@@ -348,39 +387,96 @@ export async function fetchForSavedAccount(
   const row = db.getSavedUsageAccountById(accountId)
   if (!row) return { success: false, error: 'not found', status: 'error' }
 
-  try {
-    if (row.provider === 'anthropic') {
-      const account = await findClaudeStoreAccount(row.email)
+  // Serialize the whole fetch (it may internally refresh the OAuth token) per
+  // account so concurrent callers (watcher / mass refresh / user-initiated)
+  // never race a single-use rotating refresh token against each other.
+  return withAccountLock(accountLockKey(row.provider, row.email), async () => {
+    try {
+      if (row.provider === 'anthropic') {
+        const account = await findClaudeStoreAccount(row.email)
+        if (!account) {
+          return accountError(accountId, 'account no longer in store', 'stale', row.last_usage_json)
+        }
+
+        const effective = await readClaudeEffectiveBlob(account.num, account.email)
+        const accessToken = effective?.parsed.accessToken
+        if (!accessToken) {
+          return accountError(accountId, 'Invalid Claude credentials', 'stale', row.last_usage_json)
+        }
+
+        const override: ClaudeUsageOverride = {
+          accessToken,
+          refreshToken: effective?.parsed.refreshToken,
+          expiresAt: effective?.parsed.expiresAt,
+          accountId
+        }
+
+        const result = await fetchClaudeUsage(override, {
+          caller: options.caller ?? 'usage:fetchForAccount',
+          accountId,
+          batchId: options.batchId
+        })
+
+        if (result.rotated) {
+          await updateClaudeTokens(account.num, account.email, result.rotated, result.rotated.scope)
+        }
+
+        if (!result.success || !result.data) {
+          const message = result.error ?? 'Claude usage fetch failed'
+          const needsLogin = result.needsLogin === true || isClaudeStaleError(message)
+          const status: SavedUsageStatus = needsLogin ? 'stale' : 'error'
+          db.updateSavedUsageAccountUsage(accountId, {
+            last_usage_json: row.last_usage_json,
+            status,
+            last_error: message
+          })
+          return {
+            success: false,
+            error: message,
+            status,
+            retryAfter: result.retryAfter,
+            ...(needsLogin ? { needsLogin: true } : {})
+          }
+        }
+
+        db.updateSavedUsageAccountUsage(accountId, {
+          last_usage_json: JSON.stringify(result.data),
+          status: 'ok',
+          last_error: null
+        })
+        return { success: true, data: result.data, status: 'ok' }
+      }
+
+      const account = await findCodexStoreAccount(row.email)
       if (!account) {
         return accountError(accountId, 'account no longer in store', 'stale', row.last_usage_json)
       }
 
-      const effective = await readClaudeEffectiveBlob(account.num, account.email)
-      const accessToken = effective?.parsed.accessToken
-      if (!accessToken) {
-        return accountError(accountId, 'Invalid Claude credentials', 'stale', row.last_usage_json)
+      const snapshot = await readCodexEffectiveAuth(account.accountKey)
+      const accessToken = snapshot?.tokens?.access_token
+      const refreshToken = snapshot?.tokens?.refresh_token
+      const codexAccountId = snapshot?.tokens?.account_id
+      if (!accessToken || !refreshToken || !codexAccountId) {
+        return accountError(accountId, 'Invalid OpenAI credentials', 'stale', row.last_usage_json)
       }
 
-      const override: ClaudeUsageOverride = {
+      const override: OpenAIUsageOverride = {
         accessToken,
-        refreshToken: effective?.parsed.refreshToken,
-        expiresAt: effective?.parsed.expiresAt,
-        accountId
+        refreshToken,
+        accountId: codexAccountId,
+        idToken: typeof snapshot?.tokens?.id_token === 'string' ? snapshot.tokens.id_token : undefined,
+        email: account.email
       }
 
-      const result = await fetchClaudeUsage(override, {
-        caller: options.caller ?? 'usage:fetchForAccount',
-        accountId,
-        batchId: options.batchId
-      })
+      const result = await fetchOpenAIUsage(override)
 
       if (result.rotated) {
-        await updateClaudeTokens(account.num, account.email, result.rotated, result.rotated.scope)
+        await updateCodexTokens(account.accountKey, result.rotated)
       }
 
       if (!result.success || !result.data) {
-        const message = result.error ?? 'Claude usage fetch failed'
-        const needsLogin = result.needsLogin === true || isClaudeStaleError(message)
+        const message = result.error ?? 'OpenAI usage fetch failed'
+        const needsLogin = result.needsLogin === true || isOpenAIStaleError(message)
         const status: SavedUsageStatus = needsLogin ? 'stale' : 'error'
         db.updateSavedUsageAccountUsage(accountId, {
           last_usage_json: row.last_usage_json,
@@ -391,7 +487,6 @@ export async function fetchForSavedAccount(
           success: false,
           error: message,
           status,
-          retryAfter: result.retryAfter,
           ...(needsLogin ? { needsLogin: true } : {})
         }
       }
@@ -402,65 +497,14 @@ export async function fetchForSavedAccount(
         last_error: null
       })
       return { success: true, data: result.data, status: 'ok' }
-    }
-
-    const account = await findCodexStoreAccount(row.email)
-    if (!account) {
-      return accountError(accountId, 'account no longer in store', 'stale', row.last_usage_json)
-    }
-
-    const snapshot = await readCodexEffectiveAuth(account.accountKey)
-    const accessToken = snapshot?.tokens?.access_token
-    const refreshToken = snapshot?.tokens?.refresh_token
-    const codexAccountId = snapshot?.tokens?.account_id
-    if (!accessToken || !refreshToken || !codexAccountId) {
-      return accountError(accountId, 'Invalid OpenAI credentials', 'stale', row.last_usage_json)
-    }
-
-    const override: OpenAIUsageOverride = {
-      accessToken,
-      refreshToken,
-      accountId: codexAccountId,
-      idToken: typeof snapshot?.tokens?.id_token === 'string' ? snapshot.tokens.id_token : undefined,
-      email: account.email
-    }
-
-    const result = await fetchOpenAIUsage(override)
-
-    if (result.rotated) {
-      await updateCodexTokens(account.accountKey, result.rotated)
-    }
-
-    if (!result.success || !result.data) {
-      const message = result.error ?? 'OpenAI usage fetch failed'
-      const needsLogin = result.needsLogin === true || isOpenAIStaleError(message)
-      const status: SavedUsageStatus = needsLogin ? 'stale' : 'error'
-      db.updateSavedUsageAccountUsage(accountId, {
-        last_usage_json: row.last_usage_json,
-        status,
-        last_error: message
-      })
-      return {
-        success: false,
-        error: message,
-        status,
-        ...(needsLogin ? { needsLogin: true } : {})
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (isNeedsLoginError(error)) {
+        return accountError(accountId, message, 'stale', row.last_usage_json, { needsLogin: true })
       }
+      return accountError(accountId, message, 'error', row.last_usage_json)
     }
-
-    db.updateSavedUsageAccountUsage(accountId, {
-      last_usage_json: JSON.stringify(result.data),
-      status: 'ok',
-      last_error: null
-    })
-    return { success: true, data: result.data, status: 'ok' }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    if (isNeedsLoginError(error)) {
-      return accountError(accountId, message, 'stale', row.last_usage_json, { needsLogin: true })
-    }
-    return accountError(accountId, message, 'error', row.last_usage_json)
-  }
+  })
 }
 
 export async function refreshAllForProvider(
@@ -565,35 +609,77 @@ function markCacheRowStale(provider: SavedUsageProvider, email: string, message:
  * browser/login flow — a rejected refresh token is reported as `needsLogin`
  * for the caller to act on.
  */
-export async function refreshTokensForStoreAccount(
+export function refreshTokensForStoreAccount(
   provider: UsageProvider,
   ref: RefreshTokensRef
 ): Promise<'refreshed' | 'needsLogin' | 'error'> {
+  if (provider === 'anthropic') {
+    const { num, email } = ref as { num: string; email: string }
+    return withAccountLock(accountLockKey('anthropic', email), () =>
+      refreshClaudeTokensLocked(num, email)
+    )
+  }
+
+  const { accountKey } = ref as { accountKey: string }
+  return resolveCodexEmailForLock(accountKey)
+    .then((email) =>
+      withAccountLock(accountLockKey('openai', email), () => refreshCodexTokensLocked(accountKey))
+    )
+    .catch((error) => {
+      log.warn('refreshTokensForStoreAccount failed', {
+        provider,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return 'error' as const
+    })
+}
+
+async function resolveCodexEmailForLock(accountKey: string): Promise<string> {
+  const accounts = await listCodexAccounts()
+  return accounts.find((account) => account.accountKey === accountKey)?.email ?? accountKey
+}
+
+async function refreshClaudeTokensLocked(
+  num: string,
+  email: string
+): Promise<'refreshed' | 'needsLogin' | 'error'> {
   try {
-    if (provider === 'anthropic') {
-      const { num, email } = ref as { num: string; email: string }
-      const effective = await readClaudeEffectiveBlob(num, email)
-      const refreshToken = effective?.parsed.refreshToken
-      if (!refreshToken) {
-        markCacheRowStale('anthropic', email, 'No refresh token available')
-        return 'needsLogin'
-      }
+    const effective = await readClaudeEffectiveBlob(num, email)
+    const refreshToken = effective?.parsed.refreshToken
+    if (!refreshToken) {
+      markCacheRowStale('anthropic', email, 'No refresh token available')
+      return 'needsLogin'
+    }
 
-      const outcome = await refreshAnthropicToken(refreshToken)
-      if (!outcome.ok) {
-        markCacheRowStale(
-          'anthropic',
-          email,
-          `Token refresh failed: invalid_grant (${outcome.error})`
-        )
-        return 'needsLogin'
-      }
-
-      await updateClaudeTokens(num, email, outcome.result, outcome.scope)
+    // An earlier lock holder may have already refreshed this account's token
+    // while we were waiting for the lock — re-check expiry before hitting the
+    // network again.
+    const expiresAt = effective?.parsed.expiresAt
+    if (typeof expiresAt === 'number' && expiresAt - Date.now() >= REFRESH_RECHECK_THRESHOLD_MS) {
       return 'refreshed'
     }
 
-    const { accountKey } = ref as { accountKey: string }
+    const outcome = await refreshAnthropicToken(refreshToken)
+    if (!outcome.ok) {
+      markCacheRowStale('anthropic', email, `Token refresh failed: ${outcome.error}`)
+      return 'needsLogin'
+    }
+
+    await updateClaudeTokens(num, email, outcome.result, outcome.scope)
+    return 'refreshed'
+  } catch (error) {
+    log.warn('refreshTokensForStoreAccount failed', {
+      provider: 'anthropic',
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return 'error'
+  }
+}
+
+async function refreshCodexTokensLocked(
+  accountKey: string
+): Promise<'refreshed' | 'needsLogin' | 'error'> {
+  try {
     const snapshot = await readCodexEffectiveAuth(accountKey)
     const refreshToken = snapshot?.tokens?.refresh_token
     if (!refreshToken) {
@@ -601,12 +687,18 @@ export async function refreshTokensForStoreAccount(
       return 'needsLogin'
     }
 
+    // An earlier lock holder may have already refreshed this account's token
+    // while we were waiting for the lock — re-check expiry before hitting the
+    // network again.
+    const accessToken = snapshot?.tokens?.access_token
+    const expiresAtMs = typeof accessToken === 'string' ? jwtExpMs(accessToken) : null
+    if (typeof expiresAtMs === 'number' && expiresAtMs - Date.now() >= REFRESH_RECHECK_THRESHOLD_MS) {
+      return 'refreshed'
+    }
+
     const outcome = await refreshOpenAIToken(refreshToken)
     if (!outcome.ok) {
-      await markCodexCacheRowStale(
-        accountKey,
-        `Token refresh failed: invalid_grant (${outcome.error})`
-      )
+      await markCodexCacheRowStale(accountKey, `Token refresh failed: ${outcome.error}`)
       return 'needsLogin'
     }
 
@@ -614,7 +706,7 @@ export async function refreshTokensForStoreAccount(
     return 'refreshed'
   } catch (error) {
     log.warn('refreshTokensForStoreAccount failed', {
-      provider,
+      provider: 'openai',
       error: error instanceof Error ? error.message : String(error)
     })
     return 'error'

--- a/src/main/services/saved-usage-orchestrator.ts
+++ b/src/main/services/saved-usage-orchestrator.ts
@@ -417,8 +417,19 @@ export async function fetchForSavedAccount(
           batchId: options.batchId
         })
 
+        let rotationPersistError: string | null = null
         if (result.rotated) {
-          await updateClaudeTokens(account.num, account.email, result.rotated, result.rotated.scope)
+          try {
+            await updateClaudeTokens(account.num, account.email, result.rotated, result.rotated.scope)
+          } catch (persistError) {
+            const message =
+              persistError instanceof Error ? persistError.message : String(persistError)
+            log.warn(
+              'Failed to persist rotated Claude tokens; keeping the successful usage fetch result',
+              { accountId, error: message }
+            )
+            rotationPersistError = `failed to persist rotated tokens: ${message}`
+          }
         }
 
         if (!result.success || !result.data) {
@@ -442,7 +453,7 @@ export async function fetchForSavedAccount(
         db.updateSavedUsageAccountUsage(accountId, {
           last_usage_json: JSON.stringify(result.data),
           status: 'ok',
-          last_error: null
+          last_error: rotationPersistError
         })
         return { success: true, data: result.data, status: 'ok' }
       }
@@ -470,8 +481,18 @@ export async function fetchForSavedAccount(
 
       const result = await fetchOpenAIUsage(override)
 
+      let rotationPersistError: string | null = null
       if (result.rotated) {
-        await updateCodexTokens(account.accountKey, result.rotated)
+        try {
+          await updateCodexTokens(account.accountKey, result.rotated)
+        } catch (persistError) {
+          const message = persistError instanceof Error ? persistError.message : String(persistError)
+          log.warn(
+            'Failed to persist rotated Codex tokens; keeping the successful usage fetch result',
+            { accountId, error: message }
+          )
+          rotationPersistError = `failed to persist rotated tokens: ${message}`
+        }
       }
 
       if (!result.success || !result.data) {
@@ -494,7 +515,7 @@ export async function fetchForSavedAccount(
       db.updateSavedUsageAccountUsage(accountId, {
         last_usage_json: JSON.stringify(result.data),
         status: 'ok',
-        last_error: null
+        last_error: rotationPersistError
       })
       return { success: true, data: result.data, status: 'ok' }
     } catch (error) {

--- a/src/main/services/saved-usage-orchestrator.ts
+++ b/src/main/services/saved-usage-orchestrator.ts
@@ -4,6 +4,7 @@ import {
   addClaudeAccount,
   listClaudeAccounts,
   readClaudeEffectiveBlob,
+  readClaudeLiveEmail,
   readClaudeLiveIdentity,
   readClaudeLiveRawBlob,
   removeClaudeAccount,
@@ -11,6 +12,7 @@ import {
   updateClaudeTokens,
   type ClaudeStoreAccount
 } from './account-store-claude'
+import { accountLockKey, withAccountLock, withAccountLocks } from './account-lock'
 import {
   addCodexAccount,
   listCodexAccounts,
@@ -56,36 +58,6 @@ const log = createLogger({ component: 'SavedUsageOrchestrator' })
  * there's no need to hit the network again.
  */
 const REFRESH_RECHECK_THRESHOLD_MS = 120_000
-
-/**
- * Per-account async mutex. Three callers can race to refresh the SAME
- * account's OAuth token concurrently: the 60s watcher, the boot/RPC mass
- * refresh, and a user-initiated fetch. Refresh tokens are single-use and
- * rotate on every refresh, so an overlapping second refresh would consume an
- * already-rotated token and fail with invalid_grant even though the account
- * has healthy, freshly-rotated credentials from the first refresh. Chains
- * each call onto the tail promise for its key, cleaning up the map entry once
- * the chain drains so it never grows unbounded.
- */
-const accountLockTails = new Map<string, Promise<unknown>>()
-
-function accountLockKey(provider: string, email: string): string {
-  return `${provider}:${email.toLowerCase()}`
-}
-
-function withAccountLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-  const prior = accountLockTails.get(key) ?? Promise.resolve()
-  const result = prior.then(fn, fn)
-  const tail = result.then(
-    () => undefined,
-    () => undefined
-  )
-  accountLockTails.set(key, tail)
-  void tail.finally(() => {
-    if (accountLockTails.get(key) === tail) accountLockTails.delete(key)
-  })
-  return result
-}
 
 function safeParseJson(value: string): unknown {
   return JSON.parse(value)
@@ -207,6 +179,22 @@ export async function removeSavedAccount(accountId: string): Promise<boolean> {
   return db.deleteSavedUsageAccount(accountId)
 }
 
+/**
+ * The currently-live account's email for `provider` (the account being
+ * switched AWAY from). Tolerant of any read failure — a null just means we
+ * skip the outgoing lock. Codex derives it from the managed list's `active`
+ * entry so it matches the lowercased email the saved-account lock uses.
+ */
+async function readOutgoingLiveEmail(provider: SavedUsageProvider): Promise<string | null> {
+  try {
+    if (provider === 'anthropic') return await readClaudeLiveEmail()
+    const accounts = await listCodexAccounts()
+    return accounts.find((account) => account.active)?.email ?? null
+  } catch {
+    return null
+  }
+}
+
 export async function switchAccount(
   accountId: string
 ): Promise<{ success: boolean; error?: string }> {
@@ -214,20 +202,36 @@ export async function switchAccount(
   const row = db.getSavedUsageAccountById(accountId)
   if (!row) return { success: false, error: 'not found' }
 
-  try {
-    if (row.provider === 'anthropic') {
-      const account = await findClaudeStoreAccount(row.email)
-      if (!account) return { success: false, error: 'account no longer in store' }
-      await switchClaudeAccount(account.num, account.email)
-    } else {
-      const account = await findCodexStoreAccount(row.email)
-      if (!account) return { success: false, error: 'account no longer in store' }
-      await switchCodexAccount(account.accountKey)
-    }
-    return { success: true }
-  } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : String(error) }
+  // Serialize the switch under BOTH the outgoing-live and target account locks
+  // (sorted, deadlock-free). Combined with the live-fetch lock in usage-ops,
+  // this closes the window where a concurrent rotation-persist could, between
+  // its guard-read and its live-write+mirror, clobber the just-switched live
+  // credentials or mirror the outgoing account's tokens into the target's
+  // backup slot.
+  const targetKey = accountLockKey(row.provider, row.email)
+  const outgoingEmail = await readOutgoingLiveEmail(row.provider)
+  const keys = [targetKey]
+  if (outgoingEmail) {
+    const outgoingKey = accountLockKey(row.provider, outgoingEmail)
+    if (outgoingKey !== targetKey) keys.push(outgoingKey)
   }
+
+  return withAccountLocks(keys, async () => {
+    try {
+      if (row.provider === 'anthropic') {
+        const account = await findClaudeStoreAccount(row.email)
+        if (!account) return { success: false, error: 'account no longer in store' }
+        await switchClaudeAccount(account.num, account.email)
+      } else {
+        const account = await findCodexStoreAccount(row.email)
+        if (!account) return { success: false, error: 'account no longer in store' }
+        await switchCodexAccount(account.accountKey)
+      }
+      return { success: true }
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) }
+    }
+  })
 }
 
 function upsertUsageCacheRow(

--- a/src/main/services/saved-usage-orchestrator.ts
+++ b/src/main/services/saved-usage-orchestrator.ts
@@ -1,7 +1,29 @@
 import { randomUUID } from 'crypto'
 import { getDatabase } from '../db'
-import { getClaudeAccountEmail, getOpenAIAccountEmail } from './account-service'
+import {
+  addClaudeAccount,
+  listClaudeAccounts,
+  readClaudeEffectiveBlob,
+  readClaudeLiveIdentity,
+  readClaudeLiveRawBlob,
+  removeClaudeAccount,
+  switchClaudeAccount,
+  updateClaudeTokens,
+  type ClaudeStoreAccount
+} from './account-store-claude'
+import {
+  addCodexAccount,
+  listCodexAccounts,
+  readCodexEffectiveAuth,
+  removeCodexAccount,
+  switchCodexAccount,
+  updateCodexTokens,
+  type CodexStoreAccount
+} from './account-store-codex'
+import { migrateSavedCredentialsToStores } from './credentials-migration'
 import { createLogger } from './logger'
+import { refreshAnthropicToken } from './oauth-anthropic'
+import { refreshOpenAIToken } from './oauth-openai'
 import {
   fetchOpenAIUsage,
   readCodexCredentials,
@@ -9,10 +31,11 @@ import {
 } from './openai-usage-service'
 import {
   fetchClaudeUsage,
-  readClaudeCredentialsBlob,
+  NeedsLoginError,
   type ClaudeUsageFetchContext,
   type ClaudeUsageOverride
 } from './usage-service'
+import { parseCodexIdToken } from './jwt-utils'
 import type {
   FetchForAccountResult,
   OpenAIUsageData,
@@ -24,15 +47,6 @@ import type {
 import type { SavedUsageAccount, SavedUsageProvider, SavedUsageStatus } from '../db/types'
 
 const log = createLogger({ component: 'SavedUsageOrchestrator' })
-
-interface ClaudeSavedCredentials extends ClaudeUsageOverride {
-  accessToken: string
-  email: string
-}
-
-interface OpenAISavedCredentials extends OpenAIUsageOverride {
-  email: string
-}
 
 function safeParseJson(value: string): unknown {
   return JSON.parse(value)
@@ -61,73 +75,207 @@ export function toSavedAccountDTO(row: SavedUsageAccount): SavedAccountDTO {
   }
 }
 
-export function listSavedAccounts(provider?: UsageProvider): SavedAccountDTO[] {
-  const db = getDatabase()
-  const providers: SavedUsageProvider[] = provider ? [provider] : ['anthropic', 'openai']
-  return providers.flatMap((p) => db.getSavedUsageAccountsByProvider(p).map(toSavedAccountDTO))
-}
-
-export function removeSavedAccount(accountId: string): boolean {
-  return getDatabase().deleteSavedUsageAccount(accountId)
-}
-
-export async function captureLiveAccountFromFetch(
-  provider: UsageProvider,
-  usage: UsageData | OpenAIUsageData
-): Promise<void> {
-  const db = getDatabase()
-
-  if (provider === 'anthropic') {
-    const [credentialsBlob, email] = await Promise.all([
-      readClaudeCredentialsBlob(),
-      getClaudeAccountEmail()
-    ])
-    if (!credentialsBlob?.accessToken || !email) {
-      log.warn('Skipping Claude saved usage capture because token or email is unavailable')
-      return
-    }
-
-    const credentials: ClaudeSavedCredentials = {
-      accessToken: credentialsBlob.accessToken,
-      refreshToken: credentialsBlob.refreshToken,
-      expiresAt: credentialsBlob.expiresAt,
-      email
-    }
-    db.upsertSavedUsageAccount({
-      provider,
-      email,
-      credentials_json: JSON.stringify(credentials),
-      last_usage_json: JSON.stringify(usage),
-      status: 'ok',
-      last_error: null
+async function safeMigrate(): Promise<void> {
+  try {
+    await migrateSavedCredentialsToStores()
+  } catch (error) {
+    log.warn('Failed to migrate saved credentials into account stores', {
+      error: error instanceof Error ? error.message : String(error)
     })
-    log.info('Captured Claude saved usage account', { provider })
-    return
+  }
+}
+
+/**
+ * Store-backed account list: enumerates the ccswitch stores (source of
+ * truth), ensures a usage-cache row exists for each, deletes cache rows for
+ * accounts no longer in the store, and joins the store's `plan` onto the
+ * cached usage/status fields.
+ */
+export async function listSavedAccounts(provider?: UsageProvider): Promise<SavedAccountDTO[]> {
+  await safeMigrate()
+
+  const db = getDatabase()
+  const providers: UsageProvider[] = provider ? [provider] : ['anthropic', 'openai']
+  const dtos: SavedAccountDTO[] = []
+
+  for (const p of providers) {
+    const savedProvider: SavedUsageProvider = p
+    const storeAccounts: Array<{ email: string; plan: string | null }> =
+      p === 'anthropic' ? await listClaudeAccounts() : await listCodexAccounts()
+    const cacheRows = db.getSavedUsageAccountsByProvider(savedProvider)
+    const cacheByEmail = new Map(cacheRows.map((row) => [row.email.toLowerCase(), row]))
+
+    const seenEmails = new Set<string>()
+    for (const account of storeAccounts) {
+      const email = account.email.toLowerCase()
+      if (!email) continue
+      if (seenEmails.has(email)) {
+        log.warn('Duplicate store account email; keeping the first entry', {
+          provider: p,
+          email
+        })
+        continue
+      }
+      seenEmails.add(email)
+
+      let row = cacheByEmail.get(email)
+      if (!row) {
+        row = db.upsertSavedUsageAccount({
+          provider: savedProvider,
+          email,
+          credentials_json: ''
+        })
+      }
+
+      dtos.push({ ...toSavedAccountDTO(row), plan: account.plan })
+    }
+
+    for (const row of cacheRows) {
+      if (!seenEmails.has(row.email.toLowerCase())) {
+        db.deleteSavedUsageAccount(row.id)
+      }
+    }
   }
 
-  const [auth, email] = await Promise.all([readCodexCredentials(), getOpenAIAccountEmail()])
-  const tokens = auth?.tokens
-  if (!tokens?.access_token || !tokens.refresh_token || !tokens.account_id || !email) {
-    log.warn('Skipping OpenAI saved usage capture because credentials or email are unavailable')
-    return
+  return dtos
+}
+
+async function findClaudeStoreAccount(email: string): Promise<ClaudeStoreAccount | undefined> {
+  const accounts = await listClaudeAccounts()
+  const target = email.toLowerCase()
+  return accounts.find((account) => account.email === target)
+}
+
+async function findCodexStoreAccount(email: string): Promise<CodexStoreAccount | undefined> {
+  const accounts = await listCodexAccounts()
+  const target = email.toLowerCase()
+  return accounts.find((account) => account.email === target)
+}
+
+export async function removeSavedAccount(accountId: string): Promise<boolean> {
+  const db = getDatabase()
+  const row = db.getSavedUsageAccountById(accountId)
+  if (!row) return false
+
+  if (row.provider === 'anthropic') {
+    const account = await findClaudeStoreAccount(row.email)
+    if (account) await removeClaudeAccount(account.num, account.email)
+  } else {
+    const account = await findCodexStoreAccount(row.email)
+    if (account) await removeCodexAccount(account.accountKey)
   }
 
-  const credentials: OpenAISavedCredentials = {
-    accessToken: tokens.access_token,
-    refreshToken: tokens.refresh_token,
-    accountId: tokens.account_id,
-    idToken: typeof tokens.id_token === 'string' ? tokens.id_token : undefined,
-    email
+  return db.deleteSavedUsageAccount(accountId)
+}
+
+export async function switchAccount(
+  accountId: string
+): Promise<{ success: boolean; error?: string }> {
+  const db = getDatabase()
+  const row = db.getSavedUsageAccountById(accountId)
+  if (!row) return { success: false, error: 'not found' }
+
+  try {
+    if (row.provider === 'anthropic') {
+      const account = await findClaudeStoreAccount(row.email)
+      if (!account) return { success: false, error: 'account no longer in store' }
+      await switchClaudeAccount(account.num, account.email)
+    } else {
+      const account = await findCodexStoreAccount(row.email)
+      if (!account) return { success: false, error: 'account no longer in store' }
+      await switchCodexAccount(account.accountKey)
+    }
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) }
   }
-  db.upsertSavedUsageAccount({
+}
+
+function upsertUsageCacheRow(
+  provider: UsageProvider,
+  email: string,
+  usage: UsageData | OpenAIUsageData
+): void {
+  getDatabase().upsertSavedUsageAccount({
     provider,
     email,
-    credentials_json: JSON.stringify(credentials),
+    credentials_json: '',
     last_usage_json: JSON.stringify(usage),
     status: 'ok',
     last_error: null
   })
-  log.info('Captured OpenAI saved usage account', { provider })
+}
+
+/**
+ * After a successful LIVE fetch, register the live identity in the
+ * appropriate account store when it isn't already managed, then refresh the
+ * usage cache row. Never writes credentials to SQLite.
+ */
+export async function captureLiveAccountFromFetch(
+  provider: UsageProvider,
+  usage: UsageData | OpenAIUsageData
+): Promise<void> {
+  if (provider === 'anthropic') {
+    const identity = await readClaudeLiveIdentity()
+    const email = identity.email?.toLowerCase()
+    if (!email) {
+      log.warn('Skipping Claude saved usage capture because live identity email is unavailable')
+      return
+    }
+
+    const managed = await listClaudeAccounts()
+    if (!managed.some((account) => account.email === email)) {
+      const rawBlob = await readClaudeLiveRawBlob()
+      if (!rawBlob) {
+        log.warn('Skipping Claude saved usage capture because no live credential blob is available')
+        return
+      }
+      await addClaudeAccount(email, identity.uuid ?? '', rawBlob)
+      log.info('Captured Claude live account into the managed store', { provider })
+    }
+
+    upsertUsageCacheRow(provider, email, usage)
+    return
+  }
+
+  const auth = await readCodexCredentials()
+  const idToken = auth?.tokens?.id_token
+  if (typeof idToken !== 'string' || idToken.length === 0) {
+    log.warn('Skipping OpenAI saved usage capture because no live id_token is available')
+    return
+  }
+
+  const claims = parseCodexIdToken(idToken)
+  if (!claims.userId || !claims.accountId) {
+    log.warn(
+      'Skipping OpenAI saved usage capture: id_token has no chatgpt_user_id/chatgpt_account_id'
+    )
+    return
+  }
+
+  const accountKey = `${claims.userId}::${claims.accountId}`
+  const managedCodex = await listCodexAccounts()
+  const existing = managedCodex.find((account) => account.accountKey === accountKey)
+
+  if (!existing) {
+    const accessToken = auth?.tokens?.access_token
+    const refreshToken = auth?.tokens?.refresh_token
+    if (!accessToken || !refreshToken) {
+      log.warn(
+        'Skipping OpenAI saved usage capture: live auth.json is missing access/refresh token'
+      )
+      return
+    }
+    await addCodexAccount(idToken, accessToken, refreshToken)
+    log.info('Captured OpenAI live account into the managed store', { provider })
+  }
+
+  const email = (existing?.email || claims.email || '').toLowerCase()
+  if (!email) {
+    log.warn('Skipping OpenAI saved usage cache update because no email is available')
+    return
+  }
+  upsertUsageCacheRow(provider, email, usage)
 }
 
 function isAuthStatusError(message: string): boolean {
@@ -150,12 +298,26 @@ function isClaudeStaleError(message: string): boolean {
   )
 }
 
+function isNeedsLoginError(error: unknown): boolean {
+  if (error instanceof NeedsLoginError) return true
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { needsLogin?: unknown }).needsLogin === true
+  )
+}
+
+interface AccountErrorOptions {
+  retryAfter?: number
+  needsLogin?: boolean
+}
+
 function accountError(
   accountId: string,
   message: string,
   status: SavedUsageStatus = 'error',
   lastUsageJson: string | null = null,
-  retryAfter?: number
+  options: AccountErrorOptions = {}
 ): FetchForAccountResult {
   const db = getDatabase()
   db.updateSavedUsageAccountUsage(accountId, {
@@ -163,48 +325,19 @@ function accountError(
     status,
     last_error: message
   })
-  return { success: false, error: message, status, retryAfter }
-}
-
-function parseClaudeCredentials(row: SavedUsageAccount): ClaudeSavedCredentials | null {
-  const parsed = safeParseJson(row.credentials_json) as Partial<ClaudeSavedCredentials>
-  if (typeof parsed.accessToken !== 'string' || parsed.accessToken.length === 0) return null
   return {
-    accessToken: parsed.accessToken,
-    refreshToken:
-      typeof parsed.refreshToken === 'string' && parsed.refreshToken.length > 0
-        ? parsed.refreshToken
-        : undefined,
-    expiresAt: typeof parsed.expiresAt === 'number' ? parsed.expiresAt : undefined,
-    email: row.email
-  }
-}
-
-function parseOpenAICredentials(row: SavedUsageAccount): OpenAISavedCredentials | null {
-  const parsed = safeParseJson(row.credentials_json) as Partial<OpenAISavedCredentials>
-  if (
-    typeof parsed.accessToken !== 'string' ||
-    typeof parsed.refreshToken !== 'string' ||
-    typeof parsed.accountId !== 'string' ||
-    parsed.accessToken.length === 0 ||
-    parsed.refreshToken.length === 0 ||
-    parsed.accountId.length === 0
-  ) {
-    return null
-  }
-
-  return {
-    accessToken: parsed.accessToken,
-    refreshToken: parsed.refreshToken,
-    accountId: parsed.accountId,
-    idToken: typeof parsed.idToken === 'string' ? parsed.idToken : undefined,
-    email: row.email
+    success: false,
+    error: message,
+    status,
+    retryAfter: options.retryAfter,
+    ...(options.needsLogin ? { needsLogin: true } : {})
   }
 }
 
 interface FetchForSavedAccountOptions {
   caller?: ClaudeUsageFetchContext['caller']
   batchId?: string
+  userInitiated?: boolean
 }
 
 export async function fetchForSavedAccount(
@@ -217,42 +350,50 @@ export async function fetchForSavedAccount(
 
   try {
     if (row.provider === 'anthropic') {
-      const credentials = parseClaudeCredentials(row)
-      if (!credentials)
-        return accountError(accountId, 'Invalid Claude credentials', 'error', row.last_usage_json)
+      const account = await findClaudeStoreAccount(row.email)
+      if (!account) {
+        return accountError(accountId, 'account no longer in store', 'stale', row.last_usage_json)
+      }
 
-      const result = await fetchClaudeUsage(
-        {
-          accessToken: credentials.accessToken,
-          refreshToken: credentials.refreshToken,
-          expiresAt: credentials.expiresAt,
-          accountId
-        },
-        {
-          caller: options.caller ?? 'usage:fetchForAccount',
-          accountId,
-          batchId: options.batchId
-        }
-      )
+      const effective = await readClaudeEffectiveBlob(account.num, account.email)
+      const accessToken = effective?.parsed.accessToken
+      if (!accessToken) {
+        return accountError(accountId, 'Invalid Claude credentials', 'stale', row.last_usage_json)
+      }
+
+      const override: ClaudeUsageOverride = {
+        accessToken,
+        refreshToken: effective?.parsed.refreshToken,
+        expiresAt: effective?.parsed.expiresAt,
+        accountId
+      }
+
+      const result = await fetchClaudeUsage(override, {
+        caller: options.caller ?? 'usage:fetchForAccount',
+        accountId,
+        batchId: options.batchId
+      })
+
+      if (result.rotated) {
+        await updateClaudeTokens(account.num, account.email, result.rotated, result.rotated.scope)
+      }
+
       if (!result.success || !result.data) {
         const message = result.error ?? 'Claude usage fetch failed'
-        const status: SavedUsageStatus = isClaudeStaleError(message) ? 'stale' : 'error'
+        const needsLogin = result.needsLogin === true || isClaudeStaleError(message)
+        const status: SavedUsageStatus = needsLogin ? 'stale' : 'error'
         db.updateSavedUsageAccountUsage(accountId, {
           last_usage_json: row.last_usage_json,
           status,
           last_error: message
         })
-        return { success: false, error: message, status, retryAfter: result.retryAfter }
-      }
-
-      if (result.rotated) {
-        const rotatedCredentials: ClaudeSavedCredentials = {
-          ...credentials,
-          accessToken: result.rotated.accessToken,
-          refreshToken: result.rotated.refreshToken,
-          expiresAt: result.rotated.expiresAt
+        return {
+          success: false,
+          error: message,
+          status,
+          retryAfter: result.retryAfter,
+          ...(needsLogin ? { needsLogin: true } : {})
         }
-        db.updateSavedUsageAccountCredentials(accountId, JSON.stringify(rotatedCredentials))
       }
 
       db.updateSavedUsageAccountUsage(accountId, {
@@ -263,31 +404,48 @@ export async function fetchForSavedAccount(
       return { success: true, data: result.data, status: 'ok' }
     }
 
-    const credentials = parseOpenAICredentials(row)
-    if (!credentials) {
+    const account = await findCodexStoreAccount(row.email)
+    if (!account) {
+      return accountError(accountId, 'account no longer in store', 'stale', row.last_usage_json)
+    }
+
+    const snapshot = await readCodexEffectiveAuth(account.accountKey)
+    const accessToken = snapshot?.tokens?.access_token
+    const refreshToken = snapshot?.tokens?.refresh_token
+    const codexAccountId = snapshot?.tokens?.account_id
+    if (!accessToken || !refreshToken || !codexAccountId) {
       return accountError(accountId, 'Invalid OpenAI credentials', 'stale', row.last_usage_json)
     }
 
-    const result = await fetchOpenAIUsage(credentials)
+    const override: OpenAIUsageOverride = {
+      accessToken,
+      refreshToken,
+      accountId: codexAccountId,
+      idToken: typeof snapshot?.tokens?.id_token === 'string' ? snapshot.tokens.id_token : undefined,
+      email: account.email
+    }
+
+    const result = await fetchOpenAIUsage(override)
+
+    if (result.rotated) {
+      await updateCodexTokens(account.accountKey, result.rotated)
+    }
+
     if (!result.success || !result.data) {
       const message = result.error ?? 'OpenAI usage fetch failed'
-      const status: SavedUsageStatus = isOpenAIStaleError(message) ? 'stale' : 'error'
+      const needsLogin = result.needsLogin === true || isOpenAIStaleError(message)
+      const status: SavedUsageStatus = needsLogin ? 'stale' : 'error'
       db.updateSavedUsageAccountUsage(accountId, {
         last_usage_json: row.last_usage_json,
         status,
         last_error: message
       })
-      return { success: false, error: message, status }
-    }
-
-    if (result.rotated) {
-      const rotatedCredentials: OpenAISavedCredentials = {
-        ...credentials,
-        accessToken: result.rotated.accessToken,
-        refreshToken: result.rotated.refreshToken,
-        idToken: result.rotated.idToken ?? credentials.idToken
+      return {
+        success: false,
+        error: message,
+        status,
+        ...(needsLogin ? { needsLogin: true } : {})
       }
-      db.updateSavedUsageAccountCredentials(accountId, JSON.stringify(rotatedCredentials))
     }
 
     db.updateSavedUsageAccountUsage(accountId, {
@@ -298,6 +456,9 @@ export async function fetchForSavedAccount(
     return { success: true, data: result.data, status: 'ok' }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
+    if (isNeedsLoginError(error)) {
+      return accountError(accountId, message, 'stale', row.last_usage_json, { needsLogin: true })
+    }
     return accountError(accountId, message, 'error', row.last_usage_json)
   }
 }
@@ -305,7 +466,7 @@ export async function fetchForSavedAccount(
 export async function refreshAllForProvider(
   provider: UsageProvider
 ): Promise<RefreshAllResultItem[]> {
-  const rows = getDatabase().getSavedUsageAccountsByProvider(provider)
+  const accounts = await listSavedAccounts(provider)
   const batchId = randomUUID()
   const startedAt = Date.now()
   const results: RefreshAllResultItem[] = []
@@ -313,19 +474,19 @@ export async function refreshAllForProvider(
   log.info('refreshAllForProvider start', {
     provider,
     batchId,
-    accountCount: rows.length,
-    accountIds: rows.map((row) => row.id)
+    accountCount: accounts.length,
+    accountIds: accounts.map((account) => account.id)
   })
 
-  for (const row of rows) {
-    log.info('refreshAllForProvider account start', { provider, batchId, accountId: row.id })
+  for (const account of accounts) {
+    log.info('refreshAllForProvider account start', { provider, batchId, accountId: account.id })
     try {
-      const result = await fetchForSavedAccount(row.id, {
+      const result = await fetchForSavedAccount(account.id, {
         caller: 'refreshAllForProvider',
         batchId
       })
       const item = {
-        accountId: row.id,
+        accountId: account.id,
         success: result.success,
         error: result.error,
         retryAfter: result.retryAfter
@@ -333,23 +494,27 @@ export async function refreshAllForProvider(
       results.push(item)
 
       if (result.success) {
-        log.info('refreshAllForProvider account success', { provider, batchId, accountId: row.id })
+        log.info('refreshAllForProvider account success', {
+          provider,
+          batchId,
+          accountId: account.id
+        })
       } else {
         log.warn('refreshAllForProvider account failure', {
           provider,
           batchId,
-          accountId: row.id,
+          accountId: account.id,
           error: result.error,
           retryAfter: result.retryAfter
         })
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      results.push({ accountId: row.id, success: false, error: message })
+      results.push({ accountId: account.id, success: false, error: message })
       log.warn('refreshAllForProvider account failure', {
         provider,
         batchId,
-        accountId: row.id,
+        accountId: account.id,
         error: message
       })
     }
@@ -379,4 +544,86 @@ export async function refreshAllForProvider(
   })
 
   return results
+}
+
+export type RefreshTokensRef = { num: string; email: string } | { accountKey: string }
+
+function markCacheRowStale(provider: SavedUsageProvider, email: string, message: string): void {
+  const db = getDatabase()
+  const row = db.getSavedUsageAccountByProviderEmail(provider, email)
+  if (!row) return
+  db.updateSavedUsageAccountUsage(row.id, {
+    last_usage_json: row.last_usage_json,
+    status: 'stale',
+    last_error: message
+  })
+}
+
+/**
+ * Token-only refresh for the account-maintenance watcher (and any other
+ * caller that only needs fresh tokens, not a usage fetch). Never launches a
+ * browser/login flow — a rejected refresh token is reported as `needsLogin`
+ * for the caller to act on.
+ */
+export async function refreshTokensForStoreAccount(
+  provider: UsageProvider,
+  ref: RefreshTokensRef
+): Promise<'refreshed' | 'needsLogin' | 'error'> {
+  try {
+    if (provider === 'anthropic') {
+      const { num, email } = ref as { num: string; email: string }
+      const effective = await readClaudeEffectiveBlob(num, email)
+      const refreshToken = effective?.parsed.refreshToken
+      if (!refreshToken) {
+        markCacheRowStale('anthropic', email, 'No refresh token available')
+        return 'needsLogin'
+      }
+
+      const outcome = await refreshAnthropicToken(refreshToken)
+      if (!outcome.ok) {
+        markCacheRowStale(
+          'anthropic',
+          email,
+          `Token refresh failed: invalid_grant (${outcome.error})`
+        )
+        return 'needsLogin'
+      }
+
+      await updateClaudeTokens(num, email, outcome.result, outcome.scope)
+      return 'refreshed'
+    }
+
+    const { accountKey } = ref as { accountKey: string }
+    const snapshot = await readCodexEffectiveAuth(accountKey)
+    const refreshToken = snapshot?.tokens?.refresh_token
+    if (!refreshToken) {
+      await markCodexCacheRowStale(accountKey, 'No refresh token available')
+      return 'needsLogin'
+    }
+
+    const outcome = await refreshOpenAIToken(refreshToken)
+    if (!outcome.ok) {
+      await markCodexCacheRowStale(
+        accountKey,
+        `Token refresh failed: invalid_grant (${outcome.error})`
+      )
+      return 'needsLogin'
+    }
+
+    await updateCodexTokens(accountKey, outcome.result)
+    return 'refreshed'
+  } catch (error) {
+    log.warn('refreshTokensForStoreAccount failed', {
+      provider,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return 'error'
+  }
+}
+
+async function markCodexCacheRowStale(accountKey: string, message: string): Promise<void> {
+  const accounts = await listCodexAccounts()
+  const account = accounts.find((a) => a.accountKey === accountKey)
+  if (!account) return
+  markCacheRowStale('openai', account.email, message)
 }

--- a/src/main/services/usage-ops.ts
+++ b/src/main/services/usage-ops.ts
@@ -110,8 +110,11 @@ export async function fetchOpenAIUsageOp(): Promise<OpenAIUsageResult> {
   return result
 }
 
-export async function fetchForAccountOp(accountId: string): Promise<FetchForAccountResult> {
-  return fetchForSavedAccount(accountId, { caller: 'usage:fetchForAccount' })
+export async function fetchForAccountOp(
+  accountId: string,
+  userInitiated?: boolean
+): Promise<FetchForAccountResult> {
+  return fetchForSavedAccount(accountId, { caller: 'usage:fetchForAccount', userInitiated })
 }
 
 export async function refreshAllForProviderOp(

--- a/src/main/services/usage-ops.ts
+++ b/src/main/services/usage-ops.ts
@@ -10,14 +10,74 @@ import {
   fetchForSavedAccount,
   refreshAllForProvider
 } from './saved-usage-orchestrator'
-import { fetchOpenAIUsage } from './openai-usage-service'
-import { fetchClaudeUsage } from './usage-service'
+import { fetchOpenAIUsage, readCodexCredentials } from './openai-usage-service'
+import { fetchClaudeUsage, readClaudeCredentialsBlob } from './usage-service'
+import { persistRotatedLiveClaudeTokens } from './account-store-claude'
+import { persistRotatedLiveCodexTokens } from './account-store-codex'
 import { createLogger } from './logger'
 
 const log = createLogger({ component: 'UsageOps' })
 
+/**
+ * Persist rotated LIVE Claude tokens (the ones the `claude` CLI itself owns).
+ * `usedRefreshToken` is captured *before* `fetchClaudeUsage` runs so the
+ * store's race guard can tell whether the CLI rotated the same token
+ * concurrently. This is the only path in this phase that persists to the
+ * live Keychain/credentials-file location — the saved-account (SQLite) path
+ * is still handled by saved-usage-orchestrator.ts.
+ */
+async function persistLiveClaudeRotation(result: UsageResult, usedRefreshToken: string | undefined): Promise<void> {
+  if (!result.rotated) return
+  if (!usedRefreshToken) {
+    log.warn('Skipping live Claude token persistence: no prior refresh token to race-check against')
+    return
+  }
+
+  try {
+    const outcome = await persistRotatedLiveClaudeTokens(result.rotated, usedRefreshToken, result.rotated.scope)
+    if (outcome === 'skipped-race') {
+      log.warn('Rotated live Claude tokens were not persisted (race with another process)', { outcome })
+    } else {
+      log.info('Persisted rotated live Claude tokens', { outcome })
+    }
+  } catch (error) {
+    log.warn('Failed to persist rotated live Claude tokens', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+/** OpenAI/Codex equivalent of `persistLiveClaudeRotation` — see its doc comment. */
+async function persistLiveCodexRotation(
+  result: OpenAIUsageResult,
+  usedRefreshToken: string | undefined
+): Promise<void> {
+  if (!result.rotated) return
+  if (!usedRefreshToken) {
+    log.warn('Skipping live Codex token persistence: no prior refresh token to race-check against')
+    return
+  }
+
+  try {
+    const outcome = await persistRotatedLiveCodexTokens(result.rotated, usedRefreshToken)
+    if (outcome === 'skipped-race') {
+      log.warn('Rotated live Codex tokens were not persisted (race with another process)', { outcome })
+    } else {
+      log.info('Persisted rotated live Codex tokens', { outcome })
+    }
+  } catch (error) {
+    log.warn('Failed to persist rotated live Codex tokens', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
 export async function fetchUsageOp(): Promise<UsageResult> {
+  const usedRefreshToken = (await readClaudeCredentialsBlob())?.refreshToken
   const result = await fetchClaudeUsage(undefined, { caller: 'usage:fetch' })
+
+  await persistLiveClaudeRotation(result, usedRefreshToken)
+
   if (result.success && result.data) {
     try {
       await captureLiveAccountFromFetch('anthropic', result.data)
@@ -31,7 +91,11 @@ export async function fetchUsageOp(): Promise<UsageResult> {
 }
 
 export async function fetchOpenAIUsageOp(): Promise<OpenAIUsageResult> {
+  const usedRefreshToken = (await readCodexCredentials())?.tokens?.refresh_token
   const result = await fetchOpenAIUsage()
+
+  await persistLiveCodexRotation(result, usedRefreshToken)
+
   if (result.success && result.data) {
     try {
       await captureLiveAccountFromFetch('openai', result.data)

--- a/src/main/services/usage-ops.ts
+++ b/src/main/services/usage-ops.ts
@@ -10,8 +10,8 @@ import {
   fetchForSavedAccount,
   refreshAllForProvider
 } from './saved-usage-orchestrator'
-import { fetchOpenAIUsage, readCodexCredentials } from './openai-usage-service'
-import { fetchClaudeUsage, readClaudeCredentialsBlob } from './usage-service'
+import { fetchOpenAIUsage } from './openai-usage-service'
+import { fetchClaudeUsage } from './usage-service'
 import { persistRotatedLiveClaudeTokens } from './account-store-claude'
 import { persistRotatedLiveCodexTokens } from './account-store-codex'
 import { createLogger } from './logger'
@@ -20,16 +20,22 @@ const log = createLogger({ component: 'UsageOps' })
 
 /**
  * Persist rotated LIVE Claude tokens (the ones the `claude` CLI itself owns).
- * `usedRefreshToken` is captured *before* `fetchClaudeUsage` runs so the
- * store's race guard can tell whether the CLI rotated the same token
- * concurrently. This is the only path in this phase that persists to the
- * live Keychain/credentials-file location — the saved-account (SQLite) path
- * is still handled by saved-usage-orchestrator.ts.
+ * The race guard needs the refresh token the rotation was *actually
+ * performed with* (`result.rotated.rotatedFrom`) — not a token pre-read
+ * before `fetchClaudeUsage` ran, since `fetchClaudeUsage` re-reads live
+ * credentials internally and may refresh with a newer token than whatever
+ * was read before it started (e.g. the CLI rotated concurrently). Comparing
+ * against a stale pre-read would make the guard mismatch and skip
+ * persisting a perfectly valid rotation, leaving a burned refresh token
+ * live. This is the only path in this phase that persists to the live
+ * Keychain/credentials-file location — the saved-account (SQLite) path is
+ * still handled by saved-usage-orchestrator.ts.
  */
-async function persistLiveClaudeRotation(result: UsageResult, usedRefreshToken: string | undefined): Promise<void> {
+async function persistLiveClaudeRotation(result: UsageResult): Promise<void> {
   if (!result.rotated) return
+  const usedRefreshToken = result.rotated.rotatedFrom
   if (!usedRefreshToken) {
-    log.warn('Skipping live Claude token persistence: no prior refresh token to race-check against')
+    log.warn('Skipping live Claude token persistence: rotation result has no reference refresh token')
     return
   }
 
@@ -48,13 +54,11 @@ async function persistLiveClaudeRotation(result: UsageResult, usedRefreshToken: 
 }
 
 /** OpenAI/Codex equivalent of `persistLiveClaudeRotation` — see its doc comment. */
-async function persistLiveCodexRotation(
-  result: OpenAIUsageResult,
-  usedRefreshToken: string | undefined
-): Promise<void> {
+async function persistLiveCodexRotation(result: OpenAIUsageResult): Promise<void> {
   if (!result.rotated) return
+  const usedRefreshToken = result.rotated.rotatedFrom
   if (!usedRefreshToken) {
-    log.warn('Skipping live Codex token persistence: no prior refresh token to race-check against')
+    log.warn('Skipping live Codex token persistence: rotation result has no reference refresh token')
     return
   }
 
@@ -73,10 +77,9 @@ async function persistLiveCodexRotation(
 }
 
 export async function fetchUsageOp(): Promise<UsageResult> {
-  const usedRefreshToken = (await readClaudeCredentialsBlob())?.refreshToken
   const result = await fetchClaudeUsage(undefined, { caller: 'usage:fetch' })
 
-  await persistLiveClaudeRotation(result, usedRefreshToken)
+  await persistLiveClaudeRotation(result)
 
   if (result.success && result.data) {
     try {
@@ -91,10 +94,9 @@ export async function fetchUsageOp(): Promise<UsageResult> {
 }
 
 export async function fetchOpenAIUsageOp(): Promise<OpenAIUsageResult> {
-  const usedRefreshToken = (await readCodexCredentials())?.tokens?.refresh_token
   const result = await fetchOpenAIUsage()
 
-  await persistLiveCodexRotation(result, usedRefreshToken)
+  await persistLiveCodexRotation(result)
 
   if (result.success && result.data) {
     try {

--- a/src/main/services/usage-ops.ts
+++ b/src/main/services/usage-ops.ts
@@ -12,8 +12,9 @@ import {
 } from './saved-usage-orchestrator'
 import { fetchOpenAIUsage } from './openai-usage-service'
 import { fetchClaudeUsage } from './usage-service'
-import { persistRotatedLiveClaudeTokens } from './account-store-claude'
-import { persistRotatedLiveCodexTokens } from './account-store-codex'
+import { persistRotatedLiveClaudeTokens, readClaudeLiveEmail } from './account-store-claude'
+import { listCodexAccounts, persistRotatedLiveCodexTokens } from './account-store-codex'
+import { accountLockKey, withAccountLock } from './account-lock'
 import { createLogger } from './logger'
 
 const log = createLogger({ component: 'UsageOps' })
@@ -76,10 +77,45 @@ async function persistLiveCodexRotation(result: OpenAIUsageResult): Promise<void
   }
 }
 
-export async function fetchUsageOp(): Promise<UsageResult> {
-  const result = await fetchClaudeUsage(undefined, { caller: 'usage:fetch' })
+/**
+ * The live Claude email (when logged in), used to serialize this live fetch
+ * under the SAME per-account lock the saved-account path uses. Without it a
+ * left-click live fetch racing a mass refresh/watcher tick for the same
+ * account could double-consume the single-use rotating refresh token — the
+ * loser getting invalid_grant and marking a healthy account stale.
+ */
+async function readClaudeLiveLockEmail(): Promise<string | null> {
+  try {
+    return await readClaudeLiveEmail()
+  } catch {
+    return null
+  }
+}
 
-  await persistLiveClaudeRotation(result)
+/** Codex equivalent — the managed list's `active` entry's (lowercased) email. */
+async function readCodexLiveLockEmail(): Promise<string | null> {
+  try {
+    const accounts = await listCodexAccounts()
+    return accounts.find((account) => account.active)?.email ?? null
+  } catch {
+    return null
+  }
+}
+
+export async function fetchUsageOp(): Promise<UsageResult> {
+  const liveEmail = await readClaudeLiveLockEmail()
+
+  const fetchAndPersist = async (): Promise<UsageResult> => {
+    const result = await fetchClaudeUsage(undefined, { caller: 'usage:fetch' })
+    await persistLiveClaudeRotation(result)
+    return result
+  }
+
+  // Lock only when we know which account is live; logged-out fetches (no live
+  // email) can't race a saved-account rotation for a specific account.
+  const result = liveEmail
+    ? await withAccountLock(accountLockKey('anthropic', liveEmail), fetchAndPersist)
+    : await fetchAndPersist()
 
   if (result.success && result.data) {
     try {
@@ -94,9 +130,17 @@ export async function fetchUsageOp(): Promise<UsageResult> {
 }
 
 export async function fetchOpenAIUsageOp(): Promise<OpenAIUsageResult> {
-  const result = await fetchOpenAIUsage()
+  const liveEmail = await readCodexLiveLockEmail()
 
-  await persistLiveCodexRotation(result)
+  const fetchAndPersist = async (): Promise<OpenAIUsageResult> => {
+    const result = await fetchOpenAIUsage()
+    await persistLiveCodexRotation(result)
+    return result
+  }
+
+  const result = liveEmail
+    ? await withAccountLock(accountLockKey('openai', liveEmail), fetchAndPersist)
+    : await fetchAndPersist()
 
   if (result.success && result.data) {
     try {

--- a/src/main/services/usage-service.ts
+++ b/src/main/services/usage-service.ts
@@ -221,7 +221,8 @@ export async function refreshClaudeAccessToken(
         accessToken: outcome.result.accessToken,
         refreshToken: outcome.result.refreshToken,
         expiresAt: outcome.result.expiresAt,
-        scope: outcome.scope
+        scope: outcome.scope,
+        rotatedFrom: refreshToken
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)

--- a/src/main/services/usage-service.ts
+++ b/src/main/services/usage-service.ts
@@ -394,7 +394,8 @@ export async function fetchClaudeUsage(
         success: false,
         error: message,
         ...(response.status === 429 && retryAfter !== undefined ? { retryAfter } : {}),
-        ...(needsLogin ? { needsLogin: true } : {})
+        ...(needsLogin ? { needsLogin: true } : {}),
+        ...(rotated ? { rotated } : {})
       }
     }
 
@@ -418,7 +419,8 @@ export async function fetchClaudeUsage(
     return {
       success: false,
       error: message,
-      ...(error instanceof NeedsLoginError ? { needsLogin: true } : {})
+      ...(error instanceof NeedsLoginError ? { needsLogin: true } : {}),
+      ...(rotated ? { rotated } : {})
     }
   } finally {
     if (countedInFlight) {

--- a/src/main/services/usage-service.ts
+++ b/src/main/services/usage-service.ts
@@ -1,9 +1,9 @@
 import { existsSync } from 'fs'
 import { readFile } from 'fs/promises'
-import { execFile } from 'child_process'
 import { join } from 'path'
-import { homedir, platform } from 'os'
+import { homedir } from 'os'
 import { createLogger } from './logger'
+import { keychainRead } from './keychain'
 import type { ClaudeRefreshResult, UsageData, UsageResult } from '@shared/types/usage'
 
 export type { UsageData, UsageResult }
@@ -94,24 +94,9 @@ function parseClaudeCredentials(raw: string): ClaudeUsageOverride | null {
  * service "Claude Code-credentials".
  */
 async function readFromKeychain(): Promise<ClaudeUsageOverride | null> {
-  if (platform() !== 'darwin') return null
-  try {
-    const stdout = await new Promise<string>((resolve, reject) => {
-      execFile(
-        'security',
-        ['find-generic-password', '-s', 'Claude Code-credentials', '-w'],
-        { timeout: 5000 },
-        (error, out) => {
-          if (error) reject(error)
-          else resolve(out.trim())
-        }
-      )
-    })
-    if (!stdout) return null
-    return parseClaudeCredentials(stdout)
-  } catch {
-    return null
-  }
+  const stdout = await keychainRead('Claude Code-credentials')
+  if (!stdout) return null
+  return parseClaudeCredentials(stdout)
 }
 
 /**

--- a/src/main/services/usage-service.ts
+++ b/src/main/services/usage-service.ts
@@ -4,7 +4,8 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { createLogger } from './logger'
 import { keychainRead } from './keychain'
-import type { ClaudeRefreshResult, UsageData, UsageResult } from '@shared/types/usage'
+import { refreshAnthropicToken } from './oauth-anthropic'
+import type { ClaudeRefreshResult, ScopedUsageWindow, UsageData, UsageResult } from '@shared/types/usage'
 
 export type { UsageData, UsageResult }
 
@@ -12,10 +13,23 @@ const log = createLogger({ component: 'UsageService' })
 
 const CLAUDE_CLIENT_USER_AGENT = 'claude-code/2.1.5'
 const ANTHROPIC_API_VERSION = '2023-06-01'
-const ANTHROPIC_TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token'
-const ANTHROPIC_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
 
 type ClaudeTokenSource = 'keychain' | 'file' | 'override'
+
+/**
+ * Thrown by `refreshClaudeAccessToken` (and the OpenAI equivalent) when the
+ * OAuth server rejected the refresh token itself (rather than a transient
+ * network/server error) — the discriminant callers check to decide whether
+ * to prompt the user to log back in.
+ */
+export class NeedsLoginError extends Error {
+  readonly needsLogin = true as const
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'NeedsLoginError'
+  }
+}
 
 export interface ClaudeUsageFetchContext {
   caller: 'usage:fetch' | 'usage:fetchForAccount' | 'refreshAllForProvider'
@@ -177,59 +191,6 @@ async function readCappedBody(response: Response): Promise<string> {
   }
 }
 
-async function requestTokenRefresh(refreshToken: string): Promise<ClaudeRefreshResult> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 10_000)
-
-  try {
-    const response = await fetch(ANTHROPIC_TOKEN_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken,
-        client_id: ANTHROPIC_CLIENT_ID
-      }),
-      signal: controller.signal
-    })
-
-    clearTimeout(timeout)
-
-    if (!response.ok) {
-      const body = await readCappedBody(response)
-      throw new Error(`Token refresh failed (${response.status}): ${body}`)
-    }
-
-    const data = (await response.json()) as {
-      access_token?: unknown
-      refresh_token?: unknown
-      expires_in?: unknown
-    }
-    if (
-      typeof data.access_token !== 'string' ||
-      data.access_token.length === 0 ||
-      typeof data.refresh_token !== 'string' ||
-      data.refresh_token.length === 0 ||
-      typeof data.expires_in !== 'number' ||
-      !Number.isFinite(data.expires_in)
-    ) {
-      throw new Error('Token refresh failed: invalid token response')
-    }
-
-    return {
-      accessToken: data.access_token,
-      refreshToken: data.refresh_token,
-      expiresAt: Date.now() + data.expires_in * 1000
-    }
-  } catch (error) {
-    clearTimeout(timeout)
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error('Token refresh failed: request timed out')
-    }
-    throw error
-  }
-}
-
 export async function refreshClaudeAccessToken(
   refreshToken: string | undefined,
   key: string
@@ -248,12 +209,20 @@ export async function refreshClaudeAccessToken(
     })
 
     try {
-      const result = await requestTokenRefresh(refreshToken)
+      const outcome = await refreshAnthropicToken(refreshToken)
+      if (!outcome.ok) {
+        throw new NeedsLoginError(`Token refresh failed: invalid_grant (${outcome.error})`)
+      }
       log.info('Claude token refresh success', {
         accountId: key,
-        newTokenSuffix: tokenSuffix(result.accessToken)
+        newTokenSuffix: tokenSuffix(outcome.result.accessToken)
       })
-      return result
+      return {
+        accessToken: outcome.result.accessToken,
+        refreshToken: outcome.result.refreshToken,
+        expiresAt: outcome.result.expiresAt,
+        scope: outcome.scope
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       log.warn('Claude token refresh failed', { accountId: key, error: message })
@@ -315,45 +284,87 @@ function claudeRefreshKey(override: ClaudeUsageOverride): string {
   return `access:${tokenSuffix(override.accessToken)}`
 }
 
+/** Map the usage response's `limits[]` array to model-scoped usage windows (Fable/Opus/etc). */
+function mapScopedLimits(limits: unknown): ScopedUsageWindow[] | undefined {
+  if (!Array.isArray(limits)) return undefined
+
+  const scoped: ScopedUsageWindow[] = []
+  for (const entry of limits) {
+    if (!entry || typeof entry !== 'object') continue
+    const record = entry as {
+      percent?: unknown
+      resets_at?: unknown
+      scope?: { model?: { display_name?: unknown } }
+    }
+    const displayName = record.scope?.model?.display_name
+    if (typeof displayName !== 'string' || displayName.length === 0) continue
+
+    scoped.push({
+      label: displayName,
+      used_percent: typeof record.percent === 'number' ? record.percent : 0,
+      resets_at: typeof record.resets_at === 'string' ? record.resets_at : null
+    })
+  }
+  return scoped.length > 0 ? scoped : undefined
+}
+
 export async function fetchClaudeUsage(
   override?: ClaudeUsageOverride,
   ctx?: ClaudeUsageFetchContext
 ): Promise<UsageResult> {
-  const tokenWithSource =
-    override !== undefined
-      ? { token: override.accessToken, source: 'override' as const }
-      : await readAccessTokenWithSource()
-  if (!tokenWithSource?.token) {
-    log.warn('No Claude OAuth access token found (checked keychain and credentials file)', {
-      ...ctx
-    })
-    return { success: false, error: 'No access token found' }
+  let effectiveOverride: ClaudeUsageOverride
+  let tokenSource: ClaudeTokenSource
+
+  if (override !== undefined) {
+    effectiveOverride = override
+    tokenSource = 'override'
+  } else {
+    const liveWithSource = await readAccessTokenWithSource()
+    if (!liveWithSource?.token) {
+      log.warn('No Claude OAuth access token found (checked keychain and credentials file)', {
+        ...ctx
+      })
+      return { success: false, error: 'No access token found' }
+    }
+    // The LIVE credentials (whatever the `claude` CLI itself last wrote) are
+    // refreshed just like any other account from here on — build an
+    // override so the proactive/reactive refresh logic below applies to
+    // them too.
+    const liveBlob = await readClaudeCredentialsBlob()
+    effectiveOverride = {
+      accessToken: liveWithSource.token,
+      refreshToken: liveBlob?.refreshToken,
+      expiresAt: liveBlob?.expiresAt,
+      accountId: 'live'
+    }
+    tokenSource = liveWithSource.source
   }
-  let token = tokenWithSource.token
-  const tokenSource = tokenWithSource.source
+
+  let token = effectiveOverride.accessToken
 
   let countedInFlight = false
   let rotated: ClaudeRefreshResult | undefined
-  let currentRefreshToken = override?.refreshToken
+  let currentRefreshToken = effectiveOverride.refreshToken
+  let needsLogin = false
 
   try {
     inFlight += 1
     countedInFlight = true
 
     if (
-      override?.expiresAt !== undefined &&
-      Date.now() + 60_000 >= override.expiresAt &&
+      effectiveOverride.expiresAt !== undefined &&
+      Date.now() + 60_000 >= effectiveOverride.expiresAt &&
       currentRefreshToken
     ) {
-      rotated = await refreshClaudeAccessToken(currentRefreshToken, claudeRefreshKey(override))
+      rotated = await refreshClaudeAccessToken(currentRefreshToken, claudeRefreshKey(effectiveOverride))
       token = rotated.accessToken
       currentRefreshToken = rotated.refreshToken
     }
 
     let response = await fetchClaudeUsageResponse(token, tokenSource, ctx)
 
-    if (response.status === 401 && override && currentRefreshToken) {
-      rotated = await refreshClaudeAccessToken(currentRefreshToken, claudeRefreshKey(override))
+    if (response.status === 401 && currentRefreshToken) {
+      rotated = await refreshClaudeAccessToken(currentRefreshToken, claudeRefreshKey(effectiveOverride))
       token = rotated.accessToken
       currentRefreshToken = rotated.refreshToken
       response = await fetchClaudeUsageResponse(token, tokenSource, ctx)
@@ -373,15 +384,21 @@ export async function fetchClaudeUsage(
       const responseBody = await readCappedBody(response)
       log.warn('Claude usage response', { ...responseLogData, responseBody })
       const message = `Usage API returned ${response.status}: ${response.statusText}`
+      // A 401 with no refresh token to try means we truly can't recover
+      // without the user logging back in.
+      if (response.status === 401 && !currentRefreshToken) {
+        needsLogin = true
+      }
       return {
         success: false,
         error: message,
-        ...(response.status === 429 && retryAfter !== undefined ? { retryAfter } : {})
+        ...(response.status === 429 && retryAfter !== undefined ? { retryAfter } : {}),
+        ...(needsLogin ? { needsLogin: true } : {})
       }
     }
 
     log.info('Claude usage response', responseLogData)
-    const data = (await response.json()) as UsageData
+    const data = (await response.json()) as UsageData & { limits?: unknown }
 
     // API returns extra_usage credits in cents — convert to dollars
     if (data.extra_usage) {
@@ -389,11 +406,19 @@ export async function fetchClaudeUsage(
       data.extra_usage.monthly_limit = (data.extra_usage.monthly_limit ?? 0) / 100
     }
 
+    const scoped = mapScopedLimits(data.limits)
+    if (scoped) data.scoped = scoped
+    delete data.limits
+
     return { success: true, data, ...(rotated ? { rotated } : {}) }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     log.warn('Failed to fetch Claude usage', { ...ctx, error: message, inFlight })
-    return { success: false, error: message }
+    return {
+      success: false,
+      error: message,
+      ...(error instanceof NeedsLoginError ? { needsLogin: true } : {})
+    }
   } finally {
     if (countedInFlight) {
       inFlight = Math.max(0, inFlight - 1)

--- a/src/renderer/src/api/__tests__/account-api.test.ts
+++ b/src/renderer/src/api/__tests__/account-api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { SavedAccountDTO } from '@shared/types/usage'
+import type { LoginStatusDTO, SavedAccountDTO } from '@shared/types/usage'
 import { resetRendererRpcClientForTests, setRendererRpcClient } from '../rpc-client'
 import { accountApi } from '../account-api'
 
@@ -81,5 +81,60 @@ describe('accountApi', () => {
       success: false,
       error: 'account no longer in store'
     })
+  })
+
+  it('routes loginStart through the renderer RPC client with an email hint', async () => {
+    const request = vi.fn().mockResolvedValue({ loginId: 'login-1' })
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(accountApi.loginStart('anthropic', 'user@example.com')).resolves.toEqual({
+      loginId: 'login-1'
+    })
+    expect(request).toHaveBeenCalledWith('accountOps.loginStart', {
+      provider: 'anthropic',
+      email: 'user@example.com'
+    })
+  })
+
+  it('routes loginStart through the renderer RPC client without an email hint', async () => {
+    const request = vi.fn().mockResolvedValue({ loginId: 'login-2' })
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(accountApi.loginStart('openai')).resolves.toEqual({ loginId: 'login-2' })
+    expect(request).toHaveBeenCalledWith('accountOps.loginStart', {
+      provider: 'openai',
+      email: undefined
+    })
+  })
+
+  it('routes loginStatus through the renderer RPC client', async () => {
+    const status: LoginStatusDTO = {
+      loginId: 'login-1',
+      provider: 'anthropic',
+      state: 'waiting',
+      email: null,
+      error: null
+    }
+    const request = vi.fn().mockResolvedValue(status)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(accountApi.loginStatus('login-1')).resolves.toEqual(status)
+    expect(request).toHaveBeenCalledWith('accountOps.loginStatus', { loginId: 'login-1' })
+  })
+
+  it('routes loginCancel through the renderer RPC client', async () => {
+    const request = vi.fn().mockResolvedValue(true)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(accountApi.loginCancel('login-1')).resolves.toBe(true)
+    expect(request).toHaveBeenCalledWith('accountOps.loginCancel', { loginId: 'login-1' })
   })
 })

--- a/src/renderer/src/api/__tests__/account-api.test.ts
+++ b/src/renderer/src/api/__tests__/account-api.test.ts
@@ -38,7 +38,8 @@ describe('accountApi', () => {
         last_fetched_at: '2026-05-25T00:00:00.000Z',
         status: 'ok',
         last_error: null,
-        created_at: '2026-05-24T00:00:00.000Z'
+        created_at: '2026-05-24T00:00:00.000Z',
+        plan: null
       }
     ]
     const request = vi.fn().mockResolvedValue(accounts)

--- a/src/renderer/src/api/__tests__/account-api.test.ts
+++ b/src/renderer/src/api/__tests__/account-api.test.ts
@@ -60,4 +60,26 @@ describe('accountApi', () => {
     await expect(accountApi.removeSaved('account-1')).resolves.toBe(true)
     expect(request).toHaveBeenCalledWith('accountOps.removeSaved', { accountId: 'account-1' })
   })
+
+  it('routes switchAccount through the renderer RPC client', async () => {
+    const request = vi.fn().mockResolvedValue({ success: true })
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(accountApi.switchAccount('account-1')).resolves.toEqual({ success: true })
+    expect(request).toHaveBeenCalledWith('accountOps.switchAccount', { accountId: 'account-1' })
+  })
+
+  it('routes a switchAccount failure result through unchanged', async () => {
+    const request = vi.fn().mockResolvedValue({ success: false, error: 'account no longer in store' })
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(accountApi.switchAccount('account-1')).resolves.toEqual({
+      success: false,
+      error: 'account no longer in store'
+    })
+  })
 })

--- a/src/renderer/src/api/__tests__/usage-api.test.ts
+++ b/src/renderer/src/api/__tests__/usage-api.test.ts
@@ -87,7 +87,29 @@ describe('usageApi', () => {
 
     await expect(usageApi.fetchForAccount('account-1')).resolves.toBe(result)
     expect(request).toHaveBeenCalledWith('usageOps.fetchForAccount', {
-      accountId: 'account-1'
+      accountId: 'account-1',
+      userInitiated: undefined
+    })
+  })
+
+  it('passes userInitiated through to the renderer RPC client', async () => {
+    const result: FetchForAccountResult = {
+      success: true,
+      data: {
+        five_hour: { utilization: 42, resets_at: '2026-05-26T05:00:00.000Z' },
+        seven_day: { utilization: 17, resets_at: '2026-06-02T00:00:00.000Z' }
+      },
+      status: 'ok'
+    }
+    const request = vi.fn().mockResolvedValue(result)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(usageApi.fetchForAccount('account-1', true)).resolves.toBe(result)
+    expect(request).toHaveBeenCalledWith('usageOps.fetchForAccount', {
+      accountId: 'account-1',
+      userInitiated: true
     })
   })
 })

--- a/src/renderer/src/api/account-api.ts
+++ b/src/renderer/src/api/account-api.ts
@@ -1,4 +1,4 @@
-import type { SavedAccountDTO, UsageProvider } from '@shared/types/usage'
+import type { LoginStatusDTO, SavedAccountDTO, UsageProvider } from '@shared/types/usage'
 import { getRendererRpcClient } from './rpc-client'
 
 export const accountApi = {
@@ -14,5 +14,14 @@ export const accountApi = {
     getRendererRpcClient().request<{ success: boolean; error?: string }>(
       'accountOps.switchAccount',
       { accountId }
-    )
+    ),
+  loginStart: async (provider: UsageProvider, email?: string): Promise<{ loginId: string }> =>
+    getRendererRpcClient().request<{ loginId: string }>('accountOps.loginStart', {
+      provider,
+      email
+    }),
+  loginStatus: async (loginId: string): Promise<LoginStatusDTO> =>
+    getRendererRpcClient().request<LoginStatusDTO>('accountOps.loginStatus', { loginId }),
+  loginCancel: async (loginId: string): Promise<boolean> =>
+    getRendererRpcClient().request<boolean>('accountOps.loginCancel', { loginId })
 }

--- a/src/renderer/src/api/account-api.ts
+++ b/src/renderer/src/api/account-api.ts
@@ -9,5 +9,10 @@ export const accountApi = {
   listSaved: async (provider?: UsageProvider): Promise<SavedAccountDTO[]> =>
     getRendererRpcClient().request<SavedAccountDTO[]>('accountOps.listSaved', { provider }),
   removeSaved: async (accountId: string): Promise<boolean> =>
-    getRendererRpcClient().request<boolean>('accountOps.removeSaved', { accountId })
+    getRendererRpcClient().request<boolean>('accountOps.removeSaved', { accountId }),
+  switchAccount: async (accountId: string): Promise<{ success: boolean; error?: string }> =>
+    getRendererRpcClient().request<{ success: boolean; error?: string }>(
+      'accountOps.switchAccount',
+      { accountId }
+    )
 }

--- a/src/renderer/src/api/usage-api.ts
+++ b/src/renderer/src/api/usage-api.ts
@@ -16,8 +16,12 @@ export const usageApi = {
     getRendererRpcClient().request<RefreshAllResultItem[]>('usageOps.refreshAllForProvider', {
       provider
     }),
-  fetchForAccount: async (accountId: string): Promise<FetchForAccountResult> =>
+  fetchForAccount: async (
+    accountId: string,
+    userInitiated?: boolean
+  ): Promise<FetchForAccountResult> =>
     getRendererRpcClient().request<FetchForAccountResult>('usageOps.fetchForAccount', {
-      accountId
+      accountId,
+      userInitiated
     })
 }

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import { LeftSidebar } from './LeftSidebar'
 import { MainPane } from './MainPane'
 import { RightSidebar } from './RightSidebar'
 import { Toaster } from '@/components/ui/sonner'
+import { LoginBanner } from './LoginBanner'
 import { SessionHistory } from '@/components/sessions/SessionHistory'
 import { CommandPalette } from '@/components/command-palette'
 import { SettingsModal } from '@/components/settings'
@@ -291,6 +292,7 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
             </ErrorBoundary>
           </div>
           <Toaster />
+          <LoginBanner />
           {isDragging && <DropOverlay variant={activeSessionId ? 'normal' : 'warning'} />}
           <ErrorBoundary componentName="SessionHistory" fallback={null}>
             <SessionHistory />

--- a/src/renderer/src/components/layout/LoginBanner.tsx
+++ b/src/renderer/src/components/layout/LoginBanner.tsx
@@ -1,0 +1,40 @@
+import { Loader2 } from 'lucide-react'
+import { useLoginStore } from '@/stores/useLoginStore'
+import { Button } from '@/components/ui/button'
+
+const PROVIDER_LABEL: Record<'anthropic' | 'openai', string> = {
+  anthropic: 'Claude',
+  openai: 'OpenAI'
+}
+
+export function LoginBanner(): React.JSX.Element | null {
+  const activeLogin = useLoginStore((s) => s.activeLogin)
+  const cancelLogin = useLoginStore((s) => s.cancelLogin)
+
+  if (!activeLogin) return null
+
+  const providerName = PROVIDER_LABEL[activeLogin.provider]
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-2"
+      data-testid="login-banner"
+    >
+      <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-border bg-background/95 px-3 py-1.5 text-xs shadow-lg backdrop-blur">
+        <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+        <span className="text-foreground">
+          Signing in to {providerName} — complete the sign-in in Chrome…
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-6 px-2 text-xs"
+          onClick={() => cancelLogin()}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -1,0 +1,177 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { UsageAccountRow } from './UsageIndicator'
+import type { UsageData } from '@shared/types/usage'
+
+afterEach(() => {
+  cleanup()
+})
+
+const sampleUsage: UsageData = {
+  five_hour: { utilization: 20, resets_at: '2026-05-14T12:00:00.000Z' },
+  seven_day: { utilization: 10, resets_at: '2026-05-15T12:00:00.000Z' }
+}
+
+describe('UsageAccountRow', () => {
+  it('hides the Switch button for the active account', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-1',
+          email: 'active@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: true,
+          isRefreshing: false
+        }}
+        onSwitch={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: /switch to/i })).toBeNull()
+  })
+
+  it('shows a Switch button for a non-active account and calls onSwitch when clicked', async () => {
+    const user = userEvent.setup()
+    const onSwitch = vi.fn()
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-2',
+          email: 'other@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+        onSwitch={onSwitch}
+      />
+    )
+
+    const button = screen.getByRole('button', {
+      name: /switch to other@example.com/i
+    }) as HTMLButtonElement
+    expect(button.disabled).toBe(false)
+    await user.click(button)
+    expect(onSwitch).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the Switch button and shows a spinner while switching', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-3',
+          email: 'other@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+        isSwitching
+        onSwitch={vi.fn()}
+      />
+    )
+
+    const button = screen.getByRole('button', {
+      name: /switch to other@example.com/i
+    }) as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+  })
+
+  it('shows Sign in again only when the account status is stale', () => {
+    const { rerender } = render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-4',
+          email: 'expired@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+        onSignInAgain={vi.fn()}
+      />
+    )
+    expect(screen.queryByRole('button', { name: /sign in again/i })).toBeNull()
+
+    rerender(
+      <UsageAccountRow
+        row={{
+          id: 'acc-4',
+          email: 'expired@example.com',
+          usage: sampleUsage,
+          status: 'stale',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+        onSignInAgain={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('button', { name: /sign in again/i })).not.toBeNull()
+  })
+
+  it('disables Sign in again while a login is already active', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-5',
+          email: 'expired@example.com',
+          usage: sampleUsage,
+          status: 'stale',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+        isLoginActive
+        onSignInAgain={vi.fn()}
+      />
+    )
+
+    const button = screen.getByRole('button', { name: /sign in again/i }) as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+  })
+
+  it('renders one extra row per scoped usage entry, labeled from the API', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-6',
+          email: 'scoped@example.com',
+          usage: { ...sampleUsage, scoped: [{ label: 'Fable', used_percent: 55, resets_at: null }] },
+          status: 'ok',
+          lastError: null,
+          isActive: true,
+          isRefreshing: false
+        }}
+      />
+    )
+
+    expect(screen.getByText('Fable')).not.toBeNull()
+    expect(screen.getByText('55%')).not.toBeNull()
+  })
+
+  it('does not render scoped rows when the usage payload has none', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-7',
+          email: 'plain@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: true,
+          isRefreshing: false
+        }}
+      />
+    )
+
+    expect(screen.queryByText('Fable')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -34,6 +34,29 @@ describe('UsageAccountRow', () => {
     expect(screen.queryByRole('button', { name: /switch to/i })).toBeNull()
   })
 
+  it('renders real seven_day usage when the idle five_hour window has a null resets_at', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-idle',
+          email: 'noa@example.com',
+          usage: {
+            five_hour: { utilization: 0, resets_at: null },
+            seven_day: { utilization: 66, resets_at: '2026-07-10T01:59:59.000Z' }
+          },
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+        onSwitch={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('66%')).toBeTruthy()
+    expect(screen.getByText('N/A')).toBeTruthy()
+  })
+
   it('shows a Switch button for a non-active account and calls onSwitch when clicked', async () => {
     const user = userEvent.setup()
     const onSwitch = vi.fn()

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -3,12 +3,13 @@ import {
   useUsageStore,
   useAccountStore,
   useSessionStore,
+  useLoginStore,
   resolveUsageProvider,
   resolveDefaultUsageProvider,
   normalizeUsage
 } from '@/stores'
 import { useSettingsStore } from '@/stores/useSettingsStore'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { cn } from '@/lib/utils'
 import { Loader2 } from 'lucide-react'
 import claudeIcon from '@/assets/model-icons/claude.svg'
@@ -16,6 +17,7 @@ import openaiIcon from '@/assets/model-icons/openai.svg'
 import type {
   OpenAIUsageData,
   SavedAccountDTO,
+  SavedUsageStatus,
   AnthropicRateLimitState,
   AnthropicRateLimitWindow,
   UsageData,
@@ -94,9 +96,16 @@ interface UsageRowProps {
   percent: number
   resetTime: string
   rateLimit?: AnthropicRateLimitWindow
+  labelClassName?: string
 }
 
-function UsageRow({ label, percent, resetTime, rateLimit }: UsageRowProps): React.JSX.Element {
+function UsageRow({
+  label,
+  percent,
+  resetTime,
+  rateLimit,
+  labelClassName
+}: UsageRowProps): React.JSX.Element {
   const statusLabel = getStatusLabel(rateLimit?.status)
   const displayedPercent = rateLimit?.status === 'rejected' ? 100 : percent
   const percentLabel = rateLimit?.status === 'rejected' ? 'limit' : `${Math.round(percent)}%`
@@ -107,7 +116,15 @@ function UsageRow({ label, percent, resetTime, rateLimit }: UsageRowProps): Reac
 
   return (
     <div className="flex items-center gap-1.5">
-      <span className="text-[10px] text-muted-foreground w-5 shrink-0">{label}</span>
+      <span
+        className={cn(
+          'text-[10px] text-muted-foreground shrink-0 truncate',
+          labelClassName ?? 'w-5'
+        )}
+        title={label}
+      >
+        {label}
+      </span>
       <div className="h-1.5 flex-1 rounded-full bg-muted overflow-hidden">
         <div
           className={cn(
@@ -138,11 +155,11 @@ function UsageRow({ label, percent, resetTime, rateLimit }: UsageRowProps): Reac
   )
 }
 
-interface TooltipAccountRow {
+interface AccountRowData {
   id: string
   email: string | null
   usage: UsageData | null
-  status: 'ok' | 'stale' | 'error'
+  status: SavedUsageStatus
   lastError: string | null
   isActive: boolean
   isRefreshing: boolean
@@ -159,7 +176,21 @@ function usageFromSavedAccount(
   return normalizeUsage(provider, null, account.last_usage as OpenAIUsageData)
 }
 
-function UsageTooltipAccountRow({ row }: { row: TooltipAccountRow }): React.JSX.Element {
+export interface UsageAccountRowProps {
+  row: AccountRowData
+  isSwitching?: boolean
+  isLoginActive?: boolean
+  onSwitch?: () => void
+  onSignInAgain?: () => void
+}
+
+export function UsageAccountRow({
+  row,
+  isSwitching = false,
+  isLoginActive = false,
+  onSwitch,
+  onSignInAgain
+}: UsageAccountRowProps): React.JSX.Element {
   const fiveHourPercent = row.usage ? Math.round(row.usage.five_hour.utilization) : 0
   const sevenDayPercent = row.usage ? Math.round(row.usage.seven_day.utilization) : 0
   const fiveHourReset = row.usage
@@ -168,6 +199,7 @@ function UsageTooltipAccountRow({ row }: { row: TooltipAccountRow }): React.JSX.
   const sevenDayReset = row.usage
     ? formatResetTime(row.usage.seven_day.resets_at, 'seven_day')
     : 'N/A'
+  const scoped = row.usage?.scoped ?? []
 
   return (
     <div className="relative rounded-md border border-border/50 bg-background/40 px-2 py-1.5">
@@ -197,7 +229,44 @@ function UsageTooltipAccountRow({ row }: { row: TooltipAccountRow }): React.JSX.
       <div className={cn('mt-1 space-y-0.5', row.status === 'stale' && 'opacity-50')}>
         <UsageRow label="5h" percent={fiveHourPercent} resetTime={fiveHourReset} />
         <UsageRow label="7d" percent={sevenDayPercent} resetTime={sevenDayReset} />
+        {scoped.map((entry) => (
+          <UsageRow
+            key={entry.label}
+            label={entry.label}
+            percent={Math.round(entry.used_percent)}
+            resetTime={entry.resets_at ? formatResetTime(entry.resets_at, 'seven_day') : 'N/A'}
+            labelClassName="w-10"
+          />
+        ))}
       </div>
+
+      {(onSwitch || onSignInAgain) && (
+        <div className="mt-1.5 flex items-center gap-1.5">
+          {!row.isActive && onSwitch && (
+            <button
+              type="button"
+              onClick={onSwitch}
+              disabled={isSwitching}
+              aria-label={`Switch to ${row.email ?? 'this account'}`}
+              className="inline-flex items-center gap-1 rounded-sm border border-border/60 px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSwitching && <Loader2 className="h-2.5 w-2.5 animate-spin" />}
+              Switch
+            </button>
+          )}
+          {row.status === 'stale' && onSignInAgain && (
+            <button
+              type="button"
+              onClick={onSignInAgain}
+              disabled={isLoginActive}
+              aria-label={`Sign in again as ${row.email ?? 'this account'}`}
+              className="inline-flex items-center gap-1 rounded-sm border border-destructive/40 px-1.5 py-0.5 text-[9px] font-medium text-destructive transition-colors hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Sign in again
+            </button>
+          )}
+        </div>
+      )}
 
       {row.isRefreshing && (
         <div className="absolute inset-0 flex items-center justify-center rounded-md bg-background/60">
@@ -249,6 +318,8 @@ function ProviderUsageBlock({
   const forceRefreshProvider = useUsageStore((s) => s.forceRefreshProvider)
   const refreshAllForProvider = useUsageStore((s) => s.refreshAllForProvider)
   const loadSavedAccounts = useUsageStore((s) => s.loadSavedAccounts)
+  const switchAccount = useUsageStore((s) => s.switchAccount)
+  const switchingAccountIds = useUsageStore((s) => s.switchingAccountIds)
   const savedAccounts = useUsageStore((s) => s.savedAccounts[provider])
   const savedAccountLoadError = useUsageStore((s) => s.savedAccountLoadErrors[provider])
   const refreshingProvider = useUsageStore((s) => s.refreshingProviders[provider])
@@ -266,6 +337,8 @@ function ProviderUsageBlock({
     provider === 'anthropic' ? s.anthropicEmail : s.openaiEmail
   )
   const fetchEmail = useAccountStore((s) => s.fetchEmail)
+  const startLogin = useLoginStore((s) => s.startLogin)
+  const isLoginActive = useLoginStore((s) => s.activeLogin !== null)
 
   const usage = normalizeUsage(provider, anthropicUsage, openaiUsage)
 
@@ -274,7 +347,7 @@ function ProviderUsageBlock({
   const tooltipTitle = provider === 'anthropic' ? 'Claude API Usage' : 'OpenAI API Usage'
   const iconIsRefreshing = isLoading || refreshingProvider
 
-  const tooltipRows: TooltipAccountRow[] =
+  const accountRows: AccountRowData[] =
     savedAccounts.length > 0
       ? savedAccounts.map((account) => ({
           id: account.id,
@@ -319,8 +392,8 @@ function ProviderUsageBlock({
   if (!usage) {
     if (!isExplicitlySelected) return null
     return (
-      <Tooltip>
-        <TooltipTrigger asChild>
+      <HoverCard>
+        <HoverCardTrigger asChild>
           <div
             className="px-3 py-1.5 space-y-0.5 cursor-default opacity-40"
             onMouseEnter={handleLoadSavedAccounts}
@@ -349,8 +422,8 @@ function ProviderUsageBlock({
               </div>
             </div>
           </div>
-        </TooltipTrigger>
-        <TooltipContent
+        </HoverCardTrigger>
+        <HoverCardContent
           side="top"
           sideOffset={8}
           className="w-72 max-w-[min(18rem,calc(100vw-2rem))]"
@@ -362,8 +435,17 @@ function ProviderUsageBlock({
                 Saved accounts unavailable: {savedAccountLoadError}
               </div>
             )}
-            {tooltipRows.some((row) => row.email || row.usage) ? (
-              tooltipRows.map((row) => <UsageTooltipAccountRow key={row.id} row={row} />)
+            {accountRows.some((row) => row.email || row.usage) ? (
+              accountRows.map((row) => (
+                <UsageAccountRow
+                  key={row.id}
+                  row={row}
+                  isSwitching={switchingAccountIds.has(row.id)}
+                  isLoginActive={isLoginActive}
+                  onSwitch={() => switchAccount(row.id)}
+                  onSignInAgain={() => startLogin(provider, row.email ?? undefined)}
+                />
+              ))
             ) : (
               <div className="text-[10px]">No credentials configured</div>
             )}
@@ -375,8 +457,8 @@ function ProviderUsageBlock({
               </div>
             )}
           </div>
-        </TooltipContent>
-      </Tooltip>
+        </HoverCardContent>
+      </HoverCard>
     )
   }
 
@@ -391,8 +473,8 @@ function ProviderUsageBlock({
     provider === 'anthropic' ? getRateLimitWindow(anthropicRateLimit, 'seven_day') : undefined
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
+    <HoverCard>
+      <HoverCardTrigger asChild>
         <div
           className="px-3 py-1.5 space-y-0.5 cursor-default"
           onMouseEnter={handleLoadSavedAccounts}
@@ -431,8 +513,8 @@ function ProviderUsageBlock({
             </div>
           </div>
         </div>
-      </TooltipTrigger>
-      <TooltipContent
+      </HoverCardTrigger>
+      <HoverCardContent
         side="top"
         sideOffset={8}
         className="w-72 max-w-[min(18rem,calc(100vw-2rem))]"
@@ -444,8 +526,15 @@ function ProviderUsageBlock({
               Saved accounts unavailable: {savedAccountLoadError}
             </div>
           )}
-          {tooltipRows.map((row) => (
-            <UsageTooltipAccountRow key={row.id} row={row} />
+          {accountRows.map((row) => (
+            <UsageAccountRow
+              key={row.id}
+              row={row}
+              isSwitching={switchingAccountIds.has(row.id)}
+              isLoginActive={isLoginActive}
+              onSwitch={() => switchAccount(row.id)}
+              onSignInAgain={() => startLogin(provider, row.email ?? undefined)}
+            />
           ))}
           {provider === 'anthropic' && extra?.is_enabled && (
             <div className="border-t border-background/20 pt-1 text-[10px]">
@@ -477,8 +566,8 @@ function ProviderUsageBlock({
             </div>
           )}
         </div>
-      </TooltipContent>
-    </Tooltip>
+      </HoverCardContent>
+    </HoverCard>
   )
 }
 

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -33,7 +33,13 @@ function getBarColor(percent: number, rateLimitStatus?: string): string {
   return 'bg-green-500'
 }
 
-function formatResetTime(isoString: string, type: 'five_hour' | 'seven_day'): string {
+function formatResetTime(
+  isoString: string | null | undefined,
+  type: 'five_hour' | 'seven_day'
+): string {
+  // null = window with no active session (idle 5h window); without this guard
+  // new Date(null) silently renders the 1970 epoch as a real time.
+  if (!isoString) return 'N/A'
   const date = new Date(isoString)
   if (isNaN(date.getTime())) return ''
 

--- a/src/renderer/src/components/settings/SettingsAccounts.test.tsx
+++ b/src/renderer/src/components/settings/SettingsAccounts.test.tsx
@@ -1,0 +1,167 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { useUsageStore } from '@/stores/useUsageStore'
+import { useAccountStore } from '@/stores/useAccountStore'
+import { useLoginStore } from '@/stores/useLoginStore'
+import { SettingsAccounts } from './SettingsAccounts'
+import type { SavedAccountDTO } from '@shared/types/usage'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/platform', () => ({
+  isMac: () => true
+}))
+
+const anthropicAccounts: SavedAccountDTO[] = [
+  {
+    id: 'acc-active',
+    provider: 'anthropic',
+    email: 'active@example.com',
+    last_usage: null,
+    last_fetched_at: null,
+    status: 'ok',
+    last_error: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    plan: 'Max'
+  },
+  {
+    id: 'acc-expired',
+    provider: 'anthropic',
+    email: 'expired@example.com',
+    last_usage: null,
+    last_fetched_at: null,
+    status: 'stale',
+    last_error: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    plan: null
+  }
+]
+
+// Render and flush the mount effect's async loadSavedAccounts/fetchEmail so
+// their state updates land inside act().
+async function renderSettingsAccounts(): Promise<void> {
+  render(<SettingsAccounts />)
+  await act(async () => {})
+}
+
+describe('SettingsAccounts', () => {
+  let request: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    request = vi.fn(async (method: string) => {
+      if (method === 'accountOps.listSaved') return anthropicAccounts
+      if (method === 'accountOps.getClaudeEmail') return 'active@example.com'
+      if (method === 'accountOps.getOpenAIEmail') return null
+      if (method === 'accountOps.removeSaved') return true
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+
+    useUsageStore.setState({
+      savedAccounts: { anthropic: anthropicAccounts, openai: [] },
+      savedAccountLoadErrors: { anthropic: null, openai: null },
+      refreshingAccountIds: new Set<string>(),
+      removingAccountIds: new Set<string>(),
+      switchingAccountIds: new Set<string>()
+    } as Partial<ReturnType<typeof useUsageStore.getState>>)
+    useAccountStore.setState({ anthropicEmail: 'active@example.com', openaiEmail: null })
+    useLoginStore.setState({ activeLogin: null })
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetRendererRpcClientForTests()
+  })
+
+  it('renders account rows with Active, plan, and Expired badges', async () => {
+    await renderSettingsAccounts()
+
+    expect(screen.getByText('active@example.com')).not.toBeNull()
+    expect(screen.getByText('expired@example.com')).not.toBeNull()
+    expect(screen.getByText('Active')).not.toBeNull()
+    expect(screen.getByText('Max')).not.toBeNull()
+    expect(screen.getByText('Expired')).not.toBeNull()
+  })
+
+  it('hides Switch on the active account and shows it on others', async () => {
+    await renderSettingsAccounts()
+
+    expect(screen.queryByRole('button', { name: /switch to active@example.com/i })).toBeNull()
+    expect(
+      screen.getByRole('button', { name: /switch to expired@example.com/i })
+    ).not.toBeNull()
+  })
+
+  it('shows Sign in again only for expired accounts', async () => {
+    await renderSettingsAccounts()
+
+    const signInButtons = screen.getAllByRole('button', { name: /sign in again/i })
+    expect(signInButtons).toHaveLength(1)
+  })
+
+  it('requires confirmation before removing an account', async () => {
+    const user = userEvent.setup()
+    await renderSettingsAccounts()
+
+    await user.click(screen.getByRole('button', { name: /remove expired@example.com/i }))
+
+    // No RPC call before confirming
+    expect(request).not.toHaveBeenCalledWith('accountOps.removeSaved', expect.anything())
+    expect(screen.getByText('Remove account?')).not.toBeNull()
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }))
+
+    expect(request).toHaveBeenCalledWith('accountOps.removeSaved', { accountId: 'acc-expired' })
+    // Flush the store's post-remove reload chain inside act
+    await act(async () => {})
+  })
+
+  it('disables Add account while a login is active', async () => {
+    useLoginStore.setState({
+      activeLogin: {
+        loginId: 'login-1',
+        provider: 'anthropic',
+        email: null,
+        state: 'waiting',
+        error: null
+      }
+    })
+
+    await renderSettingsAccounts()
+
+    const addButton = screen.getByTestId('add-account-anthropic') as HTMLButtonElement
+    expect(addButton.disabled).toBe(true)
+  })
+
+  it('starts a login when Add account is clicked', async () => {
+    const user = userEvent.setup()
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.loginStart') return { loginId: 'login-2' }
+      if (method === 'accountOps.listSaved') return anthropicAccounts
+      if (method === 'accountOps.getClaudeEmail') return 'active@example.com'
+      if (method === 'accountOps.getOpenAIEmail') return null
+      return null
+    })
+    await renderSettingsAccounts()
+
+    await user.click(screen.getByTestId('add-account-anthropic'))
+
+    expect(request).toHaveBeenCalledWith('accountOps.loginStart', {
+      provider: 'anthropic',
+      email: undefined
+    })
+    // Clean up the poll the real store schedules
+    await act(async () => {
+      await useLoginStore.getState().cancelLogin()
+    })
+  })
+})

--- a/src/renderer/src/components/settings/SettingsAccounts.tsx
+++ b/src/renderer/src/components/settings/SettingsAccounts.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useState } from 'react'
+import { Loader2, Plus, RefreshCw, Repeat, Trash2 } from 'lucide-react'
+import { useAccountStore, useUsageStore } from '@/stores'
+import { useLoginStore } from '@/stores/useLoginStore'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import { isMac } from '@/lib/platform'
+import type { UsageProvider } from '@shared/types/usage'
+import claudeIcon from '@/assets/model-icons/claude.svg'
+import openaiIcon from '@/assets/model-icons/openai.svg'
+
+const PROVIDERS: UsageProvider[] = ['anthropic', 'openai']
+
+function ProviderAccountsCard({ provider }: { provider: UsageProvider }): React.JSX.Element {
+  const accounts = useUsageStore((s) => s.savedAccounts[provider])
+  const loadError = useUsageStore((s) => s.savedAccountLoadErrors[provider])
+  const refreshingAccountIds = useUsageStore((s) => s.refreshingAccountIds)
+  const switchingAccountIds = useUsageStore((s) => s.switchingAccountIds)
+  const removingAccountIds = useUsageStore((s) => s.removingAccountIds)
+  const refreshSavedAccount = useUsageStore((s) => s.refreshSavedAccount)
+  const switchAccount = useUsageStore((s) => s.switchAccount)
+  const removeSavedAccount = useUsageStore((s) => s.removeSavedAccount)
+  const activeEmail = useAccountStore((s) =>
+    provider === 'anthropic' ? s.anthropicEmail : s.openaiEmail
+  )
+  const startLogin = useLoginStore((s) => s.startLogin)
+  const isLoginActive = useLoginStore((s) => s.activeLogin !== null)
+  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null)
+
+  const icon = provider === 'anthropic' ? claudeIcon : openaiIcon
+  const label = provider === 'anthropic' ? 'Claude' : 'OpenAI'
+  const canAddAccount = isMac()
+  const confirmAccount = accounts.find((a) => a.id === confirmRemoveId) ?? null
+
+  return (
+    <div className="space-y-3 rounded-md border border-border/60 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <img src={icon} alt={label} className="h-4 w-4" />
+          {label}
+        </div>
+        {canAddAccount ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            disabled={isLoginActive}
+            onClick={() => startLogin(provider)}
+            data-testid={`add-account-${provider}`}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add account
+          </Button>
+        ) : (
+          <span
+            className="text-xs text-muted-foreground/70 italic"
+            title="Signing in to add an account is only supported on macOS"
+          >
+            Add account requires macOS
+          </span>
+        )}
+      </div>
+
+      {loadError && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
+          Failed to load saved accounts: {loadError}
+        </div>
+      )}
+
+      {accounts.length === 0 ? (
+        <div className="rounded-md border border-border/60 px-3 py-2 text-xs text-muted-foreground">
+          No saved accounts yet. Sign in to Claude or Codex to capture one.
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          {accounts.map((account) => {
+            const isActive = activeEmail !== null && activeEmail === account.email
+            const isRefreshing = refreshingAccountIds.has(account.id)
+            const isSwitching = switchingAccountIds.has(account.id)
+            const isRemoving = removingAccountIds.has(account.id)
+            const isExpired = account.status === 'stale'
+
+            return (
+              <div
+                key={account.id}
+                className="flex items-center justify-between gap-3 rounded-md border border-border/60 px-3 py-2"
+                data-testid={`account-row-${account.id}`}
+              >
+                <div className="min-w-0">
+                  <div className={cn('truncate text-sm', isActive && 'font-semibold')}>
+                    {account.email}
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                    {isActive && (
+                      <span className="rounded-full bg-primary/15 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                        Active
+                      </span>
+                    )}
+                    {account.plan && (
+                      <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                        {account.plan}
+                      </span>
+                    )}
+                    {!isExpired && account.status === 'ok' && !isActive && (
+                      <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                        OK
+                      </span>
+                    )}
+                    {isExpired && (
+                      <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-medium text-destructive">
+                        Expired
+                      </span>
+                    )}
+                    {account.status === 'error' && (
+                      <span
+                        className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-medium text-destructive"
+                        title={account.last_error ?? undefined}
+                      >
+                        Error
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                    onClick={() => refreshSavedAccount(account.id, { userInitiated: true })}
+                    disabled={isRefreshing}
+                    aria-label={`Refresh ${account.email}`}
+                  >
+                    {isRefreshing ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                  {!isActive && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                      onClick={() => switchAccount(account.id)}
+                      disabled={isSwitching}
+                      aria-label={`Switch to ${account.email}`}
+                    >
+                      {isSwitching ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Repeat className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  )}
+                  {isExpired && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 text-xs text-muted-foreground hover:text-foreground"
+                      onClick={() => startLogin(provider, account.email)}
+                      disabled={isLoginActive}
+                    >
+                      Sign in again
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                    onClick={() => setConfirmRemoveId(account.id)}
+                    disabled={isRemoving}
+                    aria-label={`Remove ${account.email}`}
+                  >
+                    {isRemoving ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <AlertDialog
+        open={confirmRemoveId !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmRemoveId(null)
+        }}
+      >
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove account?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes <span className="font-semibold">{confirmAccount?.email}</span> from the
+              usage popup. You can add it back by signing in again.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (confirmRemoveId) removeSavedAccount(confirmRemoveId)
+                setConfirmRemoveId(null)
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}
+
+export function SettingsAccounts(): React.JSX.Element {
+  const loadSavedAccounts = useUsageStore((s) => s.loadSavedAccounts)
+  const fetchEmail = useAccountStore((s) => s.fetchEmail)
+
+  useEffect(() => {
+    loadSavedAccounts().catch(() => {})
+    fetchEmail('anthropic')
+    fetchEmail('openai')
+  }, [loadSavedAccounts, fetchEmail])
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-base font-medium mb-1">Accounts</h3>
+        <p className="text-sm text-muted-foreground">
+          Manage saved Claude and OpenAI accounts used for usage tracking and quick switching.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {PROVIDERS.map((provider) => (
+          <ProviderAccountsCard key={provider} provider={provider} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -1,116 +1,15 @@
-import { useEffect } from 'react'
 import { useThemeStore } from '@/stores/useThemeStore'
 import { DEFAULT_THEME_ID } from '@/lib/themes'
 import { useSettingsStore } from '@/stores/useSettingsStore'
-import { RotateCcw, Trash2 } from 'lucide-react'
+import { RotateCcw } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { useShortcutStore } from '@/stores/useShortcutStore'
-import { useAccountStore, useUsageStore } from '@/stores'
 import { toast } from '@/lib/toast'
 import type { UsageProvider } from '@shared/types/usage'
 import claudeIcon from '@/assets/model-icons/claude.svg'
 import openaiIcon from '@/assets/model-icons/openai.svg'
 import { isAgentSdkAvailable } from '@/lib/agent-sdk-availability'
-
-const SAVED_ACCOUNT_PROVIDERS: UsageProvider[] = ['anthropic', 'openai']
-
-function SavedAccountsList(): React.JSX.Element {
-  const savedAccounts = useUsageStore((s) => s.savedAccounts)
-  const loadSavedAccounts = useUsageStore((s) => s.loadSavedAccounts)
-  const removeSavedAccount = useUsageStore((s) => s.removeSavedAccount)
-  const anthropicEmail = useAccountStore((s) => s.anthropicEmail)
-  const openaiEmail = useAccountStore((s) => s.openaiEmail)
-  const fetchEmail = useAccountStore((s) => s.fetchEmail)
-
-  useEffect(() => {
-    loadSavedAccounts().catch(() => {})
-    fetchEmail('anthropic')
-    fetchEmail('openai')
-  }, [loadSavedAccounts, fetchEmail])
-
-  const activeEmails: Record<UsageProvider, string | null> = {
-    anthropic: anthropicEmail,
-    openai: openaiEmail
-  }
-
-  return (
-    <div className="mt-4 space-y-3 border-t border-border/60 pt-4">
-      <div>
-        <div className="text-sm font-medium">Saved accounts</div>
-        <p className="text-xs text-muted-foreground">
-          Remove accounts from the usage popup without signing out of provider CLIs.
-        </p>
-      </div>
-
-      {SAVED_ACCOUNT_PROVIDERS.map((provider) => {
-        const providerAccounts = savedAccounts[provider]
-        const icon = provider === 'anthropic' ? claudeIcon : openaiIcon
-        const label = provider === 'anthropic' ? 'Claude' : 'OpenAI'
-
-        return (
-          <div key={provider} className="space-y-2">
-            <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
-              <img src={icon} alt={label} className="h-3.5 w-3.5" />
-              {label}
-            </div>
-
-            {providerAccounts.length === 0 ? (
-              <div className="rounded-md border border-border/60 px-3 py-2 text-xs text-muted-foreground">
-                No saved accounts yet. Use Claude or Codex to capture one.
-              </div>
-            ) : (
-              <div className="space-y-1.5">
-                {providerAccounts.map((account) => {
-                  const isActive = activeEmails[provider] === account.email
-                  const isExpired = account.status === 'stale'
-                  return (
-                    <div
-                      key={account.id}
-                      className="flex items-center justify-between gap-3 rounded-md border border-border/60 px-3 py-2"
-                    >
-                      <div className="min-w-0">
-                        <div className={cn('truncate text-sm', isActive && 'font-semibold')}>
-                          {account.email}
-                        </div>
-                        <div className="mt-1 flex items-center gap-1.5">
-                          {isActive && (
-                            <span className="rounded-full bg-primary/15 px-1.5 py-0.5 text-[10px] font-medium text-primary">
-                              Active
-                            </span>
-                          )}
-                          {isExpired && (
-                            <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-medium text-destructive">
-                              Expired
-                            </span>
-                          )}
-                          {account.status === 'error' && (
-                            <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-medium text-destructive">
-                              Error
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7 text-muted-foreground hover:text-destructive"
-                        onClick={() => removeSavedAccount(account.id)}
-                        aria-label={`Remove ${account.email}`}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                  )
-                })}
-              </div>
-            )}
-          </div>
-        )
-      })}
-    </div>
-  )
-}
 
 export function SettingsGeneral(): React.JSX.Element {
   const { setTheme } = useThemeStore()
@@ -135,7 +34,8 @@ export function SettingsGeneral(): React.JSX.Element {
     availableAgentSdks,
     stripAtMentions,
     updateSetting,
-    resetToDefaults
+    resetToDefaults,
+    setActiveSection
   } = useSettingsStore()
   const { resetToDefaults: resetShortcuts } = useShortcutStore()
 
@@ -626,7 +526,17 @@ export function SettingsGeneral(): React.JSX.Element {
             )}
           </div>
         )}
-        <SavedAccountsList />
+        <p className="mt-4 border-t border-border/60 pt-4 text-xs text-muted-foreground">
+          Accounts have moved to{' '}
+          <button
+            type="button"
+            onClick={() => setActiveSection('accounts')}
+            className="text-primary underline underline-offset-2 hover:text-primary/80"
+            data-testid="accounts-moved-link"
+          >
+            Settings → Accounts
+          </button>
+        </p>
       </div>
 
       {/* Default Agent SDK */}

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -18,12 +18,14 @@ import {
   Database,
   Hash,
   RadioTower,
-  Building2
+  Building2,
+  Users
 } from 'lucide-react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { SettingsAppearance } from './SettingsAppearance'
 import { SettingsGeneral } from './SettingsGeneral'
+import { SettingsAccounts } from './SettingsAccounts'
 import { SettingsModels } from './SettingsModels'
 import { SettingsEditor } from './SettingsEditor'
 import { SettingsTerminal } from './SettingsTerminal'
@@ -45,6 +47,7 @@ import { cn } from '@/lib/utils'
 const SECTIONS = [
   { id: 'appearance', label: 'Appearance', icon: Palette },
   { id: 'general', label: 'General', icon: Monitor },
+  { id: 'accounts', label: 'Accounts', icon: Users },
   { id: 'custom-commands', label: 'Custom Commands', icon: Zap },
   { id: 'models', label: 'Models', icon: Sparkles },
   { id: 'pet', label: 'Pet', icon: Bug },
@@ -119,6 +122,7 @@ export function SettingsModal(): React.JSX.Element {
           <div className="flex-1 overflow-y-auto p-6">
             {activeSection === 'appearance' && <SettingsAppearance />}
             {activeSection === 'general' && <SettingsGeneral />}
+            {activeSection === 'accounts' && <SettingsAccounts />}
             {activeSection === 'custom-commands' && <SettingsCustomCommands />}
             {activeSection === 'models' && <SettingsModels />}
             {activeSection === 'pet' && <SettingsPet />}

--- a/src/renderer/src/components/ui/hover-card.tsx
+++ b/src/renderer/src/components/ui/hover-card.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react'
+import { HoverCard as HoverCardPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+import { GhosttySuppressionBoundary } from './GhosttySuppressionBoundary'
+
+function HoverCard({
+  openDelay = 150,
+  closeDelay = 250,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return (
+    <HoverCardPrimitive.Root
+      data-slot="hover-card"
+      openDelay={openDelay}
+      closeDelay={closeDelay}
+      {...props}
+    />
+  )
+}
+
+function HoverCardTrigger({ ...props }: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  return <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+}
+
+function HoverCardContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  return (
+    <HoverCardPrimitive.Portal>
+      <GhosttySuppressionBoundary scope="hover-card">
+        <HoverCardPrimitive.Content
+          data-slot="hover-card-content"
+          align={align}
+          sideOffset={sideOffset}
+          className={cn(
+            'relative overflow-hidden z-50 w-72 origin-(--radix-hover-card-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-lg/5 outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]',
+            className
+          )}
+          {...props}
+        />
+      </GhosttySuppressionBoundary>
+    </HoverCardPrimitive.Portal>
+  )
+}
+
+function HoverCardArrow({ className, ...props }: React.ComponentProps<typeof HoverCardPrimitive.Arrow>) {
+  return (
+    <HoverCardPrimitive.Arrow
+      data-slot="hover-card-arrow"
+      className={cn('bg-popover fill-popover', className)}
+      {...props}
+    />
+  )
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent, HoverCardArrow }

--- a/src/renderer/src/stores/__tests__/useLoginStore.test.ts
+++ b/src/renderer/src/stores/__tests__/useLoginStore.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { toast } from '@/lib/toast'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn()
+  }
+}))
+
+const mocks = vi.hoisted(() => ({
+  loadSavedAccounts: vi.fn(async () => {}),
+  fetchEmail: vi.fn(async () => {})
+}))
+
+vi.mock('../useUsageStore', () => ({
+  useUsageStore: { getState: () => ({ loadSavedAccounts: mocks.loadSavedAccounts }) }
+}))
+
+vi.mock('../useAccountStore', () => ({
+  useAccountStore: { getState: () => ({ fetchEmail: mocks.fetchEmail }) }
+}))
+
+import { useLoginStore } from '../useLoginStore'
+
+describe('useLoginStore', () => {
+  let request: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.loadSavedAccounts.mockClear()
+    mocks.fetchEmail.mockClear()
+    vi.mocked(toast.error).mockClear()
+    vi.mocked(toast.success).mockClear()
+    vi.mocked(toast.info).mockClear()
+
+    useLoginStore.setState({ activeLogin: null })
+
+    request = vi.fn(async () => null)
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+    vi.useRealTimers()
+  })
+
+  it('starts a login, polls, and clears on done with success toast + account reload', async () => {
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.loginStart') return { loginId: 'login-1' }
+      if (method === 'accountOps.loginStatus') {
+        return { loginId: 'login-1', provider: 'anthropic', state: 'done', email: 'a@b.com', error: null }
+      }
+      return null
+    })
+
+    await useLoginStore.getState().startLogin('anthropic')
+    expect(useLoginStore.getState().activeLogin).toMatchObject({
+      loginId: 'login-1',
+      provider: 'anthropic',
+      state: 'launching'
+    })
+
+    await vi.advanceTimersByTimeAsync(1500)
+
+    expect(useLoginStore.getState().activeLogin).toBeNull()
+    expect(toast.success).toHaveBeenCalledWith('Signed in as a@b.com')
+    expect(mocks.loadSavedAccounts).toHaveBeenCalledWith('anthropic')
+    expect(mocks.fetchEmail).toHaveBeenCalledWith('anthropic')
+  })
+
+  it('keeps polling through non-terminal states before reaching done', async () => {
+    let call = 0
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.loginStart') return { loginId: 'login-2' }
+      if (method === 'accountOps.loginStatus') {
+        call += 1
+        if (call === 1) {
+          return { loginId: 'login-2', provider: 'anthropic', state: 'waiting', email: null, error: null }
+        }
+        return { loginId: 'login-2', provider: 'anthropic', state: 'done', email: 'x@y.com', error: null }
+      }
+      return null
+    })
+
+    await useLoginStore.getState().startLogin('anthropic')
+    await vi.advanceTimersByTimeAsync(1500)
+    expect(useLoginStore.getState().activeLogin?.state).toBe('waiting')
+
+    await vi.advanceTimersByTimeAsync(1500)
+    expect(useLoginStore.getState().activeLogin).toBeNull()
+    expect(toast.success).toHaveBeenCalledWith('Signed in as x@y.com')
+  })
+
+  it('treats a login as failed after 5 consecutive poll rejections', async () => {
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.loginStart') return { loginId: 'login-3' }
+      if (method === 'accountOps.loginStatus') throw new Error('ws disconnected')
+      return null
+    })
+
+    await useLoginStore.getState().startLogin('anthropic')
+
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(1500)
+      expect(useLoginStore.getState().activeLogin).not.toBeNull()
+    }
+
+    await vi.advanceTimersByTimeAsync(1500)
+    expect(useLoginStore.getState().activeLogin).toBeNull()
+    expect(toast.error).toHaveBeenCalledWith('Sign-in failed')
+  })
+
+  it('resets the failure counter on a successful poll, so fewer-than-5 failures keep polling', async () => {
+    let call = 0
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.loginStart') return { loginId: 'login-4' }
+      if (method === 'accountOps.loginStatus') {
+        call += 1
+        // Fail 3 times, succeed, fail 3 more times (never 5 in a row) -> still polling
+        if (call === 4) {
+          return { loginId: 'login-4', provider: 'anthropic', state: 'waiting', email: null, error: null }
+        }
+        throw new Error('ws disconnected')
+      }
+      return null
+    })
+
+    await useLoginStore.getState().startLogin('anthropic')
+
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersByTimeAsync(1500)
+    }
+
+    // Still active — never hit 5 CONSECUTIVE failures because call 4 succeeded
+    expect(useLoginStore.getState().activeLogin).not.toBeNull()
+    expect(toast.error).not.toHaveBeenCalledWith('Sign-in failed')
+  })
+
+  it('surfaces the terminal failed state from the server with its error message', async () => {
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.loginStart') return { loginId: 'login-5' }
+      if (method === 'accountOps.loginStatus') {
+        return {
+          loginId: 'login-5',
+          provider: 'anthropic',
+          state: 'failed',
+          email: null,
+          error: 'Token exchange failed'
+        }
+      }
+      return null
+    })
+
+    await useLoginStore.getState().startLogin('anthropic')
+    await vi.advanceTimersByTimeAsync(1500)
+
+    expect(useLoginStore.getState().activeLogin).toBeNull()
+    expect(toast.error).toHaveBeenCalledWith('Token exchange failed')
+  })
+
+  it('cancelLogin calls the cancel API and clears local state immediately', async () => {
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.loginStart') return { loginId: 'login-6' }
+      if (method === 'accountOps.loginCancel') return true
+      if (method === 'accountOps.loginStatus') {
+        return { loginId: 'login-6', provider: 'anthropic', state: 'waiting', email: null, error: null }
+      }
+      return null
+    })
+
+    await useLoginStore.getState().startLogin('anthropic')
+    await useLoginStore.getState().cancelLogin()
+
+    expect(useLoginStore.getState().activeLogin).toBeNull()
+    expect(request).toHaveBeenCalledWith('accountOps.loginCancel', { loginId: 'login-6' })
+    expect(toast.info).toHaveBeenCalledWith('Sign-in cancelled')
+
+    // Any poll already scheduled before cancel must not resurrect activeLogin.
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(useLoginStore.getState().activeLogin).toBeNull()
+  })
+
+  it('does not clobber the existing activeLogin when the server rejects a concurrent login', async () => {
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.loginStart') return { loginId: 'login-7' }
+      if (method === 'accountOps.loginStatus') {
+        return { loginId: 'login-7', provider: 'anthropic', state: 'waiting', email: null, error: null }
+      }
+      return null
+    })
+    await useLoginStore.getState().startLogin('anthropic')
+    const before = useLoginStore.getState().activeLogin
+
+    request.mockImplementationOnce(async () => {
+      throw new Error('A login is already in progress')
+    })
+    await useLoginStore.getState().startLogin('openai')
+
+    expect(useLoginStore.getState().activeLogin).toEqual(before)
+    expect(toast.error).toHaveBeenCalledWith('A login is already in progress')
+  })
+})

--- a/src/renderer/src/stores/__tests__/useLoginStore.test.ts
+++ b/src/renderer/src/stores/__tests__/useLoginStore.test.ts
@@ -184,6 +184,56 @@ describe('useLoginStore', () => {
     expect(useLoginStore.getState().activeLogin).toBeNull()
   })
 
+  it('cancelling mid-poll must not resurrect activeLogin when the in-flight loginStatus resolves afterward', async () => {
+    let resolveStatus!: (value: {
+      loginId: string
+      provider: string
+      state: string
+      email: string | null
+      error: string | null
+    }) => void
+    const statusPromise = new Promise((resolve) => {
+      resolveStatus = resolve
+    })
+
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.loginStart') return { loginId: 'login-8' }
+      if (method === 'accountOps.loginCancel') return true
+      if (method === 'accountOps.loginStatus') return statusPromise
+      return null
+    })
+
+    await useLoginStore.getState().startLogin('anthropic')
+
+    // Let the poll timer fire, kicking off the in-flight loginStatus request.
+    await vi.advanceTimersByTimeAsync(1500)
+
+    // Cancel while that request is still in flight.
+    await useLoginStore.getState().cancelLogin()
+    expect(useLoginStore.getState().activeLogin).toBeNull()
+    vi.mocked(toast.info).mockClear()
+
+    // Now the stale in-flight request resolves with a pre-cancel status.
+    resolveStatus({
+      loginId: 'login-8',
+      provider: 'anthropic',
+      state: 'waiting',
+      email: null,
+      error: null
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(useLoginStore.getState().activeLogin).toBeNull()
+    expect(toast.info).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalled()
+
+    // And no reschedule should have happened either.
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(useLoginStore.getState().activeLogin).toBeNull()
+  })
+
   it('does not clobber the existing activeLogin when the server rejects a concurrent login', async () => {
     request.mockImplementation(async (method: string) => {
       if (method === 'accountOps.loginStart') return { loginId: 'login-7' }

--- a/src/renderer/src/stores/__tests__/useUsageStore.retry-after.test.ts
+++ b/src/renderer/src/stores/__tests__/useUsageStore.retry-after.test.ts
@@ -2,6 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
 import { useUsageStore } from '../useUsageStore'
+import { toast } from '@/lib/toast'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn()
+  }
+}))
 
 const baseState = {
   anthropicUsage: null,
@@ -30,6 +38,8 @@ describe('useUsageStore Anthropic rate-limit throttling', () => {
     vi.clearAllMocks()
 
     useUsageStore.setState(baseState)
+    vi.mocked(toast.error).mockClear()
+    vi.mocked(toast.success).mockClear()
 
     request = vi.fn(async (method: string) => {
       if (method === 'accountOps.listSaved') return []
@@ -63,14 +73,48 @@ describe('useUsageStore Anthropic rate-limit throttling', () => {
     expect(useUsageStore.getState().anthropicLastFetchedAt).toBe(Date.now() - 180_000 + 30_000)
   })
 
-  it('does not force refresh Anthropic usage within 5 seconds of a successful attempt', async () => {
+  it('force-refreshes Anthropic usage even within 5 seconds of a successful attempt (no floor gate)', async () => {
     useUsageStore.setState({
       anthropicLastFetchedAt: Date.now() - 1_000,
       anthropicLastError: null
+    })
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.fetch') return { success: true, data: undefined }
+      if (method === 'accountOps.listSaved') return []
+      return null
+    })
+
+    await useUsageStore.getState().forceRefreshProvider('anthropic')
+
+    expect(request.mock.calls.filter(([method]) => method === 'usageOps.fetch')).toHaveLength(1)
+  })
+
+  it('blocks force refresh while an active 429 retry-after window has not elapsed, and toasts', async () => {
+    useUsageStore.setState({
+      anthropicLastRetryAfter: 30,
+      anthropicLastFetchedAt: Date.now() - 180_000 + 30_000
     })
 
     await useUsageStore.getState().forceRefreshProvider('anthropic')
 
     expect(request.mock.calls.filter(([method]) => method === 'usageOps.fetch')).toHaveLength(0)
+    expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/^Rate limited — retry in \d+s$/))
+  })
+
+  it('allows force refresh again once the 429 retry-after window has elapsed', async () => {
+    useUsageStore.setState({
+      anthropicLastRetryAfter: 30,
+      // Past the DEBOUNCE_MS-based deadline encoding, so the gate should no longer be active.
+      anthropicLastFetchedAt: Date.now() - 200_000
+    })
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.fetch') return { success: true, data: undefined }
+      if (method === 'accountOps.listSaved') return []
+      return null
+    })
+
+    await useUsageStore.getState().forceRefreshProvider('anthropic')
+
+    expect(request.mock.calls.filter(([method]) => method === 'usageOps.fetch')).toHaveLength(1)
   })
 })

--- a/src/renderer/src/stores/index.ts
+++ b/src/renderer/src/stores/index.ts
@@ -61,6 +61,7 @@ export {
   normalizeUsage
 } from './useUsageStore'
 export { useAccountStore } from './useAccountStore'
+export { useLoginStore, type ActiveLogin, type LoginState } from './useLoginStore'
 export { useHintStore } from './useHintStore'
 export { useVimModeStore } from './useVimModeStore'
 export { usePRReviewStore } from './usePRReviewStore'

--- a/src/renderer/src/stores/useLoginStore.ts
+++ b/src/renderer/src/stores/useLoginStore.ts
@@ -1,0 +1,155 @@
+import { create } from 'zustand'
+import type { LoginState, LoginStatusDTO, UsageProvider } from '@shared/types/usage'
+import { accountApi } from '@/api/account-api'
+import { toast } from '@/lib/toast'
+import { useUsageStore } from './useUsageStore'
+import { useAccountStore } from './useAccountStore'
+
+export type { LoginState }
+
+export interface ActiveLogin {
+  loginId: string
+  provider: UsageProvider
+  email: string | null
+  state: LoginState
+  error: string | null
+}
+
+interface LoginState_ {
+  activeLogin: ActiveLogin | null
+  startLogin: (provider: UsageProvider, email?: string) => Promise<void>
+  cancelLogin: () => Promise<void>
+}
+
+const POLL_INTERVAL_MS = 1500
+const MAX_CONSECUTIVE_FAILURES = 5
+const NON_TERMINAL_STATES: LoginState[] = ['launching', 'waiting', 'exchanging']
+
+// Module-level poll bookkeeping. Only one login can be active at a time (the
+// server enforces this too), so a single handle/counter is sufficient.
+let pollTimeoutHandle: ReturnType<typeof setTimeout> | null = null
+let consecutiveFailures = 0
+
+function stopPolling(): void {
+  if (pollTimeoutHandle !== null) {
+    clearTimeout(pollTimeoutHandle)
+    pollTimeoutHandle = null
+  }
+  consecutiveFailures = 0
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+export const useLoginStore = create<LoginState_>()((set, get) => ({
+  activeLogin: null,
+
+  startLogin: async (provider: UsageProvider, email?: string) => {
+    try {
+      const { loginId } = await accountApi.loginStart(provider, email)
+      consecutiveFailures = 0
+      set({
+        activeLogin: {
+          loginId,
+          provider,
+          email: email ?? null,
+          state: 'launching',
+          error: null
+        }
+      })
+      schedulePoll(loginId, provider, get, set)
+    } catch (err) {
+      toast.error(errorMessage(err))
+    }
+  },
+
+  cancelLogin: async () => {
+    const current = get().activeLogin
+    if (!current) return
+
+    stopPolling()
+    set({ activeLogin: null })
+    try {
+      await accountApi.loginCancel(current.loginId)
+    } catch {
+      // best-effort — local state is already cleared
+    }
+    toast.info('Sign-in cancelled')
+  }
+}))
+
+function applyStatus(
+  status: LoginStatusDTO,
+  provider: UsageProvider,
+  set: (partial: Partial<LoginState_>) => void
+): void {
+  if (status.state === 'done') {
+    stopPolling()
+    toast.success(`Signed in as ${status.email ?? 'account'}`)
+    useUsageStore
+      .getState()
+      .loadSavedAccounts(provider)
+      .catch(() => {})
+    useAccountStore.getState().fetchEmail(provider)
+    set({ activeLogin: null })
+    return
+  }
+
+  if (status.state === 'failed') {
+    stopPolling()
+    toast.error(status.error ?? 'Sign-in failed')
+    set({ activeLogin: null })
+    return
+  }
+
+  if (status.state === 'cancelled') {
+    stopPolling()
+    toast.info('Sign-in cancelled')
+    set({ activeLogin: null })
+    return
+  }
+
+  set({
+    activeLogin: {
+      loginId: status.loginId,
+      provider,
+      email: status.email,
+      state: status.state,
+      error: status.error
+    }
+  })
+}
+
+function schedulePoll(
+  loginId: string,
+  provider: UsageProvider,
+  get: () => LoginState_,
+  set: (partial: Partial<LoginState_>) => void
+): void {
+  pollTimeoutHandle = setTimeout(() => {
+    // Bail if this login was cancelled/replaced while the timer was pending.
+    const current = get().activeLogin
+    if (!current || current.loginId !== loginId) return
+
+    accountApi
+      .loginStatus(loginId)
+      .then((status) => {
+        consecutiveFailures = 0
+        applyStatus(status, provider, set)
+        if (NON_TERMINAL_STATES.includes(status.state)) {
+          schedulePoll(loginId, provider, get, set)
+        }
+      })
+      .catch(() => {
+        consecutiveFailures += 1
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          stopPolling()
+          toast.error('Sign-in failed')
+          set({ activeLogin: null })
+          return
+        }
+        schedulePoll(loginId, provider, get, set)
+      })
+  }, POLL_INTERVAL_MS)
+}

--- a/src/renderer/src/stores/useLoginStore.ts
+++ b/src/renderer/src/stores/useLoginStore.ts
@@ -135,6 +135,11 @@ function schedulePoll(
     accountApi
       .loginStatus(loginId)
       .then((status) => {
+        // The login may have been cancelled/replaced while this request was
+        // in flight — re-check before applying its (now stale) result or
+        // rescheduling another poll for a login that's no longer active.
+        if (get().activeLogin?.loginId !== loginId) return
+
         consecutiveFailures = 0
         applyStatus(status, provider, set)
         if (NON_TERMINAL_STATES.includes(status.state)) {
@@ -142,6 +147,8 @@ function schedulePoll(
         }
       })
       .catch(() => {
+        if (get().activeLogin?.loginId !== loginId) return
+
         consecutiveFailures += 1
         if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
           stopPolling()

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -10,6 +10,9 @@ import type {
 } from '@shared/types/usage'
 import { accountApi } from '@/api/account-api'
 import { usageApi } from '@/api/usage-api'
+import { toast } from '@/lib/toast'
+import { useLoginStore } from './useLoginStore'
+import { useAccountStore } from './useAccountStore'
 
 export type { UsageData, UsageProvider, AnthropicRateLimitInfo, AnthropicRateLimitState }
 
@@ -31,11 +34,14 @@ interface UsageState {
   savedAccountLoadErrors: Record<UsageProvider, string | null>
   refreshingProviders: Record<UsageProvider, boolean>
   refreshingAccountIds: Set<string>
+  removingAccountIds: Set<string>
+  switchingAccountIds: Set<string>
 
   loadSavedAccounts: (provider?: UsageProvider) => Promise<void>
   refreshAllForProvider: (provider: UsageProvider) => Promise<void>
-  refreshSavedAccount: (id: string) => Promise<void>
+  refreshSavedAccount: (id: string, opts?: { userInitiated?: boolean }) => Promise<void>
   removeSavedAccount: (id: string) => Promise<void>
+  switchAccount: (id: string) => Promise<void>
   fetchUsageForProvider: (provider: UsageProvider) => Promise<void>
   forceRefreshProvider: (provider: UsageProvider) => Promise<void>
   setActiveProvider: (provider: UsageProvider) => void
@@ -44,10 +50,13 @@ interface UsageState {
 }
 
 const DEBOUNCE_MS = 180_000 // 3 minutes
-const FORCE_REFRESH_FLOOR_MS = 5_000
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
+}
+
+function providerLabel(provider: UsageProvider): string {
+  return provider === 'anthropic' ? 'Claude' : 'OpenAI'
 }
 
 function retryAfterFetchedAt(retryAfter: number | undefined): number | null {
@@ -72,6 +81,8 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
   savedAccountLoadErrors: { anthropic: null, openai: null },
   refreshingProviders: { anthropic: false, openai: false },
   refreshingAccountIds: new Set<string>(),
+  removingAccountIds: new Set<string>(),
+  switchingAccountIds: new Set<string>(),
 
   loadSavedAccounts: async (provider?: UsageProvider) => {
     try {
@@ -131,18 +142,36 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
     }
   },
 
-  refreshSavedAccount: async (id: string) => {
+  refreshSavedAccount: async (id: string, opts?: { userInitiated?: boolean }) => {
     const state = get()
     const provider = (['anthropic', 'openai'] as UsageProvider[]).find((p) =>
       state.savedAccounts[p].some((account) => account.id === id)
     )
+    const userInitiated = opts?.userInitiated ?? false
+    const account = provider
+      ? state.savedAccounts[provider].find((a) => a.id === id)
+      : undefined
 
     set((current) => ({
       refreshingAccountIds: new Set([...current.refreshingAccountIds, id])
     }))
     try {
-      await usageApi.fetchForAccount(id)
+      const result = await usageApi.fetchForAccount(id, userInitiated)
+      if (result.needsLogin && userInitiated && provider) {
+        useLoginStore.getState().startLogin(provider, account?.email).catch(() => {})
+      } else if (!result.success && userInitiated) {
+        toast.error(
+          `${providerLabel(provider ?? 'anthropic')} account refresh failed: ${result.error ?? 'Unknown error'}`
+        )
+      }
       await get().loadSavedAccounts(provider)
+    } catch (err) {
+      if (userInitiated) {
+        toast.error(`${providerLabel(provider ?? 'anthropic')} account refresh failed: ${errorMessage(err)}`)
+      }
+      await get()
+        .loadSavedAccounts(provider)
+        .catch(() => {})
     } finally {
       set((current) => {
         const nextIds = new Set(current.refreshingAccountIds)
@@ -153,8 +182,69 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
   },
 
   removeSavedAccount: async (id: string) => {
-    await accountApi.removeSaved(id)
-    await get().loadSavedAccounts()
+    const state = get()
+    const provider = (['anthropic', 'openai'] as UsageProvider[]).find((p) =>
+      state.savedAccounts[p].some((account) => account.id === id)
+    )
+    const account = provider
+      ? state.savedAccounts[provider].find((a) => a.id === id)
+      : undefined
+
+    set((current) => ({
+      removingAccountIds: new Set([...current.removingAccountIds, id])
+    }))
+    try {
+      await accountApi.removeSaved(id)
+      toast.success(`Removed ${account?.email ?? 'account'}`)
+    } catch (err) {
+      toast.error(`Failed to remove account: ${errorMessage(err)}`)
+    } finally {
+      set((current) => {
+        const nextIds = new Set(current.removingAccountIds)
+        nextIds.delete(id)
+        return { removingAccountIds: nextIds }
+      })
+      await get()
+        .loadSavedAccounts(provider)
+        .catch(() => {})
+    }
+  },
+
+  switchAccount: async (id: string) => {
+    const state = get()
+    const provider = (['anthropic', 'openai'] as UsageProvider[]).find((p) =>
+      state.savedAccounts[p].some((account) => account.id === id)
+    )
+    const account = provider
+      ? state.savedAccounts[provider].find((a) => a.id === id)
+      : undefined
+
+    set((current) => ({
+      switchingAccountIds: new Set([...current.switchingAccountIds, id])
+    }))
+    try {
+      const result = await accountApi.switchAccount(id)
+      if (result.success) {
+        if (provider) {
+          await useAccountStore.getState().fetchEmail(provider)
+          await get().loadSavedAccounts(provider)
+          get()
+            .forceRefreshProvider(provider)
+            .catch(() => {})
+        }
+        toast.success(`Switched to ${account?.email ?? 'account'}`)
+      } else {
+        toast.error(`Switch failed: ${result.error ?? 'Unknown error'}`)
+      }
+    } catch (err) {
+      toast.error(`Switch failed: ${errorMessage(err)}`)
+    } finally {
+      set((current) => {
+        const nextIds = new Set(current.switchingAccountIds)
+        nextIds.delete(id)
+        return { switchingAccountIds: nextIds }
+      })
+    }
   },
 
   fetchUsageForProvider: async (provider: UsageProvider) => {
@@ -232,14 +322,12 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
         state.anthropicLastRetryAfter !== null &&
         state.anthropicLastFetchedAt &&
         Date.now() - state.anthropicLastFetchedAt < DEBOUNCE_MS
-      )
+      ) {
+        const remainingMs = state.anthropicLastFetchedAt + DEBOUNCE_MS - Date.now()
+        const retrySeconds = Math.max(1, Math.ceil(remainingMs / 1000))
+        toast.error(`Rate limited — retry in ${retrySeconds}s`)
         return
-      if (
-        state.anthropicLastFetchedAt &&
-        state.anthropicLastError === null &&
-        Date.now() - state.anthropicLastFetchedAt < FORCE_REFRESH_FLOOR_MS
-      )
-        return
+      }
 
       set({ anthropicIsLoading: true, anthropicLastError: null })
       let succeeded = false
@@ -262,9 +350,14 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
             anthropicLastRetryAfter: result.retryAfter ?? null,
             ...(retryFetchedAt !== null ? { anthropicLastFetchedAt: retryFetchedAt } : {})
           })
+          toast.error(
+            `${providerLabel(provider)} usage refresh failed: ${result.error ?? 'Unknown error'}`
+          )
         }
       } catch (err) {
-        set({ anthropicLastError: errorMessage(err), anthropicLastRetryAfter: null })
+        const message = errorMessage(err)
+        set({ anthropicLastError: message, anthropicLastRetryAfter: null })
+        toast.error(`${providerLabel(provider)} usage refresh failed: ${message}`)
       } finally {
         set({
           anthropicIsLoading: false,
@@ -286,9 +379,14 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
             .catch(() => {})
         } else {
           set({ openaiLastError: result.error ?? 'Unknown error' })
+          toast.error(
+            `${providerLabel(provider)} usage refresh failed: ${result.error ?? 'Unknown error'}`
+          )
         }
       } catch (err) {
-        set({ openaiLastError: errorMessage(err) })
+        const message = errorMessage(err)
+        set({ openaiLastError: message })
+        toast.error(`${providerLabel(provider)} usage refresh failed: ${message}`)
       } finally {
         set({
           openaiIsLoading: false,

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -164,15 +164,16 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
           `${providerLabel(provider ?? 'anthropic')} account refresh failed: ${result.error ?? 'Unknown error'}`
         )
       }
-      await get().loadSavedAccounts(provider)
     } catch (err) {
       if (userInitiated) {
         toast.error(`${providerLabel(provider ?? 'anthropic')} account refresh failed: ${errorMessage(err)}`)
       }
+    } finally {
+      // Reload in its own catch so a reload hiccup after a SUCCESSFUL fetch
+      // can't reach the catch above and mis-toast a 'refresh failed'.
       await get()
         .loadSavedAccounts(provider)
         .catch(() => {})
-    } finally {
       set((current) => {
         const nextIds = new Set(current.refreshingAccountIds)
         nextIds.delete(id)
@@ -225,14 +226,23 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
     try {
       const result = await accountApi.switchAccount(id)
       if (result.success) {
+        // Toast success off the op result FIRST — before the post-switch
+        // reloads, each wrapped in its own catch so a reload hiccup after a
+        // SUCCESSFUL switch can't reach the catch below and mis-toast a
+        // 'Switch failed'.
+        toast.success(`Switched to ${account?.email ?? 'account'}`)
         if (provider) {
-          await useAccountStore.getState().fetchEmail(provider)
-          await get().loadSavedAccounts(provider)
+          await useAccountStore
+            .getState()
+            .fetchEmail(provider)
+            .catch(() => {})
+          await get()
+            .loadSavedAccounts(provider)
+            .catch(() => {})
           get()
             .forceRefreshProvider(provider)
             .catch(() => {})
         }
-        toast.success(`Switched to ${account?.email ?? 'account'}`)
       } else {
         toast.error(`Switch failed: ${result.error ?? 'Unknown error'}`)
       }

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -485,10 +485,18 @@ export function resolveDefaultUsageProvider(
   return 'anthropic'
 }
 
-function hasUsageWindow(value: unknown): value is { utilization: number; resets_at: string } {
+function hasUsageWindow(value: unknown): value is { utilization: number; resets_at: string | null } {
   if (typeof value !== 'object' || value === null) return false
   const record = value as Record<string, unknown>
-  return typeof record.utilization === 'number' && typeof record.resets_at === 'string'
+  // resets_at is legitimately null (or absent) for a window with no active
+  // session — the API sends { utilization: 0, resets_at: null } for an idle
+  // 5h window. Only reject a present, non-string, non-null resets_at.
+  return (
+    typeof record.utilization === 'number' &&
+    (record.resets_at === null ||
+      record.resets_at === undefined ||
+      typeof record.resets_at === 'string')
+  )
 }
 
 function isAnthropicUsageData(value: unknown): value is UsageData {

--- a/src/server/__tests__/account-rpc.mock-provider.test.ts
+++ b/src/server/__tests__/account-rpc.mock-provider.test.ts
@@ -1,6 +1,6 @@
 import { Effect } from 'effect'
 import { describe, expect, it, vi } from 'vitest'
-import type { SavedAccountDTO } from '../../shared/types/usage'
+import type { LoginStatusDTO, SavedAccountDTO } from '../../shared/types/usage'
 import { makeEventBus } from '../events/event-bus'
 import type { AccountOpsRpcService } from '../rpc/domains/account-ops'
 import { makeRpcRouter } from '../rpc/router'
@@ -303,6 +303,229 @@ describe('account ops RPC mocked provider', () => {
     expect(switchAccount).not.toHaveBeenCalled()
     expect(response).toMatchObject({
       id: 'account-switch-extra',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
+
+  it('routes accountOps.loginStart to the injected provider service', async () => {
+    const loginStart = vi.fn(() => Effect.succeed({ loginId: 'login-1' }))
+    const service = { loginStart } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-login-start-1',
+        method: 'accountOps.loginStart',
+        params: { provider: 'anthropic', email: 'user@example.com' }
+      })
+    )
+
+    expect(loginStart).toHaveBeenCalledWith('anthropic', 'user@example.com')
+    expect(response).toEqual({
+      id: 'account-login-start-1',
+      ok: true,
+      value: { loginId: 'login-1' }
+    })
+  })
+
+  it('routes accountOps.loginStart without an email hint', async () => {
+    const loginStart = vi.fn(() => Effect.succeed({ loginId: 'login-2' }))
+    const service = { loginStart } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-login-start-2',
+        method: 'accountOps.loginStart',
+        params: { provider: 'openai' }
+      })
+    )
+
+    expect(loginStart).toHaveBeenCalledWith('openai', undefined)
+    expect(response).toEqual({
+      id: 'account-login-start-2',
+      ok: true,
+      value: { loginId: 'login-2' }
+    })
+  })
+
+  it('validates accountOps.loginStart params before calling the provider service', async () => {
+    const loginStart = vi.fn(() => Effect.succeed({ loginId: 'login-1' }))
+    const service = { loginStart } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-login-start-invalid',
+        method: 'accountOps.loginStart',
+        params: { provider: 'other' }
+      })
+    )
+
+    expect(loginStart).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      id: 'account-login-start-invalid',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
+
+  it('rejects unexpected extra params for accountOps.loginStart', async () => {
+    const loginStart = vi.fn(() => Effect.succeed({ loginId: 'login-1' }))
+    const service = { loginStart } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-login-start-extra',
+        method: 'accountOps.loginStart',
+        params: { provider: 'anthropic', unexpected: true }
+      })
+    )
+
+    expect(loginStart).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      id: 'account-login-start-extra',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
+
+  it('routes accountOps.loginStatus to the injected provider service', async () => {
+    const status: LoginStatusDTO = {
+      loginId: 'login-1',
+      provider: 'anthropic',
+      state: 'waiting',
+      email: null,
+      error: null
+    }
+    const loginStatus = vi.fn(() => Effect.succeed(status))
+    const service = { loginStatus } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-login-status-1',
+        method: 'accountOps.loginStatus',
+        params: { loginId: 'login-1' }
+      })
+    )
+
+    expect(loginStatus).toHaveBeenCalledWith('login-1')
+    expect(response).toEqual({
+      id: 'account-login-status-1',
+      ok: true,
+      value: status
+    })
+  })
+
+  it('routes a loginStatus failure (session not found) through as an error response', async () => {
+    const loginStatus = vi.fn(() => Effect.fail(new Error('login session not found')))
+    const service = { loginStatus } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-login-status-missing',
+        method: 'accountOps.loginStatus',
+        params: { loginId: 'does-not-exist' }
+      })
+    )
+
+    expect(response).toMatchObject({
+      id: 'account-login-status-missing',
+      ok: false
+    })
+  })
+
+  it('validates accountOps.loginStatus params before calling the provider service', async () => {
+    const loginStatus = vi.fn(() =>
+      Effect.succeed({ loginId: 'login-1', provider: 'anthropic', state: 'waiting', email: null, error: null })
+    )
+    const service = { loginStatus } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-login-status-invalid',
+        method: 'accountOps.loginStatus',
+        params: { loginId: 123 }
+      })
+    )
+
+    expect(loginStatus).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      id: 'account-login-status-invalid',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
+
+  it('routes accountOps.loginCancel to the injected provider service', async () => {
+    const loginCancel = vi.fn(() => Effect.succeed(true))
+    const service = { loginCancel } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-login-cancel-1',
+        method: 'accountOps.loginCancel',
+        params: { loginId: 'login-1' }
+      })
+    )
+
+    expect(loginCancel).toHaveBeenCalledWith('login-1')
+    expect(response).toEqual({
+      id: 'account-login-cancel-1',
+      ok: true,
+      value: true
+    })
+  })
+
+  it('validates accountOps.loginCancel params before calling the provider service', async () => {
+    const loginCancel = vi.fn(() => Effect.succeed(false))
+    const service = { loginCancel } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-login-cancel-invalid',
+        method: 'accountOps.loginCancel',
+        params: {}
+      })
+    )
+
+    expect(loginCancel).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      id: 'account-login-cancel-invalid',
       ok: false,
       error: { code: 'VALIDATION_FAILED' }
     })

--- a/src/server/__tests__/account-rpc.mock-provider.test.ts
+++ b/src/server/__tests__/account-rpc.mock-provider.test.ts
@@ -210,4 +210,101 @@ describe('account ops RPC mocked provider', () => {
       error: { code: 'VALIDATION_FAILED' }
     })
   })
+
+  it('routes accountOps.switchAccount to the injected provider service', async () => {
+    const switchAccount = vi.fn(() => Effect.succeed({ success: true }))
+    const service = { switchAccount } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-switch-1',
+        method: 'accountOps.switchAccount',
+        params: { accountId: 'account-1' }
+      })
+    )
+
+    expect(switchAccount).toHaveBeenCalledWith('account-1')
+    expect(response).toEqual({
+      id: 'account-switch-1',
+      ok: true,
+      value: { success: true }
+    })
+  })
+
+  it('routes a switchAccount failure result through unchanged', async () => {
+    const switchAccount = vi.fn(() =>
+      Effect.succeed({ success: false, error: 'account no longer in store' })
+    )
+    const service = { switchAccount } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-switch-2',
+        method: 'accountOps.switchAccount',
+        params: { accountId: 'account-1' }
+      })
+    )
+
+    expect(response).toEqual({
+      id: 'account-switch-2',
+      ok: true,
+      value: { success: false, error: 'account no longer in store' }
+    })
+  })
+
+  it('validates accountOps.switchAccount params before calling the provider service', async () => {
+    const switchAccount = vi.fn(() => Effect.succeed({ success: true }))
+    const service = { switchAccount } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-switch-invalid',
+        method: 'accountOps.switchAccount',
+        params: { accountId: 123 }
+      })
+    )
+
+    expect(switchAccount).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      id: 'account-switch-invalid',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
+
+  it('rejects unexpected extra params for accountOps.switchAccount', async () => {
+    const switchAccount = vi.fn(() => Effect.succeed({ success: true }))
+    const service = { switchAccount } as unknown as AccountOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-switch-extra',
+        method: 'accountOps.switchAccount',
+        params: { accountId: 'account-1', unexpected: true }
+      })
+    )
+
+    expect(switchAccount).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      id: 'account-switch-extra',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
 })

--- a/src/server/__tests__/account-rpc.mock-provider.test.ts
+++ b/src/server/__tests__/account-rpc.mock-provider.test.ts
@@ -112,7 +112,8 @@ describe('account ops RPC mocked provider', () => {
         last_fetched_at: '2026-05-31T00:00:00.000Z',
         status: 'ok',
         last_error: null,
-        created_at: '2026-05-30T00:00:00.000Z'
+        created_at: '2026-05-30T00:00:00.000Z',
+        plan: null
       }
     ]
     const listSaved = vi.fn(() => Effect.succeed(result))

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -4714,6 +4714,33 @@ describe('rpc router', () => {
     expect(calls).toEqual([])
   })
 
+  it('passes usageOps.fetchForAccount userInitiated through to the usage ops RPC domain', async () => {
+    const calls: Array<{ accountId: string; userInitiated: boolean | undefined }> = []
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      usageOps: {
+        fetch: () => Effect.succeed({ success: false, error: 'unused' }),
+        fetchOpenai: () => Effect.succeed({ success: false, error: 'unused' }),
+        fetchForAccount: (accountId, userInitiated) =>
+          Effect.sync(() => {
+            calls.push({ accountId, userInitiated })
+            return { success: true, status: 'ok' as const }
+          }),
+        refreshAllForProvider: () => Effect.succeed([])
+      }
+    })
+
+    await Effect.runPromise(
+      router.handle({
+        id: 'usage-ops-fetch-for-account-3',
+        method: 'usageOps.fetchForAccount',
+        params: { accountId: 'account-1', userInitiated: true }
+      })
+    )
+
+    expect(calls).toEqual([{ accountId: 'account-1', userInitiated: true }])
+  })
+
   it('handles usageOps.refreshAllForProvider through the usage ops RPC domain', async () => {
     const result = [
       { accountId: 'account-1', success: true },
@@ -4794,7 +4821,8 @@ describe('rpc router', () => {
           }),
         getOpenAIEmail: () => Effect.succeed(null),
         listSaved: () => Effect.succeed([]),
-        removeSaved: () => Effect.succeed(false)
+        removeSaved: () => Effect.succeed(false),
+        switchAccount: () => Effect.succeed({ success: false })
       }
     })
 
@@ -4826,7 +4854,8 @@ describe('rpc router', () => {
           }),
         getOpenAIEmail: () => Effect.succeed(null),
         listSaved: () => Effect.succeed([]),
-        removeSaved: () => Effect.succeed(false)
+        removeSaved: () => Effect.succeed(false),
+        switchAccount: () => Effect.succeed({ success: false })
       }
     })
 
@@ -4858,7 +4887,8 @@ describe('rpc router', () => {
             return 'openai-user@example.com'
           }),
         listSaved: () => Effect.succeed([]),
-        removeSaved: () => Effect.succeed(false)
+        removeSaved: () => Effect.succeed(false),
+        switchAccount: () => Effect.succeed({ success: false })
       }
     })
 
@@ -4890,7 +4920,8 @@ describe('rpc router', () => {
             return null
           }),
         listSaved: () => Effect.succeed([]),
-        removeSaved: () => Effect.succeed(false)
+        removeSaved: () => Effect.succeed(false),
+        switchAccount: () => Effect.succeed({ success: false })
       }
     })
 
@@ -4935,7 +4966,8 @@ describe('rpc router', () => {
             calls.push(provider ?? 'all')
             return accounts
           }),
-        removeSaved: () => Effect.succeed(false)
+        removeSaved: () => Effect.succeed(false),
+        switchAccount: () => Effect.succeed({ success: false })
       }
     })
 
@@ -4967,7 +4999,8 @@ describe('rpc router', () => {
             calls.push(provider ?? 'all')
             return []
           }),
-        removeSaved: () => Effect.succeed(false)
+        removeSaved: () => Effect.succeed(false),
+        switchAccount: () => Effect.succeed({ success: false })
       }
     })
 
@@ -4999,7 +5032,8 @@ describe('rpc router', () => {
           Effect.sync(() => {
             calls.push(accountId)
             return true
-          })
+          }),
+        switchAccount: () => Effect.succeed({ success: false })
       }
     })
 
@@ -5031,7 +5065,8 @@ describe('rpc router', () => {
           Effect.sync(() => {
             calls.push(accountId)
             return false
-          })
+          }),
+        switchAccount: () => Effect.succeed({ success: false })
       }
     })
 
@@ -5045,6 +5080,72 @@ describe('rpc router', () => {
 
     expect(response).toMatchObject({
       id: 'account-ops-remove-saved-2',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+    expect(calls).toEqual([])
+  })
+
+  it('handles accountOps.switchAccount through the account ops RPC domain', async () => {
+    const calls: string[] = []
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: {
+        getClaudeEmail: () => Effect.succeed(null),
+        getOpenAIEmail: () => Effect.succeed(null),
+        listSaved: () => Effect.succeed([]),
+        removeSaved: () => Effect.succeed(false),
+        switchAccount: (accountId) =>
+          Effect.sync(() => {
+            calls.push(accountId)
+            return { success: true }
+          })
+      }
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-ops-switch-account-1',
+        method: 'accountOps.switchAccount',
+        params: { accountId: 'account-1' }
+      })
+    )
+
+    expect(response).toEqual({
+      id: 'account-ops-switch-account-1',
+      ok: true,
+      value: { success: true }
+    })
+    expect(calls).toEqual(['account-1'])
+  })
+
+  it('validates accountOps.switchAccount params', async () => {
+    const calls: string[] = []
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      accountOps: {
+        getClaudeEmail: () => Effect.succeed(null),
+        getOpenAIEmail: () => Effect.succeed(null),
+        listSaved: () => Effect.succeed([]),
+        removeSaved: () => Effect.succeed(false),
+        switchAccount: (accountId) =>
+          Effect.sync(() => {
+            calls.push(accountId)
+            return { success: true }
+          })
+      }
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'account-ops-switch-account-2',
+        method: 'accountOps.switchAccount',
+        params: { accountId: 123 }
+      })
+    )
+
+    expect(response).toMatchObject({
+      id: 'account-ops-switch-account-2',
       ok: false,
       error: { code: 'VALIDATION_FAILED' }
     })

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -4822,7 +4822,17 @@ describe('rpc router', () => {
         getOpenAIEmail: () => Effect.succeed(null),
         listSaved: () => Effect.succeed([]),
         removeSaved: () => Effect.succeed(false),
-        switchAccount: () => Effect.succeed({ success: false })
+        switchAccount: () => Effect.succeed({ success: false }),
+        loginStart: () => Effect.succeed({ loginId: 'login-1' }),
+        loginStatus: () =>
+          Effect.succeed({
+            loginId: 'login-1',
+            provider: 'anthropic' as const,
+            state: 'waiting' as const,
+            email: null,
+            error: null
+          }),
+        loginCancel: () => Effect.succeed(false)
       }
     })
 
@@ -4855,7 +4865,17 @@ describe('rpc router', () => {
         getOpenAIEmail: () => Effect.succeed(null),
         listSaved: () => Effect.succeed([]),
         removeSaved: () => Effect.succeed(false),
-        switchAccount: () => Effect.succeed({ success: false })
+        switchAccount: () => Effect.succeed({ success: false }),
+        loginStart: () => Effect.succeed({ loginId: 'login-1' }),
+        loginStatus: () =>
+          Effect.succeed({
+            loginId: 'login-1',
+            provider: 'anthropic' as const,
+            state: 'waiting' as const,
+            email: null,
+            error: null
+          }),
+        loginCancel: () => Effect.succeed(false)
       }
     })
 
@@ -4888,7 +4908,17 @@ describe('rpc router', () => {
           }),
         listSaved: () => Effect.succeed([]),
         removeSaved: () => Effect.succeed(false),
-        switchAccount: () => Effect.succeed({ success: false })
+        switchAccount: () => Effect.succeed({ success: false }),
+        loginStart: () => Effect.succeed({ loginId: 'login-1' }),
+        loginStatus: () =>
+          Effect.succeed({
+            loginId: 'login-1',
+            provider: 'anthropic' as const,
+            state: 'waiting' as const,
+            email: null,
+            error: null
+          }),
+        loginCancel: () => Effect.succeed(false)
       }
     })
 
@@ -4921,7 +4951,17 @@ describe('rpc router', () => {
           }),
         listSaved: () => Effect.succeed([]),
         removeSaved: () => Effect.succeed(false),
-        switchAccount: () => Effect.succeed({ success: false })
+        switchAccount: () => Effect.succeed({ success: false }),
+        loginStart: () => Effect.succeed({ loginId: 'login-1' }),
+        loginStatus: () =>
+          Effect.succeed({
+            loginId: 'login-1',
+            provider: 'anthropic' as const,
+            state: 'waiting' as const,
+            email: null,
+            error: null
+          }),
+        loginCancel: () => Effect.succeed(false)
       }
     })
 
@@ -4967,7 +5007,17 @@ describe('rpc router', () => {
             return accounts
           }),
         removeSaved: () => Effect.succeed(false),
-        switchAccount: () => Effect.succeed({ success: false })
+        switchAccount: () => Effect.succeed({ success: false }),
+        loginStart: () => Effect.succeed({ loginId: 'login-1' }),
+        loginStatus: () =>
+          Effect.succeed({
+            loginId: 'login-1',
+            provider: 'anthropic' as const,
+            state: 'waiting' as const,
+            email: null,
+            error: null
+          }),
+        loginCancel: () => Effect.succeed(false)
       }
     })
 
@@ -5000,7 +5050,17 @@ describe('rpc router', () => {
             return []
           }),
         removeSaved: () => Effect.succeed(false),
-        switchAccount: () => Effect.succeed({ success: false })
+        switchAccount: () => Effect.succeed({ success: false }),
+        loginStart: () => Effect.succeed({ loginId: 'login-1' }),
+        loginStatus: () =>
+          Effect.succeed({
+            loginId: 'login-1',
+            provider: 'anthropic' as const,
+            state: 'waiting' as const,
+            email: null,
+            error: null
+          }),
+        loginCancel: () => Effect.succeed(false)
       }
     })
 
@@ -5033,7 +5093,17 @@ describe('rpc router', () => {
             calls.push(accountId)
             return true
           }),
-        switchAccount: () => Effect.succeed({ success: false })
+        switchAccount: () => Effect.succeed({ success: false }),
+        loginStart: () => Effect.succeed({ loginId: 'login-1' }),
+        loginStatus: () =>
+          Effect.succeed({
+            loginId: 'login-1',
+            provider: 'anthropic' as const,
+            state: 'waiting' as const,
+            email: null,
+            error: null
+          }),
+        loginCancel: () => Effect.succeed(false)
       }
     })
 
@@ -5066,7 +5136,17 @@ describe('rpc router', () => {
             calls.push(accountId)
             return false
           }),
-        switchAccount: () => Effect.succeed({ success: false })
+        switchAccount: () => Effect.succeed({ success: false }),
+        loginStart: () => Effect.succeed({ loginId: 'login-1' }),
+        loginStatus: () =>
+          Effect.succeed({
+            loginId: 'login-1',
+            provider: 'anthropic' as const,
+            state: 'waiting' as const,
+            email: null,
+            error: null
+          }),
+        loginCancel: () => Effect.succeed(false)
       }
     })
 
@@ -5099,7 +5179,17 @@ describe('rpc router', () => {
           Effect.sync(() => {
             calls.push(accountId)
             return { success: true }
-          })
+          }),
+        loginStart: () => Effect.succeed({ loginId: 'login-1' }),
+        loginStatus: () =>
+          Effect.succeed({
+            loginId: 'login-1',
+            provider: 'anthropic' as const,
+            state: 'waiting' as const,
+            email: null,
+            error: null
+          }),
+        loginCancel: () => Effect.succeed(false)
       }
     })
 
@@ -5132,7 +5222,17 @@ describe('rpc router', () => {
           Effect.sync(() => {
             calls.push(accountId)
             return { success: true }
-          })
+          }),
+        loginStart: () => Effect.succeed({ loginId: 'login-1' }),
+        loginStatus: () =>
+          Effect.succeed({
+            loginId: 'login-1',
+            provider: 'anthropic' as const,
+            state: 'waiting' as const,
+            email: null,
+            error: null
+          }),
+        loginCancel: () => Effect.succeed(false)
       }
     })
 

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -4920,7 +4920,8 @@ describe('rpc router', () => {
         last_fetched_at: '2026-05-26T00:00:00.000Z',
         status: 'ok' as const,
         last_error: null,
-        created_at: '2026-05-25T00:00:00.000Z'
+        created_at: '2026-05-25T00:00:00.000Z',
+        plan: null
       }
     ]
     const calls: string[] = []

--- a/src/server/__tests__/usage-rpc.mock-provider.test.ts
+++ b/src/server/__tests__/usage-rpc.mock-provider.test.ts
@@ -176,12 +176,32 @@ describe('usage ops RPC mocked provider', () => {
       })
     )
 
-    expect(fetchForAccount).toHaveBeenCalledWith('account-1')
+    expect(fetchForAccount).toHaveBeenCalledWith('account-1', undefined)
     expect(response).toEqual({
       id: 'usage-fetch-for-account-1',
       ok: true,
       value: result
     })
+  })
+
+  it('passes userInitiated through to the injected provider service', async () => {
+    const result: FetchForAccountResult = { success: true, status: 'ok' }
+    const fetchForAccount = vi.fn(() => Effect.succeed(result))
+    const service = { fetchForAccount } as unknown as UsageOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      usageOps: service
+    })
+
+    await Effect.runPromise(
+      router.handle({
+        id: 'usage-fetch-for-account-user-initiated',
+        method: 'usageOps.fetchForAccount',
+        params: { accountId: 'account-1', userInitiated: true }
+      })
+    )
+
+    expect(fetchForAccount).toHaveBeenCalledWith('account-1', true)
   })
 
   it('validates usageOps.fetchForAccount params before calling the provider service', async () => {
@@ -205,6 +225,32 @@ describe('usage ops RPC mocked provider', () => {
     expect(fetchForAccount).not.toHaveBeenCalled()
     expect(response).toMatchObject({
       id: 'usage-fetch-for-account-invalid',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
+
+  it('rejects a non-boolean userInitiated for usageOps.fetchForAccount', async () => {
+    const fetchForAccount = vi.fn(() =>
+      Effect.succeed({ success: false, status: 'error' as const })
+    )
+    const service = { fetchForAccount } as unknown as UsageOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      usageOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'usage-fetch-for-account-bad-user-initiated',
+        method: 'usageOps.fetchForAccount',
+        params: { accountId: 'account-1', userInitiated: 'yes' }
+      })
+    )
+
+    expect(fetchForAccount).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      id: 'usage-fetch-for-account-bad-user-initiated',
       ok: false,
       error: { code: 'VALIDATION_FAILED' }
     })

--- a/src/server/bin.ts
+++ b/src/server/bin.ts
@@ -1,4 +1,5 @@
 import { Effect } from 'effect'
+import { startAccountMaintenance } from '../main/services/account-maintenance'
 import { startHiveServer, type StartedHiveServer } from './server'
 
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000
@@ -53,7 +54,19 @@ export const main = (): Promise<void> =>
       }) + '\n'
     )
 
-    const shutdown = createShutdownHandler(server)
+    // Account maintenance (ccswitch-store migration, launch mass refresh,
+    // expiry watcher) is only ever started here — the real spawned server
+    // process — never from `startHiveServer()` itself, so tests that start
+    // the HTTP/WS server directly never touch the real Keychain/filesystem
+    // account stores or make live network calls.
+    const stopAccountMaintenance = startAccountMaintenance()
+
+    const shutdown = createShutdownHandler({
+      close: async () => {
+        stopAccountMaintenance()
+        await server.close()
+      }
+    })
 
     process.on('SIGINT', shutdown)
     process.on('SIGTERM', shutdown)

--- a/src/server/rpc/domains/account-ops.ts
+++ b/src/server/rpc/domains/account-ops.ts
@@ -6,7 +6,8 @@ import {
 } from '../../../main/services/account-service'
 import {
   listSavedAccounts,
-  removeSavedAccount
+  removeSavedAccount,
+  switchAccount
 } from '../../../main/services/saved-usage-orchestrator'
 import type { SavedAccountDTO, UsageProvider } from '../../../shared/types/usage'
 import type { RpcHandler } from '../router'
@@ -16,6 +17,9 @@ export interface AccountOpsRpcService {
   readonly getOpenAIEmail: () => Effect.Effect<string | null, unknown, never>
   readonly listSaved: (provider?: UsageProvider) => Effect.Effect<SavedAccountDTO[], unknown, never>
   readonly removeSaved: (accountId: string) => Effect.Effect<boolean, unknown, never>
+  readonly switchAccount: (
+    accountId: string
+  ) => Effect.Effect<{ success: boolean; error?: string }, unknown, never>
 }
 
 const emptyParamsSchema = z.union([z.object({}).strict(), z.undefined(), z.null()])
@@ -25,6 +29,7 @@ const listSavedParamsSchema = z
   })
   .strict()
 const removeSavedParamsSchema = z.object({ accountId: z.string() }).strict()
+const switchAccountParamsSchema = z.object({ accountId: z.string() }).strict()
 
 export const makeLiveAccountOpsRpcService = (): AccountOpsRpcService => ({
   getClaudeEmail: () =>
@@ -38,13 +43,18 @@ export const makeLiveAccountOpsRpcService = (): AccountOpsRpcService => ({
       catch: (cause) => cause
     }),
   listSaved: (provider) =>
-    Effect.try({
+    Effect.tryPromise({
       try: () => listSavedAccounts(provider),
       catch: (cause) => cause
     }),
   removeSaved: (accountId) =>
-    Effect.try({
+    Effect.tryPromise({
       try: () => removeSavedAccount(accountId),
+      catch: (cause) => cause
+    }),
+  switchAccount: (accountId) =>
+    Effect.tryPromise({
+      try: () => switchAccount(accountId),
       catch: (cause) => cause
     })
 })
@@ -95,6 +105,17 @@ export const makeAccountOpsRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.removeSaved(accountId)
+        })
+    ],
+    [
+      'accountOps.switchAccount',
+      (params) =>
+        Effect.gen(function* () {
+          const { accountId } = yield* Effect.try({
+            try: () => switchAccountParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.switchAccount(accountId)
         })
     ]
   ])

--- a/src/server/rpc/domains/account-ops.ts
+++ b/src/server/rpc/domains/account-ops.ts
@@ -5,11 +5,16 @@ import {
   getOpenAIAccountEmail
 } from '../../../main/services/account-service'
 import {
+  loginCancel,
+  loginStart,
+  loginStatus
+} from '../../../main/services/login-service'
+import {
   listSavedAccounts,
   removeSavedAccount,
   switchAccount
 } from '../../../main/services/saved-usage-orchestrator'
-import type { SavedAccountDTO, UsageProvider } from '../../../shared/types/usage'
+import type { LoginStatusDTO, SavedAccountDTO, UsageProvider } from '../../../shared/types/usage'
 import type { RpcHandler } from '../router'
 
 export interface AccountOpsRpcService {
@@ -20,6 +25,12 @@ export interface AccountOpsRpcService {
   readonly switchAccount: (
     accountId: string
   ) => Effect.Effect<{ success: boolean; error?: string }, unknown, never>
+  readonly loginStart: (
+    provider: UsageProvider,
+    email?: string
+  ) => Effect.Effect<{ loginId: string }, unknown, never>
+  readonly loginStatus: (loginId: string) => Effect.Effect<LoginStatusDTO, unknown, never>
+  readonly loginCancel: (loginId: string) => Effect.Effect<boolean, unknown, never>
 }
 
 const emptyParamsSchema = z.union([z.object({}).strict(), z.undefined(), z.null()])
@@ -30,6 +41,14 @@ const listSavedParamsSchema = z
   .strict()
 const removeSavedParamsSchema = z.object({ accountId: z.string() }).strict()
 const switchAccountParamsSchema = z.object({ accountId: z.string() }).strict()
+const loginStartParamsSchema = z
+  .object({
+    provider: z.enum(['anthropic', 'openai']),
+    email: z.string().optional()
+  })
+  .strict()
+const loginStatusParamsSchema = z.object({ loginId: z.string() }).strict()
+const loginCancelParamsSchema = z.object({ loginId: z.string() }).strict()
 
 export const makeLiveAccountOpsRpcService = (): AccountOpsRpcService => ({
   getClaudeEmail: () =>
@@ -55,6 +74,21 @@ export const makeLiveAccountOpsRpcService = (): AccountOpsRpcService => ({
   switchAccount: (accountId) =>
     Effect.tryPromise({
       try: () => switchAccount(accountId),
+      catch: (cause) => cause
+    }),
+  loginStart: (provider, email) =>
+    Effect.tryPromise({
+      try: () => loginStart(provider, email),
+      catch: (cause) => cause
+    }),
+  loginStatus: (loginId) =>
+    Effect.try({
+      try: () => loginStatus(loginId),
+      catch: (cause) => cause
+    }),
+  loginCancel: (loginId) =>
+    Effect.tryPromise({
+      try: () => loginCancel(loginId),
       catch: (cause) => cause
     })
 })
@@ -116,6 +150,39 @@ export const makeAccountOpsRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.switchAccount(accountId)
+        })
+    ],
+    [
+      'accountOps.loginStart',
+      (params) =>
+        Effect.gen(function* () {
+          const { provider, email } = yield* Effect.try({
+            try: () => loginStartParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.loginStart(provider, email)
+        })
+    ],
+    [
+      'accountOps.loginStatus',
+      (params) =>
+        Effect.gen(function* () {
+          const { loginId } = yield* Effect.try({
+            try: () => loginStatusParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.loginStatus(loginId)
+        })
+    ],
+    [
+      'accountOps.loginCancel',
+      (params) =>
+        Effect.gen(function* () {
+          const { loginId } = yield* Effect.try({
+            try: () => loginCancelParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.loginCancel(loginId)
         })
     ]
   ])

--- a/src/server/rpc/domains/usage-ops.ts
+++ b/src/server/rpc/domains/usage-ops.ts
@@ -19,7 +19,8 @@ export interface UsageOpsRpcService {
   readonly fetch: () => Effect.Effect<UsageResult, unknown, never>
   readonly fetchOpenai: () => Effect.Effect<OpenAIUsageResult, unknown, never>
   readonly fetchForAccount: (
-    accountId: string
+    accountId: string,
+    userInitiated?: boolean
   ) => Effect.Effect<FetchForAccountResult, unknown, never>
   readonly refreshAllForProvider: (
     provider: UsageProvider
@@ -27,7 +28,9 @@ export interface UsageOpsRpcService {
 }
 
 const emptyParamsSchema = z.union([z.object({}).strict(), z.undefined(), z.null()])
-const fetchForAccountParamsSchema = z.object({ accountId: z.string() }).strict()
+const fetchForAccountParamsSchema = z
+  .object({ accountId: z.string(), userInitiated: z.boolean().optional() })
+  .strict()
 const refreshAllForProviderParamsSchema = z
   .object({ provider: z.enum(['anthropic', 'openai']) })
   .strict()
@@ -43,9 +46,9 @@ export const makeLiveUsageOpsRpcService = (): UsageOpsRpcService => ({
       try: () => fetchOpenAIUsageOp(),
       catch: (cause) => cause
     }),
-  fetchForAccount: (accountId) =>
+  fetchForAccount: (accountId, userInitiated) =>
     Effect.tryPromise({
-      try: () => fetchForAccountOp(accountId),
+      try: () => fetchForAccountOp(accountId, userInitiated),
       catch: (cause) => cause
     }),
   refreshAllForProvider: (provider) =>
@@ -85,11 +88,11 @@ export const makeUsageOpsRpcHandlers = (
       'usageOps.fetchForAccount',
       (params) =>
         Effect.gen(function* () {
-          const { accountId } = yield* Effect.try({
+          const { accountId, userInitiated } = yield* Effect.try({
             try: () => fetchForAccountParamsSchema.parse(params),
             catch: (cause) => cause
           })
-          return yield* service.fetchForAccount(accountId)
+          return yield* service.fetchForAccount(accountId, userInitiated)
         })
     ],
     [

--- a/src/shared/types/usage.ts
+++ b/src/shared/types/usage.ts
@@ -30,6 +30,14 @@ export interface ClaudeRefreshResult {
   refreshToken: string
   expiresAt: number
   scope?: string
+  /**
+   * The refresh token that was actually passed into the refresh call that
+   * produced this result — NOT necessarily the token read before the fetch
+   * started (some other process may have rotated it in between). Callers
+   * that persist rotated live tokens must race-check against this token,
+   * not against a pre-read one, or a burned refresh token can be left live.
+   */
+  rotatedFrom: string
 }
 
 export type AnthropicRateLimitType = 'five_hour' | 'seven_day'
@@ -85,6 +93,8 @@ export interface OpenAIUsageResult {
     accessToken: string
     refreshToken: string
     idToken?: string
+    /** See `ClaudeRefreshResult.rotatedFrom` — same rationale, Codex side. */
+    rotatedFrom: string
   }
   needsLogin?: boolean
 }

--- a/src/shared/types/usage.ts
+++ b/src/shared/types/usage.ts
@@ -1,3 +1,9 @@
+export interface ScopedUsageWindow {
+  label: string
+  used_percent: number
+  resets_at: string | null
+}
+
 export interface UsageData {
   five_hour: { utilization: number; resets_at: string }
   seven_day: { utilization: number; resets_at: string }
@@ -7,6 +13,7 @@ export interface UsageData {
     used_credits: number
     monthly_limit: number
   }
+  scoped?: ScopedUsageWindow[]
 }
 
 export interface UsageResult {
@@ -15,6 +22,7 @@ export interface UsageResult {
   error?: string
   retryAfter?: number
   rotated?: ClaudeRefreshResult
+  needsLogin?: boolean
 }
 
 export interface ClaudeRefreshResult {
@@ -77,6 +85,7 @@ export interface OpenAIUsageResult {
     refreshToken: string
     idToken?: string
   }
+  needsLogin?: boolean
 }
 
 export interface SavedAccountDTO {
@@ -88,6 +97,7 @@ export interface SavedAccountDTO {
   status: SavedUsageStatus
   last_error: string | null
   created_at: string
+  plan: string | null
 }
 
 export interface FetchForAccountResult {
@@ -96,6 +106,7 @@ export interface FetchForAccountResult {
   error?: string
   retryAfter?: number
   status: SavedUsageStatus
+  needsLogin?: boolean
 }
 
 export interface RefreshAllResultItem {
@@ -103,4 +114,14 @@ export interface RefreshAllResultItem {
   success: boolean
   error?: string
   retryAfter?: number
+}
+
+export type LoginState = 'launching' | 'waiting' | 'exchanging' | 'done' | 'failed' | 'cancelled'
+
+export interface LoginStatusDTO {
+  loginId: string
+  provider: UsageProvider
+  state: LoginState
+  email: string | null
+  error: string | null
 }

--- a/src/shared/types/usage.ts
+++ b/src/shared/types/usage.ts
@@ -29,6 +29,7 @@ export interface ClaudeRefreshResult {
   accessToken: string
   refreshToken: string
   expiresAt: number
+  scope?: string
 }
 
 export type AnthropicRateLimitType = 'five_hour' | 'seven_day'

--- a/src/shared/types/usage.ts
+++ b/src/shared/types/usage.ts
@@ -5,8 +5,10 @@ export interface ScopedUsageWindow {
 }
 
 export interface UsageData {
-  five_hour: { utilization: number; resets_at: string }
-  seven_day: { utilization: number; resets_at: string }
+  // resets_at is null when the window has no active session (e.g. an idle
+  // 5h window) — the API sends { utilization: 0, resets_at: null }.
+  five_hour: { utilization: number; resets_at: string | null }
+  seven_day: { utilization: number; resets_at: string | null }
   extra_usage?: {
     is_enabled: boolean
     utilization: number

--- a/test/phase-12/renderer-api-cleanup.test.ts
+++ b/test/phase-12/renderer-api-cleanup.test.ts
@@ -9368,7 +9368,7 @@ describe('renderer API cleanup', () => {
     expect(actionEnd).toBeGreaterThan(actionStart)
     expect(source).toContain("import { usageApi } from '@/api/usage-api'")
     expect(actionSource).toContain('await usageApi.fetchForAccount(id, userInitiated)')
-    expect(actionSource).toContain('await get().loadSavedAccounts(provider)')
+    expect(actionSource).toContain('.loadSavedAccounts(provider)')
     expect(actionSource).not.toContain('window.usageOps.fetchForAccount')
     expect(actionSource).not.toContain('unwrapEnvelope(await window.usageOps.fetchForAccount')
   })

--- a/test/phase-12/renderer-api-cleanup.test.ts
+++ b/test/phase-12/renderer-api-cleanup.test.ts
@@ -9358,14 +9358,16 @@ describe('renderer API cleanup', () => {
       path.resolve(__dirname, '../../src/renderer/src/stores/useUsageStore.ts'),
       'utf-8'
     )
-    const actionStart = source.indexOf('refreshSavedAccount: async (id: string) => {')
+    const actionStart = source.indexOf(
+      'refreshSavedAccount: async (id: string, opts?: { userInitiated?: boolean }) => {'
+    )
     const actionEnd = source.indexOf('  removeSavedAccount:', actionStart)
     const actionSource = source.slice(actionStart, actionEnd)
 
     expect(actionStart).toBeGreaterThan(-1)
     expect(actionEnd).toBeGreaterThan(actionStart)
     expect(source).toContain("import { usageApi } from '@/api/usage-api'")
-    expect(actionSource).toContain('await usageApi.fetchForAccount(id)')
+    expect(actionSource).toContain('await usageApi.fetchForAccount(id, userInitiated)')
     expect(actionSource).toContain('await get().loadSavedAccounts(provider)')
     expect(actionSource).not.toContain('window.usageOps.fetchForAccount')
     expect(actionSource).not.toContain('unwrapEnvelope(await window.usageOps.fetchForAccount')
@@ -9389,14 +9391,14 @@ describe('renderer API cleanup', () => {
       'utf-8'
     )
     const actionStart = source.indexOf('removeSavedAccount: async (id: string) => {')
-    const actionEnd = source.indexOf('  fetchUsageForProvider:', actionStart)
+    const actionEnd = source.indexOf('  switchAccount:', actionStart)
     const actionSource = source.slice(actionStart, actionEnd)
 
     expect(actionStart).toBeGreaterThan(-1)
     expect(actionEnd).toBeGreaterThan(actionStart)
     expect(source).toContain("import { accountApi } from '@/api/account-api'")
     expect(actionSource).toContain('await accountApi.removeSaved(id)')
-    expect(actionSource).toContain('await get().loadSavedAccounts()')
+    expect(actionSource).toContain('.loadSavedAccounts(provider)')
     expect(actionSource).not.toContain('window.accountOps.removeSaved')
     expect(actionSource).not.toContain('unwrapEnvelope(await window.accountOps.removeSaved')
   })

--- a/test/usage/account-maintenance.test.ts
+++ b/test/usage/account-maintenance.test.ts
@@ -1,0 +1,270 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  listClaudeAccounts: vi.fn(),
+  readClaudeEffectiveBlob: vi.fn(),
+  listCodexAccounts: vi.fn(),
+  readCodexEffectiveAuth: vi.fn(),
+  migrateSavedCredentialsToStores: vi.fn(),
+  refreshAllForProvider: vi.fn(),
+  refreshTokensForStoreAccount: vi.fn(),
+  shellOpenExternal: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp' },
+  shell: { openExternal: mocks.shellOpenExternal }
+}))
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+vi.mock('../../src/main/services/account-store-claude', () => ({
+  listClaudeAccounts: mocks.listClaudeAccounts,
+  readClaudeEffectiveBlob: mocks.readClaudeEffectiveBlob
+}))
+
+vi.mock('../../src/main/services/account-store-codex', () => ({
+  listCodexAccounts: mocks.listCodexAccounts,
+  readCodexEffectiveAuth: mocks.readCodexEffectiveAuth
+}))
+
+vi.mock('../../src/main/services/credentials-migration', () => ({
+  migrateSavedCredentialsToStores: mocks.migrateSavedCredentialsToStores
+}))
+
+vi.mock('../../src/main/services/saved-usage-orchestrator', () => ({
+  refreshAllForProvider: mocks.refreshAllForProvider,
+  refreshTokensForStoreAccount: mocks.refreshTokensForStoreAccount
+}))
+
+import { startAccountMaintenance } from '../../src/main/services/account-maintenance'
+import type { ClaudeStoreAccount } from '../../src/main/services/account-store-claude'
+import type { CodexStoreAccount } from '../../src/main/services/account-store-codex'
+
+const TICK_MS = 60_000
+const START = Date.parse('2026-01-01T00:00:00.000Z')
+
+function claudeAccount(overrides: Partial<ClaudeStoreAccount> = {}): ClaudeStoreAccount {
+  return {
+    num: '1',
+    email: 'claude@example.com',
+    uuid: 'uuid-1',
+    expiresAtMs: START + 50_000,
+    hasRefresh: true,
+    plan: 'pro',
+    active: true,
+    ...overrides
+  }
+}
+
+function codexAccount(overrides: Partial<CodexStoreAccount> = {}): CodexStoreAccount {
+  return {
+    accountKey: 'user-1::acct-1',
+    email: 'codex@example.com',
+    plan: 'plus',
+    expiresAtMs: START + 50_000,
+    hasRefresh: true,
+    active: true,
+    ...overrides
+  }
+}
+
+describe('account maintenance', () => {
+  let stop: (() => void) | null = null
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(START)
+    mocks.migrateSavedCredentialsToStores.mockResolvedValue(undefined)
+    mocks.refreshAllForProvider.mockResolvedValue([])
+    mocks.listClaudeAccounts.mockResolvedValue([])
+    mocks.listCodexAccounts.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    stop?.()
+    stop = null
+    vi.useRealTimers()
+  })
+
+  it('runs the migration and a one-shot launch mass refresh for both providers, without blocking the caller', async () => {
+    stop = startAccountMaintenance()
+    // startAccountMaintenance() itself returns synchronously (fire-and-forget).
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mocks.migrateSavedCredentialsToStores).toHaveBeenCalledTimes(1)
+    expect(mocks.refreshAllForProvider).toHaveBeenCalledWith('anthropic')
+    expect(mocks.refreshAllForProvider).toHaveBeenCalledWith('openai')
+  })
+
+  it('refreshes a Claude account expiring within 2 minutes and skips one expiring later', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([
+      claudeAccount({ num: '1', email: 'soon@example.com', expiresAtMs: START + 50_000 }),
+      claudeAccount({ num: '2', email: 'later@example.com', expiresAtMs: START + 10 * 60_000 })
+    ])
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({ parsed: { refreshToken: 'token-a' } })
+    mocks.refreshTokensForStoreAccount.mockResolvedValue('refreshed')
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledWith('anthropic', {
+      num: '1',
+      email: 'soon@example.com'
+    })
+  })
+
+  it('does not refresh an account without a refresh token even if it is expiring soon', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([
+      claudeAccount({ hasRefresh: false, expiresAtMs: START + 1_000 })
+    ])
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+
+    expect(mocks.refreshTokensForStoreAccount).not.toHaveBeenCalled()
+  })
+
+  it('refreshes an expiring Codex account', async () => {
+    mocks.listCodexAccounts.mockResolvedValue([codexAccount()])
+    mocks.readCodexEffectiveAuth.mockResolvedValue({ tokens: { refresh_token: 'codex-token-a' } })
+    mocks.refreshTokensForStoreAccount.mockResolvedValue('refreshed')
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledWith('openai', {
+      accountKey: 'user-1::acct-1'
+    })
+  })
+
+  it('does not retry a needsLogin account until its refresh token changes', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({ parsed: { refreshToken: 'token-a' } })
+    mocks.refreshTokensForStoreAccount.mockResolvedValue('needsLogin')
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
+
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({ parsed: { refreshToken: 'token-b' } })
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(2)
+  })
+
+  it('backs off exponentially on repeated errors, doubling the wait each time', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({ parsed: { refreshToken: 'token-a' } })
+    mocks.refreshTokensForStoreAccount.mockResolvedValue('error')
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // t=60s: first attempt fails -> 5 minute backoff (next attempt at t=360s)
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
+
+    // t=300s: still within the 5 minute backoff window
+    await vi.advanceTimersByTimeAsync(TICK_MS * 4)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
+
+    // t=360s: backoff elapsed -> retried, fails again -> 10 minute backoff (next at t=960s)
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(2)
+
+    // t=900s: still within the 10 minute backoff window
+    await vi.advanceTimersByTimeAsync(TICK_MS * 9)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(2)
+
+    // t=960s: backoff elapsed -> retried, fails again -> 20 minute backoff
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(3)
+  })
+
+  it('caps the error backoff at 30 minutes', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({ parsed: { refreshToken: 'token-a' } })
+    mocks.refreshTokensForStoreAccount.mockResolvedValue('error')
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Drive backoff through 5 -> 10 -> 20 -> 30 (capped) minutes:
+    // attempts land at t=60s, 360s, 960s, 2160s, 3960s (each +30min thereafter).
+    await vi.advanceTimersByTimeAsync(TICK_MS) // t=60s: attempt #1 (backoff -> 5m)
+    await vi.advanceTimersByTimeAsync(TICK_MS * 5) // t=360s: attempt #2 (backoff -> 10m)
+    await vi.advanceTimersByTimeAsync(TICK_MS * 10) // t=960s: attempt #3 (backoff -> 20m)
+    await vi.advanceTimersByTimeAsync(TICK_MS * 20) // t=2160s: attempt #4 (backoff -> 30m, capped)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(4)
+
+    // Only 25 minutes later: still within the capped 30 minute window.
+    await vi.advanceTimersByTimeAsync(TICK_MS * 25)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(4)
+
+    // 30 minutes after attempt #4 (t=2160+1800=3960s): retried again.
+    await vi.advanceTimersByTimeAsync(TICK_MS * 5)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(5)
+  })
+
+  it('clears the backoff after a successful refresh so the next expiring tick retries immediately', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({ parsed: { refreshToken: 'token-a' } })
+    mocks.refreshTokensForStoreAccount.mockResolvedValueOnce('error').mockResolvedValue('refreshed')
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(TICK_MS) // fails, 5 minute backoff
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(TICK_MS * 5) // t=360s: retried, succeeds
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(TICK_MS) // no backoff left -> retries again next tick
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(3)
+  })
+
+  it('never touches any login/browser API', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.listCodexAccounts.mockResolvedValue([codexAccount()])
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({ parsed: { refreshToken: 'token-a' } })
+    mocks.readCodexEffectiveAuth.mockResolvedValue({ tokens: { refresh_token: 'codex-token-a' } })
+    mocks.refreshTokensForStoreAccount.mockResolvedValue('needsLogin')
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(TICK_MS * 3)
+
+    expect(mocks.shellOpenExternal).not.toHaveBeenCalled()
+  })
+
+  it('stops the expiry watcher once the returned cleanup function is called', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({ parsed: { refreshToken: 'token-a' } })
+    mocks.refreshTokensForStoreAccount.mockResolvedValue('refreshed')
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
+
+    stop()
+    await vi.advanceTimersByTimeAsync(TICK_MS * 5)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/usage/account-maintenance.test.ts
+++ b/test/usage/account-maintenance.test.ts
@@ -267,4 +267,41 @@ describe('account maintenance', () => {
     await vi.advanceTimersByTimeAsync(TICK_MS * 5)
     expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
   })
+
+  it('does not run a tick concurrently with a still-running previous tick', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({ parsed: { refreshToken: 'token-a' } })
+
+    let releaseFirst: ((value: 'refreshed') => void) | undefined
+    const firstGate = new Promise<'refreshed'>((resolve) => {
+      releaseFirst = resolve
+    })
+    mocks.refreshTokensForStoreAccount.mockReturnValueOnce(firstGate).mockResolvedValue('refreshed')
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // t=60s: first tick fires and hangs mid-refresh (the mock's promise is
+    // still pending).
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(mocks.listClaudeAccounts).toHaveBeenCalledTimes(1)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
+
+    // t=120s: the interval fires again while the first tick's work is still
+    // in flight — the re-entrancy guard must skip this tick's body entirely
+    // (not even re-list accounts), rather than running a second tick
+    // concurrently.
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(mocks.listClaudeAccounts).toHaveBeenCalledTimes(1)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(1)
+
+    // Let the first tick's hung work finish, clearing the re-entrancy guard.
+    releaseFirst?.('refreshed')
+    await vi.advanceTimersByTimeAsync(0)
+
+    // t=180s: a fresh tick now runs normally.
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(mocks.listClaudeAccounts).toHaveBeenCalledTimes(2)
+    expect(mocks.refreshTokensForStoreAccount).toHaveBeenCalledTimes(2)
+  })
 })

--- a/test/usage/account-service.test.ts
+++ b/test/usage/account-service.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  homeDir: '/tmp/hive-account-service-test'
+}))
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return { ...actual, homedir: () => mocks.homeDir }
+})
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { getClaudeAccountEmail } from '../../src/main/services/account-service'
+
+describe('getClaudeAccountEmail', () => {
+  beforeEach(async () => {
+    mocks.homeDir = await mkdtemp(join(tmpdir(), 'hive-account-service-'))
+  })
+
+  afterEach(async () => {
+    await rm(mocks.homeDir, { recursive: true, force: true })
+  })
+
+  it('prefers the nested ~/.claude/.claude.json over the top-level file and lowercases the email', async () => {
+    // Top-level (legacy) file carries the OLD account…
+    await writeFile(
+      join(mocks.homeDir, '.claude.json'),
+      JSON.stringify({ oauthAccount: { emailAddress: 'old@example.com' } })
+    )
+    // …but the nested ccswitch-primary file was written by a switch to a NEW
+    // (mixed-case) account. The nested file must win, lowercased.
+    await mkdir(join(mocks.homeDir, '.claude'), { recursive: true })
+    await writeFile(
+      join(mocks.homeDir, '.claude', '.claude.json'),
+      JSON.stringify({ oauthAccount: { emailAddress: 'New.Account@Example.com' } })
+    )
+
+    await expect(getClaudeAccountEmail()).resolves.toBe('new.account@example.com')
+  })
+
+  it('falls back to the top-level file (lowercased) when no nested file exists', async () => {
+    await writeFile(
+      join(mocks.homeDir, '.claude.json'),
+      JSON.stringify({ oauthAccount: { emailAddress: 'Top.Level@Example.com' } })
+    )
+
+    await expect(getClaudeAccountEmail()).resolves.toBe('top.level@example.com')
+  })
+
+  it('returns null when no identity file is present', async () => {
+    await expect(getClaudeAccountEmail()).resolves.toBeNull()
+  })
+})

--- a/test/usage/account-store-claude.test.ts
+++ b/test/usage/account-store-claude.test.ts
@@ -35,6 +35,7 @@ import {
   LIVE_CLAUDE_KEYCHAIN_SERVICE,
   addClaudeAccount,
   listClaudeAccounts,
+  persistRotatedLiveClaudeTokens,
   readClaudeAccountBlob,
   readClaudeEffectiveBlob,
   readClaudeLiveEmail,
@@ -46,6 +47,7 @@ import {
 const sequencePath = () => join(mocks.homeDir, '.claude-switch-backup', 'sequence.json')
 const identityPath = () => join(mocks.homeDir, '.claude.json')
 const nestedIdentityPath = () => join(mocks.homeDir, '.claude', '.claude.json')
+const credentialsFilePath = () => join(mocks.homeDir, '.claude', '.credentials.json')
 
 function claudeBlob(
   overrides: Partial<{
@@ -320,6 +322,94 @@ describe('account-store-claude', () => {
 
       const active = await readClaudeEffectiveBlob('1', 'a@b.c')
       expect(active?.parsed.accessToken).toBe('live-token')
+    })
+  })
+
+  describe('persistRotatedLiveClaudeTokens', () => {
+    const rotated = { accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt: 9_999_999 }
+
+    it('returns no-live when there are no live credentials anywhere', async () => {
+      await expect(persistRotatedLiveClaudeTokens(rotated, 'old-refresh')).resolves.toBe('no-live')
+      expect(mocks.keychainWrite).not.toHaveBeenCalled()
+    })
+
+    it('writes to the Keychain when the live credentials came from there (keychain-sourced)', async () => {
+      mocks.keychainStore.set(LIVE_CLAUDE_KEYCHAIN_SERVICE, claudeBlob({ refreshToken: 'old-refresh' }))
+
+      const outcome = await persistRotatedLiveClaudeTokens(rotated, 'old-refresh', 'scope-a scope-b')
+
+      expect(outcome).toBe('persisted')
+      const live = JSON.parse(mocks.keychainStore.get(LIVE_CLAUDE_KEYCHAIN_SERVICE)!)
+      expect(live.claudeAiOauth).toMatchObject({
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: 9_999_999,
+        scopes: ['scope-a', 'scope-b'],
+        // Unrelated fields on the blob are preserved.
+        subscriptionType: 'max'
+      })
+      // Never fell back to the credentials file.
+      await expect(readFile(credentialsFilePath(), 'utf-8')).rejects.toThrow()
+    })
+
+    it('writes to the credentials file (mode 0600) when the live credentials came from there (no Keychain entry)', async () => {
+      await mkdir(join(mocks.homeDir, '.claude'), { recursive: true })
+      await writeFile(credentialsFilePath(), claudeBlob({ refreshToken: 'old-refresh' }))
+
+      const outcome = await persistRotatedLiveClaudeTokens(rotated, 'old-refresh')
+
+      expect(outcome).toBe('persisted')
+      expect(mocks.keychainWrite).not.toHaveBeenCalledWith(LIVE_CLAUDE_KEYCHAIN_SERVICE, expect.anything())
+
+      const { stat } = await import('fs/promises')
+      const stats = await stat(credentialsFilePath())
+      expect(stats.mode & 0o777).toBe(0o600)
+
+      const patched = JSON.parse(await readFile(credentialsFilePath(), 'utf-8'))
+      expect(patched.claudeAiOauth).toMatchObject({
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: 9_999_999
+      })
+    })
+
+    it('returns skipped-race without writing when the live refresh token no longer matches (another process rotated first)', async () => {
+      mocks.keychainStore.set(
+        LIVE_CLAUDE_KEYCHAIN_SERVICE,
+        claudeBlob({ refreshToken: 'someone-else-already-rotated-this' })
+      )
+
+      const outcome = await persistRotatedLiveClaudeTokens(rotated, 'old-refresh')
+
+      expect(outcome).toBe('skipped-race')
+      expect(mocks.keychainWrite).not.toHaveBeenCalled()
+      const live = JSON.parse(mocks.keychainStore.get(LIVE_CLAUDE_KEYCHAIN_SERVICE)!)
+      expect(live.claudeAiOauth.refreshToken).toBe('someone-else-already-rotated-this')
+    })
+
+    it('mirrors the patched blob to the managed account backup entry matching the live email', async () => {
+      await addClaudeAccount('a@b.c', 'uuid-a', claudeBlob({ accessToken: 'stale-backup-token' }))
+      await writeFile(identityPath(), JSON.stringify({ oauthAccount: { emailAddress: 'a@b.c' } }))
+      mocks.keychainStore.set(LIVE_CLAUDE_KEYCHAIN_SERVICE, claudeBlob({ refreshToken: 'old-refresh' }))
+
+      const outcome = await persistRotatedLiveClaudeTokens(rotated, 'old-refresh')
+
+      expect(outcome).toBe('persisted')
+      const backup = JSON.parse(mocks.keychainStore.get('Claude Code-Account-1-a@b.c')!)
+      expect(backup.claudeAiOauth.accessToken).toBe('new-access')
+      expect(backup.claudeAiOauth.refreshToken).toBe('new-refresh')
+    })
+
+    it('does not mirror to any account backup when the live email has no managed account', async () => {
+      await addClaudeAccount('other@example.com', 'uuid-o', claudeBlob())
+      await writeFile(identityPath(), JSON.stringify({ oauthAccount: { emailAddress: 'unmanaged@example.com' } }))
+      mocks.keychainStore.set(LIVE_CLAUDE_KEYCHAIN_SERVICE, claudeBlob({ refreshToken: 'old-refresh' }))
+
+      const outcome = await persistRotatedLiveClaudeTokens(rotated, 'old-refresh')
+
+      expect(outcome).toBe('persisted')
+      const untouchedBackup = JSON.parse(mocks.keychainStore.get('Claude Code-Account-1-other@example.com')!)
+      expect(untouchedBackup.claudeAiOauth.accessToken).toBe('access-1')
     })
   })
 })

--- a/test/usage/account-store-claude.test.ts
+++ b/test/usage/account-store-claude.test.ts
@@ -1,0 +1,325 @@
+// @vitest-environment node
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  homeDir: '/tmp/hive-account-store-claude-test',
+  keychainStore: new Map<string, string>(),
+  keychainRead: vi.fn(async (service: string) => mocks.keychainStore.get(service) ?? null),
+  keychainWrite: vi.fn(async (service: string, secret: string) => {
+    mocks.keychainStore.set(service, secret)
+  }),
+  keychainDelete: vi.fn(async (service: string) => {
+    mocks.keychainStore.delete(service)
+  })
+}))
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return { ...actual, homedir: () => mocks.homeDir }
+})
+
+vi.mock('../../src/main/services/keychain', () => ({
+  keychainRead: mocks.keychainRead,
+  keychainWrite: mocks.keychainWrite,
+  keychainDelete: mocks.keychainDelete
+}))
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import {
+  LIVE_CLAUDE_KEYCHAIN_SERVICE,
+  addClaudeAccount,
+  listClaudeAccounts,
+  readClaudeAccountBlob,
+  readClaudeEffectiveBlob,
+  readClaudeLiveEmail,
+  removeClaudeAccount,
+  switchClaudeAccount,
+  updateClaudeTokens
+} from '../../src/main/services/account-store-claude'
+
+const sequencePath = () => join(mocks.homeDir, '.claude-switch-backup', 'sequence.json')
+const identityPath = () => join(mocks.homeDir, '.claude.json')
+const nestedIdentityPath = () => join(mocks.homeDir, '.claude', '.claude.json')
+
+function claudeBlob(
+  overrides: Partial<{
+    accessToken: string
+    refreshToken: string
+    expiresAt: number
+    scopes: string[]
+    subscriptionType: string
+  }> = {}
+): string {
+  return JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'access-1',
+      refreshToken: 'refresh-1',
+      expiresAt: 1_700_000_000_000,
+      scopes: ['org:create_api_key'],
+      subscriptionType: 'max',
+      ...overrides
+    }
+  })
+}
+
+async function readSequenceFile(): Promise<any> {
+  return JSON.parse(await readFile(sequencePath(), 'utf-8'))
+}
+
+describe('account-store-claude', () => {
+  beforeEach(async () => {
+    mocks.homeDir = await mkdtemp(join(tmpdir(), 'hive-account-store-claude-'))
+    mocks.keychainStore.clear()
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    await rm(mocks.homeDir, { recursive: true, force: true })
+  })
+
+  describe('addClaudeAccount', () => {
+    it('allocates sequential numbers, reuses the number for a repeated email, and preserves added/uuid unless a new uuid is given', async () => {
+      const num1 = await addClaudeAccount('a@b.c', 'uuid-1', claudeBlob())
+      expect(num1).toBe('1')
+
+      vi.setSystemTime(new Date('2026-01-01T00:01:00.000Z'))
+      const num2 = await addClaudeAccount('d@e.f', 'uuid-2', claudeBlob())
+      expect(num2).toBe('2')
+
+      vi.setSystemTime(new Date('2026-01-01T00:02:00.000Z'))
+      const num1Again = await addClaudeAccount('a@b.c', '', claudeBlob({ accessToken: 'access-2' }))
+      expect(num1Again).toBe('1')
+
+      const sequence = await readSequenceFile()
+      expect(sequence.sequence).toEqual([1, 2])
+      expect(sequence.accounts['1']).toMatchObject({
+        email: 'a@b.c',
+        uuid: 'uuid-1',
+        added: '2026-01-01T00:00:00.000Z'
+      })
+      expect(sequence.accounts['2']).toMatchObject({ email: 'd@e.f', uuid: 'uuid-2' })
+
+      const storedBlob = mocks.keychainStore.get('Claude Code-Account-1-a@b.c')
+      expect(JSON.parse(storedBlob!).claudeAiOauth.accessToken).toBe('access-2')
+    })
+
+    it('adopts a new uuid on re-add when one is given', async () => {
+      await addClaudeAccount('a@b.c', 'uuid-1', claudeBlob())
+      await addClaudeAccount('a@b.c', 'uuid-1-updated', claudeBlob())
+
+      const sequence = await readSequenceFile()
+      expect(sequence.accounts['1'].uuid).toBe('uuid-1-updated')
+    })
+  })
+
+  describe('switchClaudeAccount', () => {
+    it('preserves the outgoing live blob into its own backup, writes the target live, merges oauthAccount preserving unrelated fields, and updates activeAccountNumber', async () => {
+      await addClaudeAccount('a@b.c', 'uuid-a', claudeBlob({ accessToken: 'a-token' }))
+      await addClaudeAccount('d@e.f', 'uuid-d', claudeBlob({ accessToken: 'd-token' }))
+
+      // Account "a@b.c" is currently live, with a FRESHER live blob than its
+      // own backup (as if it had just been refreshed in place).
+      await writeFile(
+        identityPath(),
+        JSON.stringify({
+          oauthAccount: { emailAddress: 'a@b.c', accountUuid: 'uuid-a' },
+          someOtherSetting: 'keep-me'
+        })
+      )
+      mocks.keychainStore.set(LIVE_CLAUDE_KEYCHAIN_SERVICE, claudeBlob({ accessToken: 'a-token-fresher' }))
+
+      await switchClaudeAccount('2', 'd@e.f')
+
+      const outgoingBackup = JSON.parse(mocks.keychainStore.get('Claude Code-Account-1-a@b.c')!)
+      expect(outgoingBackup.claudeAiOauth.accessToken).toBe('a-token-fresher')
+
+      const live = JSON.parse(mocks.keychainStore.get(LIVE_CLAUDE_KEYCHAIN_SERVICE)!)
+      expect(live.claudeAiOauth.accessToken).toBe('d-token')
+
+      const identity = JSON.parse(await readFile(identityPath(), 'utf-8'))
+      expect(identity).toMatchObject({
+        oauthAccount: { emailAddress: 'd@e.f', accountUuid: 'uuid-d' },
+        someOtherSetting: 'keep-me'
+      })
+
+      const sequence = await readSequenceFile()
+      expect(sequence.activeAccountNumber).toBe(2)
+    })
+
+    it('throws when the target account has no stored credentials', async () => {
+      await mkdir(join(mocks.homeDir, '.claude-switch-backup'), { recursive: true })
+      await writeFile(
+        sequencePath(),
+        JSON.stringify({
+          activeAccountNumber: null,
+          lastUpdated: new Date().toISOString(),
+          sequence: [1],
+          accounts: { '1': { email: 'ghost@example.com', uuid: 'uuid-ghost', added: new Date().toISOString() } }
+        })
+      )
+
+      await expect(switchClaudeAccount('1', 'ghost@example.com')).rejects.toThrow(
+        /No stored Claude credentials/
+      )
+    })
+
+    it('throws when the identity file exists but is not valid JSON, without clobbering it', async () => {
+      await addClaudeAccount('a@b.c', 'uuid-a', claudeBlob())
+      await writeFile(identityPath(), '{ not valid json')
+
+      await expect(switchClaudeAccount('1', 'a@b.c')).rejects.toThrow(/invalid JSON/)
+
+      const raw = await readFile(identityPath(), 'utf-8')
+      expect(raw).toBe('{ not valid json')
+    })
+
+    it('prefers ~/.claude/.claude.json over ~/.claude.json when both exist', async () => {
+      await writeFile(
+        identityPath(),
+        JSON.stringify({ oauthAccount: { emailAddress: 'top-level@example.com' } })
+      )
+      await mkdir(join(mocks.homeDir, '.claude'), { recursive: true })
+      await writeFile(
+        nestedIdentityPath(),
+        JSON.stringify({ oauthAccount: { emailAddress: 'nested@example.com' } })
+      )
+
+      await expect(readClaudeLiveEmail()).resolves.toBe('nested@example.com')
+
+      await addClaudeAccount('nested@example.com', 'uuid-nested', claudeBlob())
+      await switchClaudeAccount('1', 'nested@example.com')
+
+      const nested = JSON.parse(await readFile(nestedIdentityPath(), 'utf-8'))
+      expect(nested.oauthAccount.emailAddress).toBe('nested@example.com')
+      const topLevel = JSON.parse(await readFile(identityPath(), 'utf-8'))
+      expect(topLevel.oauthAccount.emailAddress).toBe('top-level@example.com')
+    })
+  })
+
+  describe('updateClaudeTokens', () => {
+    it('patches known token fields while preserving unknown fields, and mirrors to live only when active', async () => {
+      await addClaudeAccount(
+        'a@b.c',
+        'uuid-a',
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'old-access',
+            refreshToken: 'old-refresh',
+            expiresAt: 1000,
+            scopes: ['x'],
+            subscriptionType: 'max'
+          },
+          someUnrelatedTopLevelField: 'keep-me'
+        })
+      )
+
+      // Not active yet (no identity file) => no live write.
+      await updateClaudeTokens(
+        '1',
+        'a@b.c',
+        { accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt: 2000 },
+        'scope-a scope-b'
+      )
+
+      const backup = JSON.parse(mocks.keychainStore.get('Claude Code-Account-1-a@b.c')!)
+      expect(backup).toMatchObject({
+        claudeAiOauth: {
+          accessToken: 'new-access',
+          refreshToken: 'new-refresh',
+          expiresAt: 2000,
+          scopes: ['scope-a', 'scope-b'],
+          subscriptionType: 'max'
+        },
+        someUnrelatedTopLevelField: 'keep-me'
+      })
+      expect(mocks.keychainStore.has(LIVE_CLAUDE_KEYCHAIN_SERVICE)).toBe(false)
+
+      // Now make it the live account and update again, omitting `scope`.
+      await writeFile(identityPath(), JSON.stringify({ oauthAccount: { emailAddress: 'a@b.c' } }))
+      await updateClaudeTokens('1', 'a@b.c', {
+        accessToken: 'newer-access',
+        refreshToken: 'newer-refresh',
+        expiresAt: 3000
+      })
+
+      const live = JSON.parse(mocks.keychainStore.get(LIVE_CLAUDE_KEYCHAIN_SERVICE)!)
+      expect(live.claudeAiOauth.accessToken).toBe('newer-access')
+      expect(live.claudeAiOauth.scopes).toEqual(['scope-a', 'scope-b'])
+      expect(live.someUnrelatedTopLevelField).toBe('keep-me')
+    })
+  })
+
+  describe('removeClaudeAccount', () => {
+    it('nulls activeAccountNumber when removing the active account and never touches the live Keychain service', async () => {
+      await addClaudeAccount('a@b.c', 'uuid-a', claudeBlob())
+      await switchClaudeAccount('1', 'a@b.c')
+
+      mocks.keychainWrite.mockClear()
+      mocks.keychainDelete.mockClear()
+
+      await removeClaudeAccount('1', 'a@b.c')
+
+      const sequence = await readSequenceFile()
+      expect(sequence.activeAccountNumber).toBeNull()
+      expect(sequence.accounts['1']).toBeUndefined()
+      expect(sequence.sequence).toEqual([])
+
+      expect(mocks.keychainDelete).toHaveBeenCalledWith('Claude Code-Account-1-a@b.c')
+      expect(mocks.keychainWrite).not.toHaveBeenCalledWith(LIVE_CLAUDE_KEYCHAIN_SERVICE, expect.anything())
+      expect(mocks.keychainDelete).not.toHaveBeenCalledWith(LIVE_CLAUDE_KEYCHAIN_SERVICE)
+
+      // The identity file is untouched by removal.
+      const identity = JSON.parse(await readFile(identityPath(), 'utf-8'))
+      expect(identity.oauthAccount.emailAddress).toBe('a@b.c')
+    })
+  })
+
+  describe('listClaudeAccounts', () => {
+    it('lists accounts in sequence order, marks the active one case-insensitively, and tolerates a missing keychain entry', async () => {
+      await addClaudeAccount('a@b.c', 'uuid-a', claudeBlob({ subscriptionType: 'max' }))
+      await addClaudeAccount('nokeys@example.com', 'uuid-none', claudeBlob())
+      mocks.keychainStore.delete('Claude Code-Account-2-nokeys@example.com')
+
+      await writeFile(identityPath(), JSON.stringify({ oauthAccount: { emailAddress: 'A@B.C' } }))
+
+      const accounts = await listClaudeAccounts()
+      expect(accounts.map((a) => a.num)).toEqual(['1', '2'])
+      expect(accounts[0]).toMatchObject({ email: 'a@b.c', active: true, plan: 'max', hasRefresh: true })
+      expect(accounts[1]).toMatchObject({
+        email: 'nokeys@example.com',
+        active: false,
+        expiresAtMs: null,
+        hasRefresh: false,
+        plan: null
+      })
+    })
+  })
+
+  describe('readClaudeAccountBlob / readClaudeEffectiveBlob', () => {
+    it('returns null for a missing account', async () => {
+      await expect(readClaudeAccountBlob('99', 'nobody@example.com')).resolves.toBeNull()
+    })
+
+    it('returns the live blob when active, else falls back to the backup blob', async () => {
+      await addClaudeAccount('a@b.c', 'uuid-a', claudeBlob({ accessToken: 'backup-token' }))
+
+      const inactive = await readClaudeEffectiveBlob('1', 'a@b.c')
+      expect(inactive?.parsed.accessToken).toBe('backup-token')
+
+      await writeFile(identityPath(), JSON.stringify({ oauthAccount: { emailAddress: 'a@b.c' } }))
+      mocks.keychainStore.set(LIVE_CLAUDE_KEYCHAIN_SERVICE, claudeBlob({ accessToken: 'live-token' }))
+
+      const active = await readClaudeEffectiveBlob('1', 'a@b.c')
+      expect(active?.parsed.accessToken).toBe('live-token')
+    })
+  })
+})

--- a/test/usage/account-store-claude.test.ts
+++ b/test/usage/account-store-claude.test.ts
@@ -34,6 +34,7 @@ vi.mock('../../src/main/services/logger', () => ({
 import {
   LIVE_CLAUDE_KEYCHAIN_SERVICE,
   addClaudeAccount,
+  clearAccountStoreCacheForTests,
   listClaudeAccounts,
   persistRotatedLiveClaudeTokens,
   readClaudeAccountBlob,
@@ -81,6 +82,10 @@ describe('account-store-claude', () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    // The listClaudeAccounts() memo is module-level state that outlives a
+    // single test (fake system time resets to the same instant every test,
+    // so its TTL alone wouldn't force a re-read across tests).
+    clearAccountStoreCacheForTests()
   })
 
   afterEach(async () => {
@@ -303,6 +308,63 @@ describe('account-store-claude', () => {
         hasRefresh: false,
         plan: null
       })
+    })
+  })
+
+  describe('listClaudeAccounts caching', () => {
+    it('memoizes the result within the TTL (no extra keychain reads), a mutation through this module invalidates it immediately, and it also expires after the TTL', async () => {
+      await addClaudeAccount('a@b.c', 'uuid-a', claudeBlob({ expiresAt: 1000 }))
+
+      mocks.keychainRead.mockClear()
+      const first = await listClaudeAccounts()
+      expect(first[0].expiresAtMs).toBe(1000)
+      expect(mocks.keychainRead).toHaveBeenCalled()
+
+      // Bypass this module's own mutators to change the underlying blob
+      // directly — within the TTL window, the memoized list must not see it,
+      // and no additional keychain read should happen at all.
+      mocks.keychainRead.mockClear()
+      mocks.keychainStore.set('Claude Code-Account-1-a@b.c', claudeBlob({ expiresAt: 2000 }))
+      const second = await listClaudeAccounts()
+      expect(second[0].expiresAtMs).toBe(1000)
+      expect(mocks.keychainRead).not.toHaveBeenCalled()
+
+      // A mutation through the module's own API busts the cache immediately.
+      await updateClaudeTokens('1', 'a@b.c', {
+        accessToken: 'newer-access',
+        refreshToken: 'newer-refresh',
+        expiresAt: 3000
+      })
+      mocks.keychainRead.mockClear()
+      const third = await listClaudeAccounts()
+      expect(third[0].expiresAtMs).toBe(3000)
+      expect(mocks.keychainRead).toHaveBeenCalled()
+
+      // Bypass again, then let the TTL lapse without any mutator call.
+      mocks.keychainStore.set('Claude Code-Account-1-a@b.c', claudeBlob({ expiresAt: 4000 }))
+      vi.setSystemTime(new Date(Date.now() + 15_001))
+      mocks.keychainRead.mockClear()
+      const fourth = await listClaudeAccounts()
+      expect(fourth[0].expiresAtMs).toBe(4000)
+      expect(mocks.keychainRead).toHaveBeenCalled()
+    })
+
+    it('does not memoize a rejected call', async () => {
+      await mkdir(join(mocks.homeDir, '.claude-switch-backup'), { recursive: true })
+      await writeFile(sequencePath(), '{ not valid json')
+
+      await expect(listClaudeAccounts()).rejects.toThrow(/invalid JSON/)
+
+      await writeFile(
+        sequencePath(),
+        JSON.stringify({
+          activeAccountNumber: null,
+          lastUpdated: new Date().toISOString(),
+          sequence: [],
+          accounts: {}
+        })
+      )
+      await expect(listClaudeAccounts()).resolves.toEqual([])
     })
   })
 

--- a/test/usage/account-store-codex.test.ts
+++ b/test/usage/account-store-codex.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../src/main/services/logger', () => ({
 
 import {
   addCodexAccount,
+  clearAccountStoreCacheForTests,
   listCodexAccounts,
   persistRotatedLiveCodexTokens,
   readCodexLive,
@@ -61,6 +62,10 @@ describe('account-store-codex', () => {
     process.env.CODEX_HOME = codexHome
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    // The listCodexAccounts() memo is module-level state that outlives a
+    // single test (fake system time resets to the same instant every test,
+    // so its TTL alone wouldn't force a re-read across tests).
+    clearAccountStoreCacheForTests()
   })
 
   afterEach(async () => {
@@ -315,6 +320,51 @@ describe('account-store-codex', () => {
 
       const accounts = await listCodexAccounts()
       expect(accounts.find((a) => a.accountKey === 'user-a::acct-a')?.active).toBe(true)
+    })
+  })
+
+  describe('listCodexAccounts caching', () => {
+    it('memoizes the result within the TTL, a mutation through this module invalidates it immediately, and it also expires after the TTL', async () => {
+      const idToken = idTokenFor('user-a', 'acct-a')
+      await addCodexAccount(idToken, 'a-access', 'a-refresh')
+      const snapshotFile = join(codexHome, 'accounts', `${snapshotName('user-a::acct-a')}.auth.json`)
+
+      const first = await listCodexAccounts()
+      expect(first[0].hasRefresh).toBe(true)
+
+      // Bypass this module's own mutators to change the underlying snapshot
+      // directly — within the TTL window, the memoized list must not see it.
+      const raw = JSON.parse(await readFile(snapshotFile, 'utf-8'))
+      raw.tokens.refresh_token = ''
+      await writeFile(snapshotFile, JSON.stringify(raw))
+      const second = await listCodexAccounts()
+      expect(second[0].hasRefresh).toBe(true)
+
+      // A mutation through the module's own API busts the cache immediately.
+      await updateCodexTokens('user-a::acct-a', { accessToken: 'new-access', refreshToken: '' })
+      const third = await listCodexAccounts()
+      expect(third[0].hasRefresh).toBe(false)
+
+      // Bypass again, then let the TTL lapse without any mutator call.
+      const raw2 = JSON.parse(await readFile(snapshotFile, 'utf-8'))
+      raw2.tokens.refresh_token = 'restored-refresh'
+      await writeFile(snapshotFile, JSON.stringify(raw2))
+      vi.setSystemTime(new Date(Date.now() + 15_001))
+      const fourth = await listCodexAccounts()
+      expect(fourth[0].hasRefresh).toBe(true)
+    })
+
+    it('does not memoize a rejected call', async () => {
+      await mkdir(join(codexHome, 'accounts'), { recursive: true })
+      await writeFile(join(codexHome, 'accounts', 'registry.json'), '{ not valid json')
+
+      await expect(listCodexAccounts()).rejects.toThrow(/invalid JSON/)
+
+      await writeFile(
+        join(codexHome, 'accounts', 'registry.json'),
+        JSON.stringify({ schema_version: 3, active_account_key: null, accounts: [] })
+      )
+      await expect(listCodexAccounts()).resolves.toEqual([])
     })
   })
 

--- a/test/usage/account-store-codex.test.ts
+++ b/test/usage/account-store-codex.test.ts
@@ -1,0 +1,319 @@
+// @vitest-environment node
+import { mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import {
+  addCodexAccount,
+  listCodexAccounts,
+  readCodexLive,
+  readCodexSnapshot,
+  removeCodexAccount,
+  snapshotName,
+  switchCodexAccount,
+  updateCodexTokens
+} from '../../src/main/services/account-store-codex'
+
+function base64url(value: string): string {
+  return Buffer.from(value, 'utf-8').toString('base64url')
+}
+
+function buildIdToken(payload: Record<string, unknown>): string {
+  const header = base64url(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+  const body = base64url(JSON.stringify(payload))
+  return `${header}.${body}.fake-signature`
+}
+
+function idTokenFor(
+  userId: string,
+  accountId: string,
+  email = 'user@example.com',
+  plan = 'plus'
+): string {
+  return buildIdToken({
+    email,
+    'https://api.openai.com/auth': {
+      chatgpt_user_id: userId,
+      chatgpt_account_id: accountId,
+      chatgpt_plan_type: plan
+    }
+  })
+}
+
+function accessTokenWithExp(expSeconds: number): string {
+  const header = base64url(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+  const body = base64url(JSON.stringify({ exp: expSeconds }))
+  return `${header}.${body}.fake-signature`
+}
+
+describe('account-store-codex', () => {
+  let codexHome: string
+  const originalCodexHome = process.env.CODEX_HOME
+
+  beforeEach(async () => {
+    codexHome = await mkdtemp(join(tmpdir(), 'hive-account-store-codex-'))
+    process.env.CODEX_HOME = codexHome
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    if (originalCodexHome === undefined) delete process.env.CODEX_HOME
+    else process.env.CODEX_HOME = originalCodexHome
+    await rm(codexHome, { recursive: true, force: true })
+  })
+
+  describe('snapshotName', () => {
+    it('base64-encodes with the standard (+/) alphabet and trims trailing = padding', () => {
+      // Standard base64 of "u::a?>>" is "dTo6YT8+Pg==" (contains a literal
+      // '+'); the URL-safe alphabet would instead produce a '-' there, so
+      // this fixture actually distinguishes the two encodings.
+      expect(snapshotName('u::a?>>')).toBe('dTo6YT8+Pg')
+    })
+
+    it('produces a file name that account-store writes actually land on', async () => {
+      const idToken = idTokenFor('u', 'a?>>')
+      await addCodexAccount(idToken, 'access-1', 'refresh-1')
+
+      const stats = await stat(join(codexHome, 'accounts', 'dTo6YT8+Pg.auth.json'))
+      expect(stats.isFile()).toBe(true)
+    })
+  })
+
+  describe('addCodexAccount', () => {
+    it('derives account_key as userId::accountId from the id_token and writes snapshot + registry', async () => {
+      const idToken = idTokenFor('user-123', 'acct-456', 'person@example.com', 'pro')
+      const result = await addCodexAccount(idToken, 'access-token', 'refresh-token')
+
+      expect(result).toEqual({ accountKey: 'user-123::acct-456', email: 'person@example.com' })
+
+      const registry = JSON.parse(await readFile(join(codexHome, 'accounts', 'registry.json'), 'utf-8'))
+      expect(registry.schema_version).toBe(3)
+      expect(registry.accounts).toHaveLength(1)
+      expect(registry.accounts[0]).toMatchObject({
+        account_key: 'user-123::acct-456',
+        chatgpt_user_id: 'user-123',
+        chatgpt_account_id: 'acct-456',
+        email: 'person@example.com',
+        plan: 'pro',
+        auth_mode: 'chatgpt'
+      })
+
+      const snapshot = await readCodexSnapshot('user-123::acct-456')
+      expect(snapshot?.tokens).toMatchObject({
+        id_token: idToken,
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        account_id: 'acct-456'
+      })
+    })
+
+    it('throws when the id_token is missing chatgpt_user_id/chatgpt_account_id', async () => {
+      const idToken = buildIdToken({ email: 'x@y.z' })
+      await expect(addCodexAccount(idToken, 'a', 'r')).rejects.toThrow(
+        /chatgpt_user_id|chatgpt_account_id/
+      )
+    })
+
+    it('preserves created_at and updates email/plan on re-add', async () => {
+      await addCodexAccount(idTokenFor('user-1', 'acct-1', 'old@example.com', 'plus'), 'a1', 'r1')
+      const before = JSON.parse(await readFile(join(codexHome, 'accounts', 'registry.json'), 'utf-8'))
+      const createdAt = before.accounts[0].created_at
+
+      vi.setSystemTime(new Date('2026-02-01T00:00:00.000Z'))
+      await addCodexAccount(idTokenFor('user-1', 'acct-1', 'new@example.com', 'pro'), 'a2', 'r2')
+
+      const after = JSON.parse(await readFile(join(codexHome, 'accounts', 'registry.json'), 'utf-8'))
+      expect(after.accounts).toHaveLength(1)
+      expect(after.accounts[0].created_at).toBe(createdAt)
+      expect(after.accounts[0].email).toBe('new@example.com')
+      expect(after.accounts[0].plan).toBe('pro')
+    })
+  })
+
+  describe('switchCodexAccount', () => {
+    it('preserves the outgoing live auth.json into its own snapshot, copies the target snapshot to live, and updates the registry', async () => {
+      const idTokenA = idTokenFor('user-a', 'acct-a', 'a@example.com')
+      const idTokenB = idTokenFor('user-b', 'acct-b', 'b@example.com')
+      await addCodexAccount(idTokenA, 'a-access', 'a-refresh')
+      await addCodexAccount(idTokenB, 'b-access', 'b-refresh')
+
+      // Account A is live, with fresher tokens than its own snapshot (as if
+      // the Codex CLI had refreshed auth.json in place).
+      await writeFile(
+        join(codexHome, 'auth.json'),
+        JSON.stringify({
+          OPENAI_API_KEY: null,
+          auth_mode: 'chatgpt',
+          tokens: {
+            id_token: idTokenA,
+            access_token: 'a-access-fresher',
+            refresh_token: 'a-refresh-fresher',
+            account_id: 'acct-a'
+          },
+          last_refresh: '2026-01-01T00:00:00.000Z'
+        })
+      )
+
+      await switchCodexAccount('user-b::acct-b')
+
+      const outgoingSnapshot = await readCodexSnapshot('user-a::acct-a')
+      expect(outgoingSnapshot?.tokens?.access_token).toBe('a-access-fresher')
+
+      const live = await readCodexLive()
+      expect(live?.tokens?.access_token).toBe('b-access')
+
+      const registry = JSON.parse(await readFile(join(codexHome, 'accounts', 'registry.json'), 'utf-8'))
+      expect(registry.active_account_key).toBe('user-b::acct-b')
+      expect(registry.active_account_activated_at_ms).toBe(Date.now())
+    })
+
+    it('throws when the target account has no snapshot', async () => {
+      await expect(switchCodexAccount('nobody::here')).rejects.toThrow(/No Codex snapshot/)
+    })
+  })
+
+  describe('updateCodexTokens', () => {
+    it('patches access always, refresh/id only when provided, and mirrors to live only when active', async () => {
+      const idToken = idTokenFor('user-1', 'acct-1')
+      await addCodexAccount(idToken, 'old-access', 'old-refresh')
+
+      // Not active yet: active_account_key is still null.
+      await updateCodexTokens('user-1::acct-1', { accessToken: 'new-access' })
+      let snapshot = await readCodexSnapshot('user-1::acct-1')
+      expect(snapshot?.tokens?.access_token).toBe('new-access')
+      expect(snapshot?.tokens?.refresh_token).toBe('old-refresh')
+      await expect(readCodexLive()).resolves.toBeNull()
+
+      await switchCodexAccount('user-1::acct-1')
+      await updateCodexTokens('user-1::acct-1', {
+        accessToken: 'newer-access',
+        refreshToken: 'newer-refresh',
+        idToken: 'newer-id-token'
+      })
+
+      snapshot = await readCodexSnapshot('user-1::acct-1')
+      expect(snapshot?.tokens).toMatchObject({
+        access_token: 'newer-access',
+        refresh_token: 'newer-refresh',
+        id_token: 'newer-id-token'
+      })
+
+      const live = await readCodexLive()
+      expect(live?.tokens).toMatchObject({
+        access_token: 'newer-access',
+        refresh_token: 'newer-refresh',
+        id_token: 'newer-id-token'
+      })
+    })
+
+    it('throws when there is no snapshot for the account', async () => {
+      await expect(updateCodexTokens('nobody::here', { accessToken: 'x' })).rejects.toThrow(
+        /No Codex snapshot/
+      )
+    })
+  })
+
+  describe('file permissions', () => {
+    it('writes registry.json, snapshot files, and auth.json with mode 0600', async () => {
+      const idToken = idTokenFor('user-1', 'acct-1')
+      await addCodexAccount(idToken, 'access', 'refresh')
+      await switchCodexAccount('user-1::acct-1')
+
+      const registryStats = await stat(join(codexHome, 'accounts', 'registry.json'))
+      expect(registryStats.mode & 0o777).toBe(0o600)
+
+      const snapshotStats = await stat(
+        join(codexHome, 'accounts', `${snapshotName('user-1::acct-1')}.auth.json`)
+      )
+      expect(snapshotStats.mode & 0o777).toBe(0o600)
+
+      const liveStats = await stat(join(codexHome, 'auth.json'))
+      expect(liveStats.mode & 0o777).toBe(0o600)
+    })
+  })
+
+  describe('removeCodexAccount', () => {
+    it('deletes the snapshot and registry entry, nulls active_account_key if pointed here, and never touches auth.json', async () => {
+      const idToken = idTokenFor('user-1', 'acct-1')
+      await addCodexAccount(idToken, 'access', 'refresh')
+      await switchCodexAccount('user-1::acct-1')
+
+      const liveBefore = await readFile(join(codexHome, 'auth.json'), 'utf-8')
+
+      await removeCodexAccount('user-1::acct-1')
+
+      await expect(
+        stat(join(codexHome, 'accounts', `${snapshotName('user-1::acct-1')}.auth.json`))
+      ).rejects.toThrow()
+
+      const registry = JSON.parse(await readFile(join(codexHome, 'accounts', 'registry.json'), 'utf-8'))
+      expect(registry.accounts).toHaveLength(0)
+      expect(registry.active_account_key).toBeNull()
+
+      const liveAfter = await readFile(join(codexHome, 'auth.json'), 'utf-8')
+      expect(liveAfter).toBe(liveBefore)
+    })
+
+    it('ignores a missing snapshot file', async () => {
+      await expect(removeCodexAccount('nobody::here')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('listCodexAccounts', () => {
+    it('marks the active account by deriving its key from live id_token claims, using live tokens for it', async () => {
+      const idTokenA = idTokenFor('user-a', 'acct-a', 'a@example.com', 'plus')
+      const idTokenB = idTokenFor('user-b', 'acct-b', 'b@example.com', 'pro')
+      const nowSec = Math.floor(Date.now() / 1000)
+      await addCodexAccount(idTokenA, accessTokenWithExp(nowSec + 1000), 'a-refresh')
+      await addCodexAccount(idTokenB, accessTokenWithExp(nowSec + 2000), 'b-refresh')
+
+      const freshAccessB = accessTokenWithExp(nowSec + 9999)
+      await writeFile(
+        join(codexHome, 'auth.json'),
+        JSON.stringify({
+          auth_mode: 'chatgpt',
+          tokens: {
+            id_token: idTokenB,
+            access_token: freshAccessB,
+            refresh_token: 'b-refresh-live',
+            account_id: 'acct-b'
+          },
+          last_refresh: new Date().toISOString()
+        })
+      )
+
+      const accounts = await listCodexAccounts()
+      expect(accounts).toHaveLength(2)
+
+      const a = accounts.find((acc) => acc.accountKey === 'user-a::acct-a')!
+      expect(a.active).toBe(false)
+      expect(a.email).toBe('a@example.com')
+      expect(a.expiresAtMs).toBe((nowSec + 1000) * 1000)
+
+      const b = accounts.find((acc) => acc.accountKey === 'user-b::acct-b')!
+      expect(b.active).toBe(true)
+      expect(b.hasRefresh).toBe(true)
+      expect(b.expiresAtMs).toBe((nowSec + 9999) * 1000)
+    })
+
+    it('falls back to registry.active_account_key when the live id_token cannot be parsed', async () => {
+      const idToken = idTokenFor('user-a', 'acct-a')
+      await addCodexAccount(idToken, 'a-access', 'a-refresh')
+      await switchCodexAccount('user-a::acct-a')
+
+      const live = JSON.parse(await readFile(join(codexHome, 'auth.json'), 'utf-8'))
+      live.tokens.id_token = 'not-a-jwt'
+      await writeFile(join(codexHome, 'auth.json'), JSON.stringify(live))
+
+      const accounts = await listCodexAccounts()
+      expect(accounts.find((a) => a.accountKey === 'user-a::acct-a')?.active).toBe(true)
+    })
+  })
+})

--- a/test/usage/account-store-codex.test.ts
+++ b/test/usage/account-store-codex.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../src/main/services/logger', () => ({
 import {
   addCodexAccount,
   listCodexAccounts,
+  persistRotatedLiveCodexTokens,
   readCodexLive,
   readCodexSnapshot,
   removeCodexAccount,
@@ -470,6 +471,106 @@ describe('account-store-codex', () => {
 
       const registry = JSON.parse(await readFile(join(codexHome, 'accounts', 'registry.json'), 'utf-8'))
       expect(registry.accounts[0].plan).toBe('')
+    })
+  })
+
+  describe('persistRotatedLiveCodexTokens', () => {
+    const rotated = { accessToken: 'new-access', refreshToken: 'new-refresh', idToken: 'new-id' }
+
+    it('returns no-live when auth.json does not exist', async () => {
+      await expect(persistRotatedLiveCodexTokens(rotated, 'old-refresh')).resolves.toBe('no-live')
+    })
+
+    it('returns skipped-race without writing when the live refresh token no longer matches', async () => {
+      await writeFile(
+        join(codexHome, 'auth.json'),
+        JSON.stringify({
+          auth_mode: 'chatgpt',
+          tokens: {
+            id_token: idTokenFor('user-x', 'acct-x'),
+            access_token: 'live-access',
+            refresh_token: 'someone-else-already-rotated-this',
+            account_id: 'acct-x'
+          },
+          last_refresh: '2026-01-01T00:00:00.000Z'
+        })
+      )
+
+      const outcome = await persistRotatedLiveCodexTokens(rotated, 'old-refresh')
+
+      expect(outcome).toBe('skipped-race')
+      const live = await readCodexLive()
+      expect(live?.tokens?.access_token).toBe('live-access')
+      expect(live?.last_refresh).toBe('2026-01-01T00:00:00.000Z')
+    })
+
+    it('patches tokens and last_refresh (mode 0600) when the refresh token matches, without requiring a managed account', async () => {
+      await writeFile(
+        join(codexHome, 'auth.json'),
+        JSON.stringify({
+          OPENAI_API_KEY: null,
+          auth_mode: 'chatgpt',
+          tokens: {
+            id_token: idTokenFor('user-unmanaged', 'acct-unmanaged'),
+            access_token: 'live-access',
+            refresh_token: 'old-refresh',
+            account_id: 'acct-unmanaged'
+          },
+          last_refresh: '2026-01-01T00:00:00.000Z'
+        })
+      )
+
+      vi.setSystemTime(new Date('2026-03-01T00:00:00.000Z'))
+      const outcome = await persistRotatedLiveCodexTokens(rotated, 'old-refresh')
+
+      expect(outcome).toBe('persisted')
+      const live = await readCodexLive()
+      expect(live?.tokens).toMatchObject({
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+        id_token: 'new-id',
+        account_id: 'acct-unmanaged'
+      })
+      expect(live?.last_refresh).toBe('2026-03-01T00:00:00.000Z')
+
+      const { stat } = await import('fs/promises')
+      const stats = await stat(join(codexHome, 'auth.json'))
+      expect(stats.mode & 0o777).toBe(0o600)
+
+      // Not a managed account: no snapshot file should have been created for it.
+      await expect(readCodexSnapshot('user-unmanaged::acct-unmanaged')).resolves.toBeNull()
+    })
+
+    it('mirrors the patched auth to the snapshot when the live account_key is managed', async () => {
+      const idToken = idTokenFor('user-1', 'acct-1')
+      await addCodexAccount(idToken, 'old-access', 'old-refresh')
+      await switchCodexAccount('user-1::acct-1')
+
+      const outcome = await persistRotatedLiveCodexTokens(rotated, 'old-refresh')
+
+      expect(outcome).toBe('persisted')
+      const snapshot = await readCodexSnapshot('user-1::acct-1')
+      expect(snapshot?.tokens).toMatchObject({
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+        id_token: 'new-id'
+      })
+    })
+
+    it('only rotates the fields provided, leaving refresh/id token untouched when omitted', async () => {
+      const idToken = idTokenFor('user-2', 'acct-2')
+      await addCodexAccount(idToken, 'old-access', 'old-refresh')
+      await switchCodexAccount('user-2::acct-2')
+
+      const outcome = await persistRotatedLiveCodexTokens({ accessToken: 'access-only' }, 'old-refresh')
+
+      expect(outcome).toBe('persisted')
+      const live = await readCodexLive()
+      expect(live?.tokens).toMatchObject({
+        access_token: 'access-only',
+        refresh_token: 'old-refresh',
+        id_token: idToken
+      })
     })
   })
 })

--- a/test/usage/account-store-codex.test.ts
+++ b/test/usage/account-store-codex.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises'
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -314,6 +314,162 @@ describe('account-store-codex', () => {
 
       const accounts = await listCodexAccounts()
       expect(accounts.find((a) => a.accountKey === 'user-a::acct-a')?.active).toBe(true)
+    })
+  })
+
+  describe('unknown-field preservation (byte-level interop with ccswitch)', () => {
+    it('round-trips top-level (api/auto_switch) and entry-level (last_usage/etc) unknown fields across switch + add + remove', async () => {
+      const accountKeyA = 'user-a::acct-a'
+      const accountKeyB = 'user-b::acct-b'
+
+      const api = { account: true, usage: true }
+      const autoSwitch = { enabled: false, threshold_5h_percent: 10, threshold_weekly_percent: 5 }
+      const lastUsageA = {
+        credits: { balance: '0', has_credits: false, unlimited: false },
+        plan_type: 'pro',
+        primary: { resets_at: 1780232342, used_percent: 28, window_minutes: 300 },
+        secondary: { resets_at: 1780796401, used_percent: 18, window_minutes: 10080 }
+      }
+
+      await mkdir(join(codexHome, 'accounts'), { recursive: true })
+      await writeFile(
+        join(codexHome, 'accounts', 'registry.json'),
+        JSON.stringify({
+          schema_version: 3,
+          active_account_key: null,
+          accounts: [
+            {
+              account_key: accountKeyA,
+              chatgpt_account_id: 'acct-a',
+              chatgpt_user_id: 'user-a',
+              email: 'old-a@example.com',
+              alias: '',
+              account_name: null,
+              plan: 'pro',
+              auth_mode: 'chatgpt',
+              created_at: 1700000000,
+              last_used_at: 1700000000,
+              last_usage: lastUsageA,
+              last_usage_at: 1700000500,
+              last_local_rollout: null
+            },
+            {
+              account_key: accountKeyB,
+              chatgpt_account_id: 'acct-b',
+              chatgpt_user_id: 'user-b',
+              email: 'old-b@example.com',
+              alias: '',
+              account_name: null,
+              plan: 'plus',
+              auth_mode: 'chatgpt',
+              created_at: 1700000100,
+              last_used_at: null,
+              last_usage: null,
+              last_usage_at: null,
+              last_local_rollout: null
+            }
+          ],
+          api,
+          auto_switch: autoSwitch
+        })
+      )
+
+      // Seed snapshots so switch/remove have real files to operate on.
+      await writeFile(
+        join(codexHome, 'accounts', `${snapshotName(accountKeyA)}.auth.json`),
+        JSON.stringify({
+          OPENAI_API_KEY: null,
+          auth_mode: 'chatgpt',
+          tokens: {
+            id_token: idTokenFor('user-a', 'acct-a', 'old-a@example.com', 'pro'),
+            access_token: 'a-access',
+            refresh_token: 'a-refresh',
+            account_id: 'acct-a'
+          },
+          last_refresh: '2026-01-01T00:00:00.000Z'
+        })
+      )
+      await writeFile(
+        join(codexHome, 'accounts', `${snapshotName(accountKeyB)}.auth.json`),
+        JSON.stringify({
+          OPENAI_API_KEY: null,
+          auth_mode: 'chatgpt',
+          tokens: {
+            id_token: idTokenFor('user-b', 'acct-b', 'old-b@example.com', 'plus'),
+            access_token: 'b-access',
+            refresh_token: 'b-refresh',
+            account_id: 'acct-b'
+          },
+          last_refresh: '2026-01-01T00:00:00.000Z'
+        })
+      )
+
+      await switchCodexAccount(accountKeyB)
+      await addCodexAccount(idTokenFor('user-a', 'acct-a', 'new-a@example.com', 'proplus'), 'a2', 'r2')
+      await removeCodexAccount(accountKeyB)
+
+      const registry = JSON.parse(await readFile(join(codexHome, 'accounts', 'registry.json'), 'utf-8'))
+
+      expect(registry.api).toEqual(api)
+      expect(registry.auto_switch).toEqual(autoSwitch)
+
+      expect(registry.accounts).toHaveLength(1)
+      const entryA = registry.accounts[0]
+      expect(entryA.account_key).toBe(accountKeyA)
+      expect(entryA.email).toBe('new-a@example.com')
+      expect(entryA.plan).toBe('proplus')
+      expect(entryA.created_at).toBe(1700000000)
+      expect(entryA.last_used_at).toBe(1700000000)
+      expect(entryA.last_usage).toEqual(lastUsageA)
+      expect(entryA.last_usage_at).toBe(1700000500)
+
+      // B was active (via switch) and then removed, so active_account_key nulls out.
+      expect(registry.active_account_key).toBeNull()
+    })
+  })
+
+  describe('created_at is second-scale, and new-entry shape matches ccswitch defaults', () => {
+    it('writes created_at in seconds, not milliseconds', async () => {
+      await addCodexAccount(idTokenFor('user-1', 'acct-1'), 'a', 'r')
+      const registry = JSON.parse(await readFile(join(codexHome, 'accounts', 'registry.json'), 'utf-8'))
+      expect(registry.accounts[0].created_at).toBeLessThan(1e11)
+      expect(registry.accounts[0].created_at).toBe(Math.floor(Date.now() / 1000))
+    })
+
+    it('defaults plan to "" (not null) and null-fills last_used_at/last_usage/last_usage_at/last_local_rollout on a brand-new entry when the id_token has no plan claim', async () => {
+      const idTokenNoPlan = buildIdToken({
+        email: 'no-plan@example.com',
+        'https://api.openai.com/auth': {
+          chatgpt_user_id: 'user-np',
+          chatgpt_account_id: 'acct-np'
+        }
+      })
+      await addCodexAccount(idTokenNoPlan, 'a', 'r')
+
+      const registry = JSON.parse(await readFile(join(codexHome, 'accounts', 'registry.json'), 'utf-8'))
+      const entry = registry.accounts[0]
+      expect(entry.plan).toBe('')
+      expect(entry.last_used_at).toBeNull()
+      expect(entry.last_usage).toBeNull()
+      expect(entry.last_usage_at).toBeNull()
+      expect(entry.last_local_rollout).toBeNull()
+    })
+
+    it('maps an empty-string plan to null in the listCodexAccounts DTO while the file keeps ""', async () => {
+      const idTokenNoPlan = buildIdToken({
+        email: 'no-plan@example.com',
+        'https://api.openai.com/auth': {
+          chatgpt_user_id: 'user-np',
+          chatgpt_account_id: 'acct-np'
+        }
+      })
+      await addCodexAccount(idTokenNoPlan, 'a', 'r')
+
+      const accounts = await listCodexAccounts()
+      expect(accounts[0].plan).toBeNull()
+
+      const registry = JSON.parse(await readFile(join(codexHome, 'accounts', 'registry.json'), 'utf-8'))
+      expect(registry.accounts[0].plan).toBe('')
     })
   })
 })

--- a/test/usage/atomic-json.test.ts
+++ b/test/usage/atomic-json.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { mkdtemp, rm, stat, readFile, writeFile } from 'fs/promises'
+import { mkdir, mkdtemp, rm, stat, readFile, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -66,6 +66,17 @@ describe('atomic-json', () => {
     await atomicWriteJson(file, { a: 1 })
 
     await expect(stat(`${file}.tmp.hive`)).rejects.toThrow()
+  })
+
+  it('cleans up the .tmp.hive file (best-effort) when the rename fails', async () => {
+    // A non-empty directory at the destination path makes the final rename
+    // fail — the tmp file (already written + chmod'd) must not be left behind.
+    const target = join(dir, 'target')
+    await mkdir(join(target, 'child'), { recursive: true })
+
+    await expect(atomicWriteJson(target, { a: 1 })).rejects.toThrow()
+
+    await expect(stat(`${target}.tmp.hive`)).rejects.toThrow()
   })
 
   it('returns null from readJsonFile when the file is missing', async () => {

--- a/test/usage/atomic-json.test.ts
+++ b/test/usage/atomic-json.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { mkdtemp, rm, stat, readFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { atomicWriteJson, readJsonFile } from '../../src/main/services/atomic-json'
+
+describe('atomic-json', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'hive-atomic-json-'))
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('round-trips a value through atomicWriteJson and readJsonFile', async () => {
+    const file = join(dir, 'data.json')
+    const value = { hello: 'world', count: 3 }
+
+    await atomicWriteJson(file, value)
+
+    await expect(readJsonFile(file)).resolves.toEqual(value)
+  })
+
+  it('pretty-prints with 2-space indentation when opts.pretty is set', async () => {
+    const file = join(dir, 'pretty.json')
+
+    await atomicWriteJson(file, { a: 1 }, { pretty: true })
+
+    const raw = await readFile(file, 'utf-8')
+    expect(raw).toBe(JSON.stringify({ a: 1 }, null, 2))
+  })
+
+  it('defaults to mode 0600', async () => {
+    const file = join(dir, 'mode-default.json')
+
+    await atomicWriteJson(file, { a: 1 })
+
+    const stats = await stat(file)
+    expect(stats.mode & 0o777).toBe(0o600)
+  })
+
+  it('honors an explicit mode', async () => {
+    const file = join(dir, 'mode-explicit.json')
+
+    await atomicWriteJson(file, { a: 1 }, { mode: 0o644 })
+
+    const stats = await stat(file)
+    expect(stats.mode & 0o777).toBe(0o644)
+  })
+
+  it('creates missing parent directories recursively', async () => {
+    const file = join(dir, 'nested', 'deeper', 'data.json')
+
+    await atomicWriteJson(file, { nested: true })
+
+    await expect(readJsonFile(file)).resolves.toEqual({ nested: true })
+  })
+
+  it('does not leave a .tmp.hive file behind after a successful write', async () => {
+    const file = join(dir, 'data.json')
+
+    await atomicWriteJson(file, { a: 1 })
+
+    await expect(stat(`${file}.tmp.hive`)).rejects.toThrow()
+  })
+
+  it('returns null from readJsonFile when the file is missing', async () => {
+    await expect(readJsonFile(join(dir, 'missing.json'))).resolves.toBeNull()
+  })
+
+  it('returns null from readJsonFile when the file contents are corrupt', async () => {
+    const file = join(dir, 'corrupt.json')
+    await writeFile(file, '{ not valid json')
+
+    await expect(readJsonFile(file)).resolves.toBeNull()
+  })
+})

--- a/test/usage/credentials-migration.test.ts
+++ b/test/usage/credentials-migration.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
     getSetting: vi.fn(),
     setSetting: vi.fn(),
     getSavedUsageAccountsByProvider: vi.fn(),
-    clearSavedUsageAccountCredentials: vi.fn()
+    clearSavedUsageAccountCredentialsById: vi.fn()
   }
 }))
 
@@ -175,7 +175,8 @@ describe('migrateSavedCredentialsToStores', () => {
     expect(codexAccounts).toHaveLength(1)
     expect(codexAccounts[0].accountKey).toBe('user-1::acct-1')
 
-    expect(mocks.db.clearSavedUsageAccountCredentials).toHaveBeenCalledTimes(1)
+    expect(mocks.db.clearSavedUsageAccountCredentialsById).toHaveBeenCalledWith('anthropic-1')
+    expect(mocks.db.clearSavedUsageAccountCredentialsById).toHaveBeenCalledWith('openai-1')
     expect(mocks.db.setSetting).toHaveBeenCalledWith(MIGRATION_KEY, expect.any(String))
   })
 
@@ -238,7 +239,47 @@ describe('migrateSavedCredentialsToStores', () => {
 
     const accounts = await listClaudeAccounts()
     expect(accounts.map((a) => a.email)).toEqual(['good@example.com'])
-    expect(mocks.db.clearSavedUsageAccountCredentials).toHaveBeenCalledTimes(1)
+    // The unparseable row is structurally unusable — it is blanked (as done),
+    // not treated as a transient failure that would block the migration flag.
+    expect(mocks.db.clearSavedUsageAccountCredentialsById).toHaveBeenCalledWith('bad-1')
+    expect(mocks.db.clearSavedUsageAccountCredentialsById).toHaveBeenCalledWith('good-1')
+    expect(mocks.db.setSetting).toHaveBeenCalledWith(MIGRATION_KEY, expect.any(String))
+  })
+
+  it('does not blank a row whose store add fails transiently, leaves the flag unset, and retries on the next run', async () => {
+    const failingRow = savedAnthropicRow({ id: 'a-fail', email: 'fail@example.com' })
+    const okRow = savedAnthropicRow({ id: 'a-ok', email: 'ok@example.com' })
+    mockRowsByProvider({ anthropic: [failingRow, okRow] })
+
+    // Make ONLY the failing row's keychain write blow up (a transient ACL
+    // denial — the plan's own predicted scenario), and only on the first run.
+    let failOnce = true
+    mocks.keychainWrite.mockImplementation(async (service: string, secret: string) => {
+      if (failOnce && service.includes('fail@example.com')) {
+        failOnce = false
+        throw new Error('keychain ACL denied')
+      }
+      mocks.keychainStore.set(service, secret)
+    })
+
+    await migrateSavedCredentialsToStores()
+
+    // The failing row keeps its credentials (NOT blanked); the healthy row is
+    // blanked. The one-shot flag is NOT set, so the next boot will retry.
+    expect(mocks.db.clearSavedUsageAccountCredentialsById).not.toHaveBeenCalledWith('a-fail')
+    expect(mocks.db.clearSavedUsageAccountCredentialsById).toHaveBeenCalledWith('a-ok')
+    expect(mocks.db.setSetting).not.toHaveBeenCalled()
+
+    // Second run: keychain now works, so the previously-failing row migrates
+    // and the migration completes.
+    clearClaudeAccountStoreCacheForTests()
+    await migrateSavedCredentialsToStores()
+
+    expect(mocks.db.clearSavedUsageAccountCredentialsById).toHaveBeenCalledWith('a-fail')
+    expect(mocks.db.setSetting).toHaveBeenCalledWith(MIGRATION_KEY, expect.any(String))
+
+    const accounts = await listClaudeAccounts()
+    expect(accounts.map((a) => a.email).sort()).toEqual(['fail@example.com', 'ok@example.com'])
   })
 
   it('is idempotent: no-ops immediately once the migration setting is already recorded', async () => {
@@ -248,7 +289,7 @@ describe('migrateSavedCredentialsToStores', () => {
     await migrateSavedCredentialsToStores()
 
     expect(mocks.db.getSavedUsageAccountsByProvider).not.toHaveBeenCalled()
-    expect(mocks.db.clearSavedUsageAccountCredentials).not.toHaveBeenCalled()
+    expect(mocks.db.clearSavedUsageAccountCredentialsById).not.toHaveBeenCalled()
     expect(mocks.db.setSetting).not.toHaveBeenCalled()
   })
 

--- a/test/usage/credentials-migration.test.ts
+++ b/test/usage/credentials-migration.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment node
+import { mkdtemp, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SavedUsageAccount, SavedUsageProvider } from '../../src/main/db/types'
+
+const mocks = vi.hoisted(() => ({
+  homeDir: '/tmp/hive-credentials-migration-test',
+  keychainStore: new Map<string, string>(),
+  keychainRead: vi.fn(async (service: string) => mocks.keychainStore.get(service) ?? null),
+  keychainWrite: vi.fn(async (service: string, secret: string) => {
+    mocks.keychainStore.set(service, secret)
+  }),
+  keychainDelete: vi.fn(async (service: string) => {
+    mocks.keychainStore.delete(service)
+  }),
+  logWarn: vi.fn(),
+  db: {
+    getSetting: vi.fn(),
+    setSetting: vi.fn(),
+    getSavedUsageAccountsByProvider: vi.fn(),
+    clearSavedUsageAccountCredentials: vi.fn()
+  }
+}))
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return { ...actual, homedir: () => mocks.homeDir }
+})
+
+vi.mock('../../src/main/services/keychain', () => ({
+  keychainRead: mocks.keychainRead,
+  keychainWrite: mocks.keychainWrite,
+  keychainDelete: mocks.keychainDelete
+}))
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: mocks.logWarn, error: vi.fn() })
+}))
+
+vi.mock('../../src/main/db', () => ({
+  getDatabase: () => mocks.db
+}))
+
+import { migrateSavedCredentialsToStores } from '../../src/main/services/credentials-migration'
+import { addClaudeAccount, listClaudeAccounts } from '../../src/main/services/account-store-claude'
+import { addCodexAccount, listCodexAccounts, readCodexSnapshot } from '../../src/main/services/account-store-codex'
+
+const MIGRATION_KEY = 'saved_usage_credentials_migrated'
+
+function base64url(value: string): string {
+  return Buffer.from(value, 'utf-8').toString('base64url')
+}
+
+function buildIdToken(payload: Record<string, unknown>): string {
+  const header = base64url(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+  const body = base64url(JSON.stringify(payload))
+  return `${header}.${body}.fake-signature`
+}
+
+function codexIdToken(userId: string, accountId: string, email: string, plan = 'plus'): string {
+  return buildIdToken({
+    email,
+    'https://api.openai.com/auth': {
+      chatgpt_user_id: userId,
+      chatgpt_account_id: accountId,
+      chatgpt_plan_type: plan
+    }
+  })
+}
+
+function savedRow(overrides: Partial<SavedUsageAccount> = {}): SavedUsageAccount {
+  return {
+    id: 'row-1',
+    provider: 'anthropic',
+    email: 'unused@example.com',
+    credentials_json: '',
+    last_usage_json: null,
+    last_fetched_at: null,
+    status: 'ok',
+    last_error: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+function savedAnthropicRow(overrides: Partial<SavedUsageAccount> = {}): SavedUsageAccount {
+  const email = overrides.email ?? 'claude-user@example.com'
+  return savedRow({
+    id: 'anthropic-1',
+    provider: 'anthropic',
+    email,
+    credentials_json: JSON.stringify({
+      accessToken: 'legacy-access',
+      refreshToken: 'legacy-refresh',
+      expiresAt: 1_700_000_000_000,
+      email
+    }),
+    ...overrides
+  })
+}
+
+function savedOpenAIRow(overrides: Partial<SavedUsageAccount> = {}): SavedUsageAccount {
+  const idToken = codexIdToken('user-1', 'acct-1', 'codex-user@example.com')
+  return savedRow({
+    id: 'openai-1',
+    provider: 'openai',
+    email: 'codex-user@example.com',
+    credentials_json: JSON.stringify({
+      accessToken: 'legacy-access',
+      refreshToken: 'legacy-refresh',
+      accountId: 'acct-1',
+      idToken,
+      email: 'codex-user@example.com'
+    }),
+    ...overrides
+  })
+}
+
+function mockRowsByProvider(rows: Partial<Record<SavedUsageProvider, SavedUsageAccount[]>>): void {
+  mocks.db.getSavedUsageAccountsByProvider.mockImplementation(
+    (provider: SavedUsageProvider) => rows[provider] ?? []
+  )
+}
+
+describe('migrateSavedCredentialsToStores', () => {
+  let codexHome: string
+  const originalCodexHome = process.env.CODEX_HOME
+
+  beforeEach(async () => {
+    mocks.homeDir = await mkdtemp(join(tmpdir(), 'hive-credentials-migration-'))
+    codexHome = await mkdtemp(join(tmpdir(), 'hive-credentials-migration-codex-'))
+    process.env.CODEX_HOME = codexHome
+    mocks.keychainStore.clear()
+    vi.clearAllMocks()
+    mocks.db.getSetting.mockReturnValue(null)
+    mockRowsByProvider({})
+  })
+
+  afterEach(async () => {
+    if (originalCodexHome === undefined) delete process.env.CODEX_HOME
+    else process.env.CODEX_HOME = originalCodexHome
+    await rm(mocks.homeDir, { recursive: true, force: true })
+    await rm(codexHome, { recursive: true, force: true })
+  })
+
+  it('migrates both anthropic and openai rows into their account stores, blanks credentials, and records the setting', async () => {
+    mockRowsByProvider({ anthropic: [savedAnthropicRow()], openai: [savedOpenAIRow()] })
+
+    await migrateSavedCredentialsToStores()
+
+    const claudeAccounts = await listClaudeAccounts()
+    expect(claudeAccounts).toHaveLength(1)
+    expect(claudeAccounts[0].email).toBe('claude-user@example.com')
+    expect(claudeAccounts[0].expiresAtMs).toBe(1_700_000_000_000)
+
+    const codexAccounts = await listCodexAccounts()
+    expect(codexAccounts).toHaveLength(1)
+    expect(codexAccounts[0].accountKey).toBe('user-1::acct-1')
+
+    expect(mocks.db.clearSavedUsageAccountCredentials).toHaveBeenCalledTimes(1)
+    expect(mocks.db.setSetting).toHaveBeenCalledWith(MIGRATION_KEY, expect.any(String))
+  })
+
+  it('skips an anthropic row whose email is already managed (case-insensitive), preserving the existing account', async () => {
+    await addClaudeAccount(
+      'Claude-User@Example.com',
+      'existing-uuid',
+      JSON.stringify({
+        claudeAiOauth: { accessToken: 'pre-existing-access', refreshToken: 'pre-existing-refresh', expiresAt: 999, scopes: [] }
+      })
+    )
+    mockRowsByProvider({ anthropic: [savedAnthropicRow()] })
+
+    await migrateSavedCredentialsToStores()
+
+    const accounts = await listClaudeAccounts()
+    expect(accounts).toHaveLength(1)
+    expect(accounts[0].expiresAtMs).toBe(999)
+  })
+
+  it('skips an openai row whose account_key is already managed, preserving the existing account', async () => {
+    const idToken = codexIdToken('user-1', 'acct-1', 'existing@example.com')
+    await addCodexAccount(idToken, 'pre-existing-access', 'pre-existing-refresh')
+    mockRowsByProvider({ openai: [savedOpenAIRow()] })
+
+    await migrateSavedCredentialsToStores()
+
+    const accounts = await listCodexAccounts()
+    expect(accounts).toHaveLength(1)
+    const snapshot = await readCodexSnapshot('user-1::acct-1')
+    expect(snapshot?.tokens?.access_token).toBe('pre-existing-access')
+  })
+
+  it('skips an openai row without an idToken and logs a warning', async () => {
+    mockRowsByProvider({
+      openai: [
+        savedOpenAIRow({
+          credentials_json: JSON.stringify({
+            accessToken: 'a',
+            refreshToken: 'r',
+            accountId: 'acct-1',
+            email: 'x@y.z'
+          })
+        })
+      ]
+    })
+
+    await migrateSavedCredentialsToStores()
+
+    expect(await listCodexAccounts()).toHaveLength(0)
+    expect(mocks.logWarn).toHaveBeenCalledWith(expect.stringMatching(/idToken/i), expect.anything())
+  })
+
+  it('continues past a row with unparseable credentials_json instead of aborting the migration', async () => {
+    const badRow = savedAnthropicRow({ id: 'bad-1', email: 'bad@example.com', credentials_json: '{ not json' })
+    const goodRow = savedAnthropicRow({ id: 'good-1', email: 'good@example.com' })
+    mockRowsByProvider({ anthropic: [badRow, goodRow] })
+
+    await expect(migrateSavedCredentialsToStores()).resolves.toBeUndefined()
+
+    const accounts = await listClaudeAccounts()
+    expect(accounts.map((a) => a.email)).toEqual(['good@example.com'])
+    expect(mocks.db.clearSavedUsageAccountCredentials).toHaveBeenCalledTimes(1)
+  })
+
+  it('is idempotent: no-ops immediately once the migration setting is already recorded', async () => {
+    expect(mocks.db.getSetting(MIGRATION_KEY)).toBeFalsy()
+    mocks.db.getSetting.mockReturnValue('2026-01-01T00:00:00.000Z')
+
+    await migrateSavedCredentialsToStores()
+
+    expect(mocks.db.getSavedUsageAccountsByProvider).not.toHaveBeenCalled()
+    expect(mocks.db.clearSavedUsageAccountCredentials).not.toHaveBeenCalled()
+    expect(mocks.db.setSetting).not.toHaveBeenCalled()
+  })
+
+  it('running twice back-to-back only migrates rows once (the settings key short-circuits the second run)', async () => {
+    let migrated: string | null = null
+    mocks.db.getSetting.mockImplementation((key: string) => (key === MIGRATION_KEY ? migrated : null))
+    mocks.db.setSetting.mockImplementation((key: string, value: string) => {
+      if (key === MIGRATION_KEY) migrated = value
+    })
+    mockRowsByProvider({ anthropic: [savedAnthropicRow()] })
+
+    await migrateSavedCredentialsToStores()
+    const callsAfterFirstRun = mocks.db.getSavedUsageAccountsByProvider.mock.calls.length
+    expect(callsAfterFirstRun).toBeGreaterThan(0)
+
+    await migrateSavedCredentialsToStores()
+    expect(mocks.db.getSavedUsageAccountsByProvider.mock.calls.length).toBe(callsAfterFirstRun)
+  })
+})

--- a/test/usage/credentials-migration.test.ts
+++ b/test/usage/credentials-migration.test.ts
@@ -44,8 +44,17 @@ vi.mock('../../src/main/db', () => ({
 }))
 
 import { migrateSavedCredentialsToStores } from '../../src/main/services/credentials-migration'
-import { addClaudeAccount, listClaudeAccounts } from '../../src/main/services/account-store-claude'
-import { addCodexAccount, listCodexAccounts, readCodexSnapshot } from '../../src/main/services/account-store-codex'
+import {
+  addClaudeAccount,
+  clearAccountStoreCacheForTests as clearClaudeAccountStoreCacheForTests,
+  listClaudeAccounts
+} from '../../src/main/services/account-store-claude'
+import {
+  addCodexAccount,
+  clearAccountStoreCacheForTests as clearCodexAccountStoreCacheForTests,
+  listCodexAccounts,
+  readCodexSnapshot
+} from '../../src/main/services/account-store-codex'
 
 const MIGRATION_KEY = 'saved_usage_credentials_migrated'
 
@@ -137,6 +146,12 @@ describe('migrateSavedCredentialsToStores', () => {
     vi.clearAllMocks()
     mocks.db.getSetting.mockReturnValue(null)
     mockRowsByProvider({})
+    // These tests use the real account-store-claude/codex modules with a
+    // fresh homeDir/codexHome per test, but their listClaudeAccounts()/
+    // listCodexAccounts() memo is module-level state that outlives a single
+    // test — clear it so each test starts from a real read of its own fixtures.
+    clearClaudeAccountStoreCacheForTests()
+    clearCodexAccountStoreCacheForTests()
   })
 
   afterEach(async () => {

--- a/test/usage/jwt-utils.test.ts
+++ b/test/usage/jwt-utils.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { decodeJwtPayload, jwtExpMs, parseCodexIdToken } from '../../src/main/services/jwt-utils'
+
+function base64url(value: string): string {
+  return Buffer.from(value, 'utf-8').toString('base64url')
+}
+
+function buildJwt(payload: Record<string, unknown>): string {
+  const header = base64url(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+  const body = base64url(JSON.stringify(payload))
+  return `${header}.${body}.fake-signature`
+}
+
+describe('decodeJwtPayload', () => {
+  it('decodes the payload of a hand-built JWT', () => {
+    const token = buildJwt({ sub: 'user-123', email: 'person@example.com' })
+
+    expect(decodeJwtPayload(token)).toEqual({ sub: 'user-123', email: 'person@example.com' })
+  })
+
+  it('returns null for a malformed token', () => {
+    expect(decodeJwtPayload('not-a-jwt')).toBeNull()
+    expect(decodeJwtPayload('only.two')).toBeNull()
+    expect(decodeJwtPayload('a.b.c.d')).toBeNull()
+    expect(decodeJwtPayload('a.!!!not-base64!!!.c')).toBeNull()
+  })
+})
+
+describe('jwtExpMs', () => {
+  it('converts the exp claim from seconds to milliseconds', () => {
+    const token = buildJwt({ exp: 1_700_000_000 })
+
+    expect(jwtExpMs(token)).toBe(1_700_000_000 * 1000)
+  })
+
+  it('returns null when exp is absent', () => {
+    const token = buildJwt({ sub: 'user-123' })
+
+    expect(jwtExpMs(token)).toBeNull()
+  })
+
+  it('returns null for an invalid token', () => {
+    expect(jwtExpMs('garbage')).toBeNull()
+  })
+})
+
+describe('parseCodexIdToken', () => {
+  it('reads accountId/userId/plan from the https://api.openai.com/auth claim', () => {
+    const token = buildJwt({
+      email: 'codex-user@example.com',
+      'https://api.openai.com/auth': {
+        chatgpt_account_id: 'acct-abc',
+        chatgpt_user_id: 'user-abc',
+        chatgpt_plan_type: 'plus'
+      }
+    })
+
+    expect(parseCodexIdToken(token)).toEqual({
+      email: 'codex-user@example.com',
+      accountId: 'acct-abc',
+      userId: 'user-abc',
+      plan: 'plus'
+    })
+  })
+
+  it('falls back to the default organization id when chatgpt_account_id is absent', () => {
+    const token = buildJwt({
+      email: 'codex-user@example.com',
+      'https://api.openai.com/auth': {
+        organizations: [
+          { id: 'org-1', is_default: false },
+          { id: 'org-2', is_default: true }
+        ]
+      }
+    })
+
+    expect(parseCodexIdToken(token).accountId).toBe('org-2')
+  })
+
+  it('falls back to the first organization id when there is no default organization', () => {
+    const token = buildJwt({
+      'https://api.openai.com/auth': {
+        organizations: [{ id: 'org-1' }, { id: 'org-2' }]
+      }
+    })
+
+    expect(parseCodexIdToken(token).accountId).toBe('org-1')
+  })
+
+  it('falls back to the auth claim user_id when chatgpt_user_id is absent', () => {
+    const token = buildJwt({
+      'https://api.openai.com/auth': {
+        user_id: 'legacy-user-id'
+      }
+    })
+
+    expect(parseCodexIdToken(token).userId).toBe('legacy-user-id')
+  })
+
+  it('returns all nulls for a malformed token', () => {
+    expect(parseCodexIdToken('not-a-jwt')).toEqual({
+      email: null,
+      accountId: null,
+      userId: null,
+      plan: null
+    })
+  })
+
+  it('returns all nulls when the auth claim and email are missing entirely', () => {
+    const token = buildJwt({ sub: 'user-123' })
+
+    expect(parseCodexIdToken(token)).toEqual({
+      email: null,
+      accountId: null,
+      userId: null,
+      plan: null
+    })
+  })
+})

--- a/test/usage/keychain.test.ts
+++ b/test/usage/keychain.test.ts
@@ -113,12 +113,36 @@ describe('keychain', () => {
     it('throws when the security CLI fails', async () => {
       mocks.execFile.mockImplementation(
         (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) =>
-          cb(new Error('security: something went wrong'), '')
+          cb(new Error('security: something went wrong'), '', 'security: something went wrong')
       )
 
       await expect(keychainWrite('My Service', 'sekret')).rejects.toThrow(
         'security: something went wrong'
       )
+    })
+
+    it('never leaks the -w secret (or raw command line) in the thrown/logged error', async () => {
+      const secret = 'super-secret-refresh-token'
+      // Node's real ExecFileException.message embeds the full argv, secret and
+      // all. runSecurity must sanitize it away.
+      mocks.execFile.mockImplementation(
+        (_cmd: string, args: string[], _opts: unknown, cb: ExecFileCallback) => {
+          const raw = Object.assign(
+            new Error(`Command failed: security ${args.join(' ')}\nsecurity: write failed`),
+            { code: 1 }
+          )
+          cb(raw, '', 'security: write failed')
+        }
+      )
+
+      const error = await keychainWrite('My Service', secret).catch((e) => e as Error)
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error.message).not.toContain(secret)
+      expect(error.message).not.toContain('-w')
+      expect(error.message).toContain('add-generic-password')
+      // security's stderr is safe to surface (it never echoes -w values).
+      expect(error.message).toContain('security: write failed')
     })
 
     it('throws on non-macOS platforms without calling execFile', async () => {
@@ -160,7 +184,7 @@ describe('keychain', () => {
           const error = Object.assign(new Error('security: some other unexpected failure'), {
             code: 1
           })
-          cb(error, '')
+          cb(error, '', 'security: some other unexpected failure')
         }
       )
 
@@ -172,7 +196,11 @@ describe('keychain', () => {
     it('re-throws other security CLI failures', async () => {
       mocks.execFile.mockImplementation(
         (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) =>
-          cb(new Error('security: some other unexpected failure'), '')
+          cb(
+            new Error('security: some other unexpected failure'),
+            '',
+            'security: some other unexpected failure'
+          )
       )
 
       await expect(keychainDelete('My Service')).rejects.toThrow(

--- a/test/usage/keychain.test.ts
+++ b/test/usage/keychain.test.ts
@@ -141,6 +141,34 @@ describe('keychain', () => {
       await expect(keychainDelete('My Service')).resolves.toBeUndefined()
     })
 
+    it('resolves silently based on exit code 44 (errSecItemNotFound), even if the message wording drifts', async () => {
+      mocks.execFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) => {
+          const error = Object.assign(new Error('security: some unrecognized future wording'), {
+            code: 44
+          })
+          cb(error, '')
+        }
+      )
+
+      await expect(keychainDelete('My Service')).resolves.toBeUndefined()
+    })
+
+    it('re-throws when neither the exit code nor the message indicate item-not-found', async () => {
+      mocks.execFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) => {
+          const error = Object.assign(new Error('security: some other unexpected failure'), {
+            code: 1
+          })
+          cb(error, '')
+        }
+      )
+
+      await expect(keychainDelete('My Service')).rejects.toThrow(
+        'security: some other unexpected failure'
+      )
+    })
+
     it('re-throws other security CLI failures', async () => {
       mocks.execFile.mockImplementation(
         (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) =>

--- a/test/usage/keychain.test.ts
+++ b/test/usage/keychain.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+  platform: vi.fn(),
+  userInfo: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  default: { execFile: (...args: unknown[]) => mocks.execFile(...args) },
+  execFile: (...args: unknown[]) => mocks.execFile(...args)
+}))
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return {
+    ...actual,
+    default: { ...actual, platform: () => mocks.platform(), userInfo: () => mocks.userInfo() },
+    platform: () => mocks.platform(),
+    userInfo: () => mocks.userInfo()
+  }
+})
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { keychainRead, keychainWrite, keychainDelete } from '../../src/main/services/keychain'
+
+type ExecFileCallback = (error: Error | null, stdout: string, stderr?: string) => void
+
+describe('keychain', () => {
+  const originalUser = process.env.USER
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.platform.mockReturnValue('darwin')
+    mocks.userInfo.mockReturnValue({ username: 'fallback-user' })
+    process.env.USER = 'test-user'
+  })
+
+  afterEach(() => {
+    if (originalUser === undefined) delete process.env.USER
+    else process.env.USER = originalUser
+  })
+
+  describe('keychainRead', () => {
+    it('returns the trimmed secret on success', async () => {
+      mocks.execFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) =>
+          cb(null, '  the-secret  \n')
+      )
+
+      await expect(keychainRead('My Service')).resolves.toBe('the-secret')
+      expect(mocks.execFile).toHaveBeenCalledWith(
+        'security',
+        ['find-generic-password', '-s', 'My Service', '-w'],
+        { timeout: 5000 },
+        expect.any(Function)
+      )
+    })
+
+    it('returns null when the security CLI fails (item not found, etc.)', async () => {
+      mocks.execFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) =>
+          cb(new Error('security: item could not be found in the keychain.'), '')
+      )
+
+      await expect(keychainRead('My Service')).resolves.toBeNull()
+    })
+
+    it('returns null without touching execFile on non-macOS platforms', async () => {
+      mocks.platform.mockReturnValue('linux')
+
+      await expect(keychainRead('My Service')).resolves.toBeNull()
+      expect(mocks.execFile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('keychainWrite', () => {
+    it('invokes security with the expected argument shape', async () => {
+      mocks.execFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) => cb(null, '')
+      )
+
+      await keychainWrite('My Service', 'sekret')
+
+      expect(mocks.execFile).toHaveBeenCalledWith(
+        'security',
+        ['add-generic-password', '-U', '-s', 'My Service', '-a', 'test-user', '-w', 'sekret'],
+        { timeout: 5000 },
+        expect.any(Function)
+      )
+    })
+
+    it('falls back to os.userInfo().username when process.env.USER is unset', async () => {
+      delete process.env.USER
+      mocks.execFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) => cb(null, '')
+      )
+
+      await keychainWrite('My Service', 'sekret')
+
+      expect(mocks.execFile).toHaveBeenCalledWith(
+        'security',
+        ['add-generic-password', '-U', '-s', 'My Service', '-a', 'fallback-user', '-w', 'sekret'],
+        { timeout: 5000 },
+        expect.any(Function)
+      )
+    })
+
+    it('throws when the security CLI fails', async () => {
+      mocks.execFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) =>
+          cb(new Error('security: something went wrong'), '')
+      )
+
+      await expect(keychainWrite('My Service', 'sekret')).rejects.toThrow(
+        'security: something went wrong'
+      )
+    })
+
+    it('throws on non-macOS platforms without calling execFile', async () => {
+      mocks.platform.mockReturnValue('linux')
+
+      await expect(keychainWrite('My Service', 'sekret')).rejects.toThrow(
+        'Keychain is only available on macOS'
+      )
+      expect(mocks.execFile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('keychainDelete', () => {
+    it('resolves silently when the item is not found', async () => {
+      mocks.execFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) =>
+          cb(new Error('security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.'), '')
+      )
+
+      await expect(keychainDelete('My Service')).resolves.toBeUndefined()
+    })
+
+    it('re-throws other security CLI failures', async () => {
+      mocks.execFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) =>
+          cb(new Error('security: some other unexpected failure'), '')
+      )
+
+      await expect(keychainDelete('My Service')).rejects.toThrow(
+        'security: some other unexpected failure'
+      )
+    })
+
+    it('calls security with the expected argument shape', async () => {
+      mocks.execFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) => cb(null, '')
+      )
+
+      await keychainDelete('My Service')
+
+      expect(mocks.execFile).toHaveBeenCalledWith(
+        'security',
+        ['delete-generic-password', '-s', 'My Service'],
+        { timeout: 5000 },
+        expect.any(Function)
+      )
+    })
+
+    it('throws on non-macOS platforms without calling execFile', async () => {
+      mocks.platform.mockReturnValue('linux')
+
+      await expect(keychainDelete('My Service')).rejects.toThrow(
+        'Keychain is only available on macOS'
+      )
+      expect(mocks.execFile).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/usage/login-service.test.ts
+++ b/test/usage/login-service.test.ts
@@ -535,6 +535,48 @@ describe('login-service', () => {
     expect(driver.close).toHaveBeenCalledTimes(1)
   })
 
+  it('ignores a capture callback that fires after the login was cancelled (no post-cancel exchange)', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, loginCancel, setLoginBrowserLauncherForTests } =
+      await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+    const state = new URL(driver.gotoCalls[0]).searchParams.get('state')
+
+    const cancelled = await loginCancel(loginId)
+    expect(cancelled).toBe(true)
+    expect(loginStatus(loginId).state).toBe('cancelled')
+
+    // A late framenavigated callback (a redirect landing after the cancel) must
+    // NOT resurrect the flow into 'exchanging'/'done'.
+    driver.triggerFrameNavigated(
+      `https://console.anthropic.com/oauth/code/callback?code=abc123&state=${state}`
+    )
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(loginStatus(loginId).state).toBe('cancelled')
+    expect(loginStatus(loginId).error).toBeNull()
+    expect(mocks.exchangeAnthropicCode).not.toHaveBeenCalled()
+  })
+
+  it('times out even while still launching (a hung Chrome launch does not block future logins)', async () => {
+    // A launcher that never resolves keeps the session in 'launching' forever
+    // unless the overall timeout also covers that state.
+    const neverResolves = new Promise<never>(() => {})
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(() => neverResolves)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    expect(loginStatus(loginId).state).toBe('launching')
+
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000)
+
+    expect(loginStatus(loginId).state).toBe('failed')
+    expect(loginStatus(loginId).error).toBe('Login timed out')
+  })
+
   it('loginCancel returns false for an unknown login', async () => {
     const { loginCancel } = await importFresh()
     expect(await loginCancel('does-not-exist')).toBe(false)

--- a/test/usage/login-service.test.ts
+++ b/test/usage/login-service.test.ts
@@ -1,0 +1,592 @@
+// @vitest-environment node
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  BrowserContextLike,
+  FrameLike,
+  LoginBrowserLauncher,
+  PageLike,
+  RouteLike
+} from '../../src/main/services/login-service'
+
+const mocks = vi.hoisted(() => ({
+  homeDir: '/tmp/hive-login-service-test',
+  db: {
+    getSavedUsageAccountByProviderEmail: vi.fn()
+  },
+  addClaudeAccount: vi.fn(),
+  addCodexAccount: vi.fn(),
+  exchangeAnthropicCode: vi.fn(),
+  exchangeOpenAICode: vi.fn(),
+  listSavedAccounts: vi.fn(),
+  fetchForSavedAccount: vi.fn()
+}))
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return { ...actual, homedir: () => mocks.homeDir }
+})
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+vi.mock('../../src/main/db', () => ({
+  getDatabase: () => mocks.db
+}))
+
+vi.mock('../../src/main/services/account-store-claude', () => ({
+  addClaudeAccount: mocks.addClaudeAccount
+}))
+
+vi.mock('../../src/main/services/account-store-codex', () => ({
+  addCodexAccount: mocks.addCodexAccount
+}))
+
+vi.mock('../../src/main/services/oauth-anthropic', async () => {
+  const actual = await vi.importActual<typeof import('../../src/main/services/oauth-anthropic')>(
+    '../../src/main/services/oauth-anthropic'
+  )
+  return { ...actual, exchangeAnthropicCode: mocks.exchangeAnthropicCode }
+})
+
+vi.mock('../../src/main/services/oauth-openai', async () => {
+  const actual = await vi.importActual<typeof import('../../src/main/services/oauth-openai')>(
+    '../../src/main/services/oauth-openai'
+  )
+  return { ...actual, exchangeOpenAICode: mocks.exchangeOpenAICode }
+})
+
+vi.mock('../../src/main/services/saved-usage-orchestrator', () => ({
+  listSavedAccounts: mocks.listSavedAccounts,
+  fetchForSavedAccount: mocks.fetchForSavedAccount
+}))
+
+async function importFresh(): Promise<typeof import('../../src/main/services/login-service')> {
+  vi.resetModules()
+  return import('../../src/main/services/login-service')
+}
+
+/** In-memory fake for BrowserContextLike/PageLike, small enough to exercise every capture path. */
+function createFakeDriver(): {
+  launcher: LoginBrowserLauncher
+  close: ReturnType<typeof vi.fn>
+  gotoCalls: string[]
+  launchProfileDirs: string[]
+  triggerRoute: (url: string) => Promise<{ fulfill: ReturnType<typeof vi.fn>; continue: ReturnType<typeof vi.fn> }>
+  triggerFrameNavigated: (url: string) => void
+  triggerClose: () => void
+} {
+  const routeHandlers: Array<(route: RouteLike) => void | Promise<void>> = []
+  const closeHandlers: Array<() => void> = []
+  const gotoCalls: string[] = []
+  const launchProfileDirs: string[] = []
+  let closed = false
+  let frameNavigatedHandler: ((frame: FrameLike) => void) | null = null
+  let currentFrameUrl = ''
+
+  const mainFrame: FrameLike = { url: () => currentFrameUrl }
+
+  const page: PageLike = {
+    goto: vi.fn(async (url: string) => {
+      gotoCalls.push(url)
+      currentFrameUrl = url
+    }),
+    on: vi.fn((event: 'framenavigated', handler: (frame: FrameLike) => void) => {
+      if (event === 'framenavigated') frameNavigatedHandler = handler
+    }),
+    mainFrame: () => mainFrame
+  }
+
+  const close = vi.fn(async () => {
+    if (closed) return
+    closed = true
+    for (const handler of closeHandlers) handler()
+  })
+
+  const context: BrowserContextLike = {
+    pages: vi.fn(() => [page]),
+    newPage: vi.fn(async () => page),
+    route: vi.fn(async (_glob: string, handler: (route: RouteLike) => void | Promise<void>) => {
+      routeHandlers.push(handler)
+    }),
+    on: vi.fn((event: 'close', handler: () => void) => {
+      if (event === 'close') closeHandlers.push(handler)
+    }),
+    close
+  }
+
+  const launcher: LoginBrowserLauncher = vi.fn(async (profileDir: string) => {
+    launchProfileDirs.push(profileDir)
+    return context
+  })
+
+  return {
+    launcher,
+    close,
+    gotoCalls,
+    launchProfileDirs,
+    async triggerRoute(url: string) {
+      const fulfill = vi.fn(async () => {})
+      const cont = vi.fn(async () => {})
+      const route: RouteLike = {
+        request: () => ({ url: () => url }),
+        fulfill,
+        continue: cont
+      }
+      const handler = routeHandlers[routeHandlers.length - 1]
+      if (!handler) throw new Error('no route handler registered yet')
+      await handler(route)
+      return { fulfill, continue: cont }
+    },
+    triggerFrameNavigated(url: string) {
+      currentFrameUrl = url
+      frameNavigatedHandler?.(mainFrame)
+    },
+    triggerClose() {
+      for (const handler of closeHandlers) handler()
+    }
+  }
+}
+
+/** Advances the fake clock in small steps, letting real microtasks/fs I/O interleave, until `predicate` holds. */
+async function pumpUntil(predicate: () => boolean, maxIterations = 400): Promise<void> {
+  for (let i = 0; i < maxIterations; i++) {
+    if (predicate()) return
+    await vi.advanceTimersByTimeAsync(5)
+  }
+  if (!predicate()) {
+    throw new Error('pumpUntil: condition was never satisfied within the iteration budget')
+  }
+}
+
+describe('login-service', () => {
+  beforeEach(async () => {
+    vi.resetAllMocks()
+    mocks.homeDir = await mkdtemp(join(tmpdir(), 'hive-login-service-'))
+    mocks.db.getSavedUsageAccountByProviderEmail.mockReturnValue(null)
+    mocks.listSavedAccounts.mockResolvedValue([])
+    mocks.fetchForSavedAccount.mockResolvedValue({ success: true, status: 'ok' })
+    mocks.exchangeAnthropicCode.mockResolvedValue({
+      accessToken: 'anthropic-access-token',
+      refreshToken: 'anthropic-refresh-token',
+      expiresAt: 1_700_000_000_000,
+      scope: 'org:create_api_key user:profile user:inference',
+      account: { uuid: 'uuid-1', emailAddress: 'User@Example.com' }
+    })
+    mocks.exchangeOpenAICode.mockResolvedValue({
+      idToken: 'id-token',
+      accessToken: 'openai-access-token',
+      refreshToken: 'openai-refresh-token'
+    })
+    mocks.addClaudeAccount.mockResolvedValue('1')
+    mocks.addCodexAccount.mockResolvedValue({ accountKey: 'user-1::acct-1', email: 'codex@example.com' })
+
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    await rm(mocks.homeDir, { recursive: true, force: true })
+  })
+
+  it('runs the full happy path for an Anthropic login: launching -> waiting -> exchanging -> done', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    expect(loginStatus(loginId).state).toBe('launching')
+
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+    expect(driver.launchProfileDirs).toEqual([
+      join(mocks.homeDir, '.ccswitch', 'profiles', 'claude-user@example.com')
+    ])
+
+    const gotoUrl = driver.gotoCalls[0]
+    expect(gotoUrl.startsWith('https://claude.ai/oauth/authorize')).toBe(true)
+    const state = new URL(gotoUrl).searchParams.get('state')
+    expect(state).toBeTruthy()
+
+    const { fulfill, continue: cont } = await driver.triggerRoute(
+      `https://console.anthropic.com/oauth/code/callback?code=abc123&state=${state}`
+    )
+    expect(cont).not.toHaveBeenCalled()
+    expect(fulfill).toHaveBeenCalledWith({
+      status: 200,
+      contentType: 'text/html',
+      body: expect.stringContaining('Signed in')
+    })
+
+    await pumpUntil(() => loginStatus(loginId).state === 'done')
+
+    expect(mocks.exchangeAnthropicCode).toHaveBeenCalledWith(
+      'abc123',
+      state,
+      expect.objectContaining({ state })
+    )
+    expect(mocks.addClaudeAccount).toHaveBeenCalledWith(
+      'user@example.com',
+      'uuid-1',
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'anthropic-access-token',
+          refreshToken: 'anthropic-refresh-token',
+          expiresAt: 1_700_000_000_000,
+          scopes: ['org:create_api_key', 'user:profile', 'user:inference']
+        }
+      })
+    )
+    expect(mocks.listSavedAccounts).toHaveBeenCalledWith('anthropic')
+    expect(mocks.db.getSavedUsageAccountByProviderEmail).toHaveBeenCalledWith(
+      'anthropic',
+      'user@example.com'
+    )
+
+    const status = loginStatus(loginId)
+    expect(status.email).toBe('user@example.com')
+    expect(status.error).toBeNull()
+
+    // Fire-and-forget cache refresh — resolved from the row the DB lookup returns.
+    mocks.db.getSavedUsageAccountByProviderEmail.mockReturnValue({ id: 'row-1' })
+
+    // Context stays open ~1.5s so the user sees the Signed-in page.
+    expect(driver.close).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1500)
+    expect(driver.close).toHaveBeenCalledTimes(1)
+    // The close listener must not flip a terminal state.
+    expect(loginStatus(loginId).state).toBe('done')
+
+    // The 30-minute waiting timeout is cancelled once a login succeeds — it
+    // must not re-fire (or double-close) once the original deadline elapses.
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000)
+    expect(driver.close).toHaveBeenCalledTimes(1)
+    expect(loginStatus(loginId).state).toBe('done')
+    expect(loginStatus(loginId).error).toBeNull()
+  })
+
+  it('resolves the cache row id via getSavedUsageAccountByProviderEmail and fires fetchForSavedAccount', async () => {
+    const driver = createFakeDriver()
+    mocks.db.getSavedUsageAccountByProviderEmail.mockReturnValue({ id: 'row-42' })
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+    const state = new URL(driver.gotoCalls[0]).searchParams.get('state')
+    await driver.triggerRoute(`https://console.anthropic.com/oauth/code/callback?code=abc123&state=${state}`)
+    await pumpUntil(() => loginStatus(loginId).state === 'done')
+
+    expect(mocks.fetchForSavedAccount).toHaveBeenCalledWith('row-42')
+  })
+
+  it('runs the full happy path for an OpenAI (Codex) login', async () => {
+    const driver = createFakeDriver()
+    mocks.db.getSavedUsageAccountByProviderEmail.mockReturnValue({ id: 'row-2' })
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('openai', 'codex@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+    expect(driver.launchProfileDirs).toEqual([
+      join(mocks.homeDir, '.ccswitch', 'profiles', 'codex-codex@example.com')
+    ])
+
+    const gotoUrl = driver.gotoCalls[0]
+    expect(gotoUrl.startsWith('https://auth.openai.com/oauth/authorize')).toBe(true)
+    const state = new URL(gotoUrl).searchParams.get('state')
+
+    const { fulfill } = await driver.triggerRoute(
+      `http://localhost:1455/auth/callback?code=xyz789&state=${state}`
+    )
+    expect(fulfill).toHaveBeenCalled()
+
+    await pumpUntil(() => loginStatus(loginId).state === 'done')
+
+    expect(mocks.exchangeOpenAICode).toHaveBeenCalledWith('xyz789', expect.objectContaining({ state }))
+    expect(mocks.addCodexAccount).toHaveBeenCalledWith('id-token', 'openai-access-token', 'openai-refresh-token')
+    expect(mocks.listSavedAccounts).toHaveBeenCalledWith('openai')
+    expect(mocks.fetchForSavedAccount).toHaveBeenCalledWith('row-2')
+    expect(loginStatus(loginId).email).toBe('codex@example.com')
+  })
+
+  it('captures the code via the framenavigated fallback when routing never fires', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+    const state = new URL(driver.gotoCalls[0]).searchParams.get('state')
+
+    driver.triggerFrameNavigated(`https://console.anthropic.com/oauth/code/callback?code=abc123&state=${state}`)
+    await pumpUntil(() => loginStatus(loginId).state === 'done')
+
+    expect(mocks.exchangeAnthropicCode).toHaveBeenCalledWith('abc123', state, expect.any(Object))
+    expect(loginStatus(loginId).email).toBe('user@example.com')
+  })
+
+  it('ignores a redirect that matches the glob but not the exact redirect prefix', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('openai', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+
+    const { fulfill, continue: cont } = await driver.triggerRoute(
+      'https://evil.example.com/auth/callback?code=abc123&state=whatever'
+    )
+
+    expect(cont).toHaveBeenCalledTimes(1)
+    expect(fulfill).not.toHaveBeenCalled()
+    expect(loginStatus(loginId).state).toBe('waiting')
+    expect(mocks.exchangeOpenAICode).not.toHaveBeenCalled()
+
+    // The framenavigated fallback applies the same prefix check.
+    driver.triggerFrameNavigated('https://evil.example.com/auth/callback?code=abc123&state=whatever')
+    await vi.advanceTimersByTimeAsync(20)
+    expect(loginStatus(loginId).state).toBe('waiting')
+    expect(mocks.exchangeOpenAICode).not.toHaveBeenCalled()
+  })
+
+  it('fails on a PKCE state mismatch and never calls the token exchange', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+
+    await driver.triggerRoute(
+      'https://console.anthropic.com/oauth/code/callback?code=abc123&state=totally-wrong-state'
+    )
+    await pumpUntil(() => loginStatus(loginId).state === 'failed')
+
+    expect(loginStatus(loginId).error).toBe('State mismatch — please retry')
+    expect(mocks.exchangeAnthropicCode).not.toHaveBeenCalled()
+    expect(mocks.addClaudeAccount).not.toHaveBeenCalled()
+    expect(driver.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails when the provider redirect carries an error query param', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+
+    await driver.triggerRoute('https://console.anthropic.com/oauth/code/callback?error=access_denied')
+    await pumpUntil(() => loginStatus(loginId).state === 'failed')
+
+    expect(loginStatus(loginId).error).toBe('Provider returned error: access_denied')
+    expect(mocks.exchangeAnthropicCode).not.toHaveBeenCalled()
+  })
+
+  it('fails when no account email is returned from the Anthropic exchange', async () => {
+    mocks.exchangeAnthropicCode.mockResolvedValue({
+      accessToken: 'at',
+      refreshToken: 'rt',
+      expiresAt: 1,
+      account: { uuid: 'uuid-1' }
+    })
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+    const state = new URL(driver.gotoCalls[0]).searchParams.get('state')
+    await driver.triggerRoute(`https://console.anthropic.com/oauth/code/callback?code=abc123&state=${state}`)
+    await pumpUntil(() => loginStatus(loginId).state === 'failed')
+
+    expect(loginStatus(loginId).error).toBe('Login succeeded but no account email was returned')
+    expect(mocks.addClaudeAccount).not.toHaveBeenCalled()
+  })
+
+  it('fails when the browser window is closed before login completes', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+
+    driver.triggerClose()
+    await pumpUntil(() => loginStatus(loginId).state === 'failed')
+
+    expect(loginStatus(loginId).error).toBe('Browser closed before login completed')
+  })
+
+  it('cancels a non-terminal login; the resulting close does not overwrite the cancelled state', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, loginCancel, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+
+    const result = await loginCancel(loginId)
+
+    expect(result).toBe(true)
+    expect(driver.close).toHaveBeenCalledTimes(1)
+    // Our fake context.close() synchronously fires the 'close' listener — it must not
+    // have overwritten the terminal 'cancelled' state set before close() was called.
+    expect(loginStatus(loginId).state).toBe('cancelled')
+    expect(loginStatus(loginId).error).toBeNull()
+  })
+
+  it('loginCancel returns false for an unknown login', async () => {
+    const { loginCancel } = await importFresh()
+    expect(await loginCancel('does-not-exist')).toBe(false)
+  })
+
+  it('loginCancel returns false once the session is already terminal', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, loginCancel, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+    await loginCancel(loginId)
+    expect(loginStatus(loginId).state).toBe('cancelled')
+
+    expect(await loginCancel(loginId)).toBe(false)
+  })
+
+  it('throws when a login is already in progress', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const first = loginStart('anthropic', 'user@example.com')
+    await expect(loginStart('openai', 'other@example.com')).rejects.toThrow(
+      'A login is already in progress'
+    )
+    await first
+  })
+
+  it('lets a new loginStart supersede a terminal session; the old loginId 404s', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId: firstId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(firstId).state === 'waiting')
+    const state = new URL(driver.gotoCalls[0]).searchParams.get('state')
+    await driver.triggerRoute(`https://console.anthropic.com/oauth/code/callback?code=abc123&state=${state}`)
+    await pumpUntil(() => loginStatus(firstId).state === 'done')
+
+    const driver2 = createFakeDriver()
+    setLoginBrowserLauncherForTests(driver2.launcher)
+    const { loginId: secondId } = await loginStart('openai', 'other@example.com')
+
+    expect(() => loginStatus(firstId)).toThrow('login session not found')
+    expect(loginStatus(secondId).state).toBe('launching')
+  })
+
+  it('GCs a terminal session after 5 minutes if no new login starts', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, loginCancel, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+    await loginCancel(loginId)
+    expect(loginStatus(loginId).state).toBe('cancelled')
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000)
+
+    expect(() => loginStatus(loginId)).toThrow('login session not found')
+  })
+
+  it('fails with a timeout after 30 minutes of waiting, and closes the context', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000)
+
+    expect(loginStatus(loginId).state).toBe('failed')
+    expect(loginStatus(loginId).error).toBe('Login timed out')
+    expect(driver.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps a chrome-missing launch error to a friendly failed state', async () => {
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(async () => {
+      throw new Error(
+        `Chromium distribution 'chrome' is not found at /Applications/Google Chrome.app\nRun "npx patchright install chrome"`
+      )
+    })
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'failed')
+
+    expect(loginStatus(loginId).error).toBe(
+      'Google Chrome is required for sign-in. Please install Chrome and try again.'
+    )
+  })
+
+  it('surfaces other launch failures with their raw message', async () => {
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(async () => {
+      throw new Error('boom: some other launch failure')
+    })
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'failed')
+
+    expect(loginStatus(loginId).error).toBe('boom: some other launch failure')
+  })
+
+  it('throws on non-macOS platforms', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    try {
+      const { loginStart } = await importFresh()
+      await expect(loginStart('anthropic')).rejects.toThrow(
+        'Account sign-in is only supported on macOS'
+      )
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('uses the "-new" scratch profile when no email hint is given', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+
+    expect(driver.launchProfileDirs).toEqual([
+      join(mocks.homeDir, '.ccswitch', 'profiles', 'claude-new')
+    ])
+  })
+
+  it('isLoginActive reflects whether the current session is non-terminal', async () => {
+    const driver = createFakeDriver()
+    const { loginStart, loginStatus, loginCancel, isLoginActive, setLoginBrowserLauncherForTests } =
+      await importFresh()
+    expect(isLoginActive()).toBe(false)
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    expect(isLoginActive()).toBe(true)
+
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+    expect(isLoginActive()).toBe(true)
+
+    await loginCancel(loginId)
+    expect(isLoginActive()).toBe(false)
+  })
+})

--- a/test/usage/login-service.test.ts
+++ b/test/usage/login-service.test.ts
@@ -162,6 +162,15 @@ async function pumpUntil(predicate: () => boolean, maxIterations = 400): Promise
   }
 }
 
+/** Lets a test control exactly when a mocked async dependency resolves. */
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 describe('login-service', () => {
   beforeEach(async () => {
     vi.resetAllMocks()
@@ -261,11 +270,18 @@ describe('login-service', () => {
     expect(loginStatus(loginId).state).toBe('done')
 
     // The 30-minute waiting timeout is cancelled once a login succeeds — it
-    // must not re-fire (or double-close) once the original deadline elapses.
-    await vi.advanceTimersByTimeAsync(30 * 60 * 1000)
+    // must not re-fire (or double-close) as time passes.
+    // A 'done' session stays queryable comfortably before the 5-minute GC
+    // mark (leaving margin for the pumpUntil polling jitter above)...
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 - 1500 - 5000)
     expect(driver.close).toHaveBeenCalledTimes(1)
     expect(loginStatus(loginId).state).toBe('done')
     expect(loginStatus(loginId).error).toBeNull()
+
+    // ...and is GC'd once 5 minutes since it went 'done' has elapsed, so a
+    // stale poll doesn't retain it forever.
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(() => loginStatus(loginId)).toThrow('login session not found')
   })
 
   it('resolves the cache row id via getSavedUsageAccountByProviderEmail and fires fetchForSavedAccount', async () => {
@@ -281,6 +297,35 @@ describe('login-service', () => {
     await pumpUntil(() => loginStatus(loginId).state === 'done')
 
     expect(mocks.fetchForSavedAccount).toHaveBeenCalledWith('row-42')
+  })
+
+  it('lowercases the addCodexAccount email before the cache lookup, and swallows a rejected fetch', async () => {
+    const driver = createFakeDriver()
+    mocks.addCodexAccount.mockResolvedValue({ accountKey: 'user-1::acct-1', email: 'User@Example.com' })
+    mocks.db.getSavedUsageAccountByProviderEmail.mockReturnValue({ id: 'row-99' })
+    mocks.fetchForSavedAccount.mockRejectedValue(new Error('network blip'))
+
+    const { loginStart, loginStatus, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('openai', 'codex@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+    const state = new URL(driver.gotoCalls[0]).searchParams.get('state')
+    await driver.triggerRoute(`http://localhost:1455/auth/callback?code=xyz789&state=${state}`)
+    await pumpUntil(() => loginStatus(loginId).state === 'done')
+
+    // The orchestrator upserts rows with lowercased emails — the lookup must
+    // match that, even though addCodexAccount returned a mixed-case email.
+    expect(mocks.db.getSavedUsageAccountByProviderEmail).toHaveBeenCalledWith(
+      'openai',
+      'user@example.com'
+    )
+    expect(mocks.fetchForSavedAccount).toHaveBeenCalledWith('row-99')
+
+    // A rejected fire-and-forget fetch must not crash the flow or leave an
+    // unhandled rejection.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(loginStatus(loginId).state).toBe('done')
   })
 
   it('runs the full happy path for an OpenAI (Codex) login', async () => {
@@ -438,6 +483,56 @@ describe('login-service', () => {
     // have overwritten the terminal 'cancelled' state set before close() was called.
     expect(loginStatus(loginId).state).toBe('cancelled')
     expect(loginStatus(loginId).error).toBeNull()
+  })
+
+  it('a cancel that lands during the in-flight token exchange is not clobbered back to done', async () => {
+    const driver = createFakeDriver()
+    const deferred = createDeferred<{
+      accessToken: string
+      refreshToken: string
+      expiresAt: number
+      scope: string
+      account: { uuid: string; emailAddress: string }
+    }>()
+    mocks.exchangeAnthropicCode.mockReturnValue(deferred.promise)
+
+    const { loginStart, loginStatus, loginCancel, setLoginBrowserLauncherForTests } = await importFresh()
+    setLoginBrowserLauncherForTests(driver.launcher)
+
+    const { loginId } = await loginStart('anthropic', 'user@example.com')
+    await pumpUntil(() => loginStatus(loginId).state === 'waiting')
+    const state = new URL(driver.gotoCalls[0]).searchParams.get('state')
+
+    await driver.triggerRoute(
+      `https://console.anthropic.com/oauth/code/callback?code=abc123&state=${state}`
+    )
+    // The route handler runs extractAndHandle -> exchange() synchronously up
+    // to the awaited (still-pending) token exchange call.
+    expect(loginStatus(loginId).state).toBe('exchanging')
+
+    const cancelled = await loginCancel(loginId)
+    expect(cancelled).toBe(true)
+    expect(loginStatus(loginId).state).toBe('cancelled')
+    expect(driver.close).toHaveBeenCalledTimes(1)
+
+    // Now let the in-flight exchange resolve — it must NOT overwrite the
+    // already-terminal 'cancelled' state back to 'done'.
+    deferred.resolve({
+      accessToken: 'at',
+      refreshToken: 'rt',
+      expiresAt: 1,
+      scope: 'org:create_api_key user:profile user:inference',
+      account: { uuid: 'uuid-1', emailAddress: 'user@example.com' }
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    // The account may still get stored (the code was consumed; that's fine) —
+    // only the session STATE must hold.
+    expect(mocks.addClaudeAccount).toHaveBeenCalled()
+    expect(loginStatus(loginId).state).toBe('cancelled')
+    expect(loginStatus(loginId).error).toBeNull()
+    // No second close from the (skipped) success path.
+    expect(driver.close).toHaveBeenCalledTimes(1)
   })
 
   it('loginCancel returns false for an unknown login', async () => {

--- a/test/usage/oauth-anthropic.test.ts
+++ b/test/usage/oauth-anthropic.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest'
+import {
+  ANTHROPIC_AUTHORIZE_URL,
+  ANTHROPIC_CLIENT_ID,
+  ANTHROPIC_REDIRECT_URI,
+  ANTHROPIC_SCOPE,
+  ANTHROPIC_TOKEN_URL,
+  buildAnthropicAuthorizeUrl,
+  exchangeAnthropicCode,
+  refreshAnthropicToken
+} from '../../src/main/services/oauth-anthropic'
+import type { Pkce } from '../../src/main/services/oauth-pkce'
+
+function pkce(): Pkce {
+  return { verifier: 'test-verifier', challenge: 'test-challenge', state: 'test-state' }
+}
+
+function textResponse(body: string, init: ResponseInit): Response {
+  return new Response(body, init)
+}
+
+function jsonResponse(body: unknown, init: ResponseInit): Response {
+  return textResponse(JSON.stringify(body), { headers: { 'content-type': 'application/json' }, ...init })
+}
+
+describe('buildAnthropicAuthorizeUrl', () => {
+  it('builds the authorize URL with exactly the expected query params', () => {
+    const url = new URL(buildAnthropicAuthorizeUrl(pkce()))
+
+    expect(url.origin + url.pathname).toBe(ANTHROPIC_AUTHORIZE_URL)
+    expect(Object.fromEntries(url.searchParams.entries())).toEqual({
+      code: 'true',
+      client_id: ANTHROPIC_CLIENT_ID,
+      response_type: 'code',
+      redirect_uri: ANTHROPIC_REDIRECT_URI,
+      scope: ANTHROPIC_SCOPE,
+      code_challenge: 'test-challenge',
+      code_challenge_method: 'S256',
+      state: 'test-state'
+    })
+  })
+})
+
+describe('refreshAnthropicToken', () => {
+  it('returns needsLogin on 401', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ error: 'unauthorized' }, { status: 401 }))
+    )
+
+    const outcome = await refreshAnthropicToken('refresh-1')
+    expect(outcome).toMatchObject({ ok: false, needsLogin: true })
+  })
+
+  it('returns needsLogin on 400 (status-based, regardless of body content)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ error: 'bad request' }, { status: 400 }))
+    )
+
+    const outcome = await refreshAnthropicToken('refresh-1')
+    expect(outcome).toMatchObject({ ok: false, needsLogin: true })
+  })
+
+  it('returns needsLogin when a non-4xx-classified body still contains invalid_grant', async () => {
+    // A 400 response whose body literally contains 'invalid_grant' — exercises
+    // the body-substring branch of the needsLogin rule directly.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(textResponse('{"error":"invalid_grant"}', { status: 400 }))
+    )
+
+    const outcome = await refreshAnthropicToken('refresh-1')
+    expect(outcome).toMatchObject({ ok: false, needsLogin: true })
+    expect((outcome as { error: string }).error).toContain('400')
+  })
+
+  it('throws on a 500 response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(textResponse('internal error', { status: 500 }))
+    )
+
+    await expect(refreshAnthropicToken('refresh-1')).rejects.toThrow(/500/)
+  })
+
+  it('propagates a network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNRESET')))
+
+    await expect(refreshAnthropicToken('refresh-1')).rejects.toThrow('ECONNRESET')
+  })
+
+  it('maps a success response, computing expiresAt from expires_in', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        { access_token: 'new-access', refresh_token: 'new-refresh', expires_in: 3600, scope: 'a b' },
+        { status: 200 }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const before = Date.now()
+    const outcome = await refreshAnthropicToken('old-refresh')
+    const after = Date.now()
+
+    expect(outcome.ok).toBe(true)
+    if (!outcome.ok) throw new Error('unreachable')
+    expect(outcome.result.accessToken).toBe('new-access')
+    expect(outcome.result.refreshToken).toBe('new-refresh')
+    expect(outcome.result.expiresAt).toBeGreaterThanOrEqual(before + 3600 * 1000)
+    expect(outcome.result.expiresAt).toBeLessThanOrEqual(after + 3600 * 1000)
+    expect(outcome.scope).toBe('a b')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      ANTHROPIC_TOKEN_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({
+          grant_type: 'refresh_token',
+          refresh_token: 'old-refresh',
+          client_id: ANTHROPIC_CLIENT_ID
+        })
+      })
+    )
+  })
+
+  it('falls back to the input refresh token when the response omits one', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ access_token: 'new-access', expires_in: 60 }, { status: 200 }))
+    )
+
+    const outcome = await refreshAnthropicToken('kept-refresh-token')
+    expect(outcome.ok).toBe(true)
+    if (!outcome.ok) throw new Error('unreachable')
+    expect(outcome.result.refreshToken).toBe('kept-refresh-token')
+  })
+})
+
+describe('exchangeAnthropicCode', () => {
+  it('POSTs a JSON body with code, state, redirect_uri, client_id, code_verifier', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        {
+          access_token: 'access-1',
+          refresh_token: 'refresh-1',
+          expires_in: 3600,
+          account: { uuid: 'uuid-1', email_address: 'person@example.com' }
+        },
+        { status: 200 }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await exchangeAnthropicCode('the-code', 'the-state', pkce())
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      ANTHROPIC_TOKEN_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({
+          grant_type: 'authorization_code',
+          code: 'the-code',
+          state: 'the-state',
+          redirect_uri: ANTHROPIC_REDIRECT_URI,
+          client_id: ANTHROPIC_CLIENT_ID,
+          code_verifier: 'test-verifier'
+        })
+      })
+    )
+    expect(result).toMatchObject({
+      accessToken: 'access-1',
+      refreshToken: 'refresh-1',
+      account: { uuid: 'uuid-1', emailAddress: 'person@example.com' }
+    })
+  })
+
+  it('throws on a non-2xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(textResponse('nope', { status: 403 })))
+
+    await expect(exchangeAnthropicCode('code', 'state', pkce())).rejects.toThrow(/403/)
+  })
+})

--- a/test/usage/oauth-openai.test.ts
+++ b/test/usage/oauth-openai.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest'
+import {
+  OPENAI_AUTHORIZE_URL,
+  OPENAI_CLIENT_ID,
+  OPENAI_REDIRECT_URI,
+  OPENAI_SCOPE,
+  OPENAI_TOKEN_URL,
+  buildOpenAIAuthorizeUrl,
+  exchangeOpenAICode,
+  refreshOpenAIToken
+} from '../../src/main/services/oauth-openai'
+import type { Pkce } from '../../src/main/services/oauth-pkce'
+
+function pkce(): Pkce {
+  return { verifier: 'test-verifier', challenge: 'test-challenge', state: 'test-state' }
+}
+
+function textResponse(body: string, init: ResponseInit): Response {
+  return new Response(body, init)
+}
+
+function jsonResponse(body: unknown, init: ResponseInit): Response {
+  return textResponse(JSON.stringify(body), { headers: { 'content-type': 'application/json' }, ...init })
+}
+
+describe('buildOpenAIAuthorizeUrl', () => {
+  it('builds the authorize URL with exactly the expected query params', () => {
+    const url = new URL(buildOpenAIAuthorizeUrl(pkce()))
+
+    expect(url.origin + url.pathname).toBe(OPENAI_AUTHORIZE_URL)
+    expect(Object.fromEntries(url.searchParams.entries())).toEqual({
+      response_type: 'code',
+      client_id: OPENAI_CLIENT_ID,
+      redirect_uri: OPENAI_REDIRECT_URI,
+      scope: OPENAI_SCOPE,
+      code_challenge: 'test-challenge',
+      code_challenge_method: 'S256',
+      id_token_add_organizations: 'true',
+      codex_cli_simplified_flow: 'true',
+      state: 'test-state',
+      originator: 'codex_cli_rs'
+    })
+  })
+})
+
+describe('refreshOpenAIToken', () => {
+  it('returns needsLogin on 401', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ error: 'unauthorized' }, { status: 401 })))
+
+    const outcome = await refreshOpenAIToken('refresh-1')
+    expect(outcome).toMatchObject({ ok: false, needsLogin: true })
+  })
+
+  it('returns needsLogin on 400', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ error: 'bad request' }, { status: 400 })))
+
+    const outcome = await refreshOpenAIToken('refresh-1')
+    expect(outcome).toMatchObject({ ok: false, needsLogin: true })
+  })
+
+  it('throws on a 500 response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(textResponse('internal error', { status: 500 })))
+
+    await expect(refreshOpenAIToken('refresh-1')).rejects.toThrow(/500/)
+  })
+
+  it('propagates a network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNRESET')))
+
+    await expect(refreshOpenAIToken('refresh-1')).rejects.toThrow('ECONNRESET')
+  })
+
+  it('maps a success response and rotates refresh/id tokens when present', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        { access_token: 'new-access', refresh_token: 'new-refresh', id_token: 'new-id' },
+        { status: 200 }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const outcome = await refreshOpenAIToken('old-refresh')
+    expect(outcome).toEqual({
+      ok: true,
+      result: { accessToken: 'new-access', refreshToken: 'new-refresh', idToken: 'new-id' }
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      OPENAI_TOKEN_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({
+          client_id: OPENAI_CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: 'old-refresh'
+        })
+      })
+    )
+  })
+
+  it('omits refreshToken/idToken from the result when the response does not include them', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ access_token: 'new-access' }, { status: 200 })))
+
+    const outcome = await refreshOpenAIToken('old-refresh')
+    expect(outcome).toEqual({ ok: true, result: { accessToken: 'new-access', refreshToken: undefined, idToken: undefined } })
+  })
+})
+
+describe('exchangeOpenAICode', () => {
+  it('POSTs a form-urlencoded (not JSON) body with the expected fields', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        { id_token: 'id-1', access_token: 'access-1', refresh_token: 'refresh-1' },
+        { status: 200 }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await exchangeOpenAICode('the-code', pkce())
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      OPENAI_TOKEN_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'Content-Type': 'application/x-www-form-urlencoded' })
+      })
+    )
+    const [, init] = fetchMock.mock.calls[0]
+    expect(typeof init.body).toBe('string')
+    const parsedBody = new URLSearchParams(init.body as string)
+    expect(Object.fromEntries(parsedBody.entries())).toEqual({
+      grant_type: 'authorization_code',
+      code: 'the-code',
+      redirect_uri: OPENAI_REDIRECT_URI,
+      client_id: OPENAI_CLIENT_ID,
+      code_verifier: 'test-verifier'
+    })
+
+    expect(result).toEqual({ idToken: 'id-1', accessToken: 'access-1', refreshToken: 'refresh-1' })
+  })
+
+  it('throws on a non-2xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(textResponse('nope', { status: 400 })))
+
+    await expect(exchangeOpenAICode('code', pkce())).rejects.toThrow(/400/)
+  })
+})

--- a/test/usage/oauth-pkce.test.ts
+++ b/test/usage/oauth-pkce.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+import { createHash } from 'crypto'
+import { describe, expect, it } from 'vitest'
+import { generatePkce } from '../../src/main/services/oauth-pkce'
+
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/
+
+describe('generatePkce', () => {
+  it('produces a challenge equal to base64url(sha256(verifier))', () => {
+    const { verifier, challenge } = generatePkce()
+    const expected = createHash('sha256').update(verifier).digest('base64url')
+    expect(challenge).toBe(expected)
+  })
+
+  it('produces a verifier and state using the base64url alphabet with no padding', () => {
+    const { verifier, state } = generatePkce()
+
+    expect(verifier).toMatch(BASE64URL_RE)
+    expect(state).toMatch(BASE64URL_RE)
+    expect(verifier).not.toContain('=')
+    expect(verifier).not.toContain('+')
+    expect(verifier).not.toContain('/')
+    expect(state).not.toContain('=')
+    expect(state).not.toContain('+')
+    expect(state).not.toContain('/')
+  })
+
+  it('produces a verifier and state of the expected lengths', () => {
+    const { verifier, state } = generatePkce()
+
+    // base64url of 64 random bytes -> ceil(64*4/3) = 86 chars (no padding)
+    expect(verifier.length).toBe(86)
+    // base64url of 32 random bytes -> ceil(32*4/3) = 43 chars (no padding)
+    expect(state.length).toBe(43)
+  })
+
+  it('generates distinct values on each call', () => {
+    const first = generatePkce()
+    const second = generatePkce()
+
+    expect(first.verifier).not.toBe(second.verifier)
+    expect(first.state).not.toBe(second.state)
+    expect(first.challenge).not.toBe(second.challenge)
+  })
+})

--- a/test/usage/openai-usage-service.test.ts
+++ b/test/usage/openai-usage-service.test.ts
@@ -108,7 +108,8 @@ describe('fetchOpenAIUsage', () => {
       expect(result.rotated).toEqual({
         accessToken: 'new-access',
         refreshToken: 'new-refresh',
-        idToken: 'new-id'
+        idToken: 'new-id',
+        rotatedFrom: 'live-refresh-token'
       })
       expect(fetchMock).toHaveBeenNthCalledWith(
         1,
@@ -192,7 +193,8 @@ describe('fetchOpenAIUsage', () => {
       expect(result.rotated).toEqual({
         accessToken: 'retry-access',
         refreshToken: 'retry-refresh',
-        idToken: ''
+        idToken: '',
+        rotatedFrom: 'saved-refresh-token'
       })
     })
 
@@ -212,7 +214,8 @@ describe('fetchOpenAIUsage', () => {
       expect(result.rotated).toEqual({
         accessToken: 'retry-access',
         refreshToken: 'retry-refresh',
-        idToken: ''
+        idToken: '',
+        rotatedFrom: 'saved-refresh-token'
       })
     })
 

--- a/test/usage/openai-usage-service.test.ts
+++ b/test/usage/openai-usage-service.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment node
+import { readFile, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// openai-usage-service.ts reads `process.env.CODEX_HOME` once, at module
+// load time (`const CODEX_HOME = process.env.CODEX_HOME || ...`) — so this
+// has to be set inside `vi.hoisted`, which Vitest runs before the module
+// under test is ever imported. `require` (rather than the statically
+// imported bindings, which aren't initialized yet at hoist time) is used to
+// reach the real `fs`/`os`/`path` builtins synchronously.
+const mocks = vi.hoisted(() => {
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  const fs = require('node:fs') as typeof import('fs')
+  const os = require('node:os') as typeof import('os')
+  const path = require('node:path') as typeof import('path')
+  /* eslint-enable @typescript-eslint/no-require-imports */
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hive-openai-usage-'))
+  process.env.CODEX_HOME = dir
+  return { codexHome: dir }
+})
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp' }
+}))
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { fetchOpenAIUsage } from '../../src/main/services/openai-usage-service'
+
+const USAGE_URL = 'https://chatgpt.com/backend-api/wham/usage'
+const TOKEN_URL = 'https://auth.openai.com/oauth/token'
+const AUTH_FILE = join(mocks.codexHome, 'auth.json')
+
+function base64url(value: string): string {
+  return Buffer.from(value, 'utf-8').toString('base64url')
+}
+
+function accessTokenWithExp(expSeconds: number): string {
+  const header = base64url(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+  const body = base64url(JSON.stringify({ exp: expSeconds }))
+  return `${header}.${body}.fake-signature`
+}
+
+function jsonResponse(body: unknown, init: ResponseInit): Response {
+  return new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' }, ...init })
+}
+
+function usageBody() {
+  return {
+    plan_type: 'plus',
+    rate_limit: {
+      primary_window: { used_percent: 10, limit_window_seconds: 300, reset_after_seconds: 100, reset_at: 1000 },
+      secondary_window: null
+    }
+  }
+}
+
+async function writeLiveAuth(overrides: Partial<{ accessToken: string; refreshToken: string }> = {}): Promise<string> {
+  const nowSec = Math.floor(Date.now() / 1000)
+  const content = JSON.stringify({
+    OPENAI_API_KEY: null,
+    auth_mode: 'chatgpt',
+    tokens: {
+      id_token: 'id-token',
+      access_token: overrides.accessToken ?? accessTokenWithExp(nowSec - 100),
+      refresh_token: overrides.refreshToken ?? 'live-refresh-token',
+      account_id: 'live-account'
+    },
+    last_refresh: '2026-01-01T00:00:00.000Z'
+  })
+  await writeFile(AUTH_FILE, content, 'utf-8')
+  return content
+}
+
+describe('fetchOpenAIUsage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(async () => {
+    await rm(AUTH_FILE, { force: true })
+  })
+
+  afterAll(async () => {
+    await rm(mocks.codexHome, { recursive: true, force: true })
+  })
+
+  describe('live path (no override)', () => {
+    it('refreshes in memory and does not write auth.json from inside the service', async () => {
+      const before = await writeLiveAuth()
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            { access_token: 'new-access', refresh_token: 'new-refresh', id_token: 'new-id' },
+            { status: 200 }
+          )
+        )
+        .mockResolvedValueOnce(jsonResponse(usageBody(), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchOpenAIUsage()
+
+      expect(result.success).toBe(true)
+      expect(result.rotated).toEqual({
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        idToken: 'new-id'
+      })
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        TOKEN_URL,
+        expect.objectContaining({
+          body: JSON.stringify({
+            client_id: 'app_EMoamEEZ73f0CkXaXp7hrann',
+            grant_type: 'refresh_token',
+            refresh_token: 'live-refresh-token'
+          })
+        })
+      )
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        USAGE_URL,
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer new-access' })
+        })
+      )
+
+      // The service itself must not have persisted anything — auth.json on
+      // disk is byte-for-byte the same as before the fetch.
+      const after = await readFile(AUTH_FILE, 'utf-8')
+      expect(after).toBe(before)
+    })
+
+    it('needsLogin when the live refresh itself returns invalid_grant, without touching auth.json', async () => {
+      const before = await writeLiveAuth()
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValueOnce(jsonResponse({ error: 'invalid_grant' }, { status: 400 }))
+      )
+
+      const result = await fetchOpenAIUsage()
+
+      expect(result.success).toBe(false)
+      expect(result.needsLogin).toBe(true)
+      expect(result.error).toContain('Token refresh failed: invalid_grant')
+
+      const after = await readFile(AUTH_FILE, 'utf-8')
+      expect(after).toBe(before)
+    })
+  })
+
+  describe('override (saved-account) path', () => {
+    function override() {
+      return {
+        accessToken: accessTokenWithExp(Math.floor(Date.now() / 1000) + 10_000),
+        refreshToken: 'saved-refresh-token',
+        accountId: 'saved-account'
+      }
+    }
+
+    it('sets needsLogin on a 403 usage response (after the one-refresh-retry)', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ error: 'forbidden' }, { status: 403, statusText: 'Forbidden' }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchOpenAIUsage(override())
+
+      expect(result.success).toBe(false)
+      expect(result.needsLogin).toBe(true)
+      expect(result.error).toContain('403')
+    })
+
+    it('sets needsLogin on a 401 usage response that persists through the retry', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ error: 'expired' }, { status: 401 }))
+        .mockResolvedValueOnce(
+          jsonResponse({ access_token: 'retry-access', refresh_token: 'retry-refresh' }, { status: 200 })
+        )
+        .mockResolvedValueOnce(jsonResponse({ error: 'still unauthorized' }, { status: 401 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchOpenAIUsage(override())
+
+      expect(result.success).toBe(false)
+      expect(result.needsLogin).toBe(true)
+      expect(result.rotated).toEqual({
+        accessToken: 'retry-access',
+        refreshToken: 'retry-refresh',
+        idToken: ''
+      })
+    })
+
+    it('surfaces rotated tokens on a successful retry-after-401', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ error: 'expired' }, { status: 401 }))
+        .mockResolvedValueOnce(
+          jsonResponse({ access_token: 'retry-access', refresh_token: 'retry-refresh' }, { status: 200 })
+        )
+        .mockResolvedValueOnce(jsonResponse(usageBody(), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchOpenAIUsage(override())
+
+      expect(result.success).toBe(true)
+      expect(result.rotated).toEqual({
+        accessToken: 'retry-access',
+        refreshToken: 'retry-refresh',
+        idToken: ''
+      })
+    })
+
+    it('sets needsLogin when the refresh itself returns invalid_grant (400)', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValueOnce(jsonResponse({ error: 'invalid_grant' }, { status: 400 }))
+      )
+
+      const expiredOverride = {
+        accessToken: accessTokenWithExp(Math.floor(Date.now() / 1000) - 100),
+        refreshToken: 'dead-refresh-token',
+        accountId: 'saved-account'
+      }
+      const result = await fetchOpenAIUsage(expiredOverride)
+
+      expect(result.success).toBe(false)
+      expect(result.needsLogin).toBe(true)
+      expect(result.error).toContain('Token refresh failed: invalid_grant')
+    })
+  })
+})

--- a/test/usage/openai-usage-service.test.ts
+++ b/test/usage/openai-usage-service.test.ts
@@ -136,6 +136,31 @@ describe('fetchOpenAIUsage', () => {
       expect(after).toBe(before)
     })
 
+    it('preserves rotated tokens when the usage fetch throws after a successful proactive refresh', async () => {
+      await writeLiveAuth()
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            { access_token: 'new-access', refresh_token: 'new-refresh', id_token: 'new-id' },
+            { status: 200 }
+          )
+        )
+        .mockRejectedValueOnce(new Error('network error'))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchOpenAIUsage()
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('network error')
+      expect(result.rotated).toEqual({
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        idToken: 'new-id',
+        rotatedFrom: 'live-refresh-token'
+      })
+    })
+
     it('needsLogin when the live refresh itself returns invalid_grant, without touching auth.json', async () => {
       const before = await writeLiveAuth()
       vi.stubGlobal(

--- a/test/usage/saved-usage-orchestrator.refresh.test.ts
+++ b/test/usage/saved-usage-orchestrator.refresh.test.ts
@@ -332,6 +332,31 @@ describe('fetchForSavedAccount (Claude)', () => {
     expect(result.error).toBe('account no longer in store')
     expect(mocks.fetchClaudeUsage).not.toHaveBeenCalled()
   })
+
+  it('keeps the successful usage result when persisting the rotated tokens throws, recording the failure in last_error instead of flipping to error status', async () => {
+    mocks.fetchClaudeUsage.mockResolvedValue({
+      success: true,
+      data: usageData(),
+      rotated: {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: 2_000,
+        rotatedFrom: 'old-refresh'
+      }
+    })
+    mocks.updateClaudeTokens.mockRejectedValue(new Error('No Claude snapshot for account 1'))
+
+    const result = await fetchForSavedAccount('saved-1')
+
+    expect(result.success).toBe(true)
+    expect(result.status).toBe('ok')
+    expect(result.data).toEqual(usageData())
+    expect(mocks.db.updateSavedUsageAccountUsage).toHaveBeenCalledWith('saved-1', {
+      last_usage_json: JSON.stringify(usageData()),
+      status: 'ok',
+      last_error: 'failed to persist rotated tokens: No Claude snapshot for account 1'
+    })
+  })
 })
 
 describe('fetchForSavedAccount (OpenAI)', () => {
@@ -399,6 +424,27 @@ describe('fetchForSavedAccount (OpenAI)', () => {
 
     expect(result.success).toBe(false)
     expect(result.status).toBe('error')
+  })
+
+  it('keeps the successful usage result when persisting the rotated tokens throws, recording the failure in last_error instead of flipping to error status', async () => {
+    const data = { plan_type: 'plus', rate_limit: { primary_window: null, secondary_window: null } }
+    mocks.fetchOpenAIUsage.mockResolvedValue({
+      success: true,
+      data,
+      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh', rotatedFrom: 'old-refresh' }
+    })
+    mocks.updateCodexTokens.mockRejectedValue(new Error('No Codex snapshot for account user-1::acct-1'))
+
+    const result = await fetchForSavedAccount('saved-openai-1')
+
+    expect(result.success).toBe(true)
+    expect(result.status).toBe('ok')
+    expect(result.data).toEqual(data)
+    expect(mocks.db.updateSavedUsageAccountUsage).toHaveBeenCalledWith('saved-openai-1', {
+      last_usage_json: JSON.stringify(data),
+      status: 'ok',
+      last_error: 'failed to persist rotated tokens: No Codex snapshot for account user-1::acct-1'
+    })
   })
 })
 

--- a/test/usage/saved-usage-orchestrator.refresh.test.ts
+++ b/test/usage/saved-usage-orchestrator.refresh.test.ts
@@ -682,6 +682,231 @@ describe('refreshTokensForStoreAccount', () => {
       expect.objectContaining({ status: 'stale' })
     )
   })
+
+  it('does not hardcode invalid_grant into the stale message, but keeps the classification prefix', async () => {
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({
+      raw: '{}',
+      parsed: { accessToken: 'old-access', refreshToken: 'old-refresh', expiresAt: 1_000 }
+    })
+    mocks.refreshAnthropicToken.mockResolvedValue({
+      ok: false,
+      needsLogin: true,
+      error: 'some_other_error'
+    })
+    mocks.db.getSavedUsageAccountByProviderEmail.mockReturnValue(savedRow({ id: 'row-1' }))
+
+    const outcome = await refreshTokensForStoreAccount('anthropic', {
+      num: '1',
+      email: 'claude@example.com'
+    })
+
+    expect(outcome).toBe('needsLogin')
+    const call = mocks.db.updateSavedUsageAccountUsage.mock.calls.find(
+      ([id]: [string, unknown]) => id === 'row-1'
+    )
+    const lastError = (call?.[1] as { last_error?: string } | undefined)?.last_error
+    expect(lastError).toBe('Token refresh failed: some_other_error')
+    expect(lastError).not.toContain('invalid_grant (')
+    expect(lastError?.startsWith('Token refresh failed: ')).toBe(true)
+  })
+})
+
+describe('account-level refresh/fetch locking', () => {
+  beforeEach(() => {
+    mocks.db.getSavedUsageAccountById.mockReturnValue(savedRow())
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({
+      raw: '{}',
+      parsed: { accessToken: 'old-access', refreshToken: 'old-refresh', expiresAt: 1_000 }
+    })
+  })
+
+  function flushMicrotasks(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  it('runs two concurrent fetchForSavedAccount calls for the same account strictly sequentially', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    mocks.fetchClaudeUsage.mockImplementation(async () => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      if (inFlight > 1) {
+        throw new Error('overlap detected: more than one fetch in flight for the same account')
+      }
+      await flushMicrotasks()
+      inFlight -= 1
+      return { success: true, data: usageData() }
+    })
+
+    const [r1, r2] = await Promise.all([
+      fetchForSavedAccount('saved-1'),
+      fetchForSavedAccount('saved-1')
+    ])
+
+    expect(r1.success).toBe(true)
+    expect(r2.success).toBe(true)
+    expect(maxInFlight).toBe(1)
+    expect(mocks.fetchClaudeUsage).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not block concurrent fetches for different accounts (no global lock)', async () => {
+    const rowA = savedRow({ id: 'saved-a', email: 'a@example.com' })
+    const rowB = savedRow({ id: 'saved-b', email: 'b@example.com' })
+    mocks.db.getSavedUsageAccountById.mockImplementation((id: string) =>
+      id === 'saved-a' ? rowA : id === 'saved-b' ? rowB : null
+    )
+    mocks.listClaudeAccounts.mockResolvedValue([
+      claudeAccount({ num: '1', email: 'a@example.com' }),
+      claudeAccount({ num: '2', email: 'b@example.com' })
+    ])
+
+    let releaseA: (() => void) | undefined
+    const gateA = new Promise<void>((resolve) => {
+      releaseA = resolve
+    })
+    let bStarted = false
+
+    mocks.fetchClaudeUsage.mockImplementation(async (_override: unknown, ctx: { accountId: string }) => {
+      if (ctx.accountId === 'saved-a') {
+        await gateA
+      } else {
+        bStarted = true
+      }
+      return { success: true, data: usageData() }
+    })
+
+    const pA = fetchForSavedAccount('saved-a')
+    const pB = fetchForSavedAccount('saved-b')
+
+    // Give B a chance to reach its fetch call while A is still gated — if
+    // fetches were serialized across accounts, B would never start here.
+    await flushMicrotasks()
+    expect(bStarted).toBe(true)
+
+    releaseA?.()
+    const [resultA, resultB] = await Promise.all([pA, pB])
+    expect(resultA.success).toBe(true)
+    expect(resultB.success).toBe(true)
+  })
+
+  it('serializes refreshTokensForStoreAccount + fetchForSavedAccount for the same account: single refresh call, and the second op observes the refreshed creds', async () => {
+    let refreshed = false
+    mocks.readClaudeEffectiveBlob.mockImplementation(async () =>
+      refreshed
+        ? {
+            raw: '{}',
+            parsed: {
+              accessToken: 'new-access',
+              refreshToken: 'new-refresh',
+              expiresAt: Date.now() + 60 * 60_000
+            }
+          }
+        : {
+            raw: '{}',
+            parsed: {
+              accessToken: 'old-access',
+              refreshToken: 'old-refresh',
+              expiresAt: Date.now() + 30_000
+            }
+          }
+    )
+
+    let releaseRefresh: ((value: unknown) => void) | undefined
+    const refreshGate = new Promise((resolve) => {
+      releaseRefresh = resolve
+    })
+    mocks.refreshAnthropicToken.mockImplementation(async () => refreshGate)
+    mocks.updateClaudeTokens.mockImplementation(async () => {
+      refreshed = true
+    })
+
+    let observedAccessToken: string | undefined
+    mocks.fetchClaudeUsage.mockImplementation(async (override: { accessToken: string }) => {
+      observedAccessToken = override.accessToken
+      return { success: true, data: usageData() }
+    })
+
+    const refreshPromise = refreshTokensForStoreAccount('anthropic', {
+      num: '1',
+      email: 'claude@example.com'
+    })
+    const fetchPromise = fetchForSavedAccount('saved-1')
+
+    // Let the refresh reach (and block on) the oauth call before releasing it.
+    await flushMicrotasks()
+
+    releaseRefresh?.({
+      ok: true,
+      result: {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: Date.now() + 60 * 60_000
+      },
+      scope: 'a b'
+    })
+
+    const [refreshOutcome, fetchResult] = await Promise.all([refreshPromise, fetchPromise])
+
+    expect(refreshOutcome).toBe('refreshed')
+    expect(fetchResult.success).toBe(true)
+    expect(mocks.refreshAnthropicToken).toHaveBeenCalledTimes(1)
+    expect(observedAccessToken).toBe('new-access')
+  })
+
+  it('recheck-after-lock-acquire: a second concurrent refreshTokensForStoreAccount call observes the already-refreshed token and skips the network call', async () => {
+    let refreshed = false
+    mocks.readClaudeEffectiveBlob.mockImplementation(async () =>
+      refreshed
+        ? {
+            raw: '{}',
+            parsed: {
+              accessToken: 'new-access',
+              refreshToken: 'new-refresh',
+              expiresAt: Date.now() + 60 * 60_000
+            }
+          }
+        : {
+            raw: '{}',
+            parsed: {
+              accessToken: 'old-access',
+              refreshToken: 'old-refresh',
+              expiresAt: Date.now() + 30_000
+            }
+          }
+    )
+
+    let releaseRefresh: ((value: unknown) => void) | undefined
+    const refreshGate = new Promise((resolve) => {
+      releaseRefresh = resolve
+    })
+    mocks.refreshAnthropicToken.mockImplementation(async () => refreshGate)
+    mocks.updateClaudeTokens.mockImplementation(async () => {
+      refreshed = true
+    })
+
+    const first = refreshTokensForStoreAccount('anthropic', { num: '1', email: 'claude@example.com' })
+    const second = refreshTokensForStoreAccount('anthropic', { num: '1', email: 'claude@example.com' })
+
+    await flushMicrotasks()
+
+    releaseRefresh?.({
+      ok: true,
+      result: {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: Date.now() + 60 * 60_000
+      },
+      scope: 'a b'
+    })
+
+    const [firstOutcome, secondOutcome] = await Promise.all([first, second])
+
+    expect(firstOutcome).toBe('refreshed')
+    expect(secondOutcome).toBe('refreshed')
+    expect(mocks.refreshAnthropicToken).toHaveBeenCalledTimes(1)
+    expect(mocks.updateClaudeTokens).toHaveBeenCalledTimes(1)
+  })
 })
 
 function base64url(value: string): string {

--- a/test/usage/saved-usage-orchestrator.refresh.test.ts
+++ b/test/usage/saved-usage-orchestrator.refresh.test.ts
@@ -4,10 +4,32 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   db: {
     getSavedUsageAccountById: vi.fn(),
-    updateSavedUsageAccountCredentials: vi.fn(),
-    updateSavedUsageAccountUsage: vi.fn()
+    getSavedUsageAccountsByProvider: vi.fn(),
+    getSavedUsageAccountByProviderEmail: vi.fn(),
+    upsertSavedUsageAccount: vi.fn(),
+    updateSavedUsageAccountUsage: vi.fn(),
+    deleteSavedUsageAccount: vi.fn()
   },
-  fetchClaudeUsage: vi.fn()
+  fetchClaudeUsage: vi.fn(),
+  fetchOpenAIUsage: vi.fn(),
+  readCodexCredentials: vi.fn(),
+  listClaudeAccounts: vi.fn(),
+  readClaudeEffectiveBlob: vi.fn(),
+  readClaudeLiveIdentity: vi.fn(),
+  readClaudeLiveRawBlob: vi.fn(),
+  updateClaudeTokens: vi.fn(),
+  switchClaudeAccount: vi.fn(),
+  addClaudeAccount: vi.fn(),
+  removeClaudeAccount: vi.fn(),
+  listCodexAccounts: vi.fn(),
+  readCodexEffectiveAuth: vi.fn(),
+  updateCodexTokens: vi.fn(),
+  switchCodexAccount: vi.fn(),
+  addCodexAccount: vi.fn(),
+  removeCodexAccount: vi.fn(),
+  migrateSavedCredentialsToStores: vi.fn(),
+  refreshAnthropicToken: vi.fn(),
+  refreshOpenAIToken: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -20,36 +42,97 @@ vi.mock('../../src/main/db', () => ({
   getDatabase: () => mocks.db
 }))
 
-vi.mock('../../src/main/services/usage-service', () => ({
-  fetchClaudeUsage: mocks.fetchClaudeUsage,
-  readAccessToken: vi.fn(),
-  readClaudeCredentialsBlob: vi.fn()
-}))
+vi.mock('../../src/main/services/usage-service', async () => {
+  const actual = await vi.importActual<typeof import('../../src/main/services/usage-service')>(
+    '../../src/main/services/usage-service'
+  )
+  return {
+    ...actual,
+    fetchClaudeUsage: mocks.fetchClaudeUsage
+  }
+})
 
 vi.mock('../../src/main/services/openai-usage-service', () => ({
-  fetchOpenAIUsage: vi.fn(),
-  readCodexCredentials: vi.fn()
+  fetchOpenAIUsage: mocks.fetchOpenAIUsage,
+  readCodexCredentials: mocks.readCodexCredentials
 }))
 
-vi.mock('../../src/main/services/account-service', () => ({
-  getClaudeAccountEmail: vi.fn(),
-  getOpenAIAccountEmail: vi.fn()
+vi.mock('../../src/main/services/account-store-claude', () => ({
+  listClaudeAccounts: mocks.listClaudeAccounts,
+  readClaudeEffectiveBlob: mocks.readClaudeEffectiveBlob,
+  readClaudeLiveIdentity: mocks.readClaudeLiveIdentity,
+  readClaudeLiveRawBlob: mocks.readClaudeLiveRawBlob,
+  updateClaudeTokens: mocks.updateClaudeTokens,
+  switchClaudeAccount: mocks.switchClaudeAccount,
+  addClaudeAccount: mocks.addClaudeAccount,
+  removeClaudeAccount: mocks.removeClaudeAccount
 }))
 
-import { fetchForSavedAccount } from '../../src/main/services/saved-usage-orchestrator'
+vi.mock('../../src/main/services/account-store-codex', () => ({
+  listCodexAccounts: mocks.listCodexAccounts,
+  readCodexEffectiveAuth: mocks.readCodexEffectiveAuth,
+  updateCodexTokens: mocks.updateCodexTokens,
+  switchCodexAccount: mocks.switchCodexAccount,
+  addCodexAccount: mocks.addCodexAccount,
+  removeCodexAccount: mocks.removeCodexAccount
+}))
+
+vi.mock('../../src/main/services/credentials-migration', () => ({
+  migrateSavedCredentialsToStores: mocks.migrateSavedCredentialsToStores
+}))
+
+vi.mock('../../src/main/services/oauth-anthropic', () => ({
+  refreshAnthropicToken: mocks.refreshAnthropicToken
+}))
+
+vi.mock('../../src/main/services/oauth-openai', () => ({
+  refreshOpenAIToken: mocks.refreshOpenAIToken
+}))
+
+import {
+  captureLiveAccountFromFetch,
+  fetchForSavedAccount,
+  listSavedAccounts,
+  refreshAllForProvider,
+  refreshTokensForStoreAccount,
+  removeSavedAccount,
+  switchAccount
+} from '../../src/main/services/saved-usage-orchestrator'
 import type { SavedUsageAccount } from '../../src/main/db/types'
+import type { ClaudeStoreAccount } from '../../src/main/services/account-store-claude'
+import type { CodexStoreAccount } from '../../src/main/services/account-store-codex'
 
-function savedClaudeRow(overrides: Partial<SavedUsageAccount> = {}): SavedUsageAccount {
+function claudeAccount(overrides: Partial<ClaudeStoreAccount> = {}): ClaudeStoreAccount {
   return {
-    id: 'saved-claude-id',
+    num: '1',
+    email: 'claude@example.com',
+    uuid: 'uuid-1',
+    expiresAtMs: 2_000,
+    hasRefresh: true,
+    plan: 'pro',
+    active: true,
+    ...overrides
+  }
+}
+
+function codexAccount(overrides: Partial<CodexStoreAccount> = {}): CodexStoreAccount {
+  return {
+    accountKey: 'user-1::acct-1',
+    email: 'codex@example.com',
+    plan: 'plus',
+    expiresAtMs: 2_000,
+    hasRefresh: true,
+    active: true,
+    ...overrides
+  }
+}
+
+function savedRow(overrides: Partial<SavedUsageAccount> = {}): SavedUsageAccount {
+  return {
+    id: 'saved-1',
     provider: 'anthropic',
-    email: 'saved@example.com',
-    credentials_json: JSON.stringify({
-      accessToken: 'old-access-token',
-      refreshToken: 'old-refresh-token',
-      expiresAt: 1_000,
-      email: 'saved@example.com'
-    }),
+    email: 'claude@example.com',
+    credentials_json: '',
     last_usage_json: JSON.stringify({
       five_hour: { utilization: 10, resets_at: '2026-05-19T12:00:00.000Z' },
       seven_day: { utilization: 20, resets_at: '2026-05-20T12:00:00.000Z' }
@@ -63,96 +146,559 @@ function savedClaudeRow(overrides: Partial<SavedUsageAccount> = {}): SavedUsageA
   }
 }
 
-function usageData() {
+function usageData(): { five_hour: { utilization: number; resets_at: string }; seven_day: { utilization: number; resets_at: string } } {
   return {
     five_hour: { utilization: 12, resets_at: '2026-05-19T12:00:00.000Z' },
     seven_day: { utilization: 34, resets_at: '2026-05-20T12:00:00.000Z' }
   }
 }
 
-describe('saved Claude usage refresh orchestration', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mocks.db.getSavedUsageAccountById.mockReturnValue(savedClaudeRow())
+beforeEach(() => {
+  vi.resetAllMocks()
+  mocks.migrateSavedCredentialsToStores.mockResolvedValue(undefined)
+  mocks.listClaudeAccounts.mockResolvedValue([])
+  mocks.listCodexAccounts.mockResolvedValue([])
+  mocks.db.getSavedUsageAccountsByProvider.mockReturnValue([])
+  mocks.db.upsertSavedUsageAccount.mockImplementation((data: { email: string }) =>
+    savedRow({ ...data, id: `new-${data.email}` })
+  )
+})
+
+describe('listSavedAccounts', () => {
+  it('creates a missing cache row for a store account and joins its plan', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount({ plan: 'max' })])
+    mocks.db.getSavedUsageAccountsByProvider.mockReturnValue([])
+
+    const result = await listSavedAccounts('anthropic')
+
+    expect(mocks.migrateSavedCredentialsToStores).toHaveBeenCalled()
+    expect(mocks.db.upsertSavedUsageAccount).toHaveBeenCalledWith({
+      provider: 'anthropic',
+      email: 'claude@example.com',
+      credentials_json: ''
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].plan).toBe('max')
   })
 
-  it('persists rotated Claude credentials after a successful saved-account fetch', async () => {
+  it('does not rewrite an existing cache row (only creates when missing)', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.db.getSavedUsageAccountsByProvider.mockReturnValue([savedRow({ id: 'existing-1' })])
+
+    const result = await listSavedAccounts('anthropic')
+
+    expect(mocks.db.upsertSavedUsageAccount).not.toHaveBeenCalled()
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('existing-1')
+  })
+
+  it('deletes cache rows whose account no longer exists in the store', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([])
+    mocks.db.getSavedUsageAccountsByProvider.mockReturnValue([
+      savedRow({ id: 'orphan-1', email: 'gone@example.com' })
+    ])
+
+    const result = await listSavedAccounts('anthropic')
+
+    expect(mocks.db.deleteSavedUsageAccount).toHaveBeenCalledWith('orphan-1')
+    expect(result).toHaveLength(0)
+  })
+
+  it('keeps the first account and logs a warning when two store accounts share an email', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([
+      claudeAccount({ num: '1', plan: 'pro' }),
+      claudeAccount({ num: '2', plan: 'max' })
+    ])
+    mocks.db.getSavedUsageAccountsByProvider.mockReturnValue([])
+
+    const result = await listSavedAccounts('anthropic')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].plan).toBe('pro')
+  })
+
+  it('queries both providers when none is specified', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.listCodexAccounts.mockResolvedValue([codexAccount()])
+    mocks.db.getSavedUsageAccountsByProvider.mockReturnValue([])
+
+    const result = await listSavedAccounts()
+
+    expect(result).toHaveLength(2)
+    expect(mocks.listClaudeAccounts).toHaveBeenCalled()
+    expect(mocks.listCodexAccounts).toHaveBeenCalled()
+  })
+})
+
+describe('fetchForSavedAccount (Claude)', () => {
+  beforeEach(() => {
+    mocks.db.getSavedUsageAccountById.mockReturnValue(savedRow())
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({
+      raw: '{}',
+      parsed: { accessToken: 'old-access', refreshToken: 'old-refresh', expiresAt: 1_000 }
+    })
+  })
+
+  it('reads effective creds from the store (not SQLite credentials_json)', async () => {
+    mocks.fetchClaudeUsage.mockResolvedValue({ success: true, data: usageData() })
+
+    await fetchForSavedAccount('saved-1')
+
+    expect(mocks.readClaudeEffectiveBlob).toHaveBeenCalledWith('1', 'claude@example.com')
+    expect(mocks.fetchClaudeUsage).toHaveBeenCalledWith(
+      {
+        accessToken: 'old-access',
+        refreshToken: 'old-refresh',
+        expiresAt: 1_000,
+        accountId: 'saved-1'
+      },
+      { caller: 'usage:fetchForAccount', accountId: 'saved-1', batchId: undefined }
+    )
+  })
+
+  it('persists a rotation via updateClaudeTokens (never SQLite credentials)', async () => {
     mocks.fetchClaudeUsage.mockResolvedValue({
       success: true,
       data: usageData(),
       rotated: {
-        accessToken: 'new-access-token',
-        refreshToken: 'new-refresh-token',
-        expiresAt: 2_000
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: 2_000,
+        scope: 'a b',
+        rotatedFrom: 'old-refresh'
       }
     })
 
-    const result = await fetchForSavedAccount('saved-claude-id')
+    const result = await fetchForSavedAccount('saved-1')
 
     expect(result.success).toBe(true)
-    expect(mocks.fetchClaudeUsage).toHaveBeenCalledWith(
+    expect(mocks.updateClaudeTokens).toHaveBeenCalledWith(
+      '1',
+      'claude@example.com',
       {
-        accessToken: 'old-access-token',
-        refreshToken: 'old-refresh-token',
-        expiresAt: 1_000,
-        accountId: 'saved-claude-id'
-      },
-      {
-        caller: 'usage:fetchForAccount',
-        accountId: 'saved-claude-id',
-        batchId: undefined
-      }
-    )
-    expect(mocks.db.updateSavedUsageAccountCredentials).toHaveBeenCalledWith(
-      'saved-claude-id',
-      JSON.stringify({
-        accessToken: 'new-access-token',
-        refreshToken: 'new-refresh-token',
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
         expiresAt: 2_000,
-        email: 'saved@example.com'
-      })
+        scope: 'a b',
+        rotatedFrom: 'old-refresh'
+      },
+      'a b'
     )
     expect(mocks.db.updateSavedUsageAccountUsage).toHaveBeenCalledWith(
-      'saved-claude-id',
+      'saved-1',
       expect.objectContaining({ status: 'ok', last_error: null })
     )
   })
 
-  it('marks Claude refresh failures as stale', async () => {
+  it('marks stale + needsLogin on an invalid_grant failure', async () => {
     mocks.fetchClaudeUsage.mockResolvedValue({
       success: false,
-      error: 'Token refresh failed (400): invalid refresh'
+      error: 'Token refresh failed: invalid_grant (bad token)',
+      needsLogin: true
     })
 
-    const result = await fetchForSavedAccount('saved-claude-id')
+    const result = await fetchForSavedAccount('saved-1')
 
     expect(result.success).toBe(false)
     expect(result.status).toBe('stale')
+    expect(result.needsLogin).toBe(true)
     expect(mocks.db.updateSavedUsageAccountUsage).toHaveBeenCalledWith(
-      'saved-claude-id',
-      expect.objectContaining({
-        status: 'stale',
-        last_error: 'Token refresh failed (400): invalid refresh'
-      })
+      'saved-1',
+      expect.objectContaining({ status: 'stale' })
     )
   })
 
-  it('keeps bare Claude 403 usage responses as errors', async () => {
+  it('keeps a transient (non-auth) failure as an error status, not stale', async () => {
     mocks.fetchClaudeUsage.mockResolvedValue({
       success: false,
-      error: 'Usage API returned 403: Forbidden'
+      error: 'Usage API returned 500: Internal Server Error'
     })
 
-    const result = await fetchForSavedAccount('saved-claude-id')
+    const result = await fetchForSavedAccount('saved-1')
 
     expect(result.success).toBe(false)
     expect(result.status).toBe('error')
+    expect(result.needsLogin).toBeUndefined()
+  })
+
+  it('treats a missing store account like stale with a clear error', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([])
+
+    const result = await fetchForSavedAccount('saved-1')
+
+    expect(result.success).toBe(false)
+    expect(result.status).toBe('stale')
+    expect(result.error).toBe('account no longer in store')
+    expect(mocks.fetchClaudeUsage).not.toHaveBeenCalled()
+  })
+})
+
+describe('fetchForSavedAccount (OpenAI)', () => {
+  beforeEach(() => {
+    mocks.db.getSavedUsageAccountById.mockReturnValue(
+      savedRow({ id: 'saved-openai-1', provider: 'openai', email: 'codex@example.com' })
+    )
+    mocks.listCodexAccounts.mockResolvedValue([codexAccount()])
+    mocks.readCodexEffectiveAuth.mockResolvedValue({
+      tokens: {
+        access_token: 'old-access',
+        refresh_token: 'old-refresh',
+        account_id: 'acct-1',
+        id_token: 'id-token'
+      }
+    })
+  })
+
+  it('reads effective creds from the store and persists rotation via updateCodexTokens', async () => {
+    mocks.fetchOpenAIUsage.mockResolvedValue({
+      success: true,
+      data: { plan_type: 'plus', rate_limit: { primary_window: null, secondary_window: null } },
+      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh', rotatedFrom: 'old-refresh' }
+    })
+
+    const result = await fetchForSavedAccount('saved-openai-1')
+
+    expect(result.success).toBe(true)
+    expect(mocks.readCodexEffectiveAuth).toHaveBeenCalledWith('user-1::acct-1')
+    expect(mocks.fetchOpenAIUsage).toHaveBeenCalledWith({
+      accessToken: 'old-access',
+      refreshToken: 'old-refresh',
+      accountId: 'acct-1',
+      idToken: 'id-token',
+      email: 'codex@example.com'
+    })
+    expect(mocks.updateCodexTokens).toHaveBeenCalledWith('user-1::acct-1', {
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+      rotatedFrom: 'old-refresh'
+    })
+  })
+
+  it('marks stale + needsLogin on a 401 needing login', async () => {
+    mocks.fetchOpenAIUsage.mockResolvedValue({
+      success: false,
+      error: 'OpenAI Usage API returned 401: unauthorized',
+      needsLogin: true
+    })
+
+    const result = await fetchForSavedAccount('saved-openai-1')
+
+    expect(result.success).toBe(false)
+    expect(result.status).toBe('stale')
+    expect(result.needsLogin).toBe(true)
+  })
+
+  it('keeps a transient failure as an error status', async () => {
+    mocks.fetchOpenAIUsage.mockResolvedValue({
+      success: false,
+      error: 'OpenAI Usage API returned 500: boom'
+    })
+
+    const result = await fetchForSavedAccount('saved-openai-1')
+
+    expect(result.success).toBe(false)
+    expect(result.status).toBe('error')
+  })
+})
+
+describe('refreshAllForProvider', () => {
+  it('iterates the store-backed account list serially and marks stale only on needsLogin', async () => {
+    mocks.listClaudeAccounts.mockResolvedValue([
+      claudeAccount({ num: '1', email: 'a@example.com' }),
+      claudeAccount({ num: '2', email: 'b@example.com' })
+    ])
+    const rowA = savedRow({ id: 'row-a', email: 'a@example.com' })
+    const rowB = savedRow({ id: 'row-b', email: 'b@example.com' })
+    mocks.db.getSavedUsageAccountsByProvider.mockReturnValue([rowA, rowB])
+    mocks.db.getSavedUsageAccountById.mockImplementation((id: string) =>
+      id === 'row-a' ? rowA : id === 'row-b' ? rowB : null
+    )
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({
+      raw: '{}',
+      parsed: { accessToken: 'access', refreshToken: 'refresh', expiresAt: 1_000 }
+    })
+
+    const order: string[] = []
+    mocks.fetchClaudeUsage.mockImplementation(async (_override, ctx) => {
+      order.push(ctx.accountId)
+      if (ctx.accountId === 'row-a') {
+        return { success: false, error: 'Token refresh failed: invalid_grant (bad)', needsLogin: true }
+      }
+      return { success: false, error: 'Usage API returned 500: boom' }
+    })
+
+    const results = await refreshAllForProvider('anthropic')
+
+    expect(order).toEqual(['row-a', 'row-b'])
+    expect(results).toEqual([
+      { accountId: 'row-a', success: false, error: 'Token refresh failed: invalid_grant (bad)', retryAfter: undefined },
+      { accountId: 'row-b', success: false, error: 'Usage API returned 500: boom', retryAfter: undefined }
+    ])
     expect(mocks.db.updateSavedUsageAccountUsage).toHaveBeenCalledWith(
-      'saved-claude-id',
-      expect.objectContaining({
-        status: 'error',
-        last_error: 'Usage API returned 403: Forbidden'
-      })
+      'row-a',
+      expect.objectContaining({ status: 'stale' })
+    )
+    expect(mocks.db.updateSavedUsageAccountUsage).toHaveBeenCalledWith(
+      'row-b',
+      expect.objectContaining({ status: 'error' })
     )
   })
 })
+
+describe('removeSavedAccount', () => {
+  it('removes the managed store account and the cache row', async () => {
+    mocks.db.getSavedUsageAccountById.mockReturnValue(savedRow({ id: 'saved-1' }))
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.db.deleteSavedUsageAccount.mockReturnValue(true)
+
+    const result = await removeSavedAccount('saved-1')
+
+    expect(result).toBe(true)
+    expect(mocks.removeClaudeAccount).toHaveBeenCalledWith('1', 'claude@example.com')
+    expect(mocks.db.deleteSavedUsageAccount).toHaveBeenCalledWith('saved-1')
+  })
+
+  it('still deletes the cache row when the store account is already gone', async () => {
+    mocks.db.getSavedUsageAccountById.mockReturnValue(savedRow({ id: 'saved-1' }))
+    mocks.listClaudeAccounts.mockResolvedValue([])
+    mocks.db.deleteSavedUsageAccount.mockReturnValue(true)
+
+    const result = await removeSavedAccount('saved-1')
+
+    expect(result).toBe(true)
+    expect(mocks.removeClaudeAccount).not.toHaveBeenCalled()
+    expect(mocks.db.deleteSavedUsageAccount).toHaveBeenCalledWith('saved-1')
+  })
+
+  it('returns false without touching the store when the cache row does not exist', async () => {
+    mocks.db.getSavedUsageAccountById.mockReturnValue(null)
+
+    const result = await removeSavedAccount('missing')
+
+    expect(result).toBe(false)
+    expect(mocks.removeClaudeAccount).not.toHaveBeenCalled()
+    expect(mocks.removeCodexAccount).not.toHaveBeenCalled()
+  })
+})
+
+describe('switchAccount', () => {
+  it('switches the Claude store account on the happy path', async () => {
+    mocks.db.getSavedUsageAccountById.mockReturnValue(savedRow({ id: 'saved-1' }))
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+
+    const result = await switchAccount('saved-1')
+
+    expect(result).toEqual({ success: true })
+    expect(mocks.switchClaudeAccount).toHaveBeenCalledWith('1', 'claude@example.com')
+  })
+
+  it('maps a missing store account to an error result', async () => {
+    mocks.db.getSavedUsageAccountById.mockReturnValue(savedRow({ id: 'saved-1' }))
+    mocks.listClaudeAccounts.mockResolvedValue([])
+
+    const result = await switchAccount('saved-1')
+
+    expect(result).toEqual({ success: false, error: 'account no longer in store' })
+    expect(mocks.switchClaudeAccount).not.toHaveBeenCalled()
+  })
+
+  it('maps a thrown switch error to an error result', async () => {
+    mocks.db.getSavedUsageAccountById.mockReturnValue(savedRow({ id: 'saved-1' }))
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+    mocks.switchClaudeAccount.mockRejectedValue(new Error('keychain exploded'))
+
+    const result = await switchAccount('saved-1')
+
+    expect(result).toEqual({ success: false, error: 'keychain exploded' })
+  })
+})
+
+describe('captureLiveAccountFromFetch', () => {
+  it('adds an unknown live Claude account to the store and writes no SQLite credentials', async () => {
+    mocks.readClaudeLiveIdentity.mockResolvedValue({ email: 'New@Example.com', uuid: 'uuid-9' })
+    mocks.listClaudeAccounts.mockResolvedValue([])
+    mocks.readClaudeLiveRawBlob.mockResolvedValue('{"claudeAiOauth":{"accessToken":"a"}}')
+
+    await captureLiveAccountFromFetch('anthropic', usageData())
+
+    expect(mocks.addClaudeAccount).toHaveBeenCalledWith(
+      'new@example.com',
+      'uuid-9',
+      '{"claudeAiOauth":{"accessToken":"a"}}'
+    )
+    expect(mocks.db.upsertSavedUsageAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'anthropic', email: 'new@example.com', credentials_json: '' })
+    )
+  })
+
+  it('does not re-add a Claude live account that is already managed', async () => {
+    mocks.readClaudeLiveIdentity.mockResolvedValue({ email: 'claude@example.com', uuid: 'uuid-1' })
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+
+    await captureLiveAccountFromFetch('anthropic', usageData())
+
+    expect(mocks.addClaudeAccount).not.toHaveBeenCalled()
+    expect(mocks.db.upsertSavedUsageAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ credentials_json: '' })
+    )
+  })
+
+  it('adds an unknown live Codex account to the store and writes no SQLite credentials', async () => {
+    const idToken = buildCodexIdToken('user-9', 'acct-9', 'codex-new@example.com')
+    mocks.readCodexCredentials.mockResolvedValue({
+      tokens: {
+        id_token: idToken,
+        access_token: 'access-9',
+        refresh_token: 'refresh-9',
+        account_id: 'acct-9'
+      }
+    })
+    mocks.listCodexAccounts.mockResolvedValue([])
+
+    await captureLiveAccountFromFetch('openai', {
+      plan_type: 'plus',
+      rate_limit: { primary_window: null, secondary_window: null }
+    })
+
+    expect(mocks.addCodexAccount).toHaveBeenCalledWith(idToken, 'access-9', 'refresh-9')
+    expect(mocks.db.upsertSavedUsageAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'openai',
+        email: 'codex-new@example.com',
+        credentials_json: ''
+      })
+    )
+  })
+
+  it('does not re-add a Codex live account that is already managed', async () => {
+    const idToken = buildCodexIdToken('user-1', 'acct-1', 'codex@example.com')
+    mocks.readCodexCredentials.mockResolvedValue({
+      tokens: {
+        id_token: idToken,
+        access_token: 'access-1',
+        refresh_token: 'refresh-1',
+        account_id: 'acct-1'
+      }
+    })
+    mocks.listCodexAccounts.mockResolvedValue([codexAccount()])
+
+    await captureLiveAccountFromFetch('openai', {
+      plan_type: 'plus',
+      rate_limit: { primary_window: null, secondary_window: null }
+    })
+
+    expect(mocks.addCodexAccount).not.toHaveBeenCalled()
+  })
+})
+
+describe('refreshTokensForStoreAccount', () => {
+  it('refreshes a Claude account and persists via updateClaudeTokens', async () => {
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({
+      raw: '{}',
+      parsed: { accessToken: 'old-access', refreshToken: 'old-refresh', expiresAt: 1_000 }
+    })
+    mocks.refreshAnthropicToken.mockResolvedValue({
+      ok: true,
+      result: { accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt: 2_000 },
+      scope: 'a b'
+    })
+
+    const outcome = await refreshTokensForStoreAccount('anthropic', { num: '1', email: 'claude@example.com' })
+
+    expect(outcome).toBe('refreshed')
+    expect(mocks.updateClaudeTokens).toHaveBeenCalledWith(
+      '1',
+      'claude@example.com',
+      { accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt: 2_000 },
+      'a b'
+    )
+  })
+
+  it('reports needsLogin and marks the cache row stale on invalid_grant', async () => {
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({
+      raw: '{}',
+      parsed: { accessToken: 'old-access', refreshToken: 'old-refresh', expiresAt: 1_000 }
+    })
+    mocks.refreshAnthropicToken.mockResolvedValue({ ok: false, needsLogin: true, error: 'invalid_grant' })
+    mocks.db.getSavedUsageAccountByProviderEmail.mockReturnValue(savedRow({ id: 'row-1' }))
+
+    const outcome = await refreshTokensForStoreAccount('anthropic', { num: '1', email: 'claude@example.com' })
+
+    expect(outcome).toBe('needsLogin')
+    expect(mocks.updateClaudeTokens).not.toHaveBeenCalled()
+    expect(mocks.db.updateSavedUsageAccountUsage).toHaveBeenCalledWith(
+      'row-1',
+      expect.objectContaining({ status: 'stale' })
+    )
+  })
+
+  it('reports error (without marking stale) when the refresh call throws', async () => {
+    mocks.readClaudeEffectiveBlob.mockResolvedValue({
+      raw: '{}',
+      parsed: { accessToken: 'old-access', refreshToken: 'old-refresh', expiresAt: 1_000 }
+    })
+    mocks.refreshAnthropicToken.mockRejectedValue(new Error('network down'))
+
+    const outcome = await refreshTokensForStoreAccount('anthropic', { num: '1', email: 'claude@example.com' })
+
+    expect(outcome).toBe('error')
+    expect(mocks.db.updateSavedUsageAccountUsage).not.toHaveBeenCalled()
+  })
+
+  it('refreshes a Codex account and persists via updateCodexTokens', async () => {
+    mocks.readCodexEffectiveAuth.mockResolvedValue({
+      tokens: { access_token: 'old-access', refresh_token: 'old-refresh', account_id: 'acct-1' }
+    })
+    mocks.refreshOpenAIToken.mockResolvedValue({
+      ok: true,
+      result: { accessToken: 'new-access', refreshToken: 'new-refresh', idToken: 'new-id' }
+    })
+
+    const outcome = await refreshTokensForStoreAccount('openai', { accountKey: 'user-1::acct-1' })
+
+    expect(outcome).toBe('refreshed')
+    expect(mocks.updateCodexTokens).toHaveBeenCalledWith('user-1::acct-1', {
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+      idToken: 'new-id'
+    })
+  })
+
+  it('reports needsLogin for a Codex account rejected with invalid_grant', async () => {
+    mocks.readCodexEffectiveAuth.mockResolvedValue({
+      tokens: { access_token: 'old-access', refresh_token: 'old-refresh', account_id: 'acct-1' }
+    })
+    mocks.refreshOpenAIToken.mockResolvedValue({ ok: false, needsLogin: true, error: 'invalid_grant' })
+    mocks.listCodexAccounts.mockResolvedValue([codexAccount()])
+    mocks.db.getSavedUsageAccountByProviderEmail.mockReturnValue(savedRow({ id: 'row-openai-1' }))
+
+    const outcome = await refreshTokensForStoreAccount('openai', { accountKey: 'user-1::acct-1' })
+
+    expect(outcome).toBe('needsLogin')
+    expect(mocks.updateCodexTokens).not.toHaveBeenCalled()
+    expect(mocks.db.updateSavedUsageAccountUsage).toHaveBeenCalledWith(
+      'row-openai-1',
+      expect.objectContaining({ status: 'stale' })
+    )
+  })
+})
+
+function base64url(value: string): string {
+  return Buffer.from(value, 'utf-8').toString('base64url')
+}
+
+function buildCodexIdToken(userId: string, accountId: string, email: string, plan = 'plus'): string {
+  const header = base64url(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+  const body = base64url(
+    JSON.stringify({
+      email,
+      'https://api.openai.com/auth': {
+        chatgpt_user_id: userId,
+        chatgpt_account_id: accountId,
+        chatgpt_plan_type: plan
+      }
+    })
+  )
+  return `${header}.${body}.fake-signature`
+}

--- a/test/usage/saved-usage-orchestrator.refresh.test.ts
+++ b/test/usage/saved-usage-orchestrator.refresh.test.ts
@@ -15,18 +15,21 @@ const mocks = vi.hoisted(() => ({
   readCodexCredentials: vi.fn(),
   listClaudeAccounts: vi.fn(),
   readClaudeEffectiveBlob: vi.fn(),
+  readClaudeLiveEmail: vi.fn(),
   readClaudeLiveIdentity: vi.fn(),
   readClaudeLiveRawBlob: vi.fn(),
   updateClaudeTokens: vi.fn(),
   switchClaudeAccount: vi.fn(),
   addClaudeAccount: vi.fn(),
   removeClaudeAccount: vi.fn(),
+  persistRotatedLiveClaudeTokens: vi.fn(),
   listCodexAccounts: vi.fn(),
   readCodexEffectiveAuth: vi.fn(),
   updateCodexTokens: vi.fn(),
   switchCodexAccount: vi.fn(),
   addCodexAccount: vi.fn(),
   removeCodexAccount: vi.fn(),
+  persistRotatedLiveCodexTokens: vi.fn(),
   migrateSavedCredentialsToStores: vi.fn(),
   refreshAnthropicToken: vi.fn(),
   refreshOpenAIToken: vi.fn()
@@ -60,12 +63,14 @@ vi.mock('../../src/main/services/openai-usage-service', () => ({
 vi.mock('../../src/main/services/account-store-claude', () => ({
   listClaudeAccounts: mocks.listClaudeAccounts,
   readClaudeEffectiveBlob: mocks.readClaudeEffectiveBlob,
+  readClaudeLiveEmail: mocks.readClaudeLiveEmail,
   readClaudeLiveIdentity: mocks.readClaudeLiveIdentity,
   readClaudeLiveRawBlob: mocks.readClaudeLiveRawBlob,
   updateClaudeTokens: mocks.updateClaudeTokens,
   switchClaudeAccount: mocks.switchClaudeAccount,
   addClaudeAccount: mocks.addClaudeAccount,
-  removeClaudeAccount: mocks.removeClaudeAccount
+  removeClaudeAccount: mocks.removeClaudeAccount,
+  persistRotatedLiveClaudeTokens: mocks.persistRotatedLiveClaudeTokens
 }))
 
 vi.mock('../../src/main/services/account-store-codex', () => ({
@@ -74,7 +79,8 @@ vi.mock('../../src/main/services/account-store-codex', () => ({
   updateCodexTokens: mocks.updateCodexTokens,
   switchCodexAccount: mocks.switchCodexAccount,
   addCodexAccount: mocks.addCodexAccount,
-  removeCodexAccount: mocks.removeCodexAccount
+  removeCodexAccount: mocks.removeCodexAccount,
+  persistRotatedLiveCodexTokens: mocks.persistRotatedLiveCodexTokens
 }))
 
 vi.mock('../../src/main/services/credentials-migration', () => ({
@@ -98,6 +104,7 @@ import {
   removeSavedAccount,
   switchAccount
 } from '../../src/main/services/saved-usage-orchestrator'
+import { fetchUsageOp } from '../../src/main/services/usage-ops'
 import type { SavedUsageAccount } from '../../src/main/db/types'
 import type { ClaudeStoreAccount } from '../../src/main/services/account-store-claude'
 import type { CodexStoreAccount } from '../../src/main/services/account-store-codex'
@@ -158,6 +165,7 @@ beforeEach(() => {
   mocks.migrateSavedCredentialsToStores.mockResolvedValue(undefined)
   mocks.listClaudeAccounts.mockResolvedValue([])
   mocks.listCodexAccounts.mockResolvedValue([])
+  mocks.readClaudeLiveEmail.mockResolvedValue(null)
   mocks.db.getSavedUsageAccountsByProvider.mockReturnValue([])
   mocks.db.upsertSavedUsageAccount.mockImplementation((data: { email: string }) =>
     savedRow({ ...data, id: `new-${data.email}` })
@@ -952,6 +960,83 @@ describe('account-level refresh/fetch locking', () => {
     expect(secondOutcome).toBe('refreshed')
     expect(mocks.refreshAnthropicToken).toHaveBeenCalledTimes(1)
     expect(mocks.updateClaudeTokens).toHaveBeenCalledTimes(1)
+  })
+
+  // Fix B: the live usage-ops fetch must share the SAME per-account lock as the
+  // saved-account path so a left-click live fetch and a mass refresh/watcher
+  // tick for the same account can't double-consume the single-use refresh token.
+  it('serializes a live fetchUsageOp against a concurrent fetchForSavedAccount for the same account', async () => {
+    mocks.readClaudeLiveEmail.mockResolvedValue('claude@example.com')
+    mocks.readClaudeLiveIdentity.mockResolvedValue({ email: 'claude@example.com', uuid: 'uuid-1' })
+    mocks.db.getSavedUsageAccountById.mockReturnValue(savedRow())
+    mocks.listClaudeAccounts.mockResolvedValue([claudeAccount()])
+
+    let inFlight = 0
+    let maxInFlight = 0
+    mocks.fetchClaudeUsage.mockImplementation(async () => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      if (inFlight > 1) {
+        throw new Error('overlap detected: live fetch and saved fetch ran concurrently')
+      }
+      await flushMicrotasks()
+      inFlight -= 1
+      return { success: true, data: usageData() }
+    })
+
+    const [liveResult, savedResult] = await Promise.all([
+      fetchUsageOp(),
+      fetchForSavedAccount('saved-1')
+    ])
+
+    expect(liveResult.success).toBe(true)
+    expect(savedResult.success).toBe(true)
+    expect(maxInFlight).toBe(1)
+    expect(mocks.fetchClaudeUsage).toHaveBeenCalledTimes(2)
+  })
+
+  // Fix C: a switch must serialize against a concurrent live rotation-persist
+  // (fetchUsageOp) on the OUTGOING account, so the persist can't clobber the
+  // just-switched live credentials in its guard-read → write window.
+  it('serializes switchAccount against a concurrent live fetchUsageOp on the outgoing account', async () => {
+    // Live (outgoing) account is `old@example.com`; we switch TO `new@example.com`.
+    mocks.readClaudeLiveEmail.mockResolvedValue('old@example.com')
+    mocks.readClaudeLiveIdentity.mockResolvedValue({ email: 'old@example.com', uuid: 'uuid-old' })
+    mocks.db.getSavedUsageAccountById.mockReturnValue(
+      savedRow({ id: 'saved-target', email: 'new@example.com' })
+    )
+    mocks.listClaudeAccounts.mockResolvedValue([
+      claudeAccount({ num: '1', email: 'old@example.com' }),
+      claudeAccount({ num: '2', email: 'new@example.com', active: false })
+    ])
+
+    let inFlight = 0
+    let maxInFlight = 0
+    const track = async (): Promise<void> => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      if (inFlight > 1) {
+        throw new Error('overlap detected: switch and live persist ran concurrently')
+      }
+      await flushMicrotasks()
+      inFlight -= 1
+    }
+    mocks.switchClaudeAccount.mockImplementation(async () => {
+      await track()
+    })
+    mocks.fetchClaudeUsage.mockImplementation(async () => {
+      await track()
+      return { success: true, data: usageData() }
+    })
+
+    const [switchResult, fetchResult] = await Promise.all([
+      switchAccount('saved-target'),
+      fetchUsageOp()
+    ])
+
+    expect(switchResult).toEqual({ success: true })
+    expect(fetchResult.success).toBe(true)
+    expect(maxInFlight).toBe(1)
   })
 })
 

--- a/test/usage/usage-normalization.test.ts
+++ b/test/usage/usage-normalization.test.ts
@@ -16,6 +16,39 @@ describe('normalizeUsage', () => {
     expect(usage).toBeNull()
   })
 
+  it('keeps Anthropic usage whose idle window has a null resets_at (real API shape)', () => {
+    // The usage API returns { utilization: 0, resets_at: null } for a window with
+    // no active session — e.g. an account that hasn't started a 5h block. The
+    // seven_day data is real and must not be discarded.
+    const usage = normalizeUsage(
+      'anthropic',
+      {
+        five_hour: { utilization: 0, resets_at: null },
+        seven_day: { utilization: 66, resets_at: '2026-07-10T01:59:59.752656+00:00' }
+      } as never,
+      null
+    )
+
+    expect(usage).not.toBeNull()
+    expect(usage?.five_hour.utilization).toBe(0)
+    expect(usage?.five_hour.resets_at).toBeNull()
+    expect(usage?.seven_day.utilization).toBe(66)
+  })
+
+  it('keeps Anthropic usage whose window omits resets_at entirely', () => {
+    const usage = normalizeUsage(
+      'anthropic',
+      {
+        five_hour: { utilization: 12 },
+        seven_day: { utilization: 40, resets_at: '2026-07-10T01:59:59.000Z' }
+      } as never,
+      null
+    )
+
+    expect(usage).not.toBeNull()
+    expect(usage?.seven_day.utilization).toBe(40)
+  })
+
   it('treats Anthropic usage with a null quota window as unavailable', () => {
     const usage = normalizeUsage(
       'anthropic',

--- a/test/usage/usage-ops.test.ts
+++ b/test/usage/usage-ops.test.ts
@@ -7,7 +7,9 @@ const mocks = vi.hoisted(() => ({
   fetchOpenAIUsage: vi.fn(),
   readCodexCredentials: vi.fn(),
   persistRotatedLiveClaudeTokens: vi.fn(),
+  readClaudeLiveEmail: vi.fn(),
   persistRotatedLiveCodexTokens: vi.fn(),
+  listCodexAccounts: vi.fn(),
   captureLiveAccountFromFetch: vi.fn(),
   fetchForSavedAccount: vi.fn(),
   refreshAllForProvider: vi.fn()
@@ -30,11 +32,13 @@ vi.mock('../../src/main/services/openai-usage-service', () => ({
 }))
 
 vi.mock('../../src/main/services/account-store-claude', () => ({
-  persistRotatedLiveClaudeTokens: mocks.persistRotatedLiveClaudeTokens
+  persistRotatedLiveClaudeTokens: mocks.persistRotatedLiveClaudeTokens,
+  readClaudeLiveEmail: mocks.readClaudeLiveEmail
 }))
 
 vi.mock('../../src/main/services/account-store-codex', () => ({
-  persistRotatedLiveCodexTokens: mocks.persistRotatedLiveCodexTokens
+  persistRotatedLiveCodexTokens: mocks.persistRotatedLiveCodexTokens,
+  listCodexAccounts: mocks.listCodexAccounts
 }))
 
 vi.mock('../../src/main/services/saved-usage-orchestrator', () => ({
@@ -49,6 +53,8 @@ describe('fetchUsageOp', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.captureLiveAccountFromFetch.mockResolvedValue(undefined)
+    mocks.readClaudeLiveEmail.mockResolvedValue(null)
+    mocks.listCodexAccounts.mockResolvedValue([])
   })
 
   it('persists rotated live Claude tokens using the token the refresh actually consumed (rotatedFrom), not a pre-read token', async () => {
@@ -178,6 +184,8 @@ describe('fetchOpenAIUsageOp', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.captureLiveAccountFromFetch.mockResolvedValue(undefined)
+    mocks.readClaudeLiveEmail.mockResolvedValue(null)
+    mocks.listCodexAccounts.mockResolvedValue([])
   })
 
   it('persists rotated live Codex tokens using the token the refresh actually consumed (rotatedFrom), not a pre-read token', async () => {

--- a/test/usage/usage-ops.test.ts
+++ b/test/usage/usage-ops.test.ts
@@ -139,6 +139,39 @@ describe('fetchUsageOp', () => {
     expect(result.success).toBe(true)
     expect(mocks.persistRotatedLiveClaudeTokens).not.toHaveBeenCalled()
   })
+
+  it('persists rotated live Claude tokens even when the overall usage fetch FAILED (e.g. a transient 500 after a successful proactive rotation)', async () => {
+    // The rotation already happened server-side (the old refresh token is
+    // burned) even though the usage HTTP request itself failed — the new
+    // tokens must still be persisted or the live store is left holding a
+    // dead refresh token.
+    mocks.fetchClaudeUsage.mockResolvedValue({
+      success: false,
+      error: 'Usage API returned 500: Internal Server Error',
+      rotated: {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: 2000,
+        rotatedFrom: 'internal-refresh-token'
+      }
+    })
+    mocks.persistRotatedLiveClaudeTokens.mockResolvedValue('persisted')
+
+    const result = await fetchUsageOp()
+
+    expect(result.success).toBe(false)
+    expect(mocks.persistRotatedLiveClaudeTokens).toHaveBeenCalledWith(
+      {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: 2000,
+        rotatedFrom: 'internal-refresh-token'
+      },
+      'internal-refresh-token',
+      undefined
+    )
+    expect(mocks.captureLiveAccountFromFetch).not.toHaveBeenCalled()
+  })
 })
 
 describe('fetchOpenAIUsageOp', () => {
@@ -215,5 +248,31 @@ describe('fetchOpenAIUsageOp', () => {
 
     expect(result.success).toBe(true)
     expect(mocks.persistRotatedLiveCodexTokens).not.toHaveBeenCalled()
+  })
+
+  it('persists rotated live Codex tokens even when the overall usage fetch FAILED (e.g. a transient 500 after a successful proactive rotation)', async () => {
+    mocks.fetchOpenAIUsage.mockResolvedValue({
+      success: false,
+      error: 'OpenAI Usage API returned 500: Internal Server Error',
+      rotated: {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        rotatedFrom: 'internal-refresh-token'
+      }
+    })
+    mocks.persistRotatedLiveCodexTokens.mockResolvedValue('persisted')
+
+    const result = await fetchOpenAIUsageOp()
+
+    expect(result.success).toBe(false)
+    expect(mocks.persistRotatedLiveCodexTokens).toHaveBeenCalledWith(
+      {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        rotatedFrom: 'internal-refresh-token'
+      },
+      'internal-refresh-token'
+    )
+    expect(mocks.captureLiveAccountFromFetch).not.toHaveBeenCalled()
   })
 })

--- a/test/usage/usage-ops.test.ts
+++ b/test/usage/usage-ops.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetchClaudeUsage: vi.fn(),
+  readClaudeCredentialsBlob: vi.fn(),
+  fetchOpenAIUsage: vi.fn(),
+  readCodexCredentials: vi.fn(),
+  persistRotatedLiveClaudeTokens: vi.fn(),
+  persistRotatedLiveCodexTokens: vi.fn(),
+  captureLiveAccountFromFetch: vi.fn(),
+  fetchForSavedAccount: vi.fn(),
+  refreshAllForProvider: vi.fn()
+}))
+
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }))
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+vi.mock('../../src/main/services/usage-service', () => ({
+  fetchClaudeUsage: mocks.fetchClaudeUsage,
+  readClaudeCredentialsBlob: mocks.readClaudeCredentialsBlob
+}))
+
+vi.mock('../../src/main/services/openai-usage-service', () => ({
+  fetchOpenAIUsage: mocks.fetchOpenAIUsage,
+  readCodexCredentials: mocks.readCodexCredentials
+}))
+
+vi.mock('../../src/main/services/account-store-claude', () => ({
+  persistRotatedLiveClaudeTokens: mocks.persistRotatedLiveClaudeTokens
+}))
+
+vi.mock('../../src/main/services/account-store-codex', () => ({
+  persistRotatedLiveCodexTokens: mocks.persistRotatedLiveCodexTokens
+}))
+
+vi.mock('../../src/main/services/saved-usage-orchestrator', () => ({
+  captureLiveAccountFromFetch: mocks.captureLiveAccountFromFetch,
+  fetchForSavedAccount: mocks.fetchForSavedAccount,
+  refreshAllForProvider: mocks.refreshAllForProvider
+}))
+
+import { fetchOpenAIUsageOp, fetchUsageOp } from '../../src/main/services/usage-ops'
+
+describe('fetchUsageOp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.captureLiveAccountFromFetch.mockResolvedValue(undefined)
+  })
+
+  it('persists rotated live Claude tokens using the pre-fetch refresh token, then captures the account', async () => {
+    mocks.readClaudeCredentialsBlob.mockResolvedValue({
+      accessToken: 'old-access',
+      refreshToken: 'old-refresh',
+      expiresAt: 1000
+    })
+    mocks.fetchClaudeUsage.mockResolvedValue({
+      success: true,
+      data: { five_hour: {}, seven_day: {} },
+      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt: 2000, scope: 'a b' }
+    })
+    mocks.persistRotatedLiveClaudeTokens.mockResolvedValue('persisted')
+
+    const result = await fetchUsageOp()
+
+    expect(result.success).toBe(true)
+    expect(mocks.persistRotatedLiveClaudeTokens).toHaveBeenCalledWith(
+      { accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt: 2000, scope: 'a b' },
+      'old-refresh',
+      'a b'
+    )
+    expect(mocks.captureLiveAccountFromFetch).toHaveBeenCalledWith('anthropic', result.data)
+  })
+
+  it('does not call persist when there is nothing rotated', async () => {
+    mocks.readClaudeCredentialsBlob.mockResolvedValue({ accessToken: 'a', refreshToken: 'r', expiresAt: 1000 })
+    mocks.fetchClaudeUsage.mockResolvedValue({ success: true, data: { five_hour: {}, seven_day: {} } })
+
+    await fetchUsageOp()
+
+    expect(mocks.persistRotatedLiveClaudeTokens).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when persistRotatedLiveClaudeTokens rejects, and still captures the account', async () => {
+    mocks.readClaudeCredentialsBlob.mockResolvedValue({ accessToken: 'a', refreshToken: 'old-refresh' })
+    mocks.fetchClaudeUsage.mockResolvedValue({
+      success: true,
+      data: { five_hour: {}, seven_day: {} },
+      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt: 2000 }
+    })
+    mocks.persistRotatedLiveClaudeTokens.mockRejectedValue(new Error('keychain exploded'))
+
+    const result = await fetchUsageOp()
+
+    expect(result.success).toBe(true)
+    expect(mocks.captureLiveAccountFromFetch).toHaveBeenCalled()
+  })
+
+  it('skips persistence gracefully (without throwing) when there was no pre-fetch refresh token to compare against', async () => {
+    mocks.readClaudeCredentialsBlob.mockResolvedValue(null)
+    mocks.fetchClaudeUsage.mockResolvedValue({
+      success: true,
+      data: { five_hour: {}, seven_day: {} },
+      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt: 2000 }
+    })
+
+    const result = await fetchUsageOp()
+
+    expect(result.success).toBe(true)
+    expect(mocks.persistRotatedLiveClaudeTokens).not.toHaveBeenCalled()
+  })
+})
+
+describe('fetchOpenAIUsageOp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.captureLiveAccountFromFetch.mockResolvedValue(undefined)
+  })
+
+  it('persists rotated live Codex tokens using the pre-fetch refresh token, then captures the account', async () => {
+    mocks.readCodexCredentials.mockResolvedValue({ tokens: { refresh_token: 'old-refresh' } })
+    mocks.fetchOpenAIUsage.mockResolvedValue({
+      success: true,
+      data: { plan_type: 'plus', rate_limit: { primary_window: null, secondary_window: null } },
+      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh', idToken: 'new-id' }
+    })
+    mocks.persistRotatedLiveCodexTokens.mockResolvedValue('persisted')
+
+    const result = await fetchOpenAIUsageOp()
+
+    expect(result.success).toBe(true)
+    expect(mocks.persistRotatedLiveCodexTokens).toHaveBeenCalledWith(
+      { accessToken: 'new-access', refreshToken: 'new-refresh', idToken: 'new-id' },
+      'old-refresh'
+    )
+    expect(mocks.captureLiveAccountFromFetch).toHaveBeenCalledWith('openai', result.data)
+  })
+
+  it('logs but does not throw when persistRotatedLiveCodexTokens resolves skipped-race', async () => {
+    mocks.readCodexCredentials.mockResolvedValue({ tokens: { refresh_token: 'old-refresh' } })
+    mocks.fetchOpenAIUsage.mockResolvedValue({
+      success: true,
+      data: { plan_type: 'plus', rate_limit: { primary_window: null, secondary_window: null } },
+      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh' }
+    })
+    mocks.persistRotatedLiveCodexTokens.mockResolvedValue('skipped-race')
+
+    const result = await fetchOpenAIUsageOp()
+
+    expect(result.success).toBe(true)
+    expect(mocks.persistRotatedLiveCodexTokens).toHaveBeenCalled()
+  })
+})

--- a/test/usage/usage-ops.test.ts
+++ b/test/usage/usage-ops.test.ts
@@ -51,16 +51,27 @@ describe('fetchUsageOp', () => {
     mocks.captureLiveAccountFromFetch.mockResolvedValue(undefined)
   })
 
-  it('persists rotated live Claude tokens using the pre-fetch refresh token, then captures the account', async () => {
+  it('persists rotated live Claude tokens using the token the refresh actually consumed (rotatedFrom), not a pre-read token', async () => {
+    // A pre-read (if usage-ops still did one) would see 'stale-pre-read' —
+    // fetchClaudeUsage re-reads live credentials internally and may refresh
+    // with a newer token (e.g. the CLI rotated concurrently). The persisted
+    // race-check must use `rotated.rotatedFrom`, the token the internal
+    // refresh actually consumed, not the stale pre-read.
     mocks.readClaudeCredentialsBlob.mockResolvedValue({
       accessToken: 'old-access',
-      refreshToken: 'old-refresh',
+      refreshToken: 'stale-pre-read',
       expiresAt: 1000
     })
     mocks.fetchClaudeUsage.mockResolvedValue({
       success: true,
       data: { five_hour: {}, seven_day: {} },
-      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt: 2000, scope: 'a b' }
+      rotated: {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: 2000,
+        scope: 'a b',
+        rotatedFrom: 'internal-refresh-token'
+      }
     })
     mocks.persistRotatedLiveClaudeTokens.mockResolvedValue('persisted')
 
@@ -68,15 +79,28 @@ describe('fetchUsageOp', () => {
 
     expect(result.success).toBe(true)
     expect(mocks.persistRotatedLiveClaudeTokens).toHaveBeenCalledWith(
-      { accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt: 2000, scope: 'a b' },
-      'old-refresh',
+      {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: 2000,
+        scope: 'a b',
+        rotatedFrom: 'internal-refresh-token'
+      },
+      'internal-refresh-token',
       'a b'
     )
     expect(mocks.captureLiveAccountFromFetch).toHaveBeenCalledWith('anthropic', result.data)
   })
 
+  it('does not pre-read live Claude credentials at all', async () => {
+    mocks.fetchClaudeUsage.mockResolvedValue({ success: true, data: { five_hour: {}, seven_day: {} } })
+
+    await fetchUsageOp()
+
+    expect(mocks.readClaudeCredentialsBlob).not.toHaveBeenCalled()
+  })
+
   it('does not call persist when there is nothing rotated', async () => {
-    mocks.readClaudeCredentialsBlob.mockResolvedValue({ accessToken: 'a', refreshToken: 'r', expiresAt: 1000 })
     mocks.fetchClaudeUsage.mockResolvedValue({ success: true, data: { five_hour: {}, seven_day: {} } })
 
     await fetchUsageOp()
@@ -85,11 +109,15 @@ describe('fetchUsageOp', () => {
   })
 
   it('does not throw when persistRotatedLiveClaudeTokens rejects, and still captures the account', async () => {
-    mocks.readClaudeCredentialsBlob.mockResolvedValue({ accessToken: 'a', refreshToken: 'old-refresh' })
     mocks.fetchClaudeUsage.mockResolvedValue({
       success: true,
       data: { five_hour: {}, seven_day: {} },
-      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh', expiresAt: 2000 }
+      rotated: {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: 2000,
+        rotatedFrom: 'internal-refresh-token'
+      }
     })
     mocks.persistRotatedLiveClaudeTokens.mockRejectedValue(new Error('keychain exploded'))
 
@@ -99,8 +127,7 @@ describe('fetchUsageOp', () => {
     expect(mocks.captureLiveAccountFromFetch).toHaveBeenCalled()
   })
 
-  it('skips persistence gracefully (without throwing) when there was no pre-fetch refresh token to compare against', async () => {
-    mocks.readClaudeCredentialsBlob.mockResolvedValue(null)
+  it('skips persistence gracefully (without throwing) when the rotated result has no rotatedFrom reference token', async () => {
     mocks.fetchClaudeUsage.mockResolvedValue({
       success: true,
       data: { five_hour: {}, seven_day: {} },
@@ -120,12 +147,20 @@ describe('fetchOpenAIUsageOp', () => {
     mocks.captureLiveAccountFromFetch.mockResolvedValue(undefined)
   })
 
-  it('persists rotated live Codex tokens using the pre-fetch refresh token, then captures the account', async () => {
-    mocks.readCodexCredentials.mockResolvedValue({ tokens: { refresh_token: 'old-refresh' } })
+  it('persists rotated live Codex tokens using the token the refresh actually consumed (rotatedFrom), not a pre-read token', async () => {
+    // Same rationale as the Claude test above: fetchOpenAIUsage re-reads
+    // live credentials internally, so a pre-read (if usage-ops still did
+    // one) could be stale relative to what the internal refresh consumed.
+    mocks.readCodexCredentials.mockResolvedValue({ tokens: { refresh_token: 'stale-pre-read' } })
     mocks.fetchOpenAIUsage.mockResolvedValue({
       success: true,
       data: { plan_type: 'plus', rate_limit: { primary_window: null, secondary_window: null } },
-      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh', idToken: 'new-id' }
+      rotated: {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        idToken: 'new-id',
+        rotatedFrom: 'internal-refresh-token'
+      }
     })
     mocks.persistRotatedLiveCodexTokens.mockResolvedValue('persisted')
 
@@ -133,18 +168,33 @@ describe('fetchOpenAIUsageOp', () => {
 
     expect(result.success).toBe(true)
     expect(mocks.persistRotatedLiveCodexTokens).toHaveBeenCalledWith(
-      { accessToken: 'new-access', refreshToken: 'new-refresh', idToken: 'new-id' },
-      'old-refresh'
+      {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        idToken: 'new-id',
+        rotatedFrom: 'internal-refresh-token'
+      },
+      'internal-refresh-token'
     )
     expect(mocks.captureLiveAccountFromFetch).toHaveBeenCalledWith('openai', result.data)
   })
 
+  it('does not pre-read live Codex credentials at all', async () => {
+    mocks.fetchOpenAIUsage.mockResolvedValue({
+      success: true,
+      data: { plan_type: 'plus', rate_limit: { primary_window: null, secondary_window: null } }
+    })
+
+    await fetchOpenAIUsageOp()
+
+    expect(mocks.readCodexCredentials).not.toHaveBeenCalled()
+  })
+
   it('logs but does not throw when persistRotatedLiveCodexTokens resolves skipped-race', async () => {
-    mocks.readCodexCredentials.mockResolvedValue({ tokens: { refresh_token: 'old-refresh' } })
     mocks.fetchOpenAIUsage.mockResolvedValue({
       success: true,
       data: { plan_type: 'plus', rate_limit: { primary_window: null, secondary_window: null } },
-      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh' }
+      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh', rotatedFrom: 'internal-refresh-token' }
     })
     mocks.persistRotatedLiveCodexTokens.mockResolvedValue('skipped-race')
 
@@ -152,5 +202,18 @@ describe('fetchOpenAIUsageOp', () => {
 
     expect(result.success).toBe(true)
     expect(mocks.persistRotatedLiveCodexTokens).toHaveBeenCalled()
+  })
+
+  it('skips persistence gracefully (without throwing) when the rotated result has no rotatedFrom reference token', async () => {
+    mocks.fetchOpenAIUsage.mockResolvedValue({
+      success: true,
+      data: { plan_type: 'plus', rate_limit: { primary_window: null, secondary_window: null } },
+      rotated: { accessToken: 'new-access', refreshToken: 'new-refresh' }
+    })
+
+    const result = await fetchOpenAIUsageOp()
+
+    expect(result.success).toBe(true)
+    expect(mocks.persistRotatedLiveCodexTokens).not.toHaveBeenCalled()
   })
 })

--- a/test/usage/usage-service.refresh.test.ts
+++ b/test/usage/usage-service.refresh.test.ts
@@ -73,7 +73,8 @@ describe('fetchClaudeUsage saved-account refresh', () => {
     expect(result.success).toBe(true)
     expect(result.rotated).toMatchObject({
       accessToken: 'new-access-token',
-      refreshToken: 'new-refresh-token'
+      refreshToken: 'new-refresh-token',
+      rotatedFrom: 'old-refresh-token'
     })
     expect(result.rotated?.expiresAt).toBeGreaterThan(Date.now())
     expect(fetchMock).toHaveBeenNthCalledWith(
@@ -124,7 +125,8 @@ describe('fetchClaudeUsage saved-account refresh', () => {
     expect(result.data?.five_hour.utilization).toBe(44)
     expect(result.rotated).toMatchObject({
       accessToken: 'retry-access-token',
-      refreshToken: 'retry-refresh-token'
+      refreshToken: 'retry-refresh-token',
+      rotatedFrom: 'old-refresh-token'
     })
     expect(fetchMock).toHaveBeenNthCalledWith(
       3,
@@ -237,7 +239,8 @@ describe('fetchClaudeUsage saved-account refresh', () => {
     expect(result.success).toBe(true)
     expect(result.rotated).toMatchObject({
       accessToken: 'live-new-access',
-      refreshToken: 'live-new-refresh'
+      refreshToken: 'live-new-refresh',
+      rotatedFrom: 'live-refresh-token'
     })
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
@@ -292,7 +295,8 @@ describe('fetchClaudeUsage saved-account refresh', () => {
     expect(result.data?.five_hour.utilization).toBe(77)
     expect(result.rotated).toMatchObject({
       accessToken: 'live-retry-access',
-      refreshToken: 'live-retry-refresh'
+      refreshToken: 'live-retry-refresh',
+      rotatedFrom: 'live-refresh-token'
     })
     expect(fetchMock).toHaveBeenCalledTimes(3)
     expect(fetchMock).toHaveBeenNthCalledWith(

--- a/test/usage/usage-service.refresh.test.ts
+++ b/test/usage/usage-service.refresh.test.ts
@@ -135,7 +135,7 @@ describe('fetchClaudeUsage saved-account refresh', () => {
     )
   })
 
-  it('returns a token refresh failure when the 401 retry refresh fails', async () => {
+  it('returns a token refresh failure (with needsLogin) when the 401 retry refresh fails', async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(jsonResponse({ error: 'expired' }, { status: 401, statusText: 'Unauthorized' }))
@@ -154,6 +154,7 @@ describe('fetchClaudeUsage saved-account refresh', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toContain('Token refresh failed')
+    expect(result.needsLogin).toBe(true)
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
@@ -190,7 +191,7 @@ describe('fetchClaudeUsage saved-account refresh', () => {
     expect(fetchMock.mock.calls.filter(([url]) => String(url) === TOKEN_URL)).toHaveLength(1)
   })
 
-  it('does not attempt refresh for a legacy saved account without a refresh token', async () => {
+  it('does not attempt refresh for a legacy saved account without a refresh token, and flags needsLogin', async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(jsonResponse({ error: 'expired' }, { status: 401, statusText: 'Unauthorized' }))
@@ -203,11 +204,12 @@ describe('fetchClaudeUsage saved-account refresh', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toContain('Usage API returned 401')
+    expect(result.needsLogin).toBe(true)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(USAGE_URL, expect.anything())
   })
 
-  it('does not refresh live Claude credentials even when the stored blob is expired', async () => {
+  it('refreshes live Claude credentials proactively when the stored blob is expired, and returns rotated tokens', async () => {
     await mkdir(join(osMock.homeDir, '.claude'), { recursive: true })
     await writeFile(
       join(osMock.homeDir, '.claude', '.credentials.json'),
@@ -221,21 +223,187 @@ describe('fetchClaudeUsage saved-account refresh', () => {
     )
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse({ error: 'expired' }, { status: 401, statusText: 'Unauthorized' }))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { access_token: 'live-new-access', refresh_token: 'live-new-refresh', expires_in: 3600 },
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(jsonResponse(usageData(), { status: 200 }))
     vi.stubGlobal('fetch', fetchMock)
 
     const result = await fetchClaudeUsage(undefined, { caller: 'usage:fetch' })
 
-    expect(result.success).toBe(false)
-    expect(result.error).toContain('Usage API returned 401')
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(result.success).toBe(true)
+    expect(result.rotated).toMatchObject({
+      accessToken: 'live-new-access',
+      refreshToken: 'live-new-refresh'
+    })
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      TOKEN_URL,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          grant_type: 'refresh_token',
+          refresh_token: 'live-refresh-token',
+          client_id: '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
+        })
+      })
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
       USAGE_URL,
       expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: 'Bearer live-access-token' })
+        headers: expect.objectContaining({ Authorization: 'Bearer live-new-access' })
       })
     )
 
     await rm(osMock.homeDir, { recursive: true, force: true })
+  })
+
+  it('refreshes and retries once when the live usage request returns 401 (reactive path)', async () => {
+    await mkdir(join(osMock.homeDir, '.claude'), { recursive: true })
+    await writeFile(
+      join(osMock.homeDir, '.claude', '.credentials.json'),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'live-expired-access',
+          refreshToken: 'live-refresh-token',
+          expiresAt: Date.now() + 3600_000
+        }
+      })
+    )
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ error: 'expired' }, { status: 401, statusText: 'Unauthorized' }))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { access_token: 'live-retry-access', refresh_token: 'live-retry-refresh', expires_in: 7200 },
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(jsonResponse(usageData(77), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchClaudeUsage(undefined, { caller: 'usage:fetch' })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.five_hour.utilization).toBe(77)
+    expect(result.rotated).toMatchObject({
+      accessToken: 'live-retry-access',
+      refreshToken: 'live-retry-refresh'
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      USAGE_URL,
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer live-retry-access' })
+      })
+    )
+
+    await rm(osMock.homeDir, { recursive: true, force: true })
+  })
+
+  it('sets needsLogin and a Token refresh failed: invalid_grant error when the refresh itself needs login', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ error: 'invalid_grant' }, { status: 400, statusText: 'Bad Request' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchClaudeUsage(
+      {
+        accessToken: 'expired-access-token',
+        refreshToken: 'dead-refresh-token',
+        expiresAt: Date.now() - 1_000,
+        accountId: 'acct-needs-login'
+      },
+      { caller: 'usage:fetchForAccount', accountId: 'acct-needs-login' }
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.needsLogin).toBe(true)
+    expect(result.error).toContain('Token refresh failed: invalid_grant')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  describe('scoped (model-specific) usage limits', () => {
+    it('parses limits[] into data.scoped, dropping entries without scope.model.display_name', async () => {
+      const fetchMock = vi.fn().mockResolvedValueOnce(
+        jsonResponse(
+          {
+            ...usageData(),
+            limits: [
+              {
+                percent: 42,
+                resets_at: '2026-06-01T00:00:00.000Z',
+                scope: { model: { display_name: 'Fable' } }
+              },
+              { percent: 10, resets_at: null, scope: { model: {} } },
+              { percent: 5, scope: {} },
+              { percent: 1 }
+            ]
+          },
+          { status: 200 }
+        )
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchClaudeUsage(
+        { accessToken: 'tok', accountId: 'acct-scoped' },
+        { caller: 'usage:fetchForAccount', accountId: 'acct-scoped' }
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.data?.scoped).toEqual([
+        { label: 'Fable', used_percent: 42, resets_at: '2026-06-01T00:00:00.000Z' }
+      ])
+    })
+
+    it('defaults used_percent to 0 and resets_at to null when the entry omits them', async () => {
+      const fetchMock = vi.fn().mockResolvedValueOnce(
+        jsonResponse(
+          { ...usageData(), limits: [{ scope: { model: { display_name: 'Opus' } } }] },
+          { status: 200 }
+        )
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchClaudeUsage(
+        { accessToken: 'tok', accountId: 'acct-scoped-defaults' },
+        { caller: 'usage:fetchForAccount', accountId: 'acct-scoped-defaults' }
+      )
+
+      expect(result.data?.scoped).toEqual([{ label: 'Opus', used_percent: 0, resets_at: null }])
+    })
+
+    it('omits data.scoped entirely when limits has no usable entries', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ ...usageData(), limits: [{ percent: 5 }] }, { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchClaudeUsage(
+        { accessToken: 'tok', accountId: 'acct-scoped-empty' },
+        { caller: 'usage:fetchForAccount', accountId: 'acct-scoped-empty' }
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.data?.scoped).toBeUndefined()
+    })
+
+    it('omits data.scoped when limits is absent from the response entirely', async () => {
+      const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(usageData(), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchClaudeUsage(
+        { accessToken: 'tok', accountId: 'acct-scoped-absent' },
+        { caller: 'usage:fetchForAccount', accountId: 'acct-scoped-absent' }
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.data?.scoped).toBeUndefined()
+    })
   })
 })

--- a/test/usage/usage-service.refresh.test.ts
+++ b/test/usage/usage-service.refresh.test.ts
@@ -310,6 +310,113 @@ describe('fetchClaudeUsage saved-account refresh', () => {
     await rm(osMock.homeDir, { recursive: true, force: true })
   })
 
+  describe('rotated token surfacing on usage-request failure (after a successful proactive rotation)', () => {
+    it('carries rotated (with rotatedFrom) on a non-2xx usage response, so the new refresh token still gets persisted', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            { access_token: 'proactive-new-access', refresh_token: 'proactive-new-refresh', expires_in: 3600 },
+            { status: 200 }
+          )
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({ error: 'server error' }, { status: 500, statusText: 'Internal Server Error' })
+        )
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchClaudeUsage(
+        {
+          accessToken: 'old-access-token',
+          refreshToken: 'old-refresh-token',
+          expiresAt: Date.now() - 1_000,
+          accountId: 'acct-500'
+        },
+        { caller: 'usage:fetchForAccount', accountId: 'acct-500' }
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Usage API returned 500')
+      expect(result.rotated).toMatchObject({
+        accessToken: 'proactive-new-access',
+        refreshToken: 'proactive-new-refresh',
+        rotatedFrom: 'old-refresh-token'
+      })
+    })
+
+    it('carries rotated (with rotatedFrom) when the usage request throws (e.g. network error/timeout)', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            { access_token: 'proactive-new-access', refresh_token: 'proactive-new-refresh', expires_in: 3600 },
+            { status: 200 }
+          )
+        )
+        .mockRejectedValueOnce(new Error('network down'))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchClaudeUsage(
+        {
+          accessToken: 'old-access-token',
+          refreshToken: 'old-refresh-token',
+          expiresAt: Date.now() - 1_000,
+          accountId: 'acct-network-error'
+        },
+        { caller: 'usage:fetchForAccount', accountId: 'acct-network-error' }
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('network down')
+      expect(result.rotated).toMatchObject({
+        accessToken: 'proactive-new-access',
+        refreshToken: 'proactive-new-refresh',
+        rotatedFrom: 'old-refresh-token'
+      })
+    })
+
+    it('still surfaces the earlier proactive rotation when the reactive 401-retry refresh itself needs login', async () => {
+      const fetchMock = vi
+        .fn()
+        // Proactive refresh (expiresAt already elapsed) succeeds.
+        .mockResolvedValueOnce(
+          jsonResponse(
+            { access_token: 'proactive-new-access', refresh_token: 'proactive-new-refresh', expires_in: 3600 },
+            { status: 200 }
+          )
+        )
+        // Usage request with the freshly rotated token still comes back 401.
+        .mockResolvedValueOnce(jsonResponse({ error: 'expired' }, { status: 401, statusText: 'Unauthorized' }))
+        // The reactive retry refresh is rejected outright (invalid_grant).
+        .mockResolvedValueOnce(
+          jsonResponse({ error: 'invalid_grant' }, { status: 400, statusText: 'Bad Request' })
+        )
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchClaudeUsage(
+        {
+          accessToken: 'old-access-token',
+          refreshToken: 'old-refresh-token',
+          expiresAt: Date.now() - 1_000,
+          accountId: 'acct-double-refresh'
+        },
+        { caller: 'usage:fetchForAccount', accountId: 'acct-double-refresh' }
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.needsLogin).toBe(true)
+      // The rotated tokens from the FIRST (proactive) refresh must still be
+      // surfaced so the caller persists them — otherwise the live store is
+      // left holding the now-burned `old-refresh-token`.
+      expect(result.rotated).toMatchObject({
+        accessToken: 'proactive-new-access',
+        refreshToken: 'proactive-new-refresh',
+        rotatedFrom: 'old-refresh-token'
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+    })
+  })
+
   it('sets needsLogin and a Token refresh failed: invalid_grant error when the refresh itself needs login', async () => {
     const fetchMock = vi
       .fn()

--- a/test/usage/use-usage-store.test.ts
+++ b/test/usage/use-usage-store.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { SavedAccountDTO } from '@shared/types/usage'
 import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
 import { useUsageStore, type UsageData } from '@/stores/useUsageStore'
 import { toast } from '@/lib/toast'
@@ -186,6 +187,53 @@ describe('useUsageStore', () => {
     expect(state.openaiLastFetchedAt).toBeNull()
     expect(state.openaiIsLoading).toBe(false)
     expect(toast.error).toHaveBeenCalledWith('OpenAI usage refresh failed: OpenAI auth failed')
+  })
+
+  function anthropicAccount(id: string, email: string): SavedAccountDTO {
+    return {
+      id,
+      provider: 'anthropic',
+      email,
+      last_usage: null,
+      last_fetched_at: null,
+      status: 'ok',
+      last_error: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+      plan: null
+    }
+  }
+
+  it('does not toast a refresh failure when the fetch succeeded but the post-op reload hiccups', async () => {
+    useUsageStore.setState({
+      savedAccounts: { anthropic: [anthropicAccount('acc-1', 'a@b.com')], openai: [] }
+    } as Partial<ReturnType<typeof useUsageStore.getState>>)
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.fetchForAccount') return { success: true, status: 'ok' }
+      if (method === 'accountOps.listSaved') throw new Error('reload hiccup')
+      return null
+    })
+
+    await useUsageStore.getState().refreshSavedAccount('acc-1', { userInitiated: true })
+
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('toasts switch success even when a post-switch reload fails', async () => {
+    useUsageStore.setState({
+      savedAccounts: { anthropic: [anthropicAccount('acc-1', 'a@b.com')], openai: [] }
+    } as Partial<ReturnType<typeof useUsageStore.getState>>)
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.switchAccount') return { success: true }
+      if (method === 'accountOps.getClaudeEmail') return 'a@b.com'
+      if (method === 'accountOps.listSaved') throw new Error('reload hiccup')
+      if (method === 'usageOps.fetch') return { success: true, data: sampleUsage }
+      return null
+    })
+
+    await useUsageStore.getState().switchAccount('acc-1')
+
+    expect(toast.success).toHaveBeenCalledWith('Switched to a@b.com')
+    expect(toast.error).not.toHaveBeenCalled()
   })
 
   it('merges Anthropic rate-limit windows and drops stale windows', () => {

--- a/test/usage/use-usage-store.test.ts
+++ b/test/usage/use-usage-store.test.ts
@@ -2,6 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
 import { useUsageStore, type UsageData } from '@/stores/useUsageStore'
+import { toast } from '@/lib/toast'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn()
+  }
+}))
 
 const sampleUsage: UsageData = {
   five_hour: {
@@ -30,6 +38,8 @@ describe('useUsageStore', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-14T09:00:00.000Z'))
+    vi.mocked(toast.error).mockClear()
+    vi.mocked(toast.success).mockClear()
 
     request = vi.fn(async (method: string) => {
       if (method === 'accountOps.listSaved') return []
@@ -74,6 +84,7 @@ describe('useUsageStore', () => {
     expect(state.anthropicLastError).toBe('No access token found')
     expect(state.anthropicLastFetchedAt).toBeNull()
     expect(state.anthropicIsLoading).toBe(false)
+    expect(toast.error).not.toHaveBeenCalled()
   })
 
   it('records envelope-level Anthropic failures without rejecting or advancing debounce', async () => {
@@ -97,6 +108,49 @@ describe('useUsageStore', () => {
     expect(state.anthropicLastError).toBe('Could not decode usage response')
     expect(state.anthropicLastFetchedAt).toBeNull()
     expect(state.anthropicIsLoading).toBe(false)
+    expect(toast.error).toHaveBeenCalledWith(
+      'Claude usage refresh failed: Could not decode usage response'
+    )
+  })
+
+  it('always fetches on an explicit force refresh, even shortly after a successful attempt', async () => {
+    useUsageStore.setState({
+      anthropicLastFetchedAt: Date.now() - 1_000,
+      anthropicLastError: null
+    } as Partial<ReturnType<typeof useUsageStore.getState>>)
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.fetch') return { success: true, data: sampleUsage }
+      if (method === 'accountOps.listSaved') return []
+      return null
+    })
+
+    await useUsageStore.getState().forceRefreshProvider('anthropic')
+
+    expect(request.mock.calls.filter(([method]) => method === 'usageOps.fetch')).toHaveLength(1)
+    expect(usageState().anthropicUsage).toBe(sampleUsage)
+  })
+
+  it('blocks a force refresh while a 429 retry-after window is active and toasts instead of fetching', async () => {
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.fetch') {
+        return {
+          success: false,
+          error: 'Usage API returned 429: Too Many Requests',
+          retryAfter: 30
+        }
+      }
+      if (method === 'accountOps.listSaved') return []
+      return null
+    })
+
+    await useUsageStore.getState().forceRefreshProvider('anthropic')
+    vi.mocked(toast.error).mockClear()
+    request.mockClear()
+
+    await useUsageStore.getState().forceRefreshProvider('anthropic')
+
+    expect(request.mock.calls.filter(([method]) => method === 'usageOps.fetch')).toHaveLength(0)
+    expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/^Rate limited — retry in \d+s$/))
   })
 
   it('clears Anthropic errors and advances debounce after a successful fetch', async () => {
@@ -131,6 +185,7 @@ describe('useUsageStore', () => {
     expect(state.openaiLastError).toBe('OpenAI auth failed')
     expect(state.openaiLastFetchedAt).toBeNull()
     expect(state.openaiIsLoading).toBe(false)
+    expect(toast.error).toHaveBeenCalledWith('OpenAI usage refresh failed: OpenAI auth failed')
   })
 
   it('merges Anthropic rate-limit windows and drops stale windows', () => {


### PR DESCRIPTION
## Summary
- Add real-Chrome OAuth login flows and supporting RPCs for Claude and Codex accounts.
- Replace the usage pipeline with store-backed orchestration, rotation-safe token persistence, and account maintenance.
- Harden account-store, keychain, and migration internals to handle races, missing secrets, case-insensitive cache rows, and terminal-state edge cases.
- Update the renderer with login banners, account settings, improved usage interactions, and hover-based details.
- Add coverage across login, OAuth, usage orchestration, account maintenance, RPC routing, and renderer/store behavior.

## Testing
- Ran and expanded unit tests for login, OAuth, keychain, atomic JSON, JWT utilities, account stores, usage orchestration, and renderer stores.
- Added RPC and integration-style tests for account and usage domains, including retry and refresh flows.
- Verified saved-usage behavior for idle windows and rotation/failure recovery scenarios.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large auth surface: macOS Keychain, live CLI credential files, OAuth refresh rotation, account switching, and automated background token refresh—errors can break sign-in or clobber credentials in race scenarios (mitigated but not eliminated).
> 
> **Overview**
> Introduces **ccswitch-compatible** Claude (Keychain + `sequence.json`) and Codex (`registry.json` / snapshots) account stores as the source of truth, with SQLite `saved_usage_accounts` reduced to a **usage cache** after a one-time credentials migration.
> 
> **OAuth and maintenance:** Shared PKCE and Anthropic/OpenAI authorize/refresh/exchange helpers; in-process **Chrome** sign-in via `patchright` (`login-service`); boot-time migration, mass refresh, and a 60s expiry watcher (`account-maintenance`, wired from the server bin). **Per-account async locks** serialize refresh, live fetch, switch, and watcher so single-use refresh tokens are not double-consumed; live rotations persist with a re-read race guard before writing CLI-facing creds.
> 
> **Usage pipeline:** Orchestrator lists/removes/switches against the stores, reads effective creds from Keychain/files, persists rotations to store slots, and surfaces `needsLogin` / stale status. Live usage ops mirror rotated tokens to live Claude/Codex locations under the same locks. Claude live identity for the Active badge uses the nested `.claude.json` path; DB upserts normalize emails and match legacy mixed-case rows.
> 
> **UI:** Login banner, usage hover card with per-account **Switch** / **Sign in again**, scoped usage rows, and new `accountOps` RPC wrappers (switch, login start/status/cancel). Packaged app unpacks `patchright` from ASAR for Chrome child processes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8513e10b1c11fc0cb1f5bdca37c4be0fb7896c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->