### PR TITLE
Add copy path actions to change-file context menus

### DIFF
--- a/src/renderer/src/components/file-tree/ChangesView.tsx
+++ b/src/renderer/src/components/file-tree/ChangesView.tsx
@@ -14,7 +14,8 @@ import {
   EyeOff,
   FileDiff,
   Link,
-  Paperclip
+  Paperclip,
+  Copy
 } from 'lucide-react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { toast } from '@/lib/toast'
@@ -32,6 +33,7 @@ import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useDiffCommentStore } from '@/stores/useDiffCommentStore'
+import { projectApi } from '@/api/project-api'
 import { FileIcon } from './FileIcon'
 import { GitStatusIndicator } from './GitStatusIndicator'
 import { GitCommitForm } from '@/components/git/GitCommitForm'
@@ -725,6 +727,7 @@ export function ChangesView({
                             <FileDiff className="h-3.5 w-3.5 mr-2" />
                             Open Diff
                           </ContextMenuItem>
+                          <CopyPathMenuItems file={item.file} />
                         </ContextMenuContent>
                       }
                     />
@@ -743,6 +746,7 @@ export function ChangesView({
                             <FileDiff className="h-3.5 w-3.5 mr-2" />
                             Open Diff
                           </ContextMenuItem>
+                          <CopyPathMenuItems file={item.file} />
                         </ContextMenuContent>
                       }
                     />
@@ -761,6 +765,7 @@ export function ChangesView({
                             <FileDiff className="h-3.5 w-3.5 mr-2" />
                             Open Diff
                           </ContextMenuItem>
+                          <CopyPathMenuItems file={item.file} />
                           <ContextMenuSeparator />
                           <ContextMenuItem
                             onClick={() => handleDiscardFile(item.file)}
@@ -783,6 +788,7 @@ export function ChangesView({
                             <Plus className="h-3.5 w-3.5 mr-2" />
                             Stage
                           </ContextMenuItem>
+                          <CopyPathMenuItems file={item.file} />
                           <ContextMenuSeparator />
                           <ContextMenuItem
                             onClick={() => handleDiscardFile(item.file)}
@@ -880,6 +886,22 @@ export function ChangesView({
 }
 
 /* ---- Sub-components ---- */
+
+function CopyPathMenuItems({ file }: { file: GitFileStatus }): React.JSX.Element {
+  return (
+    <>
+      <ContextMenuSeparator />
+      <ContextMenuItem onClick={() => projectApi.copyToClipboard(file.path)}>
+        <Copy className="h-3.5 w-3.5 mr-2" />
+        Copy Path
+      </ContextMenuItem>
+      <ContextMenuItem onClick={() => projectApi.copyToClipboard(file.relativePath)}>
+        <Copy className="h-3.5 w-3.5 mr-2" />
+        Copy Relative Path
+      </ContextMenuItem>
+    </>
+  )
+}
 
 interface FileRowProps {
   file: GitFileStatus
@@ -1203,6 +1225,7 @@ const MemberChanges = memo(function MemberChanges({
                             <FileDiff className="h-3.5 w-3.5 mr-2" />
                             Open Diff
                           </ContextMenuItem>
+                          <CopyPathMenuItems file={item.file} />
                         </ContextMenuContent>
                       }
                     />
@@ -1219,6 +1242,7 @@ const MemberChanges = memo(function MemberChanges({
                             <Minus className="h-3.5 w-3.5 mr-2" />
                             Unstage
                           </ContextMenuItem>
+                          <CopyPathMenuItems file={item.file} />
                         </ContextMenuContent>
                       }
                     />
@@ -1235,6 +1259,7 @@ const MemberChanges = memo(function MemberChanges({
                             <Plus className="h-3.5 w-3.5 mr-2" />
                             Stage
                           </ContextMenuItem>
+                          <CopyPathMenuItems file={item.file} />
                           <ContextMenuSeparator />
                           <ContextMenuItem
                             onClick={() => onDiscardChanges(wp, item.file.relativePath)}
@@ -1259,6 +1284,7 @@ const MemberChanges = memo(function MemberChanges({
                             <Plus className="h-3.5 w-3.5 mr-2" />
                             Stage
                           </ContextMenuItem>
+                          <CopyPathMenuItems file={item.file} />
                         </ContextMenuContent>
                       }
                     />


### PR DESCRIPTION
## Summary
- Added context menu actions to copy a file's full path or relative path from the Changes tab.
- Reused the new copy-path menu items across tracked, unstaged, staged, and member change rows.
- Wired the actions through `projectApi.copyToClipboard` and added the copy icon for consistency.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only clipboard UI in the changes list; no git or staging behavior changes.
> 
> **Overview**
> Adds **Copy Path** and **Copy Relative Path** to the right-click menu for files listed in the Changes tab (conflicts, staged, modified, and untracked), including per-repo rows in connection mode.
> 
> A shared `CopyPathMenuItems` helper calls `projectApi.copyToClipboard` with `file.path` or `file.relativePath`, separated from existing actions with a menu divider and a copy icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc5e1dacd032a581f73ff8ed5f2c550af9e537d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->