### PR TITLE
Fix missing ticket timers for Claude CLI handoffs

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -62,6 +62,7 @@ import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
+import { markClaudeCliPromptStarted } from '@/lib/claude-cli-send-tracking'
 import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
 import { buildSdkPlanImplementationPrompt } from '@/lib/proposedPlan'
 import { toast } from '@/lib/toast'
@@ -2124,6 +2125,7 @@ function PlanReviewModeContent({
               if (handoffPrompt) {
                 sessionStore.dequeuePendingMessage(newSessionId)
               }
+              markClaudeCliPromptStarted(newSessionId)
               startHivePromptTelemetry({
                 sessionId: newSessionId,
                 prompt: handoffPrompt,
@@ -2207,6 +2209,7 @@ function PlanReviewModeContent({
             if (handoffPrompt) {
               sessionStore.dequeuePendingMessage(newSessionId)
             }
+            markClaudeCliPromptStarted(newSessionId)
             startHivePromptTelemetry({
               sessionId: newSessionId,
               prompt: handoffPrompt,

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -18,6 +18,7 @@ import { HandoffSplitButton } from './HandoffSplitButton'
 import { SavePlanAsFileModal } from './SavePlanAsFileModal'
 import { buildHandoffPrompt, type HandoffSelectionOverride } from '@/lib/handoffSelection'
 import { lastSendMode } from '@/lib/message-send-times'
+import { markClaudeCliPromptStarted } from '@/lib/claude-cli-send-tracking'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { startBackgroundSessionPrompt } from '@/lib/backgroundSessionStart'
 import {
@@ -96,6 +97,7 @@ async function startTicketModalHandoffSession(opts: {
     if (opts.handoffPrompt) {
       useSessionStore.getState().dequeuePendingMessage(opts.sessionId)
     }
+    markClaudeCliPromptStarted(opts.sessionId)
     return
   }
 

--- a/src/renderer/src/lib/backgroundSessionStart.claude-cli.test.ts
+++ b/src/renderer/src/lib/backgroundSessionStart.claude-cli.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { lastSendMode, messageSendTimes, userExplicitSendTimes } from './message-send-times'
 import { startBackgroundSessionPrompt } from './backgroundSessionStart'
 
 const terminalApiMocks = vi.hoisted(() => ({
@@ -47,6 +49,10 @@ describe('startBackgroundSessionPrompt — claude-code-cli follow-up delivery', 
   beforeEach(() => {
     vi.clearAllMocks()
     seedClaudeCliSession()
+    messageSendTimes.delete('s1')
+    userExplicitSendTimes.delete('s1')
+    lastSendMode.delete('s1')
+    useWorktreeStatusStore.getState().clearSessionStatus('s1')
   })
 
   it('delivers straight to the live PTY and does not queue when delivered', async () => {
@@ -64,6 +70,22 @@ describe('startBackgroundSessionPrompt — claude-code-cli follow-up delivery', 
     expect(terminalApiMocks.startHivePromptTelemetry).not.toHaveBeenCalled()
   })
 
+  it('records send times and working status when delivered so the ticket timer runs', async () => {
+    mockSendClaudeCliPrompt(true)
+
+    await startBackgroundSessionPrompt({
+      worktreePath: '/repo',
+      sessionId: 's1',
+      prompt: 'follow-up question',
+      bumpTarget: {}
+    })
+
+    expect(userExplicitSendTimes.get('s1')).toBeTypeOf('number')
+    expect(messageSendTimes.get('s1')).toBeTypeOf('number')
+    expect(lastSendMode.get('s1')).toBe('build')
+    expect(useWorktreeStatusStore.getState().sessionStatuses['s1']?.status).toBe('working')
+  })
+
   it('queues the prompt for the next spawn when no live PTY exists', async () => {
     const sendClaudeCliPrompt = mockSendClaudeCliPrompt(false)
 
@@ -77,5 +99,20 @@ describe('startBackgroundSessionPrompt — claude-code-cli follow-up delivery', 
     expect(sendClaudeCliPrompt).toHaveBeenCalledWith('s1', 'follow-up question')
     expect(useSessionStore.getState().pendingMessages.get('s1')).toBe('follow-up question')
     expect(terminalApiMocks.startHivePromptTelemetry).not.toHaveBeenCalled()
+  })
+
+  it('does not record send times or working status when the prompt was only queued', async () => {
+    mockSendClaudeCliPrompt(false)
+
+    await startBackgroundSessionPrompt({
+      worktreePath: '/repo',
+      sessionId: 's1',
+      prompt: 'follow-up question',
+      bumpTarget: {}
+    })
+
+    expect(userExplicitSendTimes.get('s1')).toBeUndefined()
+    expect(messageSendTimes.get('s1')).toBeUndefined()
+    expect(useWorktreeStatusStore.getState().sessionStatuses['s1']?.status).toBeUndefined()
   })
 })

--- a/src/renderer/src/lib/backgroundSessionStart.ts
+++ b/src/renderer/src/lib/backgroundSessionStart.ts
@@ -6,6 +6,7 @@ import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { lastSendMode, messageSendTimes, userExplicitSendTimes } from '@/lib/message-send-times'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
+import { markClaudeCliPromptStarted } from '@/lib/claude-cli-send-tracking'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { opencodeApi } from '@/api/opencode-api'
 import { dbApi } from '@/api/db-api'
@@ -67,7 +68,10 @@ export async function startBackgroundSessionPrompt(opts: {
     )
     if (!delivered) {
       useSessionStore.getState().setPendingMessage(opts.sessionId, opts.prompt)
+      return
     }
+    markClaudeCliPromptStarted(opts.sessionId)
+    bumpWorktreeLastMessage(opts.bumpTarget)
     return
   }
 

--- a/src/renderer/src/lib/claude-cli-send-tracking.ts
+++ b/src/renderer/src/lib/claude-cli-send-tracking.ts
@@ -1,0 +1,20 @@
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { lastSendMode, messageSendTimes, userExplicitSendTimes } from '@/lib/message-send-times'
+import { snapshotTokenBaseline } from '@/lib/token-baselines'
+
+/**
+ * Records the send-time / status bookkeeping for a prompt just delivered to a
+ * claude-cli session (handoff or background follow-up). The opencode paths do
+ * this inline after connect; the CLI paths deliver via the PTY bridge instead
+ * and get their status from PTY hook events — but the elapsed ticket timer
+ * reads userExplicitSendTimes, which nothing event-driven ever writes. Call
+ * this only after delivery succeeds so a failed spawn does not leave the
+ * session stuck 'working'.
+ */
+export function markClaudeCliPromptStarted(sessionId: string): void {
+  messageSendTimes.set(sessionId, Date.now())
+  userExplicitSendTimes.set(sessionId, Date.now())
+  snapshotTokenBaseline(sessionId)
+  lastSendMode.set(sessionId, 'build')
+  useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+}


### PR DESCRIPTION
## Summary
- Record Claude CLI prompt send bookkeeping when a handoff or background follow-up is actually delivered.
- Restore ticket timer behavior by updating send timestamps, token baselines, last send mode, and worktree status for delivered CLI prompts.
- Keep queued prompts unchanged so failed deliveries do not mark sessions as working.
- Add tests covering delivered vs queued Claude CLI background prompts.

## Testing
- `vitest src/renderer/src/lib/backgroundSessionStart.claude-cli.test.ts`
- Verified delivered prompts populate `userExplicitSendTimes`, `messageSendTimes`, `lastSendMode`, and working status.
- Verified queued prompts do not record send times or working status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized renderer state for Claude CLI send tracking and kanban UI timers; guarded so only successful delivery updates status.
> 
> **Overview**
> Fixes **kanban ticket timers** not starting after Claude CLI **handoffs** and **background follow-ups**, because those paths deliver via the PTY bridge and never wrote `userExplicitSendTimes` (unlike OpenCode sends).
> 
> Adds **`markClaudeCliPromptStarted`** to centralize post-delivery bookkeeping: send timestamps, token baseline, `lastSendMode`, and **working** session status. It is invoked from kanban handoffs, `ClaudeCliSessionView` handoff startup, and `startBackgroundSessionPrompt` only when the prompt is **actually delivered** to a live PTY.
> 
> Queued prompts (no PTY yet) **skip** this helper and return early so failed spawns do not leave sessions stuck in **working**. Tests cover delivered vs queued background CLI follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a35b7a42fbac039d707e92c752b1eccfa52dc8b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->