### PR TITLE
Fix cmd+click selection for connection tickets

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -634,12 +634,21 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
         return
       }
 
+      // Cmd+click on a connection ticket — select the connection in the
+      // sidebar (same as ConnectionItem.handleClick), don't open the session
+      const ticketConnectionId = connectionId ?? connectionSession?.connectionId
+      if ((e.metaKey || e.ctrlKey) && ticketConnectionId && !isArchived) {
+        e.preventDefault()
+        useConnectionStore.getState().selectConnection(ticketConnectionId)
+        return
+      }
+
       useKanbanStore.getState().setSelectedTicketRef({
         projectId: ticket.project_id,
         ticketId: ticket.id
       })
     },
-    [ticket.id, ticket.worktree_id, ticket.project_id, isArchived, isPinnedMode, recordBoardTelegramTarget, blockingDiagnostic]
+    [ticket.id, ticket.worktree_id, ticket.project_id, isArchived, isPinnedMode, connectionId, connectionSession, recordBoardTelegramTarget, blockingDiagnostic]
   )
 
   // ── Middle-click — select attached worktree (same as sidebar) ─


### PR DESCRIPTION
## Summary
- Updated kanban ticket click handling so `Cmd/Ctrl+click` on a connection ticket selects the connection in the sidebar instead of opening the session.
- Kept the existing normal ticket selection behavior unchanged for non-modified clicks.
- Added the connection identifiers to the handler dependencies so the shortcut stays in sync with ticket state.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI click-handler branch with no auth, data, or API changes.
> 
> **Overview**
> **Cmd/Ctrl+click** on kanban cards for connection-backed tickets now **selects that connection in the sidebar** (matching `ConnectionItem` click behavior) instead of opening the ticket detail modal.
> 
> The shortcut resolves the connection from the board’s `connectionId` prop or from a ticket whose session lives on a connection. The existing **worktree** Cmd+click path still runs first when `worktree_id` is set. `handleClick` dependencies were updated so connection state stays correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d76adb5cfa66039d319fc81231f4e86834dc5af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->