### PR TITLE
Count subagent transcript tokens in Claude telemetry

### DIFF
--- a/src/main/services/__tests__/hive-enterprise-claude-cli-telemetry.test.ts
+++ b/src/main/services/__tests__/hive-enterprise-claude-cli-telemetry.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -154,6 +154,17 @@ function makeTranscript(text: string): string {
   const file = join(dir, 'transcript.jsonl')
   writeFileSync(file, text)
   return file
+}
+
+/**
+ * Write a subagent transcript next to the main transcript, mirroring Claude's
+ * on-disk layout: `<dir>/<sessionId>/subagents/agent-<id>.jsonl` for a main
+ * transcript at `<dir>/<sessionId>.jsonl`.
+ */
+function writeSubagentTranscript(transcriptPath: string, agentId: string, text: string): void {
+  const subagentsDir = join(transcriptPath.replace(/\.jsonl$/, ''), 'subagents')
+  mkdirSync(subagentsDir, { recursive: true })
+  writeFileSync(join(subagentsDir, `agent-${agentId}.jsonl`), text)
 }
 
 describe('Claude CLI Hive Enterprise telemetry', () => {
@@ -391,6 +402,129 @@ describe('Claude CLI Hive Enterprise telemetry', () => {
       {
         input: {
           promptId,
+          inputTokens: 140,
+          outputTokens: 30,
+          cacheReadTokens: 25,
+          cacheWriteTokens: 9
+        }
+      }
+    ])
+  })
+
+  it('includes subagent transcript usage in idle token deltas', async () => {
+    const transcriptPath = makeTranscript(
+      `${assistantLine({ input: 100, output: 5, cacheRead: 20, cacheWrite: 7 })}\n`
+    )
+    const db = makeDb({
+      hiveEnterpriseServerUrl: 'https://enterprise.example.com',
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1'
+    })
+
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'Fan out subagents',
+        transcript_path: transcriptPath
+      },
+      { db, requestGraphql }
+    )
+
+    // The turn spawns two Task subagents; their usage is written to separate
+    // transcripts under <sessionDir>/subagents/, never to the main transcript.
+    writeSubagentTranscript(
+      transcriptPath,
+      'a1',
+      [
+        assistantLine({ input: 50, output: 40, cacheRead: 1000, cacheWrite: 60 }),
+        assistantLine({ input: 10, output: 20, cacheRead: 2000, cacheWrite: 30 })
+      ].join('\n') + '\n'
+    )
+    writeSubagentTranscript(
+      transcriptPath,
+      'a2',
+      `${assistantLine({ input: 5, output: 15, cacheRead: 500, cacheWrite: 25 })}\n`
+    )
+    writeFileSync(
+      transcriptPath,
+      [
+        assistantLine({ input: 100, output: 5, cacheRead: 20, cacheWrite: 7 }),
+        assistantLine({ input: 140, output: 30, cacheRead: 25, cacheWrite: 9 })
+      ].join('\n') + '\n'
+    )
+
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      { hook_event_name: 'Stop', transcript_path: transcriptPath },
+      { db, requestGraphql }
+    )
+
+    expect(requestGraphql.mock.calls[1]).toEqual([
+      'https://enterprise.example.com/api/graphql',
+      'token-1',
+      expect.stringContaining('recordPromptIdle'),
+      {
+        input: {
+          promptId: SERVER_PROMPT_ID,
+          inputTokens: 140 + 50 + 10 + 5,
+          outputTokens: 30 + 40 + 20 + 15,
+          cacheReadTokens: 25 + 1000 + 2000 + 500,
+          cacheWriteTokens: 9 + 60 + 30 + 25
+        }
+      }
+    ])
+  })
+
+  it('excludes subagent usage from before the prompt via the start baseline', async () => {
+    const transcriptPath = makeTranscript(
+      `${assistantLine({ input: 100, output: 5, cacheRead: 20, cacheWrite: 7 })}\n`
+    )
+    // A subagent from a PREVIOUS prompt already exists at prompt start.
+    writeSubagentTranscript(
+      transcriptPath,
+      'old',
+      `${assistantLine({ input: 500, output: 400, cacheRead: 9000, cacheWrite: 300 })}\n`
+    )
+    const db = makeDb({
+      hiveEnterpriseServerUrl: 'https://enterprise.example.com',
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1'
+    })
+
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'Continue',
+        transcript_path: transcriptPath
+      },
+      { db, requestGraphql }
+    )
+
+    writeFileSync(
+      transcriptPath,
+      [
+        assistantLine({ input: 100, output: 5, cacheRead: 20, cacheWrite: 7 }),
+        assistantLine({ input: 140, output: 30, cacheRead: 25, cacheWrite: 9 })
+      ].join('\n') + '\n'
+    )
+
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      { hook_event_name: 'Stop', transcript_path: transcriptPath },
+      { db, requestGraphql }
+    )
+
+    // Only this turn's main-transcript delta — the old subagent's usage was
+    // captured in the baseline and must not leak into this prompt's totals.
+    expect(requestGraphql.mock.calls[1]).toEqual([
+      'https://enterprise.example.com/api/graphql',
+      'token-1',
+      expect.stringContaining('recordPromptIdle'),
+      {
+        input: {
+          promptId: SERVER_PROMPT_ID,
           inputTokens: 140,
           outputTokens: 30,
           cacheReadTokens: 25,

--- a/src/main/services/hive-enterprise-claude-cli-telemetry.ts
+++ b/src/main/services/hive-enterprise-claude-cli-telemetry.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { APP_SETTINGS_DB_KEY, DEFAULT_HIVE_ENTERPRISE_SERVER_URL } from '@shared/types/settings'
 import type { DatabaseService } from '../db/database'
 import { getDatabase } from '../db'
@@ -160,6 +161,33 @@ function readTranscript(path: string | null): string {
   }
 }
 
+/**
+ * Task subagents write their usage to separate transcripts under
+ * `<sessionDir>/subagents/agent-*.jsonl` (nested subagents included, flat),
+ * never to the main transcript — for a main transcript at
+ * `<dir>/<sessionId>.jsonl` the session dir is `<dir>/<sessionId>/`.
+ */
+function subagentTranscriptPaths(transcriptPath: string | null): string[] {
+  if (!transcriptPath || !transcriptPath.endsWith('.jsonl')) return []
+  const subagentsDir = join(transcriptPath.slice(0, -'.jsonl'.length), 'subagents')
+  try {
+    return readdirSync(subagentsDir)
+      .filter((name) => name.endsWith('.jsonl'))
+      .map((name) => join(subagentsDir, name))
+  } catch {
+    return []
+  }
+}
+
+/** Sum assistant usage across the main transcript and all subagent transcripts. */
+export function tokenCountersFromTranscriptFiles(transcriptPath: string | null): TokenCounters {
+  let total = tokenCountersFromClaudeTranscript(readTranscript(transcriptPath))
+  for (const subagentPath of subagentTranscriptPaths(transcriptPath)) {
+    total = addCounters(total, tokenCountersFromClaudeTranscript(readTranscript(subagentPath)))
+  }
+  return total
+}
+
 async function waitForTranscriptUsageDelta(
   transcriptPath: string | null,
   baseline: TokenCounters
@@ -168,10 +196,7 @@ async function waitForTranscriptUsageDelta(
   let delta = zeroCounters()
 
   for (let attempt = 0; attempt <= attempts; attempt++) {
-    delta = subtractCounters(
-      tokenCountersFromClaudeTranscript(readTranscript(transcriptPath)),
-      baseline
-    )
+    delta = subtractCounters(tokenCountersFromTranscriptFiles(transcriptPath), baseline)
     if (tokenTotal(delta) > 0 || !transcriptPath || attempt === attempts) {
       return delta
     }
@@ -332,7 +357,7 @@ async function buildPromptStartInput(
   const transcript = readTranscript(transcriptPath)
 
   return {
-    baseline: tokenCountersFromClaudeTranscript(transcript),
+    baseline: tokenCountersFromTranscriptFiles(transcriptPath),
     input: {
       prompt,
       sessionId,


### PR DESCRIPTION
## Summary
- Include token usage from Claude subagent transcripts under `<sessionDir>/subagents/agent-*.jsonl` when computing prompt-start baselines and idle deltas.
- Preserve the existing idle wait/retry behavior while fixing undercounting caused by subagent activity not appearing in the main transcript.
- Add regression coverage for subagent usage being included for the current prompt and excluded when it belongs to a previous prompt baseline.

## Testing
- Added Vitest coverage in `src/main/services/__tests__/hive-enterprise-claude-cli-telemetry.test.ts` for subagent transcript aggregation and baseline handling.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how enterprise usage metrics are computed for billing/analytics; logic is localized but incorrect baselines could still misreport token totals.
> 
> **Overview**
> **Claude CLI Hive Enterprise telemetry** now totals assistant token usage from the main transcript **and** Task subagent JSONL files under `<sessionDir>/subagents/`, fixing undercounting when subagents run off the main transcript.
> 
> Prompt-start **baselines** and **Stop** idle deltas both use the new `tokenCountersFromTranscriptFiles` helper (including the existing flush poll/retry). Subagent usage that already existed at prompt start stays in the baseline so it is not double-counted on idle. **Context length** on prompt start is still derived from the main transcript only.
> 
> Vitest adds coverage for aggregating current-turn subagent usage and for excluding pre-prompt subagent files via the start baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911bc51efd214c7a191a8a85eeb586ed5c5470fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->