### PR TITLE
Report active accounts and show org member avatars

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -25,6 +25,10 @@ playwright-cli -s=<s> tab-select 1   # tab 0 is the pet overlay, tab 1 is the ma
 ## Data & test targets
 
 - Dev shares the real `~/.hive/hive.db` with the installed app — only exercise the
+  test projects below, OR set `HIVE_DESKTOP_BASE_DIR=<dir>` at launch to point the
+  backend at an isolated data dir (`<dir>/hive.db`). Plain `HOME=` is NOT enough:
+  `app.getPath('home')` ignores `$HOME` on macOS, so the backend would still open
+  the real DB (verified 2026-07-08).
   **test-python** (GitHub remote) and **ct-test** (no remote) projects.
 - Inspect state read-only: `sqlite3 -readonly ~/.hive/hive.db "..."` (projects, worktrees,
   connections, connection_members tables).

--- a/src/main/desktop/backend-manager.ts
+++ b/src/main/desktop/backend-manager.ts
@@ -537,7 +537,11 @@ export const startDesktopBackend = async (
 
   const log = deps.logger ?? defaultLog
   const headless = input.headless ?? false
-  const baseDir = input.baseDir ?? join(app.getPath('home'), '.hive')
+  // HIVE_DESKTOP_BASE_DIR redirects the backend's data dir (and thus its
+  // hive.db) for E2E/dev runs. `app.getPath('home')` ignores $HOME on macOS
+  // (getpwuid), so without this a dev build always opens the real user DB.
+  const baseDir =
+    input.baseDir ?? process.env.HIVE_DESKTOP_BASE_DIR ?? join(app.getPath('home'), '.hive')
   // `dev:web` pins the backend to a known free port via HIVE_DESKTOP_BACKEND_PORT so
   // its Vite dev server can target it. When set, scan only that single port.
   const pinnedPort = parseDesktopBackendPortEnv(process.env.HIVE_DESKTOP_BACKEND_PORT)

--- a/src/main/services/__tests__/hive-enterprise-claude-cli-telemetry.test.ts
+++ b/src/main/services/__tests__/hive-enterprise-claude-cli-telemetry.test.ts
@@ -20,6 +20,14 @@ vi.mock('../git-service', () => ({
   }))
 }))
 
+const accountServiceMocks = vi.hoisted(() => ({
+  getClaudeAccountEmail: vi.fn()
+}))
+
+vi.mock('../account-service', () => ({
+  getClaudeAccountEmail: accountServiceMocks.getClaudeAccountEmail
+}))
+
 // The server now generates the prompt id and returns it from recordPromptStart.
 const SERVER_PROMPT_ID = 'ServerGenerated123_prompt'
 
@@ -167,6 +175,7 @@ describe('Claude CLI Hive Enterprise telemetry', () => {
       url: 'git@github.com:example/hive.git',
       remote: 'origin'
     })
+    accountServiceMocks.getClaudeAccountEmail.mockResolvedValue('alice@example.com')
     requestGraphql.mockResolvedValue({
       recordPromptStart: { recorded: true, promptId: SERVER_PROMPT_ID }
     })
@@ -220,11 +229,63 @@ describe('Claude CLI Hive Enterprise telemetry', () => {
           isGoalPrompt: false,
           contextLength: 127,
           loggedAt: '2026-06-07T10:00:00.000Z',
-          connectionProjects: JSON.stringify([{ name: 'Hive Electron', path: '/repo' }])
+          connectionProjects: JSON.stringify([{ name: 'Hive Electron', path: '/repo' }]),
+          accountEmail: 'alice@example.com',
+          accountProvider: 'anthropic'
         })
       }
     )
     expect(requestGraphql.mock.calls[0][3].input).not.toHaveProperty('promptId')
