### PR TITLE
Highlight active account row in usage indicator

### DIFF
--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -371,6 +371,64 @@ describe('UsageAccountRow', () => {
     expect(screen.getByTestId('member-avatar')).toBeTruthy()
   })
 
+  it('draws a bold purple border on the active account when highlightActive is set', () => {
+    const { container } = render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-hl-1',
+          email: 'active@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: true,
+          isRefreshing: false
+        }}
+        highlightActive
+      />
+    )
+
+    const rowEl = container.firstChild as HTMLElement
+    expect(rowEl.className).toContain('border-purple-500')
+    expect(rowEl.className).toContain('border-2')
+  })
+
+  it('does not draw the purple border on non-active accounts even when highlightActive is set', () => {
+    const { container } = render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-hl-2',
+          email: 'other@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+        highlightActive
+      />
+    )
+
+    expect((container.firstChild as HTMLElement).className).not.toContain('border-purple-500')
+  })
+
+  it('does not draw the purple border on the active account without highlightActive', () => {
+    const { container } = render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-hl-3',
+          email: 'active@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: true,
+          isRefreshing: false
+        }}
+      />
+    )
+
+    expect((container.firstChild as HTMLElement).className).not.toContain('border-purple-500')
+  })
+
   it('renders nothing from the avatar stack when members is undefined', () => {
     render(
       <UsageAccountRow

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -210,6 +210,7 @@ export interface UsageAccountRowProps {
   row: AccountRowData
   isSwitching?: boolean
   isLoginActive?: boolean
+  highlightActive?: boolean
   onSwitch?: () => void
   onRefresh?: () => void
   onSignInAgain?: () => void
@@ -221,6 +222,7 @@ export function UsageAccountRow({
   row,
   isSwitching = false,
   isLoginActive = false,
+  highlightActive = false,
   onSwitch,
   onRefresh,
   onSignInAgain,
@@ -232,7 +234,12 @@ export function UsageAccountRow({
   const scoped = row.usage?.scoped ?? []
 
   return (
-    <div className="relative rounded-md border border-border/50 bg-background/40 px-2 py-1.5">
+    <div
+      className={cn(
+        'relative rounded-md border border-border/50 bg-background/40 px-2 py-1.5',
+        highlightActive && row.isActive && 'border-2 border-purple-500'
+      )}
+    >
       <div className="flex items-center justify-between gap-2">
         <div
           className={cn(
@@ -492,6 +499,11 @@ function ProviderUsageBlock({
           }
         ]
 
+  // With multiple accounts, the active one goes last and gets a purple border
+  // so it reads as "currently active" at a glance.
+  const orderedRows = [...accountRows].sort((a, b) => Number(a.isActive) - Number(b.isActive))
+  const highlightActive = accountRows.length > 1
+
   const handleRefreshActive = (): void => {
     forceRefreshProvider(provider)
     void fetchEmail(provider).then(() => reportActiveAccountsSnapshot())
@@ -564,12 +576,13 @@ function ProviderUsageBlock({
               </div>
             )}
             {accountRows.some((row) => row.email || row.usage) ? (
-              accountRows.map((row) => (
+              orderedRows.map((row) => (
                 <UsageAccountRow
                   key={row.id}
                   row={row}
                   isSwitching={switchingAccountIds.has(row.id)}
                   isLoginActive={isLoginActive}
+                  highlightActive={highlightActive}
                   onSwitch={() => switchAccount(row.id)}
                   onRefresh={
                     savedAccounts.length > 0
@@ -660,12 +673,13 @@ function ProviderUsageBlock({
               Saved accounts unavailable: {savedAccountLoadError}
             </div>
           )}
-          {accountRows.map((row) => (
+          {orderedRows.map((row) => (
             <UsageAccountRow
               key={row.id}
               row={row}
               isSwitching={switchingAccountIds.has(row.id)}
               isLoginActive={isLoginActive}
+              highlightActive={highlightActive}
               onSwitch={() => switchAccount(row.id)}
               onRefresh={
                 savedAccounts.length > 0


### PR DESCRIPTION
## Summary
- Add an active-account highlight to `UsageAccountRow` when `highlightActive` is enabled.
- Sort account rows so the active account renders last, making the highlighted row visually prominent.
- Cover the new behavior with tests for active, inactive, and default cases.

## Testing
- Added unit tests in `UsageIndicator.test.tsx` to verify the purple border appears only for the active row when highlighting is enabled.
- Added unit tests to confirm inactive rows do not receive the active border.
- Added unit tests to confirm the border is not applied when `highlightActive` is false.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in the usage indicator popover with unit test coverage; no auth, data, or switching logic changes.
> 
> **Overview**
> When the usage hover card lists **more than one** saved account, rows are **reordered so the active account appears last**, and that row gets a **bold purple border** so the current account is obvious at a glance.
> 
> `UsageAccountRow` gains an optional `highlightActive` flag: with it on, only the row marked `isActive` receives `border-2 border-purple-500`; inactive rows and single-account lists stay on the default border. The parent usage popover turns highlighting on automatically whenever there are multiple accounts.
> 
> Unit tests assert the border classes for active vs inactive rows and when `highlightActive` is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b147fc22b70f98c83185181f64f27987907cac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->