### PR TITLE
Treat expired usage windows as N/A

### DIFF
--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -11,9 +11,13 @@ afterEach(() => {
   cleanup()
 })
 
+const inOneHour = (): string => new Date(Date.now() + 60 * 60 * 1000).toISOString()
+const inOneDay = (): string => new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+const oneHourAgo = (): string => new Date(Date.now() - 60 * 60 * 1000).toISOString()
+
 const sampleUsage: UsageData = {
-  five_hour: { utilization: 20, resets_at: '2026-05-14T12:00:00.000Z' },
-  seven_day: { utilization: 10, resets_at: '2026-05-15T12:00:00.000Z' }
+  five_hour: { utilization: 20, resets_at: inOneHour() },
+  seven_day: { utilization: 10, resets_at: inOneDay() }
 }
 
 describe('UsageAccountRow', () => {
@@ -44,7 +48,7 @@ describe('UsageAccountRow', () => {
           email: 'noa@example.com',
           usage: {
             five_hour: { utilization: 0, resets_at: null },
-            seven_day: { utilization: 66, resets_at: '2026-07-10T01:59:59.000Z' }
+            seven_day: { utilization: 66, resets_at: inOneDay() }
           },
           status: 'ok',
           lastError: null,
@@ -56,6 +60,56 @@ describe('UsageAccountRow', () => {
     )
 
     expect(screen.getByText('66%')).toBeTruthy()
+    expect(screen.getByText('N/A')).toBeTruthy()
+  })
+
+  it('shows N/A and an empty bar for a window whose reset time is in the past', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-stale-window',
+          email: 'stale@example.com',
+          usage: {
+            five_hour: { utilization: 42, resets_at: oneHourAgo() },
+            seven_day: { utilization: 66, resets_at: inOneDay() }
+          },
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+      />
+    )
+
+    // Stale five_hour window: percent and reset time are both replaced
+    expect(screen.queryByText('42%')).toBeNull()
+    expect(screen.getByText('0%')).toBeTruthy()
+    expect(screen.getByText('N/A')).toBeTruthy()
+    // Fresh seven_day window still renders normally
+    expect(screen.getByText('66%')).toBeTruthy()
+  })
+
+  it('shows N/A and an empty bar for a scoped entry whose reset time is in the past', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-stale-scoped',
+          email: 'stale-scoped@example.com',
+          usage: {
+            ...sampleUsage,
+            scoped: [{ label: 'Fable', used_percent: 55, resets_at: oneHourAgo() }]
+          },
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+      />
+    )
+
+    expect(screen.getByText('Fable')).toBeTruthy()
+    expect(screen.queryByText('55%')).toBeNull()
+    expect(screen.getByText('0%')).toBeTruthy()
     expect(screen.getByText('N/A')).toBeTruthy()
   })
 

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -76,6 +76,27 @@ function formatResetTime(
   return `${month} ${day}, ${timeStr}`
 }
 
