### PR TITLE
Add colored connection indicator to kanban tickets

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -38,7 +38,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { Button } from '@/components/ui/button'
 import { NoteEditorModal } from './NoteEditorModal'
 import { MoveToProjectModal } from './MoveToProjectModal'
-import { cn } from '@/lib/utils'
+import { cn, parseColorQuad } from '@/lib/utils'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { opencodeApi } from '@/api/opencode-api'
 import { systemApi } from '@/api/system-api'
@@ -341,6 +341,17 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
         if (!connectionSession) return null
         const conn = state.connections.find((c) => c.id === connectionSession.connectionId)
         return conn?.custom_name || conn?.name || null
+      },
+      [connectionSession]
+    )
+  )
+
+  const connectionColor = useConnectionStore(
+    useCallback(
+      (state) => {
+        if (!connectionSession) return null
+        const conn = state.connections.find((c) => c.id === connectionSession.connectionId)
+        return conn?.color ?? null
       },
       [connectionSession]
     )
@@ -1034,10 +1045,25 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
 
                 {/* Connection badge — shown on project board when ticket has connection session */}
                 {!connectionId && connectionName && (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                    <LinkIcon className="h-3 w-3" />
-                    {connectionName}
-                  </span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        data-testid="kanban-ticket-connection"
+                        className="inline-flex items-center rounded-full bg-muted/40 px-2 py-0.5 cursor-help"
+                      >
+                        {connectionColor ? (
+                          <span
+                            className="h-2.5 w-2.5 rounded-full shrink-0"
+                            style={{ backgroundColor: parseColorQuad(connectionColor)[1] }}
+                            aria-hidden="true"
+                          />
+                        ) : (
+                          <LinkIcon className="h-3 w-3 text-muted-foreground" />
+                        )}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>{connectionName}</TooltipContent>
+                  </Tooltip>
                 )}
 
                 {/* PR badge */}


### PR DESCRIPTION
## Summary
- Replaced the connection name badge with a compact tooltip-triggered indicator on kanban tickets.
- Shows the connection color as a dot when available, falling back to the link icon when no color is set.
- Preserves the connection name in a tooltip and adds a test id for targeting the badge.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Kanban card UI only; no changes to session, connection, or data persistence logic.
> 
> **Overview**
> On **project** kanban boards, tickets linked to a connection session no longer show an inline connection name chip. The badge is now a small **tooltip** control (`kanban-ticket-connection`) that shows the connection’s **color dot** (via `parseColorQuad`, matching the sidebar) or the link icon when no color is set; the full connection name appears on hover.
> 
> A `connectionColor` selector was added alongside the existing connection name lookup from `useConnectionStore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4f56a0c5720009f38ac28f9c46c819bf4019b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->