### PR TITLE
Add backup/restore workflow and RPC support

### DIFF
--- a/src/main/desktop/backend-manager.ts
+++ b/src/main/desktop/backend-manager.ts
@@ -1066,6 +1066,67 @@ const handleDesktopBackendCommand = (
       })
   }
 
+  if (message.command === 'backupOpenFileDialog') {
+    return dialog
+      .showOpenDialog({
+        title: 'Open Hive Backup',
+        filters: [{ name: 'Hive Backup', extensions: ['yaml', 'yml'] }],
+        properties: ['openFile']
+      })
+      .then((result) => {
+        sendDesktopBackendCommandResult(
+          child,
+          makeDesktopCommandResult(message.id, {
+            ok: true,
+            value: {
+              filePath:
+                result.canceled || result.filePaths.length === 0 ? null : result.filePaths[0]
+            }
+          }),
+          log
+        )
+      })
+      .catch((error) => {
+        sendDesktopBackendCommandResult(
+          child,
+          makeDesktopCommandResult(message.id, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error)
+          }),
+          log
+        )
+      })
+  }
+
+  if (message.command === 'backupSaveFileDialog') {
+    return dialog
+      .showSaveDialog({
+        title: 'Export Hive Backup',
+        defaultPath: message.payload.defaultFileName,
+        filters: [{ name: 'Hive Backup', extensions: ['yaml', 'yml'] }]
+      })
+      .then((result) => {
+        sendDesktopBackendCommandResult(
+          child,
+          makeDesktopCommandResult(message.id, {
+            ok: true,
+            value: { filePath: result.canceled || !result.filePath ? null : result.filePath }
+          }),
+          log
+        )
+      })
+      .catch((error) => {
+        sendDesktopBackendCommandResult(
+          child,
+          makeDesktopCommandResult(message.id, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error)
+          }),
+          log
+        )
+      })
+  }
+
   if (message.command === 'systemGetAppVersion') {
     try {
       const version = app.getVersion()

--- a/src/main/services/git-repository.test.ts
+++ b/src/main/services/git-repository.test.ts
@@ -3,7 +3,12 @@ import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { cloneRepository, deriveProjectNameFromGitUrl, isSafeGitRemoteUrl } from './git-repository'
+import {
+  cloneRepository,
+  deriveProjectNameFromGitUrl,
+  isSafeGitRemoteUrl,
+  normalizeGitRemoteUrl
+} from './git-repository'
 
 const simpleGitMock = vi.hoisted(() => ({
   clone: vi.fn(),
@@ -62,6 +67,106 @@ describe('isSafeGitRemoteUrl', () => {
     expect(isSafeGitRemoteUrl('--upload-pack=x')).toBe(false)
     expect(isSafeGitRemoteUrl('')).toBe(false)
     expect(isSafeGitRemoteUrl('https://github.com/u/r with-space.git')).toBe(false)
+  })
+})
+
+describe('normalizeGitRemoteUrl', () => {
+  it('normalizes scp-like syntax to host/org/repo', () => {
+    expect(normalizeGitRemoteUrl('git@github.com:acme/hive.git')).toBe('github.com/acme/hive')
+  })
+
+  it('normalizes https URLs, with and without .git / trailing slash', () => {
+    expect(normalizeGitRemoteUrl('https://github.com/acme/hive')).toBe('github.com/acme/hive')
+    expect(normalizeGitRemoteUrl('https://github.com/acme/hive.git')).toBe('github.com/acme/hive')
+    expect(normalizeGitRemoteUrl('https://github.com/acme/hive.git/')).toBe(
+      'github.com/acme/hive'
+    )
+  })
+
+  it('strips userinfo from https URLs', () => {
+    expect(normalizeGitRemoteUrl('https://user@github.com/acme/hive.git')).toBe(
+      'github.com/acme/hive'
+    )
+    expect(normalizeGitRemoteUrl('https://user:pass@github.com/acme/hive.git')).toBe(
+      'github.com/acme/hive'
+    )
+  })
+
+  it('normalizes ssh:// URLs without an explicit port', () => {
+    expect(normalizeGitRemoteUrl('ssh://git@github.com/acme/hive.git')).toBe(
+      'github.com/acme/hive'
+    )
+  })
+
+  it('drops the port from ssh:// URLs when it is the standard port 22', () => {
+    expect(normalizeGitRemoteUrl('ssh://git@GitHub.com:22/acme/hive')).toBe(
+      'github.com/acme/hive'
+    )
+  })
+
+  it('keeps a non-standard port for ssh:// URLs', () => {
+    expect(normalizeGitRemoteUrl('ssh://git@github.com:2222/acme/hive.git')).toBe(
+      'github.com:2222/acme/hive'
+    )
+  })
+
+  it('drops the port from https:// URLs when it is the standard port 443', () => {
+    expect(normalizeGitRemoteUrl('https://github.com:443/acme/hive.git')).toBe(
+      'github.com/acme/hive'
+    )
+  })
+
+  it('keeps a non-standard port for https:// URLs', () => {
+    expect(normalizeGitRemoteUrl('https://github.com:8443/acme/hive.git')).toBe(
+      'github.com:8443/acme/hive'
+    )
+  })
+
+  it('drops the port from http:// URLs when it is the standard port 80', () => {
+    expect(normalizeGitRemoteUrl('http://github.com:80/acme/hive.git')).toBe(
+      'github.com/acme/hive'
+    )
+  })
+
+  it('drops the port from git:// URLs when it is the standard port 9418', () => {
+    expect(normalizeGitRemoteUrl('git://github.com:9418/acme/hive.git')).toBe(
+      'github.com/acme/hive'
+    )
+  })
+
+  it('normalizes plain git:// URLs', () => {
+    expect(normalizeGitRemoteUrl('git://github.com/acme/hive.git')).toBe('github.com/acme/hive')
+  })
+
+  it('lowercases the host but preserves path case', () => {
+    expect(normalizeGitRemoteUrl('https://github.com/Acme/Hive')).toBe('github.com/Acme/Hive')
+  })
+
+  it('treats all equivalent forms of the same repo as equal', () => {
+    const forms = [
+      'git@github.com:acme/hive.git',
+      'https://github.com/acme/hive',
+      'https://github.com/acme/hive.git/',
+      'ssh://git@github.com/acme/hive.git',
+      'ssh://git@GitHub.com:22/acme/hive'
+    ]
+
+    const normalized = forms.map((url) => normalizeGitRemoteUrl(url))
+    expect(new Set(normalized).size).toBe(1)
+    expect(normalized[0]).toBe('github.com/acme/hive')
+  })
+
+  it('returns null for null, undefined, empty, or whitespace-only input', () => {
+    expect(normalizeGitRemoteUrl(null)).toBeNull()
+    expect(normalizeGitRemoteUrl(undefined)).toBeNull()
+    expect(normalizeGitRemoteUrl('')).toBeNull()
+    expect(normalizeGitRemoteUrl('   ')).toBeNull()
+  })
+
+  it('does not throw on unparseable/garbage input', () => {
+    expect(() => normalizeGitRemoteUrl('not a url at all')).not.toThrow()
+    expect(normalizeGitRemoteUrl('not a url at all')).toBe('not a url at all')
+    expect(() => normalizeGitRemoteUrl('::::')).not.toThrow()
   })
 })
 

--- a/src/main/services/git-repository.ts
+++ b/src/main/services/git-repository.ts
@@ -27,6 +27,72 @@ export function deriveProjectNameFromGitUrl(url: string): string | null {
   return name ? name : null
 }
 
+const STANDARD_PORTS_BY_SCHEME: Record<string, string> = {
+  ssh: '22',
+  https: '443',
+  http: '80',
+  git: '9418'
+}
+
+/**
+ * Normalize a git remote URL so that ssh/https/scp-like forms of the same
+ * repository compare equal. Returns null for null/undefined/empty input and
+ * never throws, even for unparseable garbage.
+ */
+export function normalizeGitRemoteUrl(url: string | null | undefined): string | null {
+  if (url === null || url === undefined) return null
+  const trimmed = url.trim()
+  if (!trimmed) return null
+
+  try {
+    // scp-like syntax: user@host:org/repo(.git) — but not a URL scheme like ssh://
+    const scpMatch = trimmed.match(/^(?:[^@/\s]+@)?([^:/\s]+):(.+)$/)
+    if (scpMatch && !/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(trimmed)) {
+      const host = scpMatch[1].toLowerCase()
+      const path = stripPathDecorations(scpMatch[2])
+      return `${host}/${path}`
+    }
+
+    const schemeMatch = trimmed.match(/^([A-Za-z][A-Za-z0-9+.-]*):\/\/(.+)$/)
+    if (schemeMatch) {
+      const scheme = schemeMatch[1].toLowerCase()
+      const rest = schemeMatch[2]
+
+      // Strip userinfo (user@ or user:pass@) before the host.
+      const afterAuth = rest.replace(/^[^/@]+@/, '')
+
+      const hostMatch = afterAuth.match(/^([^/]+)(\/.*)?$/)
+      if (!hostMatch) return trimmed
+
+      let hostPort = hostMatch[1]
+      const pathPart = hostMatch[2] ?? ''
+
+      let port: string | null = null
+      const portMatch = hostPort.match(/^(.+):(\d+)$/)
+      if (portMatch) {
+        hostPort = portMatch[1]
+        port = portMatch[2]
+      }
+
+      const host = hostPort.toLowerCase()
+      const standardPort = STANDARD_PORTS_BY_SCHEME[scheme]
+      const keepPort = port && port !== standardPort ? port : null
+
+      const path = stripPathDecorations(pathPart.replace(/^\//, ''))
+      const hostWithPort = keepPort ? `${host}:${keepPort}` : host
+      return path ? `${hostWithPort}/${path}` : hostWithPort
+    }
+
+    return trimmed
+  } catch {
+    return trimmed
+  }
+}
+
+function stripPathDecorations(path: string): string {
+  return path.replace(/\/+$/, '').replace(/\.git$/i, '')
+}
+
 export function isSafeGitRemoteUrl(url: string): boolean {
   if (!url || url.startsWith('-')) return false
   if (/[\s\x00-\x1f\x7f]/.test(url)) return false

--- a/src/renderer/src/api/__tests__/backup-api.test.ts
+++ b/src/renderer/src/api/__tests__/backup-api.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { backupApi } from '../backup-api'
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '../rpc-client'
+
+describe('backupApi', () => {
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+  })
+
+  it('routes exportBackup through the renderer RPC client', async () => {
+    const result = { success: true, path: '/tmp/hive-backup.yaml', projectCount: 3 }
+    const request = vi.fn().mockResolvedValue(result)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(backupApi.exportBackup()).resolves.toEqual(result)
+    expect(request).toHaveBeenCalledWith('backupOps.exportBackup', {})
+  })
+
+  it('routes openBackupFile through the renderer RPC client', async () => {
+    const backup = {
+      version: 1,
+      kind: 'hive-backup' as const,
+      created_at: '2026-07-09T00:00:00.000Z',
+      app_version: '1.2.12',
+      projects: []
+    }
+    const result = { canceled: false, backup }
+    const request = vi.fn().mockResolvedValue(result)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(backupApi.openBackupFile()).resolves.toEqual(result)
+    expect(request).toHaveBeenCalledWith('backupOps.openBackupFile', {})
+  })
+
+  it('routes classifyProjects through the renderer RPC client', async () => {
+    const projects = [{ name: 'hive', path: '/Users/me/hive', remoteUrl: 'git@github.com:a/b.git' }]
+    const result = [
+      {
+        path: '/Users/me/hive',
+        classification: 'exists-match' as const,
+        alreadyInHive: true,
+        hiveProjectId: 'project-1',
+        effectivePath: '/Users/me/hive',
+        localRemoteUrl: 'git@github.com:a/b.git'
+      }
+    ]
+    const request = vi.fn().mockResolvedValue(result)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(backupApi.classifyProjects(projects)).resolves.toEqual(result)
+    expect(request).toHaveBeenCalledWith('backupOps.classifyProjects', { projects })
+  })
+
+  it('routes restoreProject through the renderer RPC client', async () => {
+    const project = {
+      name: 'hive',
+      path: '/Users/me/hive',
+      remote_url: 'git@github.com:a/b.git',
+      description: null,
+      tags: null,
+      language: null,
+      setup_script: null,
+      run_script: null,
+      archive_script: null,
+      worktree_create_script: null,
+      custom_commands: null,
+      auto_assign_port: false,
+      sort_order: 0,
+      kanban_simple_mode: false,
+      kanban_storage_mode: 'internal' as const,
+      kanban_markdown_config: null,
+      custom_icon: null,
+      worktrees: [],
+      tickets: null,
+      ticket_dependencies: null
+    }
+    const options = { cloneParentDir: '/Users/me/code' }
+    const result = {
+      success: true,
+      projectId: 'project-1',
+      projectName: 'hive',
+      action: 'cloned' as const,
+      warnings: [],
+      worktrees: [],
+      tickets: { restored: 0, dependencyErrors: 0, skipped: true }
+    }
+    const request = vi.fn().mockResolvedValue(result)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(backupApi.restoreProject(project, options)).resolves.toEqual(result)
+    expect(request).toHaveBeenCalledWith('backupOps.restoreProject', { project, options })
+  })
+})

--- a/src/renderer/src/api/backup-api.ts
+++ b/src/renderer/src/api/backup-api.ts
@@ -1,0 +1,34 @@
+import type {
+  BackupExportResult,
+  BackupOpenResult,
+  BackupProject,
+  ProjectClassification,
+  RestoreProjectResult
+} from '@shared/types/backup'
+import { getRendererRpcClient } from './rpc-client'
+
+export type { BackupExportResult, BackupOpenResult }
+
+export const backupApi = {
+  exportBackup: async (): Promise<BackupExportResult> =>
+    getRendererRpcClient().request<BackupExportResult>('backupOps.exportBackup', {}),
+
+  openBackupFile: async (): Promise<BackupOpenResult> =>
+    getRendererRpcClient().request<BackupOpenResult>('backupOps.openBackupFile', {}),
+
+  classifyProjects: async (
+    projects: { name: string; path: string; remoteUrl: string | null }[]
+  ): Promise<ProjectClassification[]> =>
+    getRendererRpcClient().request<ProjectClassification[]>('backupOps.classifyProjects', {
+      projects
+    }),
+
+  restoreProject: async (
+    project: BackupProject,
+    options: { cloneParentDir: string | null }
+  ): Promise<RestoreProjectResult> =>
+    getRendererRpcClient().request<RestoreProjectResult>('backupOps.restoreProject', {
+      project,
+      options
+    })
+}

--- a/src/renderer/src/components/settings/SettingsBackup.test.tsx
+++ b/src/renderer/src/components/settings/SettingsBackup.test.tsx
@@ -106,4 +106,45 @@ describe('SettingsBackup', () => {
     expect(screen.getByTestId('restore-wizard')).not.toBeNull()
     expect(screen.getByText('2 projects found in this backup.')).not.toBeNull()
   })
+
+  it('shows an error toast when opening the backup file fails', async () => {
+    const user = userEvent.setup()
+    const request: ReturnType<typeof vi.fn> = vi.fn(async (method: string) => {
+      if (method === 'backupOps.openBackupFile') {
+        return { canceled: false, error: 'Failed to parse backup file: bad YAML' }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+
+    render(<SettingsBackup />)
+
+    await user.click(screen.getByTestId('backup-restore'))
+    await act(async () => {})
+
+    expect(toast.error).toHaveBeenCalledWith('Could not read backup file', {
+      description: 'Failed to parse backup file: bad YAML'
+    })
+    expect(screen.queryByTestId('restore-wizard')).toBeNull()
+  })
+
+  it('does not toast when opening the backup file is canceled', async () => {
+    const user = userEvent.setup()
+    const request: ReturnType<typeof vi.fn> = vi.fn(async (method: string) => {
+      if (method === 'backupOps.openBackupFile') {
+        return { canceled: true }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+
+    render(<SettingsBackup />)
+
+    await user.click(screen.getByTestId('backup-restore'))
+    await act(async () => {})
+
+    expect(toast.success).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('restore-wizard')).toBeNull()
+  })
 })

--- a/src/renderer/src/components/settings/SettingsBackup.test.tsx
+++ b/src/renderer/src/components/settings/SettingsBackup.test.tsx
@@ -1,0 +1,109 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { toast } from '@/lib/toast'
+import { SettingsBackup } from './SettingsBackup'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn()
+  }
+}))
+
+describe('SettingsBackup', () => {
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+    vi.clearAllMocks()
+  })
+
+  it('exports a backup and shows a success toast', async () => {
+    const user = userEvent.setup()
+    const request: ReturnType<typeof vi.fn> = vi.fn(async (method: string) => {
+      if (method === 'backupOps.exportBackup') {
+        return { success: true, path: '/tmp/hive-backup.yaml', projectCount: 2 }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+
+    render(<SettingsBackup />)
+
+    await user.click(screen.getByTestId('backup-export'))
+    await act(async () => {})
+
+    expect(request).toHaveBeenCalledWith('backupOps.exportBackup', {})
+    expect(toast.success).toHaveBeenCalledWith('Backup exported', {
+      description: '2 projects → /tmp/hive-backup.yaml'
+    })
+  })
+
+  it('shows an error toast when export fails', async () => {
+    const user = userEvent.setup()
+    const request: ReturnType<typeof vi.fn> = vi.fn(async (method: string) => {
+      if (method === 'backupOps.exportBackup') {
+        return { success: false, error: 'disk full' }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+
+    render(<SettingsBackup />)
+
+    await user.click(screen.getByTestId('backup-export'))
+    await act(async () => {})
+
+    expect(toast.error).toHaveBeenCalledWith('Failed to export backup', {
+      description: 'disk full'
+    })
+  })
+
+  it('does not toast when export is canceled', async () => {
+    const user = userEvent.setup()
+    const request: ReturnType<typeof vi.fn> = vi.fn(async (method: string) => {
+      if (method === 'backupOps.exportBackup') {
+        return { success: false, canceled: true }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+
+    render(<SettingsBackup />)
+
+    await user.click(screen.getByTestId('backup-export'))
+    await act(async () => {})
+
+    expect(toast.success).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('opens the restore wizard after reading a backup file', async () => {
+    const user = userEvent.setup()
+    const backup = {
+      version: 1,
+      kind: 'hive-backup' as const,
+      created_at: '2026-07-09T00:00:00.000Z',
+      app_version: '1.2.12',
+      projects: [{ name: 'hive' }, { name: 'other' }]
+    }
+    const request: ReturnType<typeof vi.fn> = vi.fn(async (method: string) => {
+      if (method === 'backupOps.openBackupFile') {
+        return { canceled: false, backup }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+
+    render(<SettingsBackup />)
+
+    await user.click(screen.getByTestId('backup-restore'))
+    await act(async () => {})
+
+    expect(request).toHaveBeenCalledWith('backupOps.openBackupFile', {})
+    expect(screen.getByTestId('restore-wizard')).not.toBeNull()
+    expect(screen.getByText('2 projects found in this backup.')).not.toBeNull()
+  })
+})

--- a/src/renderer/src/components/settings/SettingsBackup.tsx
+++ b/src/renderer/src/components/settings/SettingsBackup.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react'
+import { DatabaseBackup, FolderDown, Loader2 } from 'lucide-react'
+
+import type { BackupFile } from '@shared/types/backup'
+import { Button } from '@/components/ui/button'
+import { backupApi } from '@/api/backup-api'
+import { toast } from '@/lib/toast'
+import { RestoreWizard } from './backup/RestoreWizard'
+
+export function SettingsBackup(): React.JSX.Element {
+  const [exporting, setExporting] = useState(false)
+  const [opening, setOpening] = useState(false)
+  const [pendingBackup, setPendingBackup] = useState<BackupFile | null>(null)
+  const [wizardOpen, setWizardOpen] = useState(false)
+
+  const handleExport = async (): Promise<void> => {
+    setExporting(true)
+    try {
+      const result = await backupApi.exportBackup()
+      if (result.canceled) return
+      if (result.success) {
+        toast.success('Backup exported', {
+          description: `${result.projectCount} projects → ${result.path}`
+        })
+      } else {
+        toast.error('Failed to export backup', { description: result.error })
+      }
+    } catch (error) {
+      toast.error('Failed to export backup', {
+        description: error instanceof Error ? error.message : String(error)
+      })
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  const handleOpenBackupFile = async (): Promise<void> => {
+    setOpening(true)
+    try {
+      const result = await backupApi.openBackupFile()
+      if (result.canceled) return
+      if (result.backup) {
+        setPendingBackup(result.backup)
+        setWizardOpen(true)
+      } else {
+        toast.error('Could not read backup file', { description: result.error })
+      }
+    } catch (error) {
+      toast.error('Could not read backup file', {
+        description: error instanceof Error ? error.message : String(error)
+      })
+    } finally {
+      setOpening(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-base font-medium mb-1">Backup</h3>
+        <p className="text-sm text-muted-foreground">Back up and restore your projects</p>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <div className="text-sm font-medium">Back up</div>
+          <p className="text-xs text-muted-foreground">
+            Export all projects, their worktrees, and boards to a YAML file. Sessions, account
+            credentials, and ticket attachments are not included.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleExport}
+          disabled={exporting}
+          data-testid="backup-export"
+        >
+          {exporting ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <DatabaseBackup className="h-3.5 w-3.5" />
+          )}
+          {exporting ? 'Exporting...' : 'Export backup…'}
+        </Button>
+      </div>
+
+      <div className="border-t pt-4 space-y-3">
+        <div>
+          <div className="text-sm font-medium">Restore</div>
+          <p className="text-xs text-muted-foreground">
+            Load a backup file and choose which projects to restore.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleOpenBackupFile}
+          disabled={opening}
+          data-testid="backup-restore"
+        >
+          {opening ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <FolderDown className="h-3.5 w-3.5" />
+          )}
+          {opening ? 'Reading...' : 'Restore from backup…'}
+        </Button>
+      </div>
+
+      {pendingBackup && (
+        <RestoreWizard backup={pendingBackup} open={wizardOpen} onOpenChange={setWizardOpen} />
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/SettingsBackup.tsx
+++ b/src/renderer/src/components/settings/SettingsBackup.tsx
@@ -19,9 +19,12 @@ export function SettingsBackup(): React.JSX.Element {
       const result = await backupApi.exportBackup()
       if (result.canceled) return
       if (result.success) {
-        toast.success('Backup exported', {
-          description: `${result.projectCount} projects → ${result.path}`
-        })
+        const base = `${result.projectCount} projects → ${result.path}`
+        const description =
+          result.warnings && result.warnings.length > 0
+            ? `${base}\n${result.warnings.join('\n')}`
+            : base
+        toast.success('Backup exported', { description })
       } else {
         toast.error('Failed to export backup', { description: result.error })
       }
@@ -66,7 +69,8 @@ export function SettingsBackup(): React.JSX.Element {
           <div className="text-sm font-medium">Back up</div>
           <p className="text-xs text-muted-foreground">
             Export all projects, their worktrees, and boards to a YAML file. Sessions, account
-            credentials, and ticket attachments are not included.
+            credentials, and ticket attachments are not included. Markdown-mode boards export
+            their configuration only — their cards live in the repo&apos;s .md files.
           </p>
         </div>
         <Button

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -16,6 +16,7 @@ import {
   Send,
   Zap,
   Database,
+  DatabaseBackup,
   Hash,
   RadioTower,
   Building2,
@@ -42,6 +43,7 @@ import { SettingsAdvanced } from './SettingsAdvanced'
 import { SettingsPet } from './SettingsPet'
 import { SettingsCustomCommands } from './SettingsCustomCommands'
 import { SettingsStorage } from './SettingsStorage'
+import { SettingsBackup } from './SettingsBackup'
 import { cn } from '@/lib/utils'
 
 const SECTIONS = [
@@ -61,6 +63,7 @@ const SECTIONS = [
   { id: 'security', label: 'Security', icon: Shield },
   { id: 'privacy', label: 'Privacy', icon: Eye },
   { id: 'storage', label: 'Storage', icon: Database },
+  { id: 'backup', label: 'Backup', icon: DatabaseBackup },
   { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
   { id: 'advanced', label: 'Advanced', icon: Wrench },
   { id: 'updates', label: 'Updates', icon: Download }
@@ -136,6 +139,7 @@ export function SettingsModal(): React.JSX.Element {
             {activeSection === 'security' && <SettingsSecurity />}
             {activeSection === 'privacy' && <SettingsPrivacy />}
             {activeSection === 'storage' && <SettingsStorage />}
+            {activeSection === 'backup' && <SettingsBackup />}
             {activeSection === 'shortcuts' && <SettingsShortcuts />}
             {activeSection === 'updates' && <SettingsUpdates />}
             {activeSection === 'advanced' && <SettingsAdvanced />}

--- a/src/renderer/src/components/settings/backup/RestoreWizard.test.tsx
+++ b/src/renderer/src/components/settings/backup/RestoreWizard.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
-import type { BackupFile, ProjectClassification } from '@shared/types/backup'
+import type { BackupFile, ProjectClassification, RestoreProjectResult } from '@shared/types/backup'
 import { RestoreWizard } from './RestoreWizard'
 
 function makeProject(name: string, path: string, remoteUrl: string | null): BackupFile['projects'][number] {
@@ -165,5 +165,95 @@ describe('RestoreWizard', () => {
 
     expect(screen.getByText('Browse…')).not.toBeNull()
     expect(screen.getByText(/will be cloned into the folder you choose/)).not.toBeNull()
+  })
+
+  it('runs restore sequentially, synthesizes a failed result when restoreProject rejects, and refreshes stores before showing the summary', async () => {
+    const user = userEvent.setup()
+
+    const twoProjectBackup: BackupFile = {
+      version: 1,
+      kind: 'hive-backup',
+      created_at: '2026-07-09T00:00:00.000Z',
+      app_version: '1.2.12',
+      projects: [
+        makeProject('proj-a', '/Users/me/proj-a', 'git@github.com:a/a.git'),
+        makeProject('proj-b', '/Users/me/proj-b', 'git@github.com:a/b.git')
+      ]
+    }
+    const twoClassifications: ProjectClassification[] = [
+      {
+        path: '/Users/me/proj-a',
+        classification: 'exists-match',
+        alreadyInHive: false,
+        hiveProjectId: null,
+        effectivePath: '/Users/me/proj-a',
+        localRemoteUrl: 'git@github.com:a/a.git'
+      },
+      {
+        path: '/Users/me/proj-b',
+        classification: 'exists-match',
+        alreadyInHive: false,
+        hiveProjectId: null,
+        effectivePath: '/Users/me/proj-b',
+        localRemoteUrl: 'git@github.com:a/b.git'
+      }
+    ]
+    const successResult: RestoreProjectResult = {
+      success: true,
+      projectId: 'project-a',
+      projectName: 'proj-a',
+      action: 'pulled',
+      warnings: [],
+      worktrees: [],
+      tickets: { restored: 0, dependencyErrors: 0, skipped: true }
+    }
+
+    let restoreCallCount = 0
+    const request: ReturnType<typeof vi.fn> = vi.fn(async (method: string) => {
+      if (method === 'backupOps.classifyProjects') return twoClassifications
+      if (method === 'backupOps.restoreProject') {
+        restoreCallCount += 1
+        if (restoreCallCount === 1) return successResult
+        throw new Error('network exploded')
+      }
+      if (method === 'db.project.getAll') return []
+      if (method === 'db.worktree.getActiveByProject') return []
+      throw new Error(`unexpected method ${method}`)
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+
+    render(<RestoreWizard backup={twoProjectBackup} open={true} onOpenChange={vi.fn()} />)
+
+    await screen.findByText('proj-a')
+    const continueButton = screen.getByRole('button', { name: 'Continue' })
+    await user.click(continueButton)
+
+    // Both rows are exists-match (no clone needed), so Continue goes straight
+    // to `run`, which kicks off automatically and lands on `summary`.
+    await screen.findByText('Restore complete.', {}, { timeout: 3000 })
+
+    // First project: real success synthesized by the server mock.
+    expect(screen.getByText('proj-a')).not.toBeNull()
+    expect(screen.getAllByText('Pulled')).not.toHaveLength(0)
+
+    // Second project: restoreProject rejected — the client must synthesize a
+    // failed result rather than crash, and surface the error inline.
+    expect(screen.getByText('proj-b')).not.toBeNull()
+    expect(screen.getByText('network exploded')).not.toBeNull()
+
+    expect(restoreCallCount).toBe(2)
+
+    // Store refresh (db.project.getAll via useProjectStore.loadProjects) must
+    // have already resolved by the time summary renders — `refreshStores` is
+    // awaited before `setStep('summary')` in the component.
+    const projectRefreshCalls = request.mock.calls.filter((call) => call[0] === 'db.project.getAll')
+    expect(projectRefreshCalls.length).toBeGreaterThan(0)
+
+    // Only the successful result (which carries a projectId) triggers a
+    // worktree reload — the synthesized failure has no projectId.
+    const worktreeRefreshCalls = request.mock.calls.filter(
+      (call) => call[0] === 'db.worktree.getActiveByProject'
+    )
+    expect(worktreeRefreshCalls).toEqual([['db.worktree.getActiveByProject', { projectId: 'project-a' }]])
   })
 })

--- a/src/renderer/src/components/settings/backup/RestoreWizard.test.tsx
+++ b/src/renderer/src/components/settings/backup/RestoreWizard.test.tsx
@@ -80,7 +80,7 @@ const classifications: ProjectClassification[] = [
 ]
 
 function setup(): ReturnType<typeof vi.fn> {
-  const request = vi.fn(async (method: string) => {
+  const request: ReturnType<typeof vi.fn> = vi.fn(async (method: string) => {
     if (method === 'backupOps.classifyProjects') return classifications
     throw new Error(`unexpected method ${method}`)
   })

--- a/src/renderer/src/components/settings/backup/RestoreWizard.test.tsx
+++ b/src/renderer/src/components/settings/backup/RestoreWizard.test.tsx
@@ -1,0 +1,169 @@
+import { act, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import type { BackupFile, ProjectClassification } from '@shared/types/backup'
+import { RestoreWizard } from './RestoreWizard'
+
+function makeProject(name: string, path: string, remoteUrl: string | null): BackupFile['projects'][number] {
+  return {
+    name,
+    path,
+    remote_url: remoteUrl,
+    description: null,
+    tags: null,
+    language: null,
+    setup_script: null,
+    run_script: null,
+    archive_script: null,
+    worktree_create_script: null,
+    custom_commands: null,
+    auto_assign_port: false,
+    sort_order: 0,
+    kanban_simple_mode: false,
+    kanban_storage_mode: 'internal',
+    kanban_markdown_config: null,
+    custom_icon: null,
+    worktrees: [],
+    tickets: null,
+    ticket_dependencies: null
+  }
+}
+
+const backup: BackupFile = {
+  version: 1,
+  kind: 'hive-backup',
+  created_at: '2026-07-09T00:00:00.000Z',
+  app_version: '1.2.12',
+  projects: [
+    makeProject('exists-proj', '/Users/me/exists-proj', 'git@github.com:a/exists.git'),
+    makeProject('clone-proj', '/Users/me/clone-proj', 'git@github.com:a/clone.git'),
+    makeProject('conflict-proj', '/Users/me/conflict-proj', 'git@github.com:a/conflict.git'),
+    makeProject('no-remote-proj', '/Users/me/no-remote-proj', null)
+  ]
+}
+
+const classifications: ProjectClassification[] = [
+  {
+    path: '/Users/me/exists-proj',
+    classification: 'exists-match',
+    alreadyInHive: true,
+    hiveProjectId: 'project-1',
+    effectivePath: '/Users/me/exists-proj',
+    localRemoteUrl: 'git@github.com:a/exists.git'
+  },
+  {
+    path: '/Users/me/clone-proj',
+    classification: 'missing-clone',
+    alreadyInHive: false,
+    hiveProjectId: null,
+    effectivePath: '/Users/me/clone-proj',
+    localRemoteUrl: null
+  },
+  {
+    path: '/Users/me/conflict-proj',
+    classification: 'conflict',
+    alreadyInHive: false,
+    hiveProjectId: null,
+    effectivePath: '/Users/me/conflict-proj',
+    localRemoteUrl: 'git@github.com:other/repo.git'
+  },
+  {
+    path: '/Users/me/no-remote-proj',
+    classification: 'skipped-no-remote',
+    alreadyInHive: false,
+    hiveProjectId: null,
+    effectivePath: '/Users/me/no-remote-proj',
+    localRemoteUrl: null
+  }
+]
+
+function setup(): ReturnType<typeof vi.fn> {
+  const request = vi.fn(async (method: string) => {
+    if (method === 'backupOps.classifyProjects') return classifications
+    throw new Error(`unexpected method ${method}`)
+  })
+  setRendererRpcClient({ request, subscribe: vi.fn() })
+  return request
+}
+
+describe('RestoreWizard', () => {
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+    vi.clearAllMocks()
+  })
+
+  it('classifies projects on open and renders badges per classification', async () => {
+    setup()
+    render(<RestoreWizard backup={backup} open={true} onOpenChange={vi.fn()} />)
+
+    await screen.findByText('Exists — will pull')
+    expect(screen.getByText('Already in Hive')).not.toBeNull()
+    expect(screen.getByText('Will clone')).not.toBeNull()
+    expect(screen.getByText('Conflict — different repo here')).not.toBeNull()
+    expect(screen.getByText("No remote — can't restore")).not.toBeNull()
+  })
+
+  it('defaults to all enabled rows selected and disables conflict/no-remote rows', async () => {
+    setup()
+    render(<RestoreWizard backup={backup} open={true} onOpenChange={vi.fn()} />)
+
+    await screen.findByText('Exists — will pull')
+
+    // 2 enabled rows (exists-match, missing-clone) selected by default.
+    expect(screen.getByText('2 selected')).not.toBeNull()
+
+    const conflictRow = screen.getByText('conflict-proj').closest('label')
+    const noRemoteRow = screen.getByText('no-remote-proj').closest('label')
+    expect(conflictRow).not.toBeNull()
+    expect(noRemoteRow).not.toBeNull()
+
+    const conflictCheckbox = within(conflictRow!).getByRole('checkbox')
+    const noRemoteCheckbox = within(noRemoteRow!).getByRole('checkbox')
+    expect(conflictCheckbox).toHaveAttribute('disabled')
+    expect(noRemoteCheckbox).toHaveAttribute('disabled')
+    expect(conflictCheckbox).toHaveAttribute('aria-checked', 'false')
+    expect(noRemoteCheckbox).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('select-all only toggles enabled rows, and clicking a disabled row is a no-op', async () => {
+    const user = userEvent.setup()
+    setup()
+    render(<RestoreWizard backup={backup} open={true} onOpenChange={vi.fn()} />)
+
+    await screen.findByText('Exists — will pull')
+    expect(screen.getByText('2 selected')).not.toBeNull()
+
+    const conflictRow = screen.getByText('conflict-proj').closest('label')!
+    const conflictCheckbox = within(conflictRow).getByRole('checkbox')
+    await user.click(conflictCheckbox)
+    // Still 2 selected — disabled row cannot be toggled.
+    expect(screen.getByText('2 selected')).not.toBeNull()
+
+    const selectAll = screen.getByText('Select all').closest('div')!
+    const selectAllCheckbox = within(selectAll).getByRole('checkbox')
+    await user.click(selectAllCheckbox)
+    expect(screen.getByText('0 selected')).not.toBeNull()
+
+    await user.click(selectAllCheckbox)
+    expect(screen.getByText('2 selected')).not.toBeNull()
+  })
+
+  it('Continue is disabled with zero selection and moves to the folder step when a clone is selected', async () => {
+    const user = userEvent.setup()
+    setup()
+    render(<RestoreWizard backup={backup} open={true} onOpenChange={vi.fn()} />)
+
+    await screen.findByText('Exists — will pull')
+
+    const continueButton = screen.getByRole('button', { name: 'Continue' })
+    expect(continueButton).not.toBeDisabled()
+
+    await user.click(continueButton)
+    await act(async () => {})
+
+    expect(screen.getByText('Browse…')).not.toBeNull()
+    expect(screen.getByText(/will be cloned into the folder you choose/)).not.toBeNull()
+  })
+})

--- a/src/renderer/src/components/settings/backup/RestoreWizard.tsx
+++ b/src/renderer/src/components/settings/backup/RestoreWizard.tsx
@@ -1,5 +1,16 @@
-import type { BackupFile } from '@shared/types/backup'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { AlertTriangle, CheckCircle2, Circle, Loader2, XCircle } from 'lucide-react'
+import type {
+  BackupFile,
+  BackupProject,
+  ProjectClassification,
+  ProjectClassificationKind,
+  RestoreProjectResult,
+  RestoreWorktreeResult
+} from '@shared/types/backup'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
 import {
   Dialog,
   DialogContent,
@@ -8,6 +19,11 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
+import { backupApi } from '@/api/backup-api'
+import { projectApi } from '@/api/project-api'
+import { useProjectStore, useWorktreeStore } from '@/stores'
+import { toast } from '@/lib/toast'
+import { cn } from '@/lib/utils'
 
 export interface RestoreWizardProps {
   backup: BackupFile
@@ -15,26 +31,547 @@ export interface RestoreWizardProps {
   onOpenChange: (open: boolean) => void
 }
 
-// Minimal stub — Task 6 replaces the internals (classification, restore loop,
-// per-project review UI) but should not need to touch this props contract or
-// SettingsBackup's wiring of it.
+type Step = 'select' | 'folder' | 'run' | 'summary'
+
+type RowRunStatus =
+  | { kind: 'pending' }
+  | { kind: 'running' }
+  | { kind: 'not-run' }
+  | { kind: 'result'; result: RestoreProjectResult }
+
+interface ProjectRow {
+  project: BackupProject
+  classification: ProjectClassification | null
+}
+
+function isDisabledClassification(kind: ProjectClassificationKind): boolean {
+  return kind === 'conflict' || kind === 'skipped-no-remote'
+}
+
+// POSIX basename via string split — backed-up paths always originate from the
+// exporting machine's git working tree, never a Windows path.
+function basename(path: string): string {
+  const trimmed = path.replace(/\/+$/, '')
+  const parts = trimmed.split('/')
+  return parts[parts.length - 1] || trimmed
+}
+
+const ACTION_LABELS: Record<RestoreProjectResult['action'], string> = {
+  cloned: 'Cloned',
+  pulled: 'Pulled',
+  attached: 'Attached',
+  'skipped-conflict': 'Skipped (conflict)',
+  'skipped-no-remote': 'Skipped (no remote)',
+  failed: 'Failed'
+}
+
+const WORKTREE_STATUS_LABELS: Record<RestoreWorktreeResult['status'], string> = {
+  created: 'created',
+  'skipped-existing': 'skipped (exists)',
+  'created-fresh-branch': 'created fresh from default',
+  failed: 'failed'
+}
+
+function ClassificationBadges({
+  classification
+}: {
+  classification: ProjectClassification
+}): React.JSX.Element {
+  const warnClass = 'bg-amber-500/15 text-amber-500'
+  switch (classification.classification) {
+    case 'exists-match':
+      return (
+        <>
+          <span className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-green-500/15 text-green-500">
+            Exists — will pull
+          </span>
+          {classification.alreadyInHive && (
+            <span className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-blue-500/15 text-blue-500">
+              Already in Hive
+            </span>
+          )}
+        </>
+      )
+    case 'missing-clone':
+      return (
+        <span className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-blue-500/15 text-blue-500">
+          Will clone
+        </span>
+      )
+    case 'conflict':
+      return (
+        <span className={cn('shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded', warnClass)}>
+          Conflict — different repo here
+        </span>
+      )
+    case 'skipped-no-remote':
+      return (
+        <span className={cn('shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded', warnClass)}>
+          No remote — can&apos;t restore
+        </span>
+      )
+    default:
+      return <></>
+  }
+}
+
+function ticketsSummary(tickets: RestoreProjectResult['tickets']): string | null {
+  if (!tickets) return null
+  if (tickets.skipped) return 'tickets skipped (already in Hive)'
+  const parts = [`${tickets.restored} ticket${tickets.restored === 1 ? '' : 's'} restored`]
+  if (tickets.dependencyErrors > 0) {
+    parts.push(
+      `${tickets.dependencyErrors} dependency error${tickets.dependencyErrors === 1 ? '' : 's'}`
+    )
+  }
+  return parts.join(' — ')
+}
+
 export function RestoreWizard({ backup, open, onOpenChange }: RestoreWizardProps): React.JSX.Element {
+  const [step, setStep] = useState<Step>('select')
+  const [classifications, setClassifications] = useState<ProjectClassification[] | null>(null)
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set())
+  const [cloneParentDir, setCloneParentDir] = useState<string | null>(null)
+  const [rowStatuses, setRowStatuses] = useState<Map<string, RowRunStatus>>(new Map())
+  const [cancelRequested, setCancelRequested] = useState(false)
+  const [browsing, setBrowsing] = useState(false)
+
+  const cancelledRef = useRef(false)
+  const runStartedRef = useRef(false)
+
+  // On mount, and whenever the backup changes, reset wizard state and classify.
+  useEffect(() => {
+    setStep('select')
+    setClassifications(null)
+    setSelectedPaths(new Set())
+    setCloneParentDir(null)
+    setRowStatuses(new Map())
+    setCancelRequested(false)
+    cancelledRef.current = false
+    runStartedRef.current = false
+
+    let cancelled = false
+    const projects = backup.projects.map((p) => ({
+      name: p.name,
+      path: p.path,
+      remoteUrl: p.remote_url
+    }))
+
+    backupApi
+      .classifyProjects(projects)
+      .then((result) => {
+        if (cancelled) return
+        setClassifications(result)
+        const enabledPaths = result
+          .filter((c) => !isDisabledClassification(c.classification))
+          .map((c) => c.path)
+        setSelectedPaths(new Set(enabledPaths))
+      })
+      .catch((err) => {
+        if (cancelled) return
+        toast.error('Failed to check project status', {
+          description: err instanceof Error ? err.message : String(err)
+        })
+        setClassifications([])
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [backup])
+
+  const rows: ProjectRow[] = useMemo(
+    () =>
+      backup.projects.map((project, i) => ({
+        project,
+        classification: classifications?.[i] ?? null
+      })),
+    [backup.projects, classifications]
+  )
+
+  const enabledPaths = useMemo(
+    () =>
+      rows
+        .filter((r) => r.classification && !isDisabledClassification(r.classification.classification))
+        .map((r) => r.project.path),
+    [rows]
+  )
+
+  const allEnabledSelected =
+    enabledPaths.length > 0 && enabledPaths.every((p) => selectedPaths.has(p))
+
+  const toggleRow = (path: string): void => {
+    setSelectedPaths((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }
+
+  const toggleAll = (): void => {
+    setSelectedPaths(allEnabledSelected ? new Set() : new Set(enabledPaths))
+  }
+
+  const selectedRows = useMemo(
+    () => rows.filter((r) => selectedPaths.has(r.project.path)),
+    [rows, selectedPaths]
+  )
+
+  const toCloneRows = useMemo(
+    () => selectedRows.filter((r) => r.classification?.classification === 'missing-clone'),
+    [selectedRows]
+  )
+
+  const handleContinue = (): void => {
+    setStep(toCloneRows.length > 0 ? 'folder' : 'run')
+  }
+
+  const handleBrowse = useCallback(async (): Promise<void> => {
+    setBrowsing(true)
+    try {
+      const path = await projectApi.openDirectoryDialog()
+      if (path) setCloneParentDir(path)
+    } finally {
+      setBrowsing(false)
+    }
+  }, [])
+
+  const refreshStores = useCallback(async (results: RestoreProjectResult[]): Promise<void> => {
+    await useProjectStore.getState().loadProjects()
+    for (const result of results) {
+      if (result.success && result.projectId) {
+        await useWorktreeStore.getState().loadWorktrees(result.projectId, { force: true })
+      }
+    }
+  }, [])
+
+  const runRestore = useCallback(async (): Promise<void> => {
+    const pending = new Map<string, RowRunStatus>()
+    for (const r of selectedRows) pending.set(r.project.path, { kind: 'pending' })
+    setRowStatuses(pending)
+
+    const results: RestoreProjectResult[] = []
+
+    for (let i = 0; i < selectedRows.length; i++) {
+      if (cancelledRef.current) {
+        setRowStatuses((prev) => {
+          const next = new Map(prev)
+          for (let j = i; j < selectedRows.length; j++) {
+            next.set(selectedRows[j].project.path, { kind: 'not-run' })
+          }
+          return next
+        })
+        break
+      }
+
+      const { project } = selectedRows[i]
+      setRowStatuses((prev) => new Map(prev).set(project.path, { kind: 'running' }))
+
+      let result: RestoreProjectResult
+      try {
+        result = await backupApi.restoreProject(project, { cloneParentDir })
+      } catch (err) {
+        // Server contract says restoreProject never throws, but guard the RPC
+        // boundary anyway (transport errors, etc.) and treat as a failed result.
+        result = {
+          success: false,
+          projectName: project.name,
+          action: 'failed',
+          warnings: [],
+          worktrees: [],
+          tickets: null,
+          error: err instanceof Error ? err.message : String(err)
+        }
+      }
+
+      results.push(result)
+      setRowStatuses((prev) => new Map(prev).set(project.path, { kind: 'result', result }))
+    }
+
+    await refreshStores(results)
+    setStep('summary')
+  }, [selectedRows, cloneParentDir, refreshStores])
+
+  useEffect(() => {
+    if (step !== 'run') return
+    if (runStartedRef.current) return
+    runStartedRef.current = true
+    void runRestore()
+  }, [step, runRestore])
+
+  const handleCancelRemaining = (): void => {
+    cancelledRef.current = true
+    setCancelRequested(true)
+  }
+
+  const handleOpenChange = (next: boolean): void => {
+    if (!next && step === 'run') return // not closable mid-run
+    onOpenChange(next)
+  }
+
+  const handleClose = (): void => onOpenChange(false)
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent data-testid="restore-wizard">
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        data-testid="restore-wizard"
+        className="max-w-lg max-h-[85vh] flex flex-col overflow-hidden"
+      >
         <DialogHeader>
           <DialogTitle>Restore from backup</DialogTitle>
           <DialogDescription>
-            {backup.projects.length} project{backup.projects.length === 1 ? '' : 's'} found in this
-            backup.
+            {step === 'select' && (
+              <>
+                {backup.projects.length} project{backup.projects.length === 1 ? '' : 's'} found in
+                this backup.
+              </>
+            )}
+            {step === 'folder' && (
+              <>
+                {toCloneRows.length} project{toCloneRows.length === 1 ? '' : 's'} will be cloned
+                into the folder you choose.
+              </>
+            )}
+            {step === 'run' && <>Restoring selected projects…</>}
+            {step === 'summary' && <>Restore complete.</>}
           </DialogDescription>
         </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Close
-          </Button>
-        </DialogFooter>
+
+        {step === 'select' && (
+          <>
+            {classifications === null ? (
+              <div className="flex items-center justify-center py-10">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center gap-2 px-1 py-1 border-b">
+                  <Checkbox checked={allEnabledSelected} onCheckedChange={toggleAll} />
+                  <span className="text-xs text-muted-foreground font-medium">Select all</span>
+                  <span className="text-xs text-muted-foreground ml-auto">
+                    {selectedPaths.size} selected
+                  </span>
+                </div>
+                <div className="flex-1 overflow-y-auto space-y-1 min-h-0">
+                  {rows.map((row) => {
+                    const classification = row.classification
+                    if (!classification) return null
+                    const disabled = isDisabledClassification(classification.classification)
+                    const secondaryPath =
+                      classification.effectivePath &&
+                      classification.effectivePath !== row.project.path
+                        ? classification.effectivePath
+                        : row.project.path
+                    return (
+                      <label
+                        key={row.project.path}
+                        className={cn(
+                          'flex items-start gap-2 p-2 rounded',
+                          disabled ? 'opacity-60 cursor-not-allowed' : 'hover:bg-muted cursor-pointer'
+                        )}
+                      >
+                        <Checkbox
+                          checked={selectedPaths.has(row.project.path)}
+                          onCheckedChange={() => toggleRow(row.project.path)}
+                          disabled={disabled}
+                          className="mt-0.5"
+                        />
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="text-sm font-medium truncate">{row.project.name}</span>
+                            <ClassificationBadges classification={classification} />
+                          </div>
+                          <div className="text-xs text-muted-foreground truncate mt-0.5">
+                            {secondaryPath}
+                          </div>
+                        </div>
+                      </label>
+                    )
+                  })}
+                </div>
+              </>
+            )}
+            <DialogFooter>
+              <Button variant="outline" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleContinue} disabled={selectedPaths.size === 0}>
+                Continue
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {step === 'folder' && (
+          <>
+            <div className="space-y-2">
+              <div className="flex gap-2">
+                <Input
+                  readOnly
+                  value={cloneParentDir ?? ''}
+                  placeholder="Select a folder…"
+                  className="flex-1 cursor-pointer"
+                  onClick={handleBrowse}
+                  data-testid="restore-wizard-folder-input"
+                />
+                <Button variant="outline" onClick={handleBrowse} disabled={browsing}>
+                  Browse…
+                </Button>
+              </div>
+              {cloneParentDir && (
+                <div className="text-xs text-muted-foreground space-y-0.5 max-h-40 overflow-y-auto">
+                  {toCloneRows.map((row) => (
+                    <div key={row.project.path} className="font-mono truncate">
+                      {cloneParentDir}/{basename(row.project.path)}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setStep('select')}>
+                Back
+              </Button>
+              <Button onClick={() => setStep('run')} disabled={!cloneParentDir}>
+                Start restore
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {step === 'run' && (
+          <>
+            <div className="flex-1 overflow-y-auto space-y-1 min-h-0">
+              {selectedRows.map((row) => {
+                const status = rowStatuses.get(row.project.path)
+                return (
+                  <div key={row.project.path} className="flex items-center gap-2 p-2 rounded">
+                    <RunRowIcon status={status} />
+                    <span
+                      className={cn(
+                        'text-sm truncate',
+                        (!status || status.kind === 'pending') && 'text-muted-foreground'
+                      )}
+                    >
+                      {row.project.name}
+                    </span>
+                    <span className="text-xs text-muted-foreground ml-auto truncate">
+                      {runRowLabel(status)}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={handleCancelRemaining} disabled={cancelRequested}>
+                {cancelRequested ? 'Cancelling…' : 'Cancel remaining'}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {step === 'summary' && (
+          <>
+            <div className="flex-1 overflow-y-auto space-y-3 min-h-0">
+              {selectedRows.map((row) => {
+                const status = rowStatuses.get(row.project.path)
+                return (
+                  <div key={row.project.path} className="border rounded p-2 space-y-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium truncate">{row.project.name}</span>
+                      {status?.kind === 'result' && (
+                        <span className="text-xs text-muted-foreground">
+                          {ACTION_LABELS[status.result.action]}
+                        </span>
+                      )}
+                    </div>
+                    {status?.kind === 'not-run' && (
+                      <div className="text-xs text-amber-500">not restored (cancelled)</div>
+                    )}
+                    {status?.kind === 'result' && (
+                      <>
+                        {status.result.error && (
+                          <div className="text-xs text-red-500">{status.result.error}</div>
+                        )}
+                        {status.result.worktrees.map((wt) => (
+                          <div key={wt.branch} className="text-xs text-muted-foreground pl-2">
+                            {wt.branch} — {WORKTREE_STATUS_LABELS[wt.status]}
+                            {wt.status === 'failed' && wt.error ? `: ${wt.error}` : ''}
+                          </div>
+                        ))}
+                        {ticketsSummary(status.result.tickets) && (
+                          <div className="text-xs text-muted-foreground pl-2">
+                            {ticketsSummary(status.result.tickets)}
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </div>
+                )
+              })}
+              {(() => {
+                const warnings = selectedRows.flatMap((row) => {
+                  const status = rowStatuses.get(row.project.path)
+                  if (status?.kind !== 'result') return []
+                  return status.result.warnings.map((w) => ({ project: row.project.name, w }))
+                })
+                if (warnings.length === 0) return null
+                return (
+                  <div className="rounded bg-amber-500/10 border border-amber-500/30 p-2 space-y-1">
+                    {warnings.map((entry, i) => (
+                      <div key={i} className="text-xs text-amber-500 flex items-start gap-1">
+                        <AlertTriangle className="h-3 w-3 mt-0.5 shrink-0" />
+                        <span>
+                          {entry.project}: {entry.w}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )
+              })()}
+            </div>
+            <DialogFooter>
+              <Button onClick={handleClose}>Close</Button>
+            </DialogFooter>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   )
+}
+
+function runRowLabel(status: RowRunStatus | undefined): string {
+  if (!status) return ''
+  switch (status.kind) {
+    case 'pending':
+      return ''
+    case 'running':
+      return ''
+    case 'not-run':
+      return 'cancelled'
+    case 'result':
+      if (status.result.success) {
+        return ACTION_LABELS[status.result.action]
+      }
+      return status.result.error || ACTION_LABELS[status.result.action]
+    default:
+      return ''
+  }
+}
+
+function RunRowIcon({ status }: { status: RowRunStatus | undefined }): React.JSX.Element {
+  if (!status || status.kind === 'pending') {
+    return <Circle className="h-4 w-4 shrink-0 text-muted-foreground/50" />
+  }
+  if (status.kind === 'running') {
+    return <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+  }
+  if (status.kind === 'not-run') {
+    return <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
+  }
+  if (status.result.success) {
+    return <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />
+  }
+  return <XCircle className="h-4 w-4 shrink-0 text-red-500" />
 }

--- a/src/renderer/src/components/settings/backup/RestoreWizard.tsx
+++ b/src/renderer/src/components/settings/backup/RestoreWizard.tsx
@@ -115,9 +115,19 @@ function ClassificationBadges({
   }
 }
 
-function ticketsSummary(tickets: RestoreProjectResult['tickets']): string | null {
+// `tickets.skipped` is set by the server for three distinct reasons (markdown
+// storage mode, the project was already in Hive, or the board had no
+// tickets to restore) — only the markdown-mode case is cheaply distinguishable
+// here (we already have `kanbanStorageMode` per row), so the other two share
+// a neutral "tickets skipped" label rather than a wrongly specific reason.
+function ticketsSummary(
+  tickets: RestoreProjectResult['tickets'],
+  kanbanStorageMode: BackupProject['kanban_storage_mode']
+): string | null {
   if (!tickets) return null
-  if (tickets.skipped) return 'tickets skipped (already in Hive)'
+  if (tickets.skipped) {
+    return kanbanStorageMode === 'markdown' ? 'tickets skipped (markdown mode)' : 'tickets skipped'
+  }
   const parts = [`${tickets.restored} ticket${tickets.restored === 1 ? '' : 's'} restored`]
   if (tickets.dependencyErrors > 0) {
     parts.push(
@@ -500,9 +510,9 @@ export function RestoreWizard({ backup, open, onOpenChange }: RestoreWizardProps
                             {wt.status === 'failed' && wt.error ? `: ${wt.error}` : ''}
                           </div>
                         ))}
-                        {ticketsSummary(status.result.tickets) && (
+                        {ticketsSummary(status.result.tickets, row.project.kanban_storage_mode) && (
                           <div className="text-xs text-muted-foreground pl-2">
-                            {ticketsSummary(status.result.tickets)}
+                            {ticketsSummary(status.result.tickets, row.project.kanban_storage_mode)}
                           </div>
                         )}
                       </>

--- a/src/renderer/src/components/settings/backup/RestoreWizard.tsx
+++ b/src/renderer/src/components/settings/backup/RestoreWizard.tsx
@@ -1,0 +1,40 @@
+import type { BackupFile } from '@shared/types/backup'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+
+export interface RestoreWizardProps {
+  backup: BackupFile
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+// Minimal stub — Task 6 replaces the internals (classification, restore loop,
+// per-project review UI) but should not need to touch this props contract or
+// SettingsBackup's wiring of it.
+export function RestoreWizard({ backup, open, onOpenChange }: RestoreWizardProps): React.JSX.Element {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid="restore-wizard">
+        <DialogHeader>
+          <DialogTitle>Restore from backup</DialogTitle>
+          <DialogDescription>
+            {backup.projects.length} project{backup.projects.length === 1 ? '' : 's'} found in this
+            backup.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/server/rpc/domains/__tests__/backup-ops.test.ts
+++ b/src/server/rpc/domains/__tests__/backup-ops.test.ts
@@ -157,7 +157,6 @@ function makeDeps(overrides: Partial<BackupOpsDeps> = {}): BackupOpsDeps {
     git: {
       getRemoteUrl: vi.fn(async () => null),
       hasUncommittedChanges: vi.fn(async () => false),
-      pull: vi.fn(async () => ({ success: true })),
       getDefaultBranch: vi.fn(async () => 'main')
     },
     fs: makeFsDeps(),
@@ -556,6 +555,7 @@ interface ExecGitScript {
   fetchFails?: boolean
   worktreeAddFailFor?: Set<string>
   branchCreateFailFor?: Set<string>
+  pullFailsWith?: string
 }
 
 /** Dispatches the raw `execGit(cwd, args)` calls restoreProject issues for
@@ -563,6 +563,10 @@ interface ExecGitScript {
 function execGitScript(script: ExecGitScript = {}): BackupOpsDeps['execGit'] {
   return vi.fn(async (_cwd: string, args: string[]) => {
     const [cmd] = args
+    if (cmd === 'pull') {
+      if (script.pullFailsWith) throw new Error(script.pullFailsWith)
+      return ''
+    }
     if (cmd === 'fetch') {
       if (script.fetchFails) throw new Error('fetch failed')
       return ''
@@ -896,7 +900,78 @@ describe('backupOps.restoreProject', () => {
 
     expect(result.action).toBe('attached')
     expect(result.warnings).toContain('uncommitted changes — pull skipped')
-    expect(deps.git.pull).not.toHaveBeenCalled()
+    const execGitCalls = (deps.execGit as ReturnType<typeof vi.fn>).mock.calls
+    expect(execGitCalls.some((call) => call[1][0] === 'pull')).toBe(false)
+  })
+
+  it('pulls fast-forward-only via execGit on a clean tree and reports pulled', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: {
+        ...makeDeps().git,
+        getRemoteUrl: vi.fn(async () => null),
+        hasUncommittedChanges: vi.fn(async () => false)
+      },
+      execGit: execGitScript()
+    })
+    const bp = backupProject({ path: '/repo' })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.action).toBe('pulled')
+    expect(result.warnings).toEqual([])
+    expect(deps.execGit).toHaveBeenCalledWith('/repo', ['pull', '--ff-only'])
+  })
+
+  it('warns and reports attached (not pulled) when the ff-only pull fails, and still processes worktrees/tickets', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: {
+        ...makeDeps().git,
+        getRemoteUrl: vi.fn(async () => null),
+        hasUncommittedChanges: vi.fn(async () => false)
+      },
+      execGit: execGitScript({
+        pullFailsWith: 'fatal: Not possible to fast-forward, aborting.',
+        revParseHeads: { 'feature/a': true }
+      })
+    })
+    const bp = backupProject({
+      path: '/repo',
+      worktrees: [{ name: 'feature-a', branch_name: 'feature/a', base_branch: 'main' }],
+      tickets: [
+        {
+          key: 't1',
+          title: 'Ticket',
+          description: null,
+          column: 'todo',
+          sort_order: 0,
+          mode: null,
+          mark: null,
+          total_tokens: 0,
+          archived_at: null,
+          worktree_branch: null
+        }
+      ]
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.action).toBe('attached')
+    expect(
+      result.warnings.some((w) => w.includes('fatal: Not possible to fast-forward'))
+    ).toBe(true)
+    expect(result.worktrees).toEqual([{ branch: 'feature/a', status: 'created' }])
+    expect(result.tickets).toEqual({ restored: 1, dependencyErrors: 0, skipped: false })
+    expect(result.success).toBe(true)
   })
 
   it('skips worktree creation when an active worktree already has the branch', async () => {
@@ -1117,7 +1192,6 @@ describe('backupOps.restoreProject', () => {
       tickets: null
     })
     expect(deps.cloneRepository).not.toHaveBeenCalled()
-    expect(deps.git.pull).not.toHaveBeenCalled()
     expect(deps.createProjectWithDefaultWorktree).not.toHaveBeenCalled()
     expect(deps.syncWorktreesOp).not.toHaveBeenCalled()
     expect(deps.execGit).not.toHaveBeenCalled()

--- a/src/server/rpc/domains/__tests__/backup-ops.test.ts
+++ b/src/server/rpc/domains/__tests__/backup-ops.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { readFile, stat, writeFile } from 'node:fs/promises'
+import { access, mkdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -8,7 +8,7 @@ import YAML from 'yaml'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { KanbanTicket, Project, TicketDependency, Worktree } from '../../../../main/db'
-import type { BackupFile } from '../../../../shared/types/backup'
+import type { BackupFile, BackupProject } from '../../../../shared/types/backup'
 import {
   makeBackupOpsRpcHandlers,
   makeBackupOpsRpcService,
@@ -123,7 +123,12 @@ function makeFsDeps(): BackupOpsDeps['fs'] {
   return {
     readFile: (path) => readFile(path),
     writeFile: (path, content) => writeFile(path, content, 'utf-8'),
-    stat: (path) => stat(path)
+    stat: (path) => stat(path),
+    exists: (path) =>
+      access(path)
+        .then(() => true)
+        .catch(() => false),
+    mkdir: (path) => mkdir(path, { recursive: true }).then(() => undefined)
   }
 }
 
@@ -134,15 +139,66 @@ function makeDeps(overrides: Partial<BackupOpsDeps> = {}): BackupOpsDeps {
       getActiveWorktreesByProject: () => [],
       getWorktreesByProject: () => [],
       getKanbanTicketsByProject: () => [],
-      getDependenciesForProject: () => []
+      getDependenciesForProject: () => [],
+      getProjectByPath: () => null,
+      createWorktree: vi.fn((data) => worktree({ ...data, id: `wt-${data.branch_name}` })),
+      updateProject: vi.fn(() => null),
+      updateProjectKanbanStorageMode: vi.fn(() => null),
+      updateProjectKanbanMarkdownConfig: vi.fn(() => null),
+      updateProjectSimpleMode: vi.fn(),
+      createKanbanTicket: vi.fn((data) =>
+        ticket({ ...data, id: `ticket-${data.title}`, mark: null })
+      ),
+      updateKanbanTicket: vi.fn(() => null),
+      addTicketTokens: vi.fn(),
+      addTicketDependency: vi.fn(() => ({ success: true })),
+      transaction: vi.fn((fn) => fn())
     },
     git: {
-      getRemoteUrl: vi.fn(async () => null)
+      getRemoteUrl: vi.fn(async () => null),
+      hasUncommittedChanges: vi.fn(async () => false),
+      pull: vi.fn(async () => ({ success: true })),
+      getDefaultBranch: vi.fn(async () => 'main')
     },
     fs: makeFsDeps(),
     getAppVersion: vi.fn(async () => '1.2.3'),
     requestSaveFileDialog: vi.fn(async () => null),
     requestOpenFileDialog: vi.fn(async () => null),
+    execGit: vi.fn(async () => ''),
+    homedir: vi.fn(() => '/home/tester'),
+    cloneRepository: vi.fn(async () => ({ success: true })),
+    isGitRepository: vi.fn(() => true),
+    createProjectWithDefaultWorktree: vi.fn((data) =>
+      project({ id: `project-${data.name}`, name: data.name, path: data.path })
+    ),
+    uploadIcon: vi.fn(() => ({ success: true })),
+    syncWorktreesOp: vi.fn(async () => ({ success: true })),
+    ...overrides
+  }
+}
+
+function backupProject(overrides: Partial<BackupProject> = {}): BackupProject {
+  return {
+    name: 'repo',
+    path: '/repo',
+    remote_url: null,
+    description: null,
+    tags: null,
+    language: null,
+    setup_script: null,
+    run_script: null,
+    archive_script: null,
+    worktree_create_script: null,
+    custom_commands: null,
+    auto_assign_port: false,
+    sort_order: 0,
+    kanban_simple_mode: false,
+    kanban_storage_mode: 'internal',
+    kanban_markdown_config: null,
+    custom_icon: null,
+    worktrees: [],
+    tickets: null,
+    ticket_dependencies: null,
     ...overrides
   }
 }
@@ -194,6 +250,7 @@ describe('backupOps.exportBackup', () => {
 
     const deps = makeDeps({
       db: {
+        ...makeDeps().db,
         getAllProjects: () => [internalProject, markdownProject],
         getActiveWorktreesByProject: (projectId) => (projectId === 'project-a' ? [wtA] : []),
         getWorktreesByProject: (projectId) => (projectId === 'project-a' ? [wtA] : []),
@@ -204,7 +261,7 @@ describe('backupOps.exportBackup', () => {
         },
         getDependenciesForProject: (projectId) => (projectId === 'project-a' ? [dependencyA] : [])
       },
-      git: { getRemoteUrl },
+      git: { ...makeDeps().git, getRemoteUrl },
       requestSaveFileDialog: vi.fn(async () => outPath)
     })
 
@@ -244,6 +301,7 @@ describe('backupOps.exportBackup', () => {
     const writeFileSpy = vi.fn(async () => undefined)
     const deps = makeDeps({
       db: {
+        ...makeDeps().db,
         getAllProjects: () => [project()],
         getActiveWorktreesByProject: () => [],
         getWorktreesByProject: () => [],
@@ -268,6 +326,7 @@ describe('backupOps.exportBackup', () => {
 
     const deps = makeDeps({
       db: {
+        ...makeDeps().db,
         getAllProjects: () => [proj],
         getActiveWorktreesByProject: () => [],
         getWorktreesByProject: () => [],
@@ -294,6 +353,7 @@ describe('backupOps.exportBackup', () => {
 
     const deps = makeDeps({
       db: {
+        ...makeDeps().db,
         getAllProjects: () => [proj],
         getActiveWorktreesByProject: () => [],
         getWorktreesByProject: () => [],
@@ -323,6 +383,7 @@ describe('backupOps.exportBackup', () => {
 
     const deps = makeDeps({
       db: {
+        ...makeDeps().db,
         getAllProjects: () => [proj],
         getActiveWorktreesByProject: () => [],
         getWorktreesByProject: () => [],
@@ -343,6 +404,7 @@ describe('backupOps.exportBackup', () => {
   it('returns a failure result when an unexpected error occurs', async () => {
     const deps = makeDeps({
       db: {
+        ...makeDeps().db,
         getAllProjects: () => {
           throw new Error('db exploded')
         },
@@ -474,12 +536,652 @@ describe('backupOps.openBackupFile', () => {
   })
 })
 
+/** fs deps that never touch the real filesystem — every existence check is
+ * driven by an explicit allow-list, and mkdir/readFile/writeFile/stat are
+ * no-op mocks. */
+function mockFs(existingPaths: string[] = []): BackupOpsDeps['fs'] {
+  const set = new Set(existingPaths)
+  return {
+    readFile: vi.fn(async () => Buffer.from('')),
+    writeFile: vi.fn(async () => undefined),
+    stat: vi.fn(async () => ({ size: 0 })),
+    exists: vi.fn(async (path: string) => set.has(path)),
+    mkdir: vi.fn(async () => undefined)
+  }
+}
+
+interface ExecGitScript {
+  revParseHeads?: Record<string, boolean>
+  revParseRemotes?: Record<string, boolean>
+  fetchFails?: boolean
+  worktreeAddFailFor?: Set<string>
+  branchCreateFailFor?: Set<string>
+}
+
+/** Dispatches the raw `execGit(cwd, args)` calls restoreProject issues for
+ * worktree/branch plumbing, driven by a small script object per test. */
+function execGitScript(script: ExecGitScript = {}): BackupOpsDeps['execGit'] {
+  return vi.fn(async (_cwd: string, args: string[]) => {
+    const [cmd] = args
+    if (cmd === 'fetch') {
+      if (script.fetchFails) throw new Error('fetch failed')
+      return ''
+    }
+    if (cmd === 'rev-parse') {
+      const ref = args[2] ?? ''
+      if (ref.startsWith('refs/heads/')) {
+        const branch = ref.slice('refs/heads/'.length)
+        if (script.revParseHeads?.[branch]) return 'deadbeef'
+        throw new Error(`unknown revision: ${branch}`)
+      }
+      if (ref.startsWith('refs/remotes/origin/')) {
+        const branch = ref.slice('refs/remotes/origin/'.length)
+        if (script.revParseRemotes?.[branch]) return 'deadbeef'
+        throw new Error(`unknown revision: ${branch}`)
+      }
+      throw new Error(`unexpected rev-parse ref: ${ref}`)
+    }
+    if (cmd === 'branch') {
+      const branch = args[1]
+      if (script.branchCreateFailFor?.has(branch)) throw new Error('branch create failed')
+      return ''
+    }
+    if (cmd === 'worktree') {
+      const branch = args[3]
+      if (script.worktreeAddFailFor?.has(branch)) throw new Error('already checked out')
+      return ''
+    }
+    return ''
+  })
+}
+
+describe('backupOps.classifyProjects', () => {
+  it('classifies ssh-form backup remote vs https-form local remote as exists-match', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/backup/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: {
+        ...makeDeps().git,
+        getRemoteUrl: vi.fn(async (repoPath: string) =>
+          repoPath === '/backup/repo' ? 'https://github.com/org/repo.git' : null
+        )
+      },
+      db: { ...makeDeps().db, getProjectByPath: () => null }
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const [result] = await Effect.runPromise(
+      service.classifyProjects({
+        projects: [
+          { name: 'repo', path: '/backup/repo', remoteUrl: 'git@github.com:org/repo.git' }
+        ]
+      })
+    )
+
+    expect(result).toMatchObject({
+      path: '/backup/repo',
+      classification: 'exists-match',
+      alreadyInHive: false,
+      hiveProjectId: null,
+      effectivePath: '/backup/repo',
+      localRemoteUrl: 'https://github.com/org/repo.git'
+    })
+  })
+
+  it('classifies path exists + different remote as conflict', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/backup/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: {
+        ...makeDeps().git,
+        getRemoteUrl: vi.fn(async () => 'git@github.com:org/other.git')
+      }
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const [result] = await Effect.runPromise(
+      service.classifyProjects({
+        projects: [
+          { name: 'repo', path: '/backup/repo', remoteUrl: 'git@github.com:org/repo.git' }
+        ]
+      })
+    )
+
+    expect(result.classification).toBe('conflict')
+    expect(result.alreadyInHive).toBe(false)
+    expect(result.hiveProjectId).toBeNull()
+  })
+
+  it('classifies path exists + non-git dir as conflict', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/backup/repo']),
+      isGitRepository: vi.fn(() => false)
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const [result] = await Effect.runPromise(
+      service.classifyProjects({
+        projects: [{ name: 'repo', path: '/backup/repo', remoteUrl: null }]
+      })
+    )
+
+    expect(result).toMatchObject({
+      classification: 'conflict',
+      alreadyInHive: false,
+      hiveProjectId: null,
+      localRemoteUrl: null
+    })
+  })
+
+  it('classifies missing path + remote as missing-clone', async () => {
+    const deps = makeDeps({ fs: mockFs([]) })
+
+    const service = makeBackupOpsRpcService(deps)
+    const [result] = await Effect.runPromise(
+      service.classifyProjects({
+        projects: [
+          { name: 'repo', path: '/backup/repo', remoteUrl: 'git@github.com:org/repo.git' }
+        ]
+      })
+    )
+
+    expect(result.classification).toBe('missing-clone')
+  })
+
+  it('classifies missing path + null remote as skipped-no-remote', async () => {
+    const deps = makeDeps({ fs: mockFs([]) })
+
+    const service = makeBackupOpsRpcService(deps)
+    const [result] = await Effect.runPromise(
+      service.classifyProjects({
+        projects: [{ name: 'repo', path: '/backup/repo', remoteUrl: null }]
+      })
+    )
+
+    expect(result.classification).toBe('skipped-no-remote')
+  })
+
+  it('marks a path-matched project already-in-Hive', async () => {
+    const hiveProject = project({ id: 'hive-1', path: '/backup/repo' })
+    const deps = makeDeps({
+      fs: mockFs(['/backup/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: { ...makeDeps().git, getRemoteUrl: vi.fn(async () => null) },
+      db: { ...makeDeps().db, getProjectByPath: (path) => (path === '/backup/repo' ? hiveProject : null) }
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const [result] = await Effect.runPromise(
+      service.classifyProjects({
+        projects: [{ name: 'repo', path: '/backup/repo', remoteUrl: null }]
+      })
+    )
+
+    expect(result).toMatchObject({
+      classification: 'exists-match',
+      alreadyInHive: true,
+      hiveProjectId: 'hive-1',
+      effectivePath: '/backup/repo'
+    })
+  })
+
+  it('matches by remote across Hive with a different local path than the backup', async () => {
+    const hiveProject = project({ id: 'hive-1', path: '/hive/other-repo' })
+    const deps = makeDeps({
+      fs: mockFs([]), // backup path itself does not exist on disk
+      db: { ...makeDeps().db, getAllProjects: () => [hiveProject] },
+      git: {
+        ...makeDeps().git,
+        getRemoteUrl: vi.fn(async (repoPath: string) =>
+          repoPath === '/hive/other-repo' ? 'git@github.com:org/repo.git' : null
+        )
+      }
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const [result] = await Effect.runPromise(
+      service.classifyProjects({
+        projects: [
+          { name: 'repo', path: '/backup/repo', remoteUrl: 'https://github.com/org/repo.git' }
+        ]
+      })
+    )
+
+    expect(result).toMatchObject({
+      path: '/backup/repo',
+      classification: 'exists-match',
+      alreadyInHive: true,
+      hiveProjectId: 'hive-1',
+      effectivePath: '/hive/other-repo'
+    })
+  })
+
+  it('classifies both-null remotes at the same path as exists-match', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/backup/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: { ...makeDeps().git, getRemoteUrl: vi.fn(async () => null) }
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const [result] = await Effect.runPromise(
+      service.classifyProjects({
+        projects: [{ name: 'repo', path: '/backup/repo', remoteUrl: null }]
+      })
+    )
+
+    expect(result.classification).toBe('exists-match')
+  })
+
+  it('computes each Hive project remote once per batch, not per input entry', async () => {
+    const hiveA = project({ id: 'hive-a', path: '/hive/a' })
+    const hiveB = project({ id: 'hive-b', path: '/hive/b' })
+    const getRemoteUrl = vi.fn(async (repoPath: string) => {
+      if (repoPath === '/hive/a') return 'git@github.com:org/a.git'
+      if (repoPath === '/hive/b') return 'git@github.com:org/b.git'
+      return null
+    })
+    const deps = makeDeps({
+      fs: mockFs([]),
+      db: { ...makeDeps().db, getAllProjects: () => [hiveA, hiveB] },
+      git: { ...makeDeps().git, getRemoteUrl }
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    await Effect.runPromise(
+      service.classifyProjects({
+        projects: [
+          { name: 'a', path: '/backup/a', remoteUrl: 'git@github.com:org/a.git' },
+          { name: 'b', path: '/backup/b', remoteUrl: 'git@github.com:org/b.git' },
+          { name: 'c', path: '/backup/c', remoteUrl: 'git@github.com:org/c.git' }
+        ]
+      })
+    )
+
+    // Exactly one lookup per Hive project (2), regardless of the 3 input entries.
+    expect(getRemoteUrl).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('backupOps.restoreProject', () => {
+  it('clones a missing project and creates it in Hive', async () => {
+    const deps = makeDeps({
+      fs: mockFs([]),
+      cloneRepository: vi.fn(async () => ({ success: true })),
+      execGit: execGitScript()
+    })
+    const bp = backupProject({
+      name: 'repo',
+      path: '/original/repo',
+      remote_url: 'git@github.com:org/repo.git'
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: '/clones' } })
+    )
+
+    expect(result.action).toBe('cloned')
+    expect(result.success).toBe(true)
+    expect(deps.cloneRepository).toHaveBeenCalledWith(
+      'git@github.com:org/repo.git',
+      '/clones/repo'
+    )
+    expect(deps.createProjectWithDefaultWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'repo', path: '/clones/repo' })
+    )
+    expect(deps.syncWorktreesOp).toHaveBeenCalledWith({
+      projectId: 'project-repo',
+      projectPath: '/clones/repo'
+    })
+  })
+
+  it('suffixes the clone destination on collision', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/clones/repo']),
+      cloneRepository: vi.fn(async () => ({ success: true })),
+      execGit: execGitScript()
+    })
+    const bp = backupProject({
+      name: 'repo',
+      path: '/original/repo',
+      remote_url: 'git@github.com:org/repo.git'
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: '/clones' } })
+    )
+
+    expect(deps.cloneRepository).toHaveBeenCalledWith(
+      'git@github.com:org/repo.git',
+      '/clones/repo-2'
+    )
+  })
+
+  it('fails with no clone folder selected when missing-clone and cloneParentDir is null', async () => {
+    const deps = makeDeps({ fs: mockFs([]) })
+    const bp = backupProject({ remote_url: 'git@github.com:org/repo.git' })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result).toMatchObject({
+      success: false,
+      action: 'failed',
+      error: 'no clone folder selected'
+    })
+    expect(deps.cloneRepository).not.toHaveBeenCalled()
+  })
+
+  it('skips the pull and warns when the working tree is dirty', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: {
+        ...makeDeps().git,
+        getRemoteUrl: vi.fn(async () => null),
+        hasUncommittedChanges: vi.fn(async () => true)
+      },
+      execGit: execGitScript()
+    })
+    const bp = backupProject({ path: '/repo' })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.action).toBe('attached')
+    expect(result.warnings).toContain('uncommitted changes — pull skipped')
+    expect(deps.git.pull).not.toHaveBeenCalled()
+  })
+
+  it('skips worktree creation when an active worktree already has the branch', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: { ...makeDeps().git, getRemoteUrl: vi.fn(async () => null) },
+      db: {
+        ...makeDeps().db,
+        getActiveWorktreesByProject: () => [worktree({ branch_name: 'feature/a' })]
+      },
+      execGit: execGitScript()
+    })
+    const bp = backupProject({
+      path: '/repo',
+      worktrees: [{ name: 'feature-a', branch_name: 'feature/a', base_branch: 'main' }]
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.worktrees).toEqual([{ branch: 'feature/a', status: 'skipped-existing' }])
+    const execGitCalls = (deps.execGit as ReturnType<typeof vi.fn>).mock.calls
+    expect(execGitCalls.some((call) => call[1][0] === 'worktree')).toBe(false)
+  })
+
+  it('falls back to a fresh branch from default when local and remote branches are missing', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: {
+        ...makeDeps().git,
+        getRemoteUrl: vi.fn(async () => 'git@github.com:org/repo.git'),
+        getDefaultBranch: vi.fn(async () => 'main')
+      },
+      db: { ...makeDeps().db, getActiveWorktreesByProject: () => [] },
+      execGit: execGitScript({ revParseHeads: {}, revParseRemotes: {} })
+    })
+    const bp = backupProject({
+      path: '/repo',
+      remote_url: 'git@github.com:org/repo.git',
+      worktrees: [{ name: 'feature-a', branch_name: 'feature/missing', base_branch: 'main' }]
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.worktrees).toEqual([
+      { branch: 'feature/missing', status: 'created-fresh-branch' }
+    ])
+    expect(
+      result.warnings.some((w) => w.includes('feature/missing') && w.includes('main'))
+    ).toBe(true)
+  })
+
+  it('marks a failed worktree add as failed and still attempts later worktrees', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: { ...makeDeps().git, getRemoteUrl: vi.fn(async () => null) },
+      db: { ...makeDeps().db, getActiveWorktreesByProject: () => [] },
+      execGit: execGitScript({
+        revParseHeads: { 'feature/a': true, 'feature/b': true },
+        worktreeAddFailFor: new Set(['feature/a'])
+      })
+    })
+    const bp = backupProject({
+      path: '/repo',
+      worktrees: [
+        { name: 'feature-a', branch_name: 'feature/a', base_branch: 'main' },
+        { name: 'feature-b', branch_name: 'feature/b', base_branch: 'main' }
+      ]
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.worktrees).toEqual([
+      { branch: 'feature/a', status: 'failed', error: 'already checked out' },
+      { branch: 'feature/b', status: 'created' }
+    ])
+  })
+
+  it('skips tickets and leaves the project row untouched when already in Hive', async () => {
+    const existing = project({ id: 'existing-1', path: '/repo' })
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: { ...makeDeps().git, getRemoteUrl: vi.fn(async () => null) },
+      db: { ...makeDeps().db, getProjectByPath: () => existing },
+      execGit: execGitScript()
+    })
+    const bp = backupProject({
+      path: '/repo',
+      tickets: [
+        {
+          key: 't1',
+          title: 'Ticket',
+          description: null,
+          column: 'todo',
+          sort_order: 0,
+          mode: null,
+          mark: null,
+          total_tokens: 0,
+          archived_at: null,
+          worktree_branch: null
+        }
+      ]
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.tickets).toEqual({ restored: 0, dependencyErrors: 0, skipped: true })
+    expect(result.projectId).toBe('existing-1')
+    expect(deps.db.updateProject).not.toHaveBeenCalled()
+  })
+
+  it('restores tickets, remaps keys, resolves worktree_id by branch, and reports a dependency error for an unknown key', async () => {
+    const createdWorktree = worktree({ id: 'wt-feature-a', branch_name: 'feature/a' })
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: { ...makeDeps().git, getRemoteUrl: vi.fn(async () => null) },
+      db: {
+        ...makeDeps().db,
+        getActiveWorktreesByProject: () => [createdWorktree],
+        createKanbanTicket: vi.fn((data) => ticket({ ...data, id: `created-${data.title}` })),
+        addTicketDependency: vi.fn((dependentId: string, blockerId: string) => {
+          if (dependentId === 'created-Second' && blockerId === 'created-First') {
+            return { success: true }
+          }
+          return { success: false, error: 'unexpected dependency' }
+        })
+      },
+      execGit: execGitScript()
+    })
+    const bp = backupProject({
+      path: '/repo',
+      worktrees: [{ name: 'feature-a', branch_name: 'feature/a', base_branch: 'main' }],
+      tickets: [
+        {
+          key: 't1',
+          title: 'First',
+          description: null,
+          column: 'todo',
+          sort_order: 0,
+          mode: null,
+          mark: null,
+          total_tokens: 0,
+          archived_at: null,
+          worktree_branch: 'feature/a'
+        },
+        {
+          key: 't2',
+          title: 'Second',
+          description: null,
+          column: 'done',
+          sort_order: 1,
+          mode: null,
+          mark: null,
+          total_tokens: 500,
+          archived_at: '2026-01-01T00:00:00.000Z',
+          worktree_branch: null
+        }
+      ],
+      ticket_dependencies: [
+        { dependent: 't2', blocker: 't1' },
+        { dependent: 't2', blocker: 'unknown-key' }
+      ]
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(deps.db.createKanbanTicket).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'First', worktree_id: 'wt-feature-a' })
+    )
+    expect(deps.db.createKanbanTicket).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Second', worktree_id: null })
+    )
+    expect(deps.db.updateKanbanTicket).toHaveBeenCalledWith('created-Second', {
+      archived_at: '2026-01-01T00:00:00.000Z'
+    })
+    expect(deps.db.addTicketTokens).toHaveBeenCalledWith('created-Second', 500)
+    expect(deps.db.addTicketDependency).toHaveBeenCalledWith('created-Second', 'created-First')
+    expect(result.tickets).toEqual({ restored: 2, dependencyErrors: 1, skipped: false })
+  })
+
+  it('returns skipped-conflict and touches nothing when the path holds a different repo', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => false)
+    })
+    const bp = backupProject({ path: '/repo', remote_url: 'git@github.com:org/repo.git' })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result).toMatchObject({
+      success: false,
+      action: 'skipped-conflict',
+      warnings: ['path exists but contains a different repository'],
+      worktrees: [],
+      tickets: null
+    })
+    expect(deps.cloneRepository).not.toHaveBeenCalled()
+    expect(deps.git.pull).not.toHaveBeenCalled()
+    expect(deps.createProjectWithDefaultWorktree).not.toHaveBeenCalled()
+    expect(deps.syncWorktreesOp).not.toHaveBeenCalled()
+    expect(deps.execGit).not.toHaveBeenCalled()
+  })
+
+  it('returns skipped-no-remote when the path is missing and there is no remote', async () => {
+    const deps = makeDeps({ fs: mockFs([]) })
+    const bp = backupProject({ path: '/repo', remote_url: null })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result).toMatchObject({
+      success: false,
+      action: 'skipped-no-remote',
+      worktrees: [],
+      tickets: null
+    })
+  })
+
+  it('never throws out of the service when a dep throws unexpectedly', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: {
+        ...makeDeps().git,
+        getRemoteUrl: vi.fn(async () => null),
+        hasUncommittedChanges: vi.fn(async () => {
+          throw new Error('boom')
+        })
+      }
+    })
+    const bp = backupProject({ path: '/repo' })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.action).toBe('failed')
+    expect(result.error).toContain('boom')
+  })
+})
+
 describe('backupOps handler param validation', () => {
   it('rejects backupOps.exportBackup params with unexpected keys', async () => {
     const exportBackup = vi.fn(() => Effect.succeed({ success: true }))
     const handlers = makeBackupOpsRpcHandlers({
       exportBackup,
-      openBackupFile: vi.fn(() => Effect.succeed({ canceled: true }))
+      openBackupFile: vi.fn(() => Effect.succeed({ canceled: true })),
+      classifyProjects: vi.fn(() => Effect.succeed([])),
+      restoreProject: vi.fn(() =>
+        Effect.succeed({
+          success: true,
+          projectName: 'repo',
+          action: 'pulled' as const,
+          warnings: [],
+          worktrees: [],
+          tickets: null
+        })
+      )
     })
     const handler = handlers.get('backupOps.exportBackup')!
 

--- a/src/server/rpc/domains/__tests__/backup-ops.test.ts
+++ b/src/server/rpc/domains/__tests__/backup-ops.test.ts
@@ -1348,7 +1348,7 @@ describe('backupOps.restoreProject', () => {
     expect(execGitCalls.some((call) => call[1][0] === 'branch')).toBe(false)
   })
 
-  it('sanitizes a project name containing path-traversal segments so the worktree path stays under ~/.hive-worktrees', async () => {
+  it('sanitizes a project name containing a leading path-traversal run so the worktree path stays under ~/.hive-worktrees', async () => {
     const deps = makeDeps({
       fs: mockFs(['/repo']),
       isGitRepository: vi.fn(() => true),
@@ -1374,6 +1374,97 @@ describe('backupOps.restoreProject', () => {
     const worktreePath = worktreeAddCall[1][2] as string
     expect(worktreePath.startsWith('/home/tester/.hive-worktrees/')).toBe(true)
     expect(worktreePath.includes('..')).toBe(false)
+  })
+
+  // Adversarial regression test: a naive `slug()` (lowercase + charset
+  // replace + trim only LEADING/TRAILING `-/.` runs) leaves `/` and `.`
+  // untouched *inside* the string. A project name like
+  // `a/../../../../../../tmp/pwned` starts with a real character so nothing
+  // gets trimmed, and the embedded `../../../../../../` survives into
+  // `path.join(homedir(), '.hive-worktrees', name, ...)`, which then
+  // normalizes the `..` segments right out of `.hive-worktrees` and lands on
+  // an attacker-chosen absolute path (e.g. `/tmp/pwned--wt`). This asserts
+  // both that the sanitizer neutralizes the traversal AND that the
+  // defense-in-depth containment check would catch anything that slipped
+  // through, by inspecting every mkdir/`git worktree add` argv path.
+  it('contains an embedded path-traversal project name (adversarial bypass) so every worktree/mkdir path stays under ~/.hive-worktrees', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: { ...makeDeps().git, getRemoteUrl: vi.fn(async () => null) },
+      db: { ...makeDeps().db, getActiveWorktreesByProject: () => [] },
+      homedir: vi.fn(() => '/home/tester'),
+      execGit: execGitScript({ revParseHeads: { 'feature/a': true } })
+    })
+    const bp = backupProject({
+      name: 'a/../../../../../../tmp/pwned',
+      path: '/repo',
+      worktrees: [{ name: 'feature-a', branch_name: 'feature/a', base_branch: 'main' }]
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.worktrees).toEqual([{ branch: 'feature/a', status: 'created' }])
+
+    const boundary = '/home/tester/.hive-worktrees/'
+    const execGitCalls = (deps.execGit as ReturnType<typeof vi.fn>).mock.calls
+    const worktreeAddCall = execGitCalls.find((call) => call[1][0] === 'worktree')!
+    const worktreePath = worktreeAddCall[1][2] as string
+    expect(worktreePath.startsWith(boundary)).toBe(true)
+    expect(worktreePath.includes('..')).toBe(false)
+    expect(worktreePath.includes('/tmp/pwned')).toBe(false)
+
+    const mkdirCalls = (deps.fs.mkdir as ReturnType<typeof vi.fn>).mock.calls
+    for (const [mkdirPath] of mkdirCalls) {
+      expect((mkdirPath as string).startsWith(boundary)).toBe(true)
+    }
+  })
+
+  it('contains an embedded path-traversal worktree entry name (adversarial bypass) so every worktree/mkdir path stays under ~/.hive-worktrees', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: { ...makeDeps().git, getRemoteUrl: vi.fn(async () => null) },
+      db: { ...makeDeps().db, getActiveWorktreesByProject: () => [] },
+      homedir: vi.fn(() => '/home/tester'),
+      execGit: execGitScript({ revParseHeads: { 'feature/a': true } })
+    })
+    const bp = backupProject({
+      name: 'repo',
+      path: '/repo',
+      worktrees: [
+        {
+          name: 'a/../../../../../../tmp/pwned',
+          branch_name: 'feature/a',
+          base_branch: 'main'
+        }
+      ]
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.worktrees).toEqual([{ branch: 'feature/a', status: 'created' }])
+
+    const boundary = '/home/tester/.hive-worktrees/'
+    const execGitCalls = (deps.execGit as ReturnType<typeof vi.fn>).mock.calls
+    const worktreeAddCall = execGitCalls.find((call) => call[1][0] === 'worktree')!
+    const worktreePath = worktreeAddCall[1][2] as string
+    expect(worktreePath.startsWith(boundary)).toBe(true)
+    expect(worktreePath.includes('..')).toBe(false)
+    expect(worktreePath.includes('/tmp/pwned')).toBe(false)
+
+    const mkdirCalls = (deps.fs.mkdir as ReturnType<typeof vi.fn>).mock.calls
+    for (const [mkdirPath] of mkdirCalls) {
+      expect((mkdirPath as string).startsWith(boundary)).toBe(true)
+    }
   })
 
   it('fails the clone flow instead of escaping the chosen folder when the backed-up path basename is ".."', async () => {

--- a/src/server/rpc/domains/__tests__/backup-ops.test.ts
+++ b/src/server/rpc/domains/__tests__/backup-ops.test.ts
@@ -1,0 +1,477 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { readFile, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { Effect } from 'effect'
+import YAML from 'yaml'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { KanbanTicket, Project, TicketDependency, Worktree } from '../../../../main/db'
+import type { BackupFile } from '../../../../shared/types/backup'
+import {
+  makeBackupOpsRpcHandlers,
+  makeBackupOpsRpcService,
+  type BackupOpsDeps
+} from '../backup-ops'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  vi.restoreAllMocks()
+})
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hive-backup-ops-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+const now = '2026-06-04T00:00:00.000Z'
+
+function project(overrides: Partial<Project> & Record<string, unknown> = {}): Project {
+  return {
+    id: 'project-1',
+    name: 'repo',
+    path: '/repo',
+    description: null,
+    tags: null,
+    language: null,
+    custom_icon: null,
+    detected_icon: null,
+    setup_script: null,
+    run_script: null,
+    archive_script: null,
+    worktree_create_script: null,
+    custom_commands: [],
+    auto_assign_port: false,
+    kanban_storage_mode: 'internal',
+    kanban_markdown_config: null,
+    sort_order: 0,
+    created_at: now,
+    last_accessed_at: now,
+    ...overrides
+  } as Project
+}
+
+function worktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'worktree-1',
+    project_id: 'project-1',
+    name: 'repo',
+    branch_name: 'main',
+    path: '/repo-worktree',
+    status: 'active',
+    is_default: false,
+    branch_renamed: 1,
+    last_message_at: null,
+    session_titles: '[]',
+    last_model_provider_id: null,
+    last_model_id: null,
+    last_model_variant: null,
+    attachments: '[]',
+    pinned: 0,
+    context: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    teleported_to: null,
+    base_branch: null,
+    created_at: now,
+    last_accessed_at: now,
+    ...overrides
+  }
+}
+
+function ticket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'project-1',
+    title: 'Ticket',
+    description: null,
+    attachments: [],
+    column: 'todo',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: null,
+    mode: null,
+    plan_ready: false,
+    created_at: now,
+    updated_at: now,
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
+    created_from_session: false,
+    auto_approve_plan: false,
+    ...overrides
+  }
+}
+
+/** Builds real fs-backed deps for exportBackup tests: writeFile/readFile/stat hit disk. */
+function makeFsDeps(): BackupOpsDeps['fs'] {
+  return {
+    readFile: (path) => readFile(path),
+    writeFile: (path, content) => writeFile(path, content, 'utf-8'),
+    stat: (path) => stat(path)
+  }
+}
+
+function makeDeps(overrides: Partial<BackupOpsDeps> = {}): BackupOpsDeps {
+  return {
+    db: {
+      getAllProjects: () => [],
+      getActiveWorktreesByProject: () => [],
+      getWorktreesByProject: () => [],
+      getKanbanTicketsByProject: () => [],
+      getDependenciesForProject: () => []
+    },
+    git: {
+      getRemoteUrl: vi.fn(async () => null)
+    },
+    fs: makeFsDeps(),
+    getAppVersion: vi.fn(async () => '1.2.3'),
+    requestSaveFileDialog: vi.fn(async () => null),
+    requestOpenFileDialog: vi.fn(async () => null),
+    ...overrides
+  }
+}
+
+describe('backupOps.exportBackup', () => {
+  it('exports internal-mode tickets/dependencies and omits tickets for markdown-mode projects', async () => {
+    const dir = makeTempDir()
+    const outPath = join(dir, 'out.yaml')
+
+    const internalProject = project({
+      id: 'project-a',
+      name: 'internal-repo',
+      path: '/internal-repo',
+      kanban_storage_mode: 'internal'
+    })
+    const markdownProject = project({
+      id: 'project-b',
+      name: 'markdown-repo',
+      path: '/markdown-repo',
+      kanban_storage_mode: 'markdown'
+    })
+
+    const wtA = worktree({ id: 'wt-a', project_id: 'project-a', branch_name: 'feature/a' })
+    const ticketA1 = ticket({
+      id: 'ticket-a1',
+      project_id: 'project-a',
+      title: 'First',
+      worktree_id: 'wt-a'
+    })
+    const ticketA2 = ticket({
+      id: 'ticket-a2',
+      project_id: 'project-a',
+      title: 'Second',
+      archived_at: '2026-01-01T00:00:00.000Z'
+    })
+    const dependencyA: TicketDependency = {
+      dependent_id: 'ticket-a2',
+      blocker_id: 'ticket-a1',
+      created_at: now
+    }
+
+    // Tickets exist in the DB for the markdown-mode project too — they must
+    // NOT appear in the export.
+    const markdownTicket = ticket({ id: 'ticket-b1', project_id: 'project-b', title: 'Hidden' })
+
+    const getRemoteUrl = vi.fn(async (repoPath: string) =>
+      repoPath === '/internal-repo' ? 'git@github.com:org/internal-repo.git' : null
+    )
+
+    const deps = makeDeps({
+      db: {
+        getAllProjects: () => [internalProject, markdownProject],
+        getActiveWorktreesByProject: (projectId) => (projectId === 'project-a' ? [wtA] : []),
+        getWorktreesByProject: (projectId) => (projectId === 'project-a' ? [wtA] : []),
+        getKanbanTicketsByProject: (projectId) => {
+          if (projectId === 'project-a') return [ticketA1, ticketA2]
+          if (projectId === 'project-b') return [markdownTicket]
+          return []
+        },
+        getDependenciesForProject: (projectId) => (projectId === 'project-a' ? [dependencyA] : [])
+      },
+      git: { getRemoteUrl },
+      requestSaveFileDialog: vi.fn(async () => outPath)
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.exportBackup())
+
+    expect(result).toMatchObject({ success: true, path: outPath, projectCount: 2 })
+
+    const written = YAML.parse(readFileSync(outPath, 'utf-8')) as BackupFile
+    expect(written.version).toBe(1)
+    expect(written.kind).toBe('hive-backup')
+    expect(typeof written.created_at).toBe('string')
+    expect(written.app_version).toBe('1.2.3')
+
+    const exportedA = written.projects.find((p) => p.name === 'internal-repo')!
+    expect(exportedA.remote_url).toBe('git@github.com:org/internal-repo.git')
+    expect(exportedA.kanban_storage_mode).toBe('internal')
+    expect(exportedA.tickets).toHaveLength(2)
+    expect(exportedA.tickets?.map((t) => t.key)).toEqual(['t1', 't2'])
+    const first = exportedA.tickets?.find((t) => t.title === 'First')
+    const second = exportedA.tickets?.find((t) => t.title === 'Second')
+    expect(first?.worktree_branch).toBe('feature/a')
+    expect(second?.archived_at).toBe('2026-01-01T00:00:00.000Z')
+    expect(exportedA.ticket_dependencies).toEqual([{ dependent: 't2', blocker: 't1' }])
+    for (const t of exportedA.tickets ?? []) {
+      expect(t).not.toHaveProperty('attachments')
+    }
+
+    const exportedB = written.projects.find((p) => p.name === 'markdown-repo')!
+    expect(exportedB.remote_url).toBeNull()
+    expect(exportedB.kanban_storage_mode).toBe('markdown')
+    expect(exportedB.tickets).toBeNull()
+    expect(exportedB.ticket_dependencies).toBeNull()
+  })
+
+  it('returns canceled without writing when the save dialog is dismissed', async () => {
+    const writeFileSpy = vi.fn(async () => undefined)
+    const deps = makeDeps({
+      db: {
+        getAllProjects: () => [project()],
+        getActiveWorktreesByProject: () => [],
+        getWorktreesByProject: () => [],
+        getKanbanTicketsByProject: () => [],
+        getDependenciesForProject: () => []
+      },
+      fs: { ...makeFsDeps(), writeFile: writeFileSpy },
+      requestSaveFileDialog: vi.fn(async () => null)
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.exportBackup())
+
+    expect(result).toEqual({ success: false, canceled: true })
+    expect(writeFileSpy).not.toHaveBeenCalled()
+  })
+
+  it('drops a custom_icon that is missing on disk and continues exporting', async () => {
+    const dir = makeTempDir()
+    const outPath = join(dir, 'out.yaml')
+    const proj = project({ custom_icon: join(dir, 'does-not-exist.png') })
+
+    const deps = makeDeps({
+      db: {
+        getAllProjects: () => [proj],
+        getActiveWorktreesByProject: () => [],
+        getWorktreesByProject: () => [],
+        getKanbanTicketsByProject: () => [],
+        getDependenciesForProject: () => []
+      },
+      requestSaveFileDialog: vi.fn(async () => outPath)
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.exportBackup())
+
+    expect(result.success).toBe(true)
+    const written = YAML.parse(readFileSync(outPath, 'utf-8')) as BackupFile
+    expect(written.projects[0].custom_icon).toBeNull()
+  })
+
+  it('embeds a custom_icon under the size limit as base64', async () => {
+    const dir = makeTempDir()
+    const outPath = join(dir, 'out.yaml')
+    const iconPath = join(dir, 'icon.png')
+    writeFileSync(iconPath, Buffer.from('fake-png-bytes'))
+    const proj = project({ custom_icon: iconPath })
+
+    const deps = makeDeps({
+      db: {
+        getAllProjects: () => [proj],
+        getActiveWorktreesByProject: () => [],
+        getWorktreesByProject: () => [],
+        getKanbanTicketsByProject: () => [],
+        getDependenciesForProject: () => []
+      },
+      requestSaveFileDialog: vi.fn(async () => outPath)
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.exportBackup())
+
+    expect(result.success).toBe(true)
+    const written = YAML.parse(readFileSync(outPath, 'utf-8')) as BackupFile
+    expect(written.projects[0].custom_icon).toEqual({
+      filename: 'icon.png',
+      data_base64: Buffer.from('fake-png-bytes').toString('base64')
+    })
+  })
+
+  it('drops a custom_icon larger than 1 MB and continues exporting', async () => {
+    const dir = makeTempDir()
+    const outPath = join(dir, 'out.yaml')
+    const iconPath = join(dir, 'big-icon.png')
+    writeFileSync(iconPath, Buffer.alloc(1024 * 1024 + 1))
+    const proj = project({ custom_icon: iconPath })
+
+    const deps = makeDeps({
+      db: {
+        getAllProjects: () => [proj],
+        getActiveWorktreesByProject: () => [],
+        getWorktreesByProject: () => [],
+        getKanbanTicketsByProject: () => [],
+        getDependenciesForProject: () => []
+      },
+      requestSaveFileDialog: vi.fn(async () => outPath)
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.exportBackup())
+
+    expect(result.success).toBe(true)
+    const written = YAML.parse(readFileSync(outPath, 'utf-8')) as BackupFile
+    expect(written.projects[0].custom_icon).toBeNull()
+  })
+
+  it('returns a failure result when an unexpected error occurs', async () => {
+    const deps = makeDeps({
+      db: {
+        getAllProjects: () => {
+          throw new Error('db exploded')
+        },
+        getActiveWorktreesByProject: () => [],
+        getWorktreesByProject: () => [],
+        getKanbanTicketsByProject: () => [],
+        getDependenciesForProject: () => []
+      }
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.exportBackup())
+
+    expect(result).toEqual({ success: false, error: 'db exploded' })
+  })
+})
+
+describe('backupOps.openBackupFile', () => {
+  const validBackup: BackupFile = {
+    version: 1,
+    kind: 'hive-backup',
+    created_at: now,
+    app_version: '1.2.3',
+    projects: [
+      {
+        name: 'repo',
+        path: '/repo',
+        remote_url: null,
+        description: null,
+        tags: null,
+        language: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        worktree_create_script: null,
+        custom_commands: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        kanban_simple_mode: false,
+        kanban_storage_mode: 'internal',
+        kanban_markdown_config: null,
+        custom_icon: null,
+        worktrees: [],
+        tickets: [],
+        ticket_dependencies: []
+      }
+    ]
+  }
+
+  it('round-trips a valid backup file', async () => {
+    const dir = makeTempDir()
+    const filePath = join(dir, 'valid.yaml')
+    writeFileSync(filePath, YAML.stringify(validBackup), 'utf-8')
+
+    const deps = makeDeps({ requestOpenFileDialog: vi.fn(async () => filePath) })
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.openBackupFile())
+
+    expect(result.canceled).toBe(false)
+    expect(result.backup).toMatchObject({
+      version: 1,
+      kind: 'hive-backup',
+      app_version: '1.2.3'
+    })
+  })
+
+  it('reports a newer-version error for version > 1', async () => {
+    const dir = makeTempDir()
+    const filePath = join(dir, 'newer.yaml')
+    writeFileSync(filePath, YAML.stringify({ ...validBackup, version: 2 }), 'utf-8')
+
+    const deps = makeDeps({ requestOpenFileDialog: vi.fn(async () => filePath) })
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.openBackupFile())
+
+    expect(result.canceled).toBe(false)
+    expect(result.backup).toBeUndefined()
+    expect(result.error).toMatch(/newer version of Hive/)
+  })
+
+  it('reports a readable error for malformed YAML without throwing', async () => {
+    const dir = makeTempDir()
+    const filePath = join(dir, 'broken.yaml')
+    writeFileSync(filePath, 'foo: [unclosed', 'utf-8')
+
+    const deps = makeDeps({ requestOpenFileDialog: vi.fn(async () => filePath) })
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.openBackupFile())
+
+    expect(result.canceled).toBe(false)
+    expect(result.backup).toBeUndefined()
+    expect(typeof result.error).toBe('string')
+  })
+
+  it('reports an error when kind is not hive-backup', async () => {
+    const dir = makeTempDir()
+    const filePath = join(dir, 'wrong-kind.yaml')
+    writeFileSync(filePath, YAML.stringify({ ...validBackup, kind: 'something-else' }), 'utf-8')
+
+    const deps = makeDeps({ requestOpenFileDialog: vi.fn(async () => filePath) })
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.openBackupFile())
+
+    expect(result.canceled).toBe(false)
+    expect(result.backup).toBeUndefined()
+    expect(typeof result.error).toBe('string')
+  })
+
+  it('returns canceled when the open dialog is dismissed', async () => {
+    const deps = makeDeps({ requestOpenFileDialog: vi.fn(async () => null) })
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.openBackupFile())
+
+    expect(result).toEqual({ canceled: true })
+  })
+})
+
+describe('backupOps handler param validation', () => {
+  it('rejects backupOps.exportBackup params with unexpected keys', async () => {
+    const exportBackup = vi.fn(() => Effect.succeed({ success: true }))
+    const handlers = makeBackupOpsRpcHandlers({
+      exportBackup,
+      openBackupFile: vi.fn(() => Effect.succeed({ canceled: true }))
+    })
+    const handler = handlers.get('backupOps.exportBackup')!
+
+    await expect(
+      Effect.runPromise(handler({ unexpected: true }, { eventBus: {} as never }))
+    ).rejects.toBeTruthy()
+    expect(exportBackup).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/rpc/domains/__tests__/backup-ops.test.ts
+++ b/src/server/rpc/domains/__tests__/backup-ops.test.ts
@@ -458,6 +458,20 @@ describe('backupOps.openBackupFile', () => {
 
     expect(result).toEqual({ canceled: true })
   })
+
+  it('handles requestOpenFileDialog rejection gracefully', async () => {
+    const deps = makeDeps({
+      requestOpenFileDialog: vi.fn(async () => {
+        throw new Error('Desktop command failed: backupOpenFileDialog')
+      })
+    })
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.openBackupFile())
+
+    expect(result.canceled).toBe(false)
+    expect(result.backup).toBeUndefined()
+    expect(result.error).toContain('Desktop command failed')
+  })
 })
 
 describe('backupOps handler param validation', () => {

--- a/src/server/rpc/domains/__tests__/backup-ops.test.ts
+++ b/src/server/rpc/domains/__tests__/backup-ops.test.ts
@@ -341,6 +341,8 @@ describe('backupOps.exportBackup', () => {
     expect(result.success).toBe(true)
     const written = YAML.parse(readFileSync(outPath, 'utf-8')) as BackupFile
     expect(written.projects[0].custom_icon).toBeNull()
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings?.[0]).toContain('custom icon for repo skipped')
   })
 
   it('embeds a custom_icon under the size limit as base64', async () => {
@@ -371,6 +373,7 @@ describe('backupOps.exportBackup', () => {
       filename: 'icon.png',
       data_base64: Buffer.from('fake-png-bytes').toString('base64')
     })
+    expect(result.warnings).toBeUndefined()
   })
 
   it('drops a custom_icon larger than 1 MB and continues exporting', async () => {
@@ -398,6 +401,8 @@ describe('backupOps.exportBackup', () => {
     expect(result.success).toBe(true)
     const written = YAML.parse(readFileSync(outPath, 'utf-8')) as BackupFile
     expect(written.projects[0].custom_icon).toBeNull()
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings?.[0]).toContain('custom icon for repo skipped (larger than 1 MB)')
   })
 
   it('returns a failure result when an unexpected error occurs', async () => {
@@ -532,6 +537,55 @@ describe('backupOps.openBackupFile', () => {
     expect(result.canceled).toBe(false)
     expect(result.backup).toBeUndefined()
     expect(result.error).toContain('Desktop command failed')
+  })
+
+  it('rejects a picked file larger than 50 MB without reading its contents', async () => {
+    const readFileSpy = vi.fn(async () => Buffer.from(''))
+    const deps = makeDeps({
+      requestOpenFileDialog: vi.fn(async () => '/huge/backup.yaml'),
+      fs: {
+        ...makeFsDeps(),
+        stat: vi.fn(async () => ({ size: 51 * 1024 * 1024 })),
+        readFile: readFileSpy
+      }
+    })
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.openBackupFile())
+
+    expect(result.canceled).toBe(false)
+    expect(result.backup).toBeUndefined()
+    expect(result.error).toMatch(/too large/i)
+    expect(readFileSpy).not.toHaveBeenCalled()
+  })
+
+  it('reports an error for a project with duplicate ticket keys instead of letting them silently misroute dependencies', async () => {
+    const dir = makeTempDir()
+    const filePath = join(dir, 'dup-keys.yaml')
+    const duplicateTicket = {
+      key: 't1',
+      title: 'Dup',
+      description: null,
+      column: 'todo' as const,
+      sort_order: 0,
+      mode: null,
+      mark: null,
+      total_tokens: 0,
+      archived_at: null,
+      worktree_branch: null
+    }
+    const backupWithDupKeys: BackupFile = {
+      ...validBackup,
+      projects: [{ ...validBackup.projects[0], tickets: [duplicateTicket, duplicateTicket] }]
+    }
+    writeFileSync(filePath, YAML.stringify(backupWithDupKeys), 'utf-8')
+
+    const deps = makeDeps({ requestOpenFileDialog: vi.fn(async () => filePath) })
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(service.openBackupFile())
+
+    expect(result.canceled).toBe(false)
+    expect(result.backup).toBeUndefined()
+    expect(result.error).toContain('duplicate ticket key')
   })
 })
 
@@ -838,6 +892,36 @@ describe('backupOps.restoreProject', () => {
       projectId: 'project-repo',
       projectPath: '/clones/repo'
     })
+  })
+
+  it('restores fine when kanban_markdown_config is entirely absent (zod z.unknown() optional-key edge case), rather than persisting JSON.stringify(undefined)', async () => {
+    // Simulates the real DB layer, which throws on a non-string/non-null bind
+    // value — proves the `undefined` case is skipped rather than persisted.
+    const updateProjectKanbanMarkdownConfig = vi.fn((_id: string, config: string | null) => {
+      if (config !== null && typeof config !== 'string') {
+        throw new TypeError('SQLite3 can only bind numbers, strings, bigints, buffers, and null')
+      }
+      return null
+    })
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: { ...makeDeps().git, getRemoteUrl: vi.fn(async () => null) },
+      db: { ...makeDeps().db, updateProjectKanbanMarkdownConfig }
+    })
+    const bp = backupProject({ path: '/repo' }) as unknown as Record<string, unknown>
+    delete bp.kanban_markdown_config
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({
+        project: bp as unknown as BackupProject,
+        options: { cloneParentDir: null }
+      })
+    )
+
+    expect(result.success).toBe(true)
+    expect(updateProjectKanbanMarkdownConfig).not.toHaveBeenCalled()
   })
 
   it('suffixes the clone destination on collision', async () => {
@@ -1236,6 +1320,82 @@ describe('backupOps.restoreProject', () => {
     expect(result.success).toBe(false)
     expect(result.action).toBe('failed')
     expect(result.error).toContain('boom')
+  })
+
+  it('rejects a branch name that would be parsed as a git flag, without ever passing it to execGit', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: { ...makeDeps().git, getRemoteUrl: vi.fn(async () => null) },
+      db: { ...makeDeps().db, getActiveWorktreesByProject: () => [] },
+      execGit: execGitScript()
+    })
+    const bp = backupProject({
+      path: '/repo',
+      worktrees: [{ name: 'evil', branch_name: '-f', base_branch: 'main' }]
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.worktrees).toEqual([
+      { branch: '-f', status: 'failed', error: 'invalid branch name' }
+    ])
+    const execGitCalls = (deps.execGit as ReturnType<typeof vi.fn>).mock.calls
+    expect(execGitCalls.some((call) => call[1].includes('-f'))).toBe(false)
+    expect(execGitCalls.some((call) => call[1][0] === 'branch')).toBe(false)
+  })
+
+  it('sanitizes a project name containing path-traversal segments so the worktree path stays under ~/.hive-worktrees', async () => {
+    const deps = makeDeps({
+      fs: mockFs(['/repo']),
+      isGitRepository: vi.fn(() => true),
+      git: { ...makeDeps().git, getRemoteUrl: vi.fn(async () => null) },
+      db: { ...makeDeps().db, getActiveWorktreesByProject: () => [] },
+      homedir: vi.fn(() => '/home/tester'),
+      execGit: execGitScript({ revParseHeads: { 'feature/a': true } })
+    })
+    const bp = backupProject({
+      name: '../../tmp/evil',
+      path: '/repo',
+      worktrees: [{ name: 'feature-a', branch_name: 'feature/a', base_branch: 'main' }]
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: null } })
+    )
+
+    expect(result.worktrees).toEqual([{ branch: 'feature/a', status: 'created' }])
+    const execGitCalls = (deps.execGit as ReturnType<typeof vi.fn>).mock.calls
+    const worktreeAddCall = execGitCalls.find((call) => call[1][0] === 'worktree')!
+    const worktreePath = worktreeAddCall[1][2] as string
+    expect(worktreePath.startsWith('/home/tester/.hive-worktrees/')).toBe(true)
+    expect(worktreePath.includes('..')).toBe(false)
+  })
+
+  it('fails the clone flow instead of escaping the chosen folder when the backed-up path basename is ".."', async () => {
+    const deps = makeDeps({
+      fs: mockFs([]),
+      cloneRepository: vi.fn(async () => ({ success: true })),
+      execGit: execGitScript()
+    })
+    const bp = backupProject({
+      name: 'repo',
+      path: '/some/project/..',
+      remote_url: 'git@github.com:org/repo.git'
+    })
+
+    const service = makeBackupOpsRpcService(deps)
+    const result = await Effect.runPromise(
+      service.restoreProject({ project: bp, options: { cloneParentDir: '/clones' } })
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.action).toBe('failed')
+    expect(deps.cloneRepository).not.toHaveBeenCalled()
   })
 })
 

--- a/src/server/rpc/domains/backup-ops.ts
+++ b/src/server/rpc/domains/backup-ops.ts
@@ -1,0 +1,569 @@
+import { basename } from 'node:path'
+
+import { Effect } from 'effect'
+import YAML from 'yaml'
+import { z } from 'zod'
+import { isDesktopCommandResult, makeDesktopCommandRequest } from '../../../shared/desktop-command'
+import type { BackupFile } from '../../../shared/types/backup'
+import type { KanbanTicket, Project, TicketDependency, Worktree } from '../../../main/db'
+import type { RpcHandler } from '../router'
+
+// Raw SQLite row fields spread onto `Project` by `mapProjectRow` but not
+// declared on the `Project` interface (see database.ts:319 and the
+// `kanban_simple_mode` column added in the projects table).
+interface ProjectRawExtras {
+  readonly kanban_simple_mode?: number | boolean
+}
+
+const MAX_CUSTOM_ICON_BYTES = 1024 * 1024
+
+export interface BackupExportResult {
+  readonly success: boolean
+  readonly canceled?: boolean
+  readonly path?: string
+  readonly projectCount?: number
+  readonly error?: string
+}
+
+export interface BackupOpenResult {
+  readonly canceled: boolean
+  readonly backup?: BackupFile
+  readonly error?: string
+}
+
+interface BackupOpsDb {
+  readonly getAllProjects: () => Project[]
+  readonly getActiveWorktreesByProject: (projectId: string) => Worktree[]
+  readonly getWorktreesByProject: (projectId: string) => Worktree[]
+  readonly getKanbanTicketsByProject: (
+    projectId: string,
+    includeArchived: boolean
+  ) => KanbanTicket[]
+  readonly getDependenciesForProject: (projectId: string) => TicketDependency[]
+}
+
+interface BackupOpsGit {
+  // Resolves to the raw remote URL, or null when there is no remote / the
+  // lookup fails. Never expected to reject.
+  readonly getRemoteUrl: (repoPath: string) => Promise<string | null>
+}
+
+interface BackupOpsFs {
+  readonly readFile: (path: string) => Promise<Buffer>
+  readonly writeFile: (path: string, content: string) => Promise<void>
+  readonly stat: (path: string) => Promise<{ readonly size: number }>
+}
+
+export interface BackupOpsDeps {
+  readonly db: BackupOpsDb
+  readonly git: BackupOpsGit
+  readonly fs: BackupOpsFs
+  readonly getAppVersion: () => Promise<string>
+  readonly requestSaveFileDialog: (defaultFileName: string) => Promise<string | null>
+  readonly requestOpenFileDialog: () => Promise<string | null>
+}
+
+export interface BackupOpsRpcService {
+  readonly exportBackup: () => Effect.Effect<BackupExportResult, unknown, never>
+  readonly openBackupFile: () => Effect.Effect<BackupOpenResult, unknown, never>
+}
+
+const emptyParamsSchema = z.union([z.object({}).strict(), z.undefined(), z.null()])
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+// ---------------------------------------------------------------------------
+// backupFileSchema — mirrors src/shared/types/backup.ts. Nested objects use
+// .passthrough() so forward-compatible extra keys from a newer Hive version
+// don't hard-fail import; the top level still requires `kind: 'hive-backup'`.
+// ---------------------------------------------------------------------------
+
+const backupProjectIconSchema = z
+  .object({
+    filename: z.string(),
+    data_base64: z.string()
+  })
+  .passthrough()
+
+const backupWorktreeSchema = z
+  .object({
+    name: z.string(),
+    branch_name: z.string(),
+    base_branch: z.string().nullable()
+  })
+  .passthrough()
+
+const backupTicketSchema = z
+  .object({
+    key: z.string(),
+    title: z.string(),
+    description: z.string().nullable(),
+    column: z.enum(['todo', 'in_progress', 'review', 'done']),
+    sort_order: z.number(),
+    mode: z.enum(['build', 'plan', 'super-plan']).nullable(),
+    mark: z.string().nullable(),
+    total_tokens: z.number(),
+    archived_at: z.string().nullable(),
+    worktree_branch: z.string().nullable()
+  })
+  .passthrough()
+
+const backupTicketDependencySchema = z
+  .object({
+    dependent: z.string(),
+    blocker: z.string()
+  })
+  .passthrough()
+
+const backupProjectSchema = z
+  .object({
+    name: z.string(),
+    path: z.string(),
+    remote_url: z.string().nullable(),
+    description: z.string().nullable(),
+    tags: z.array(z.string()).nullable(),
+    language: z.string().nullable(),
+    setup_script: z.string().nullable(),
+    run_script: z.string().nullable(),
+    archive_script: z.string().nullable(),
+    worktree_create_script: z.string().nullable(),
+    custom_commands: z.array(z.unknown()).nullable(),
+    auto_assign_port: z.boolean(),
+    sort_order: z.number(),
+    kanban_simple_mode: z.boolean(),
+    kanban_storage_mode: z.enum(['internal', 'markdown']),
+    kanban_markdown_config: z.unknown().nullable(),
+    custom_icon: backupProjectIconSchema.nullable(),
+    worktrees: z.array(backupWorktreeSchema),
+    tickets: z.array(backupTicketSchema).nullable(),
+    ticket_dependencies: z.array(backupTicketDependencySchema).nullable()
+  })
+  .passthrough()
+
+const backupFileSchema = z.object({
+  version: z.number(),
+  kind: z.literal('hive-backup'),
+  created_at: z.string(),
+  app_version: z.string(),
+  projects: z.array(backupProjectSchema)
+})
+
+// ---------------------------------------------------------------------------
+// exportBackup
+// ---------------------------------------------------------------------------
+
+function defaultBackupFileName(now: Date = new Date()): string {
+  return `hive-backup-${now.toISOString().slice(0, 10)}.yaml`
+}
+
+async function getRemoteUrlSafe(deps: BackupOpsDeps, repoPath: string): Promise<string | null> {
+  try {
+    return await deps.git.getRemoteUrl(repoPath)
+  } catch {
+    return null
+  }
+}
+
+function parseProjectTags(raw: string | null): string[] | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function parseKanbanMarkdownConfig(raw: string | null | undefined): unknown | null {
+  if (typeof raw !== 'string' || raw.trim() === '') return null
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+function isProjectSimpleMode(project: Project): boolean {
+  return Boolean((project as unknown as ProjectRawExtras).kanban_simple_mode)
+}
+
+function resolveStorageMode(project: Project): 'internal' | 'markdown' {
+  return project.kanban_storage_mode === 'markdown' ? 'markdown' : 'internal'
+}
+
+async function readCustomIcon(
+  deps: BackupOpsDeps,
+  iconPath: string | null
+): Promise<BackupFile['projects'][number]['custom_icon']> {
+  if (!iconPath) return null
+  try {
+    const stats = await deps.fs.stat(iconPath)
+    if (stats.size > MAX_CUSTOM_ICON_BYTES) return null
+    const data = await deps.fs.readFile(iconPath)
+    return { filename: basename(iconPath), data_base64: data.toString('base64') }
+  } catch {
+    return null
+  }
+}
+
+function buildTicketsAndDependencies(
+  deps: BackupOpsDeps,
+  project: Project
+): {
+  tickets: BackupFile['projects'][number]['tickets']
+  ticketDependencies: BackupFile['projects'][number]['ticket_dependencies']
+} {
+  const worktreeBranchById = new Map(
+    deps.db.getWorktreesByProject(project.id).map((worktree) => [worktree.id, worktree.branch_name])
+  )
+  const kanbanTickets = deps.db.getKanbanTicketsByProject(project.id, true)
+  const keyByTicketId = new Map<string, string>()
+
+  const tickets = kanbanTickets.map((ticket, index) => {
+    const key = `t${index + 1}`
+    keyByTicketId.set(ticket.id, key)
+    return {
+      key,
+      title: ticket.title,
+      description: ticket.description,
+      column: ticket.column,
+      sort_order: ticket.sort_order,
+      mode: ticket.mode,
+      mark: ticket.mark,
+      total_tokens: ticket.total_tokens,
+      archived_at: ticket.archived_at,
+      worktree_branch: ticket.worktree_id
+        ? (worktreeBranchById.get(ticket.worktree_id) ?? null)
+        : null
+    }
+  })
+
+  const ticketDependencies = deps.db
+    .getDependenciesForProject(project.id)
+    .map((dependency) => ({
+      dependent: keyByTicketId.get(dependency.dependent_id),
+      blocker: keyByTicketId.get(dependency.blocker_id)
+    }))
+    .filter(
+      (edge): edge is { dependent: string; blocker: string } =>
+        edge.dependent !== undefined && edge.blocker !== undefined
+    )
+
+  return { tickets, ticketDependencies }
+}
+
+async function buildBackupProject(
+  deps: BackupOpsDeps,
+  project: Project
+): Promise<BackupFile['projects'][number]> {
+  const storageMode = resolveStorageMode(project)
+  const isMarkdownMode = storageMode === 'markdown'
+
+  const { tickets, ticketDependencies } = isMarkdownMode
+    ? { tickets: null, ticketDependencies: null }
+    : buildTicketsAndDependencies(deps, project)
+
+  return {
+    name: project.name,
+    path: project.path,
+    remote_url: await getRemoteUrlSafe(deps, project.path),
+    description: project.description,
+    tags: parseProjectTags(project.tags),
+    language: project.language,
+    setup_script: project.setup_script,
+    run_script: project.run_script,
+    archive_script: project.archive_script,
+    worktree_create_script: project.worktree_create_script,
+    custom_commands: project.custom_commands,
+    auto_assign_port: project.auto_assign_port,
+    sort_order: project.sort_order,
+    kanban_simple_mode: isProjectSimpleMode(project),
+    kanban_storage_mode: storageMode,
+    kanban_markdown_config: parseKanbanMarkdownConfig(project.kanban_markdown_config),
+    custom_icon: await readCustomIcon(deps, project.custom_icon),
+    worktrees: deps.db
+      .getActiveWorktreesByProject(project.id)
+      .filter((worktree) => !worktree.is_default)
+      .map((worktree) => ({
+        name: worktree.name,
+        branch_name: worktree.branch_name,
+        base_branch: worktree.base_branch
+      })),
+    tickets,
+    ticket_dependencies: ticketDependencies
+  }
+}
+
+async function exportBackup(deps: BackupOpsDeps): Promise<BackupExportResult> {
+  try {
+    const projects = deps.db.getAllProjects()
+    const backupProjects: BackupFile['projects'] = []
+    for (const project of projects) {
+      backupProjects.push(await buildBackupProject(deps, project))
+    }
+
+    const backupFile: BackupFile = {
+      version: 1,
+      kind: 'hive-backup',
+      created_at: new Date().toISOString(),
+      app_version: await deps.getAppVersion(),
+      projects: backupProjects
+    }
+
+    const filePath = await deps.requestSaveFileDialog(defaultBackupFileName())
+    if (filePath === null) {
+      return { success: false, canceled: true }
+    }
+
+    await deps.fs.writeFile(filePath, YAML.stringify(backupFile))
+
+    return { success: true, path: filePath, projectCount: backupProjects.length }
+  } catch (error) {
+    return { success: false, error: errorMessage(error) }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// openBackupFile
+// ---------------------------------------------------------------------------
+
+async function openBackupFile(deps: BackupOpsDeps): Promise<BackupOpenResult> {
+  const filePath = await deps.requestOpenFileDialog()
+  if (filePath === null) {
+    return { canceled: true }
+  }
+
+  let raw: string
+  try {
+    raw = (await deps.fs.readFile(filePath)).toString('utf-8')
+  } catch (error) {
+    return { canceled: false, error: errorMessage(error) }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = YAML.parse(raw)
+  } catch (error) {
+    return { canceled: false, error: `Failed to parse backup file: ${errorMessage(error)}` }
+  }
+
+  if (isRecord(parsed) && typeof parsed.version === 'number' && parsed.version > 1) {
+    return { canceled: false, error: 'This backup was created by a newer version of Hive.' }
+  }
+
+  const result = backupFileSchema.safeParse(parsed)
+  if (!result.success) {
+    return { canceled: false, error: z.prettifyError(result.error) }
+  }
+
+  return { canceled: false, backup: result.data }
+}
+
+// ---------------------------------------------------------------------------
+// Dialog request helpers — structurally copied from
+// requestKanbanSaveBoardExportDialog / requestKanbanOpenBoardImportFileDialog
+// in kanban.ts (~lines 870-976), injected through BackupOpsDeps for testing.
+// ---------------------------------------------------------------------------
+
+const isBackupDialogResult = (value: unknown): value is { readonly filePath: string | null } => {
+  if (!value || typeof value !== 'object') return false
+  const result = value as Record<string, unknown>
+  return result.filePath === null || typeof result.filePath === 'string'
+}
+
+function requestBackupSaveFileDialog(defaultFileName: string): Promise<string | null> {
+  const send = process.send
+  if (typeof send !== 'function') {
+    return Promise.resolve(null)
+  }
+
+  const id = `backup-save-file-dialog-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const command = 'backupSaveFileDialog'
+
+  return new Promise<string | null>((resolve, reject) => {
+    let settled = false
+    const cleanup = (): void => {
+      process.off('message', onMessage)
+    }
+    const finish = (value?: string | null, error?: Error): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve(value ?? null)
+    }
+
+    const onMessage = (message: unknown): void => {
+      if (!isDesktopCommandResult(message) || message.id !== id) return
+      if (!message.ok) {
+        finish(null, new Error(message.error ?? `Desktop command failed: ${command}`))
+        return
+      }
+      if (!isBackupDialogResult(message.value)) {
+        finish(null, new Error(`Desktop command returned invalid response: ${command}`))
+        return
+      }
+      finish(message.value.filePath)
+    }
+
+    process.on('message', onMessage)
+    send.call(process, makeDesktopCommandRequest(id, command, { defaultFileName }), (error) => {
+      if (!error) return
+      finish(null, error)
+    })
+  })
+}
+
+function requestBackupOpenFileDialog(): Promise<string | null> {
+  const send = process.send
+  if (typeof send !== 'function') {
+    return Promise.resolve(null)
+  }
+
+  const id = `backup-open-file-dialog-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const command = 'backupOpenFileDialog'
+
+  return new Promise<string | null>((resolve, reject) => {
+    let settled = false
+    const cleanup = (): void => {
+      process.off('message', onMessage)
+    }
+    const finish = (value?: string | null, error?: Error): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve(value ?? null)
+    }
+
+    const onMessage = (message: unknown): void => {
+      if (!isDesktopCommandResult(message) || message.id !== id) return
+      if (!message.ok) {
+        finish(null, new Error(message.error ?? `Desktop command failed: ${command}`))
+        return
+      }
+      if (!isBackupDialogResult(message.value)) {
+        finish(null, new Error(`Desktop command returned invalid response: ${command}`))
+        return
+      }
+      finish(message.value.filePath)
+    }
+
+    process.on('message', onMessage)
+    send.call(process, makeDesktopCommandRequest(id, command), (error) => {
+      if (!error) return
+      finish(null, error)
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Live deps + service/handler wiring
+// ---------------------------------------------------------------------------
+
+async function readLiveAppVersion(): Promise<string> {
+  try {
+    const { readFile } = await import('node:fs/promises')
+    const raw = await readFile('package.json', 'utf-8')
+    const parsed = JSON.parse(raw) as { readonly version?: unknown }
+    return typeof parsed.version === 'string' ? parsed.version : ''
+  } catch {
+    return ''
+  }
+}
+
+async function createLiveDeps(): Promise<BackupOpsDeps> {
+  const [{ getDatabase }, { gitService }, fsModule] = await Promise.all([
+    import('../../../main/db'),
+    import('../../../main/effect/git/facade'),
+    import('node:fs/promises')
+  ])
+  const db = getDatabase()
+
+  return {
+    db: {
+      getAllProjects: () => db.getAllProjects(),
+      getActiveWorktreesByProject: (projectId) => db.getActiveWorktreesByProject(projectId),
+      getWorktreesByProject: (projectId) => db.getWorktreesByProject(projectId),
+      getKanbanTicketsByProject: (projectId, includeArchived) =>
+        db.getKanbanTicketsByProject(projectId, includeArchived),
+      getDependenciesForProject: (projectId) => db.getDependenciesForProject(projectId)
+    },
+    git: {
+      getRemoteUrl: (repoPath) =>
+        gitService.getRemoteUrl(repoPath).then((result) => result.url ?? null)
+    },
+    fs: {
+      readFile: (path) => fsModule.readFile(path),
+      writeFile: (path, content) => fsModule.writeFile(path, content, 'utf-8'),
+      stat: (path) => fsModule.stat(path)
+    },
+    getAppVersion: () => readLiveAppVersion(),
+    requestSaveFileDialog: (defaultFileName) => requestBackupSaveFileDialog(defaultFileName),
+    requestOpenFileDialog: () => requestBackupOpenFileDialog()
+  }
+}
+
+export const makeBackupOpsRpcService = (deps: BackupOpsDeps): BackupOpsRpcService => ({
+  exportBackup: () =>
+    Effect.tryPromise({
+      try: () => exportBackup(deps),
+      catch: (cause) => cause
+    }),
+  openBackupFile: () =>
+    Effect.tryPromise({
+      try: () => openBackupFile(deps),
+      catch: (cause) => cause
+    })
+})
+
+export const makeLiveBackupOpsRpcService = (): BackupOpsRpcService => ({
+  exportBackup: () =>
+    Effect.tryPromise({
+      try: async () => exportBackup(await createLiveDeps()),
+      catch: (cause) => cause
+    }),
+  openBackupFile: () =>
+    Effect.tryPromise({
+      try: async () => openBackupFile(await createLiveDeps()),
+      catch: (cause) => cause
+    })
+})
+
+export const makeBackupOpsRpcHandlers = (
+  service: BackupOpsRpcService = makeLiveBackupOpsRpcService()
+): ReadonlyMap<string, RpcHandler> =>
+  new Map<string, RpcHandler>([
+    [
+      'backupOps.exportBackup',
+      (params) =>
+        Effect.gen(function* () {
+          yield* Effect.try({
+            try: () => emptyParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.exportBackup()
+        })
+    ],
+    [
+      'backupOps.openBackupFile',
+      (params) =>
+        Effect.gen(function* () {
+          yield* Effect.try({
+            try: () => emptyParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.openBackupFile()
+        })
+    ]
+  ])

--- a/src/server/rpc/domains/backup-ops.ts
+++ b/src/server/rpc/domains/backup-ops.ts
@@ -1,12 +1,36 @@
-import { basename } from 'node:path'
+import { execFile } from 'node:child_process'
+import { homedir } from 'node:os'
+import { basename, dirname, join } from 'node:path'
+import { promisify } from 'node:util'
 
 import { Effect } from 'effect'
 import YAML from 'yaml'
 import { z } from 'zod'
+import type { CustomProjectCommand } from '@shared/lib/custom-commands'
 import { isDesktopCommandResult, makeDesktopCommandRequest } from '../../../shared/desktop-command'
-import type { BackupFile } from '../../../shared/types/backup'
-import type { KanbanTicket, Project, TicketDependency, Worktree } from '../../../main/db'
+import type {
+  BackupFile,
+  BackupProject,
+  ProjectClassification,
+  RestoreProjectResult,
+  RestoreWorktreeResult
+} from '../../../shared/types/backup'
+import type {
+  KanbanTicket,
+  KanbanTicketCreate,
+  KanbanTicketUpdate,
+  Project,
+  ProjectCreate,
+  ProjectUpdate,
+  TicketDependency,
+  TicketMark,
+  Worktree,
+  WorktreeCreate
+} from '../../../main/db'
+import { normalizeGitRemoteUrl } from '../../../main/services/git-repository'
 import type { RpcHandler } from '../router'
+
+const execFileAsync = promisify(execFile)
 
 // Raw SQLite row fields spread onto `Project` by `mapProjectRow` but not
 // declared on the `Project` interface (see database.ts:319 and the
@@ -40,18 +64,47 @@ interface BackupOpsDb {
     includeArchived: boolean
   ) => KanbanTicket[]
   readonly getDependenciesForProject: (projectId: string) => TicketDependency[]
+  readonly getProjectByPath: (path: string) => Project | null
+  readonly createWorktree: (data: WorktreeCreate) => Worktree
+  readonly updateProject: (
+    id: string,
+    data: Pick<ProjectUpdate, 'language' | 'custom_commands' | 'auto_assign_port'>
+  ) => Project | null
+  readonly updateProjectKanbanStorageMode: (
+    id: string,
+    mode: 'internal' | 'markdown'
+  ) => Project | null
+  readonly updateProjectKanbanMarkdownConfig: (id: string, config: string | null) => Project | null
+  readonly updateProjectSimpleMode: (id: string, enabled: boolean) => void
+  readonly createKanbanTicket: (data: KanbanTicketCreate) => KanbanTicket
+  readonly updateKanbanTicket: (
+    id: string,
+    data: Pick<KanbanTicketUpdate, 'archived_at'>
+  ) => KanbanTicket | null
+  readonly addTicketTokens: (ticketId: string, tokens: number) => void
+  readonly addTicketDependency: (
+    dependentId: string,
+    blockerId: string
+  ) => { success: boolean; error?: string }
+  readonly transaction: <T>(fn: () => T) => T
 }
 
 interface BackupOpsGit {
   // Resolves to the raw remote URL, or null when there is no remote / the
   // lookup fails. Never expected to reject.
   readonly getRemoteUrl: (repoPath: string) => Promise<string | null>
+  readonly hasUncommittedChanges: (repoPath: string) => Promise<boolean>
+  // ff-only pull semantics via the facade; never expected to reject.
+  readonly pull: (repoPath: string) => Promise<{ success: boolean; error?: string }>
+  readonly getDefaultBranch: (repoPath: string) => Promise<string>
 }
 
 interface BackupOpsFs {
   readonly readFile: (path: string) => Promise<Buffer>
   readonly writeFile: (path: string, content: string) => Promise<void>
   readonly stat: (path: string) => Promise<{ readonly size: number }>
+  readonly exists: (path: string) => Promise<boolean>
+  readonly mkdir: (path: string) => Promise<void>
 }
 
 export interface BackupOpsDeps {
@@ -61,11 +114,38 @@ export interface BackupOpsDeps {
   readonly getAppVersion: () => Promise<string>
   readonly requestSaveFileDialog: (defaultFileName: string) => Promise<string | null>
   readonly requestOpenFileDialog: () => Promise<string | null>
+  // Raw `git` invocation for worktree/branch plumbing not covered by the
+  // gitService facade (rev-parse existence checks, fetch, worktree add).
+  // Rejects on non-zero exit, mirroring teleport-ops.ts's execGit.
+  readonly execGit: (cwd: string, args: string[]) => Promise<string>
+  readonly homedir: () => string
+  readonly cloneRepository: (
+    url: string,
+    destDir: string
+  ) => Promise<{ success: boolean; error?: string }>
+  readonly isGitRepository: (path: string) => boolean
+  readonly createProjectWithDefaultWorktree: (data: ProjectCreate) => Project
+  readonly uploadIcon: (
+    projectId: string,
+    base64Data: string,
+    filename: string
+  ) => { success: boolean; error?: string }
+  readonly syncWorktreesOp: (params: {
+    projectId: string
+    projectPath: string
+  }) => Promise<{ success: boolean; error?: string }>
 }
 
 export interface BackupOpsRpcService {
   readonly exportBackup: () => Effect.Effect<BackupExportResult, unknown, never>
   readonly openBackupFile: () => Effect.Effect<BackupOpenResult, unknown, never>
+  readonly classifyProjects: (params: {
+    projects: ReadonlyArray<{ name: string; path: string; remoteUrl: string | null }>
+  }) => Effect.Effect<ProjectClassification[], unknown, never>
+  readonly restoreProject: (params: {
+    project: BackupProject
+    options: { cloneParentDir: string | null }
+  }) => Effect.Effect<RestoreProjectResult, unknown, never>
 }
 
 const emptyParamsSchema = z.union([z.object({}).strict(), z.undefined(), z.null()])
@@ -151,6 +231,29 @@ const backupFileSchema = z.object({
   app_version: z.string(),
   projects: z.array(backupProjectSchema)
 })
+
+// ---------------------------------------------------------------------------
+// classifyProjects / restoreProject param schemas
+// ---------------------------------------------------------------------------
+
+const classifyProjectsParamsSchema = z
+  .object({
+    projects: z.array(
+      z.object({
+        name: z.string(),
+        path: z.string(),
+        remoteUrl: z.string().nullable()
+      })
+    )
+  })
+  .strict()
+
+const restoreProjectParamsSchema = z
+  .object({
+    project: backupProjectSchema,
+    options: z.object({ cloneParentDir: z.string().nullable() }).strict()
+  })
+  .strict()
 
 // ---------------------------------------------------------------------------
 // exportBackup
@@ -368,6 +471,499 @@ async function openBackupFile(deps: BackupOpsDeps): Promise<BackupOpenResult> {
 }
 
 // ---------------------------------------------------------------------------
+// classifyProjects
+// ---------------------------------------------------------------------------
+
+/**
+ * One normalized-remote lookup per Hive project, computed once per
+ * classifyProjects/restoreProject call (never per input entry) — mirrors
+ * `ensureRemoteProject` in teleport-ops.ts.
+ */
+async function buildHiveRemoteMap(
+  deps: BackupOpsDeps
+): Promise<Map<string, { project: Project; rawRemote: string | null }>> {
+  const map = new Map<string, { project: Project; rawRemote: string | null }>()
+  for (const project of deps.db.getAllProjects()) {
+    const rawRemote = await getRemoteUrlSafe(deps, project.path)
+    const normalized = normalizeGitRemoteUrl(rawRemote)
+    if (normalized !== null && !map.has(normalized)) {
+      map.set(normalized, { project, rawRemote })
+    }
+  }
+  return map
+}
+
+async function classifyOne(
+  deps: BackupOpsDeps,
+  hiveByRemote: Map<string, { project: Project; rawRemote: string | null }>,
+  input: { name: string; path: string; remoteUrl: string | null }
+): Promise<ProjectClassification> {
+  const backupRemote = normalizeGitRemoteUrl(input.remoteUrl)
+
+  if (backupRemote !== null) {
+    const match = hiveByRemote.get(backupRemote)
+    if (match) {
+      return {
+        path: input.path,
+        classification: 'exists-match',
+        alreadyInHive: true,
+        hiveProjectId: match.project.id,
+        effectivePath: match.project.path,
+        localRemoteUrl: match.rawRemote
+      }
+    }
+  }
+
+  const pathExists = await deps.fs.exists(input.path)
+  if (pathExists) {
+    if (!deps.isGitRepository(input.path)) {
+      return {
+        path: input.path,
+        classification: 'conflict',
+        alreadyInHive: false,
+        hiveProjectId: null,
+        effectivePath: input.path,
+        localRemoteUrl: null
+      }
+    }
+
+    const localRemoteRaw = await getRemoteUrlSafe(deps, input.path)
+    const localRemote = normalizeGitRemoteUrl(localRemoteRaw)
+    const remotesMatch =
+      (localRemote !== null && localRemote === backupRemote) ||
+      (localRemote === null && backupRemote === null)
+
+    if (remotesMatch) {
+      const existing = deps.db.getProjectByPath(input.path)
+      return {
+        path: input.path,
+        classification: 'exists-match',
+        alreadyInHive: existing !== null,
+        hiveProjectId: existing?.id ?? null,
+        effectivePath: input.path,
+        localRemoteUrl: localRemoteRaw
+      }
+    }
+
+    return {
+      path: input.path,
+      classification: 'conflict',
+      alreadyInHive: false,
+      hiveProjectId: null,
+      effectivePath: input.path,
+      localRemoteUrl: localRemoteRaw
+    }
+  }
+
+  return {
+    path: input.path,
+    classification: backupRemote === null ? 'skipped-no-remote' : 'missing-clone',
+    alreadyInHive: false,
+    hiveProjectId: null,
+    effectivePath: input.path,
+    localRemoteUrl: null
+  }
+}
+
+async function classifyProjects(
+  deps: BackupOpsDeps,
+  projects: ReadonlyArray<{ name: string; path: string; remoteUrl: string | null }>
+): Promise<ProjectClassification[]> {
+  const hiveByRemote = await buildHiveRemoteMap(deps)
+  const results: ProjectClassification[] = []
+  for (const project of projects) {
+    results.push(await classifyOne(deps, hiveByRemote, project))
+  }
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// restoreProject
+// ---------------------------------------------------------------------------
+
+// Local copies of teleport-ops.ts's `slug`/`uniquePath` helpers. Duplicated
+// rather than imported so backup-ops.ts doesn't pull in teleport-ops.ts's
+// module graph (Discord/teleport-remote-client wiring) for two small pure
+// helpers; per the task brief this duplication is acceptable.
+function slug(value: string): string {
+  const cleaned = value
+    .toLowerCase()
+    .replace(/[^a-z0-9._/-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-/.]+|[-/.]+$/g, '')
+    .slice(0, 64)
+  return cleaned || 'worktree'
+}
+
+async function uniquePath(deps: BackupOpsDeps, basePath: string): Promise<string> {
+  if (!(await deps.fs.exists(basePath))) return basePath
+  for (let i = 2; i < 100; i += 1) {
+    const candidate = `${basePath}-${i}`
+    if (!(await deps.fs.exists(candidate))) return candidate
+  }
+  throw new Error(`Could not choose a free path for ${basePath}`)
+}
+
+const nonSuccessActions: ReadonlySet<RestoreProjectResult['action']> = new Set([
+  'failed',
+  'skipped-conflict',
+  'skipped-no-remote'
+])
+
+async function restoreProject(
+  deps: BackupOpsDeps,
+  project: BackupProject,
+  options: { cloneParentDir: string | null }
+): Promise<RestoreProjectResult> {
+  const projectName = project.name
+  const warnings: string[] = []
+
+  try {
+    const hiveByRemote = await buildHiveRemoteMap(deps)
+    const classification = await classifyOne(deps, hiveByRemote, {
+      name: project.name,
+      path: project.path,
+      remoteUrl: project.remote_url
+    })
+
+    if (classification.classification === 'conflict') {
+      return {
+        success: false,
+        projectName,
+        action: 'skipped-conflict',
+        warnings: ['path exists but contains a different repository'],
+        worktrees: [],
+        tickets: null
+      }
+    }
+    if (classification.classification === 'skipped-no-remote') {
+      return {
+        success: false,
+        projectName,
+        action: 'skipped-no-remote',
+        warnings: [],
+        worktrees: [],
+        tickets: null
+      }
+    }
+
+    let effectivePath: string
+    let action: RestoreProjectResult['action']
+    let isFreshClone = false
+
+    if (classification.classification === 'exists-match') {
+      effectivePath = classification.effectivePath
+      action = 'attached'
+    } else {
+      // missing-clone
+      if (!options.cloneParentDir) {
+        return {
+          success: false,
+          projectName,
+          action: 'failed',
+          error: 'no clone folder selected',
+          warnings: [],
+          worktrees: [],
+          tickets: null
+        }
+      }
+      if (!project.remote_url) {
+        return {
+          success: false,
+          projectName,
+          action: 'failed',
+          error: 'no remote url to clone from',
+          warnings: [],
+          worktrees: [],
+          tickets: null
+        }
+      }
+
+      const dest = await uniquePath(deps, join(options.cloneParentDir, basename(project.path)))
+      const cloneResult = await deps.cloneRepository(project.remote_url, dest)
+      if (!cloneResult.success) {
+        return {
+          success: false,
+          projectName,
+          action: 'failed',
+          error: cloneResult.error ?? 'Failed to clone repository',
+          warnings: [],
+          worktrees: [],
+          tickets: null
+        }
+      }
+      effectivePath = dest
+      action = 'cloned'
+      isFreshClone = true
+    }
+
+    // Step 3: pull (only for exists-match — a fresh clone is already current)
+    if (!isFreshClone) {
+      const dirty = await deps.git.hasUncommittedChanges(effectivePath)
+      if (dirty) {
+        warnings.push('uncommitted changes — pull skipped')
+        action = 'attached'
+      } else {
+        const pullResult = await deps.git.pull(effectivePath)
+        if (!pullResult.success) {
+          warnings.push(pullResult.error ?? 'pull failed')
+          action = 'attached'
+        } else {
+          action = 'pulled'
+        }
+      }
+    }
+
+    // Step 4: register in Hive
+    const existingProject = deps.db.getProjectByPath(effectivePath)
+    let projectId: string
+    let wasAlreadyInHive: boolean
+
+    if (existingProject) {
+      projectId = existingProject.id
+      wasAlreadyInHive = true
+    } else {
+      const created = deps.createProjectWithDefaultWorktree({
+        name: project.name,
+        path: effectivePath,
+        description: project.description,
+        tags: project.tags,
+        setup_script: project.setup_script,
+        run_script: project.run_script,
+        archive_script: project.archive_script,
+        worktree_create_script: project.worktree_create_script
+      })
+      projectId = created.id
+
+      deps.db.updateProject(projectId, {
+        language: project.language,
+        custom_commands: project.custom_commands as CustomProjectCommand[] | null,
+        auto_assign_port: project.auto_assign_port
+      })
+      deps.db.updateProjectKanbanStorageMode(projectId, project.kanban_storage_mode)
+      if (project.kanban_markdown_config !== null) {
+        deps.db.updateProjectKanbanMarkdownConfig(
+          projectId,
+          JSON.stringify(project.kanban_markdown_config)
+        )
+      }
+      deps.db.updateProjectSimpleMode(projectId, project.kanban_simple_mode)
+
+      if (project.custom_icon) {
+        const iconResult = deps.uploadIcon(
+          projectId,
+          project.custom_icon.data_base64,
+          project.custom_icon.filename
+        )
+        if (!iconResult.success) {
+          warnings.push(`Failed to restore project icon: ${iconResult.error ?? 'unknown error'}`)
+        }
+      }
+
+      wasAlreadyInHive = false
+    }
+
+    // Step 5: sync worktrees from disk
+    const syncResult = await deps.syncWorktreesOp({ projectId, projectPath: effectivePath })
+    if (!syncResult.success) {
+      warnings.push(syncResult.error ?? 'Failed to sync worktrees')
+    }
+
+    // Step 6: worktrees (raw git, teleport-style)
+    const worktreeResults: RestoreWorktreeResult[] = []
+    const knownBranches = new Set(
+      deps.db.getActiveWorktreesByProject(projectId).map((worktree) => worktree.branch_name)
+    )
+
+    if (project.worktrees.length > 0 && project.remote_url !== null) {
+      try {
+        await deps.execGit(effectivePath, ['fetch', 'origin'])
+      } catch (error) {
+        warnings.push(`git fetch origin failed: ${errorMessage(error)}`)
+      }
+    }
+
+    for (const entry of project.worktrees) {
+      if (knownBranches.has(entry.branch_name)) {
+        worktreeResults.push({ branch: entry.branch_name, status: 'skipped-existing' })
+        continue
+      }
+
+      let localExists = true
+      try {
+        await deps.execGit(effectivePath, [
+          'rev-parse',
+          '--verify',
+          `refs/heads/${entry.branch_name}`
+        ])
+      } catch {
+        localExists = false
+      }
+
+      let status: 'created' | 'created-fresh-branch' = 'created'
+
+      if (!localExists) {
+        let remoteExists = true
+        try {
+          await deps.execGit(effectivePath, [
+            'rev-parse',
+            '--verify',
+            `refs/remotes/origin/${entry.branch_name}`
+          ])
+        } catch {
+          remoteExists = false
+        }
+
+        try {
+          if (remoteExists) {
+            await deps.execGit(effectivePath, [
+              'branch',
+              entry.branch_name,
+              `origin/${entry.branch_name}`
+            ])
+            status = 'created'
+          } else {
+            const defaultBranch = await deps.git.getDefaultBranch(effectivePath)
+            await deps.execGit(effectivePath, ['branch', entry.branch_name, defaultBranch])
+            status = 'created-fresh-branch'
+            warnings.push(
+              `branch ${entry.branch_name} not found on remote — created from ${defaultBranch}`
+            )
+          }
+        } catch (error) {
+          worktreeResults.push({
+            branch: entry.branch_name,
+            status: 'failed',
+            error: errorMessage(error)
+          })
+          continue
+        }
+      }
+
+      const worktreePath = await uniquePath(
+        deps,
+        join(
+          deps.homedir(),
+          '.hive-worktrees',
+          project.name,
+          `${project.name}--${slug(entry.name)}`
+        )
+      )
+
+      try {
+        await deps.fs.mkdir(dirname(worktreePath))
+        await deps.execGit(effectivePath, ['worktree', 'add', worktreePath, entry.branch_name])
+      } catch (error) {
+        worktreeResults.push({
+          branch: entry.branch_name,
+          status: 'failed',
+          error: errorMessage(error)
+        })
+        continue
+      }
+
+      deps.db.createWorktree({
+        project_id: projectId,
+        name: entry.name,
+        branch_name: entry.branch_name,
+        path: worktreePath,
+        base_branch: entry.base_branch
+      })
+      knownBranches.add(entry.branch_name)
+      worktreeResults.push({ branch: entry.branch_name, status })
+    }
+
+    // Step 7: tickets
+    let tickets: RestoreProjectResult['tickets']
+    const shouldSkipTickets =
+      project.kanban_storage_mode === 'markdown' ||
+      !project.tickets ||
+      project.tickets.length === 0 ||
+      wasAlreadyInHive
+
+    if (shouldSkipTickets) {
+      tickets = { restored: 0, dependencyErrors: 0, skipped: true }
+    } else {
+      const branchToWorktreeId = new Map(
+        deps.db
+          .getActiveWorktreesByProject(projectId)
+          .map((worktree) => [worktree.branch_name, worktree.id])
+      )
+      const keyToId = new Map<string, string>()
+      const ticketList = project.tickets ?? []
+
+      deps.db.transaction(() => {
+        for (const ticketEntry of ticketList) {
+          const created = deps.db.createKanbanTicket({
+            project_id: projectId,
+            title: ticketEntry.title,
+            description: ticketEntry.description,
+            attachments: [],
+            column: ticketEntry.column,
+            sort_order: ticketEntry.sort_order,
+            worktree_id: ticketEntry.worktree_branch
+              ? (branchToWorktreeId.get(ticketEntry.worktree_branch) ?? null)
+              : null,
+            mode: ticketEntry.mode,
+            mark: ticketEntry.mark as TicketMark | null
+          })
+          if (ticketEntry.archived_at) {
+            deps.db.updateKanbanTicket(created.id, { archived_at: ticketEntry.archived_at })
+          }
+          if (ticketEntry.total_tokens > 0) {
+            deps.db.addTicketTokens(created.id, ticketEntry.total_tokens)
+          }
+          keyToId.set(ticketEntry.key, created.id)
+        }
+      })
+
+      let dependencyErrors = 0
+      for (const edge of project.ticket_dependencies ?? []) {
+        const dependentId = keyToId.get(edge.dependent)
+        const blockerId = keyToId.get(edge.blocker)
+        if (!dependentId || !blockerId) {
+          dependencyErrors += 1
+          warnings.push(
+            `Could not restore dependency ${edge.dependent} -> ${edge.blocker}: unknown ticket key`
+          )
+          continue
+        }
+        const depResult = deps.db.addTicketDependency(dependentId, blockerId)
+        if (!depResult.success) {
+          dependencyErrors += 1
+          warnings.push(
+            depResult.error ?? `Could not restore dependency ${edge.dependent} -> ${edge.blocker}`
+          )
+        }
+      }
+
+      tickets = { restored: keyToId.size, dependencyErrors, skipped: false }
+    }
+
+    // Step 8
+    return {
+      success: !nonSuccessActions.has(action),
+      projectId,
+      projectName,
+      action,
+      warnings,
+      worktrees: worktreeResults,
+      tickets
+    }
+  } catch (error) {
+    return {
+      success: false,
+      projectName,
+      action: 'failed',
+      error: errorMessage(error),
+      warnings,
+      worktrees: [],
+      tickets: null
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Dialog request helpers — structurally copied from
 // requestKanbanSaveBoardExportDialog / requestKanbanOpenBoardImportFileDialog
 // in kanban.ts (~lines 870-976), injected through BackupOpsDeps for testing.
@@ -486,11 +1082,26 @@ async function readLiveAppVersion(): Promise<string> {
   }
 }
 
+// Local copy of teleport-ops.ts's execGit — duplicated for the same reason as
+// `slug`/`uniquePath` above (avoid pulling teleport-ops.ts's module graph in).
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd, encoding: 'utf-8' })
+  return stdout.trim()
+}
+
 async function createLiveDeps(): Promise<BackupOpsDeps> {
-  const [{ getDatabase }, { gitService }, fsModule] = await Promise.all([
+  const [
+    { getDatabase },
+    { gitService },
+    fsModule,
+    { isGitRepository, createProjectWithDefaultWorktree, uploadIcon, cloneRepository },
+    { syncWorktreesOp }
+  ] = await Promise.all([
     import('../../../main/db'),
     import('../../../main/effect/git/facade'),
-    import('node:fs/promises')
+    import('node:fs/promises'),
+    import('../../../main/services/project-ops'),
+    import('../../../main/services/worktree-ops')
   ])
   const db = getDatabase()
 
@@ -501,20 +1112,49 @@ async function createLiveDeps(): Promise<BackupOpsDeps> {
       getWorktreesByProject: (projectId) => db.getWorktreesByProject(projectId),
       getKanbanTicketsByProject: (projectId, includeArchived) =>
         db.getKanbanTicketsByProject(projectId, includeArchived),
-      getDependenciesForProject: (projectId) => db.getDependenciesForProject(projectId)
+      getDependenciesForProject: (projectId) => db.getDependenciesForProject(projectId),
+      getProjectByPath: (path) => db.getProjectByPath(path),
+      createWorktree: (data) => db.createWorktree(data),
+      updateProject: (id, data) => db.updateProject(id, data),
+      updateProjectKanbanStorageMode: (id, mode) => db.updateProjectKanbanStorageMode(id, mode),
+      updateProjectKanbanMarkdownConfig: (id, config) =>
+        db.updateProjectKanbanMarkdownConfig(id, config),
+      updateProjectSimpleMode: (id, enabled) => db.updateProjectSimpleMode(id, enabled),
+      createKanbanTicket: (data) => db.createKanbanTicket(data),
+      updateKanbanTicket: (id, data) => db.updateKanbanTicket(id, data),
+      addTicketTokens: (ticketId, tokens) => db.addTicketTokens(ticketId, tokens),
+      addTicketDependency: (dependentId, blockerId) =>
+        db.addTicketDependency(dependentId, blockerId),
+      transaction: (fn) => db.transaction(fn)
     },
     git: {
       getRemoteUrl: (repoPath) =>
-        gitService.getRemoteUrl(repoPath).then((result) => result.url ?? null)
+        gitService.getRemoteUrl(repoPath).then((result) => result.url ?? null),
+      hasUncommittedChanges: (repoPath) => gitService.hasUncommittedChanges(repoPath),
+      pull: (repoPath) => gitService.pull(repoPath),
+      getDefaultBranch: (repoPath) => gitService.getDefaultBranch(repoPath)
     },
     fs: {
       readFile: (path) => fsModule.readFile(path),
       writeFile: (path, content) => fsModule.writeFile(path, content, 'utf-8'),
-      stat: (path) => fsModule.stat(path)
+      stat: (path) => fsModule.stat(path),
+      exists: (path) =>
+        fsModule
+          .access(path)
+          .then(() => true)
+          .catch(() => false),
+      mkdir: (path) => fsModule.mkdir(path, { recursive: true }).then(() => undefined)
     },
     getAppVersion: () => readLiveAppVersion(),
     requestSaveFileDialog: (defaultFileName) => requestBackupSaveFileDialog(defaultFileName),
-    requestOpenFileDialog: () => requestBackupOpenFileDialog()
+    requestOpenFileDialog: () => requestBackupOpenFileDialog(),
+    execGit: (cwd, args) => runGit(cwd, args),
+    homedir: () => homedir(),
+    cloneRepository: (url, destDir) => cloneRepository(url, destDir),
+    isGitRepository: (path) => isGitRepository(path),
+    createProjectWithDefaultWorktree: (data) => createProjectWithDefaultWorktree(db, data),
+    uploadIcon: (projectId, base64Data, filename) => uploadIcon(projectId, base64Data, filename),
+    syncWorktreesOp: (params) => syncWorktreesOp(params)
   }
 }
 
@@ -528,6 +1168,16 @@ export const makeBackupOpsRpcService = (deps: BackupOpsDeps): BackupOpsRpcServic
     Effect.tryPromise({
       try: () => openBackupFile(deps),
       catch: (cause) => cause
+    }),
+  classifyProjects: (params) =>
+    Effect.tryPromise({
+      try: () => classifyProjects(deps, params.projects),
+      catch: (cause) => cause
+    }),
+  restoreProject: (params) =>
+    Effect.tryPromise({
+      try: () => restoreProject(deps, params.project, params.options),
+      catch: (cause) => cause
     })
 })
 
@@ -540,6 +1190,16 @@ export const makeLiveBackupOpsRpcService = (): BackupOpsRpcService => ({
   openBackupFile: () =>
     Effect.tryPromise({
       try: async () => openBackupFile(await createLiveDeps()),
+      catch: (cause) => cause
+    }),
+  classifyProjects: (params) =>
+    Effect.tryPromise({
+      try: async () => classifyProjects(await createLiveDeps(), params.projects),
+      catch: (cause) => cause
+    }),
+  restoreProject: (params) =>
+    Effect.tryPromise({
+      try: async () => restoreProject(await createLiveDeps(), params.project, params.options),
       catch: (cause) => cause
     })
 })
@@ -568,6 +1228,28 @@ export const makeBackupOpsRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.openBackupFile()
+        })
+    ],
+    [
+      'backupOps.classifyProjects',
+      (params) =>
+        Effect.gen(function* () {
+          const parsed = yield* Effect.try({
+            try: () => classifyProjectsParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.classifyProjects(parsed)
+        })
+    ],
+    [
+      'backupOps.restoreProject',
+      (params) =>
+        Effect.gen(function* () {
+          const parsed = yield* Effect.try({
+            try: () => restoreProjectParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.restoreProject(parsed)
         })
     ]
   ])

--- a/src/server/rpc/domains/backup-ops.ts
+++ b/src/server/rpc/domains/backup-ops.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process'
 import { homedir } from 'node:os'
-import { basename, dirname, join } from 'node:path'
+import { basename, dirname, join, resolve, sep } from 'node:path'
 import { promisify } from 'node:util'
 
 import { Effect } from 'effect'
@@ -616,14 +616,28 @@ async function classifyProjects(
 // rather than imported so backup-ops.ts doesn't pull in teleport-ops.ts's
 // module graph (Discord/teleport-remote-client wiring) for two small pure
 // helpers; per the task brief this duplication is acceptable.
-function slug(value: string): string {
+//
+// NOTE: unlike teleport-ops.ts's `slug`, this is used to build filesystem
+// path SEGMENTS (project name / worktree name) that are later joined under
+// `~/.hive-worktrees`, and those values come from a hand-editable backup
+// YAML. A slug that preserves `/` and only trims LEADING/TRAILING `-/.`
+// runs (e.g. teleport-ops.ts's version) lets an embedded `a/../../../tmp/x`
+// segment survive untouched and `path.join` will happily normalize the
+// `..` components right out of the intended `.hive-worktrees` root. This
+// version therefore replaces `/`/`\` with `-` (so no path separator ever
+// reaches `join`) and collapses runs of 2+ dots down to a single `.` (so
+// `..` can never reappear even after the separator replacement), before
+// applying the original charset/trim behavior.
+function sanitizePathSegment(value: string, fallback: string): string {
   const cleaned = value
     .toLowerCase()
-    .replace(/[^a-z0-9._/-]+/g, '-')
+    .replace(/[\\/]+/g, '-')
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/\.{2,}/g, '.')
     .replace(/-+/g, '-')
-    .replace(/^[-/.]+|[-/.]+$/g, '')
+    .replace(/^[-.]+|[-.]+$/g, '')
     .slice(0, 64)
-  return cleaned || 'worktree'
+  return cleaned || fallback
 }
 
 async function uniquePath(deps: BackupOpsDeps, basePath: string): Promise<string> {
@@ -846,7 +860,8 @@ async function restoreProject(
       }
     }
 
-    const safeProjectName = slug(project.name)
+    const safeProjectName = sanitizePathSegment(project.name, 'project')
+    const hiveWorktreesRoot = join(deps.homedir(), '.hive-worktrees')
 
     for (const entry of project.worktrees) {
       if (knownBranches.has(entry.branch_name)) {
@@ -920,9 +935,27 @@ async function restoreProject(
           deps.homedir(),
           '.hive-worktrees',
           safeProjectName,
-          `${safeProjectName}--${slug(entry.name)}`
+          `${safeProjectName}--${sanitizePathSegment(entry.name, 'worktree')}`
         )
       )
+
+      // Defense in depth: sanitizePathSegment above should already keep
+      // worktreePath under hiveWorktreesRoot, but a hand-edited backup YAML
+      // is untrusted input, so re-verify the fully resolved path before ever
+      // touching the filesystem or invoking git — never mkdir/execGit
+      // outside the `.hive-worktrees` boundary.
+      const resolvedWorktreePath = resolve(worktreePath)
+      if (
+        resolvedWorktreePath !== hiveWorktreesRoot &&
+        !resolvedWorktreePath.startsWith(hiveWorktreesRoot + sep)
+      ) {
+        worktreeResults.push({
+          branch: entry.branch_name,
+          status: 'failed',
+          error: 'invalid worktree path'
+        })
+        continue
+      }
 
       try {
         await deps.fs.mkdir(dirname(worktreePath))

--- a/src/server/rpc/domains/backup-ops.ts
+++ b/src/server/rpc/domains/backup-ops.ts
@@ -42,6 +42,7 @@ interface ProjectRawExtras {
 }
 
 const MAX_CUSTOM_ICON_BYTES = 1024 * 1024
+const MAX_BACKUP_FILE_BYTES = 50 * 1024 * 1024
 
 interface BackupOpsDb {
   readonly getAllProjects: () => Project[]
@@ -209,6 +210,24 @@ const backupProjectSchema = z
     ticket_dependencies: z.array(backupTicketDependencySchema).nullable()
   })
   .passthrough()
+  // Ticket dependency edges and worktree_branch assignments are resolved by
+  // `key` during restore (see `keyToId` in restoreProject) — a duplicate key
+  // within one project would silently misroute a dependency/worktree edge to
+  // whichever ticket happens to win the map insert.
+  .superRefine((project, ctx) => {
+    if (!project.tickets) return
+    const seen = new Set<string>()
+    for (const ticket of project.tickets) {
+      if (seen.has(ticket.key)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `duplicate ticket key "${ticket.key}" in project "${project.name}"`,
+          path: ['tickets']
+        })
+      }
+      seen.add(ticket.key)
+    }
+  })
 
 const backupFileSchema = z.object({
   version: z.number(),
@@ -286,15 +305,21 @@ function resolveStorageMode(project: Project): 'internal' | 'markdown' {
 
 async function readCustomIcon(
   deps: BackupOpsDeps,
-  iconPath: string | null
+  projectName: string,
+  iconPath: string | null,
+  warnings: string[]
 ): Promise<BackupFile['projects'][number]['custom_icon']> {
   if (!iconPath) return null
   try {
     const stats = await deps.fs.stat(iconPath)
-    if (stats.size > MAX_CUSTOM_ICON_BYTES) return null
+    if (stats.size > MAX_CUSTOM_ICON_BYTES) {
+      warnings.push(`custom icon for ${projectName} skipped (larger than 1 MB)`)
+      return null
+    }
     const data = await deps.fs.readFile(iconPath)
     return { filename: basename(iconPath), data_base64: data.toString('base64') }
-  } catch {
+  } catch (error) {
+    warnings.push(`custom icon for ${projectName} skipped (${errorMessage(error)})`)
     return null
   }
 }
@@ -347,7 +372,8 @@ function buildTicketsAndDependencies(
 
 async function buildBackupProject(
   deps: BackupOpsDeps,
-  project: Project
+  project: Project,
+  warnings: string[]
 ): Promise<BackupFile['projects'][number]> {
   const storageMode = resolveStorageMode(project)
   const isMarkdownMode = storageMode === 'markdown'
@@ -373,7 +399,7 @@ async function buildBackupProject(
     kanban_simple_mode: isProjectSimpleMode(project),
     kanban_storage_mode: storageMode,
     kanban_markdown_config: parseKanbanMarkdownConfig(project.kanban_markdown_config),
-    custom_icon: await readCustomIcon(deps, project.custom_icon),
+    custom_icon: await readCustomIcon(deps, project.name, project.custom_icon, warnings),
     worktrees: deps.db
       .getActiveWorktreesByProject(project.id)
       .filter((worktree) => !worktree.is_default)
@@ -391,8 +417,9 @@ async function exportBackup(deps: BackupOpsDeps): Promise<BackupExportResult> {
   try {
     const projects = deps.db.getAllProjects()
     const backupProjects: BackupFile['projects'] = []
+    const warnings: string[] = []
     for (const project of projects) {
-      backupProjects.push(await buildBackupProject(deps, project))
+      backupProjects.push(await buildBackupProject(deps, project, warnings))
     }
 
     const backupFile: BackupFile = {
@@ -410,7 +437,12 @@ async function exportBackup(deps: BackupOpsDeps): Promise<BackupExportResult> {
 
     await deps.fs.writeFile(filePath, YAML.stringify(backupFile))
 
-    return { success: true, path: filePath, projectCount: backupProjects.length }
+    return {
+      success: true,
+      path: filePath,
+      projectCount: backupProjects.length,
+      ...(warnings.length > 0 ? { warnings } : {})
+    }
   } catch (error) {
     return { success: false, error: errorMessage(error) }
   }
@@ -425,6 +457,19 @@ async function openBackupFile(deps: BackupOpsDeps): Promise<BackupOpenResult> {
     const filePath = await deps.requestOpenFileDialog()
     if (filePath === null) {
       return { canceled: true }
+    }
+
+    try {
+      const stats = await deps.fs.stat(filePath)
+      if (stats.size > MAX_BACKUP_FILE_BYTES) {
+        const sizeMb = (stats.size / (1024 * 1024)).toFixed(1)
+        return {
+          canceled: false,
+          error: `Backup file is too large (${sizeMb} MB — limit is 50 MB).`
+        }
+      }
+    } catch (error) {
+      return { canceled: false, error: errorMessage(error) }
     }
 
     let raw: string
@@ -590,6 +635,25 @@ async function uniquePath(deps: BackupOpsDeps, basePath: string): Promise<string
   throw new Error(`Could not choose a free path for ${basePath}`)
 }
 
+// Backed-up branch names come from a hand-editable YAML file and flow into
+// `git branch <name> <start>` / `git worktree add <path> <name>` as raw
+// positional argv (see execGitScript in the test file for the exact call
+// shapes). A name starting with `-` would be parsed by git as a flag (e.g.
+// `-f` force-resets whatever ref happens to sit in that argv slot) instead of
+// a ref — mirrors `invalidBranch` in `src/main/effect/git/layers.ts:37`,
+// widened to also reject whitespace/control characters, which are never
+// valid in a git ref name.
+function invalidBranchName(branch: string): boolean {
+  return !branch || branch.startsWith('-') || /[\s\x00-\x1f\x7f]/.test(branch)
+}
+
+// A clone destination basename derived from a backed-up `path` that is empty
+// or resolves to `.`/`..` (e.g. a `path` ending in `/..`) would place the
+// clone outside the user-chosen parent folder.
+function invalidCloneBasename(name: string): boolean {
+  return !name || name === '.' || name === '..'
+}
+
 const nonSuccessActions: ReadonlySet<RestoreProjectResult['action']> = new Set([
   'failed',
   'skipped-conflict',
@@ -665,7 +729,20 @@ async function restoreProject(
         }
       }
 
-      const dest = await uniquePath(deps, join(options.cloneParentDir, basename(project.path)))
+      const cloneBasename = basename(project.path)
+      if (invalidCloneBasename(cloneBasename)) {
+        return {
+          success: false,
+          projectName,
+          action: 'failed',
+          error: `cannot derive a clone destination from path "${project.path}"`,
+          warnings: [],
+          worktrees: [],
+          tickets: null
+        }
+      }
+
+      const dest = await uniquePath(deps, join(options.cloneParentDir, cloneBasename))
       const cloneResult = await deps.cloneRepository(project.remote_url, dest)
       if (!cloneResult.success) {
         return {
@@ -727,7 +804,7 @@ async function restoreProject(
         auto_assign_port: project.auto_assign_port
       })
       deps.db.updateProjectKanbanStorageMode(projectId, project.kanban_storage_mode)
-      if (project.kanban_markdown_config !== null) {
+      if (project.kanban_markdown_config != null) {
         deps.db.updateProjectKanbanMarkdownConfig(
           projectId,
           JSON.stringify(project.kanban_markdown_config)
@@ -769,9 +846,20 @@ async function restoreProject(
       }
     }
 
+    const safeProjectName = slug(project.name)
+
     for (const entry of project.worktrees) {
       if (knownBranches.has(entry.branch_name)) {
         worktreeResults.push({ branch: entry.branch_name, status: 'skipped-existing' })
+        continue
+      }
+
+      if (invalidBranchName(entry.branch_name)) {
+        worktreeResults.push({
+          branch: entry.branch_name,
+          status: 'failed',
+          error: 'invalid branch name'
+        })
         continue
       }
 
@@ -831,8 +919,8 @@ async function restoreProject(
         join(
           deps.homedir(),
           '.hive-worktrees',
-          project.name,
-          `${project.name}--${slug(entry.name)}`
+          safeProjectName,
+          `${safeProjectName}--${slug(entry.name)}`
         )
       )
 

--- a/src/server/rpc/domains/backup-ops.ts
+++ b/src/server/rpc/domains/backup-ops.ts
@@ -332,35 +332,39 @@ async function exportBackup(deps: BackupOpsDeps): Promise<BackupExportResult> {
 // ---------------------------------------------------------------------------
 
 async function openBackupFile(deps: BackupOpsDeps): Promise<BackupOpenResult> {
-  const filePath = await deps.requestOpenFileDialog()
-  if (filePath === null) {
-    return { canceled: true }
-  }
-
-  let raw: string
   try {
-    raw = (await deps.fs.readFile(filePath)).toString('utf-8')
+    const filePath = await deps.requestOpenFileDialog()
+    if (filePath === null) {
+      return { canceled: true }
+    }
+
+    let raw: string
+    try {
+      raw = (await deps.fs.readFile(filePath)).toString('utf-8')
+    } catch (error) {
+      return { canceled: false, error: errorMessage(error) }
+    }
+
+    let parsed: unknown
+    try {
+      parsed = YAML.parse(raw)
+    } catch (error) {
+      return { canceled: false, error: `Failed to parse backup file: ${errorMessage(error)}` }
+    }
+
+    if (isRecord(parsed) && typeof parsed.version === 'number' && parsed.version > 1) {
+      return { canceled: false, error: 'This backup was created by a newer version of Hive.' }
+    }
+
+    const result = backupFileSchema.safeParse(parsed)
+    if (!result.success) {
+      return { canceled: false, error: z.prettifyError(result.error) }
+    }
+
+    return { canceled: false, backup: result.data }
   } catch (error) {
     return { canceled: false, error: errorMessage(error) }
   }
-
-  let parsed: unknown
-  try {
-    parsed = YAML.parse(raw)
-  } catch (error) {
-    return { canceled: false, error: `Failed to parse backup file: ${errorMessage(error)}` }
-  }
-
-  if (isRecord(parsed) && typeof parsed.version === 'number' && parsed.version > 1) {
-    return { canceled: false, error: 'This backup was created by a newer version of Hive.' }
-  }
-
-  const result = backupFileSchema.safeParse(parsed)
-  if (!result.success) {
-    return { canceled: false, error: z.prettifyError(result.error) }
-  }
-
-  return { canceled: false, backup: result.data }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/rpc/domains/backup-ops.ts
+++ b/src/server/rpc/domains/backup-ops.ts
@@ -94,8 +94,6 @@ interface BackupOpsGit {
   // lookup fails. Never expected to reject.
   readonly getRemoteUrl: (repoPath: string) => Promise<string | null>
   readonly hasUncommittedChanges: (repoPath: string) => Promise<boolean>
-  // ff-only pull semantics via the facade; never expected to reject.
-  readonly pull: (repoPath: string) => Promise<{ success: boolean; error?: string }>
   readonly getDefaultBranch: (repoPath: string) => Promise<string>
 }
 
@@ -704,12 +702,12 @@ async function restoreProject(
         warnings.push('uncommitted changes — pull skipped')
         action = 'attached'
       } else {
-        const pullResult = await deps.git.pull(effectivePath)
-        if (!pullResult.success) {
-          warnings.push(pullResult.error ?? 'pull failed')
-          action = 'attached'
-        } else {
+        try {
+          await deps.execGit(effectivePath, ['pull', '--ff-only'])
           action = 'pulled'
+        } catch (error) {
+          warnings.push(errorMessage(error))
+          action = 'attached'
         }
       }
     }
@@ -1131,7 +1129,6 @@ async function createLiveDeps(): Promise<BackupOpsDeps> {
       getRemoteUrl: (repoPath) =>
         gitService.getRemoteUrl(repoPath).then((result) => result.url ?? null),
       hasUncommittedChanges: (repoPath) => gitService.hasUncommittedChanges(repoPath),
-      pull: (repoPath) => gitService.pull(repoPath),
       getDefaultBranch: (repoPath) => gitService.getDefaultBranch(repoPath)
     },
     fs: {

--- a/src/server/rpc/domains/backup-ops.ts
+++ b/src/server/rpc/domains/backup-ops.ts
@@ -9,7 +9,9 @@ import { z } from 'zod'
 import type { CustomProjectCommand } from '@shared/lib/custom-commands'
 import { isDesktopCommandResult, makeDesktopCommandRequest } from '../../../shared/desktop-command'
 import type {
+  BackupExportResult,
   BackupFile,
+  BackupOpenResult,
   BackupProject,
   ProjectClassification,
   RestoreProjectResult,
@@ -40,20 +42,6 @@ interface ProjectRawExtras {
 }
 
 const MAX_CUSTOM_ICON_BYTES = 1024 * 1024
-
-export interface BackupExportResult {
-  readonly success: boolean
-  readonly canceled?: boolean
-  readonly path?: string
-  readonly projectCount?: number
-  readonly error?: string
-}
-
-export interface BackupOpenResult {
-  readonly canceled: boolean
-  readonly backup?: BackupFile
-  readonly error?: string
-}
 
 interface BackupOpsDb {
   readonly getAllProjects: () => Project[]

--- a/src/server/rpc/router.ts
+++ b/src/server/rpc/router.ts
@@ -14,6 +14,11 @@ import {
   type AttachmentOpsRpcService
 } from './domains/attachment-ops'
 import {
+  makeBackupOpsRpcHandlers,
+  makeLiveBackupOpsRpcService,
+  type BackupOpsRpcService
+} from './domains/backup-ops'
+import {
   makeAnalyticsOpsRpcHandlers,
   makeLiveAnalyticsOpsRpcService,
   type AnalyticsOpsRpcService
@@ -146,6 +151,7 @@ export interface RpcContext {
   readonly accountOps?: AccountOpsRpcService
   readonly analyticsOps?: AnalyticsOpsRpcService
   readonly attachmentOps?: AttachmentOpsRpcService
+  readonly backupOps?: BackupOpsRpcService
   readonly bash?: BashRpcService
   readonly codexDebugLoggerOps?: CodexDebugLoggerOpsRpcService
   readonly connectionOps?: ConnectionOpsRpcService
@@ -200,6 +206,7 @@ const makeDefaultRpcHandlers = (context: RpcContext): ReadonlyMap<string, RpcHan
     ...makeAccountOpsRpcHandlers(context.accountOps ?? makeLiveAccountOpsRpcService()),
     ...makeAnalyticsOpsRpcHandlers(context.analyticsOps ?? makeLiveAnalyticsOpsRpcService()),
     ...makeAttachmentOpsRpcHandlers(context.attachmentOps ?? makeLiveAttachmentOpsRpcService()),
+    ...makeBackupOpsRpcHandlers(context.backupOps ?? makeLiveBackupOpsRpcService()),
     ...makeBashRpcHandlers(context.bash, context.eventBus),
     ...makeCodexDebugLoggerOpsRpcHandlers(
       context.codexDebugLoggerOps ?? makeLiveCodexDebugLoggerOpsRpcService()

--- a/src/shared/desktop-command.ts
+++ b/src/shared/desktop-command.ts
@@ -18,6 +18,8 @@ export type DesktopCommandName =
   | 'gitShowInFinder'
   | 'kanbanOpenBoardImportFileDialog'
   | 'kanbanSaveBoardExportDialog'
+  | 'backupOpenFileDialog'
+  | 'backupSaveFileDialog'
   | 'systemGetAppVersion'
   | 'systemGetAppPaths'
   | 'systemIsPackaged'
@@ -196,6 +198,18 @@ export interface KanbanSaveBoardExportDialogPayload {
 }
 
 export interface KanbanSaveBoardExportDialogResult {
+  readonly filePath: string | null
+}
+
+export interface BackupOpenFileDialogResult {
+  readonly filePath: string | null
+}
+
+export interface BackupSaveFileDialogPayload {
+  readonly defaultFileName: string
+}
+
+export interface BackupSaveFileDialogResult {
   readonly filePath: string | null
 }
 
@@ -862,6 +876,8 @@ export type DesktopCommandRequest =
   | GitShowInFinderDesktopCommandRequest
   | KanbanOpenBoardImportFileDialogDesktopCommandRequest
   | KanbanSaveBoardExportDialogDesktopCommandRequest
+  | BackupOpenFileDialogDesktopCommandRequest
+  | BackupSaveFileDialogDesktopCommandRequest
   | SystemGetAppVersionDesktopCommandRequest
   | SystemGetAppPathsDesktopCommandRequest
   | SystemIsPackagedDesktopCommandRequest
@@ -1037,6 +1053,19 @@ export interface KanbanSaveBoardExportDialogDesktopCommandRequest {
   readonly id: string
   readonly command: 'kanbanSaveBoardExportDialog'
   readonly payload: KanbanSaveBoardExportDialogPayload
+}
+
+export interface BackupOpenFileDialogDesktopCommandRequest {
+  readonly type: typeof DESKTOP_COMMAND_REQUEST_TYPE
+  readonly id: string
+  readonly command: 'backupOpenFileDialog'
+}
+
+export interface BackupSaveFileDialogDesktopCommandRequest {
+  readonly type: typeof DESKTOP_COMMAND_REQUEST_TYPE
+  readonly id: string
+  readonly command: 'backupSaveFileDialog'
+  readonly payload: BackupSaveFileDialogPayload
 }
 
 export interface SystemGetAppVersionDesktopCommandRequest {
@@ -1715,6 +1744,15 @@ export function makeDesktopCommandRequest(
 ): KanbanSaveBoardExportDialogDesktopCommandRequest
 export function makeDesktopCommandRequest(
   id: string,
+  command: 'backupOpenFileDialog'
+): BackupOpenFileDialogDesktopCommandRequest
+export function makeDesktopCommandRequest(
+  id: string,
+  command: 'backupSaveFileDialog',
+  payload: BackupSaveFileDialogPayload
+): BackupSaveFileDialogDesktopCommandRequest
+export function makeDesktopCommandRequest(
+  id: string,
   command: 'systemGetAppVersion'
 ): SystemGetAppVersionDesktopCommandRequest
 export function makeDesktopCommandRequest(
@@ -2154,6 +2192,7 @@ export function makeDesktopCommandRequest(
     | ProjectGetProjectIconPathPayload
     | GitShowInFinderPayload
     | KanbanSaveBoardExportDialogPayload
+    | BackupSaveFileDialogPayload
     | OpenInChromePayload
     | UpdateMenuStatePayload
     | SetKeepAwakePayload
@@ -2325,6 +2364,19 @@ export function makeDesktopCommandRequest(
       command,
       payload
     } as KanbanSaveBoardExportDialogDesktopCommandRequest
+  }
+
+  if (command === 'backupSaveFileDialog') {
+    if (!payload) {
+      throw new Error('Missing backupSaveFileDialog payload')
+    }
+
+    return {
+      type: DESKTOP_COMMAND_REQUEST_TYPE,
+      id,
+      command,
+      payload
+    } as BackupSaveFileDialogDesktopCommandRequest
   }
 
   if (command === 'systemGetAppVersion') {
@@ -3371,6 +3423,9 @@ export const isDesktopCommandRequest = (value: unknown): value is DesktopCommand
       value.command === 'kanbanOpenBoardImportFileDialog' ||
       (value.command === 'kanbanSaveBoardExportDialog' &&
         isKanbanSaveBoardExportDialogPayload(value.payload)) ||
+      value.command === 'backupOpenFileDialog' ||
+      (value.command === 'backupSaveFileDialog' &&
+        isBackupSaveFileDialogPayload(value.payload)) ||
       value.command === 'systemGetAppVersion' ||
       value.command === 'systemGetAppPaths' ||
       value.command === 'systemIsPackaged' ||
@@ -3622,6 +3677,11 @@ const isKanbanSaveBoardExportDialogPayload = (
   value: unknown
 ): value is KanbanSaveBoardExportDialogPayload =>
   isRecord(value) && typeof value.projectName === 'string'
+
+const isBackupSaveFileDialogPayload = (
+  value: unknown
+): value is BackupSaveFileDialogPayload =>
+  isRecord(value) && typeof value.defaultFileName === 'string'
 
 const isUpdaterCheckForUpdatePayload = (value: unknown): value is UpdaterCheckForUpdatePayload =>
   isRecord(value) && (value.manual === undefined || typeof value.manual === 'boolean')

--- a/src/shared/types/backup.ts
+++ b/src/shared/types/backup.ts
@@ -1,0 +1,93 @@
+// The YAML file root
+export interface BackupFile {
+  version: number // 1 for now
+  kind: 'hive-backup'
+  created_at: string // ISO timestamp
+  app_version: string
+  projects: BackupProject[]
+}
+
+export interface BackupProject {
+  name: string
+  path: string // original absolute path
+  remote_url: string | null // normalized-agnostic raw URL as read from git; null if no remote
+  description: string | null
+  tags: string[] | null
+  language: string | null
+  setup_script: string | null
+  run_script: string | null
+  archive_script: string | null
+  worktree_create_script: string | null
+  custom_commands: unknown[] | null // CustomProjectCommand[] round-tripped as YAML
+  auto_assign_port: boolean
+  sort_order: number // exported for fidelity; NOT applied on restore
+  kanban_simple_mode: boolean
+  kanban_storage_mode: 'internal' | 'markdown'
+  kanban_markdown_config: unknown | null // parsed JSON object
+  custom_icon: BackupProjectIcon | null
+  worktrees: BackupWorktree[]
+  tickets: BackupTicket[] | null // null/absent for markdown-mode projects
+  ticket_dependencies: BackupTicketDependency[] | null
+}
+
+export interface BackupProjectIcon {
+  filename: string
+  data_base64: string
+}
+
+export interface BackupWorktree {
+  name: string
+  branch_name: string
+  base_branch: string | null
+}
+
+export interface BackupTicket {
+  key: string // stable export-time key t1..tN for dependency edges
+  title: string
+  description: string | null
+  column: 'todo' | 'in_progress' | 'review' | 'done'
+  sort_order: number
+  mode: 'build' | 'plan' | 'super-plan' | null
+  mark: string | null // 'common'|'rare'|'epic'|'legendary'
+  total_tokens: number
+  archived_at: string | null
+  worktree_branch: string | null // branch_name of assigned worktree
+}
+
+export interface BackupTicketDependency {
+  dependent: string // BackupTicket.key
+  blocker: string // BackupTicket.key
+}
+
+// Restore-side result types (returned by RPC methods; also used by the renderer wizard)
+export type ProjectClassificationKind =
+  | 'exists-match' // path (or remote-matched Hive project) exists, remote matches → pull
+  | 'missing-clone' // path missing, has remote → clone
+  | 'conflict' // path exists but is a different/non-git repo → skipped
+  | 'skipped-no-remote' // path missing and no remote → cannot restore
+
+export interface ProjectClassification {
+  path: string // the backed-up path (identity key in the wizard)
+  classification: ProjectClassificationKind
+  alreadyInHive: boolean
+  hiveProjectId: string | null
+  effectivePath: string // where restore will operate (differs when matched by remote)
+  localRemoteUrl: string | null
+}
+
+export interface RestoreWorktreeResult {
+  branch: string
+  status: 'created' | 'skipped-existing' | 'created-fresh-branch' | 'failed'
+  error?: string
+}
+
+export interface RestoreProjectResult {
+  success: boolean
+  projectId?: string
+  projectName: string
+  action: 'cloned' | 'pulled' | 'attached' | 'skipped-conflict' | 'skipped-no-remote' | 'failed'
+  warnings: string[]
+  worktrees: RestoreWorktreeResult[]
+  tickets: { restored: number; dependencyErrors: number; skipped: boolean } | null
+  error?: string
+}

--- a/src/shared/types/backup.ts
+++ b/src/shared/types/backup.ts
@@ -91,3 +91,20 @@ export interface RestoreProjectResult {
   tickets: { restored: number; dependencyErrors: number; skipped: boolean } | null
   error?: string
 }
+
+// backupOps.exportBackup / backupOps.openBackupFile RPC result shapes.
+// Shared between the server RPC domain (src/server/rpc/domains/backup-ops.ts)
+// and the renderer API wrapper (src/renderer/src/api/backup-api.ts).
+export interface BackupExportResult {
+  readonly success: boolean
+  readonly canceled?: boolean
+  readonly path?: string
+  readonly projectCount?: number
+  readonly error?: string
+}
+
+export interface BackupOpenResult {
+  readonly canceled: boolean
+  readonly backup?: BackupFile
+  readonly error?: string
+}

--- a/src/shared/types/backup.ts
+++ b/src/shared/types/backup.ts
@@ -100,6 +100,10 @@ export interface BackupExportResult {
   readonly canceled?: boolean
   readonly path?: string
   readonly projectCount?: number
+  // Non-fatal issues encountered while building the export (e.g. a custom
+  // icon that was skipped for being missing or oversized). Absent/empty when
+  // the export had nothing to warn about.
+  readonly warnings?: string[]
   readonly error?: string
 }
 

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,3 +1,4 @@
+export * from './backup'
 export * from './project'
 export * from './worktree'
 export * from './session'


### PR DESCRIPTION
## Summary
- Adds shared backup types, desktop commands, and RPC endpoints for exporting and opening backup files.
- Implements backup/restore backend logic, including git remote normalization, project classification, and restore safeguards.
- Adds renderer API, settings UI, and a restore wizard modal wired into the settings flow.
- Expands test coverage for backup APIs, RPC domain behavior, git repository edge cases, and restore wizard interactions.

## Testing
- `Not run`
- Added/updated unit and component tests for backup API, backup ops, SettingsBackup, RestoreWizard, and git repository behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restore mutates the local DB, runs git clone/pull/worktree commands, and writes files from user-supplied YAML; mitigations exist but mistakes or edge cases could affect project data or disk layout.
> 
> **Overview**
> Adds **project backup and restore** as a first-class Settings flow: users can export Hive projects (metadata, worktrees, internal kanban tickets) to a versioned `hive-backup` YAML file and restore selected projects through a guided wizard.
> 
> **Backend:** New `backupOps` RPC handlers (`exportBackup`, `openBackupFile`, `classifyProjects`, `restoreProject`) build/validate YAML (Zod, 50 MB import cap, duplicate ticket key checks), drive Electron **open/save** dialogs via `backupOpenFileDialog` / `backupSaveFileDialog`, and run restore logic (clone vs pull vs attach, worktree recreation, ticket remapping). **`normalizeGitRemoteUrl`** is added so SSH/HTTPS/SCP forms of the same repo classify as matches. Restore hardens untrusted backup input (sanitized path segments, branch-name validation, worktree paths confined under `~/.hive-worktrees`).
> 
> **UI:** `SettingsBackup` plus **`RestoreWizard`** (classify → optional clone folder → sequential restore → summary) wired through `backupApi` and a new Settings **Backup** section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2367ed772312b3567e9d5f11fe4975c1a611e0fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->