### PR TITLE
Add GPT-5.6 model support and accent styling

### DIFF
--- a/src/main/services/__tests__/codex-models.test.ts
+++ b/src/main/services/__tests__/codex-models.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CODEX_MODELS,
+  getAvailableCodexModels,
+  getCodexModelInfo,
+  normalizeCodexModelSlug,
+  resolveCodexModelSlug
+} from '../codex-models'
+
+describe('gpt-5.6 models', () => {
+  it.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])('%s is registered', (id) => {
+    const model = CODEX_MODELS.find((m) => m.id === id)
+    expect(model).toBeDefined()
+    expect(model?.limit).toEqual({ context: 372000, output: 32000 })
+  })
+
+  it.each(['gpt-5.6-sol', 'gpt-5.6-terra'])('%s offers ultra through low efforts', (id) => {
+    const model = CODEX_MODELS.find((m) => m.id === id)
+    expect(Object.keys(model!.variants)).toEqual(['ultra', 'max', 'xhigh', 'high', 'medium', 'low'])
+  })
+
+  it('gpt-5.6-luna offers max through low efforts without ultra', () => {
+    const model = CODEX_MODELS.find((m) => m.id === 'gpt-5.6-luna')
+    expect(Object.keys(model!.variants)).toEqual(['max', 'xhigh', 'high', 'medium', 'low'])
+  })
+
+  it('exposes the 5.6 models to the renderer', () => {
+    const [provider] = getAvailableCodexModels()
+    expect(provider.models['gpt-5.6-sol']?.name).toBe('GPT-5.6 Sol')
+    expect(provider.models['gpt-5.6-terra']?.name).toBe('GPT-5.6 Terra')
+    expect(provider.models['gpt-5.6-luna']?.name).toBe('GPT-5.6 Luna')
+  })
+
+  it('resolves shorthand aliases', () => {
+    expect(normalizeCodexModelSlug('5.6-sol')).toBe('gpt-5.6-sol')
+    expect(normalizeCodexModelSlug('5.6-terra')).toBe('gpt-5.6-terra')
+    expect(normalizeCodexModelSlug('5.6-luna')).toBe('gpt-5.6-luna')
+    expect(resolveCodexModelSlug('gpt-5.6-sol')).toBe('gpt-5.6-sol')
+    expect(getCodexModelInfo('5.6-luna')?.id).toBe('gpt-5.6-luna')
+  })
+
+  it('keeps gpt-5.5 as the default model', () => {
+    expect(resolveCodexModelSlug(undefined)).toBe('gpt-5.5')
+    expect(resolveCodexModelSlug('not-a-model')).toBe('gpt-5.5')
+  })
+})

--- a/src/main/services/codex-models.ts
+++ b/src/main/services/codex-models.ts
@@ -6,7 +6,7 @@ export interface CodexModelInfo {
   defaultVariant: string
 }
 
