### PR TITLE
Improve recent connections filtering UI

### DIFF
--- a/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
+++ b/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { Loader2, Link, Search, StickyNote, Trash2 } from 'lucide-react'
+import { Loader2, Link, Search, StickyNote, Trash2, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { subsequenceMatch } from '@/lib/subsequence-match'
 import {
   Dialog,
   DialogContent,
@@ -10,6 +11,7 @@ import {
   DialogFooter
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import {
   ContextMenu,
@@ -21,7 +23,7 @@ import { useConnectionStore } from '@/stores'
 import { connectionApi } from '@/api/connection-api'
 import { toast } from '@/lib/toast'
 import { formatRelativeTime } from '@/lib/format-utils'
-import type { RecentConnectionEntry } from '@shared/types/connection'
+import type { RecentConnectionEntry, RecentConnectionProject } from '@shared/types/connection'
 
 interface RecentConnectionsDialogProps {
   open: boolean
@@ -40,6 +42,8 @@ export function RecentConnectionsDialog({
   const [isCreating, setIsCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [filter, setFilter] = useState('')
+  const [projectFilter, setProjectFilter] = useState('')
+  const [selectedProjectIds, setSelectedProjectIds] = useState<Set<string>>(new Set())
 
   // Inline note edit state
   const [editingNoteId, setEditingNoteId] = useState<string | null>(null)
@@ -58,6 +62,8 @@ export function RecentConnectionsDialog({
     setEntries([])
     setIsLoading(true)
     setFilter('')
+    setProjectFilter('')
+    setSelectedProjectIds(new Set())
     setEditingNoteId(null)
 
     connectionApi
@@ -79,15 +85,69 @@ export function RecentConnectionsDialog({
       })
   }, [open])
 
+  // Every project that appears in at least one recent connection
+  const allProjects = useMemo(() => {
+    const byId = new Map<string, RecentConnectionProject>()
+    for (const entry of entries) {
+      for (const project of entry.projects) {
+        if (!byId.has(project.id)) byId.set(project.id, project)
+      }
+    }
+    return Array.from(byId.values()).sort((a, b) => a.name.localeCompare(b.name))
+  }, [entries])
+
+  // Same fuzzy matching + ranking as the sidebar project filter
+  const filteredProjects = useMemo(() => {
+    const q = projectFilter.trim()
+    if (!q) return allProjects
+    return allProjects
+      .map((project) => ({
+        project,
+        nameMatch: subsequenceMatch(q, project.name),
+        pathMatch: subsequenceMatch(q, project.path)
+      }))
+      .filter(({ nameMatch, pathMatch }) => nameMatch.matched || pathMatch.matched)
+      .sort((a, b) => {
+        const aScore = a.nameMatch.matched ? a.nameMatch.score : a.pathMatch.score + 1000
+        const bScore = b.nameMatch.matched ? b.nameMatch.score : b.pathMatch.score + 1000
+        return aScore - bScore
+      })
+      .map(({ project }) => project)
+  }, [allProjects, projectFilter])
+
+  const selectedProjects = useMemo(
+    () => allProjects.filter((p) => selectedProjectIds.has(p.id)),
+    [allProjects, selectedProjectIds]
+  )
+
+  const toggleProject = useCallback((projectId: string) => {
+    setSelectedProjectIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(projectId)) {
+        next.delete(projectId)
+      } else {
+        next.add(projectId)
+      }
+      return next
+    })
+  }, [])
+
   const filteredEntries = useMemo(() => {
+    let result = entries
+    if (selectedProjectIds.size > 0) {
+      result = result.filter((entry) => {
+        const memberIds = new Set(entry.projects.map((p) => p.id))
+        return Array.from(selectedProjectIds).every((id) => memberIds.has(id))
+      })
+    }
     const q = filter.trim().toLowerCase()
-    if (!q) return entries
-    return entries.filter((entry) =>
+    if (!q) return result
+    return result.filter((entry) =>
       `${entry.projects.map((p) => p.name).join(' + ')} ${entry.note ?? ''}`
         .toLowerCase()
         .includes(q)
     )
-  }, [entries, filter])
+  }, [entries, filter, selectedProjectIds])
 
   // The Create handler resolves against `entries`, so a selected row hidden by
   // the filter would still be creatable invisibly -- drop the selection instead.
@@ -209,9 +269,22 @@ export function RecentConnectionsDialog({
     }, 100)
   }, [])
 
+  // With projects selected, the selection chips already say what's common to
+  // every row -- only the remaining (unselected) projects are worth showing.
+  const renderProjectsLabel = (entry: RecentConnectionEntry): React.ReactNode => {
+    if (selectedProjectIds.size === 0) {
+      return entry.projects.map((p) => p.name).join(' + ')
+    }
+    const remaining = entry.projects.filter((p) => !selectedProjectIds.has(p.id))
+    if (remaining.length === 0) {
+      return <span className="italic text-muted-foreground">selected projects only</span>
+    }
+    return `+ ${remaining.map((p) => p.name).join(' + ')}`
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md" data-testid="recent-connections-dialog">
+      <DialogContent className="sm:max-w-3xl" data-testid="recent-connections-dialog">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Link className="h-4 w-4" />
@@ -222,115 +295,204 @@ export function RecentConnectionsDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="relative">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Filter by project or note..."
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            className="pl-9"
-            autoFocus
-            data-testid="recent-connections-filter"
-          />
-        </div>
+        {selectedProjects.length > 0 && (
+          <div
+            className="flex flex-wrap items-center gap-1.5"
+            data-testid="recent-connections-selected-projects"
+          >
+            {selectedProjects.map((project) => (
+              <button
+                key={project.id}
+                onClick={() => toggleProject(project.id)}
+                className={cn(
+                  'inline-flex items-center gap-1 rounded-full border border-border',
+                  'bg-accent/40 px-2 py-0.5 text-xs hover:bg-accent transition-colors'
+                )}
+                title="Remove from filter"
+                data-testid={`recent-connections-selected-chip-${project.id}`}
+              >
+                {project.name}
+                <X className="h-3 w-3 text-muted-foreground" />
+              </button>
+            ))}
+            <button
+              onClick={() => setSelectedProjectIds(new Set())}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors px-1"
+              data-testid="recent-connections-clear-selection"
+            >
+              Clear
+            </button>
+          </div>
+        )}
 
-        <div className="max-h-[300px] overflow-y-auto border rounded-md">
-          {error ? (
-            <div
-              className="px-4 py-8 text-center text-sm text-destructive"
-              data-testid="recent-connections-error"
-            >
-              {error}
+        {/* min-w-0: as a grid item of DialogContent this row would otherwise
+            size to its content's min-width and overflow the dialog */}
+        <div className="flex min-w-0 gap-3">
+          {/* Project filter panel */}
+          <div className="flex w-56 shrink-0 flex-col gap-2">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Filter projects..."
+                value={projectFilter}
+                onChange={(e) => setProjectFilter(e.target.value)}
+                className="pl-9"
+                data-testid="recent-connections-project-filter"
+              />
             </div>
-          ) : isLoading ? (
             <div
-              className="flex items-center justify-center py-8"
-              data-testid="recent-connections-loading"
+              className="h-[340px] overflow-y-auto border rounded-md"
+              data-testid="recent-connections-project-list"
             >
-              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              {allProjects.length === 0 ? (
+                <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  No projects yet
+                </div>
+              ) : filteredProjects.length === 0 ? (
+                <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  No projects match your filter
+                </div>
+              ) : (
+                <div className="py-1">
+                  {filteredProjects.map((project) => (
+                    <label
+                      key={project.id}
+                      className={cn(
+                        'flex items-center gap-2.5 w-full px-3 py-1.5 text-sm cursor-pointer',
+                        'hover:bg-accent/50 transition-colors',
+                        selectedProjectIds.has(project.id) && 'bg-accent/30'
+                      )}
+                      data-testid={`recent-connections-project-option-${project.id}`}
+                    >
+                      <Checkbox
+                        checked={selectedProjectIds.has(project.id)}
+                        onCheckedChange={() => toggleProject(project.id)}
+                        data-testid={`recent-connections-project-checkbox-${project.id}`}
+                      />
+                      <span className="truncate">{project.name}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
             </div>
-          ) : entries.length === 0 ? (
-            <div
-              className="px-4 py-8 text-center text-sm text-muted-foreground"
-              data-testid="recent-connections-empty"
-            >
-              No recent connections yet. Create one by right-clicking a worktree and choosing
-              Connect to…
+          </div>
+
+          {/* Connection list */}
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Filter by project or note..."
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                className="pl-9"
+                autoFocus
+                data-testid="recent-connections-filter"
+              />
             </div>
-          ) : filteredEntries.length === 0 ? (
-            <div
-              className="px-4 py-8 text-center text-sm text-muted-foreground"
-              data-testid="recent-connections-no-match"
-            >
-              No connections match your filter
-            </div>
-          ) : (
-            <div className="py-1">
-              {filteredEntries.map((entry) =>
-                editingNoteId === entry.id ? (
-                  <div key={entry.id} className="flex flex-col w-full px-3 py-2 text-sm text-left">
-                    <input
-                      ref={noteInputRef}
-                      autoFocus
-                      value={noteInput}
-                      onChange={(e) => setNoteInput(e.target.value)}
-                      onKeyDown={handleNoteKeyDown}
-                      onBlur={handleNoteBlur}
-                      onClick={(e) => e.stopPropagation()}
-                      className="bg-background border border-border rounded px-1.5 py-0.5 text-sm w-full focus:outline-none focus:ring-1 focus:ring-ring"
-                      placeholder="Add a note..."
-                      data-testid="recent-connection-note-input"
-                    />
-                    <span className="text-xs text-muted-foreground truncate">
-                      {formatRelativeTime(Date.parse(entry.last_used_at))}
-                    </span>
-                  </div>
-                ) : (
-                  <ContextMenu key={entry.id}>
-                    <ContextMenuTrigger asChild>
-                      <button
-                        className={cn(
-                          'flex flex-col w-full px-3 py-2 text-sm text-left',
-                          'hover:bg-accent/50 transition-colors',
-                          selectedId === entry.id && 'bg-accent/30'
-                        )}
-                        onClick={() => setSelectedId(entry.id)}
-                        data-testid={`recent-connection-row-${entry.id}`}
+
+            <div className="h-[340px] overflow-y-auto border rounded-md">
+              {error ? (
+                <div
+                  className="px-4 py-8 text-center text-sm text-destructive"
+                  data-testid="recent-connections-error"
+                >
+                  {error}
+                </div>
+              ) : isLoading ? (
+                <div
+                  className="flex items-center justify-center py-8"
+                  data-testid="recent-connections-loading"
+                >
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              ) : entries.length === 0 ? (
+                <div
+                  className="px-4 py-8 text-center text-sm text-muted-foreground"
+                  data-testid="recent-connections-empty"
+                >
+                  No recent connections yet. Create one by right-clicking a worktree and choosing
+                  Connect to…
+                </div>
+              ) : filteredEntries.length === 0 ? (
+                <div
+                  className="px-4 py-8 text-center text-sm text-muted-foreground"
+                  data-testid="recent-connections-no-match"
+                >
+                  No connections match your filter
+                </div>
+              ) : (
+                <div className="py-1">
+                  {filteredEntries.map((entry) =>
+                    editingNoteId === entry.id ? (
+                      <div
+                        key={entry.id}
+                        className="flex flex-col w-full px-3 py-2 text-sm text-left"
                       >
-                        <span className="truncate">
-                          {entry.note && (
-                            <span
-                              className="italic text-primary"
-                              data-testid={`recent-connection-note-${entry.id}`}
-                            >
-                              {entry.note}
-                              {' — '}
-                            </span>
-                          )}
-                          {entry.projects.map((p) => p.name).join(' + ')}
-                        </span>
+                        <input
+                          ref={noteInputRef}
+                          autoFocus
+                          value={noteInput}
+                          onChange={(e) => setNoteInput(e.target.value)}
+                          onKeyDown={handleNoteKeyDown}
+                          onBlur={handleNoteBlur}
+                          onClick={(e) => e.stopPropagation()}
+                          className="bg-background border border-border rounded px-1.5 py-0.5 text-sm w-full focus:outline-none focus:ring-1 focus:ring-ring"
+                          placeholder="Add a note..."
+                          data-testid="recent-connection-note-input"
+                        />
                         <span className="text-xs text-muted-foreground truncate">
                           {formatRelativeTime(Date.parse(entry.last_used_at))}
                         </span>
-                      </button>
-                    </ContextMenuTrigger>
-                    <ContextMenuContent className="w-52">
-                      <ContextMenuItem onClick={() => handleStartNoteEdit(entry)}>
-                        <StickyNote className="h-4 w-4 mr-2" />
-                        {entry.note ? 'Edit note' : 'Add note'}
-                      </ContextMenuItem>
-                      {entry.note && (
-                        <ContextMenuItem onClick={() => void persistNote(entry.id, null)}>
-                          <Trash2 className="h-4 w-4 mr-2" />
-                          Remove note
-                        </ContextMenuItem>
-                      )}
-                    </ContextMenuContent>
-                  </ContextMenu>
-                )
+                      </div>
+                    ) : (
+                      <ContextMenu key={entry.id}>
+                        <ContextMenuTrigger asChild>
+                          <button
+                            className={cn(
+                              'flex flex-col w-full px-3 py-2 text-sm text-left',
+                              'hover:bg-accent/50 transition-colors',
+                              selectedId === entry.id && 'bg-accent/30'
+                            )}
+                            onClick={() => setSelectedId(entry.id)}
+                            data-testid={`recent-connection-row-${entry.id}`}
+                          >
+                            <span className="truncate">
+                              {entry.note && (
+                                <span
+                                  className="italic text-primary"
+                                  data-testid={`recent-connection-note-${entry.id}`}
+                                >
+                                  {entry.note}
+                                  {' — '}
+                                </span>
+                              )}
+                              {renderProjectsLabel(entry)}
+                            </span>
+                            <span className="text-xs text-muted-foreground truncate">
+                              {formatRelativeTime(Date.parse(entry.last_used_at))}
+                            </span>
+                          </button>
+                        </ContextMenuTrigger>
+                        <ContextMenuContent className="w-52">
+                          <ContextMenuItem onClick={() => handleStartNoteEdit(entry)}>
+                            <StickyNote className="h-4 w-4 mr-2" />
+                            {entry.note ? 'Edit note' : 'Add note'}
+                          </ContextMenuItem>
+                          {entry.note && (
+                            <ContextMenuItem onClick={() => void persistNote(entry.id, null)}>
+                              <Trash2 className="h-4 w-4 mr-2" />
+                              Remove note
+                            </ContextMenuItem>
+                          )}
+                        </ContextMenuContent>
+                      </ContextMenu>
+                    )
+                  )}
+                </div>
               )}
             </div>
-          )}
+          </div>
         </div>
 
         <DialogFooter>

--- a/src/renderer/src/components/connections/__tests__/RecentConnectionsDialog.test.tsx
+++ b/src/renderer/src/components/connections/__tests__/RecentConnectionsDialog.test.tsx
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { RecentConnectionsDialog } from '../RecentConnectionsDialog'
+import type { RecentConnectionEntry } from '@shared/types/connection'
+
+vi.mock('@/api/connection-api', () => ({
+  connectionApi: {
+    getRecentConnections: vi.fn(),
+    setRecentConnectionNote: vi.fn()
+  }
+}))
+
+import { connectionApi } from '@/api/connection-api'
+
+const alpha = { id: 'proj-a', name: 'alpha-service', path: '/repo/alpha-service' }
+const beta = { id: 'proj-b', name: 'beta-web', path: '/repo/beta-web' }
+const gamma = { id: 'proj-c', name: 'gamma-api', path: '/repo/gamma-api' }
+
+function entry(
+  id: string,
+  projects: (typeof alpha)[],
+  note: string | null = null
+): RecentConnectionEntry {
+  return {
+    id,
+    project_set_key: projects.map((p) => p.id).join('|'),
+    projects,
+    last_used_at: '2026-07-01T00:00:00.000Z',
+    use_count: 1,
+    note
+  }
+}
+
+const entries = [
+  entry('e1', [alpha, beta]),
+  entry('e2', [alpha, gamma]),
+  entry('e3', [beta, gamma])
+]
+
+async function renderDialog(data: RecentConnectionEntry[] = entries): Promise<void> {
+  vi.mocked(connectionApi.getRecentConnections).mockResolvedValue({
+    success: true,
+    entries: data
+  })
+  render(<RecentConnectionsDialog open onOpenChange={() => {}} />)
+  await waitFor(() =>
+    expect(screen.queryByTestId('recent-connections-loading')).not.toBeInTheDocument()
+  )
+}
+
+describe('RecentConnectionsDialog project filter panel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lists the unique projects from all entries in the project panel', async () => {
+    await renderDialog()
+
+    const panel = screen.getByTestId('recent-connections-project-list')
+    expect(within(panel).getByText('alpha-service')).toBeInTheDocument()
+    expect(within(panel).getByText('beta-web')).toBeInTheDocument()
+    expect(within(panel).getByText('gamma-api')).toBeInTheDocument()
+    // Unique: alpha appears in two entries but is listed once
+    expect(within(panel).getAllByText('alpha-service')).toHaveLength(1)
+  })
+
+  it('filters projects with fuzzy subsequence matching like the sidebar', async () => {
+    await renderDialog()
+
+    const input = screen.getByTestId('recent-connections-project-filter')
+    // "gapi" is a subsequence of "gamma-api" but not of the others
+    await userEvent.type(input, 'gapi')
+
+    const panel = screen.getByTestId('recent-connections-project-list')
+    expect(within(panel).getByText('gamma-api')).toBeInTheDocument()
+    expect(within(panel).queryByText('alpha-service')).not.toBeInTheDocument()
+    expect(within(panel).queryByText('beta-web')).not.toBeInTheDocument()
+  })
+
+  it('selecting a project filters entries to connections containing it', async () => {
+    await renderDialog()
+
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-a'))
+
+    expect(screen.getByTestId('recent-connection-row-e1')).toBeInTheDocument()
+    expect(screen.getByTestId('recent-connection-row-e2')).toBeInTheDocument()
+    expect(screen.queryByTestId('recent-connection-row-e3')).not.toBeInTheDocument()
+  })
+
+  it('shows only the unselected projects prefixed with + in each row', async () => {
+    await renderDialog()
+
+    // Before selection: full names joined with +
+    expect(screen.getByTestId('recent-connection-row-e1')).toHaveTextContent(
+      'alpha-service + beta-web'
+    )
+
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-a'))
+
+    const row1 = screen.getByTestId('recent-connection-row-e1')
+    expect(row1).toHaveTextContent('+ beta-web')
+    expect(row1).not.toHaveTextContent('alpha-service')
+    expect(screen.getByTestId('recent-connection-row-e2')).toHaveTextContent('+ gamma-api')
+  })
+
+  it('requires all selected projects and hides them from row labels', async () => {
+    await renderDialog([...entries, entry('e4', [alpha, beta, gamma])])
+
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-a'))
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-b'))
+
+    // Only entries containing both alpha and beta remain
+    expect(screen.getByTestId('recent-connection-row-e1')).toBeInTheDocument()
+    expect(screen.getByTestId('recent-connection-row-e4')).toBeInTheDocument()
+    expect(screen.queryByTestId('recent-connection-row-e2')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('recent-connection-row-e3')).not.toBeInTheDocument()
+
+    // e4 shows only the remaining project; e1 has no remaining projects
+    expect(screen.getByTestId('recent-connection-row-e4')).toHaveTextContent('+ gamma-api')
+    const row1 = screen.getByTestId('recent-connection-row-e1')
+    expect(row1).not.toHaveTextContent('alpha-service')
+    expect(row1).not.toHaveTextContent('beta-web')
+  })
+
+  it('shows selected projects as chips at the top and removes them on click', async () => {
+    await renderDialog()
+
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-a'))
+
+    const chips = screen.getByTestId('recent-connections-selected-projects')
+    expect(within(chips).getByText('alpha-service')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('recent-connections-selected-chip-proj-a'))
+
+    expect(screen.queryByTestId('recent-connections-selected-projects')).not.toBeInTheDocument()
+    // All rows are back with full labels
+    expect(screen.getByTestId('recent-connection-row-e3')).toBeInTheDocument()
+    expect(screen.getByTestId('recent-connection-row-e1')).toHaveTextContent(
+      'alpha-service + beta-web'
+    )
+  })
+
+  it('combines the text filter with the project selection', async () => {
+    await renderDialog([...entries, entry('e5', [alpha, beta], 'release pair')])
+
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-a'))
+    await userEvent.type(screen.getByTestId('recent-connections-filter'), 'release')
+
+    expect(screen.getByTestId('recent-connection-row-e5')).toBeInTheDocument()
+    expect(screen.queryByTestId('recent-connection-row-e1')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('recent-connection-row-e2')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a dedicated project filter panel to the Recent Connections dialog with fuzzy subsequence matching and selectable project checkboxes.
- Filters connection rows by requiring all selected projects, while keeping the text search filter for project names and notes.
- Updates row labels to omit already-selected projects and show a compact "selected projects only" state when applicable.
- Expands the dialog layout to support the new side-by-side filtering UI.
- Adds coverage for project listing, fuzzy filtering, combined filters, chip removal, and row label behavior.

## Testing
- Added Vitest coverage in `RecentConnectionsDialog.test.tsx` for project deduplication, subsequence filtering, selection chips, and combined filtering.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filtering and display changes in the Recent Connections dialog; no API or connection-creation logic changes beyond existing selection clearing when rows are hidden.
> 
> **Overview**
> **Recent Connections** now has a side-by-side layout (wider dialog) with a **project filter panel** on the left and the connection list on the right.
> 
> The panel lists unique projects from recent entries, supports **fuzzy subsequence** search (same `subsequenceMatch` behavior as the sidebar), and **checkbox multi-select**. Connections are filtered to rows that include **all** selected projects; the existing text filter on project names and notes still applies on top.
> 
> **Selected projects** appear as removable chips above the lists. Row labels **omit** already-selected project names (showing `+` for extra projects only, or *selected projects only* when nothing remains). Filter state resets when the dialog opens.
> 
> Adds **Vitest** coverage in `RecentConnectionsDialog.test.tsx` for listing, fuzzy filter, AND selection, chips, combined filters, and label behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1f13a325cbc0a946df33f9e11718404574ffb60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->