+// A reset time already in the past means the snapshot predates the window's
+// reset — the utilization no longer reflects reality, so callers show N/A and
+// an empty bar instead of a confidently-wrong percentage. null is NOT stale:
+// it means "no active window" (see formatResetTime).
+function isResetInPast(isoString: string | null | undefined): boolean {
+  if (!isoString) return false
+  const time = new Date(isoString).getTime()
+  return !isNaN(time) && time < Date.now()
+}
+
+function usageWindowDisplay(
+  window: { utilization: number; resets_at: string | null } | undefined,
+  type: 'five_hour' | 'seven_day'
+): { percent: number; resetTime: string } {
+  if (!window || isResetInPast(window.resets_at)) return { percent: 0, resetTime: 'N/A' }
+  return {
+    percent: Math.round(window.utilization),
+    resetTime: formatResetTime(window.resets_at, type)
+  }
+}
+
 function formatRelativeReset(resetsAt: number): string {
   const seconds = Math.max(0, Math.ceil(resetsAt - Date.now() / 1000))
   const hours = Math.floor(seconds / 3600)
@@ -206,14 +227,8 @@ export function UsageAccountRow({
   members,
   membersLoading = false
 }: UsageAccountRowProps): React.JSX.Element {
-  const fiveHourPercent = row.usage ? Math.round(row.usage.five_hour.utilization) : 0
-  const sevenDayPercent = row.usage ? Math.round(row.usage.seven_day.utilization) : 0
-  const fiveHourReset = row.usage
-    ? formatResetTime(row.usage.five_hour.resets_at, 'five_hour')
-    : 'N/A'
-  const sevenDayReset = row.usage
-    ? formatResetTime(row.usage.seven_day.resets_at, 'seven_day')
-    : 'N/A'
+  const fiveHour = usageWindowDisplay(row.usage?.five_hour, 'five_hour')
+  const sevenDay = usageWindowDisplay(row.usage?.seven_day, 'seven_day')
   const scoped = row.usage?.scoped ?? []
 
   return (
@@ -243,17 +258,23 @@ export function UsageAccountRow({
       )}
 
       <div className={cn('mt-1 space-y-0.5', row.status === 'stale' && 'opacity-50')}>
-        <UsageRow label="5h" percent={fiveHourPercent} resetTime={fiveHourReset} />
-        <UsageRow label="7d" percent={sevenDayPercent} resetTime={sevenDayReset} />
-        {scoped.map((entry) => (
-          <UsageRow
-            key={entry.label}
-            label={entry.label}
-            percent={Math.round(entry.used_percent)}
-            resetTime={entry.resets_at ? formatResetTime(entry.resets_at, 'seven_day') : 'N/A'}
-            labelClassName="w-10"
-          />
-        ))}
+        <UsageRow label="5h" percent={fiveHour.percent} resetTime={fiveHour.resetTime} />
+        <UsageRow label="7d" percent={sevenDay.percent} resetTime={sevenDay.resetTime} />
+        {scoped.map((entry) => {
+          const display = usageWindowDisplay(
+            { utilization: entry.used_percent, resets_at: entry.resets_at },
+            'seven_day'
+          )
+          return (
+            <UsageRow
+              key={entry.label}
+              label={entry.label}
+              percent={display.percent}
+              resetTime={display.resetTime}
+              labelClassName="w-10"
+            />
+          )
+        })}
       </div>
 
       {(onSwitch || onRefresh || onSignInAgain) && (
@@ -576,10 +597,8 @@ function ProviderUsageBlock({
     )
   }
 
-  const fiveHourPercent = Math.round(usage.five_hour.utilization)
-  const sevenDayPercent = Math.round(usage.seven_day.utilization)
-  const fiveHourReset = formatResetTime(usage.five_hour.resets_at, 'five_hour')
-  const sevenDayReset = formatResetTime(usage.seven_day.resets_at, 'seven_day')
+  const fiveHour = usageWindowDisplay(usage.five_hour, 'five_hour')
+  const sevenDay = usageWindowDisplay(usage.seven_day, 'seven_day')
   const extra = usage.extra_usage
   const fiveHourRateLimit =
     provider === 'anthropic' ? getRateLimitWindow(anthropicRateLimit, 'five_hour') : undefined
@@ -614,14 +633,14 @@ function ProviderUsageBlock({
             <div className="flex-1 space-y-0.5">
               <UsageRow
                 label="5h"
-                percent={fiveHourPercent}
-                resetTime={fiveHourReset}
+                percent={fiveHour.percent}
+                resetTime={fiveHour.resetTime}
                 rateLimit={fiveHourRateLimit}
               />
               <UsageRow
                 label="7d"
-                percent={sevenDayPercent}
-                resetTime={sevenDayReset}
+                percent={sevenDay.percent}
+                resetTime={sevenDay.resetTime}
                 rateLimit={sevenDayRateLimit}
               />
             </div>


### PR DESCRIPTION
## Summary
- Show `N/A` and an empty bar when a usage window’s `resets_at` is already in the past.
- Apply the stale-window handling consistently for account rows, scoped usage rows, and provider usage blocks.
- Add tests covering stale standard windows and scoped entries.

## Testing
- Added unit tests in `UsageIndicator.test.tsx` for past-reset 5h/7d windows.
- Added unit tests for a scoped usage entry with an expired reset time.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in the usage indicator; no API, auth, or persistence behavior is modified.
> 
> **Overview**
> Usage rows no longer show stale utilization when a window’s **`resets_at`** is already in the past. **`isResetInPast`** and **`usageWindowDisplay`** centralize that rule: expired windows render **0%**, an empty bar, and **N/A** for reset time; **`null`** **`resets_at`** is unchanged (still “no active window,” not stale).
> 
> The same display path is wired into **account rows** (5h/7d), **scoped** usage lines, and the compact **provider** usage block in the hover trigger.
> 
> Tests use relative timestamps and add coverage for past-reset **5h** windows and **scoped** entries, while still asserting fresh windows render normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d31342023755710a7f202c077b30b24158fb0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->