+  })
+
+  it('stamps null account fields when no Claude account email can be resolved', async () => {
+    accountServiceMocks.getClaudeAccountEmail.mockResolvedValue(null)
+    const transcriptPath = makeTranscript('')
+    const db = makeDb({
+      hiveEnterpriseServerUrl: 'https://enterprise.example.com',
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1'
+    })
+
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'No account logged in',
+        transcript_path: transcriptPath
+      },
+      { db, requestGraphql }
+    )
+
+    expect(requestGraphql.mock.calls[0][3].input).toMatchObject({
+      accountEmail: null,
+      accountProvider: null
+    })
+  })
+
+  it('stamps null account fields when the Claude account email read fails', async () => {
+    accountServiceMocks.getClaudeAccountEmail.mockRejectedValue(new Error('keychain unavailable'))
+    const transcriptPath = makeTranscript('')
+    const db = makeDb({
+      hiveEnterpriseServerUrl: 'https://enterprise.example.com',
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1'
+    })
+
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'Account read fails',
+        transcript_path: transcriptPath
+      },
+      { db, requestGraphql }
+    )
+
+    expect(requestGraphql.mock.calls[0][3].input).toMatchObject({
+      accountEmail: null,
+      accountProvider: null
+    })
   })
 
   it('sends zero context length when the Claude CLI transcript has no prior assistant context', async () => {

--- a/src/main/services/hive-enterprise-claude-cli-telemetry.ts
+++ b/src/main/services/hive-enterprise-claude-cli-telemetry.ts
@@ -3,6 +3,7 @@ import { APP_SETTINGS_DB_KEY, DEFAULT_HIVE_ENTERPRISE_SERVER_URL } from '@shared
 import type { DatabaseService } from '../db/database'
 import { getDatabase } from '../db'
 import type { Project } from '../db/types'
+import { getClaudeAccountEmail } from './account-service'
 import { GitService } from './git-service'
 import { createLogger } from './logger'
 import { isTaskNotificationPrompt } from './claude-cli-subagent-tracker'
@@ -71,6 +72,11 @@ interface PromptStartInput {
   handoffSessionId: string | null
   loggedAt: string
   connectionProjects: string | null
+  // Stamp only — the server-side touch on this mutation refreshes the
+  // matching member_active_accounts row's last_seen_at. This hook is Claude
+  // CLI-only, so a resolved email always means the 'anthropic' provider.
+  accountEmail: string | null
+  accountProvider: string | null
 }
 
 interface PromptIdleInput {
@@ -330,6 +336,7 @@ async function buildPromptStartInput(
     (worktree?.project_id ? db.getProject(worktree.project_id) : null) ??
     (session?.project_id ? db.getProject(session.project_id) : null)
   const transcript = readTranscript(transcriptPath)
+  const accountEmail = await getClaudeAccountEmail().catch(() => null)
 
   return {
     baseline: tokenCountersFromClaudeTranscript(transcript),
@@ -351,7 +358,9 @@ async function buildPromptStartInput(
       isGoalPrompt: prompt.trimStart().startsWith('/goal'),
       handoffSessionId: null,
       loggedAt: now.toISOString(),
-      connectionProjects: connectionProjects(db, session?.connection_id ?? null)
+      connectionProjects: connectionProjects(db, session?.connection_id ?? null),
+      accountEmail,
+      accountProvider: accountEmail ? 'anthropic' : null
     }
   }
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import { isHiveTelemetryEnabled, refreshHiveEnterpriseOrg } from '@/api/hive-ent
 import { AppLayout } from '@/components/layout'
 import { ErrorBoundary } from '@/components/error'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { reportActiveAccountsSnapshot } from '@/lib/hive-account-report'
 import { initPlatform } from '@/lib/platform'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useTipStore } from '@/stores/useTipStore'
@@ -28,6 +29,7 @@ function App(): React.JSX.Element {
     if (!isHiveTelemetryEnabled({ hiveAuthToken, hiveOrganizationId })) return
     didRefreshHiveOrg.current = true
     void refreshHiveEnterpriseOrg()
+    void reportActiveAccountsSnapshot()
   }, [hiveAuthToken, hiveOrganizationId, settingsLoading])
 
   if (!ready) return <div />

--- a/src/renderer/src/api/hive-enterprise/client.ts
+++ b/src/renderer/src/api/hive-enterprise/client.ts
@@ -1,19 +1,24 @@
 import { GraphQLClient } from 'graphql-request'
 import { useSettingsStore, type AppSettings } from '@/stores/useSettingsStore'
 import {
+  ListAccountMembersDocument,
   MeDocument,
   RecordPromptIdleDocument,
   RecordPromptStartDocument,
-  RecordQuestionsAnsweredDocument
+  RecordQuestionsAnsweredDocument,
+  ReportActiveAccountsDocument
 } from './operations'
 import type {
+  GqlHiveEnterpriseListAccountMembersQuery,
   GqlHiveEnterpriseMeQuery,
   GqlHiveEnterpriseRecordPromptIdleMutation,
   GqlHiveEnterpriseRecordPromptIdleMutationVariables,
   GqlHiveEnterpriseRecordPromptStartMutation,
   GqlHiveEnterpriseRecordPromptStartMutationVariables,
   GqlHiveEnterpriseRecordQuestionsAnsweredMutation,
-  GqlHiveEnterpriseRecordQuestionsAnsweredMutationVariables
+  GqlHiveEnterpriseRecordQuestionsAnsweredMutationVariables,
+  GqlHiveEnterpriseReportActiveAccountsMutation,
+  GqlHiveEnterpriseReportActiveAccountsMutationVariables
 } from './generated'
 
 type TelemetryGateSettings = Pick<AppSettings, 'hiveAuthToken' | 'hiveOrganizationId'>
@@ -110,6 +115,57 @@ export async function recordHiveQuestionsAnswered(
     await reconcileOrgSettings(data.recordQuestionsAnswered)
   } catch (error) {
     console.warn('[HiveEnterprise] recordQuestionsAnswered failed:', error)
+  }
+}
+
+/**
+ * Report the caller's current active account(s) so hive-enterprise can keep
+ * its member↔account mapping fresh. The server upserts one row per (member,
+ * provider) — this always sends the full snapshot, never a partial diff — and
+ * echoes org settings back like the other telemetry mutations. Cadence
+ * (immediate-on-change vs hourly heartbeat) and dedupe live in the caller
+ * (`hive-account-report.ts`); this helper is a thin, fire-and-forget-safe
+ * transport that just reports success/failure.
+ */
+export async function reportHiveActiveAccounts(
+  accounts: GqlHiveEnterpriseReportActiveAccountsMutationVariables['accounts']
+): Promise<boolean> {
+  const settings = useSettingsStore.getState()
+  if (!isHiveTelemetryEnabled(settings)) return false
+  try {
+    const data = await requestWithRefresh<
+      GqlHiveEnterpriseReportActiveAccountsMutation,
+      GqlHiveEnterpriseReportActiveAccountsMutationVariables
+    >(ReportActiveAccountsDocument, { accounts })
+    await reconcileOrgSettings(data.reportActiveAccounts)
+    return data.reportActiveAccounts.recorded
+  } catch (error) {
+    console.warn('[HiveEnterprise] reportActiveAccounts failed:', error)
+    return false
+  }
+}
+
+/**
+ * Fetch the org's member↔active-account mapping for the usage popover's
+ * avatar stack. Every org member (dev role included) can read this — the
+ * server resolves org from the JWT, not a client-supplied id. Returns null on
+ * error or when telemetry is disabled so callers can distinguish "nothing to
+ * show" from "should render an empty state".
+ */
+export async function fetchHiveAccountMembers(): Promise<
+  GqlHiveEnterpriseListAccountMembersQuery['listAccountMembers'] | null
+> {
+  const settings = useSettingsStore.getState()
+  if (!isHiveTelemetryEnabled(settings)) return null
+  try {
+    const data = await requestWithRefresh<
+      GqlHiveEnterpriseListAccountMembersQuery,
+      Record<string, never>
+    >(ListAccountMembersDocument)
+    return data.listAccountMembers
+  } catch (error) {
+    console.warn('[HiveEnterprise] listAccountMembers failed:', error)
+    return null
   }
 }
 

--- a/src/renderer/src/api/hive-enterprise/generated.ts
+++ b/src/renderer/src/api/hive-enterprise/generated.ts
@@ -15,6 +15,23 @@ export type Scalars = {
   InteractId: { input: string; output: string; }
 };
 
+export type GqlAccountMemberEntry = {
+  __typename?: 'AccountMemberEntry';
+  accountEmail: Scalars['String']['output'];
+  lastSeenAt: Scalars['String']['output'];
+  member: GqlMember;
+  provider: GqlAccountProvider;
+};
+
+export type GqlAccountProvider =
+  | 'anthropic'
+  | 'openai';
+
+export type GqlActiveAccountInput = {
+  email: Scalars['String']['input'];
+  provider: GqlAccountProvider;
+};
+
 export type GqlInvite = {
   __typename?: 'Invite';
   acceptedAt?: Maybe<Scalars['String']['output']>;
@@ -45,6 +62,7 @@ export type GqlMutation = {
   recordPromptStart: GqlPromptStartResult;
   recordQuestionsAnswered: GqlQuestionAnsweredResult;
   removeMember: Scalars['Boolean']['output'];
+  reportActiveAccounts: GqlReportActiveAccountsResult;
 };
 
 
@@ -78,6 +96,11 @@ export type GqlMutationRemoveMemberArgs = {
   userId: Scalars['InteractId']['input'];
 };
 
+
+export type GqlMutationReportActiveAccountsArgs = {
+  accounts: Array<GqlActiveAccountInput>;
+};
+
 export type GqlOrganization = {
   __typename?: 'Organization';
   id: Scalars['InteractId']['output'];
@@ -102,6 +125,8 @@ export type GqlPromptMutationResult = {
 };
 
 export type GqlPromptStartInput = {
+  accountEmail?: InputMaybe<Scalars['String']['input']>;
+  accountProvider?: InputMaybe<Scalars['String']['input']>;
   connectionProjects?: InputMaybe<Scalars['String']['input']>;
   contextLength?: InputMaybe<Scalars['Int']['input']>;
   gitRemoteUrl?: InputMaybe<Scalars['String']['input']>;
@@ -133,6 +158,7 @@ export type GqlPromptStartResult = {
 
 export type GqlQuery = {
   __typename?: 'Query';
+  listAccountMembers: Array<GqlAccountMemberEntry>;
   listInvites: Array<GqlInvite>;
   listMembers: Array<GqlMember>;
   listOrganizations: Array<GqlOrganization>;
@@ -159,6 +185,13 @@ export type GqlQuestionAnsweredInput = {
 
 export type GqlQuestionAnsweredResult = {
   __typename?: 'QuestionAnsweredResult';
+  recordQuestions: Scalars['Boolean']['output'];
+  recorded: Scalars['Boolean']['output'];
+  storePrompts: Scalars['Boolean']['output'];
+};
+
+export type GqlReportActiveAccountsResult = {
+  __typename?: 'ReportActiveAccountsResult';
   recordQuestions: Scalars['Boolean']['output'];
   recorded: Scalars['Boolean']['output'];
   storePrompts: Scalars['Boolean']['output'];
@@ -243,4 +276,38 @@ export type GqlHiveEnterpriseRecordQuestionsAnsweredMutation = (
     { __typename?: 'QuestionAnsweredResult' }
     & Pick<GqlQuestionAnsweredResult, 'recorded' | 'storePrompts' | 'recordQuestions'>
   ) }
+);
+
+export type GqlHiveEnterpriseReportActiveAccountsMutationVariables = Exact<{
+  accounts: Array<GqlActiveAccountInput> | GqlActiveAccountInput;
+}>;
+
+
+export type GqlHiveEnterpriseReportActiveAccountsMutation = (
+  { __typename?: 'Mutation' }
+  & { reportActiveAccounts: (
+    { __typename?: 'ReportActiveAccountsResult' }
+    & Pick<GqlReportActiveAccountsResult, 'recorded' | 'storePrompts' | 'recordQuestions'>
+  ) }
+);
+
+export type GqlHiveEnterpriseListAccountMembersQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GqlHiveEnterpriseListAccountMembersQuery = (
+  { __typename?: 'Query' }
+  & { listAccountMembers: Array<(
+    { __typename?: 'AccountMemberEntry' }
+    & Pick<GqlAccountMemberEntry, 'provider' | 'accountEmail' | 'lastSeenAt'>
+    & { member: (
+      { __typename?: 'Member' }
+      & Pick<
+        GqlMember,
+        | 'id'
+        | 'email'
+        | 'name'
+        | 'picture'
+      >
+    ) }
+  )> }
 );

--- a/src/renderer/src/api/hive-enterprise/operations.ts
+++ b/src/renderer/src/api/hive-enterprise/operations.ts
@@ -44,3 +44,29 @@ export const RecordQuestionsAnsweredDocument = /* GraphQL */ `
     }
   }
 `
+
+export const ReportActiveAccountsDocument = /* GraphQL */ `
+  mutation HiveEnterpriseReportActiveAccounts($accounts: [ActiveAccountInput!]!) {
+    reportActiveAccounts(accounts: $accounts) {
+      recorded
+      storePrompts
+      recordQuestions
+    }
+  }
+`
+
+export const ListAccountMembersDocument = /* GraphQL */ `
+  query HiveEnterpriseListAccountMembers {
+    listAccountMembers {
+      provider
+      accountEmail
+      lastSeenAt
+      member {
+        id
+        email
+        name
+        picture
+      }
+    }
+  }
+`

--- a/src/renderer/src/components/layout/MemberAvatarStack.test.tsx
+++ b/src/renderer/src/components/layout/MemberAvatarStack.test.tsx
@@ -1,0 +1,162 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { MemberAvatarStack, type AccountMemberInfo } from './MemberAvatarStack'
+
+// Radix's Tooltip content renders an Arrow that measures itself via
+// `useSize`, which unconditionally constructs a `ResizeObserver` — jsdom has
+// none. Stub it so hovering a trigger open doesn't throw.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+;(globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+  ResizeObserverStub
+
+afterEach(() => {
+  cleanup()
+})
+
+function renderStack(props: { members: AccountMemberInfo[] | undefined; loading: boolean }): ReturnType<typeof render> {
+  return render(
+    <TooltipProvider>
+      <MemberAvatarStack {...props} />
+    </TooltipProvider>
+  )
+}
+
+function makeMember(overrides: Partial<AccountMemberInfo> = {}): AccountMemberInfo {
+  return {
+    id: 'member-1',
+    email: 'alice@example.com',
+    name: 'Alice',
+    picture: null,
+    ...overrides
+  }
+}
+
+describe('MemberAvatarStack', () => {
+  it('shows a skeleton circle while loading', () => {
+    renderStack({ members: undefined, loading: true })
+
+    expect(screen.getByTestId('member-avatar-stack-loading')).toBeTruthy()
+    expect(screen.queryAllByTestId('member-avatar')).toHaveLength(0)
+  })
+
+  it('renders one avatar per member when at or under the cap', () => {
+    const members = [
+      makeMember({ id: 'm1', name: 'Alice' }),
+      makeMember({ id: 'm2', name: 'Bob' }),
+      makeMember({ id: 'm3', name: 'Carol' })
+    ]
+    renderStack({ members, loading: false })
+
+    expect(screen.getAllByTestId('member-avatar')).toHaveLength(3)
+    expect(screen.queryByTestId('member-avatar-overflow')).toBeNull()
+  })
+
+  it('caps at 3 avatars and shows a +N overflow bubble for more than 3 members', () => {
+    const members = [
+      makeMember({ id: 'm1', name: 'Alice' }),
+      makeMember({ id: 'm2', name: 'Bob' }),
+      makeMember({ id: 'm3', name: 'Carol' }),
+      makeMember({ id: 'm4', name: 'Dave' }),
+      makeMember({ id: 'm5', name: 'Eve' })
+    ]
+    renderStack({ members, loading: false })
+
+    expect(screen.getAllByTestId('member-avatar')).toHaveLength(3)
+    const overflow = screen.getByTestId('member-avatar-overflow')
+    expect(overflow.textContent).toBe('+2')
+  })
+
+  it('falls back to initials when the member has no picture', () => {
+    renderStack({
+      members: [makeMember({ id: 'm1', name: 'Alice', picture: null })],
+      loading: false
+    })
+
+    expect(screen.getByText('A')).toBeTruthy()
+  })
+
+  it('falls back to initials from the email when name is null and there is no picture', () => {
+    renderStack({
+      members: [makeMember({ id: 'm1', name: null, email: 'bob@example.com', picture: null })],
+      loading: false
+    })
+
+    expect(screen.getByText('b')).toBeTruthy()
+  })
+
+  it('falls back to initials when the avatar image fails to load', () => {
+    renderStack({
+      members: [
+        makeMember({ id: 'm1', name: 'Alice', picture: 'https://example.com/alice.png' })
+      ],
+      loading: false
+    })
+
+    const img = screen.getByRole('img', { hidden: true }) as HTMLImageElement
+    fireEvent.error(img)
+
+    expect(screen.getByText('A')).toBeTruthy()
+  })
+
+  it('shows the member name in a tooltip on hover', async () => {
+    const user = userEvent.setup()
+    renderStack({
+      members: [makeMember({ id: 'm1', name: 'Alice', email: 'alice@example.com' })],
+      loading: false
+    })
+
+    await user.hover(screen.getByTestId('member-avatar'))
+
+    const tooltip = await screen.findByRole('tooltip')
+    expect(within(tooltip).getByText('Alice')).toBeTruthy()
+  })
+
+  it('falls back to the email in the tooltip when the member has no name', async () => {
+    const user = userEvent.setup()
+    renderStack({
+      members: [makeMember({ id: 'm2', name: null, email: 'bob@example.com' })],
+      loading: false
+    })
+
+    await user.hover(screen.getByTestId('member-avatar'))
+
+    const tooltip = await screen.findByRole('tooltip')
+    expect(within(tooltip).getByText('bob@example.com')).toBeTruthy()
+  })
+
+  it('lists the remaining member names one per line in the overflow tooltip', async () => {
+    const user = userEvent.setup()
+    const members = [
+      makeMember({ id: 'm1', name: 'Alice' }),
+      makeMember({ id: 'm2', name: 'Bob' }),
+      makeMember({ id: 'm3', name: 'Carol' }),
+      makeMember({ id: 'm4', name: 'Dave' }),
+      makeMember({ id: 'm5', name: null, email: 'eve@example.com' })
+    ]
+    renderStack({ members, loading: false })
+
+    const overflow = screen.getByTestId('member-avatar-overflow')
+    await user.hover(overflow)
+
+    const tooltip = await screen.findByRole('tooltip')
+    expect(within(tooltip).getByText('Dave')).toBeTruthy()
+    expect(within(tooltip).getByText('eve@example.com')).toBeTruthy()
+  })
+
+  it('renders nothing when members is undefined and not loading', () => {
+    const { container } = renderStack({ members: undefined, loading: false })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when members is an empty array and not loading', () => {
+    const { container } = renderStack({ members: [], loading: false })
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/src/renderer/src/components/layout/MemberAvatarStack.tsx
+++ b/src/renderer/src/components/layout/MemberAvatarStack.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+/**
+ * The subset of a synced org member's profile the usage popover needs to
+ * render an avatar stack. Mirrors the `member` shape returned by the
+ * `listAccountMembers` GraphQL query (see `fetchHiveAccountMembers` in
+ * `@/api/hive-enterprise/client`).
+ */
+export interface AccountMemberInfo {
+  id: string
+  email: string
+  name: string | null
+  picture: string | null
+}
+
+const MAX_VISIBLE_AVATARS = 3
+
+const AVATAR_CLASSNAME = 'h-4 w-4 rounded-full ring-1 ring-background shrink-0'
+const TRIGGER_CLASSNAME = 'shrink-0 cursor-default bg-transparent border-none p-0 rounded-full'
+
+function initialFor(member: AccountMemberInfo): string {
+  const source = member.name ?? member.email
+  return source ? source[0] : '?'
+}
+
+function MemberAvatar({ member }: { member: AccountMemberInfo }): React.JSX.Element {
+  const [failed, setFailed] = useState(false)
+  const label = member.name ?? member.email
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={TRIGGER_CLASSNAME}
+          aria-label={label}
+          data-testid="member-avatar"
+        >
+          {!failed && member.picture ? (
+            <img
+              src={member.picture}
+              alt={label}
+              className={cn(AVATAR_CLASSNAME, 'bg-white')}
+              onError={() => setFailed(true)}
+            />
+          ) : (
+            <div
+              className={cn(
+                AVATAR_CLASSNAME,
+                'bg-muted flex items-center justify-center text-[9px] font-medium text-muted-foreground uppercase'
+              )}
+            >
+              {initialFor(member)}
+            </div>
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function MemberAvatarOverflow({ members }: { members: AccountMemberInfo[] }): React.JSX.Element {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={TRIGGER_CLASSNAME}
+          aria-label={`${members.length} more members`}
+          data-testid="member-avatar-overflow"
+        >
+          <div
+            className={cn(
+              AVATAR_CLASSNAME,
+              'bg-muted flex items-center justify-center text-[9px] font-medium text-muted-foreground'
+            )}
+          >
+            +{members.length}
+          </div>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {members.map((member) => (
+          <div key={member.id}>{member.name ?? member.email}</div>
+        ))}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export interface MemberAvatarStackProps {
+  members: AccountMemberInfo[] | undefined
+  loading: boolean
+}
+
+export function MemberAvatarStack({
+  members,
+  loading
+}: MemberAvatarStackProps): React.JSX.Element | null {
+  if (loading) {
+    return (
+      <div className="flex -space-x-1.5 items-center" data-testid="member-avatar-stack-loading">
+        <div className="h-4 w-4 rounded-full bg-muted animate-pulse ring-1 ring-background" />
+      </div>
+    )
+  }
+
+  if (!members || members.length === 0) return null
+
+  const visible = members.slice(0, MAX_VISIBLE_AVATARS)
+  const overflow = members.slice(MAX_VISIBLE_AVATARS)
+
+  return (
+    <div className="flex -space-x-1.5 items-center" data-testid="member-avatar-stack">
+      {visible.map((member) => (
+        <MemberAvatar key={member.id} member={member} />
+      ))}
+      {overflow.length > 0 && <MemberAvatarOverflow members={overflow} />}
+    </div>
+  )
+}

--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -2,7 +2,9 @@ import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { UsageAccountRow } from './UsageIndicator'
+import type { AccountMemberInfo } from './MemberAvatarStack'
 import type { UsageData } from '@shared/types/usage'
 
 afterEach(() => {
@@ -288,5 +290,49 @@ describe('UsageAccountRow', () => {
     )
 
     expect(screen.queryByText('Fable')).toBeNull()
+  })
+
+  it('renders the member avatar stack when members is given', () => {
+    const members: AccountMemberInfo[] = [
+      { id: 'member-1', email: 'alice@example.com', name: 'Alice', picture: null }
+    ]
+    render(
+      <TooltipProvider>
+        <UsageAccountRow
+          row={{
+            id: 'acc-8',
+            email: 'shared@example.com',
+            usage: sampleUsage,
+            status: 'ok',
+            lastError: null,
+            isActive: true,
+            isRefreshing: false
+          }}
+          members={members}
+          membersLoading={false}
+        />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByTestId('member-avatar')).toBeTruthy()
+  })
+
+  it('renders nothing from the avatar stack when members is undefined', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-9',
+          email: 'shared@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: true,
+          isRefreshing: false
+        }}
+      />
+    )
+
+    expect(screen.queryByTestId('member-avatar')).toBeNull()
+    expect(screen.queryByTestId('member-avatar-stack-loading')).toBeNull()
   })
 })

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import {
   useUsageStore,
   useAccountStore,
@@ -10,6 +10,9 @@ import {
 } from '@/stores'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+import { reportActiveAccountsSnapshot } from '@/lib/hive-account-report'
+import { fetchHiveAccountMembers, isHiveTelemetryEnabled } from '@/api/hive-enterprise/client'
+import { MemberAvatarStack, type AccountMemberInfo } from './MemberAvatarStack'
 import { cn } from '@/lib/utils'
 import { Loader2, RefreshCw } from 'lucide-react'
 import claudeIcon from '@/assets/model-icons/claude.svg'
@@ -189,6 +192,8 @@ export interface UsageAccountRowProps {
   onSwitch?: () => void
   onRefresh?: () => void
   onSignInAgain?: () => void
+  members?: AccountMemberInfo[]
+  membersLoading?: boolean
 }
 
 export function UsageAccountRow({
@@ -197,7 +202,9 @@ export function UsageAccountRow({
   isLoginActive = false,
   onSwitch,
   onRefresh,
-  onSignInAgain
+  onSignInAgain,
+  members,
+  membersLoading = false
 }: UsageAccountRowProps): React.JSX.Element {
   const fiveHourPercent = row.usage ? Math.round(row.usage.five_hour.utilization) : 0
   const sevenDayPercent = row.usage ? Math.round(row.usage.seven_day.utilization) : 0
@@ -220,6 +227,7 @@ export function UsageAccountRow({
         >
           {row.email ?? 'Active account'}
         </div>
+        <MemberAvatarStack members={members} loading={membersLoading} />
         {row.isActive && (
           <span className="shrink-0 rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-medium text-primary">
             Active
@@ -329,6 +337,68 @@ function getVisibleProviders(
   return PROVIDER_ORDER.filter((p) => selectedProviders.includes(p))
 }
 
+interface AccountMembersMapState {
+  membersByAccount: Map<string, AccountMemberInfo[]> | null
+  loading: boolean
+  refresh: () => void
+}
+
+/**
+ * Fresh-fetch-on-hover for the popover's member avatar stack. Every hover
+ * (mouseenter/focus on either HoverCard trigger) calls `refresh()`, which
+ * re-fetches the full org mapping and rebuilds a `provider:email` (lowercase)
+ * -> members lookup. No launch fetch, no TTL cache — intentionally always
+ * fresh per the product decision that staleness here is confusing (a member
+ * could have switched accounts seconds ago).
+ */
+function useAccountMembersMap(): AccountMembersMapState {
+  const [membersByAccount, setMembersByAccount] = useState<Map<
+    string,
+    AccountMemberInfo[]
+  > | null>(null)
+  const [loading, setLoading] = useState(false)
+  const loadingRef = useRef(false)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const refresh = useCallback((): void => {
+    if (loadingRef.current) return
+    if (!isHiveTelemetryEnabled(useSettingsStore.getState())) return
+
+    loadingRef.current = true
+    setLoading(true)
+    void fetchHiveAccountMembers()
+      .then((entries) => {
+        const map = new Map<string, AccountMemberInfo[]>()
+        for (const entry of entries ?? []) {
+          const key = `${entry.provider}:${entry.accountEmail.toLowerCase()}`
+          const info: AccountMemberInfo = {
+            id: entry.member.id,
+            email: entry.member.email,
+            name: entry.member.name ?? null,
+            picture: entry.member.picture ?? null
+          }
+          const existing = map.get(key)
+          if (existing) existing.push(info)
+          else map.set(key, [info])
+        }
+        if (mountedRef.current) setMembersByAccount(map)
+      })
+      .finally(() => {
+        loadingRef.current = false
+        if (mountedRef.current) setLoading(false)
+      })
+  }, [])
+
+  return { membersByAccount, loading, refresh }
+}
+
 function ProviderUsageBlock({
   provider,
   isExplicitlySelected
@@ -364,6 +434,12 @@ function ProviderUsageBlock({
   const fetchEmail = useAccountStore((s) => s.fetchEmail)
   const startLogin = useLoginStore((s) => s.startLogin)
   const isLoginActive = useLoginStore((s) => s.activeLogin !== null)
+  const telemetryEnabled = useSettingsStore((s) => isHiveTelemetryEnabled(s))
+  const {
+    membersByAccount,
+    loading: membersLoading,
+    refresh: refreshMembers
+  } = useAccountMembersMap()
 
   const usage = normalizeUsage(provider, anthropicUsage, openaiUsage)
 
@@ -397,7 +473,7 @@ function ProviderUsageBlock({
 
   const handleRefreshActive = (): void => {
     forceRefreshProvider(provider)
-    fetchEmail(provider)
+    void fetchEmail(provider).then(() => reportActiveAccountsSnapshot())
   }
 
   const handleRefreshAll = (event: React.MouseEvent): void => {
@@ -407,6 +483,12 @@ function ProviderUsageBlock({
 
   const handleLoadSavedAccounts = (): void => {
     loadSavedAccounts(provider).catch(() => {})
+    refreshMembers()
+  }
+
+  const membersFor = (rowEmail: string | null): AccountMemberInfo[] | undefined => {
+    if (!telemetryEnabled) return undefined
+    return membersByAccount?.get(`${provider}:${rowEmail?.toLowerCase() ?? ''}`) ?? []
   }
 
   useEffect(() => {
@@ -474,6 +556,8 @@ function ProviderUsageBlock({
                       : undefined
                   }
                   onSignInAgain={() => startLogin(provider, row.email ?? undefined)}
+                  members={membersFor(row.email)}
+                  membersLoading={membersLoading}
                 />
               ))
             ) : (
@@ -570,6 +654,8 @@ function ProviderUsageBlock({
                   : undefined
               }
               onSignInAgain={() => startLogin(provider, row.email ?? undefined)}
+              members={membersFor(row.email)}
+              membersLoading={membersLoading}
             />
           ))}
           {provider === 'anthropic' && extra?.is_enabled && (
@@ -649,6 +735,9 @@ export function UsageIndicator(): React.JSX.Element | null {
       fetchUsageForProvider(p)
       fetchEmail(p)
     })
+    // Deduped heartbeat carrier — reportActiveAccountsSnapshot itself owns the
+    // change-detection and 1h-heartbeat gating, this is just another trigger.
+    void reportActiveAccountsSnapshot()
   }, [activeSessionId, setActiveProvider, fetchUsageForProvider, fetchEmail, loadSavedAccounts])
 
   const visibleProviders = getVisibleProviders(

--- a/src/renderer/src/lib/hive-account-report.test.ts
+++ b/src/renderer/src/lib/hive-account-report.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  isHiveTelemetryEnabled: vi.fn(() => true),
+  reportHiveActiveAccounts: vi.fn(async () => true),
+  fetchEmail: vi.fn(async () => {})
+}))
+
+vi.mock('@/api/hive-enterprise/client', () => ({
+  isHiveTelemetryEnabled: mocks.isHiveTelemetryEnabled,
+  reportHiveActiveAccounts: mocks.reportHiveActiveAccounts
+}))
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: {
+    getState: () => ({ hiveAuthToken: 'token-1', hiveOrganizationId: 'org-1' })
+  }
+}))
+
+// The mock's `fetchEmail` mutates this object directly, mirroring how the
+// real zustand store's `set` updates state in place — the module under test
+// reads `anthropicEmail`/`openaiEmail` off a fresh `getState()` call after
+// each await, so mutating here is what makes "email changed mid-flight"
+// observable to it.
+const accountState = {
+  anthropicEmail: null as string | null,
+  openaiEmail: null as string | null
+}
+
+vi.mock('@/stores/useAccountStore', () => ({
+  useAccountStore: {
+    getState: () => ({
+      get anthropicEmail() {
+        return accountState.anthropicEmail
+      },
+      get openaiEmail() {
+        return accountState.openaiEmail
+      },
+      fetchEmail: mocks.fetchEmail
+    })
+  }
+}))
+
+import {
+  reportActiveAccountsSnapshot,
+  resetHiveAccountReportStateForTests
+} from './hive-account-report'
+
+describe('hive-account-report', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-08T10:00:00.000Z'))
+    vi.clearAllMocks()
+    mocks.isHiveTelemetryEnabled.mockReturnValue(true)
+    mocks.reportHiveActiveAccounts.mockResolvedValue(true)
+    mocks.fetchEmail.mockResolvedValue(undefined)
+    accountState.anthropicEmail = null
+    accountState.openaiEmail = null
+    resetHiveAccountReportStateForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends the full snapshot when both providers have an active account', async () => {
+    accountState.anthropicEmail = 'alice@example.com'
+    accountState.openaiEmail = 'Bob@example.com'
+
+    await reportActiveAccountsSnapshot()
+
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenCalledTimes(1)
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenCalledWith([
+      { provider: 'anthropic', email: 'alice@example.com' },
+      { provider: 'openai', email: 'bob@example.com' }
+    ])
+  })
+
+  it('omits a provider whose email is null', async () => {
+    accountState.anthropicEmail = 'alice@example.com'
+    accountState.openaiEmail = null
+
+    await reportActiveAccountsSnapshot()
+
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenCalledWith([
+      { provider: 'anthropic', email: 'alice@example.com' }
+    ])
+  })
+
+  it('sends nothing when the snapshot is empty', async () => {
+    await reportActiveAccountsSnapshot()
+
+    expect(mocks.reportHiveActiveAccounts).not.toHaveBeenCalled()
+  })
+
+  it('skips a repeat send of an identical snapshot within the 1h heartbeat window', async () => {
+    accountState.anthropicEmail = 'alice@example.com'
+
+    await reportActiveAccountsSnapshot()
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(new Date('2026-07-08T10:30:00.000Z')) // +30min, still < 1h
+    await reportActiveAccountsSnapshot()
+
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-sends an identical snapshot as a heartbeat once an hour has elapsed', async () => {
+    accountState.anthropicEmail = 'alice@example.com'
+
+    await reportActiveAccountsSnapshot()
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(new Date('2026-07-08T11:00:01.000Z')) // +1h and 1s
+    await reportActiveAccountsSnapshot()
+
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenCalledTimes(2)
+  })
+
+  it('sends immediately when the active account email changes', async () => {
+    accountState.anthropicEmail = 'alice@example.com'
+    await reportActiveAccountsSnapshot()
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenCalledTimes(1)
+
+    accountState.anthropicEmail = 'carol@example.com'
+    await reportActiveAccountsSnapshot()
+
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenCalledTimes(2)
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenLastCalledWith([
+      { provider: 'anthropic', email: 'carol@example.com' }
+    ])
+  })
+
+  it('retries on the next trigger after a failed send instead of caching it as sent', async () => {
+    accountState.anthropicEmail = 'alice@example.com'
+    mocks.reportHiveActiveAccounts.mockResolvedValueOnce(false)
+
+    await reportActiveAccountsSnapshot()
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenCalledTimes(1)
+
+    // Same snapshot, no time elapsed — a successful send would have been
+    // deduped, but the prior attempt failed so last-sent state was never set.
+    await reportActiveAccountsSnapshot()
+
+    expect(mocks.reportHiveActiveAccounts).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not call the server or read accounts when telemetry is disabled', async () => {
+    mocks.isHiveTelemetryEnabled.mockReturnValue(false)
+    accountState.anthropicEmail = 'alice@example.com'
+
+    await reportActiveAccountsSnapshot()
+
+    expect(mocks.reportHiveActiveAccounts).not.toHaveBeenCalled()
+    expect(mocks.fetchEmail).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/hive-account-report.ts
+++ b/src/renderer/src/lib/hive-account-report.ts
@@ -1,0 +1,76 @@
+import type { UsageProvider } from '@shared/types/usage'
+import { isHiveTelemetryEnabled, reportHiveActiveAccounts } from '@/api/hive-enterprise/client'
+import { useAccountStore } from '@/stores/useAccountStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+
+/**
+ * Reports the caller's active accounts to hive-enterprise so the org's
+ * member↔account mapping (usage popover avatar stack) stays fresh, without
+ * spamming the server on every trigger (launch, prompt send, account switch,
+ * usage refresh — see the call sites). A full snapshot is sent immediately
+ * whenever it differs from the last one successfully sent; otherwise at most
+ * one heartbeat per hour keeps `last_seen_at` from going stale while nothing
+ * has actually changed.
+ */
+const HEARTBEAT_MS = 60 * 60 * 1000 // 1 hour
+
+const PROVIDERS: readonly UsageProvider[] = ['anthropic', 'openai']
+
+let lastSentKey: string | null = null
+let lastSentAt = 0
+let inFlight = false
+
+/** Reset module-level state between tests; not used by production code. */
+export function resetHiveAccountReportStateForTests(): void {
+  lastSentKey = null
+  lastSentAt = 0
+  inFlight = false
+}
+
+interface AccountSnapshotEntry {
+  provider: UsageProvider
+  email: string
+}
+
+/**
+ * Re-read each provider's active-account email via `fetchEmail` (cheap local
+ * IPC/file read) before building the snapshot — this doubles as detection for
+ * an account switch that happened outside this app's own switch flow (e.g. a
+ * `claude login` in a terminal). A provider whose email read fails is simply
+ * omitted, never reported as logged-out: `fetchEmail` already resets its slot
+ * to null on failure, and we must not overwrite a still-valid server row with
+ * a transient local read error.
+ */
+async function resolveActiveAccountSnapshot(): Promise<AccountSnapshotEntry[]> {
+  const entries: AccountSnapshotEntry[] = []
+  for (const provider of PROVIDERS) {
+    await useAccountStore.getState().fetchEmail(provider)
+    const state = useAccountStore.getState()
+    const email = provider === 'anthropic' ? state.anthropicEmail : state.openaiEmail
+    if (email) entries.push({ provider, email: email.toLowerCase() })
+  }
+  return entries
+}
+
+export async function reportActiveAccountsSnapshot(): Promise<void> {
+  if (!isHiveTelemetryEnabled(useSettingsStore.getState())) return
+  if (inFlight) return
+
+  inFlight = true
+  try {
+    const snapshot = await resolveActiveAccountSnapshot()
+    if (snapshot.length === 0) return
+
+    const key = JSON.stringify(snapshot)
+    const now = Date.now()
+    if (key === lastSentKey && now - lastSentAt < HEARTBEAT_MS) return
+
+    const success = await reportHiveActiveAccounts(snapshot)
+    if (success) {
+      lastSentKey = key
+      lastSentAt = now
+    }
+  } finally {
+    inFlight = false
+  }
+}

--- a/src/renderer/src/lib/hive-enterprise-telemetry-metadata.test.ts
+++ b/src/renderer/src/lib/hive-enterprise-telemetry-metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildHivePromptMetadata } from './hive-enterprise-telemetry'
+import { buildHivePromptMetadata, resolveHivePromptAccountProvider } from './hive-enterprise-telemetry'
 
 describe('Hive Enterprise prompt metadata', () => {
   it('captures provider, model, mode, goal, handoff, timestamp, and connection projects', () => {
@@ -39,5 +39,24 @@ describe('Hive Enterprise prompt metadata', () => {
         { name: 'hive-enterprise', path: '/workspace/hive-enterprise' }
       ])
     })
+  })
+})
+
+describe('resolveHivePromptAccountProvider', () => {
+  it('maps claude-code and claude-code-cli sessions to anthropic', () => {
+    expect(resolveHivePromptAccountProvider('claude-code')).toBe('anthropic')
+    expect(resolveHivePromptAccountProvider('claude-code-cli')).toBe('anthropic')
+  })
+
+  it('maps codex sessions to openai', () => {
+    expect(resolveHivePromptAccountProvider('codex')).toBe('openai')
+  })
+
+  it('maps opencode, terminal, unknown, and missing SDKs to null', () => {
+    expect(resolveHivePromptAccountProvider('opencode')).toBeNull()
+    expect(resolveHivePromptAccountProvider('terminal')).toBeNull()
+    expect(resolveHivePromptAccountProvider('some-future-sdk')).toBeNull()
+    expect(resolveHivePromptAccountProvider(null)).toBeNull()
+    expect(resolveHivePromptAccountProvider(undefined)).toBeNull()
   })
 })

--- a/src/renderer/src/lib/hive-enterprise-telemetry.ts
+++ b/src/renderer/src/lib/hive-enterprise-telemetry.ts
@@ -5,8 +5,11 @@ import {
   recordHivePromptStart,
   recordHiveQuestionsAnswered
 } from '@/api/hive-enterprise/client'
+import { reportActiveAccountsSnapshot } from '@/lib/hive-account-report'
 import { currentPromptIdBySession } from '@/lib/message-send-times'
 import { computeTokenFieldDelta } from '@/lib/token-baselines'
+import { isClaudeFamily } from '@shared/types/agent-sdk'
+import { useAccountStore } from '@/stores/useAccountStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useContextStore } from '@/stores/useContextStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
@@ -81,6 +84,30 @@ export interface HivePromptMetadata {
   handoffSessionId: string | null
   loggedAt: string
   connectionProjects: string | null
+}
+
+type HiveAccountProvider = 'anthropic' | 'openai'
+
+/**
+ * Map a prompt's session SDK to the provider whose active-account email
+ * should be stamped on the prompt row. Only Claude-family (`claude-code`,
+ * `claude-code-cli`) and `codex` sessions have an unambiguous active account
+ * to attribute to; `opencode`/`terminal`/unknown SDKs stamp null rather than
+ * guess. Deliberately NOT `resolveUsageProvider` (useUsageStore.ts) — that
+ * helper defaults unknown SDKs to `'anthropic'`, which is a reasonable guess
+ * for "which usage bar to show" but wrong for a durable attribution record.
+ */
+export function resolveHivePromptAccountProvider(
+  agentSdk: string | null | undefined
+): HiveAccountProvider | null {
+  if (isClaudeFamily(agentSdk)) return 'anthropic'
+  if (agentSdk === 'codex') return 'openai'
+  return null
+}
+
+function readHiveAccountEmail(provider: HiveAccountProvider): string | null {
+  const state = useAccountStore.getState()
+  return provider === 'anthropic' ? state.anthropicEmail : state.openaiEmail
 }
 
 const handoffSessionIdByChildSession = new Map<string, string>()
@@ -182,9 +209,22 @@ export function startHivePromptTelemetry(input: StartHivePromptTelemetryInput): 
   const source = input.source ?? deriveBoardSource()
 
   void (async () => {
+    void reportActiveAccountsSnapshot()
+
     const remote = worktree?.path
       ? await gitApi.getRemoteUrl(worktree.path, 'origin').catch(() => null)
       : null
+
+    // Stamp the prompt row with the active account for the session's SDK, if
+    // any. The email may not be loaded yet (e.g. app just launched), so give
+    // it one fetchEmail retry before giving up and stamping null.
+    const accountProvider = resolveHivePromptAccountProvider(session?.agent_sdk)
+    let accountEmail = accountProvider ? readHiveAccountEmail(accountProvider) : null
+    if (accountProvider && !accountEmail) {
+      await useAccountStore.getState().fetchEmail(accountProvider).catch(() => {})
+      accountEmail = readHiveAccountEmail(accountProvider)
+    }
+    accountEmail = accountEmail ? accountEmail.toLowerCase() : null
 
     // The server generates the prompt id and returns it; store it so the
     // matching idle event can correlate. A null id means nothing was recorded.
@@ -199,6 +239,8 @@ export function startHivePromptTelemetry(input: StartHivePromptTelemetryInput): 
       gitRemoteUrl: remote?.success ? (remote.url ?? null) : null,
       contextLength,
       source,
+      accountEmail,
+      accountProvider: accountEmail ? accountProvider : null,
       ...metadata
     })
     if (promptId) currentPromptIdBySession.set(input.sessionId, promptId)

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -10,6 +10,7 @@ import type {
 } from '@shared/types/usage'
 import { accountApi } from '@/api/account-api'
 import { usageApi } from '@/api/usage-api'
+import { reportActiveAccountsSnapshot } from '@/lib/hive-account-report'
 import { toast } from '@/lib/toast'
 import { useLoginStore } from './useLoginStore'
 import { useAccountStore } from './useAccountStore'
@@ -236,6 +237,7 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
             .getState()
             .fetchEmail(provider)
             .catch(() => {})
+          void reportActiveAccountsSnapshot()
           await get()
             .loadSavedAccounts(provider)
             .catch(() => {})


### PR DESCRIPTION
## Summary
- Adds active-account reporting from the renderer so Hive Enterprise can keep member/account mappings fresh, with immediate change detection and hourly heartbeat dedupe.
- Stamps Claude CLI prompt telemetry with the resolved Claude account email so the backend can refresh per-member usage state.
- Adds a member avatar stack to the usage popover, including hover tooltips, overflow handling, and loading states.
- Updates desktop backend base-dir resolution to honor `HIVE_DESKTOP_BASE_DIR` for isolated dev/E2E runs.

## Testing
- Added unit coverage for active-account snapshot dedupe, heartbeat, and retry behavior in `hive-account-report`.
- Added unit coverage for member avatar rendering, overflow, tooltip content, and image fallback behavior.
- Added unit coverage for usage row integration with member avatars.
- Added telemetry tests for Claude CLI prompt start account stamping, including null and failure cases.
- Not run manually in this turn.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches enterprise telemetry and account attribution across main/renderer with new server mutations; behavior is gated on org login and mostly fire-and-forget, but wrong stamping could skew org usage attribution.
> 
> **Overview**
> Adds **Hive Enterprise member↔account sync** so orgs can see who is on which API account, and surfaces that in the usage popover.
> 
> The renderer sends a **full active-account snapshot** (`reportActiveAccounts`) on launch, session changes, account switches, usage refresh, and before prompt telemetry—via `hive-account-report` with **change detection**, **hourly heartbeat**, and **retry on failure**. New GraphQL helpers also **fetch `listAccountMembers`** for the UI.
> 
> **Prompt start** telemetry (renderer + Claude CLI hook) now stamps **`accountEmail` / `accountProvider`** when resolvable, so the server can refresh `last_seen_at` on member account rows. Claude CLI uses `getClaudeAccountEmail`; SDK paths use `resolveHivePromptAccountProvider` (Claude → anthropic, codex → openai, else null).
> 
> The usage popover adds a **`MemberAvatarStack`** (cap 3 + overflow, tooltips, loading) keyed by `provider:email`, **re-fetched on hover** for fresh mappings.
> 
> Desktop dev/E2E can isolate data via **`HIVE_DESKTOP_BASE_DIR`** (macOS ignores `$HOME` for `app.getPath('home')`); verify skill docs updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7c7589040847a9d956dd7907abf0f26019199a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->