### PR TITLE
Add manual refresh action to usage accounts

### DIFF
--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -83,6 +83,98 @@ describe('UsageAccountRow', () => {
     expect(onSwitch).toHaveBeenCalledTimes(1)
   })
 
+  it('shows a Refresh button and calls onRefresh when clicked', async () => {
+    const user = userEvent.setup()
+    const onRefresh = vi.fn()
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-r1',
+          email: 'other@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+        onSwitch={vi.fn()}
+        onRefresh={onRefresh}
+      />
+    )
+
+    const button = screen.getByRole('button', {
+      name: /refresh usage for other@example.com/i
+    }) as HTMLButtonElement
+    expect(button.disabled).toBe(false)
+    await user.click(button)
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the Refresh button for the active account too', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-r2',
+          email: 'active@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: true,
+          isRefreshing: false
+        }}
+        onSwitch={vi.fn()}
+        onRefresh={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: /switch to/i })).toBeNull()
+    expect(
+      screen.getByRole('button', { name: /refresh usage for active@example.com/i })
+    ).toBeTruthy()
+  })
+
+  it('disables the Refresh button while the account is refreshing', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-r3',
+          email: 'other@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: true
+        }}
+        onSwitch={vi.fn()}
+        onRefresh={vi.fn()}
+      />
+    )
+
+    const button = screen.getByRole('button', {
+      name: /refresh usage for other@example.com/i
+    }) as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+  })
+
+  it('does not render a Refresh button when onRefresh is not provided', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'anthropic-active',
+          email: 'active@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: true,
+          isRefreshing: false
+        }}
+        onSwitch={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: /refresh usage/i })).toBeNull()
+  })
+
   it('disables the Switch button and shows a spinner while switching', () => {
     render(
       <UsageAccountRow

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -11,7 +11,7 @@ import {
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { cn } from '@/lib/utils'
-import { Loader2 } from 'lucide-react'
+import { Loader2, RefreshCw } from 'lucide-react'
 import claudeIcon from '@/assets/model-icons/claude.svg'
 import openaiIcon from '@/assets/model-icons/openai.svg'
 import type {
@@ -187,6 +187,7 @@ export interface UsageAccountRowProps {
   isSwitching?: boolean
   isLoginActive?: boolean
   onSwitch?: () => void
+  onRefresh?: () => void
   onSignInAgain?: () => void
 }
 
@@ -195,6 +196,7 @@ export function UsageAccountRow({
   isSwitching = false,
   isLoginActive = false,
   onSwitch,
+  onRefresh,
   onSignInAgain
 }: UsageAccountRowProps): React.JSX.Element {
   const fiveHourPercent = row.usage ? Math.round(row.usage.five_hour.utilization) : 0
@@ -246,7 +248,7 @@ export function UsageAccountRow({
         ))}
       </div>
 
-      {(onSwitch || onSignInAgain) && (
+      {(onSwitch || onRefresh || onSignInAgain) && (
         <div className="mt-1.5 flex items-center gap-1.5">
           {!row.isActive && onSwitch && (
             <button
@@ -258,6 +260,22 @@ export function UsageAccountRow({
             >
               {isSwitching && <Loader2 className="h-2.5 w-2.5 animate-spin" />}
               Switch
+            </button>
+          )}
+          {onRefresh && (
+            <button
+              type="button"
+              onClick={onRefresh}
+              disabled={row.isRefreshing}
+              aria-label={`Refresh usage for ${row.email ?? 'this account'}`}
+              className="inline-flex items-center gap-1 rounded-sm border border-border/60 px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {row.isRefreshing ? (
+                <Loader2 className="h-2.5 w-2.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-2.5 w-2.5" />
+              )}
+              Refresh
             </button>
           )}
           {row.status === 'stale' && onSignInAgain && (
@@ -325,6 +343,7 @@ function ProviderUsageBlock({
   const refreshAllForProvider = useUsageStore((s) => s.refreshAllForProvider)
   const loadSavedAccounts = useUsageStore((s) => s.loadSavedAccounts)
   const switchAccount = useUsageStore((s) => s.switchAccount)
+  const refreshSavedAccount = useUsageStore((s) => s.refreshSavedAccount)
   const switchingAccountIds = useUsageStore((s) => s.switchingAccountIds)
   const savedAccounts = useUsageStore((s) => s.savedAccounts[provider])
   const savedAccountLoadError = useUsageStore((s) => s.savedAccountLoadErrors[provider])
@@ -449,6 +468,11 @@ function ProviderUsageBlock({
                   isSwitching={switchingAccountIds.has(row.id)}
                   isLoginActive={isLoginActive}
                   onSwitch={() => switchAccount(row.id)}
+                  onRefresh={
+                    savedAccounts.length > 0
+                      ? () => refreshSavedAccount(row.id, { userInitiated: true })
+                      : undefined
+                  }
                   onSignInAgain={() => startLogin(provider, row.email ?? undefined)}
                 />
               ))
@@ -540,6 +564,11 @@ function ProviderUsageBlock({
               isSwitching={switchingAccountIds.has(row.id)}
               isLoginActive={isLoginActive}
               onSwitch={() => switchAccount(row.id)}
+              onRefresh={
+                savedAccounts.length > 0
+                  ? () => refreshSavedAccount(row.id, { userInitiated: true })
+                  : undefined
+              }
               onSignInAgain={() => startLogin(provider, row.email ?? undefined)}
             />
           ))}


### PR DESCRIPTION
## Summary
- Add a `Refresh` action to usage account rows in the usage popover.
- Wire the action to refresh a saved account with a user-initiated flag.
- Show a loading spinner and disable the button while the account is refreshing.
- Add coverage for rendering, click behavior, disabled state, and omission when refresh is unavailable.

## Testing
- `Not run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change reusing existing `refreshSavedAccount` store logic; no auth or data-model changes in this diff.
> 
> **Overview**
> Adds a **Refresh** control on each saved-account row in the usage hover popover so users can manually re-fetch usage without leaving the sidebar.
> 
> `UsageAccountRow` gains an optional `onRefresh` callback and a small button (with `RefreshCw` / spinner) that is disabled while `row.isRefreshing` is true; the button is omitted when no handler is passed (e.g. synthetic single-account rows). The popover wires `onRefresh` to `refreshSavedAccount(id, { userInitiated: true })` only when saved accounts are loaded.
> 
> Tests cover click behavior, active vs inactive rows, disabled state during refresh, and hiding the button when refresh is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f6fe31f3312eb862be79d35c658bdc09761977d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->