-export const CODEX_REASONING_EFFORTS = ['xhigh', 'high', 'medium', 'low'] as const
+export const CODEX_REASONING_EFFORTS = ['ultra', 'max', 'xhigh', 'high', 'medium', 'low'] as const
 export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORTS)[number]
 
 const CODEX_EFFORT_VARIANTS: Record<string, Record<string, never>> = {
@@ -16,7 +16,39 @@ const CODEX_EFFORT_VARIANTS: Record<string, Record<string, never>> = {
   low: {}
 }
 
+// gpt-5.6 efforts (wire values from codex models.json): luna stops at max, sol/terra add ultra.
+const CODEX_EFFORT_VARIANTS_MAX: Record<string, Record<string, never>> = {
+  max: {},
+  ...CODEX_EFFORT_VARIANTS
+}
+
+const CODEX_EFFORT_VARIANTS_ULTRA: Record<string, Record<string, never>> = {
+  ultra: {},
+  ...CODEX_EFFORT_VARIANTS_MAX
+}
+
 export const CODEX_MODELS: CodexModelInfo[] = [
+  {
+    id: 'gpt-5.6-sol',
+    name: 'GPT-5.6 Sol',
+    limit: { context: 372000, output: 32000 },
+    variants: CODEX_EFFORT_VARIANTS_ULTRA,
+    defaultVariant: 'high'
+  },
+  {
+    id: 'gpt-5.6-terra',
+    name: 'GPT-5.6 Terra',
+    limit: { context: 372000, output: 32000 },
+    variants: CODEX_EFFORT_VARIANTS_ULTRA,
+    defaultVariant: 'high'
+  },
+  {
+    id: 'gpt-5.6-luna',
+    name: 'GPT-5.6 Luna',
+    limit: { context: 372000, output: 32000 },
+    variants: CODEX_EFFORT_VARIANTS_MAX,
+    defaultVariant: 'high'
+  },
   {
     id: 'gpt-5.5',
     name: 'GPT-5.5',
@@ -103,6 +135,9 @@ export function getCodexModelInfo(
 // ── Model slug normalization ──────────────────────────────────────
 
 export const CODEX_MODEL_ALIASES: Record<string, string> = {
+  '5.6-sol': 'gpt-5.6-sol',
+  '5.6-terra': 'gpt-5.6-terra',
+  '5.6-luna': 'gpt-5.6-luna',
   '5.5': 'gpt-5.5',
   '5.4': 'gpt-5.4',
   '5.3': 'gpt-5.3-codex',

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -60,10 +60,16 @@ type SdkFilterOption = {
 
 const ULTRACODE_TOOLTIP = 'xhigh effort + dynamic-workflow orchestration'
 
-/** Styling for a variant chip. ultracode gets a distinct accent so it reads as
- * the special CLI-only mode it is, rather than just another effort level. */
-function variantChipClass(isActive: boolean, isUltracode: boolean): string {
-  if (isUltracode) {
+/** ultracode and codex's `ultra` effort share the violet accent so both read as
+ * special top-tier modes rather than just another effort level. */
+function isAccentVariant(variant: string): boolean {
+  return variant === ULTRACODE_VARIANT || variant === 'ultra'
+}
+
+/** Styling for a variant chip. Accent variants (ultracode, ultra) get a
+ * distinct look so they read as the special modes they are. */
+function variantChipClass(isActive: boolean, isAccent: boolean): string {
+  if (isAccent) {
     return cn(
       'text-[10px] px-1.5 py-0.5 rounded font-medium',
       isActive
@@ -579,7 +585,7 @@ export const ModelSelector = memo(function ModelSelector({
               <span
                 className={cn(
                   'text-[10px] font-semibold uppercase',
-                  selectedModel.variant === ULTRACODE_VARIANT
+                  isAccentVariant(selectedModel.variant)
                     ? 'text-violet-600 dark:text-violet-300'
                     : 'text-primary'
                 )}
@@ -636,7 +642,7 @@ export const ModelSelector = memo(function ModelSelector({
                           return (
                             <button
                               key={variant}
-                              className={variantChipClass(isActiveVariant, isUltracode)}
+                              className={variantChipClass(isActiveVariant, isAccentVariant(variant))}
                               title={isUltracode ? ULTRACODE_TOOLTIP : undefined}
                               onClick={(e) => {
                                 e.stopPropagation()
@@ -696,7 +702,7 @@ export const ModelSelector = memo(function ModelSelector({
                           return (
                             <button
                               key={variant}
-                              className={variantChipClass(isActiveVariant, isUltracode)}
+                              className={variantChipClass(isActiveVariant, isAccentVariant(variant))}
                               title={isUltracode ? ULTRACODE_TOOLTIP : undefined}
                               onClick={(e) => {
                                 e.stopPropagation()


### PR DESCRIPTION
## Summary
- Register `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` in the Codex model catalog with their effort variants and aliases.
- Keep `gpt-5.5` as the default fallback when no valid model slug is provided.
- Update the model selector so `ultra` and `ultracode` share the violet accent treatment.
- Add coverage for model registration, alias resolution, and renderer exposure.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog and UI-only changes with tests; no auth, security, or data-path changes, and existing models keep prior effort sets.
> 
> **Overview**
> Adds **GPT-5.6 Sol, Terra, and Luna** to the Codex catalog with 372k context limits, shorthand aliases (`5.6-sol`, etc.), and tiered reasoning efforts: Sol/Terra include **ultra** through **low**; Luna tops out at **max** (no ultra). **`CODEX_REASONING_EFFORTS`** now includes `ultra` and `max`; **`gpt-5.5`** remains the default when the slug is missing or invalid.
> 
> The model selector treats Codex **`ultra`** like **`ultracode`** with the violet accent on chips and the active variant indicator. New Vitest coverage checks registration, alias resolution, renderer exposure, and default fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e69cde84e249379d72ebbf058e68aa2bb77c48c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->