### PR TITLE
Add multi-model ticket launch flow

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -2694,7 +2694,12 @@ export class DatabaseService {
           external_url: draft.external_url,
           github_pr_number: draft.github_pr_number,
           github_pr_url: draft.github_pr_url,
-          mark: draft.mark
+          mark: draft.mark,
+          note: draft.note,
+          model_provider_id: draft.model_provider_id,
+          model_id: draft.model_id,
+          model_variant: draft.model_variant,
+          variant_group_id: draft.variant_group_id
         })
         createdTickets.push(ticket)
         createdByDraftKey.set(draft.draft_key, ticket)

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -363,7 +363,11 @@ export class DatabaseService {
       goal_success_criteria: (row.goal_success_criteria as string) ?? null,
       note: (row.note as string) ?? null,
       created_from_session: row.created_from_session === 1,
-      auto_approve_plan: row.auto_approve_plan === 1
+      auto_approve_plan: row.auto_approve_plan === 1,
+      model_provider_id: (row.model_provider_id as string) ?? null,
+      model_id: (row.model_id as string) ?? null,
+      model_variant: (row.model_variant as string) ?? null,
+      variant_group_id: (row.variant_group_id as string) ?? null
     }
   }
 
@@ -681,6 +685,10 @@ export class DatabaseService {
     this.safeAddColumn('kanban_tickets', 'goal_success_criteria', 'TEXT DEFAULT NULL')
     this.safeAddColumn('kanban_tickets', 'created_from_session', 'INTEGER NOT NULL DEFAULT 0')
     this.safeAddColumn('kanban_tickets', 'auto_approve_plan', 'INTEGER NOT NULL DEFAULT 0')
+    this.safeAddColumn('kanban_tickets', 'model_provider_id', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('kanban_tickets', 'model_id', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('kanban_tickets', 'model_variant', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('kanban_tickets', 'variant_group_id', 'TEXT DEFAULT NULL')
     this.safeAddColumn('sessions', 'session_type', "TEXT NOT NULL DEFAULT 'default'")
     this.safeAddColumn(
       'discord_resources',
@@ -789,6 +797,10 @@ export class DatabaseService {
     this.safeAddColumn('markdown_kanban_card_state', 'last_seen_path', 'TEXT DEFAULT NULL')
     this.safeAddColumn('markdown_kanban_card_state', 'orphaned_at', 'TEXT DEFAULT NULL')
     this.safeAddColumn('markdown_kanban_card_state', 'auto_approve_plan', 'INTEGER NOT NULL DEFAULT 0')
+    this.safeAddColumn('markdown_kanban_card_state', 'model_provider_id', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('markdown_kanban_card_state', 'model_id', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('markdown_kanban_card_state', 'model_variant', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('markdown_kanban_card_state', 'variant_group_id', 'TEXT DEFAULT NULL')
   }
 
   // Settings operations
@@ -2591,10 +2603,15 @@ export class DatabaseService {
     const githubPrUrl = data.github_pr_url ?? null
     const mark = data.mark ?? null
     const createdFromSession = data.created_from_session ? 1 : 0
+    const note = data.note ?? null
+    const modelProviderId = data.model_provider_id ?? null
+    const modelId = data.model_id ?? null
+    const modelVariant = data.model_variant ?? null
+    const variantGroupId = data.variant_group_id ?? null
 
     db.prepare(
-      `INSERT INTO kanban_tickets (id, project_id, title, description, attachments, "column", sort_order, current_session_id, worktree_id, mode, plan_ready, external_provider, external_id, external_url, github_pr_number, github_pr_url, mark, created_from_session, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO kanban_tickets (id, project_id, title, description, attachments, "column", sort_order, current_session_id, worktree_id, mode, plan_ready, external_provider, external_id, external_url, github_pr_number, github_pr_url, mark, created_from_session, note, model_provider_id, model_id, model_variant, variant_group_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       id,
       data.project_id,
@@ -2614,6 +2631,11 @@ export class DatabaseService {
       githubPrUrl,
       mark,
       createdFromSession,
+      note,
+      modelProviderId,
+      modelId,
+      modelVariant,
+      variantGroupId,
       now,
       now
     )
@@ -2637,6 +2659,11 @@ export class DatabaseService {
       github_pr_url: githubPrUrl,
       mark,
       created_from_session: createdFromSession,
+      note,
+      model_provider_id: modelProviderId,
+      model_id: modelId,
+      model_variant: modelVariant,
+      variant_group_id: variantGroupId,
       total_tokens: 0,
       created_at: now,
       updated_at: now
@@ -2811,6 +2838,22 @@ export class DatabaseService {
     if (data.auto_approve_plan !== undefined) {
       updates.push('auto_approve_plan = ?')
       values.push(data.auto_approve_plan ? 1 : 0)
+    }
+    if (data.model_provider_id !== undefined) {
+      updates.push('model_provider_id = ?')
+      values.push(data.model_provider_id)
+    }
+    if (data.model_id !== undefined) {
+      updates.push('model_id = ?')
+      values.push(data.model_id)
+    }
+    if (data.model_variant !== undefined) {
+      updates.push('model_variant = ?')
+      values.push(data.model_variant)
+    }
+    if (data.variant_group_id !== undefined) {
+      updates.push('variant_group_id = ?')
+      values.push(data.variant_group_id)
     }
 
     if (updates.length === 1) return existing // Only updated_at, nothing meaningful changed

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -35,6 +35,7 @@ export type {
   KanbanTicketBatchCreate,
   KanbanTicketBatchCreateResult,
   KanbanTicketUpdate,
+  KanbanTicketDuplicateOverrides,
   KanbanTicketColumn,
   KanbanMarkdownConfig,
   KanbanStorageConfig,

--- a/src/main/db/migration-safety.test.ts
+++ b/src/main/db/migration-safety.test.ts
@@ -202,6 +202,101 @@ describeIf('database migration safety', () => {
     db.close()
   })
 
+  it('supports the multi-model ticket columns end-to-end on a fresh database', () => {
+    const db = new DatabaseService(makeDbPath())
+    db.init()
+
+    expect(columnNames(db, 'kanban_tickets')).toEqual(
+      expect.arrayContaining(['model_provider_id', 'model_id', 'model_variant', 'variant_group_id'])
+    )
+    expect(columnNames(db, 'markdown_kanban_card_state')).toEqual(
+      expect.arrayContaining(['model_provider_id', 'model_id', 'model_variant', 'variant_group_id'])
+    )
+
+    const project = db.createProject({ name: 'Project', path: makeDbPath() })
+
+    // Create without model fields -> all four null
+    const bareTicket = db.createKanbanTicket({ project_id: project.id, title: 'No model' })
+    expect(bareTicket.model_provider_id).toBeNull()
+    expect(bareTicket.model_id).toBeNull()
+    expect(bareTicket.model_variant).toBeNull()
+    expect(bareTicket.variant_group_id).toBeNull()
+    expect(bareTicket.note).toBeNull()
+
+    // Create with model fields + note -> round-trips via create response, get, and list
+    const ticket = db.createKanbanTicket({
+      project_id: project.id,
+      title: 'With model',
+      note: 'private annotation',
+      model_provider_id: 'anthropic',
+      model_id: 'claude-sonnet-5',
+      model_variant: 'high',
+      variant_group_id: 'group-1'
+    })
+    expect(ticket.note).toBe('private annotation')
+    expect(ticket.model_provider_id).toBe('anthropic')
+    expect(ticket.model_id).toBe('claude-sonnet-5')
+    expect(ticket.model_variant).toBe('high')
+    expect(ticket.variant_group_id).toBe('group-1')
+
+    const fetched = db.getKanbanTicket(ticket.id)
+    expect(fetched?.note).toBe('private annotation')
+    expect(fetched?.model_provider_id).toBe('anthropic')
+    expect(fetched?.model_id).toBe('claude-sonnet-5')
+    expect(fetched?.model_variant).toBe('high')
+    expect(fetched?.variant_group_id).toBe('group-1')
+
+    const listedTicket = db
+      .getKanbanTicketsByProject(project.id)
+      .find((candidate) => candidate.id === ticket.id)
+    expect(listedTicket?.model_provider_id).toBe('anthropic')
+    expect(listedTicket?.variant_group_id).toBe('group-1')
+
+    // Update: set each field, then clear each field back to null
+    const updatedSet = db.updateKanbanTicket(ticket.id, {
+      model_provider_id: 'openai',
+      model_id: 'gpt-5',
+      model_variant: 'medium',
+      variant_group_id: 'group-2'
+    })
+    expect(updatedSet?.model_provider_id).toBe('openai')
+    expect(updatedSet?.model_id).toBe('gpt-5')
+    expect(updatedSet?.model_variant).toBe('medium')
+    expect(updatedSet?.variant_group_id).toBe('group-2')
+
+    const updatedClear = db.updateKanbanTicket(ticket.id, {
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
+    })
+    expect(updatedClear?.model_provider_id).toBeNull()
+    expect(updatedClear?.model_id).toBeNull()
+    expect(updatedClear?.model_variant).toBeNull()
+    expect(updatedClear?.variant_group_id).toBeNull()
+
+    db.close()
+  })
+
+  it('is idempotent when the ticket model columns already exist', () => {
+    const dbPath = makeDbPath()
+    const db1 = new DatabaseService(dbPath)
+    db1.init()
+    db1.close()
+
+    // Re-running init() on an already-migrated database must not throw
+    // (safeAddColumn no-ops when the column is already present).
+    const db2 = new DatabaseService(dbPath)
+    expect(() => db2.init()).not.toThrow()
+    expect(columnNames(db2, 'kanban_tickets')).toEqual(
+      expect.arrayContaining(['model_provider_id', 'model_id', 'model_variant', 'variant_group_id'])
+    )
+    expect(columnNames(db2, 'markdown_kanban_card_state')).toEqual(
+      expect.arrayContaining(['model_provider_id', 'model_id', 'model_variant', 'variant_group_id'])
+    )
+    db2.close()
+  })
+
   it('upgrades an origin/main v31-shaped database to v34 without losing existing worktrees', () => {
     const dbPath = makeDbPath()
     seedOriginMainVersion31Shape(dbPath)

--- a/src/main/db/migration-safety.test.ts
+++ b/src/main/db/migration-safety.test.ts
@@ -151,6 +151,104 @@ const seedOriginMainVersion31Shape = (dbPath: string): void => {
   db.close()
 }
 
+const seedTicketModelColumnsV38Shape = (dbPath: string): void => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Database = require('better-sqlite3')
+  const db = new Database(dbPath)
+  db.pragma('foreign_keys = ON')
+  db.exec(`
+    CREATE TABLE settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+
+    CREATE TABLE projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      path TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL,
+      last_accessed_at TEXT NOT NULL
+    );
+
+    CREATE TABLE worktrees (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      name TEXT NOT NULL,
+      branch_name TEXT NOT NULL,
+      path TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at TEXT NOT NULL,
+      last_accessed_at TEXT NOT NULL
+    );
+
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      worktree_id TEXT REFERENCES worktrees(id) ON DELETE SET NULL,
+      project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      status TEXT NOT NULL DEFAULT 'active',
+      mode TEXT NOT NULL DEFAULT 'build',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    -- v38 shape: kanban_tickets has auto_approve_plan (added at v38) but NOT
+    -- the model_provider_id/model_id/model_variant/variant_group_id columns
+    -- added at v39.
+    CREATE TABLE kanban_tickets (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      description TEXT,
+      attachments TEXT NOT NULL DEFAULT '[]',
+      "column" TEXT NOT NULL DEFAULT 'todo',
+      sort_order REAL NOT NULL DEFAULT 0,
+      current_session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL,
+      worktree_id TEXT REFERENCES worktrees(id) ON DELETE SET NULL,
+      mode TEXT,
+      plan_ready INTEGER NOT NULL DEFAULT 0,
+      archived_at TEXT DEFAULT NULL,
+      github_pr_number INTEGER DEFAULT NULL,
+      github_pr_url TEXT DEFAULT NULL,
+      mark TEXT DEFAULT NULL,
+      note TEXT DEFAULT NULL,
+      goal_mode INTEGER NOT NULL DEFAULT 0,
+      goal_success_criteria TEXT DEFAULT NULL,
+      created_from_session INTEGER NOT NULL DEFAULT 0,
+      auto_approve_plan INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    -- Same v38 shape for the markdown runtime-state table.
+    CREATE TABLE markdown_kanban_card_state (
+      project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      card_id TEXT NOT NULL,
+      current_session_id TEXT DEFAULT NULL REFERENCES sessions(id) ON DELETE SET NULL,
+      worktree_id TEXT DEFAULT NULL REFERENCES worktrees(id) ON DELETE SET NULL,
+      note TEXT DEFAULT NULL,
+      attachments TEXT NOT NULL DEFAULT '[]',
+      plan_ready INTEGER NOT NULL DEFAULT 0,
+      total_tokens INTEGER NOT NULL DEFAULT 0,
+      pending_launch_config TEXT DEFAULT NULL,
+      last_seen_path TEXT DEFAULT NULL,
+      orphaned_at TEXT DEFAULT NULL,
+      auto_approve_plan INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (project_id, card_id)
+    );
+
+    INSERT INTO settings (key, value) VALUES ('schema_version', '38');
+    INSERT INTO projects (id, name, path, created_at, last_accessed_at)
+      VALUES ('project-1', 'Project', '/tmp/project-1', '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z');
+    INSERT INTO kanban_tickets (id, project_id, title, note, auto_approve_plan, created_at, updated_at)
+      VALUES ('ticket-1', 'project-1', 'Pre-upgrade ticket', 'kept note', 1, '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z');
+    INSERT INTO markdown_kanban_card_state (project_id, card_id, note, auto_approve_plan, created_at, updated_at)
+      VALUES ('project-1', 'card-1', 'kept card note', 0, '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z');
+  `)
+  db.close()
+}
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true })
@@ -312,6 +410,45 @@ describeIf('database migration safety', () => {
     expect(db.getRawDb().prepare('SELECT COUNT(*) AS count FROM worktrees').get()).toEqual({
       count: 1
     })
+
+    db.close()
+  })
+
+  it('upgrades a v38-shaped database to v39, adding the ticket model columns and preserving pre-upgrade tickets', () => {
+    const dbPath = makeDbPath()
+    seedTicketModelColumnsV38Shape(dbPath)
+
+    const db = new DatabaseService(dbPath)
+    db.init()
+
+    expect(db.getSchemaVersion()).toBe(CURRENT_SCHEMA_VERSION)
+    expect(columnNames(db, 'kanban_tickets')).toEqual(
+      expect.arrayContaining(['model_provider_id', 'model_id', 'model_variant', 'variant_group_id'])
+    )
+    expect(columnNames(db, 'markdown_kanban_card_state')).toEqual(
+      expect.arrayContaining(['model_provider_id', 'model_id', 'model_variant', 'variant_group_id'])
+    )
+
+    // The ticket written before the upgrade keeps its pre-existing fields and
+    // round-trips with the four new columns null.
+    const ticket = db.getKanbanTicket('ticket-1')
+    expect(ticket?.title).toBe('Pre-upgrade ticket')
+    expect(ticket?.note).toBe('kept note')
+    expect(ticket?.auto_approve_plan).toBe(true)
+    expect(ticket?.model_provider_id).toBeNull()
+    expect(ticket?.model_id).toBeNull()
+    expect(ticket?.model_variant).toBeNull()
+    expect(ticket?.variant_group_id).toBeNull()
+
+    const cardStateRow = db
+      .getRawDb()
+      .prepare('SELECT * FROM markdown_kanban_card_state WHERE project_id = ? AND card_id = ?')
+      .get('project-1', 'card-1') as Record<string, unknown>
+    expect(cardStateRow.note).toBe('kept card note')
+    expect(cardStateRow.model_provider_id).toBeNull()
+    expect(cardStateRow.model_id).toBeNull()
+    expect(cardStateRow.model_variant).toBeNull()
+    expect(cardStateRow.variant_group_id).toBeNull()
 
     db.close()
   })

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 38
+export const CURRENT_SCHEMA_VERSION = 39
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -663,6 +663,15 @@ DROP TABLE IF EXISTS diff_comments;`
     up: `-- NOTE: ALTER TABLE for kanban_tickets.auto_approve_plan and
          -- markdown_kanban_card_state.auto_approve_plan is handled idempotently by
          -- safeAddColumn() in database.ts to avoid "duplicate column" errors.`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 39,
+    name: 'add_ticket_model_columns',
+    up: `-- NOTE: ALTER TABLE for kanban_tickets.model_provider_id/model_id/model_variant/
+         -- variant_group_id and the same four columns on markdown_kanban_card_state is
+         -- handled idempotently by safeAddColumn() in database.ts to avoid
+         -- "duplicate column" errors.`,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -573,6 +573,16 @@ export interface KanbanTicketUpdate {
   variant_group_id?: string | null
 }
 
+/** Fields a caller may override on a freshly duplicated ticket; see KanbanBackend.duplicate. */
+export interface KanbanTicketDuplicateOverrides {
+  column?: KanbanTicketColumn
+  sort_order?: number
+  model_provider_id?: string | null
+  model_id?: string | null
+  model_variant?: string | null
+  variant_group_id?: string | null
+}
+
 export interface BoardAssistantDraft {
   draftKey: string
   title: string

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -610,6 +610,11 @@ export interface KanbanTicketBatchCreateItem {
   github_pr_number?: number | null
   github_pr_url?: string | null
   mark?: TicketMark | null
+  note?: string | null
+  model_provider_id?: string | null
+  model_id?: string | null
+  model_variant?: string | null
+  variant_group_id?: string | null
   depends_on?: string[]
 }
 

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -516,6 +516,10 @@ export interface KanbanTicket {
   created_from_session: boolean
   /** One-shot: auto-approve the next claude-cli ExitPlanMode plan, then self-clears. */
   auto_approve_plan: boolean
+  model_provider_id: string | null
+  model_id: string | null
+  model_variant: string | null
+  variant_group_id: string | null
 }
 
 export interface KanbanTicketCreate {
@@ -537,6 +541,11 @@ export interface KanbanTicketCreate {
   github_pr_url?: string | null
   mark?: TicketMark | null
   created_from_session?: boolean
+  note?: string | null
+  model_provider_id?: string | null
+  model_id?: string | null
+  model_variant?: string | null
+  variant_group_id?: string | null
 }
 
 export interface KanbanTicketUpdate {
@@ -558,6 +567,10 @@ export interface KanbanTicketUpdate {
   goal_success_criteria?: string | null
   note?: string | null
   auto_approve_plan?: boolean
+  model_provider_id?: string | null
+  model_id?: string | null
+  model_variant?: string | null
+  variant_group_id?: string | null
 }
 
 export interface BoardAssistantDraft {

--- a/src/main/services/__tests__/kanban-backend.batch-model-fields.test.ts
+++ b/src/main/services/__tests__/kanban-backend.batch-model-fields.test.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { closeDatabase, getDatabase } from '../../db'
+import type { Project } from '../../db'
+import { getKanbanBackendForProject } from '../kanban-backend'
+
+/**
+ * kanban.ticket.createBatch accepts `note` and the 4 model badge fields on
+ * each draft (kanbanTicketBatchCreateItemSchema inherits them from the
+ * create schema), but both storage backends used to drop them while building
+ * the created tickets — a batch draft carrying model metadata silently came
+ * back with those fields null. These tests pin the fix: both backends must
+ * forward note + the 4 model fields from a batch draft into the created ticket.
+ */
+describe('KanbanBackend.createBatch note + model field forwarding', () => {
+  const tempDirs: string[] = []
+  let project: Project
+
+  beforeEach(() => {
+    const dbDir = mkdtempSync(join(tmpdir(), 'hive-batch-backend-db-'))
+    tempDirs.push(dbDir)
+    process.env.HIVE_SERVER_DB_PATH = join(dbDir, 'hive.db')
+    closeDatabase()
+    const db = getDatabase()
+    project = db.createProject({ name: 'Batch Project', path: '/tmp/hive-batch-project' })
+  })
+
+  afterEach(() => {
+    closeDatabase()
+    delete process.env.HIVE_SERVER_DB_PATH
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  describe('SQLite (internal) backend', () => {
+    it('round-trips note + the 4 model fields from a batch draft into the created ticket', async () => {
+      const backend = getKanbanBackendForProject(project.id)
+
+      const result = await backend.createBatch(project.id, {
+        drafts: [
+          {
+            draft_key: 'draft-1',
+            project_id: project.id,
+            title: 'Batch-created with model fields',
+            note: 'batch scratch note',
+            model_provider_id: 'anthropic',
+            model_id: 'claude-opus-4-6',
+            model_variant: 'thinking',
+            variant_group_id: 'batch-group-1'
+          }
+        ]
+      })
+
+      expect(result.tickets).toHaveLength(1)
+      const created = result.tickets[0]
+      expect(created.note).toBe('batch scratch note')
+      expect(created.model_provider_id).toBe('anthropic')
+      expect(created.model_id).toBe('claude-opus-4-6')
+      expect(created.model_variant).toBe('thinking')
+      expect(created.variant_group_id).toBe('batch-group-1')
+
+      const fetched = await backend.get(project.id, created.id)
+      expect(fetched?.note).toBe('batch scratch note')
+      expect(fetched?.model_provider_id).toBe('anthropic')
+      expect(fetched?.model_id).toBe('claude-opus-4-6')
+      expect(fetched?.model_variant).toBe('thinking')
+      expect(fetched?.variant_group_id).toBe('batch-group-1')
+    })
+
+    it('defaults note and the 4 model fields to null when a batch draft omits them', async () => {
+      const backend = getKanbanBackendForProject(project.id)
+
+      const result = await backend.createBatch(project.id, {
+        drafts: [{ draft_key: 'draft-1', project_id: project.id, title: 'Plain batch ticket' }]
+      })
+
+      const created = result.tickets[0]
+      expect(created.note).toBeNull()
+      expect(created.model_provider_id).toBeNull()
+      expect(created.model_id).toBeNull()
+      expect(created.model_variant).toBeNull()
+      expect(created.variant_group_id).toBeNull()
+    })
+  })
+
+  describe('Markdown backend', () => {
+    let mdProject: Project
+
+    beforeEach(() => {
+      const projectDir = mkdtempSync(join(tmpdir(), 'hive-batch-md-project-'))
+      tempDirs.push(projectDir)
+      const db = getDatabase()
+      mdProject = db.createProject({ name: 'Markdown Batch Project', path: projectDir })
+      db.updateProjectKanbanStorageMode(mdProject.id, 'markdown')
+    })
+
+    it('round-trips note + the 4 model fields from a batch draft into the created ticket', async () => {
+      const backend = getKanbanBackendForProject(mdProject.id)
+
+      const result = await backend.createBatch(mdProject.id, {
+        drafts: [
+          {
+            draft_key: 'draft-1',
+            project_id: mdProject.id,
+            title: 'Batch-created with model fields',
+            note: 'batch scratch note',
+            model_provider_id: 'openai',
+            model_id: 'gpt-5.6',
+            model_variant: 'high',
+            variant_group_id: 'batch-group-md'
+          }
+        ]
+      })
+
+      expect(result.tickets).toHaveLength(1)
+      const created = result.tickets[0]
+      expect(created.note).toBe('batch scratch note')
+      expect(created.model_provider_id).toBe('openai')
+      expect(created.model_id).toBe('gpt-5.6')
+      expect(created.model_variant).toBe('high')
+      expect(created.variant_group_id).toBe('batch-group-md')
+
+      const fetched = await backend.get(mdProject.id, created.id)
+      expect(fetched?.note).toBe('batch scratch note')
+      expect(fetched?.model_provider_id).toBe('openai')
+      expect(fetched?.model_id).toBe('gpt-5.6')
+      expect(fetched?.model_variant).toBe('high')
+      expect(fetched?.variant_group_id).toBe('batch-group-md')
+    })
+
+    it('defaults note and the 4 model fields to null when a batch draft omits them', async () => {
+      const backend = getKanbanBackendForProject(mdProject.id)
+
+      const result = await backend.createBatch(mdProject.id, {
+        drafts: [{ draft_key: 'draft-1', project_id: mdProject.id, title: 'Plain batch ticket' }]
+      })
+
+      const created = result.tickets[0]
+      expect(created.note).toBeNull()
+      expect(created.model_provider_id).toBeNull()
+      expect(created.model_id).toBeNull()
+      expect(created.model_variant).toBeNull()
+      expect(created.variant_group_id).toBeNull()
+    })
+  })
+})

--- a/src/main/services/__tests__/kanban-backend.duplicate.test.ts
+++ b/src/main/services/__tests__/kanban-backend.duplicate.test.ts
@@ -1,0 +1,227 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { closeDatabase, getDatabase } from '../../db'
+import type { Project } from '../../db'
+import { getKanbanBackendForProject } from '../kanban-backend'
+
+/**
+ * kanban.ticket.duplicate creates a fresh, unstarted sibling ticket. Per the
+ * duplication policy: title/description/attachments/mark/note are copied;
+ * external links, PR links, session/worktree linkage, goal/launch state,
+ * token totals, and archived state are NOT copied; column/sort_order/model
+ * fields can be overridden and column defaults to the source's column.
+ */
+describe('KanbanBackend.duplicate', () => {
+  const tempDirs: string[] = []
+  let project: Project
+
+  beforeEach(() => {
+    const dbDir = mkdtempSync(join(tmpdir(), 'hive-duplicate-backend-db-'))
+    tempDirs.push(dbDir)
+    process.env.HIVE_SERVER_DB_PATH = join(dbDir, 'hive.db')
+    closeDatabase()
+    const db = getDatabase()
+    project = db.createProject({ name: 'Duplicate Project', path: '/tmp/hive-duplicate-project' })
+  })
+
+  afterEach(() => {
+    closeDatabase()
+    delete process.env.HIVE_SERVER_DB_PATH
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  describe('SQLite (internal) backend', () => {
+    it('copies title/description/attachments/mark/note, excludes everything else, and defaults column to the source column', async () => {
+      const db = getDatabase()
+      const worktree = db.createWorktree({
+        project_id: project.id,
+        name: 'main',
+        branch_name: 'main',
+        path: project.path
+      })
+      const session = db.createSession({
+        worktree_id: worktree.id,
+        project_id: project.id,
+        name: 'Session'
+      })
+
+      const backend = getKanbanBackendForProject(project.id)
+      const source = await backend.create(project.id, {
+        project_id: project.id,
+        title: 'Ship it',
+        description: 'Full description',
+        attachments: [{ id: 'att-1' }],
+        mark: 'epic',
+        note: 'my scratch note',
+        column: 'review',
+        external_provider: 'jira',
+        external_id: 'JIRA-1',
+        external_url: 'https://jira.example.com/JIRA-1',
+        github_pr_number: 42,
+        github_pr_url: 'https://github.com/example/pull/42',
+        mode: 'plan',
+        plan_ready: true
+      })
+      await getDatabase().updateKanbanTicket(source.id, {
+        worktree_id: worktree.id,
+        current_session_id: session.id,
+        pending_launch_config: '{"foo":true}',
+        goal_mode: true,
+        goal_success_criteria: 'All green',
+        auto_approve_plan: true
+      })
+      getDatabase().addTicketTokens(source.id, 500)
+      const sourceBeforeDuplicate = await backend.get(project.id, source.id)
+
+      const duplicate = await backend.duplicate(project.id, source.id)
+
+      expect(duplicate.id).not.toBe(source.id)
+      expect(duplicate.title).toBe('Ship it')
+      expect(duplicate.description).toBe('Full description')
+      expect(duplicate.attachments).toEqual([{ id: 'att-1' }])
+      expect(duplicate.mark).toBe('epic')
+      expect(duplicate.note).toBe('my scratch note')
+      expect(duplicate.column).toBe('review')
+
+      expect(duplicate.external_provider).toBeNull()
+      expect(duplicate.external_id).toBeNull()
+      expect(duplicate.external_url).toBeNull()
+      expect(duplicate.github_pr_number).toBeNull()
+      expect(duplicate.github_pr_url).toBeNull()
+      expect(duplicate.current_session_id).toBeNull()
+      expect(duplicate.worktree_id).toBeNull()
+      expect(duplicate.mode).toBeNull()
+      expect(duplicate.plan_ready).toBe(false)
+      expect(duplicate.pending_launch_config).toBeNull()
+      expect(duplicate.goal_mode).toBe(false)
+      expect(duplicate.goal_success_criteria).toBeNull()
+      expect(duplicate.total_tokens).toBe(0)
+      expect(duplicate.auto_approve_plan).toBe(false)
+      expect(duplicate.archived_at).toBeNull()
+      expect(duplicate.model_provider_id).toBeNull()
+      expect(duplicate.model_id).toBeNull()
+      expect(duplicate.model_variant).toBeNull()
+      expect(duplicate.variant_group_id).toBeNull()
+
+      const sourceAfterDuplicate = await backend.get(project.id, source.id)
+      expect(sourceAfterDuplicate).toEqual(sourceBeforeDuplicate)
+    })
+
+    it('applies overrides for column, sort_order, and the model/group fields', async () => {
+      const backend = getKanbanBackendForProject(project.id)
+      const source = await backend.create(project.id, {
+        project_id: project.id,
+        title: 'Multi-model ticket',
+        column: 'todo'
+      })
+
+      const duplicate = await backend.duplicate(project.id, source.id, {
+        column: 'in_progress',
+        sort_order: 7,
+        model_provider_id: 'anthropic',
+        model_id: 'claude-opus-4-6',
+        model_variant: 'thinking',
+        variant_group_id: 'group-xyz'
+      })
+
+      expect(duplicate.column).toBe('in_progress')
+      expect(duplicate.sort_order).toBe(7)
+      expect(duplicate.model_provider_id).toBe('anthropic')
+      expect(duplicate.model_id).toBe('claude-opus-4-6')
+      expect(duplicate.model_variant).toBe('thinking')
+      expect(duplicate.variant_group_id).toBe('group-xyz')
+    })
+
+    it('rejects duplicating a ticket that does not exist', async () => {
+      const backend = getKanbanBackendForProject(project.id)
+      await expect(backend.duplicate(project.id, 'missing-ticket')).rejects.toThrow()
+    })
+  })
+
+  describe('Markdown backend', () => {
+    let mdProject: Project
+
+    beforeEach(() => {
+      const projectDir = mkdtempSync(join(tmpdir(), 'hive-duplicate-md-project-'))
+      tempDirs.push(projectDir)
+      const db = getDatabase()
+      mdProject = db.createProject({ name: 'Markdown Duplicate Project', path: projectDir })
+      db.updateProjectKanbanStorageMode(mdProject.id, 'markdown')
+    })
+
+    it('copies title/description/attachments/mark/note into a distinct new .md file, leaving the source untouched', async () => {
+      const backend = getKanbanBackendForProject(mdProject.id)
+      const source = await backend.create(mdProject.id, {
+        project_id: mdProject.id,
+        title: 'Ship it',
+        description: 'Body text',
+        attachments: [{ id: 'att-1' }],
+        mark: 'rare',
+        note: 'scratch',
+        column: 'review'
+      })
+
+      const folder = join(mdProject.path, 'docs', 'kanban')
+      const filesBefore = readdirSync(folder).filter((name) => name.endsWith('.md'))
+      expect(filesBefore).toHaveLength(1)
+      const sourcePath = join(folder, filesBefore[0])
+      const sourceContentBefore = readFileSync(sourcePath, 'utf-8')
+
+      const duplicate = await backend.duplicate(mdProject.id, source.id)
+
+      expect(duplicate.id).not.toBe(source.id)
+      expect(duplicate.title).toBe('Ship it')
+      expect(duplicate.description).toBe('Body text')
+      expect(duplicate.attachments).toEqual([{ id: 'att-1' }])
+      expect(duplicate.mark).toBe('rare')
+      expect(duplicate.note).toBe('scratch')
+      expect(duplicate.column).toBe('review')
+      expect(duplicate.model_provider_id).toBeNull()
+      expect(duplicate.model_id).toBeNull()
+      expect(duplicate.model_variant).toBeNull()
+      expect(duplicate.variant_group_id).toBeNull()
+
+      const filesAfter = readdirSync(folder).filter((name) => name.endsWith('.md'))
+      expect(filesAfter).toHaveLength(2)
+      expect(readFileSync(sourcePath, 'utf-8')).toBe(sourceContentBefore)
+
+      const fetchedDuplicate = await backend.get(mdProject.id, duplicate.id)
+      expect(fetchedDuplicate?.note).toBe('scratch')
+      expect(fetchedDuplicate?.attachments).toEqual([{ id: 'att-1' }])
+    })
+
+    it('applies overrides for column, sort_order, and the model/group fields', async () => {
+      const backend = getKanbanBackendForProject(mdProject.id)
+      const source = await backend.create(mdProject.id, {
+        project_id: mdProject.id,
+        title: 'Multi-model ticket',
+        column: 'todo'
+      })
+
+      const duplicate = await backend.duplicate(mdProject.id, source.id, {
+        column: 'in_progress',
+        model_provider_id: 'openai',
+        model_id: 'gpt-5.6',
+        model_variant: 'high',
+        variant_group_id: 'group-md'
+      })
+
+      expect(duplicate.column).toBe('in_progress')
+      expect(duplicate.model_provider_id).toBe('openai')
+      expect(duplicate.model_id).toBe('gpt-5.6')
+      expect(duplicate.model_variant).toBe('high')
+      expect(duplicate.variant_group_id).toBe('group-md')
+    })
+
+    it('rejects duplicating a ticket that does not exist', async () => {
+      const backend = getKanbanBackendForProject(mdProject.id)
+      await expect(backend.duplicate(mdProject.id, 'missing-ticket')).rejects.toThrow()
+    })
+  })
+})

--- a/src/main/services/__tests__/kanban-backend.markdown-model-fields.test.ts
+++ b/src/main/services/__tests__/kanban-backend.markdown-model-fields.test.ts
@@ -1,0 +1,143 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+
+import { closeDatabase, getDatabase } from '../../db'
+import type { Project } from '../../db'
+import { getKanbanBackendForProject } from '../kanban-backend'
+
+/**
+ * Markdown-mode tickets keep runtime state (note, model badge fields) in the
+ * markdown_kanban_card_state table, never in the .md file's YAML frontmatter.
+ * These tests exercise MarkdownKanbanBackend directly against a real temp
+ * sqlite db + temp project folder, mirroring how `note` already round-trips.
+ */
+describe('MarkdownKanbanBackend model field runtime mirroring', () => {
+  const tempDirs: string[] = []
+  let project: Project
+
+  beforeEach(() => {
+    const dbDir = mkdtempSync(join(tmpdir(), 'hive-markdown-backend-db-'))
+    const projectDir = mkdtempSync(join(tmpdir(), 'hive-markdown-backend-project-'))
+    tempDirs.push(dbDir, projectDir)
+
+    process.env.HIVE_SERVER_DB_PATH = join(dbDir, 'hive.db')
+    closeDatabase()
+    const db = getDatabase()
+    project = db.createProject({ name: 'Markdown Project', path: projectDir })
+    db.updateProjectKanbanStorageMode(project.id, 'markdown')
+  })
+
+  afterEach(() => {
+    closeDatabase()
+    delete process.env.HIVE_SERVER_DB_PATH
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  const readCardFrontmatter = (): Record<string, unknown> => {
+    const folder = join(project.path, 'docs', 'kanban')
+    const files = readdirSync(folder).filter((name) => name.endsWith('.md'))
+    expect(files).toHaveLength(1)
+    const raw = readFileSync(join(folder, files[0]), 'utf-8')
+    const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/)
+    expect(match).not.toBeNull()
+    return YAML.parse(match![1]) as Record<string, unknown>
+  }
+
+  it('round-trips note + the 4 model fields through create, get, and list', async () => {
+    const backend = getKanbanBackendForProject(project.id)
+    const created = await backend.create(project.id, {
+      project_id: project.id,
+      title: 'Ship multi-model launch',
+      note: 'scratch note',
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-6',
+      model_variant: 'thinking',
+      variant_group_id: 'group-1'
+    })
+
+    expect(created.note).toBe('scratch note')
+    expect(created.model_provider_id).toBe('anthropic')
+    expect(created.model_id).toBe('claude-opus-4-6')
+    expect(created.model_variant).toBe('thinking')
+    expect(created.variant_group_id).toBe('group-1')
+
+    const fetched = await backend.get(project.id, created.id)
+    expect(fetched?.note).toBe('scratch note')
+    expect(fetched?.model_provider_id).toBe('anthropic')
+    expect(fetched?.model_id).toBe('claude-opus-4-6')
+    expect(fetched?.model_variant).toBe('thinking')
+    expect(fetched?.variant_group_id).toBe('group-1')
+
+    const listed = await backend.list(project.id, false)
+    const listedTicket = listed.find((ticket) => ticket.id === created.id)
+    expect(listedTicket?.note).toBe('scratch note')
+    expect(listedTicket?.model_provider_id).toBe('anthropic')
+    expect(listedTicket?.model_id).toBe('claude-opus-4-6')
+    expect(listedTicket?.model_variant).toBe('thinking')
+    expect(listedTicket?.variant_group_id).toBe('group-1')
+  })
+
+  it('defaults note and the 4 model fields to null when omitted from create', async () => {
+    const backend = getKanbanBackendForProject(project.id)
+    const created = await backend.create(project.id, {
+      project_id: project.id,
+      title: 'Plain ticket'
+    })
+
+    expect(created.note).toBeNull()
+    expect(created.model_provider_id).toBeNull()
+    expect(created.model_id).toBeNull()
+    expect(created.model_variant).toBeNull()
+    expect(created.variant_group_id).toBeNull()
+  })
+
+  it('update sets then clears each of the 4 model fields, never touching frontmatter', async () => {
+    const backend = getKanbanBackendForProject(project.id)
+    const created = await backend.create(project.id, {
+      project_id: project.id,
+      title: 'Badge me later'
+    })
+
+    const updated = await backend.update(project.id, created.id, {
+      model_provider_id: 'openai',
+      model_id: 'gpt-5.6',
+      model_variant: 'high',
+      variant_group_id: 'group-2'
+    })
+    expect(updated?.model_provider_id).toBe('openai')
+    expect(updated?.model_id).toBe('gpt-5.6')
+    expect(updated?.model_variant).toBe('high')
+    expect(updated?.variant_group_id).toBe('group-2')
+
+    const frontmatterAfterSet = readCardFrontmatter()
+    expect(frontmatterAfterSet).not.toHaveProperty('model_provider_id')
+    expect(frontmatterAfterSet).not.toHaveProperty('model_id')
+    expect(frontmatterAfterSet).not.toHaveProperty('model_variant')
+    expect(frontmatterAfterSet).not.toHaveProperty('variant_group_id')
+    expect(frontmatterAfterSet).not.toHaveProperty('note')
+
+    const cleared = await backend.update(project.id, created.id, {
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
+    })
+    expect(cleared?.model_provider_id).toBeNull()
+    expect(cleared?.model_id).toBeNull()
+    expect(cleared?.model_variant).toBeNull()
+    expect(cleared?.variant_group_id).toBeNull()
+
+    const frontmatterAfterClear = readCardFrontmatter()
+    expect(frontmatterAfterClear).not.toHaveProperty('model_provider_id')
+    expect(frontmatterAfterClear).not.toHaveProperty('model_id')
+    expect(frontmatterAfterClear).not.toHaveProperty('model_variant')
+    expect(frontmatterAfterClear).not.toHaveProperty('variant_group_id')
+    expect(frontmatterAfterClear).not.toHaveProperty('note')
+  })
+})

--- a/src/main/services/__tests__/kanban-backend.move-to-project.test.ts
+++ b/src/main/services/__tests__/kanban-backend.move-to-project.test.ts
@@ -1,0 +1,141 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { closeDatabase, getDatabase } from '../../db'
+import type { Project } from '../../db'
+import { getKanbanBackendForProject, moveKanbanTicketToProject } from '../kanban-backend'
+
+/**
+ * Cross-backend project moves (internal ↔ markdown) go through a
+ * recreate-in-target + follow-up-update path in moveKanbanTicketToProject,
+ * unlike internal→internal moves which just re-point project_id and keep
+ * every column. The model badge/group fields must survive that recreate the
+ * same way `note` does — internal→internal moves already keep them, so a
+ * cross-backend move silently dropping them would be inconsistent.
+ */
+describe('moveKanbanTicketToProject cross-backend model field preservation', () => {
+  const tempDirs: string[] = []
+  let internalProject: Project
+  let markdownProject: Project
+
+  beforeEach(() => {
+    const dbDir = mkdtempSync(join(tmpdir(), 'hive-move-backend-db-'))
+    const markdownDir = mkdtempSync(join(tmpdir(), 'hive-move-md-project-'))
+    tempDirs.push(dbDir, markdownDir)
+
+    process.env.HIVE_SERVER_DB_PATH = join(dbDir, 'hive.db')
+    closeDatabase()
+    const db = getDatabase()
+    internalProject = db.createProject({
+      name: 'Internal Project',
+      path: '/tmp/hive-move-internal-project'
+    })
+    markdownProject = db.createProject({ name: 'Markdown Project', path: markdownDir })
+    db.updateProjectKanbanStorageMode(markdownProject.id, 'markdown')
+  })
+
+  afterEach(() => {
+    closeDatabase()
+    delete process.env.HIVE_SERVER_DB_PATH
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('internal → markdown keeps note + the 4 model fields', async () => {
+    const internalBackend = getKanbanBackendForProject(internalProject.id)
+    const source = await internalBackend.create(internalProject.id, {
+      project_id: internalProject.id,
+      title: 'Cross-backend move',
+      note: 'kept note',
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-6',
+      model_variant: 'thinking',
+      variant_group_id: 'group-move-1'
+    })
+
+    const moved = await moveKanbanTicketToProject(
+      internalProject.id,
+      source.id,
+      markdownProject.id
+    )
+
+    expect(moved).not.toBeNull()
+    expect(moved?.project_id).toBe(markdownProject.id)
+    expect(moved?.note).toBe('kept note')
+    expect(moved?.model_provider_id).toBe('anthropic')
+    expect(moved?.model_id).toBe('claude-opus-4-6')
+    expect(moved?.model_variant).toBe('thinking')
+    expect(moved?.variant_group_id).toBe('group-move-1')
+
+    // Round-trips through the target backend's own read path too.
+    const markdownBackend = getKanbanBackendForProject(markdownProject.id)
+    const fetched = await markdownBackend.get(markdownProject.id, source.id)
+    expect(fetched?.note).toBe('kept note')
+    expect(fetched?.model_provider_id).toBe('anthropic')
+    expect(fetched?.model_id).toBe('claude-opus-4-6')
+    expect(fetched?.model_variant).toBe('thinking')
+    expect(fetched?.variant_group_id).toBe('group-move-1')
+
+    // Source is gone.
+    expect(await internalBackend.get(internalProject.id, source.id)).toBeNull()
+  })
+
+  it('markdown → internal keeps note + the 4 model fields', async () => {
+    const markdownBackend = getKanbanBackendForProject(markdownProject.id)
+    const source = await markdownBackend.create(markdownProject.id, {
+      project_id: markdownProject.id,
+      title: 'Cross-backend move back',
+      note: 'kept md note',
+      model_provider_id: 'openai',
+      model_id: 'gpt-5.6',
+      model_variant: 'high',
+      variant_group_id: 'group-move-2'
+    })
+
+    const moved = await moveKanbanTicketToProject(
+      markdownProject.id,
+      source.id,
+      internalProject.id
+    )
+
+    expect(moved).not.toBeNull()
+    expect(moved?.project_id).toBe(internalProject.id)
+    expect(moved?.note).toBe('kept md note')
+    expect(moved?.model_provider_id).toBe('openai')
+    expect(moved?.model_id).toBe('gpt-5.6')
+    expect(moved?.model_variant).toBe('high')
+    expect(moved?.variant_group_id).toBe('group-move-2')
+
+    const internalBackend = getKanbanBackendForProject(internalProject.id)
+    const fetched = await internalBackend.get(internalProject.id, source.id)
+    expect(fetched?.model_provider_id).toBe('openai')
+    expect(fetched?.model_id).toBe('gpt-5.6')
+    expect(fetched?.model_variant).toBe('high')
+    expect(fetched?.variant_group_id).toBe('group-move-2')
+
+    expect(await markdownBackend.get(markdownProject.id, source.id)).toBeNull()
+  })
+
+  it('cross-backend moves default the 4 model fields to null when the source never launched', async () => {
+    const internalBackend = getKanbanBackendForProject(internalProject.id)
+    const source = await internalBackend.create(internalProject.id, {
+      project_id: internalProject.id,
+      title: 'Never launched'
+    })
+
+    const moved = await moveKanbanTicketToProject(
+      internalProject.id,
+      source.id,
+      markdownProject.id
+    )
+
+    expect(moved?.model_provider_id).toBeNull()
+    expect(moved?.model_id).toBeNull()
+    expect(moved?.model_variant).toBeNull()
+    expect(moved?.variant_group_id).toBeNull()
+  })
+})

--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -1904,6 +1904,12 @@ export async function moveKanbanTicketToProject(
         goal_mode: sourceTicket.goal_mode,
         goal_success_criteria: sourceTicket.goal_success_criteria,
         note: sourceTicket.note,
+        // Badge/group metadata survives internal→internal moves untouched —
+        // keep the cross-backend recreate path consistent.
+        model_provider_id: sourceTicket.model_provider_id,
+        model_id: sourceTicket.model_id,
+        model_variant: sourceTicket.model_variant,
+        variant_group_id: sourceTicket.variant_group_id,
         pending_launch_config: null
       })) ?? created
 

--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -39,6 +39,7 @@ import type {
   KanbanTicketBatchCreateResult,
   KanbanTicketColumn,
   KanbanTicketCreate,
+  KanbanTicketDuplicateOverrides,
   KanbanTicketUpdate,
   MarkdownCardDiagnostic,
   Project,
@@ -171,6 +172,11 @@ export interface KanbanBackend {
   get(projectId: string, ticketId: string): Promise<KanbanTicket | null>
   list(projectId: string, includeArchived: boolean): Promise<KanbanTicket[]>
   create(projectId: string, data: KanbanTicketCreate): Promise<KanbanTicket>
+  duplicate(
+    projectId: string,
+    ticketId: string,
+    overrides?: KanbanTicketDuplicateOverrides
+  ): Promise<KanbanTicket>
   createBatch(
     projectId: string,
     data: KanbanTicketBatchCreate
@@ -242,6 +248,25 @@ class InternalKanbanBackend implements KanbanBackend {
   async create(projectId: string, data: KanbanTicketCreate): Promise<KanbanTicket> {
     assertProjectPayload(projectId, data.project_id)
     return getDatabase().createKanbanTicket({ ...data, project_id: projectId })
+  }
+
+  async duplicate(
+    projectId: string,
+    ticketId: string,
+    overrides?: KanbanTicketDuplicateOverrides
+  ): Promise<KanbanTicket> {
+    const source = await this.get(projectId, ticketId)
+    if (!source) throw new Error('Ticket does not exist')
+    return getDatabase().createKanbanTicket({
+      title: source.title,
+      description: source.description,
+      attachments: source.attachments,
+      mark: source.mark,
+      note: source.note,
+      ...overrides,
+      project_id: projectId,
+      column: overrides?.column ?? source.column
+    })
   }
 
   async createBatch(
@@ -547,6 +572,25 @@ class MarkdownKanbanBackend implements KanbanBackend {
     const ticket = await this.get(projectId, id)
     if (!ticket) throw new Error('Created markdown ticket could not be loaded')
     return ticket
+  }
+
+  async duplicate(
+    projectId: string,
+    ticketId: string,
+    overrides?: KanbanTicketDuplicateOverrides
+  ): Promise<KanbanTicket> {
+    const card = await this.requireMutableCard(projectId, ticketId)
+    const source = card.ticket
+    return this.create(projectId, {
+      title: source.title,
+      description: source.description,
+      attachments: source.attachments,
+      mark: source.mark,
+      note: source.note,
+      ...overrides,
+      project_id: projectId,
+      column: overrides?.column ?? source.column
+    })
   }
 
   async createBatch(

--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -120,6 +120,10 @@ interface MarkdownRuntimeState {
   auto_approve_plan: boolean
   total_tokens: number
   pending_launch_config: string | null
+  model_provider_id: string | null
+  model_id: string | null
+  model_variant: string | null
+  variant_group_id: string | null
   updated_at: string | null
 }
 
@@ -145,6 +149,10 @@ function emptyRuntimeState(): MarkdownRuntimeState {
     auto_approve_plan: false,
     total_tokens: 0,
     pending_launch_config: null,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
     updated_at: null
   }
 }
@@ -526,7 +534,12 @@ class MarkdownKanbanBackend implements KanbanBackend {
         attachments: data.attachments ?? [],
         current_session_id: data.current_session_id ?? null,
         worktree_id: data.worktree_id ?? null,
-        plan_ready: data.plan_ready ?? false
+        plan_ready: data.plan_ready ?? false,
+        note: data.note ?? null,
+        model_provider_id: data.model_provider_id ?? null,
+        model_id: data.model_id ?? null,
+        model_variant: data.model_variant ?? null,
+        variant_group_id: data.variant_group_id ?? null
       },
       false
     )
@@ -697,6 +710,12 @@ class MarkdownKanbanBackend implements KanbanBackend {
     if (data.pending_launch_config !== undefined)
       runtimeUpdates.pending_launch_config = data.pending_launch_config
     if (data.note !== undefined) runtimeUpdates.note = data.note
+    if (data.model_provider_id !== undefined)
+      runtimeUpdates.model_provider_id = data.model_provider_id
+    if (data.model_id !== undefined) runtimeUpdates.model_id = data.model_id
+    if (data.model_variant !== undefined) runtimeUpdates.model_variant = data.model_variant
+    if (data.variant_group_id !== undefined)
+      runtimeUpdates.variant_group_id = data.variant_group_id
 
     if (Object.keys(publicUpdates).length > 0 || body !== undefined) {
       let touchedPaths: string[]
@@ -1485,7 +1504,11 @@ class MarkdownKanbanBackend implements KanbanBackend {
       goal_mode: asBoolean(frontmatter.goal_mode) ?? false,
       goal_success_criteria: nullableString(frontmatter.goal_success_criteria),
       note: runtime.note,
-      auto_approve_plan: runtime.auto_approve_plan
+      auto_approve_plan: runtime.auto_approve_plan,
+      model_provider_id: runtime.model_provider_id,
+      model_id: runtime.model_id,
+      model_variant: runtime.model_variant,
+      variant_group_id: runtime.variant_group_id
     }
 
     return { ticket, filePath, frontmatter }
@@ -1503,6 +1526,10 @@ class MarkdownKanbanBackend implements KanbanBackend {
       total_tokens: runtime.total_tokens,
       pending_launch_config: runtime.pending_launch_config,
       note: runtime.note,
+      model_provider_id: runtime.model_provider_id,
+      model_id: runtime.model_id,
+      model_variant: runtime.model_variant,
+      variant_group_id: runtime.variant_group_id,
       updated_at: laterIso(card.ticket.updated_at, runtime.updated_at ?? card.ticket.created_at)
     }
     this.markRuntimeSeen(projectId, card.ticket.id, card.filePath)
@@ -1599,6 +1626,10 @@ class MarkdownKanbanBackend implements KanbanBackend {
           auto_approve_plan: number
           total_tokens: number
           pending_launch_config: string | null
+          model_provider_id: string | null
+          model_id: string | null
+          model_variant: string | null
+          variant_group_id: string | null
           updated_at: string | null
         }
       | undefined
@@ -1614,6 +1645,10 @@ class MarkdownKanbanBackend implements KanbanBackend {
       auto_approve_plan: row.auto_approve_plan === 1,
       total_tokens: row.total_tokens ?? 0,
       pending_launch_config: row.pending_launch_config,
+      model_provider_id: row.model_provider_id,
+      model_id: row.model_id,
+      model_variant: row.model_variant,
+      variant_group_id: row.variant_group_id,
       updated_at: row.updated_at
     }
   }
@@ -1666,6 +1701,22 @@ class MarkdownKanbanBackend implements KanbanBackend {
     if (data.pending_launch_config !== undefined) {
       updates.push('pending_launch_config = ?')
       values.push(data.pending_launch_config)
+    }
+    if (data.model_provider_id !== undefined) {
+      updates.push('model_provider_id = ?')
+      values.push(data.model_provider_id)
+    }
+    if (data.model_id !== undefined) {
+      updates.push('model_id = ?')
+      values.push(data.model_id)
+    }
+    if (data.model_variant !== undefined) {
+      updates.push('model_variant = ?')
+      values.push(data.model_variant)
+    }
+    if (data.variant_group_id !== undefined) {
+      updates.push('variant_group_id = ?')
+      values.push(data.variant_group_id)
     }
     if (!preserveUpdatedAt) {
       updates.push('updated_at = ?')

--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -660,7 +660,12 @@ class MarkdownKanbanBackend implements KanbanBackend {
           attachments: draft.attachments ?? [],
           current_session_id: draft.current_session_id ?? null,
           worktree_id: draft.worktree_id ?? null,
-          plan_ready: draft.plan_ready ?? false
+          plan_ready: draft.plan_ready ?? false,
+          note: draft.note ?? null,
+          model_provider_id: draft.model_provider_id ?? null,
+          model_id: draft.model_id ?? null,
+          model_variant: draft.model_variant ?? null,
+          variant_group_id: draft.variant_group_id ?? null
         }
       })
     }

--- a/src/renderer/src/api/__tests__/kanban-api.test.ts
+++ b/src/renderer/src/api/__tests__/kanban-api.test.ts
@@ -110,6 +110,64 @@ describe('kanbanApi', () => {
     expect(request).toHaveBeenCalledWith('kanban.ticket.create', data)
   })
 
+  it('routes ticket.duplicate through the renderer RPC client', async () => {
+    const ticket = {
+      id: 'ticket-2',
+      project_id: 'project-1',
+      title: 'Fix the board',
+      column: 'in_progress',
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-6',
+      model_variant: 'thinking',
+      variant_group_id: 'group-1'
+    }
+    const request = vi.fn().mockResolvedValue(ticket)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    const overrides = {
+      column: 'in_progress',
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-6',
+      model_variant: 'thinking',
+      variant_group_id: 'group-1'
+    }
+    await expect(
+      kanbanApi.ticket.duplicate<typeof ticket, typeof overrides>(
+        'project-1',
+        'ticket-1',
+        overrides
+      )
+    ).resolves.toEqual(ticket)
+    expect(request).toHaveBeenCalledWith('kanban.ticket.duplicate', {
+      projectId: 'project-1',
+      id: 'ticket-1',
+      overrides
+    })
+  })
+
+  it('routes ticket.duplicate without overrides through the renderer RPC client', async () => {
+    const ticket = {
+      id: 'ticket-2',
+      project_id: 'project-1',
+      title: 'Fix the board',
+      column: 'todo'
+    }
+    const request = vi.fn().mockResolvedValue(ticket)
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await expect(
+      kanbanApi.ticket.duplicate<typeof ticket, Record<string, never>>('project-1', 'ticket-1')
+    ).resolves.toEqual(ticket)
+    expect(request).toHaveBeenCalledWith('kanban.ticket.duplicate', {
+      projectId: 'project-1',
+      id: 'ticket-1'
+    })
+  })
+
   it('routes ticket.createBatch through the renderer RPC client', async () => {
     const result = {
       tickets: [{ id: 'ticket-1', project_id: 'project-1', title: 'Draft ticket' }],

--- a/src/renderer/src/api/kanban-api.ts
+++ b/src/renderer/src/api/kanban-api.ts
@@ -43,6 +43,16 @@ export const kanbanApi = {
       data: TData
     ): Promise<TResult> =>
       getRendererRpcClient().request<TResult>('kanban.ticket.create', data),
+    duplicate: async <TResult, TOverrides extends object>(
+      projectId: string,
+      id: string,
+      overrides?: TOverrides
+    ): Promise<TResult> =>
+      getRendererRpcClient().request<TResult>('kanban.ticket.duplicate', {
+        projectId,
+        id,
+        ...(overrides === undefined ? {} : { overrides })
+      }),
     createBatch: async <TResult, TData extends object>(
       projectId: string,
       data: TData

--- a/src/renderer/src/components/kanban/KanbanTicketCard.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { KanbanTicketCard } from './KanbanTicketCard'
+import type { KanbanTicket } from '../../../../main/db/types'
+
+const now = '2026-01-01T00:00:00.000Z'
+
+const baseTicket: KanbanTicket = {
+  id: 'ticket-1',
+  project_id: 'project-1',
+  title: 'Fix the thing',
+  description: null,
+  attachments: [],
+  column: 'todo',
+  sort_order: 0,
+  current_session_id: null,
+  worktree_id: null,
+  mode: null,
+  plan_ready: false,
+  created_at: now,
+  updated_at: now,
+  archived_at: null,
+  external_provider: null,
+  external_id: null,
+  external_url: null,
+  github_pr_number: null,
+  github_pr_url: null,
+  mark: null,
+  total_tokens: 0,
+  pending_launch_config: null,
+  goal_mode: false,
+  goal_success_criteria: null,
+  note: null,
+  created_from_session: false,
+  auto_approve_plan: false,
+  model_provider_id: null,
+  model_id: null,
+  model_variant: null,
+  variant_group_id: null
+}
+
+describe('KanbanTicketCard model badge', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the model badge when the ticket has model fields, even with no other badges', () => {
+    const ticket: KanbanTicket = {
+      ...baseTicket,
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-5-20251101',
+      model_variant: null
+    }
+
+    render(<KanbanTicketCard ticket={ticket} />)
+
+    expect(screen.getByText('claude-opus-4-5-20251101')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Claude' })).toBeInTheDocument()
+  })
+
+  it('does not render a model badge when the ticket has no model_id', () => {
+    render(<KanbanTicketCard ticket={baseTicket} />)
+
+    expect(screen.queryByRole('img', { name: 'Claude' })).toBeNull()
+    expect(screen.queryByRole('img', { name: 'OpenAI' })).toBeNull()
+  })
+})

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -33,6 +33,7 @@ import {
   FastForward
 } from 'lucide-react'
 import { CheckeredFlagIcon } from './CheckeredFlagIcon'
+import { TicketModelBadge } from './TicketModelBadge'
 import { UpdateStatusModal } from './UpdateStatusModal'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
@@ -974,7 +975,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || blockingDiagnostic || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode || ticket.auto_approve_plan) && (
+            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || blockingDiagnostic || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode || ticket.auto_approve_plan || ticket.model_id) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
@@ -1030,6 +1031,9 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                     </TooltipContent>
                   </Tooltip>
                 )}
+
+                {/* Model badge */}
+                <TicketModelBadge ticket={ticket} />
 
                 {/* Project tag (connection mode) or worktree name badge */}
                 {projectTag ? (

--- a/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
@@ -233,7 +233,11 @@ const ticket: KanbanTicket = {
   goal_success_criteria: null,
   note: null,
   created_from_session: false,
-  auto_approve_plan: false
+  auto_approve_plan: false,
+  model_provider_id: null,
+  model_id: null,
+  model_variant: null,
+  variant_group_id: null
 }
 
 const worktree: Worktree = {

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -72,6 +72,7 @@ import {
   type TicketRunScriptState
 } from '@/hooks/useTicketRunScript'
 import { TicketRunButton } from './TicketRunButton'
+import { TicketModelBadge } from './TicketModelBadge'
 import { useQuestionStore, type QuestionRequest } from '@/stores/useQuestionStore'
 import { QuestionPrompt } from '@/components/sessions/QuestionPrompt'
 import { FollowupInput } from './FollowupInput'
@@ -1208,9 +1209,12 @@ function KanbanTicketModalContent({
             {/* Shared ticket context header for non-edit modes */}
             {modalMode !== 'edit' && (
               <div className="space-y-2 pb-3 border-b border-border/40">
-                <h2 className="text-base font-semibold text-foreground leading-tight">
-                  {ticket.title}
-                </h2>
+                <div className="flex items-center gap-2">
+                  <h2 className="text-base font-semibold text-foreground leading-tight min-w-0 flex-1">
+                    {ticket.title}
+                  </h2>
+                  <TicketModelBadge ticket={ticket} className="shrink-0" />
+                </div>
                 {ticket.description && (
                   <div className="prose prose-sm dark:prose-invert max-w-none text-sm text-muted-foreground max-h-[120px] overflow-y-auto">
                     <MarkdownRenderer content={ticket.description} />
@@ -1426,6 +1430,7 @@ function EditModeContent({
                 <ProviderIcon provider={ticket.external_provider} />
               </button>
             )}
+            <TicketModelBadge ticket={ticket} />
           </div>
           <JumpToSessionButton ticket={ticket} onClose={onClose} />
         </div>

--- a/src/renderer/src/components/kanban/TicketModelBadge.test.tsx
+++ b/src/renderer/src/components/kanban/TicketModelBadge.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TicketModelBadge } from './TicketModelBadge'
+import { cacheHandoffModelCatalog, clearHandoffModelCatalogCache } from '@/lib/handoffSelection'
+
+describe('TicketModelBadge', () => {
+  afterEach(() => {
+    clearHandoffModelCatalogCache()
+    vi.restoreAllMocks()
+  })
+
+  it('renders nothing when the ticket has no model_id', () => {
+    const { container } = render(
+      <TicketModelBadge
+        ticket={{ model_provider_id: null, model_id: null, model_variant: null }}
+      />
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the raw model_id as a fallback display name when the catalog has no match', () => {
+    render(
+      <TicketModelBadge
+        ticket={{
+          model_provider_id: 'anthropic',
+          model_id: 'claude-opus-4-5-20251101',
+          model_variant: null
+        }}
+      />
+    )
+
+    expect(screen.getByText('claude-opus-4-5-20251101')).toBeInTheDocument()
+  })
+
+  it('renders the provider icon for a recognized provider', () => {
+    render(
+      <TicketModelBadge
+        ticket={{
+          model_provider_id: 'anthropic',
+          model_id: 'claude-opus-4-5-20251101',
+          model_variant: null
+        }}
+      />
+    )
+
+    expect(screen.getByRole('img', { name: 'Claude' })).toBeInTheDocument()
+  })
+
+  it('omits the icon for an unrecognized provider/modelId', () => {
+    render(
+      <TicketModelBadge
+        ticket={{
+          model_provider_id: 'some-unknown-provider',
+          model_id: 'mystery-model',
+          model_variant: null
+        }}
+      />
+    )
+
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+
+  it('puts the variant in the title tooltip, not the visible text', () => {
+    render(
+      <TicketModelBadge
+        ticket={{
+          model_provider_id: 'anthropic',
+          model_id: 'opus',
+          model_variant: 'high'
+        }}
+      />
+    )
+
+    const badge = screen.getByTitle('opus (high)')
+    expect(badge).toBeInTheDocument()
+    expect(badge.textContent).not.toContain('high')
+  })
+
+  it('uses the pretty display name from the cached model catalog when there is a hit', () => {
+    cacheHandoffModelCatalog('claude-code', {
+      providers: [
+        {
+          id: 'anthropic',
+          name: 'Anthropic',
+          models: {
+            opus: { id: 'opus', name: 'Claude Opus 4.5' }
+          }
+        }
+      ]
+    })
+
+    render(
+      <TicketModelBadge
+        ticket={{
+          model_provider_id: 'anthropic',
+          model_id: 'opus',
+          model_variant: null
+        }}
+      />
+    )
+
+    expect(screen.getByText('Claude Opus 4.5')).toBeInTheDocument()
+    expect(screen.getByTitle('Claude Opus 4.5')).toBeInTheDocument()
+  })
+
+  it('applies the passed className to the chip', () => {
+    render(
+      <TicketModelBadge
+        ticket={{ model_provider_id: 'anthropic', model_id: 'opus', model_variant: null }}
+        className="custom-class"
+      />
+    )
+
+    expect(screen.getByText('opus').closest('span')).toHaveClass('custom-class')
+  })
+})

--- a/src/renderer/src/components/kanban/TicketModelBadge.tsx
+++ b/src/renderer/src/components/kanban/TicketModelBadge.tsx
@@ -1,0 +1,49 @@
+import { resolveModelIconAsset } from '@/components/worktrees/ModelIcon'
+import { getAvailableHandoffAgentSdks, getCachedModelCatalog } from '@/lib/handoffSelection'
+import { findModelInfo, getModelDisplayName } from '@/lib/parseProviders'
+import { cn } from '@/lib/utils'
+import type { KanbanTicket } from '../../../../main/db/types'
+
+/** Looks up the pretty model name from any cached handoff SDK catalog, falling back to the raw modelId. */
+function resolveModelDisplayName(providerId: string | null, modelId: string): string {
+  if (providerId) {
+    for (const sdk of getAvailableHandoffAgentSdks()) {
+      const catalog = getCachedModelCatalog(sdk)
+      if (!catalog) continue
+      const modelInfo = findModelInfo(catalog, providerId, modelId)
+      if (modelInfo) return getModelDisplayName(modelInfo)
+    }
+  }
+
+  return modelId
+}
+
+interface TicketModelBadgeProps {
+  ticket: Pick<KanbanTicket, 'model_provider_id' | 'model_id' | 'model_variant'>
+  className?: string
+}
+
+export function TicketModelBadge({
+  ticket,
+  className
+}: TicketModelBadgeProps): React.JSX.Element | null {
+  const { model_provider_id: providerId, model_id: modelId, model_variant: variant } = ticket
+  if (!modelId) return null
+
+  const icon = resolveModelIconAsset(providerId, modelId)
+  const displayName = resolveModelDisplayName(providerId, modelId)
+  const title = variant ? `${displayName} (${variant})` : displayName
+
+  return (
+    <span
+      title={title}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground',
+        className
+      )}
+    >
+      {icon && <img src={icon.src} alt={icon.alt} className="h-3 w-3 shrink-0" draggable={false} />}
+      {displayName}
+    </span>
+  )
+}

--- a/src/renderer/src/components/kanban/TicketModelBadge.tsx
+++ b/src/renderer/src/components/kanban/TicketModelBadge.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { resolveModelIconAsset } from '@/components/worktrees/ModelIcon'
 import { getAvailableHandoffAgentSdks, getCachedModelCatalog } from '@/lib/handoffSelection'
 import { findModelInfo, getModelDisplayName } from '@/lib/parseProviders'
@@ -29,15 +28,10 @@ export function TicketModelBadge({
   className
 }: TicketModelBadgeProps): React.JSX.Element | null {
   const { model_provider_id: providerId, model_id: modelId, model_variant: variant } = ticket
-  // modelId falls back to '' when absent so the hook can run unconditionally (rules of hooks);
-  // the result is discarded by the early return below in that case.
-  const displayName = useMemo(
-    () => resolveModelDisplayName(providerId, modelId ?? ''),
-    [providerId, modelId]
-  )
   if (!modelId) return null
 
   const icon = resolveModelIconAsset(providerId, modelId)
+  const displayName = resolveModelDisplayName(providerId, modelId)
   const title = variant ? `${displayName} (${variant})` : displayName
 
   return (

--- a/src/renderer/src/components/kanban/TicketModelBadge.tsx
+++ b/src/renderer/src/components/kanban/TicketModelBadge.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { resolveModelIconAsset } from '@/components/worktrees/ModelIcon'
 import { getAvailableHandoffAgentSdks, getCachedModelCatalog } from '@/lib/handoffSelection'
 import { findModelInfo, getModelDisplayName } from '@/lib/parseProviders'
@@ -28,10 +29,15 @@ export function TicketModelBadge({
   className
 }: TicketModelBadgeProps): React.JSX.Element | null {
   const { model_provider_id: providerId, model_id: modelId, model_variant: variant } = ticket
+  // modelId falls back to '' when absent so the hook can run unconditionally (rules of hooks);
+  // the result is discarded by the early return below in that case.
+  const displayName = useMemo(
+    () => resolveModelDisplayName(providerId, modelId ?? ''),
+    [providerId, modelId]
+  )
   if (!modelId) return null
 
   const icon = resolveModelIconAsset(providerId, modelId)
-  const displayName = resolveModelDisplayName(providerId, modelId)
   const title = variant ? `${displayName} (${variant})` : displayName
 
   return (

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -459,7 +459,11 @@ describe('WorktreePickerModal Claude CLI launch', () => {
       sort_order: 1,
       plan_ready: false,
       goal_mode: false,
-      goal_success_criteria: null
+      goal_success_criteria: null,
+      // Badge fields are now stamped on every launch (connection path included).
+      model_provider_id: 'anthropic',
+      model_id: 'opus',
+      model_variant: 'high'
     })
     expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', {
       sessionId: 'connection-session-1',

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -122,6 +122,10 @@ const baseTicket: KanbanTicket = {
   mark: null,
   note: null,
   total_tokens: 0,
+  model_provider_id: null,
+  model_id: null,
+  model_variant: null,
+  variant_group_id: null,
   created_at: '2026-01-01T00:00:00.000Z',
   updated_at: '2026-01-01T00:00:00.000Z'
 }

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -466,7 +466,10 @@ describe('WorktreePickerModal Claude CLI launch', () => {
       model_variant: 'high',
       // A single-model (re)launch clears any stale variant_group_id from a
       // prior failed multi-launch of this ticket.
-      variant_group_id: null
+      variant_group_id: null,
+      // Clears a stale Save & Queue config so a manually-launched queued
+      // ticket can't be auto-launched again later (connection path included).
+      pending_launch_config: null
     })
     expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', {
       sessionId: 'connection-session-1',

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -463,7 +463,10 @@ describe('WorktreePickerModal Claude CLI launch', () => {
       // Badge fields are now stamped on every launch (connection path included).
       model_provider_id: 'anthropic',
       model_id: 'opus',
-      model_variant: 'high'
+      model_variant: 'high',
+      // A single-model (re)launch clears any stale variant_group_id from a
+      // prior failed multi-launch of this ticket.
+      variant_group_id: null
     })
     expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', {
       sessionId: 'connection-session-1',

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -477,6 +477,87 @@ describe('WorktreePickerModal Claude CLI launch', () => {
     })
   })
 
+  it('stamps the connection-ticket badge from the session row when it differs from the picked model (round 4)', async () => {
+    const { updateTicket } = setupStores()
+    // createConnectionSession resolves the ACTUAL model via its own chain —
+    // when the returned session row carries model fields, they must win over
+    // the modal's independently computed selected/auto/fallback chain.
+    const createConnectionSession = vi.fn(
+      async (
+        connectionId: string,
+        sdk: TestAgentSdk = 'opencode',
+        mode: TestSessionMode = 'build'
+      ) => ({
+        success: true,
+        session: makeSession({
+          id: 'connection-session-1',
+          worktree_id: null,
+          connection_id: connectionId,
+          agent_sdk: sdk,
+          mode: mode === 'super-plan' ? 'plan' : mode,
+          model_provider_id: 'openai',
+          model_id: 'session-truth-model',
+          model_variant: null
+        })
+      })
+    )
+    useSessionStore.setState({ createConnectionSession })
+    await renderAndSelectClaudeCliForConnection()
+
+    await userEvent.click(screen.getByTestId('model-selector-pick-opus'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(updateTicket).toHaveBeenCalledTimes(1))
+    expect(updateTicket).toHaveBeenCalledWith(
+      'ticket-1',
+      'project-1',
+      expect.objectContaining({
+        model_provider_id: 'openai',
+        model_id: 'session-truth-model',
+        model_variant: null
+      })
+    )
+  })
+
+  it('falls back to the picked model for the connection-ticket badge when the session row has no model fields', async () => {
+    const { updateTicket } = setupStores()
+    const createConnectionSession = vi.fn(
+      async (
+        connectionId: string,
+        sdk: TestAgentSdk = 'opencode',
+        mode: TestSessionMode = 'build'
+      ) => ({
+        success: true,
+        session: makeSession({
+          id: 'connection-session-1',
+          worktree_id: null,
+          connection_id: connectionId,
+          agent_sdk: sdk,
+          mode: mode === 'super-plan' ? 'plan' : mode,
+          model_provider_id: null,
+          model_id: null,
+          model_variant: null
+        })
+      })
+    )
+    useSessionStore.setState({ createConnectionSession })
+    await renderAndSelectClaudeCliForConnection()
+
+    await userEvent.click(screen.getByTestId('model-selector-pick-opus'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(updateTicket).toHaveBeenCalledTimes(1))
+    expect(updateTicket).toHaveBeenCalledWith(
+      'ticket-1',
+      'project-1',
+      expect.objectContaining({
+        model_provider_id: 'anthropic',
+        model_id: 'opus',
+        model_variant: 'high'
+      })
+    )
+  })
+
   it('omits the synthetic plan prefix for Claude CLI plan launches', async () => {
     await renderAndSelectClaudeCli()
 

--- a/src/renderer/src/components/kanban/WorktreePickerModal.goal-plan-file.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.goal-plan-file.test.tsx
@@ -102,6 +102,10 @@ function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
     mark: null,
     note: null,
     total_tokens: 0,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
     created_at: '2026-01-01T00:00:00.000Z',
     updated_at: '2026-01-01T00:00:00.000Z',
     ...overrides

--- a/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
@@ -520,7 +520,10 @@ describe('WorktreePickerModal multi-model UI', () => {
         model_variant: 'high',
         // Single-model launches must clear any stale variant_group_id from a
         // prior failed multi-launch of this ticket.
-        variant_group_id: null
+        variant_group_id: null,
+        // Clears a stale Save & Queue config so a manually-launched queued
+        // ticket can't be auto-launched again later.
+        pending_launch_config: null
       })
     )
     expect(runMultiModelLaunch).not.toHaveBeenCalled()

--- a/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
@@ -529,7 +529,57 @@ describe('WorktreePickerModal multi-model UI', () => {
     expect(typeof update.pending_launch_config).toBe('string')
   })
 
+  it('stamps the badge from the session row when it differs from the picked model — the session is what actually runs (round 4)', async () => {
+    const { updateTicket } = setupStores()
+    // createSession resolves the ACTUAL model through its own chain (it can
+    // pick the first cached catalog entry) — when the returned session row
+    // carries model fields, they must win over the modal's independently
+    // computed selected/auto/fallback chain.
+    const createSession = vi.fn(
+      async (
+        worktreeId: string,
+        projectId: string,
+        sdk: TestAgentSdk = 'opencode',
+        mode: TestSessionMode = 'build'
+      ) => ({
+        success: true,
+        session: makeSession({
+          worktree_id: worktreeId,
+          project_id: projectId,
+          agent_sdk: sdk,
+          mode: mode === 'super-plan' ? 'plan' : mode,
+          model_provider_id: 'openai',
+          model_id: 'session-truth-model',
+          model_variant: null
+        })
+      })
+    )
+    useSessionStore.setState({ createSession })
+    await renderModal()
+
+    await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+    await userEvent.click(screen.getByTestId('pick-model-claude-code-cli'))
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', expect.any(Object))
+    )
+    expect(updateTicket).toHaveBeenCalledWith(
+      'ticket-1',
+      'project-1',
+      expect.objectContaining({
+        model_provider_id: 'openai',
+        model_id: 'session-truth-model',
+        model_variant: null
+      })
+    )
+  })
+
   it('stamps model badge fields on the single-model launch update', async () => {
+    // The default mocked session row carries NO model fields — this is the
+    // fallback case: the badge comes from the picked model (then the per-SDK
+    // resolution / hard-fallback chain).
     const { updateTicket } = setupStores()
     await renderModal()
 

--- a/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
@@ -498,6 +498,37 @@ describe('WorktreePickerModal multi-model UI', () => {
     expect(parsed.models[1].model).toEqual(FALLBACK_MODELS.codex)
   })
 
+  it('clears stale badge/group fields in saveConfigOnly mode — badge means "what launched", so a queued-not-yet-launched ticket must have none (round 3)', async () => {
+    const { updateTicket } = setupStores()
+    // The ticket carries badge fields from a PREVIOUS launch (backward-drag
+    // doesn't clear them). Save & Queue must null them — auto-launch stamps
+    // the fresh ones at launch time.
+    const staleTicket: KanbanTicket = {
+      ...baseTicket,
+      model_provider_id: 'anthropic',
+      model_id: 'stale-model',
+      model_variant: 'high',
+      variant_group_id: 'stale-group'
+    }
+    useKanbanStore.setState({ tickets: new Map([['project-1', [staleTicket]]]) })
+    await renderModal({ saveConfigOnly: true, ticket: staleTicket })
+
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(updateTicket).toHaveBeenCalledTimes(1))
+    const update = updateTicket.mock.calls[0][2] as Record<string, unknown>
+    expect(update).toEqual(
+      expect.objectContaining({
+        model_provider_id: null,
+        model_id: null,
+        model_variant: null,
+        variant_group_id: null
+      })
+    )
+    // The queued config itself is still written.
+    expect(typeof update.pending_launch_config).toBe('string')
+  })
+
   it('stamps model badge fields on the single-model launch update', async () => {
     const { updateTicket } = setupStores()
     await renderModal()

--- a/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
@@ -1,0 +1,508 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorktreePickerModal, _resetLastSourceBranch } from './WorktreePickerModal'
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { PLAN_MODE_PREFIX } from '@/lib/constants'
+import { runMultiModelLaunch } from '@/lib/multi-model-launch'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useUsageStore } from '@/stores/useUsageStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket, Session } from '../../../../main/db/types'
+
+vi.mock('@/lib/multi-model-launch', () => ({
+  runMultiModelLaunch: vi.fn()
+}))
+
+vi.mock('@/api/hive-enterprise/client', () => ({
+  isHiveTelemetryEnabled: vi.fn(() => false),
+  recordHivePromptStart: vi.fn(),
+  recordHivePromptIdle: vi.fn(),
+  recordHiveQuestionsAnswered: vi.fn()
+}))
+
+// Minimal ModelSelector: exposes the SDK override it was handed and a pick
+// button so tests can set an explicit model per row.
+vi.mock('@/components/sessions/ModelSelector', () => ({
+  ModelSelector: ({
+    value,
+    onChange,
+    agentSdkOverride
+  }: {
+    value?: { modelID?: string } | null
+    onChange?: (model: {
+      agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex'
+      providerID: string
+      modelID: string
+      variant?: string
+    }) => void
+    agentSdkOverride?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex'
+  }) => (
+    <div data-testid={`model-selector-${agentSdkOverride ?? 'none'}`}>
+      <span data-testid={`model-value-${agentSdkOverride ?? 'none'}`}>
+        {value?.modelID ?? 'null'}
+      </span>
+      <button
+        type="button"
+        data-testid={`pick-model-${agentSdkOverride ?? 'none'}`}
+        onClick={() =>
+          onChange?.({
+            agentSdk: agentSdkOverride,
+            providerID: 'anthropic',
+            modelID: 'picked-model',
+            variant: 'high'
+          })
+        }
+      >
+        pick
+      </button>
+    </div>
+  )
+}))
+
+vi.mock('@/components/sessions/CodexFastToggle', () => ({
+  CodexFastToggle: () => <div data-testid="codex-fast-toggle" />
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}))
+
+vi.mock('@/api/settings-api', () => ({
+  settingsApi: {
+    detectEditors: vi.fn(),
+    detectTerminals: vi.fn(),
+    loadCustomCommandsFile: vi.fn().mockResolvedValue({ commands: [] }),
+    onSettingsUpdated: vi.fn(() => vi.fn()),
+    openWithTerminal: vi.fn()
+  }
+}))
+
+vi.mock('@/api/pet-api', () => ({
+  petApi: {
+    updateSettings: vi.fn().mockResolvedValue({
+      success: true,
+      value: { enabled: true, size: 'md', position: { x: 0, y: 0 }, hatched: true }
+    })
+  }
+}))
+
+const initialSettingsState = useSettingsStore.getState()
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+const initialConnectionState = useConnectionStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialUsageState = useUsageStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
+
+type TestAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+type TestSessionMode = 'build' | 'plan' | 'super-plan'
+
+const baseTicket: KanbanTicket = {
+  id: 'ticket-1',
+  project_id: 'project-1',
+  title: 'Multi model ticket',
+  description: 'Ship the multi-model launcher',
+  column: 'todo',
+  sort_order: 0,
+  worktree_id: null,
+  current_session_id: null,
+  mode: 'build',
+  plan_ready: false,
+  goal_mode: false,
+  goal_success_criteria: null,
+  pending_launch_config: null,
+  created_from_session: false,
+  auto_approve_plan: false,
+  attachments: [],
+  archived_at: null,
+  external_provider: null,
+  external_id: null,
+  external_url: null,
+  github_pr_number: null,
+  github_pr_url: null,
+  mark: null,
+  note: null,
+  total_tokens: 0,
+  model_provider_id: null,
+  model_id: null,
+  model_variant: null,
+  variant_group_id: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z'
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    pinned_to_board: false,
+    ...overrides
+  }
+}
+
+function setupStores(): { updateTicket: ReturnType<typeof vi.fn> } {
+  const createSession = vi.fn(
+    async (
+      worktreeId: string,
+      projectId: string,
+      sdk: TestAgentSdk = 'opencode',
+      mode: TestSessionMode = 'build'
+    ) => ({
+      success: true,
+      session: makeSession({
+        worktree_id: worktreeId,
+        project_id: projectId,
+        agent_sdk: sdk,
+        mode: mode === 'super-plan' ? 'plan' : mode
+      })
+    })
+  )
+  const updateTicket = vi.fn(async () => undefined)
+
+  useSettingsStore.setState({
+    availableAgentSdks: { opencode: true, claude: true, codex: true },
+    defaultAgentSdk: 'opencode',
+    selectedModel: null,
+    selectedModelByProvider: {},
+    defaultModels: null,
+    codexFastMode: false,
+    codexFastModeAccepted: true,
+    boardMode: 'toggle'
+  })
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '/repo',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        worktree_create_script: null,
+        custom_commands: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        last_accessed_at: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([
+      [
+        'project-1',
+        [
+          {
+            id: 'worktree-1',
+            project_id: 'project-1',
+            name: 'Feature',
+            branch_name: 'feature',
+            path: '/repo/feature',
+            status: 'active',
+            is_default: false,
+            branch_renamed: 0,
+            last_message_at: null,
+            session_titles: '[]',
+            last_model_provider_id: null,
+            last_model_id: null,
+            last_model_variant: null,
+            attachments: '[]',
+            created_at: '2026-01-01T00:00:00.000Z',
+            last_accessed_at: '2026-01-01T00:00:00.000Z',
+            github_pr_number: null,
+            github_pr_url: null
+          }
+        ]
+      ]
+    ]),
+    worktreeOrderByProject: new Map(),
+    syncWorktrees: vi.fn(),
+    createWorktreeFromBranch: vi.fn()
+  })
+  useConnectionStore.setState({
+    connections: [
+      {
+        id: 'connection-1',
+        name: 'Feature connection',
+        custom_name: null,
+        status: 'active',
+        path: '/repo/connection',
+        color: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        members: []
+      }
+    ],
+    loaded: true
+  })
+  useKanbanStore.setState({
+    tickets: new Map([['project-1', [baseTicket]]]),
+    updateTicket,
+    computeSortOrder: vi.fn(() => 1),
+    getTicketsByColumn: vi.fn(() => []),
+    getTicketsByColumnForConnection: vi.fn(() => [])
+  })
+  useSessionStore.setState({
+    sessionsByWorktree: new Map(),
+    sessionsByConnection: new Map(),
+    modeBySession: new Map(),
+    createSession,
+    createConnectionSession: vi.fn(),
+    setSessionModel: vi.fn(async () => undefined),
+    setSessionMode: vi.fn(async () => undefined),
+    setOpenCodeSessionId: vi.fn(),
+    setActiveSession: vi.fn(),
+    dequeuePendingMessage: vi.fn()
+  })
+  useWorktreeStatusStore.setState({
+    setSessionStatus: vi.fn(),
+    setLastMessageTime: vi.fn()
+  })
+  useUsageStore.setState({ fetchUsageForProvider: vi.fn() })
+
+  return { updateTicket }
+}
+
+function renderModal(props: Partial<React.ComponentProps<typeof WorktreePickerModal>> = {}): void {
+  render(
+    <WorktreePickerModal
+      ticket={baseTicket}
+      projectId="project-1"
+      open
+      onOpenChange={vi.fn()}
+      onSendComplete={vi.fn()}
+      {...props}
+    />
+  )
+}
+
+describe('WorktreePickerModal multi-model UI', () => {
+  let request: ReturnType<typeof vi.fn>
+
+  beforeAll(async () => {
+    // Absorb useSettingsStore's one-shot 200ms import timer (nulls
+    // availableAgentSdks under the mocked RPC client) before any test renders.
+    const bootRequest: ReturnType<typeof vi.fn> = vi.fn(async () => null)
+    setRendererRpcClient({ request: bootRequest, subscribe: vi.fn() })
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    resetRendererRpcClientForTests()
+  })
+
+  beforeEach(() => {
+    _resetLastSourceBranch()
+    vi.clearAllMocks()
+    resetRendererRpcClientForTests()
+    request = vi.fn(async (method: string) => {
+      if (method === 'terminalOps.createClaudeCli') return { success: true }
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    setupStores()
+    // Never resolves — proves the modal closes without awaiting the orchestrator.
+    vi.mocked(runMultiModelLaunch).mockImplementation(() => new Promise<void>(() => {}))
+  })
+
+  afterEach(() => {
+    cleanup()
+    useSettingsStore.setState(initialSettingsState, true)
+    useSessionStore.setState(initialSessionState, true)
+    useWorktreeStore.setState(initialWorktreeState, true)
+    useConnectionStore.setState(initialConnectionState, true)
+    useKanbanStore.setState(initialKanbanState, true)
+    useProjectStore.setState(initialProjectState, true)
+    useUsageStore.setState(initialUsageState, true)
+    useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
+    resetRendererRpcClientForTests()
+  })
+
+  it('adds and removes model rows and updates the send button label', async () => {
+    renderModal()
+
+    expect(screen.getByTestId('wt-picker-send-btn')).toHaveTextContent('Send')
+    expect(screen.queryByTestId('extra-model-row-1')).toBeNull()
+
+    await userEvent.click(screen.getByTestId('add-model-row'))
+    expect(screen.getByTestId('extra-model-row-1')).toBeInTheDocument()
+    expect(screen.getByTestId('wt-picker-send-btn')).toHaveTextContent('Start 2 sessions')
+
+    await userEvent.click(screen.getByTestId('add-model-row'))
+    expect(screen.getByTestId('extra-model-row-2')).toBeInTheDocument()
+    expect(screen.getByTestId('wt-picker-send-btn')).toHaveTextContent('Start 3 sessions')
+
+    await userEvent.click(screen.getByTestId('extra-model-row-1-remove'))
+    expect(screen.getByTestId('wt-picker-send-btn')).toHaveTextContent('Start 2 sessions')
+
+    await userEvent.click(screen.getByTestId('extra-model-row-1-remove'))
+    expect(screen.queryByTestId('extra-model-row-1')).toBeNull()
+    expect(screen.getByTestId('wt-picker-send-btn')).toHaveTextContent('Send')
+  })
+
+  it('hides the rows for an existing worktree, connection mode, and pre-assign mode', async () => {
+    renderModal()
+    await userEvent.click(screen.getByTestId('add-model-row'))
+    expect(screen.getByTestId('extra-model-row-1')).toBeInTheDocument()
+
+    // Switching to an existing worktree hides the extra-row UI.
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    expect(screen.queryByTestId('add-model-row')).toBeNull()
+    expect(screen.queryByTestId('extra-model-row-1')).toBeNull()
+    // The single-model path is used → label reverts to Send.
+    expect(screen.getByTestId('wt-picker-send-btn')).toHaveTextContent('Send')
+
+    cleanup()
+    renderModal({ connectionId: 'connection-1' })
+    expect(screen.queryByTestId('add-model-row')).toBeNull()
+
+    cleanup()
+    renderModal({ preAssignOnly: true })
+    expect(screen.queryByTestId('add-model-row')).toBeNull()
+  })
+
+  it('hands multi-model launches to runMultiModelLaunch with raw prompt and row-ordered entries', async () => {
+    const onOpenChange = vi.fn()
+    const onSendComplete = vi.fn()
+    render(
+      <WorktreePickerModal
+        ticket={baseTicket}
+        projectId="project-1"
+        open
+        onOpenChange={onOpenChange}
+        onSendComplete={onSendComplete}
+      />
+    )
+
+    // Row 1 = opencode + plan mode; extra row = codex.
+    await userEvent.click(screen.getByTestId('wt-picker-mode-toggle')) // build -> plan
+    await userEvent.click(screen.getByTestId('add-model-row'))
+    await userEvent.click(screen.getByTestId('extra-model-row-1-sdk-codex'))
+
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(runMultiModelLaunch).toHaveBeenCalledTimes(1))
+    const plan = vi.mocked(runMultiModelLaunch).mock.calls[0][0]
+
+    expect(plan.entries.map((e) => e.sdk)).toEqual(['opencode', 'codex'])
+    expect(plan.entries[0].model).toBeNull()
+    expect(plan.entries[1].model).toBeNull()
+    expect(plan.mode).toBe('plan')
+    expect(plan.sourceBranch).toBe('main')
+    expect(plan.goalMode).toBe(false)
+    expect(plan.ticket).toEqual({ id: 'ticket-1', title: 'Multi model ticket' })
+    // RAW prompt — no per-SDK composition (the opencode plan prefix must be absent).
+    expect(plan.prompt).not.toContain(PLAN_MODE_PREFIX)
+    expect(plan.prompt).toContain('<ticket title="Multi model ticket">')
+
+    // Modal closes immediately, before the never-resolving orchestrator settles.
+    expect(onSendComplete).toHaveBeenCalledTimes(1)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+
+    // The multi branch mutates nothing itself — the orchestrator owns all of it.
+    expect(useKanbanStore.getState().updateTicket).not.toHaveBeenCalled()
+    expect(useWorktreeStore.getState().createWorktreeFromBranch).not.toHaveBeenCalled()
+  })
+
+  it('serializes multi-model entries plus legacy row-1 fields in saveConfigOnly mode', async () => {
+    const { updateTicket } = setupStores()
+    render(
+      <WorktreePickerModal
+        ticket={baseTicket}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+        saveConfigOnly
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('add-model-row'))
+    await userEvent.click(screen.getByTestId('extra-model-row-1-sdk-codex'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(updateTicket).toHaveBeenCalledTimes(1))
+    const update = updateTicket.mock.calls[0][2] as { pending_launch_config: string }
+    const parsed = JSON.parse(update.pending_launch_config)
+
+    // Legacy row-1 fields stay for backward compat with old builds.
+    expect(parsed.sdk).toBe('opencode')
+    expect(parsed.codexFastMode).toBe(false)
+    // Multi-model entries, row 1 first.
+    expect(parsed.models).toHaveLength(2)
+    expect(parsed.models[0].sdk).toBe('opencode')
+    expect(parsed.models[1].sdk).toBe('codex')
+  })
+
+  it('stamps model badge fields on the single-model launch update', async () => {
+    const { updateTicket } = setupStores()
+    renderModal()
+
+    await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+    await userEvent.click(screen.getByTestId('pick-model-claude-code-cli'))
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', expect.any(Object))
+    )
+    expect(updateTicket).toHaveBeenCalledWith(
+      'ticket-1',
+      'project-1',
+      expect.objectContaining({
+        worktree_id: 'worktree-1',
+        model_provider_id: 'anthropic',
+        model_id: 'picked-model',
+        model_variant: 'high'
+      })
+    )
+    expect(runMultiModelLaunch).not.toHaveBeenCalled()
+  })
+
+  it('clears goal mode when an added row uses an SDK that does not support goals', async () => {
+    renderModal()
+
+    // Row 1 = codex (goal-capable) → enable goal mode.
+    await userEvent.click(screen.getByTestId('sdk-toggle-codex'))
+    await userEvent.click(screen.getByTestId('goal-mode-toggle'))
+    await userEvent.type(screen.getByTestId('goal-success-criteria'), 'Tests pass')
+    expect(screen.getByTestId('goal-success-criteria')).toBeInTheDocument()
+
+    // Add a row (defaults to codex, still goal-capable) then flip it to opencode.
+    await userEvent.click(screen.getByTestId('add-model-row'))
+    await userEvent.click(screen.getByTestId('extra-model-row-1-sdk-opencode'))
+
+    // Goal mode is no longer available → the block disappears.
+    expect(screen.queryByTestId('goal-mode-toggle')).toBeNull()
+
+    // Restore a goal-capable SDK: the toggle returns but goal mode stays OFF
+    // (it was cleared, mirroring the row-1 SDK-switch reset).
+    await userEvent.click(screen.getByTestId('extra-model-row-1-sdk-codex'))
+    expect(screen.getByTestId('goal-mode-toggle')).toBeInTheDocument()
+    expect(screen.queryByTestId('goal-success-criteria')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
@@ -1,9 +1,10 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { WorktreePickerModal, _resetLastSourceBranch } from './WorktreePickerModal'
 import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
 import { PLAN_MODE_PREFIX } from '@/lib/constants'
+import { FALLBACK_MODELS } from '@shared/model-resolution'
 import { runMultiModelLaunch } from '@/lib/multi-model-launch'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -290,7 +291,9 @@ function setupStores(): { updateTicket: ReturnType<typeof vi.fn> } {
   return { updateTicket }
 }
 
-function renderModal(props: Partial<React.ComponentProps<typeof WorktreePickerModal>> = {}): void {
+async function renderModal(
+  props: Partial<React.ComponentProps<typeof WorktreePickerModal>> = {}
+): Promise<void> {
   render(
     <WorktreePickerModal
       ticket={baseTicket}
@@ -301,6 +304,9 @@ function renderModal(props: Partial<React.ComponentProps<typeof WorktreePickerMo
       {...props}
     />
   )
+  // Flush the modal's async open effects (branch fetch → setBranches /
+  // setBranchesLoading) inside act so no state update settles outside it.
+  await act(async () => {})
 }
 
 describe('WorktreePickerModal multi-model UI', () => {
@@ -343,7 +349,7 @@ describe('WorktreePickerModal multi-model UI', () => {
   })
 
   it('adds and removes model rows and updates the send button label', async () => {
-    renderModal()
+    await renderModal()
 
     expect(screen.getByTestId('wt-picker-send-btn')).toHaveTextContent('Send')
     expect(screen.queryByTestId('extra-model-row-1')).toBeNull()
@@ -365,7 +371,7 @@ describe('WorktreePickerModal multi-model UI', () => {
   })
 
   it('hides the rows for an existing worktree, connection mode, and pre-assign mode', async () => {
-    renderModal()
+    await renderModal()
     await userEvent.click(screen.getByTestId('add-model-row'))
     expect(screen.getByTestId('extra-model-row-1')).toBeInTheDocument()
 
@@ -377,26 +383,18 @@ describe('WorktreePickerModal multi-model UI', () => {
     expect(screen.getByTestId('wt-picker-send-btn')).toHaveTextContent('Send')
 
     cleanup()
-    renderModal({ connectionId: 'connection-1' })
+    await renderModal({ connectionId: 'connection-1' })
     expect(screen.queryByTestId('add-model-row')).toBeNull()
 
     cleanup()
-    renderModal({ preAssignOnly: true })
+    await renderModal({ preAssignOnly: true })
     expect(screen.queryByTestId('add-model-row')).toBeNull()
   })
 
   it('hands multi-model launches to runMultiModelLaunch with raw prompt and row-ordered entries', async () => {
     const onOpenChange = vi.fn()
     const onSendComplete = vi.fn()
-    render(
-      <WorktreePickerModal
-        ticket={baseTicket}
-        projectId="project-1"
-        open
-        onOpenChange={onOpenChange}
-        onSendComplete={onSendComplete}
-      />
-    )
+    await renderModal({ onOpenChange, onSendComplete })
 
     // Row 1 = opencode + plan mode; extra row = codex.
     await userEvent.click(screen.getByTestId('wt-picker-mode-toggle')) // build -> plan
@@ -410,7 +408,9 @@ describe('WorktreePickerModal multi-model UI', () => {
 
     expect(plan.entries.map((e) => e.sdk)).toEqual(['opencode', 'codex'])
     expect(plan.entries[0].model).toBeNull()
-    expect(plan.entries[1].model).toBeNull()
+    // Unpicked extra rows snapshot the concrete row-resolved model (here the
+    // hard SDK fallback) so the launch can't diverge from what was displayed.
+    expect(plan.entries[1].model).toEqual(FALLBACK_MODELS.codex)
     expect(plan.mode).toBe('plan')
     expect(plan.sourceBranch).toBe('main')
     expect(plan.goalMode).toBe(false)
@@ -428,18 +428,55 @@ describe('WorktreePickerModal multi-model UI', () => {
     expect(useWorktreeStore.getState().createWorktreeFromBranch).not.toHaveBeenCalled()
   })
 
+  it('resolves an unpicked extra row from the row SDK mode default, not the per-SDK default', async () => {
+    // The build-mode default targets codex, and codex ALSO has a per-SDK
+    // default. The unpicked codex row must display AND launch the mode default
+    // — downstream null-resolution would pick the per-SDK default instead.
+    useSettingsStore.setState({
+      defaultModels: {
+        build: {
+          agentSdk: 'codex',
+          providerID: 'codex',
+          modelID: 'mode-default-model',
+          variant: 'fast'
+        },
+        plan: null,
+        ask: null,
+        review: null
+      },
+      selectedModelByProvider: {
+        codex: { providerID: 'codex', modelID: 'per-sdk-model' }
+      }
+    })
+    await renderModal()
+
+    // Pin row 1 to opencode so the codex mode default belongs to the extra row only.
+    await userEvent.click(screen.getByTestId('sdk-toggle-opencode'))
+    await userEvent.click(screen.getByTestId('add-model-row'))
+    await userEvent.click(screen.getByTestId('extra-model-row-1-sdk-codex'))
+
+    // The row's ModelSelector displays the mode default...
+    expect(screen.getByTestId('model-value-codex')).toHaveTextContent('mode-default-model')
+
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+    await waitFor(() => expect(runMultiModelLaunch).toHaveBeenCalledTimes(1))
+    const plan = vi.mocked(runMultiModelLaunch).mock.calls[0][0]
+
+    // ...and the launch entry carries that same concrete model.
+    expect(plan.entries[1].model).toMatchObject({
+      providerID: 'codex',
+      modelID: 'mode-default-model',
+      variant: 'fast'
+    })
+    // Row 1 (opencode) has no default anywhere → stays null; the codex mode
+    // default must not leak across SDKs.
+    expect(plan.entries[0].sdk).toBe('opencode')
+    expect(plan.entries[0].model).toBeNull()
+  })
+
   it('serializes multi-model entries plus legacy row-1 fields in saveConfigOnly mode', async () => {
     const { updateTicket } = setupStores()
-    render(
-      <WorktreePickerModal
-        ticket={baseTicket}
-        projectId="project-1"
-        open
-        onOpenChange={vi.fn()}
-        onSendComplete={vi.fn()}
-        saveConfigOnly
-      />
-    )
+    await renderModal({ saveConfigOnly: true })
 
     await userEvent.click(screen.getByTestId('add-model-row'))
     await userEvent.click(screen.getByTestId('extra-model-row-1-sdk-codex'))
@@ -452,15 +489,18 @@ describe('WorktreePickerModal multi-model UI', () => {
     // Legacy row-1 fields stay for backward compat with old builds.
     expect(parsed.sdk).toBe('opencode')
     expect(parsed.codexFastMode).toBe(false)
-    // Multi-model entries, row 1 first.
+    // Multi-model entries, row 1 first. The unpicked extra row snapshots the
+    // concrete row-resolved model instead of null.
     expect(parsed.models).toHaveLength(2)
     expect(parsed.models[0].sdk).toBe('opencode')
+    expect(parsed.models[0].model).toBeNull()
     expect(parsed.models[1].sdk).toBe('codex')
+    expect(parsed.models[1].model).toEqual(FALLBACK_MODELS.codex)
   })
 
   it('stamps model badge fields on the single-model launch update', async () => {
     const { updateTicket } = setupStores()
-    renderModal()
+    await renderModal()
 
     await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
     await userEvent.click(screen.getByTestId('pick-model-claude-code-cli'))
@@ -484,7 +524,7 @@ describe('WorktreePickerModal multi-model UI', () => {
   })
 
   it('clears goal mode when an added row uses an SDK that does not support goals', async () => {
-    renderModal()
+    await renderModal()
 
     // Row 1 = codex (goal-capable) → enable goal mode.
     await userEvent.click(screen.getByTestId('sdk-toggle-codex'))

--- a/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
@@ -517,7 +517,10 @@ describe('WorktreePickerModal multi-model UI', () => {
         worktree_id: 'worktree-1',
         model_provider_id: 'anthropic',
         model_id: 'picked-model',
-        model_variant: 'high'
+        model_variant: 'high',
+        // Single-model launches must clear any stale variant_group_id from a
+        // prior failed multi-launch of this ticket.
+        variant_group_id: null
       })
     )
     expect(runMultiModelLaunch).not.toHaveBeenCalled()

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -686,7 +686,10 @@ export function WorktreePickerModal({
           goal_success_criteria: goalMode ? goalCriteria.trim() : null,
           model_provider_id: badgeModel.providerID,
           model_id: badgeModel.modelID,
-          model_variant: badgeModel.variant ?? null
+          model_variant: badgeModel.variant ?? null,
+          // A single-model (re)launch shouldn't keep claiming membership in a
+          // stale multi-launch group.
+          variant_group_id: null
         })
 
         void autoPinBaseWorktree(ticket.project_id)
@@ -923,7 +926,11 @@ export function WorktreePickerModal({
         onSendComplete?.()
         onOpenChange(false)
         toast.success(`Starting ${entries.length} sessions`)
-        void runMultiModelLaunch(plan)
+        // The orchestrator itself never rethrows (it toasts internally) — this
+        // .catch is defense-in-depth against an unhandled rejection reaching here.
+        void runMultiModelLaunch(plan).catch((err) => {
+          console.error('runMultiModelLaunch rejected unexpectedly', err)
+        })
         return
       }
 
@@ -1033,7 +1040,10 @@ export function WorktreePickerModal({
         goal_success_criteria: goalMode ? goalCriteria.trim() : null,
         model_provider_id: badgeModel.providerID,
         model_id: badgeModel.modelID,
-        model_variant: badgeModel.variant ?? null
+        model_variant: badgeModel.variant ?? null,
+        // A single-model (re)launch shouldn't keep claiming membership in a
+        // stale multi-launch group.
+        variant_group_id: null
       })
 
       // Trigger usage refresh so the board shows up-to-date usage (debounced in store)

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -1043,7 +1043,10 @@ export function WorktreePickerModal({
         model_variant: badgeModel.variant ?? null,
         // A single-model (re)launch shouldn't keep claiming membership in a
         // stale multi-launch group.
-        variant_group_id: null
+        variant_group_id: null,
+        // Clears a stale Save & Queue config so this manual launch can't be
+        // auto-launched again later (e.g. once its blocking dependency resolves).
+        pending_launch_config: null
       })
 
       // Trigger usage refresh so the board shows up-to-date usage (debounced in store)

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -847,7 +847,15 @@ export function WorktreePickerModal({
           sort_order: sortOrder,
           mode,
           goal_mode: goalMode,
-          goal_success_criteria: goalMode ? goalCriteria.trim() : null
+          goal_success_criteria: goalMode ? goalCriteria.trim() : null,
+          // Badge fields mean "what launched" — a queued-not-yet-launched
+          // ticket must have none (backward-drag doesn't clear them, so a
+          // relaunch-requeue would show the PREVIOUS launch's badge until
+          // auto-launch overwrites). Auto-launch stamps them at launch time.
+          model_provider_id: null,
+          model_id: null,
+          model_variant: null,
+          variant_group_id: null
         })
 
         onSendComplete?.()

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -689,7 +689,10 @@ export function WorktreePickerModal({
           model_variant: badgeModel.variant ?? null,
           // A single-model (re)launch shouldn't keep claiming membership in a
           // stale multi-launch group.
-          variant_group_id: null
+          variant_group_id: null,
+          // Clears a stale Save & Queue config so this manual launch can't be
+          // auto-launched again later (same hole as the worktree path below).
+          pending_launch_config: null
         })
 
         void autoPinBaseWorktree(ticket.project_id)

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
-import { Hammer, Map, Plus, GitBranch, Send, ChevronDown, Loader2, Search } from 'lucide-react'
+import { Hammer, Map, Plus, GitBranch, Send, ChevronDown, Loader2, Search, X } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -20,7 +20,7 @@ import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
-import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
+import { useSettingsStore, resolveModelForSdk, type SelectedModel } from '@/stores/useSettingsStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
 import { ModelSelector } from '@/components/sessions/ModelSelector'
@@ -40,6 +40,10 @@ import type { KanbanTicket, Session } from '../../../../main/db/types'
 import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
 import { supportsGoalMode } from '@shared/types/agent-sdk'
 import { createPlanFile, exceedsGoalPromptLimit, planFilePrompt } from '@/lib/goal-plan-file'
+import { FALLBACK_MODELS } from '@shared/model-resolution'
+import { runMultiModelLaunch, type MultiModelLaunchPlan } from '@/lib/multi-model-launch'
+import type { LaunchModelConfig } from '@/lib/ticket-launch'
+import type { AvailableAgentSdks } from '@/lib/agent-sdk-availability'
 
 // Stable empty array to avoid referential-inequality loops in Zustand selectors
 const EMPTY_ARRAY: readonly never[] = []
@@ -186,6 +190,104 @@ function toRequestModel(
   return { providerID: model.providerID, modelID: model.modelID, variant: model.variant }
 }
 
+// One extra provider/model launched alongside the existing row-1 controls.
+interface ExtraModelRow {
+  key: string // crypto.randomUUID() — stable React key
+  sdk: PickerAgentSdk
+  model: SelectedModel | null // null = resolve for that row's sdk at launch
+  codexFastMode: boolean // per-row; seeded from the global codexFastMode
+}
+
+// Resolve a row's display/launch-default model. Never inherits another SDK's
+// default: the mode default only wins when it's already for this SDK, otherwise
+// the per-SDK resolution then the hard SDK fallback.
+function resolveRowDefaultModel(sdk: PickerAgentSdk, mode: PickerMode): SelectedModel {
+  const settings = useSettingsStore.getState()
+  const modeModel = settings.getModelForMode(mode)
+  if (modeModel && modeModel.agentSdk === sdk) return modeModel
+  const resolved = resolveModelForSdk(sdk) ?? FALLBACK_MODELS[sdk]
+  return { providerID: resolved.providerID, modelID: resolved.modelID, variant: resolved.variant }
+}
+
+// ── SDK toggle button group (shared by row 1 and each extra row) ────
+interface SdkToggleGroupProps {
+  value: PickerAgentSdk
+  onChange: (sdk: PickerAgentSdk) => void
+  availableAgentSdks: AvailableAgentSdks | null
+  idPrefix: string
+}
+
+function SdkToggleGroup({
+  value,
+  onChange,
+  availableAgentSdks,
+  idPrefix
+}: SdkToggleGroupProps): React.JSX.Element | null {
+  // Only render when 2+ SDKs are available (a single SDK has nothing to toggle).
+  const buttonCount = availableAgentSdks
+    ? [
+        availableAgentSdks.opencode,
+        availableAgentSdks.claude,
+        availableAgentSdks.codex,
+        availableAgentSdks.claude
+      ].filter(Boolean).length
+    : 0
+  if (!availableAgentSdks || buttonCount < 2) return null
+
+  const buttonClass = (active: boolean): string =>
+    cn(
+      'px-2.5 py-1 rounded-md text-xs border transition-colors',
+      active
+        ? 'bg-primary text-primary-foreground border-primary'
+        : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+    )
+
+  return (
+    <div className="flex gap-1.5" data-testid={idPrefix}>
+      {availableAgentSdks.opencode && (
+        <button
+          type="button"
+          data-testid={`${idPrefix}-opencode`}
+          onClick={() => onChange('opencode')}
+          className={buttonClass(value === 'opencode')}
+        >
+          OpenCode
+        </button>
+      )}
+      {availableAgentSdks.claude && (
+        <button
+          type="button"
+          data-testid={`${idPrefix}-claude-code`}
+          onClick={() => onChange('claude-code')}
+          className={buttonClass(value === 'claude-code')}
+        >
+          Claude Code
+        </button>
+      )}
+      {availableAgentSdks.codex && (
+        <button
+          type="button"
+          data-testid={`${idPrefix}-codex`}
+          onClick={() => onChange('codex')}
+          className={buttonClass(value === 'codex')}
+        >
+          Codex
+        </button>
+      )}
+      {availableAgentSdks.claude && (
+        <button
+          type="button"
+          data-testid={`${idPrefix}-claude-code-cli`}
+          onClick={() => onChange('claude-code-cli')}
+          className={buttonClass(value === 'claude-code-cli')}
+        >
+          Claude CLI
+        </button>
+      )}
+    </div>
+  )
+}
+
 // ── Component ───────────────────────────────────────────────────────
 export function WorktreePickerModal({
   ticket,
@@ -219,6 +321,7 @@ export function WorktreePickerModal({
     variant?: string
   } | null>(null)
   const [selectedSdk, setSelectedSdk] = useState<PickerAgentSdk | null>(null)
+  const [extraModelRows, setExtraModelRows] = useState<ExtraModelRow[]>([])
 
   // ── Store access ────────────────────────────────────────────────
   const worktrees = useWorktreeStore(
@@ -267,15 +370,18 @@ export function WorktreePickerModal({
 
   const agentSdk =
     selectedSdk ?? selectedModel?.agentSdk ?? autoResolvedModel?.agentSdk ?? baseAgentSdk
-  const goalAvailable = supportsGoalMode(agentSdk) && mode === 'build' && !preAssignOnly
-  const availableSdkButtonCount = availableAgentSdks
-    ? [
-        availableAgentSdks.opencode,
-        availableAgentSdks.claude,
-        availableAgentSdks.codex,
-        availableAgentSdks.claude
-      ].filter(Boolean).length
-    : 0
+  // Extra model rows + the "+ Add model" button only apply to a brand-new
+  // worktree in the normal or save-config flows (an existing worktree hosts one
+  // session; connection/pre-assign never multi-launch).
+  const extraRowsVisible = isNewWorktree && !isConnectionMode && !preAssignOnly
+  const isMultiModel = extraRowsVisible && extraModelRows.length > 0
+  // Goal mode needs EVERY launched SDK to support it — row 1 (already gated
+  // below via agentSdk) plus every visible extra row.
+  const goalAvailable =
+    supportsGoalMode(agentSdk) &&
+    (extraRowsVisible ? extraModelRows.every((r) => supportsGoalMode(r.sdk)) : true) &&
+    mode === 'build' &&
+    !preAssignOnly
 
   // ── Count in-progress tickets per worktree ──────────────────────
   const ticketCountByWorktree = useMemo(() => {
@@ -324,6 +430,7 @@ export function WorktreePickerModal({
       setGoalCriteria('')
       setSelectedModel(null)
       setSelectedSdk(null)
+      setExtraModelRows([])
       setSourceBranch(_lastSourceBranchByProject[projectId] ?? null)
       setBranches([])
       setBranchFilter('')
@@ -356,6 +463,37 @@ export function WorktreePickerModal({
       setGoalMode(false)
       setGoalCriteria('')
     }
+  }, [])
+
+  // ── Extra model rows ────────────────────────────────────────────
+  const addModelRow = useCallback(() => {
+    setExtraModelRows((rows) => [
+      ...rows,
+      { key: crypto.randomUUID(), sdk: agentSdk, model: null, codexFastMode }
+    ])
+  }, [agentSdk, codexFastMode])
+
+  const removeModelRow = useCallback((key: string) => {
+    setExtraModelRows((rows) => rows.filter((r) => r.key !== key))
+  }, [])
+
+  const handleRowSdkChange = useCallback((key: string, sdk: PickerAgentSdk) => {
+    // Reset the row's model (new SDK has different models), mirroring handleSdkChange.
+    setExtraModelRows((rows) => rows.map((r) => (r.key === key ? { ...r, sdk, model: null } : r)))
+    if (!supportsGoalMode(sdk)) {
+      setGoalMode(false)
+      setGoalCriteria('')
+    }
+  }, [])
+
+  const updateRowModel = useCallback((key: string, model: SelectedModel) => {
+    setExtraModelRows((rows) => rows.map((r) => (r.key === key ? { ...r, model } : r)))
+  }, [])
+
+  const updateRowCodexFastMode = useCallback((key: string, value: boolean) => {
+    setExtraModelRows((rows) =>
+      rows.map((r) => (r.key === key ? { ...r, codexFastMode: value } : r))
+    )
   }, [])
 
   // ── Handle mode toggle ──────────────────────────────────────────
@@ -488,6 +626,9 @@ export function WorktreePickerModal({
         // Create connection session
         const createConnectionSession = useSessionStore.getState().createConnectionSession
         const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
+        // Badge model is always resolvable — fall back to the per-SDK / hard
+        // fallback so the persisted badge columns are never null on a launch.
+        const badgeModel = effectiveModel ?? resolveModelForSdk(agentSdk) ?? FALLBACK_MODELS[agentSdk]
         const modelOverride = effectiveModel ? { ...effectiveModel, agentSdk } : undefined
         const cliPendingPrompt =
           agentSdk === 'claude-code-cli'
@@ -542,7 +683,10 @@ export function WorktreePickerModal({
           sort_order: sortOrder,
           plan_ready: false,
           goal_mode: goalMode,
-          goal_success_criteria: goalMode ? goalCriteria.trim() : null
+          goal_success_criteria: goalMode ? goalCriteria.trim() : null,
+          model_provider_id: badgeModel.providerID,
+          model_id: badgeModel.modelID,
+          model_variant: badgeModel.variant ?? null
         })
 
         void autoPinBaseWorktree(ticket.project_id)
@@ -652,6 +796,18 @@ export function WorktreePickerModal({
     try {
       let worktreeId = selectedWorktreeId
 
+      // Row 1 (the existing controls) first, then each extra model row. Row 1's
+      // model uses the same effective-model chain as the single-model launch;
+      // extra rows pass their own model (null = the pipeline resolves per SDK).
+      const entries: LaunchModelConfig[] = [
+        { sdk: agentSdk, model: selectedModel ?? autoResolvedModel ?? null, codexFastMode },
+        ...extraModelRows.map((r) => ({
+          sdk: r.sdk,
+          model: r.model,
+          codexFastMode: r.codexFastMode
+        }))
+      ]
+
       // ── Save config only path: serialize config, don't create session ─
       if (saveConfigOnly) {
         const pendingConfig = {
@@ -664,7 +820,10 @@ export function WorktreePickerModal({
           sdk: agentSdk,
           codexFastMode,
           goalMode,
-          goalSuccessCriteria: goalMode ? goalCriteria.trim() : null
+          goalSuccessCriteria: goalMode ? goalCriteria.trim() : null,
+          // Multi-model entries (row 1 first). Legacy sdk/model/codexFastMode
+          // above stay so older builds can still auto-launch entries[0].
+          ...(isMultiModel ? { models: entries } : {})
         }
 
         const sortOrder = useKanbanStore
@@ -739,6 +898,33 @@ export function WorktreePickerModal({
 
       void autoPinBaseWorktree(projectId)
 
+      // ── Multi-model launch: hand off to the background orchestrator ──
+      // It owns EVERYTHING after this point — worktree creation, ticket
+      // duplication, all ticket updates, and the per-SDK prompt composition — so
+      // the modal creates/mutates nothing here and closes immediately (no spinner).
+      if (isMultiModel) {
+        const targetBranch = sourceBranch ?? defaultBranchName
+        _lastSourceBranchByProject[projectId] = targetBranch
+        const plan: MultiModelLaunchPlan = {
+          ticket: { id: ticket.id, title: ticket.title },
+          projectId,
+          // RAW prompt — the pipeline composes per SDK (plan prefix, goal wrap,
+          // oversized-goal plan-file swap) inside launchTicketWithModel; composing
+          // it here would double-prefix.
+          prompt: promptText.trim() || buildPrompt(mode, ticket),
+          mode,
+          sourceBranch: targetBranch,
+          goalMode,
+          goalSuccessCriteria: goalMode ? goalCriteria.trim() : null,
+          entries
+        }
+        onSendComplete?.()
+        onOpenChange(false)
+        toast.success(`Starting ${entries.length} sessions`)
+        void runMultiModelLaunch(plan)
+        return
+      }
+
       // Create new worktree if needed
       if (isNewWorktree && project) {
         const targetBranch = sourceBranch ?? defaultBranchName
@@ -781,6 +967,9 @@ export function WorktreePickerModal({
 
       // Create session in the selected worktree
       const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
+      // Badge model is always resolvable — fall back to the per-SDK / hard
+      // fallback so the persisted badge columns are never null on a launch.
+      const badgeModel = effectiveModel ?? resolveModelForSdk(agentSdk) ?? FALLBACK_MODELS[agentSdk]
       const modelOverride = effectiveModel ? { ...effectiveModel, agentSdk } : undefined
       const cliPendingPrompt =
         agentSdk === 'claude-code-cli'
@@ -839,7 +1028,10 @@ export function WorktreePickerModal({
         sort_order: sortOrder,
         plan_ready: false,
         goal_mode: goalMode,
-        goal_success_criteria: goalMode ? goalCriteria.trim() : null
+        goal_success_criteria: goalMode ? goalCriteria.trim() : null,
+        model_provider_id: badgeModel.providerID,
+        model_id: badgeModel.modelID,
+        model_variant: badgeModel.variant ?? null
       })
 
       // Trigger usage refresh so the board shows up-to-date usage (debounced in store)
@@ -970,7 +1162,9 @@ export function WorktreePickerModal({
     goalCriteria,
     composedGoalPrompt,
     isConnectionMode,
-    connectionId
+    connectionId,
+    extraModelRows,
+    isMultiModel
   ])
 
   // ── Mode toggle chip ────────────────────────────────────────────
@@ -1207,70 +1401,12 @@ export function WorktreePickerModal({
                 Provider & Model
               </label>
               {/* SDK toggle — only when 2+ SDKs are available */}
-              {availableAgentSdks && availableSdkButtonCount >= 2 && (
-                <div className="flex gap-1.5" data-testid="sdk-toggle">
-                  {availableAgentSdks.opencode && (
-                    <button
-                      type="button"
-                      data-testid="sdk-toggle-opencode"
-                      onClick={() => handleSdkChange('opencode')}
-                      className={cn(
-                        'px-2.5 py-1 rounded-md text-xs border transition-colors',
-                        agentSdk === 'opencode'
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
-                      )}
-                    >
-                      OpenCode
-                    </button>
-                  )}
-                  {availableAgentSdks.claude && (
-                    <button
-                      type="button"
-                      data-testid="sdk-toggle-claude-code"
-                      onClick={() => handleSdkChange('claude-code')}
-                      className={cn(
-                        'px-2.5 py-1 rounded-md text-xs border transition-colors',
-                        agentSdk === 'claude-code'
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
-                      )}
-                    >
-                      Claude Code
-                    </button>
-                  )}
-                  {availableAgentSdks.codex && (
-                    <button
-                      type="button"
-                      data-testid="sdk-toggle-codex"
-                      onClick={() => handleSdkChange('codex')}
-                      className={cn(
-                        'px-2.5 py-1 rounded-md text-xs border transition-colors',
-                        agentSdk === 'codex'
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
-                      )}
-                    >
-                      Codex
-                    </button>
-                  )}
-                  {availableAgentSdks.claude && (
-                    <button
-                      type="button"
-                      data-testid="sdk-toggle-claude-code-cli"
-                      onClick={() => handleSdkChange('claude-code-cli')}
-                      className={cn(
-                        'px-2.5 py-1 rounded-md text-xs border transition-colors',
-                        agentSdk === 'claude-code-cli'
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
-                      )}
-                    >
-                      Claude CLI
-                    </button>
-                  )}
-                </div>
-              )}
+              <SdkToggleGroup
+                value={agentSdk}
+                onChange={handleSdkChange}
+                availableAgentSdks={availableAgentSdks}
+                idPrefix="sdk-toggle"
+              />
               {goalAvailable && (
                 <div className="space-y-2 rounded-md border border-border/50 bg-muted/20 px-3 py-2.5">
                   <div className="flex items-center justify-between gap-3">
@@ -1326,6 +1462,69 @@ export function WorktreePickerModal({
                   </div>
                 )}
               </div>
+
+              {/* ── Extra model rows (new worktree only) ── */}
+              {extraRowsVisible && (
+                <div className="space-y-2" data-testid="extra-model-rows">
+                  {extraModelRows.map((row, i) => {
+                    const rowIndex = i + 1
+                    const rowModelValue = row.model ?? resolveRowDefaultModel(row.sdk, mode)
+                    return (
+                      <div
+                        key={row.key}
+                        data-testid={`extra-model-row-${rowIndex}`}
+                        className="space-y-2 rounded-md border border-border/50 bg-muted/10 px-3 py-2.5"
+                      >
+                        <SdkToggleGroup
+                          value={row.sdk}
+                          onChange={(sdk) => handleRowSdkChange(row.key, sdk)}
+                          availableAgentSdks={availableAgentSdks}
+                          idPrefix={`extra-model-row-${rowIndex}-sdk`}
+                        />
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <div className="min-w-0">
+                            <ModelSelector
+                              value={rowModelValue}
+                              onChange={(model) => updateRowModel(row.key, model)}
+                              agentSdkOverride={row.sdk}
+                            />
+                          </div>
+                          {row.sdk === 'codex' && (
+                            <div className="shrink-0">
+                              <CodexFastToggle
+                                enabled={row.codexFastMode}
+                                accepted={codexFastModeAccepted}
+                                onToggle={() =>
+                                  updateRowCodexFastMode(row.key, !row.codexFastMode)
+                                }
+                                onAccept={() => updateSetting('codexFastModeAccepted', true)}
+                              />
+                            </div>
+                          )}
+                          <button
+                            type="button"
+                            data-testid={`extra-model-row-${rowIndex}-remove`}
+                            onClick={() => removeModelRow(row.key)}
+                            aria-label="Remove model"
+                            className="ml-auto shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
+                      </div>
+                    )
+                  })}
+                  <button
+                    type="button"
+                    data-testid="add-model-row"
+                    onClick={addModelRow}
+                    className="flex items-center gap-1.5 rounded-md border border-dashed border-border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    Add model
+                  </button>
+                </div>
+              )}
             </div>
           )}
 
@@ -1397,7 +1596,11 @@ export function WorktreePickerModal({
             ) : (
               <>
                 <Send className="h-3.5 w-3.5" />
-                {isSending ? 'Starting...' : 'Send'}
+                {isSending
+                  ? 'Starting...'
+                  : isMultiModel
+                    ? `Start ${1 + extraModelRows.length} sessions`
+                    : 'Send'}
               </>
             )}
           </Button>

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -42,7 +42,7 @@ import { supportsGoalMode } from '@shared/types/agent-sdk'
 import { createPlanFile, exceedsGoalPromptLimit, planFilePrompt } from '@/lib/goal-plan-file'
 import { FALLBACK_MODELS } from '@shared/model-resolution'
 import { runMultiModelLaunch, type MultiModelLaunchPlan } from '@/lib/multi-model-launch'
-import type { LaunchModelConfig } from '@/lib/ticket-launch'
+import { resolveBadgeModel, type LaunchModelConfig } from '@/lib/ticket-launch'
 import type { AvailableAgentSdks } from '@/lib/agent-sdk-availability'
 
 // Stable empty array to avoid referential-inequality loops in Zustand selectors
@@ -626,9 +626,6 @@ export function WorktreePickerModal({
         // Create connection session
         const createConnectionSession = useSessionStore.getState().createConnectionSession
         const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
-        // Badge model is always resolvable — fall back to the per-SDK / hard
-        // fallback so the persisted badge columns are never null on a launch.
-        const badgeModel = effectiveModel ?? resolveModelForSdk(agentSdk) ?? FALLBACK_MODELS[agentSdk]
         const modelOverride = effectiveModel ? { ...effectiveModel, agentSdk } : undefined
         const cliPendingPrompt =
           agentSdk === 'claude-code-cli'
@@ -675,6 +672,14 @@ export function WorktreePickerModal({
             0
           )
 
+        // Badge records what the session ACTUALLY runs: the created session
+        // row's resolved model wins over the modal's own chain (createSession
+        // resolves independently and can differ), then the picked/auto model,
+        // then the per-SDK resolution + hard fallback (never null).
+        const badgeModel = resolveBadgeModel(
+          { sdk: agentSdk, model: effectiveModel ?? null, codexFastMode },
+          sessionResult.session
+        )
         await updateTicket(ticket.id, ticket.project_id, {
           current_session_id: sessionId,
           worktree_id: null,
@@ -686,7 +691,7 @@ export function WorktreePickerModal({
           goal_success_criteria: goalMode ? goalCriteria.trim() : null,
           model_provider_id: badgeModel.providerID,
           model_id: badgeModel.modelID,
-          model_variant: badgeModel.variant ?? null,
+          model_variant: badgeModel.variant,
           // A single-model (re)launch shouldn't keep claiming membership in a
           // stale multi-launch group.
           variant_group_id: null,
@@ -987,9 +992,6 @@ export function WorktreePickerModal({
 
       // Create session in the selected worktree
       const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
-      // Badge model is always resolvable — fall back to the per-SDK / hard
-      // fallback so the persisted badge columns are never null on a launch.
-      const badgeModel = effectiveModel ?? resolveModelForSdk(agentSdk) ?? FALLBACK_MODELS[agentSdk]
       const modelOverride = effectiveModel ? { ...effectiveModel, agentSdk } : undefined
       const cliPendingPrompt =
         agentSdk === 'claude-code-cli'
@@ -1040,6 +1042,14 @@ export function WorktreePickerModal({
         .getState()
         .computeSortOrder(useKanbanStore.getState().getTicketsByColumn(projectId, 'in_progress'), 0)
 
+      // Badge records what the session ACTUALLY runs: the created session
+      // row's resolved model wins over the modal's own chain (createSession
+      // resolves independently and can differ), then the picked/auto model,
+      // then the per-SDK resolution + hard fallback (never null).
+      const badgeModel = resolveBadgeModel(
+        { sdk: agentSdk, model: effectiveModel ?? null, codexFastMode },
+        sessionResult.session
+      )
       await updateTicket(ticket.id, projectId, {
         current_session_id: sessionId,
         worktree_id: worktreeId,
@@ -1051,7 +1061,7 @@ export function WorktreePickerModal({
         goal_success_criteria: goalMode ? goalCriteria.trim() : null,
         model_provider_id: badgeModel.providerID,
         model_id: badgeModel.modelID,
-        model_variant: badgeModel.variant ?? null,
+        model_variant: badgeModel.variant,
         // A single-model (re)launch shouldn't keep claiming membership in a
         // stale multi-launch group.
         variant_group_id: null,

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -798,12 +798,14 @@ export function WorktreePickerModal({
 
       // Row 1 (the existing controls) first, then each extra model row. Row 1's
       // model uses the same effective-model chain as the single-model launch;
-      // extra rows pass their own model (null = the pipeline resolves per SDK).
+      // unpicked extra rows snapshot the concrete row-resolved model the
+      // ModelSelector displayed — downstream null-resolution ignores mode
+      // defaults, so passing null could launch a different model than shown.
       const entries: LaunchModelConfig[] = [
         { sdk: agentSdk, model: selectedModel ?? autoResolvedModel ?? null, codexFastMode },
         ...extraModelRows.map((r) => ({
           sdk: r.sdk,
-          model: r.model,
+          model: r.model ?? resolveRowDefaultModel(r.sdk, mode),
           codexFastMode: r.codexFastMode
         }))
       ]

--- a/src/renderer/src/components/kanban/WorktreePickerModal.ultracode.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.ultracode.test.tsx
@@ -104,6 +104,10 @@ const baseTicket: KanbanTicket = {
   mark: null,
   note: null,
   total_tokens: 0,
+  model_provider_id: null,
+  model_id: null,
+  model_variant: null,
+  variant_group_id: null,
   created_at: '2026-01-01T00:00:00.000Z',
   updated_at: '2026-01-01T00:00:00.000Z'
 }

--- a/src/renderer/src/components/worktrees/ModelIcon.test.tsx
+++ b/src/renderer/src/components/worktrees/ModelIcon.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { ModelIcon } from './ModelIcon'
+import { ModelIcon, resolveModelIconAsset } from './ModelIcon'
 import { useSettingsStore, useSessionStore, useWorktreeStore } from '@/stores'
+import claudeIcon from '@/assets/model-icons/claude.svg'
+import openaiIcon from '@/assets/model-icons/openai.svg'
 
 const baseWorktree = {
   id: 'worktree-1',
@@ -54,5 +56,46 @@ describe('ModelIcon', () => {
     render(<ModelIcon worktreeId="worktree-1" />)
 
     expect(screen.getByRole('img', { name: 'Claude' })).toBeInTheDocument()
+  })
+})
+
+describe('resolveModelIconAsset', () => {
+  it('resolves the Claude icon for the anthropic provider', () => {
+    const asset = resolveModelIconAsset('anthropic', 'opus')
+    expect(asset).toEqual({ src: claudeIcon, alt: 'Claude' })
+  })
+
+  it('resolves the Claude icon for the claude-code provider', () => {
+    const asset = resolveModelIconAsset('claude-code', 'some-model')
+    expect(asset?.alt).toBe('Claude')
+  })
+
+  it('resolves the OpenAI icon for the codex provider', () => {
+    const asset = resolveModelIconAsset('codex', 'gpt-5.5')
+    expect(asset).toEqual({ src: openaiIcon, alt: 'OpenAI' })
+  })
+
+  it('resolves the OpenAI icon for the openai provider', () => {
+    const asset = resolveModelIconAsset('openai', 'some-model')
+    expect(asset?.alt).toBe('OpenAI')
+  })
+
+  it('falls back to a claude-* modelId match when the provider is unrecognized', () => {
+    const asset = resolveModelIconAsset('unknown-provider', 'claude-opus-4-5')
+    expect(asset?.alt).toBe('Claude')
+  })
+
+  it('falls back to a gpt-* modelId match when the provider is unrecognized', () => {
+    const asset = resolveModelIconAsset('unknown-provider', 'gpt-5.5')
+    expect(asset?.alt).toBe('OpenAI')
+  })
+
+  it('returns null for an unknown provider and modelId', () => {
+    expect(resolveModelIconAsset('unknown-provider', 'some-model')).toBeNull()
+  })
+
+  it('returns null when both providerId and modelId are missing', () => {
+    expect(resolveModelIconAsset(null, null)).toBeNull()
+    expect(resolveModelIconAsset(undefined, undefined)).toBeNull()
   })
 })

--- a/src/renderer/src/components/worktrees/ModelIcon.tsx
+++ b/src/renderer/src/components/worktrees/ModelIcon.tsx
@@ -23,6 +23,28 @@ function getModelIcon(
   return null
 }
 
+/**
+ * Pure providerId/modelId → icon asset resolver, shared by any component that
+ * needs to render a provider's model icon without the worktree/session store
+ * lookups `ModelIcon` layers on top.
+ */
+export function resolveModelIconAsset(
+  providerId: string | null | undefined,
+  modelId: string | null | undefined
+): { src: string; alt: string } | null {
+  const matched = getModelIcon(modelId)
+
+  if ((providerId && CLAUDE_PROVIDER_IDS.has(providerId)) || matched?.label === 'Claude') {
+    return { src: claudeIcon, alt: 'Claude' }
+  }
+
+  if ((providerId && OPENAI_PROVIDER_IDS.has(providerId)) || matched?.label === 'OpenAI') {
+    return { src: openaiIcon, alt: 'OpenAI' }
+  }
+
+  return null
+}
+
 interface ModelIconProps {
   worktreeId: string
   className?: string
@@ -54,19 +76,9 @@ export function ModelIcon({ worktreeId, className }: ModelIconProps): React.JSX.
 
   if (!showModelIcons) return null
 
-  const matched = getModelIcon(lastModelInfo?.modelId)
-  if (
-    (lastModelInfo?.providerId && CLAUDE_PROVIDER_IDS.has(lastModelInfo.providerId)) ||
-    matched?.label === 'Claude'
-  ) {
-    return <img src={claudeIcon} alt="Claude" className={cn(className)} draggable={false} />
-  }
-
-  if (
-    (lastModelInfo?.providerId && OPENAI_PROVIDER_IDS.has(lastModelInfo.providerId)) ||
-    matched?.label === 'OpenAI'
-  ) {
-    return <img src={openaiIcon} alt="OpenAI" className={cn(className)} draggable={false} />
+  const asset = resolveModelIconAsset(lastModelInfo?.providerId, lastModelInfo?.modelId)
+  if (asset) {
+    return <img src={asset.src} alt={asset.alt} className={cn(className)} draggable={false} />
   }
 
   if (!lastModelInfo?.providerId && !lastModelInfo?.modelId) {

--- a/src/renderer/src/lib/auto-launch.multi-model.test.ts
+++ b/src/renderer/src/lib/auto-launch.multi-model.test.ts
@@ -72,7 +72,7 @@ describe('autoLaunchTicket multi-model routing', () => {
     useProjectStore.setState(initialProjectState, true)
   })
 
-  it('routes multi-entry + new worktree to runMultiModelLaunch with clearPendingConfig true', async () => {
+  it('routes multi-entry + new worktree to runMultiModelLaunch', async () => {
     await autoLaunchTicket({
       id: 'ticket-1',
       project_id: 'project-1',
@@ -98,8 +98,7 @@ describe('autoLaunchTicket multi-model routing', () => {
       sourceBranch: 'main',
       goalMode: true,
       goalSuccessCriteria: 'Tests pass',
-      entries: twoEntries,
-      clearPendingConfig: true
+      entries: twoEntries
     })
     expect(launchTicketWithModel).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/lib/auto-launch.multi-model.test.ts
+++ b/src/renderer/src/lib/auto-launch.multi-model.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { autoLaunchTicket } from './auto-launch'
+import { launchTicketWithModel } from '@/lib/ticket-launch'
+import { runMultiModelLaunch } from '@/lib/multi-model-launch'
+import { useProjectStore } from '@/stores/useProjectStore'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/ticket-launch', () => ({
+  launchTicketWithModel: vi.fn()
+}))
+
+vi.mock('@/lib/multi-model-launch', () => ({
+  runMultiModelLaunch: vi.fn()
+}))
+
+vi.mock('@/lib/auto-pin', () => ({
+  autoPinBaseWorktree: vi.fn()
+}))
+
+const initialProjectState = useProjectStore.getState()
+
+function setupProject(): void {
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '/repo',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        worktree_create_script: null,
+        custom_commands: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        last_accessed_at: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+}
+
+const twoEntries = [
+  { sdk: 'opencode' as const, model: { providerID: 'anthropic', modelID: 'opus' }, codexFastMode: false },
+  { sdk: 'codex' as const, model: { providerID: 'codex', modelID: 'gpt-5.5' }, codexFastMode: false }
+]
+
+describe('autoLaunchTicket multi-model routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupProject()
+    vi.mocked(launchTicketWithModel).mockResolvedValue({
+      success: true,
+      sessionId: 'session-1',
+      worktreeId: 'worktree-1'
+    })
+    vi.mocked(runMultiModelLaunch).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    useProjectStore.setState(initialProjectState, true)
+  })
+
+  it('routes multi-entry + new worktree to runMultiModelLaunch with clearPendingConfig true', async () => {
+    await autoLaunchTicket({
+      id: 'ticket-1',
+      project_id: 'project-1',
+      title: 'Fix Login Bug',
+      pending_launch_config: JSON.stringify({
+        worktree: { type: 'new', sourceBranch: 'main' },
+        prompt: 'Implement the fix',
+        mode: 'build',
+        model: null,
+        sdk: 'opencode',
+        codexFastMode: false,
+        goalMode: true,
+        goalSuccessCriteria: 'Tests pass',
+        models: twoEntries
+      })
+    })
+
+    expect(runMultiModelLaunch).toHaveBeenCalledWith({
+      ticket: { id: 'ticket-1', title: 'Fix Login Bug' },
+      projectId: 'project-1',
+      prompt: 'Implement the fix',
+      mode: 'build',
+      sourceBranch: 'main',
+      goalMode: true,
+      goalSuccessCriteria: 'Tests pass',
+      entries: twoEntries,
+      clearPendingConfig: true
+    })
+    expect(launchTicketWithModel).not.toHaveBeenCalled()
+  })
+
+  it('keeps the single-path entries[0] behavior for multi-entry + existing worktree', async () => {
+    await autoLaunchTicket({
+      id: 'ticket-1',
+      project_id: 'project-1',
+      title: 'Fix Login Bug',
+      pending_launch_config: JSON.stringify({
+        worktree: { type: 'existing', worktreeId: 'worktree-1' },
+        prompt: 'Implement the fix',
+        mode: 'build',
+        model: null,
+        sdk: 'opencode',
+        codexFastMode: false,
+        goalMode: false,
+        goalSuccessCriteria: null,
+        models: twoEntries
+      })
+    })
+
+    expect(runMultiModelLaunch).not.toHaveBeenCalled()
+    expect(launchTicketWithModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ticketId: 'ticket-1',
+        projectId: 'project-1',
+        worktree: { type: 'existing', worktreeId: 'worktree-1' },
+        modelConfig: twoEntries[0]
+      })
+    )
+  })
+
+  it('single-entry configs never call runMultiModelLaunch, even with a new worktree', async () => {
+    await autoLaunchTicket({
+      id: 'ticket-1',
+      project_id: 'project-1',
+      title: 'Fix Login Bug',
+      pending_launch_config: JSON.stringify({
+        worktree: { type: 'new', sourceBranch: 'main' },
+        prompt: 'Implement the fix',
+        mode: 'build',
+        model: { providerID: 'anthropic', modelID: 'opus' },
+        sdk: 'opencode',
+        codexFastMode: false,
+        goalMode: false,
+        goalSuccessCriteria: null
+      })
+    })
+
+    expect(runMultiModelLaunch).not.toHaveBeenCalled()
+    expect(launchTicketWithModel).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -81,8 +81,7 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
       sourceBranch: config.worktree.sourceBranch,
       goalMode: configGoalMode,
       goalSuccessCriteria: configGoalSuccessCriteria,
-      entries,
-      clearPendingConfig: true
+      entries
     })
     return
   }

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -1,22 +1,8 @@
-import { useKanbanStore } from '@/stores/useKanbanStore'
-import { useSessionStore } from '@/stores/useSessionStore'
-import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useProjectStore } from '@/stores/useProjectStore'
-import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
-import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
-import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
-import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
-import { snapshotTokenBaseline } from '@/lib/token-baselines'
-import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
 import { toast } from '@/lib/toast'
-import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
-import { unwrapEnvelope } from '@/lib/ipc-envelope'
-import { opencodeApi } from '@/api/opencode-api'
-import { dbApi } from '@/api/db-api'
-import { terminalApi } from '@/api/terminal-api'
-import { startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
 import { autoPinBaseWorktree } from '@/lib/auto-pin'
-import { createPlanFile, exceedsGoalPromptLimit, planFilePrompt } from '@/lib/goal-plan-file'
+import { launchTicketWithModel, type LaunchModelConfig } from '@/lib/ticket-launch'
+import type { HandoffAgentSdk } from '@shared/types/agent-sdk'
 
 type AutoLaunchMode = 'build' | 'plan' | 'super-plan'
 
@@ -27,48 +13,33 @@ interface AutoLaunchTicket {
   pending_launch_config: string | null
 }
 
+/** One provider/model entry in a (multi-model) pending launch config. */
+export interface PendingLaunchModelEntry {
+  sdk: HandoffAgentSdk
+  model: { providerID: string; modelID: string; variant?: string } | null
+  codexFastMode: boolean
+}
+
 interface PendingLaunchConfig {
   worktree: { type: 'new'; sourceBranch: string } | { type: 'existing'; worktreeId: string }
   prompt: string
   mode: AutoLaunchMode
   model: { providerID: string; modelID: string; variant?: string } | null
-  sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex'
+  sdk: HandoffAgentSdk
   codexFastMode: boolean
   goalMode: boolean
   goalSuccessCriteria: string | null
+  /** NEW (optional): multi-model launch entries; [0] applies to the original ticket. */
+  models?: PendingLaunchModelEntry[]
 }
 
-function wrapGoalPrompt(prompt: string, criteria: string): string {
-  const stripped = prompt.replace(/^\/goal\s+/, '')
-  return `/goal ${stripped}. Goal success criteria: ${criteria}`
-}
-
-function composeAutoLaunchPrompt(
-  config: PendingLaunchConfig,
-  sessionAgentSdk: string | null | undefined,
-  configGoalMode: boolean,
-  configGoalSuccessCriteria: string | null,
-  options: { claudeCli: boolean }
-): string | null {
-  const trimmedPrompt = config.prompt.trim()
-  if (!trimmedPrompt) return null
-
-  const skipPrefix =
-    options.claudeCli ||
-    sessionAgentSdk === 'claude-code' ||
-    sessionAgentSdk === 'codex' ||
-    sessionAgentSdk === 'claude-code-cli'
-  const modePrefix =
-    config.mode === 'super-plan'
-      ? getSuperPlanModePrefix(sessionAgentSdk)
-      : config.mode === 'plan' && !skipPrefix
-        ? PLAN_MODE_PREFIX
-        : ''
-  const fullPrompt = modePrefix + trimmedPrompt
-
-  return configGoalMode && configGoalSuccessCriteria
-    ? wrapGoalPrompt(fullPrompt, configGoalSuccessCriteria)
-    : fullPrompt
+/**
+ * Normalize a pending launch config into the list of model entries to launch.
+ * Legacy configs (no `models`) yield a single entry from the top-level fields.
+ */
+export function resolveModelEntries(config: PendingLaunchConfig): LaunchModelConfig[] {
+  if (config.models?.length) return config.models
+  return [{ sdk: config.sdk, model: config.model, codexFastMode: config.codexFastMode }]
 }
 
 export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> {
@@ -90,211 +61,37 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
     return
   }
 
+  // Pin the base worktree once per batch (not per model — a future multi-launch
+  // must not re-pin for every model it spawns).
   void autoPinBaseWorktree(ticket.project_id)
 
-  try {
-    // 1. Resolve worktree
-    let worktreeId: string
-    if (config.worktree.type === 'new') {
-      const nameHint = canonicalizeTicketTitle(ticket.title)
-      const result = await useWorktreeStore
-        .getState()
-        .createWorktreeFromBranch(
-          ticket.project_id,
-          project.path,
-          project.name,
-          config.worktree.sourceBranch,
-          nameHint || undefined
-        )
-      if (!result.success || !result.worktree?.id) {
-        toast.error(`Auto-launch failed: ${result.error || 'Could not create worktree'}`)
-        return
-      }
-      worktreeId = result.worktree.id
-    } else {
-      worktreeId = config.worktree.worktreeId
-    }
+  const entries = resolveModelEntries(config)
 
-    // Resolve the worktree record once — needed for plan-file creation and the
-    // OpenCode connect below. Newly created worktrees are already in the store.
-    const findWorktree = (): { path: string } | undefined =>
-      Array.from(useWorktreeStore.getState().worktreesByProject.values())
-        .flat()
-        .find((w) => w.id === worktreeId)
-    let worktree = findWorktree()
-    if (!worktree) {
-      // The project's worktrees may not be loaded yet (e.g. auto-launch firing
-      // from a store subscription shortly after startup)
-      await useWorktreeStore.getState().loadWorktrees(ticket.project_id)
-      worktree = findWorktree()
-    }
+  // TODO(task 5): route to runMultiModelLaunch when
+  // `entries.length > 1 && config.worktree.type === 'new'` — one worktree +
+  // duplicated ticket per model. Until then, launch only entries[0] so existing
+  // single-model behavior is unchanged.
+  const result = await launchTicketWithModel({
+    ticketId: ticket.id,
+    projectId: ticket.project_id,
+    ticketTitle: ticket.title,
+    worktree: config.worktree,
+    prompt: config.prompt,
+    mode: config.mode,
+    modelConfig: entries[0],
+    goalMode: configGoalMode,
+    goalSuccessCriteria: configGoalSuccessCriteria,
+    ticketUpdateExtras: { pending_launch_config: null }
+  })
 
-    // Oversized goal prompts get rejected by the CLI — persist the full ticket
-    // prompt as PLAN_{uuid}.md in the worktree root and send a short
-    // "Implement PLAN_{uuid}.md" goal prompt instead (the /goal wrapper stays).
-    if (configGoalMode && configGoalSuccessCriteria && worktree?.path) {
-      const composed = composeAutoLaunchPrompt(
-        config,
-        config.sdk,
-        configGoalMode,
-        configGoalSuccessCriteria,
-        { claudeCli: config.sdk === 'claude-code-cli' }
-      )
-      if (exceedsGoalPromptLimit(composed)) {
-        const fileName = await createPlanFile(worktree.path, config.prompt.trim())
-        config = { ...config, prompt: planFilePrompt(fileName) }
-      }
-    }
-
-    // 2. Create session
-    const modelOverride = config.model ? { ...config.model, agentSdk: config.sdk } : undefined
-    const cliPendingPrompt =
-      config.sdk === 'claude-code-cli'
-        ? composeAutoLaunchPrompt(config, config.sdk, configGoalMode, configGoalSuccessCriteria, {
-            claudeCli: true
-          })
-        : null
-    const createOptions = {
-      autoFocus: false,
-      ...(modelOverride ? { modelOverride } : {}),
-      ...(cliPendingPrompt ? { pendingMessage: cliPendingPrompt } : {})
-    }
-    const sessionResult = await useSessionStore
-      .getState()
-      .createSession(worktreeId, ticket.project_id, config.sdk, config.mode, createOptions)
-    if (!sessionResult.success || !sessionResult.session) {
-      toast.error(`Auto-launch failed: ${sessionResult.error || 'Could not create session'}`)
-      return
-    }
-
-    const sessionId = sessionResult.session.id
-    const sessionAgentSdk = sessionResult.session.agent_sdk
-
-    // 3. Set status tracking
-    messageSendTimes.set(sessionId, Date.now())
-    userExplicitSendTimes.set(sessionId, Date.now())
-    snapshotTokenBaseline(sessionId)
-    lastSendMode.set(sessionId, isPlanLike(config.mode) ? 'plan' : 'build')
-    useWorktreeStatusStore
-      .getState()
-      .setSessionStatus(sessionId, isPlanLike(config.mode) ? 'planning' : 'working')
-
-    // 4. Apply model override
-    const effectiveModel = config.model ?? undefined
-    if (config.model) {
-      await useSessionStore.getState().setSessionModel(sessionId, config.model)
-    }
-
-    // 5. Update ticket: clear pending config, set session + worktree
-    await useKanbanStore.getState().updateTicket(ticket.id, ticket.project_id, {
-      pending_launch_config: null,
-      current_session_id: sessionId,
-      worktree_id: worktreeId,
-      mode: config.mode,
-      goal_mode: configGoalMode,
-      goal_success_criteria: configGoalMode ? configGoalSuccessCriteria : null
-    })
-
-    // 6. Trigger usage refresh
-    useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(config.sdk))
-
-    // 7. Toast notification
+  if (result.success) {
     toast.success(`Auto-launched: ${ticket.title}`)
-
-    if (sessionAgentSdk === 'claude-code-cli') {
-      const outboundPrompt =
-        cliPendingPrompt ??
-        composeAutoLaunchPrompt(
-          config,
-          sessionAgentSdk,
-          configGoalMode,
-          configGoalSuccessCriteria,
-          {
-            claudeCli: true
-          }
-        )
-
-      if (config.mode === 'super-plan') {
-        // Await so the persisted mode is committed before the main process
-        // reads it in buildClaudeCliPtySpawn (createClaudeCli).
-        await useSessionStore.getState().setSessionMode(sessionId, 'plan')
-      }
-
-      bumpWorktreeLastMessage({ worktreeId })
-      const result = unwrapEnvelope(
-        await terminalApi.createClaudeCli(sessionId, {
-          pendingPrompt: outboundPrompt
-        })
-      )
-      if (result.success && outboundPrompt) {
-        useSessionStore.getState().dequeuePendingMessage(sessionId)
-      }
-      return
-    }
-
-    // 8. Connect to OpenCode and send prompt
-    if (!worktree?.path) return
-
-    const connectResult = unwrapEnvelope(await opencodeApi.connect(worktree.path, sessionId))
-    if (!connectResult.success || !connectResult.sessionId) {
-      toast.error(`Auto-launch failed: ${connectResult.error || 'Could not start session'}`)
-      return
-    }
-
-    useSessionStore.getState().setOpenCodeSessionId(sessionId, connectResult.sessionId)
-    await dbApi.session.update(sessionId, { opencode_session_id: connectResult.sessionId })
-
-    // 9. Send prompt
-    if (config.prompt.trim()) {
-      const outboundPrompt = composeAutoLaunchPrompt(
-        config,
-        sessionAgentSdk,
-        configGoalMode,
-        configGoalSuccessCriteria,
-        { claudeCli: false }
-      )
-      if (!outboundPrompt) return
-
-      const promptOptions =
-        sessionAgentSdk === 'codex' ? { codexFastMode: config.codexFastMode } : undefined
-
-      if (config.mode === 'super-plan') {
-        useSessionStore.getState().setSessionMode(sessionId, 'plan')
-      }
-
-      bumpWorktreeLastMessage({ worktreeId })
-      startHivePromptTelemetry({
-        sessionId,
-        prompt: outboundPrompt,
-        worktreeId,
-        modelId: effectiveModel?.modelID,
-        providerId: effectiveModel?.providerID,
-        modelVariant: effectiveModel?.variant,
-        mode: config.mode,
-        // Auto-launch is not an interactive send from a tab.
-        source: 'other'
-      })
-      unwrapEnvelope(
-        await opencodeApi.prompt(
-          worktree.path,
-          connectResult.sessionId,
-          [{ type: 'text', text: outboundPrompt }],
-          // Strip `agentSdk` — the prompt RPC model schema is .strict() and
-          // rejects it ("RPC parameters failed validation").
-          effectiveModel
-            ? {
-                providerID: effectiveModel.providerID,
-                modelID: effectiveModel.modelID,
-                variant: effectiveModel.variant
-              }
-            : undefined,
-          promptOptions
-        )
-      )
-    }
-  } catch (err) {
-    console.error('Auto-launch failed for ticket:', ticket.id, err)
-    const detail = err instanceof Error ? err.message : null
-    toast.error(`Auto-launch failed for: ${ticket.title}${detail ? ` — ${detail}` : ''}`)
+    return
   }
+
+  // launchTicketWithModel funnels every failure (worktree/session/connect and
+  // any thrown error) into a single result, so the two historical failure
+  // toasts collapse to one. Keep the console.error for diagnostics.
+  console.error('Auto-launch failed for ticket:', ticket.id, result.error)
+  toast.error(`Auto-launch failed: ${result.error || 'Could not launch session'}`)
 }

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -2,6 +2,7 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { toast } from '@/lib/toast'
 import { autoPinBaseWorktree } from '@/lib/auto-pin'
 import { launchTicketWithModel, type LaunchModelConfig } from '@/lib/ticket-launch'
+import { runMultiModelLaunch } from '@/lib/multi-model-launch'
 import type { HandoffAgentSdk } from '@shared/types/agent-sdk'
 
 type AutoLaunchMode = 'build' | 'plan' | 'super-plan'
@@ -67,10 +68,25 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
 
   const entries = resolveModelEntries(config)
 
-  // TODO(task 5): route to runMultiModelLaunch when
-  // `entries.length > 1 && config.worktree.type === 'new'` — one worktree +
-  // duplicated ticket per model. Until then, launch only entries[0] so existing
-  // single-model behavior is unchanged.
+  // Multiple models + a brand-new worktree: one worktree + duplicated ticket
+  // per model, all launched by the background orchestrator. An EXISTING
+  // worktree can only host one session, so multi-entry + existing worktree
+  // keeps the single-path entries[0] behavior below.
+  if (entries.length > 1 && config.worktree.type === 'new') {
+    await runMultiModelLaunch({
+      ticket: { id: ticket.id, title: ticket.title },
+      projectId: ticket.project_id,
+      prompt: config.prompt,
+      mode: config.mode,
+      sourceBranch: config.worktree.sourceBranch,
+      goalMode: configGoalMode,
+      goalSuccessCriteria: configGoalSuccessCriteria,
+      entries,
+      clearPendingConfig: true
+    })
+    return
+  }
+
   const result = await launchTicketWithModel({
     ticketId: ticket.id,
     projectId: ticket.project_id,

--- a/src/renderer/src/lib/multi-model-launch.test.ts
+++ b/src/renderer/src/lib/multi-model-launch.test.ts
@@ -1,0 +1,334 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runMultiModelLaunch, type MultiModelLaunchPlan } from './multi-model-launch'
+import { launchTicketWithModel } from '@/lib/ticket-launch'
+import { toast } from '@/lib/toast'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useUsageStore } from '@/stores/useUsageStore'
+import type { KanbanTicket } from '../../../main/db/types'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/ticket-launch', () => ({
+  launchTicketWithModel: vi.fn()
+}))
+
+const initialKanbanState = useKanbanStore.getState()
+const initialUsageState = useUsageStore.getState()
+const initialSettingsState = useSettingsStore.getState()
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'existing-1',
+    project_id: 'project-1',
+    title: 'Existing ticket',
+    description: null,
+    attachments: [],
+    column: 'in_progress',
+    sort_order: 5,
+    current_session_id: null,
+    worktree_id: null,
+    mode: null,
+    plan_ready: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
+    created_from_session: false,
+    auto_approve_plan: false,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
+    ...overrides
+  }
+}
+
+function basePlan(overrides: Partial<MultiModelLaunchPlan> = {}): MultiModelLaunchPlan {
+  return {
+    ticket: { id: 'ticket-1', title: 'Fix Login Bug' },
+    projectId: 'project-1',
+    prompt: 'Implement the fix',
+    mode: 'build',
+    sourceBranch: 'main',
+    goalMode: false,
+    goalSuccessCriteria: null,
+    entries: [
+      {
+        sdk: 'opencode',
+        model: { providerID: 'anthropic', modelID: 'claude-opus-4-5-20251101' },
+        codexFastMode: false
+      },
+      {
+        sdk: 'codex',
+        model: { providerID: 'codex', modelID: 'gpt-5.5-codex' },
+        codexFastMode: true
+      },
+      {
+        sdk: 'claude-code-cli',
+        model: { providerID: 'anthropic', modelID: 'sonnet', variant: 'high' },
+        codexFastMode: false
+      }
+    ],
+    clearPendingConfig: true,
+    ...overrides
+  }
+}
+
+function setupStores(existingTickets: KanbanTicket[] = [makeTicket()]): {
+  updateTicket: ReturnType<typeof vi.fn>
+  duplicateTicket: ReturnType<typeof vi.fn>
+  fetchUsageForProvider: ReturnType<typeof vi.fn>
+} {
+  const updateTicket = vi.fn(async () => undefined)
+  let dupCounter = 0
+  const duplicateTicket = vi.fn(async (): Promise<KanbanTicket> => {
+    dupCounter += 1
+    return makeTicket({ id: `dup-${dupCounter}` })
+  })
+  const fetchUsageForProvider = vi.fn()
+
+  useKanbanStore.setState({
+    tickets: new Map([['project-1', existingTickets]]),
+    updateTicket,
+    duplicateTicket
+  })
+  useUsageStore.setState({ fetchUsageForProvider })
+  // Guard against persisted per-provider defaults leaking in from localStorage
+  // in the test environment (see ticket-launch.test.ts's identical guard).
+  useSettingsStore.setState({ selectedModel: null, selectedModelByProvider: {} })
+
+  return { updateTicket, duplicateTicket, fetchUsageForProvider }
+}
+
+describe('runMultiModelLaunch', () => {
+  beforeAll(() => {
+    // Absorb the useSettingsStore one-shot 200ms import timer so it cannot
+    // null store state mid-test (see global constraints).
+    return new Promise((resolve) => setTimeout(resolve, 220))
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(launchTicketWithModel).mockResolvedValue({
+      success: true,
+      sessionId: 'session-x',
+      worktreeId: 'worktree-x'
+    })
+  })
+
+  afterEach(() => {
+    useKanbanStore.setState(initialKanbanState, true)
+    useUsageStore.setState(initialUsageState, true)
+    useSettingsStore.setState(initialSettingsState, true)
+  })
+
+  it('makes all N tickets appear immediately with badge fields, a shared group id, and fractional sort orders', async () => {
+    const { updateTicket, duplicateTicket } = setupStores()
+
+    await runMultiModelLaunch(basePlan())
+
+    // base = computeSortOrder([{sort_order: 5}], 0) = 5 - 1 = 4
+    expect(updateTicket).toHaveBeenCalledTimes(1)
+    const [originalId, originalProjectId, originalData] = updateTicket.mock.calls[0]
+    expect(originalId).toBe('ticket-1')
+    expect(originalProjectId).toBe('project-1')
+    expect(originalData).toMatchObject({
+      column: 'in_progress',
+      sort_order: 4,
+      mode: 'build',
+      plan_ready: false,
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-5-20251101',
+      model_variant: null,
+      goal_mode: false,
+      goal_success_criteria: null,
+      pending_launch_config: null
+    })
+    const groupId = originalData.variant_group_id as string
+    expect(typeof groupId).toBe('string')
+    expect(groupId.length).toBeGreaterThan(0)
+
+    expect(duplicateTicket).toHaveBeenCalledTimes(2)
+    expect(duplicateTicket).toHaveBeenNthCalledWith(1, 'project-1', 'ticket-1', {
+      column: 'in_progress',
+      sort_order: 4 + 1 / 3,
+      model_provider_id: 'codex',
+      model_id: 'gpt-5.5-codex',
+      model_variant: null,
+      variant_group_id: groupId
+    })
+    expect(duplicateTicket).toHaveBeenNthCalledWith(2, 'project-1', 'ticket-1', {
+      column: 'in_progress',
+      sort_order: 4 + 2 / 3,
+      model_provider_id: 'anthropic',
+      model_id: 'sonnet',
+      model_variant: 'high',
+      variant_group_id: groupId
+    })
+  })
+
+  it('falls back through resolveModelForSdk/FALLBACK_MODELS when an entry has no explicit model', async () => {
+    const { updateTicket, duplicateTicket } = setupStores()
+
+    await runMultiModelLaunch(
+      basePlan({
+        entries: [
+          { sdk: 'opencode', model: { providerID: 'anthropic', modelID: 'opus' }, codexFastMode: false },
+          { sdk: 'claude-code-cli', model: null, codexFastMode: false }
+        ]
+      })
+    )
+
+    // FALLBACK_MODELS['claude-code-cli'] = { providerID: 'anthropic', modelID: 'sonnet', variant: 'high' }
+    expect(duplicateTicket).toHaveBeenCalledWith(
+      'project-1',
+      'ticket-1',
+      expect.objectContaining({
+        model_provider_id: 'anthropic',
+        model_id: 'sonnet',
+        model_variant: 'high'
+      })
+    )
+    expect(updateTicket).toHaveBeenCalledTimes(1)
+  })
+
+  it('launches sequentially — the second launch does not start before the first resolves', async () => {
+    setupStores()
+    let firstResolved = false
+    let secondStartedBeforeFirstResolved = false
+    vi.mocked(launchTicketWithModel).mockImplementation(async (spec) => {
+      if (spec.ticketId === 'ticket-1') {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        firstResolved = true
+        return { success: true, sessionId: 's1', worktreeId: 'w1' }
+      }
+      if (!firstResolved) secondStartedBeforeFirstResolved = true
+      return { success: true, sessionId: 's2', worktreeId: 'w2' }
+    })
+
+    await runMultiModelLaunch(basePlan())
+
+    expect(secondStartedBeforeFirstResolved).toBe(false)
+  })
+
+  it('launches with the right worktree nameHints (title slug + model slug)', async () => {
+    setupStores()
+
+    await runMultiModelLaunch(basePlan())
+
+    expect(launchTicketWithModel).toHaveBeenCalledTimes(3)
+    const calls = vi.mocked(launchTicketWithModel).mock.calls
+    expect(calls[0][0]).toMatchObject({
+      ticketId: 'ticket-1',
+      worktree: { type: 'new', sourceBranch: 'main', nameHint: 'fix-login-bug-claude-opus-4-5' },
+      prompt: 'Implement the fix',
+      mode: 'build',
+      goalMode: false,
+      goalSuccessCriteria: null
+    })
+    expect(calls[0][0].modelConfig).toEqual(basePlan().entries[0])
+    expect(calls[0][0]).not.toHaveProperty('ticketUpdateExtras')
+
+    expect(calls[1][0]).toMatchObject({
+      ticketId: 'dup-1',
+      worktree: { type: 'new', sourceBranch: 'main', nameHint: 'fix-login-bug-gpt-5-5-codex' }
+    })
+    expect(calls[2][0]).toMatchObject({
+      ticketId: 'dup-2',
+      worktree: { type: 'new', sourceBranch: 'main', nameHint: 'fix-login-bug-sonnet' }
+    })
+  })
+
+  it('moves a failed launch back to To Do with cleared fields (keeping variant_group_id), toasts, and still launches the next entry', async () => {
+    const { updateTicket } = setupStores([
+      makeTicket({ id: 'existing-1', column: 'in_progress', sort_order: 5 }),
+      makeTicket({ id: 'todo-1', column: 'todo', sort_order: 2 })
+    ])
+    vi.mocked(launchTicketWithModel).mockImplementation(async (spec) => {
+      if (spec.ticketId === 'dup-1') return { success: false, error: 'boom' }
+      return { success: true, sessionId: 's', worktreeId: 'w' }
+    })
+
+    await runMultiModelLaunch(basePlan())
+
+    expect(toast.error).toHaveBeenCalledWith('Failed to launch gpt-5.5-codex: boom')
+
+    // The failure-recovery updateTicket call is the second call (after the
+    // initial "appears immediately" call for the original ticket).
+    expect(updateTicket).toHaveBeenCalledTimes(2)
+    const [failedId, failedProjectId, failedData] = updateTicket.mock.calls[1]
+    expect(failedId).toBe('dup-1')
+    expect(failedProjectId).toBe('project-1')
+    expect(failedData).toEqual({
+      column: 'todo',
+      sort_order: 1, // computeSortOrder([{sort_order: 2}], 0) = 2 - 1 = 1
+      current_session_id: null,
+      worktree_id: null,
+      plan_ready: false,
+      mode: null,
+      goal_mode: false,
+      goal_success_criteria: null,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null
+    })
+    expect(failedData).not.toHaveProperty('variant_group_id')
+
+    // entry-2 (dup-2) still launched despite entry-1's failure.
+    expect(launchTicketWithModel).toHaveBeenCalledTimes(3)
+    expect(vi.mocked(launchTicketWithModel).mock.calls[2][0].ticketId).toBe('dup-2')
+  })
+
+  it('skips the launch for a model whose duplicateTicket call fails, but still launches the next entry', async () => {
+    setupStores()
+    const duplicateTicket = vi.fn(async (_projectId: string, _ticketId: string, overrides: unknown) => {
+      const o = overrides as { model_id: string }
+      if (o.model_id === 'gpt-5.5-codex') return null
+      return makeTicket({ id: 'dup-2' })
+    })
+    useKanbanStore.setState({ duplicateTicket })
+
+    await runMultiModelLaunch(basePlan())
+
+    expect(toast.error).toHaveBeenCalledWith('Failed to duplicate ticket for gpt-5.5-codex')
+
+    expect(launchTicketWithModel).toHaveBeenCalledTimes(2)
+    const calls = vi.mocked(launchTicketWithModel).mock.calls
+    expect(calls[0][0].ticketId).toBe('ticket-1')
+    expect(calls[1][0].ticketId).toBe('dup-2')
+  })
+
+  it('refreshes usage once per distinct SDK among entries, after the loop', async () => {
+    const { fetchUsageForProvider } = setupStores()
+
+    await runMultiModelLaunch(
+      basePlan({
+        entries: [
+          { sdk: 'opencode', model: { providerID: 'anthropic', modelID: 'opus' }, codexFastMode: false },
+          { sdk: 'opencode', model: { providerID: 'anthropic', modelID: 'sonnet' }, codexFastMode: false },
+          { sdk: 'codex', model: { providerID: 'codex', modelID: 'gpt-5.5' }, codexFastMode: false }
+        ]
+      })
+    )
+
+    expect(fetchUsageForProvider).toHaveBeenCalledTimes(2)
+    expect(fetchUsageForProvider).toHaveBeenNthCalledWith(1, 'anthropic')
+    expect(fetchUsageForProvider).toHaveBeenNthCalledWith(2, 'openai')
+  })
+})

--- a/src/renderer/src/lib/multi-model-launch.test.ts
+++ b/src/renderer/src/lib/multi-model-launch.test.ts
@@ -153,6 +153,10 @@ describe('runMultiModelLaunch', () => {
       sort_order: 4,
       mode: 'build',
       plan_ready: false,
+      // Stale session/worktree links from a previous launch of this ticket
+      // must be detached before the batch starts.
+      current_session_id: null,
+      worktree_id: null,
       model_provider_id: 'anthropic',
       model_id: 'claude-opus-4-5-20251101',
       model_variant: null,
@@ -243,7 +247,6 @@ describe('runMultiModelLaunch', () => {
       goalSuccessCriteria: null
     })
     expect(calls[0][0].modelConfig).toEqual(basePlan().entries[0])
-    expect(calls[0][0]).not.toHaveProperty('ticketUpdateExtras')
 
     expect(calls[1][0]).toMatchObject({
       ticketId: 'dup-1',
@@ -253,6 +256,15 @@ describe('runMultiModelLaunch', () => {
       ticketId: 'dup-2',
       worktree: { type: 'new', sourceBranch: 'main', nameHint: 'fix-login-bug-sonnet' }
     })
+
+    // Every launch carries ticketUpdateExtras.variant_group_id so the pipeline's
+    // shared success update (which defaults it to null) re-stamps the batch's
+    // shared group id instead of clearing it.
+    const groupId = calls[0][0].ticketUpdateExtras?.variant_group_id as string
+    expect(typeof groupId).toBe('string')
+    expect(groupId.length).toBeGreaterThan(0)
+    expect(calls[1][0].ticketUpdateExtras).toEqual({ variant_group_id: groupId })
+    expect(calls[2][0].ticketUpdateExtras).toEqual({ variant_group_id: groupId })
   })
 
   it('moves a failed launch back to To Do with cleared fields (keeping variant_group_id), toasts, and still launches the next entry', async () => {
@@ -295,6 +307,41 @@ describe('runMultiModelLaunch', () => {
     expect(vi.mocked(launchTicketWithModel).mock.calls[2][0].ticketId).toBe('dup-2')
   })
 
+  it('continues to the next entry and toasts both failures when the failure-recovery update itself throws', async () => {
+    setupStores([
+      makeTicket({ id: 'existing-1', column: 'in_progress', sort_order: 5 }),
+      makeTicket({ id: 'todo-1', column: 'todo', sort_order: 2 })
+    ])
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    // Only the recovery ("move back to todo") update throws — the initial
+    // "appears immediately" update (column: 'in_progress') must keep succeeding.
+    const updateTicket = vi.fn(async (_ticketId: string, _projectId: string, data: unknown) => {
+      if ((data as { column?: string }).column === 'todo') {
+        throw new Error('recovery rpc failed')
+      }
+    })
+    useKanbanStore.setState({ updateTicket })
+    vi.mocked(launchTicketWithModel).mockImplementation(async (spec) => {
+      if (spec.ticketId === 'dup-1') return { success: false, error: 'boom' }
+      return { success: true, sessionId: 's', worktreeId: 'w' }
+    })
+
+    await runMultiModelLaunch(basePlan())
+
+    expect(toast.error).toHaveBeenCalledWith('Failed to launch gpt-5.5-codex: boom')
+    expect(toast.error).toHaveBeenCalledWith(
+      'Failed to reset gpt-5.5-codex after launch failure: recovery rpc failed'
+    )
+    expect(errorSpy).toHaveBeenCalled()
+
+    // entry-2 (dup-2) still launched despite the recovery update throwing —
+    // the loop must never abort because of it.
+    expect(launchTicketWithModel).toHaveBeenCalledTimes(3)
+    expect(vi.mocked(launchTicketWithModel).mock.calls[2][0].ticketId).toBe('dup-2')
+
+    errorSpy.mockRestore()
+  })
+
   it('skips the launch for a model whose duplicateTicket call fails, but still launches the next entry', async () => {
     setupStores()
     const duplicateTicket = vi.fn(async (_projectId: string, _ticketId: string, overrides: unknown) => {
@@ -312,6 +359,54 @@ describe('runMultiModelLaunch', () => {
     const calls = vi.mocked(launchTicketWithModel).mock.calls
     expect(calls[0][0].ticketId).toBe('ticket-1')
     expect(calls[1][0].ticketId).toBe('dup-2')
+  })
+
+  it('skips the launch for a model whose duplicateTicket call throws, but still launches the next entry', async () => {
+    setupStores()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const duplicateTicket = vi.fn(async (_projectId: string, _ticketId: string, overrides: unknown) => {
+      const o = overrides as { model_id: string }
+      if (o.model_id === 'gpt-5.5-codex') throw new Error('duplicate rpc failed')
+      return makeTicket({ id: 'dup-2' })
+    })
+    useKanbanStore.setState({ duplicateTicket })
+
+    await runMultiModelLaunch(basePlan())
+
+    expect(toast.error).toHaveBeenCalledWith('Failed to duplicate ticket for gpt-5.5-codex')
+    expect(errorSpy).toHaveBeenCalled()
+
+    expect(launchTicketWithModel).toHaveBeenCalledTimes(2)
+    const calls = vi.mocked(launchTicketWithModel).mock.calls
+    expect(calls[0][0].ticketId).toBe('ticket-1')
+    expect(calls[1][0].ticketId).toBe('dup-2')
+
+    errorSpy.mockRestore()
+  })
+
+  it('toasts and does not throw when the orchestrator hits an unexpected top-level error', async () => {
+    setupStores()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    // Any unguarded throw in the setup/original-update phase must be caught
+    // by the top-level try/catch rather than propagating as an unhandled
+    // rejection (the modal fires this with `void`, no top-level .catch).
+    useKanbanStore.setState({
+      updateTicket: vi.fn(async () => {
+        throw new Error('board update exploded')
+      })
+    })
+
+    await expect(runMultiModelLaunch(basePlan())).resolves.toBeUndefined()
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Failed to launch "Fix Login Bug": board update exploded'
+    )
+    expect(errorSpy).toHaveBeenCalled()
+    // Nothing downstream ran — the batch legitimately aborted, but it toasted
+    // instead of vanishing as an unhandled rejection.
+    expect(launchTicketWithModel).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
   })
 
   it('refreshes usage once per distinct SDK among entries, after the loop', async () => {

--- a/src/renderer/src/lib/multi-model-launch.test.ts
+++ b/src/renderer/src/lib/multi-model-launch.test.ts
@@ -5,6 +5,8 @@ import { toast } from '@/lib/toast'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useUsageStore } from '@/stores/useUsageStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { dbApi } from '@/api/db-api'
 import type { KanbanTicket } from '../../../main/db/types'
 
 vi.mock('@/lib/toast', () => ({
@@ -18,9 +20,18 @@ vi.mock('@/lib/ticket-launch', () => ({
   launchTicketWithModel: vi.fn()
 }))
 
+vi.mock('@/api/db-api', () => ({
+  dbApi: {
+    session: {
+      update: vi.fn(async () => undefined)
+    }
+  }
+}))
+
 const initialKanbanState = useKanbanStore.getState()
 const initialUsageState = useUsageStore.getState()
 const initialSettingsState = useSettingsStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
 
 function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
   return {
@@ -85,7 +96,6 @@ function basePlan(overrides: Partial<MultiModelLaunchPlan> = {}): MultiModelLaun
         codexFastMode: false
       }
     ],
-    clearPendingConfig: true,
     ...overrides
   }
 }
@@ -112,6 +122,7 @@ function setupStores(existingTickets: KanbanTicket[] = [makeTicket()]): {
   // Guard against persisted per-provider defaults leaking in from localStorage
   // in the test environment (see ticket-launch.test.ts's identical guard).
   useSettingsStore.setState({ selectedModel: null, selectedModelByProvider: {} })
+  useWorktreeStatusStore.setState({ setSessionStatus: vi.fn() })
 
   return { updateTicket, duplicateTicket, fetchUsageForProvider }
 }
@@ -136,6 +147,7 @@ describe('runMultiModelLaunch', () => {
     useKanbanStore.setState(initialKanbanState, true)
     useUsageStore.setState(initialUsageState, true)
     useSettingsStore.setState(initialSettingsState, true)
+    useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
   })
 
   it('makes all N tickets appear immediately with badge fields, a shared group id, and fractional sort orders', async () => {
@@ -361,7 +373,12 @@ describe('runMultiModelLaunch', () => {
     expect(calls[1][0].ticketId).toBe('dup-2')
   })
 
-  it('skips the launch for a model whose duplicateTicket call throws, but still launches the next entry', async () => {
+  it('has no dead catch around duplicateTicket: a thrown error propagates to the top-level catch (Fix 6)', async () => {
+    // useKanbanStore.duplicateTicket is documented to catch internally and
+    // resolve null on failure — it never throws. If it somehow did throw, the
+    // per-entry loop no longer has its own try/catch around the call, so the
+    // throw surfaces through the function's single top-level catch instead of
+    // being swallowed with a duplicate console.error.
     setupStores()
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const duplicateTicket = vi.fn(async (_projectId: string, _ticketId: string, overrides: unknown) => {
@@ -371,15 +388,87 @@ describe('runMultiModelLaunch', () => {
     })
     useKanbanStore.setState({ duplicateTicket })
 
+    await expect(runMultiModelLaunch(basePlan())).resolves.toBeUndefined()
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Failed to launch "Fix Login Bug": duplicate rpc failed'
+    )
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Multi-model launch failed for "Fix Login Bug"',
+      expect.any(Error)
+    )
+    // The batch aborted at the top level — no per-model "Failed to duplicate"
+    // toast, and nothing launched.
+    expect(toast.error).not.toHaveBeenCalledWith('Failed to duplicate ticket for gpt-5.5-codex')
+    expect(launchTicketWithModel).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+
+  it('marks an orphaned session completed before clearing ticket links when a launch fails after session creation (Fix 5)', async () => {
+    setupStores([
+      makeTicket({ id: 'existing-1', column: 'in_progress', sort_order: 5 }),
+      makeTicket({ id: 'todo-1', column: 'todo', sort_order: 2 })
+    ])
+    vi.mocked(launchTicketWithModel).mockImplementation(async (spec) => {
+      if (spec.ticketId === 'dup-1') {
+        return { success: false, error: 'connect refused', sessionId: 'orphan-session', worktreeId: 'w' }
+      }
+      return { success: true, sessionId: 's', worktreeId: 'w' }
+    })
+
     await runMultiModelLaunch(basePlan())
 
-    expect(toast.error).toHaveBeenCalledWith('Failed to duplicate ticket for gpt-5.5-codex')
-    expect(errorSpy).toHaveBeenCalled()
+    expect(dbApi.session.update).toHaveBeenCalledWith('orphan-session', {
+      status: 'completed',
+      completed_at: expect.any(String)
+    })
+    expect(useWorktreeStatusStore.getState().setSessionStatus).toHaveBeenCalledWith(
+      'orphan-session',
+      'completed'
+    )
+    // entry-2 still launches despite the failure.
+    expect(launchTicketWithModel).toHaveBeenCalledTimes(3)
+  })
 
-    expect(launchTicketWithModel).toHaveBeenCalledTimes(2)
-    const calls = vi.mocked(launchTicketWithModel).mock.calls
-    expect(calls[0][0].ticketId).toBe('ticket-1')
-    expect(calls[1][0].ticketId).toBe('dup-2')
+  it('does not attempt to complete a session when the failed launch never created one', async () => {
+    setupStores([
+      makeTicket({ id: 'existing-1', column: 'in_progress', sort_order: 5 }),
+      makeTicket({ id: 'todo-1', column: 'todo', sort_order: 2 })
+    ])
+    vi.mocked(launchTicketWithModel).mockImplementation(async (spec) => {
+      if (spec.ticketId === 'dup-1') return { success: false, error: 'no provider' }
+      return { success: true, sessionId: 's', worktreeId: 'w' }
+    })
+
+    await runMultiModelLaunch(basePlan())
+
+    expect(dbApi.session.update).not.toHaveBeenCalled()
+  })
+
+  it('logs and continues when marking the orphaned session completed itself throws', async () => {
+    setupStores([
+      makeTicket({ id: 'existing-1', column: 'in_progress', sort_order: 5 }),
+      makeTicket({ id: 'todo-1', column: 'todo', sort_order: 2 })
+    ])
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(dbApi.session.update).mockRejectedValueOnce(new Error('session update rpc failed'))
+    vi.mocked(launchTicketWithModel).mockImplementation(async (spec) => {
+      if (spec.ticketId === 'dup-1') {
+        return { success: false, error: 'connect refused', sessionId: 'orphan-session', worktreeId: 'w' }
+      }
+      return { success: true, sessionId: 's', worktreeId: 'w' }
+    })
+
+    await runMultiModelLaunch(basePlan())
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to complete orphaned session for gpt-5.5-codex',
+      expect.any(Error)
+    )
+    // The board-recovery update and the next entry's launch still proceed.
+    expect(toast.error).toHaveBeenCalledWith('Failed to launch gpt-5.5-codex: connect refused')
+    expect(launchTicketWithModel).toHaveBeenCalledTimes(3)
 
     errorSpy.mockRestore()
   })

--- a/src/renderer/src/lib/multi-model-launch.ts
+++ b/src/renderer/src/lib/multi-model-launch.ts
@@ -1,11 +1,12 @@
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { resolveModelForSdk } from '@/stores/useSettingsStore'
 import { toast } from '@/lib/toast'
 import { launchTicketWithModel, type LaunchModelConfig } from '@/lib/ticket-launch'
 import { canonicalizeModelSlug, canonicalizeTicketTitle } from '@shared/types/branch-utils'
 import { FALLBACK_MODELS } from '@shared/model-resolution'
-import type { KanbanTicket } from '../../../main/db/types'
+import { dbApi } from '@/api/db-api'
 
 type LaunchMode = 'build' | 'plan' | 'super-plan'
 
@@ -20,8 +21,6 @@ export interface MultiModelLaunchPlan {
   goalSuccessCriteria: string | null
   /** N >= 2; entries[0] applies to the original ticket, entries[1..] to duplicates. */
   entries: LaunchModelConfig[]
-  /** True when invoked from the auto-launch seam (clears pending_launch_config on the original ticket). */
-  clearPendingConfig?: boolean
 }
 
 interface EffectiveModel {
@@ -55,8 +54,9 @@ function errorMessage(err: unknown): string {
  * parallel, since worktree creation serializes anyway. A single model's
  * failure (duplicate or launch) is toasted and does not block the rest.
  *
- * The whole body is wrapped in try/catch: `updateTicket`/`duplicateTicket`
- * rethrow on RPC failure (useKanbanStore), and this function is fired with
+ * The whole body is wrapped in try/catch: `updateTicket` rethrows on RPC
+ * failure (useKanbanStore) — `duplicateTicket` does not, it catches
+ * internally and resolves `null` instead — and this function is fired with
  * `void` at the call site (no `.catch`), so an unguarded throw here would be
  * an unhandled rejection that silently kills the rest of the batch. Every
  * throw is toasted instead — this function never rethrows.
@@ -93,30 +93,32 @@ export async function runMultiModelLaunch(plan: MultiModelLaunchPlan): Promise<v
       variant_group_id: variantGroupId,
       goal_mode: plan.goalMode,
       goal_success_criteria: goalSuccessCriteria,
-      ...(plan.clearPendingConfig ? { pending_launch_config: null } : {})
+      // Every multi-model launch (auto-launch or manual, via the modal) must
+      // clear any pending_launch_config on the original ticket — otherwise a
+      // ticket queued via Save & Queue with a `models` array can auto-launch
+      // the full multi-model batch again after these sessions already started.
+      pending_launch_config: null
     })
 
     // Duplicates appear immediately as entries 1..N-1. A failed duplicate
-    // (either a `null` return or a thrown RPC error) skips that model's
-    // launch (ticketIds[i] stays null) but doesn't block the rest.
+    // (a `null` return) skips that model's launch (ticketIds[i] stays null)
+    // but doesn't block the rest.
     const ticketIds: (string | null)[] = [plan.ticket.id]
     for (let i = 1; i < plan.entries.length; i++) {
       const model = effectiveModels[i]
-      let duplicate: KanbanTicket | null = null
-      try {
-        duplicate = await useKanbanStore
-          .getState()
-          .duplicateTicket(plan.projectId, plan.ticket.id, {
-            column: 'in_progress',
-            sort_order: sortOrders[i],
-            model_provider_id: model.providerID,
-            model_id: model.modelID,
-            model_variant: model.variant,
-            variant_group_id: variantGroupId
-          })
-      } catch (err) {
-        console.error(`Failed to duplicate ticket for ${model.modelID}`, err)
-      }
+      // useKanbanStore.duplicateTicket catches internally and returns null on
+      // failure — it never throws, so a null return is the only failure case
+      // to handle here.
+      const duplicate = await useKanbanStore
+        .getState()
+        .duplicateTicket(plan.projectId, plan.ticket.id, {
+          column: 'in_progress',
+          sort_order: sortOrders[i],
+          model_provider_id: model.providerID,
+          model_id: model.modelID,
+          model_variant: model.variant,
+          variant_group_id: variantGroupId
+        })
       if (!duplicate) {
         toast.error(`Failed to duplicate ticket for ${model.modelID}`)
         ticketIds.push(null)
@@ -153,6 +155,22 @@ export async function runMultiModelLaunch(plan: MultiModelLaunchPlan): Promise<v
 
       if (!result.success) {
         toast.error(`Failed to launch ${model.modelID}: ${result.error}`)
+        // The launch can fail after the session was already created (e.g. the
+        // OpenCode connect or Claude CLI spawn step) — mark it finished before
+        // the ticket's link is cleared below so it doesn't linger as a phantom
+        // "working" session nothing else points at. Its own try/catch so a
+        // failure here never blocks the board-recovery update that follows.
+        if (result.sessionId) {
+          try {
+            await dbApi.session.update(result.sessionId, {
+              status: 'completed',
+              completed_at: new Date().toISOString()
+            })
+            useWorktreeStatusStore.getState().setSessionStatus(result.sessionId, 'completed')
+          } catch (err) {
+            console.error(`Failed to complete orphaned session for ${model.modelID}`, err)
+          }
+        }
         // The recovery update gets its own try/catch so a board-update
         // failure here never aborts the loop — the next entry must still launch.
         try {

--- a/src/renderer/src/lib/multi-model-launch.ts
+++ b/src/renderer/src/lib/multi-model-launch.ts
@@ -5,6 +5,7 @@ import { toast } from '@/lib/toast'
 import { launchTicketWithModel, type LaunchModelConfig } from '@/lib/ticket-launch'
 import { canonicalizeModelSlug, canonicalizeTicketTitle } from '@shared/types/branch-utils'
 import { FALLBACK_MODELS } from '@shared/model-resolution'
+import type { KanbanTicket } from '../../../main/db/types'
 
 type LaunchMode = 'build' | 'plan' | 'super-plan'
 
@@ -43,113 +44,150 @@ function resolveEffectiveModel(entry: LaunchModelConfig): EffectiveModel {
   }
 }
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
 /**
  * Background orchestrator for launching one ticket per model. Makes all N
  * tickets appear in In Progress immediately (original + duplicates), then
  * launches each model sequentially — a plain awaited for-loop, never
  * parallel, since worktree creation serializes anyway. A single model's
  * failure (duplicate or launch) is toasted and does not block the rest.
+ *
+ * The whole body is wrapped in try/catch: `updateTicket`/`duplicateTicket`
+ * rethrow on RPC failure (useKanbanStore), and this function is fired with
+ * `void` at the call site (no `.catch`), so an unguarded throw here would be
+ * an unhandled rejection that silently kills the rest of the batch. Every
+ * throw is toasted instead — this function never rethrows.
  */
 export async function runMultiModelLaunch(plan: MultiModelLaunchPlan): Promise<void> {
-  const variantGroupId = crypto.randomUUID()
-  const effectiveModels = plan.entries.map(resolveEffectiveModel)
-  const goalSuccessCriteria = plan.goalMode ? plan.goalSuccessCriteria : null
+  try {
+    const variantGroupId = crypto.randomUUID()
+    const effectiveModels = plan.entries.map(resolveEffectiveModel)
+    const goalSuccessCriteria = plan.goalMode ? plan.goalSuccessCriteria : null
 
-  // All N sort orders land adjacent above the current top of In Progress,
-  // in row order (entry 0 topmost): base is one below today's top, and each
-  // subsequent entry gets a fraction of a step below that.
-  const inProgressTickets = useKanbanStore
-    .getState()
-    .getTicketsByColumn(plan.projectId, 'in_progress')
-  const base = useKanbanStore.getState().computeSortOrder(inProgressTickets, 0)
-  const sortOrders = plan.entries.map((_, i) => base + i / plan.entries.length)
-
-  // Original ticket appears immediately as entry 0.
-  await useKanbanStore.getState().updateTicket(plan.ticket.id, plan.projectId, {
-    column: 'in_progress',
-    sort_order: sortOrders[0],
-    mode: plan.mode,
-    plan_ready: false,
-    model_provider_id: effectiveModels[0].providerID,
-    model_id: effectiveModels[0].modelID,
-    model_variant: effectiveModels[0].variant,
-    variant_group_id: variantGroupId,
-    goal_mode: plan.goalMode,
-    goal_success_criteria: goalSuccessCriteria,
-    ...(plan.clearPendingConfig ? { pending_launch_config: null } : {})
-  })
-
-  // Duplicates appear immediately as entries 1..N-1. A failed duplicate skips
-  // that model's launch (ticketIds[i] stays null) but doesn't block the rest.
-  const ticketIds: (string | null)[] = [plan.ticket.id]
-  for (let i = 1; i < plan.entries.length; i++) {
-    const model = effectiveModels[i]
-    const duplicate = await useKanbanStore
+    // All N sort orders land adjacent above the current top of In Progress,
+    // in row order (entry 0 topmost): base is one below today's top, and each
+    // subsequent entry gets a fraction of a step below that.
+    const inProgressTickets = useKanbanStore
       .getState()
-      .duplicateTicket(plan.projectId, plan.ticket.id, {
-        column: 'in_progress',
-        sort_order: sortOrders[i],
-        model_provider_id: model.providerID,
-        model_id: model.modelID,
-        model_variant: model.variant,
-        variant_group_id: variantGroupId
-      })
-    if (!duplicate) {
-      toast.error(`Failed to duplicate ticket for ${model.modelID}`)
-      ticketIds.push(null)
-      continue
-    }
-    ticketIds.push(duplicate.id)
-  }
+      .getTicketsByColumn(plan.projectId, 'in_progress')
+    const base = useKanbanStore.getState().computeSortOrder(inProgressTickets, 0)
+    const sortOrders = plan.entries.map((_, i) => base + i / plan.entries.length)
 
-  // Sequential launches — never parallel, git worktree creation serializes anyway.
-  const titleSlug = canonicalizeTicketTitle(plan.ticket.title)
-  for (let i = 0; i < plan.entries.length; i++) {
-    const ticketId = ticketIds[i]
-    if (!ticketId) continue
-
-    const model = effectiveModels[i]
-    const modelSlug = canonicalizeModelSlug(model.modelID)
-    const nameHint = titleSlug ? `${titleSlug}-${modelSlug}` : modelSlug
-
-    const result = await launchTicketWithModel({
-      ticketId,
-      projectId: plan.projectId,
-      ticketTitle: plan.ticket.title,
-      worktree: { type: 'new', sourceBranch: plan.sourceBranch, nameHint },
-      prompt: plan.prompt,
+    // Original ticket appears immediately as entry 0. Also detaches any stale
+    // session/worktree link from a previous launch of this ticket — otherwise
+    // a late event for that old session (e.g. it completes mid-batch) could
+    // yank this ticket around while the new launch is still in flight.
+    await useKanbanStore.getState().updateTicket(plan.ticket.id, plan.projectId, {
+      column: 'in_progress',
+      sort_order: sortOrders[0],
       mode: plan.mode,
-      modelConfig: plan.entries[i],
-      goalMode: plan.goalMode,
-      goalSuccessCriteria: plan.goalSuccessCriteria
+      plan_ready: false,
+      current_session_id: null,
+      worktree_id: null,
+      model_provider_id: effectiveModels[0].providerID,
+      model_id: effectiveModels[0].modelID,
+      model_variant: effectiveModels[0].variant,
+      variant_group_id: variantGroupId,
+      goal_mode: plan.goalMode,
+      goal_success_criteria: goalSuccessCriteria,
+      ...(plan.clearPendingConfig ? { pending_launch_config: null } : {})
     })
 
-    if (!result.success) {
-      toast.error(`Failed to launch ${model.modelID}: ${result.error}`)
-      // Re-read To Do from the store — an earlier failure in this same loop
-      // may have already moved a ticket there.
-      const todoTickets = useKanbanStore.getState().getTicketsByColumn(plan.projectId, 'todo')
-      const todoSortOrder = useKanbanStore.getState().computeSortOrder(todoTickets, 0)
-      await useKanbanStore.getState().updateTicket(ticketId, plan.projectId, {
-        column: 'todo',
-        sort_order: todoSortOrder,
-        current_session_id: null,
-        worktree_id: null,
-        plan_ready: false,
-        mode: null,
-        goal_mode: false,
-        goal_success_criteria: null,
-        model_provider_id: null,
-        model_id: null,
-        model_variant: null
-        // variant_group_id intentionally kept — inert in v1.
-      })
+    // Duplicates appear immediately as entries 1..N-1. A failed duplicate
+    // (either a `null` return or a thrown RPC error) skips that model's
+    // launch (ticketIds[i] stays null) but doesn't block the rest.
+    const ticketIds: (string | null)[] = [plan.ticket.id]
+    for (let i = 1; i < plan.entries.length; i++) {
+      const model = effectiveModels[i]
+      let duplicate: KanbanTicket | null = null
+      try {
+        duplicate = await useKanbanStore
+          .getState()
+          .duplicateTicket(plan.projectId, plan.ticket.id, {
+            column: 'in_progress',
+            sort_order: sortOrders[i],
+            model_provider_id: model.providerID,
+            model_id: model.modelID,
+            model_variant: model.variant,
+            variant_group_id: variantGroupId
+          })
+      } catch (err) {
+        console.error(`Failed to duplicate ticket for ${model.modelID}`, err)
+      }
+      if (!duplicate) {
+        toast.error(`Failed to duplicate ticket for ${model.modelID}`)
+        ticketIds.push(null)
+        continue
+      }
+      ticketIds.push(duplicate.id)
     }
-  }
 
-  // Usage refresh once per distinct SDK among entries.
-  const distinctSdks = new Set(plan.entries.map((entry) => entry.sdk))
-  for (const sdk of distinctSdks) {
-    useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(sdk))
+    // Sequential launches — never parallel, git worktree creation serializes anyway.
+    const titleSlug = canonicalizeTicketTitle(plan.ticket.title)
+    for (let i = 0; i < plan.entries.length; i++) {
+      const ticketId = ticketIds[i]
+      if (!ticketId) continue
+
+      const model = effectiveModels[i]
+      const modelSlug = canonicalizeModelSlug(model.modelID)
+      const nameHint = titleSlug ? `${titleSlug}-${modelSlug}` : modelSlug
+
+      const result = await launchTicketWithModel({
+        ticketId,
+        projectId: plan.projectId,
+        ticketTitle: plan.ticket.title,
+        worktree: { type: 'new', sourceBranch: plan.sourceBranch, nameHint },
+        prompt: plan.prompt,
+        mode: plan.mode,
+        modelConfig: plan.entries[i],
+        goalMode: plan.goalMode,
+        goalSuccessCriteria: plan.goalSuccessCriteria,
+        // The pipeline's success update nulls variant_group_id by default
+        // (single-launch hygiene) — re-stamp it here so multi-launched
+        // tickets keep their shared group id.
+        ticketUpdateExtras: { variant_group_id: variantGroupId }
+      })
+
+      if (!result.success) {
+        toast.error(`Failed to launch ${model.modelID}: ${result.error}`)
+        // The recovery update gets its own try/catch so a board-update
+        // failure here never aborts the loop — the next entry must still launch.
+        try {
+          // Re-read To Do from the store — an earlier failure in this same loop
+          // may have already moved a ticket there.
+          const todoTickets = useKanbanStore.getState().getTicketsByColumn(plan.projectId, 'todo')
+          const todoSortOrder = useKanbanStore.getState().computeSortOrder(todoTickets, 0)
+          await useKanbanStore.getState().updateTicket(ticketId, plan.projectId, {
+            column: 'todo',
+            sort_order: todoSortOrder,
+            current_session_id: null,
+            worktree_id: null,
+            plan_ready: false,
+            mode: null,
+            goal_mode: false,
+            goal_success_criteria: null,
+            model_provider_id: null,
+            model_id: null,
+            model_variant: null
+            // variant_group_id intentionally kept — inert in v1.
+          })
+        } catch (err) {
+          console.error(`Failed to move ${model.modelID} back to To Do after launch failure`, err)
+          toast.error(`Failed to reset ${model.modelID} after launch failure: ${errorMessage(err)}`)
+        }
+      }
+    }
+
+    // Usage refresh once per distinct SDK among entries.
+    const distinctSdks = new Set(plan.entries.map((entry) => entry.sdk))
+    for (const sdk of distinctSdks) {
+      useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(sdk))
+    }
+  } catch (err) {
+    console.error(`Multi-model launch failed for "${plan.ticket.title}"`, err)
+    toast.error(`Failed to launch "${plan.ticket.title}": ${errorMessage(err)}`)
   }
 }

--- a/src/renderer/src/lib/multi-model-launch.ts
+++ b/src/renderer/src/lib/multi-model-launch.ts
@@ -1,0 +1,155 @@
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
+import { resolveModelForSdk } from '@/stores/useSettingsStore'
+import { toast } from '@/lib/toast'
+import { launchTicketWithModel, type LaunchModelConfig } from '@/lib/ticket-launch'
+import { canonicalizeModelSlug, canonicalizeTicketTitle } from '@shared/types/branch-utils'
+import { FALLBACK_MODELS } from '@shared/model-resolution'
+
+type LaunchMode = 'build' | 'plan' | 'super-plan'
+
+export interface MultiModelLaunchPlan {
+  /** The original ticket — becomes entries[0]'s ticket. */
+  ticket: { id: string; title: string }
+  projectId: string
+  prompt: string
+  mode: LaunchMode
+  sourceBranch: string
+  goalMode: boolean
+  goalSuccessCriteria: string | null
+  /** N >= 2; entries[0] applies to the original ticket, entries[1..] to duplicates. */
+  entries: LaunchModelConfig[]
+  /** True when invoked from the auto-launch seam (clears pending_launch_config on the original ticket). */
+  clearPendingConfig?: boolean
+}
+
+interface EffectiveModel {
+  providerID: string
+  modelID: string
+  variant: string | null
+}
+
+/**
+ * Resolve the provider/model/variant to launch and stamp on the ticket badge,
+ * same chain launchTicketWithModel falls back to when no session row exists
+ * yet: explicit config model -> per-SDK resolution -> hard SDK fallback.
+ */
+function resolveEffectiveModel(entry: LaunchModelConfig): EffectiveModel {
+  const resolved = entry.model ?? resolveModelForSdk(entry.sdk) ?? FALLBACK_MODELS[entry.sdk]
+  return {
+    providerID: resolved.providerID,
+    modelID: resolved.modelID,
+    variant: resolved.variant ?? null
+  }
+}
+
+/**
+ * Background orchestrator for launching one ticket per model. Makes all N
+ * tickets appear in In Progress immediately (original + duplicates), then
+ * launches each model sequentially — a plain awaited for-loop, never
+ * parallel, since worktree creation serializes anyway. A single model's
+ * failure (duplicate or launch) is toasted and does not block the rest.
+ */
+export async function runMultiModelLaunch(plan: MultiModelLaunchPlan): Promise<void> {
+  const variantGroupId = crypto.randomUUID()
+  const effectiveModels = plan.entries.map(resolveEffectiveModel)
+  const goalSuccessCriteria = plan.goalMode ? plan.goalSuccessCriteria : null
+
+  // All N sort orders land adjacent above the current top of In Progress,
+  // in row order (entry 0 topmost): base is one below today's top, and each
+  // subsequent entry gets a fraction of a step below that.
+  const inProgressTickets = useKanbanStore
+    .getState()
+    .getTicketsByColumn(plan.projectId, 'in_progress')
+  const base = useKanbanStore.getState().computeSortOrder(inProgressTickets, 0)
+  const sortOrders = plan.entries.map((_, i) => base + i / plan.entries.length)
+
+  // Original ticket appears immediately as entry 0.
+  await useKanbanStore.getState().updateTicket(plan.ticket.id, plan.projectId, {
+    column: 'in_progress',
+    sort_order: sortOrders[0],
+    mode: plan.mode,
+    plan_ready: false,
+    model_provider_id: effectiveModels[0].providerID,
+    model_id: effectiveModels[0].modelID,
+    model_variant: effectiveModels[0].variant,
+    variant_group_id: variantGroupId,
+    goal_mode: plan.goalMode,
+    goal_success_criteria: goalSuccessCriteria,
+    ...(plan.clearPendingConfig ? { pending_launch_config: null } : {})
+  })
+
+  // Duplicates appear immediately as entries 1..N-1. A failed duplicate skips
+  // that model's launch (ticketIds[i] stays null) but doesn't block the rest.
+  const ticketIds: (string | null)[] = [plan.ticket.id]
+  for (let i = 1; i < plan.entries.length; i++) {
+    const model = effectiveModels[i]
+    const duplicate = await useKanbanStore
+      .getState()
+      .duplicateTicket(plan.projectId, plan.ticket.id, {
+        column: 'in_progress',
+        sort_order: sortOrders[i],
+        model_provider_id: model.providerID,
+        model_id: model.modelID,
+        model_variant: model.variant,
+        variant_group_id: variantGroupId
+      })
+    if (!duplicate) {
+      toast.error(`Failed to duplicate ticket for ${model.modelID}`)
+      ticketIds.push(null)
+      continue
+    }
+    ticketIds.push(duplicate.id)
+  }
+
+  // Sequential launches — never parallel, git worktree creation serializes anyway.
+  const titleSlug = canonicalizeTicketTitle(plan.ticket.title)
+  for (let i = 0; i < plan.entries.length; i++) {
+    const ticketId = ticketIds[i]
+    if (!ticketId) continue
+
+    const model = effectiveModels[i]
+    const modelSlug = canonicalizeModelSlug(model.modelID)
+    const nameHint = titleSlug ? `${titleSlug}-${modelSlug}` : modelSlug
+
+    const result = await launchTicketWithModel({
+      ticketId,
+      projectId: plan.projectId,
+      ticketTitle: plan.ticket.title,
+      worktree: { type: 'new', sourceBranch: plan.sourceBranch, nameHint },
+      prompt: plan.prompt,
+      mode: plan.mode,
+      modelConfig: plan.entries[i],
+      goalMode: plan.goalMode,
+      goalSuccessCriteria: plan.goalSuccessCriteria
+    })
+
+    if (!result.success) {
+      toast.error(`Failed to launch ${model.modelID}: ${result.error}`)
+      // Re-read To Do from the store — an earlier failure in this same loop
+      // may have already moved a ticket there.
+      const todoTickets = useKanbanStore.getState().getTicketsByColumn(plan.projectId, 'todo')
+      const todoSortOrder = useKanbanStore.getState().computeSortOrder(todoTickets, 0)
+      await useKanbanStore.getState().updateTicket(ticketId, plan.projectId, {
+        column: 'todo',
+        sort_order: todoSortOrder,
+        current_session_id: null,
+        worktree_id: null,
+        plan_ready: false,
+        mode: null,
+        goal_mode: false,
+        goal_success_criteria: null,
+        model_provider_id: null,
+        model_id: null,
+        model_variant: null
+        // variant_group_id intentionally kept — inert in v1.
+      })
+    }
+  }
+
+  // Usage refresh once per distinct SDK among entries.
+  const distinctSdks = new Set(plan.entries.map((entry) => entry.sdk))
+  for (const sdk of distinctSdks) {
+    useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(sdk))
+  }
+}

--- a/src/renderer/src/lib/ticket-launch.test.ts
+++ b/src/renderer/src/lib/ticket-launch.test.ts
@@ -231,11 +231,30 @@ describe('launchTicketWithModel', () => {
         model_provider_id: 'anthropic',
         model_id: 'opus',
         model_variant: 'high',
+        // Default hygiene: a (re)launch through this shared pipeline clears
+        // any stale variant_group_id unless extras override it (next test).
+        variant_group_id: null,
         pending_launch_config: null
       })
     )
     expect(toast.error).not.toHaveBeenCalled()
     expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('lets ticketUpdateExtras.variant_group_id override the default null (extras win)', async () => {
+    const { updateTicket } = setupStores()
+
+    await launchTicketWithModel(
+      baseSpec({
+        ticketUpdateExtras: { pending_launch_config: null, variant_group_id: 'group-123' }
+      })
+    )
+
+    expect(updateTicket).toHaveBeenCalledWith(
+      'ticket-1',
+      'project-1',
+      expect.objectContaining({ variant_group_id: 'group-123' })
+    )
   })
 
   it('returns {success:false} without creating a session when worktree creation fails', async () => {

--- a/src/renderer/src/lib/ticket-launch.test.ts
+++ b/src/renderer/src/lib/ticket-launch.test.ts
@@ -285,7 +285,7 @@ describe('launchTicketWithModel', () => {
     expect(toast.error).not.toHaveBeenCalled()
   })
 
-  it('returns {success:false} when the OpenCode connect fails', async () => {
+  it('returns {success:false} with the created sessionId/worktreeId when the OpenCode connect fails (Fix 5)', async () => {
     nextSession = makeSession({ agent_sdk: 'opencode' })
     setupStores()
     vi.mocked(opencodeApi.connect).mockResolvedValue({
@@ -299,9 +299,96 @@ describe('launchTicketWithModel', () => {
       })
     )
 
-    expect(result).toEqual({ success: false, error: 'connect refused' })
+    expect(result).toEqual({
+      success: false,
+      error: 'connect refused',
+      sessionId: 'session-1',
+      worktreeId: 'worktree-1'
+    })
     expect(opencodeApi.prompt).not.toHaveBeenCalled()
     expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('returns {success:false, sessionId, worktreeId} when the resolved worktree has no path (Fix 1)', async () => {
+    nextSession = makeSession({ agent_sdk: 'opencode' })
+    setupStores()
+    // Worktree exists but carries no path — the pre-fix pipeline treated this
+    // as a silent success without connecting or sending a prompt.
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([['project-1', [makeWorktree({ path: '' })]]])
+    })
+
+    const result = await launchTicketWithModel(
+      baseSpec({
+        modelConfig: { sdk: 'opencode', model: null, codexFastMode: false }
+      })
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Worktree path not found',
+      sessionId: 'session-1',
+      worktreeId: 'worktree-1'
+    })
+    expect(opencodeApi.connect).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('returns {success:false, sessionId, worktreeId} when the claude-code-cli spawn RPC reports failure (Fix 2)', async () => {
+    setupStores()
+    request = vi.fn(async (method: string) => {
+      if (method === 'terminalOps.createClaudeCli') {
+        return { success: false, error: 'pty spawn failed' }
+      }
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+
+    const result = await launchTicketWithModel(baseSpec())
+
+    expect(result).toEqual({
+      success: false,
+      error: 'pty spawn failed',
+      sessionId: 'session-1',
+      worktreeId: 'worktree-1'
+    })
+    expect(useSessionStore.getState().dequeuePendingMessage).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a default error message when the claude-code-cli spawn RPC fails without one', async () => {
+    setupStores()
+    request = vi.fn(async (method: string) => {
+      if (method === 'terminalOps.createClaudeCli') return { success: false }
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+
+    const result = await launchTicketWithModel(baseSpec())
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Failed to start Claude CLI',
+      sessionId: 'session-1',
+      worktreeId: 'worktree-1'
+    })
+  })
+
+  it('includes the created sessionId/worktreeId in the catch fallback when a later step throws (Fix 5)', async () => {
+    setupStores()
+    useSessionStore.setState({
+      setSessionModel: vi.fn(async () => {
+        throw new Error('model apply failed')
+      })
+    })
+
+    const result = await launchTicketWithModel(baseSpec())
+
+    expect(result).toEqual({
+      success: false,
+      error: 'model apply failed',
+      sessionId: 'session-1',
+      worktreeId: 'worktree-1'
+    })
   })
 
   it('passes an explicit nameHint through to createWorktreeFromBranch', async () => {

--- a/src/renderer/src/lib/ticket-launch.test.ts
+++ b/src/renderer/src/lib/ticket-launch.test.ts
@@ -275,14 +275,28 @@ describe('launchTicketWithModel', () => {
     expect(toast.error).not.toHaveBeenCalled()
   })
 
-  it('returns {success:false} when session creation fails', async () => {
+  it('returns {success:false} with the resolved worktreeId when session creation fails', async () => {
     const createSession = vi.fn(async () => ({ success: false, error: 'no provider' }))
     useSessionStore.setState({ createSession })
 
     const result = await launchTicketWithModel(baseSpec())
 
-    expect(result).toEqual({ success: false, error: 'no provider' })
+    expect(result).toEqual({ success: false, error: 'no provider', worktreeId: 'worktree-1' })
     expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('includes the created worktreeId when session creation fails after a NEW worktree was created (round 2)', async () => {
+    // Without the id in the failure result, the just-created git worktree
+    // would be invisible to callers — no ticket link ever gets stamped on
+    // this path, so nothing else records that it exists.
+    const createSession = vi.fn(async () => ({ success: false, error: 'no provider' }))
+    useSessionStore.setState({ createSession })
+
+    const result = await launchTicketWithModel(
+      baseSpec({ worktree: { type: 'new', sourceBranch: 'main' } })
+    )
+
+    expect(result).toEqual({ success: false, error: 'no provider', worktreeId: 'worktree-1' })
   })
 
   it('returns {success:false} with the created sessionId/worktreeId when the OpenCode connect fails (Fix 5)', async () => {
@@ -307,6 +321,65 @@ describe('launchTicketWithModel', () => {
     })
     expect(opencodeApi.prompt).not.toHaveBeenCalled()
     expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('returns {success:false, sessionId, worktreeId} when the OpenCode prompt result reports failure (round 2)', async () => {
+    nextSession = makeSession({ agent_sdk: 'opencode' })
+    setupStores()
+    vi.mocked(opencodeApi.prompt).mockResolvedValue({
+      success: true,
+      value: { success: false, error: 'command bridge unavailable' }
+    })
+
+    const result = await launchTicketWithModel(
+      baseSpec({
+        modelConfig: { sdk: 'opencode', model: null, codexFastMode: false }
+      })
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error: 'command bridge unavailable',
+      sessionId: 'session-1',
+      worktreeId: 'worktree-1'
+    })
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a default error message when the OpenCode prompt fails without one', async () => {
+    nextSession = makeSession({ agent_sdk: 'opencode' })
+    setupStores()
+    vi.mocked(opencodeApi.prompt).mockResolvedValue({
+      success: true,
+      value: { success: false }
+    })
+
+    const result = await launchTicketWithModel(
+      baseSpec({
+        modelConfig: { sdk: 'opencode', model: null, codexFastMode: false }
+      })
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Could not send prompt',
+      sessionId: 'session-1',
+      worktreeId: 'worktree-1'
+    })
+  })
+
+  it('returns success when the OpenCode prompt result succeeds', async () => {
+    nextSession = makeSession({ agent_sdk: 'opencode' })
+    setupStores()
+
+    const result = await launchTicketWithModel(
+      baseSpec({
+        modelConfig: { sdk: 'opencode', model: null, codexFastMode: false }
+      })
+    )
+
+    expect(result).toEqual({ success: true, sessionId: 'session-1', worktreeId: 'worktree-1' })
+    expect(opencodeApi.prompt).toHaveBeenCalledTimes(1)
   })
 
   it('returns {success:false, sessionId, worktreeId} when the resolved worktree has no path (Fix 1)', async () => {

--- a/src/renderer/src/lib/ticket-launch.test.ts
+++ b/src/renderer/src/lib/ticket-launch.test.ts
@@ -1,0 +1,368 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { launchTicketWithModel } from './ticket-launch'
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { opencodeApi } from '@/api/opencode-api'
+import { toast } from '@/lib/toast'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useUsageStore } from '@/stores/useUsageStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { Session, Worktree } from '../../../main/db/types'
+
+vi.mock('@/api/settings-api', () => ({
+  settingsApi: {
+    detectEditors: vi.fn(),
+    detectTerminals: vi.fn(),
+    onSettingsUpdated: vi.fn(() => vi.fn()),
+    openWithTerminal: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@/api/opencode-api', () => ({
+  opencodeApi: {
+    connect: vi.fn(),
+    prompt: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/hive-enterprise-telemetry', () => ({
+  startHivePromptTelemetry: vi.fn()
+}))
+
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialUsageState = useUsageStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: 'anthropic',
+    model_id: 'opus',
+    model_variant: 'high',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    pinned_to_board: false,
+    ...overrides
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'worktree-1',
+    project_id: 'project-1',
+    name: 'Feature',
+    branch_name: 'feature',
+    path: '/repo/feature',
+    status: 'active',
+    is_default: false,
+    branch_renamed: 0,
+    last_message_at: null,
+    session_titles: '[]',
+    last_model_provider_id: null,
+    last_model_id: null,
+    last_model_variant: null,
+    attachments: '[]',
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_accessed_at: '2026-01-01T00:00:00.000Z',
+    github_pr_number: null,
+    github_pr_url: null,
+    ...overrides
+  } as Worktree
+}
+
+// The created session the mocked store returns — individual tests reassign this
+// to control the badge-resolution source (session row vs. config vs. fallback).
+let nextSession: Session
+
+function setupStores(): {
+  createSession: ReturnType<typeof vi.fn>
+  createWorktreeFromBranch: ReturnType<typeof vi.fn>
+  updateTicket: ReturnType<typeof vi.fn>
+  setSessionModel: ReturnType<typeof vi.fn>
+} {
+  const createSession = vi.fn(async () => ({ success: true, session: nextSession }))
+  const createWorktreeFromBranch = vi.fn(async () => ({
+    success: true,
+    worktree: makeWorktree()
+  }))
+  const setSessionModel = vi.fn(async () => undefined)
+  const updateTicket = vi.fn(async () => undefined)
+
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '/repo',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        worktree_create_script: null,
+        custom_commands: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        last_accessed_at: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([['project-1', [makeWorktree()]]]),
+    createWorktreeFromBranch
+  })
+  useKanbanStore.setState({ updateTicket })
+  useSessionStore.setState({
+    createSession,
+    setSessionModel,
+    setOpenCodeSessionId: vi.fn(),
+    setSessionMode: vi.fn(async () => undefined),
+    dequeuePendingMessage: vi.fn()
+  })
+  useWorktreeStatusStore.setState({
+    setSessionStatus: vi.fn(),
+    setLastMessageTime: vi.fn()
+  })
+  useUsageStore.setState({ fetchUsageForProvider: vi.fn() })
+
+  return { createSession, createWorktreeFromBranch, updateTicket, setSessionModel }
+}
+
+function baseSpec(overrides: Record<string, unknown> = {}): Parameters<typeof launchTicketWithModel>[0] {
+  return {
+    ticketId: 'ticket-1',
+    projectId: 'project-1',
+    ticketTitle: 'My Ticket Title',
+    worktree: { type: 'existing', worktreeId: 'worktree-1' },
+    prompt: 'Implement the ticket',
+    mode: 'build',
+    modelConfig: {
+      sdk: 'claude-code-cli',
+      model: { providerID: 'anthropic', modelID: 'opus', variant: 'high' },
+      codexFastMode: false
+    },
+    goalMode: false,
+    goalSuccessCriteria: null,
+    ticketUpdateExtras: { pending_launch_config: null },
+    ...overrides
+  } as Parameters<typeof launchTicketWithModel>[0]
+}
+
+describe('launchTicketWithModel', () => {
+  let request: ReturnType<typeof vi.fn>
+
+  beforeAll(() => {
+    // Absorb the useSettingsStore one-shot 200ms import timer so it cannot null
+    // store state mid-test (see global constraints).
+    return new Promise((resolve) => setTimeout(resolve, 220))
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetRendererRpcClientForTests()
+    request = vi.fn(async (method: string) => {
+      if (method === 'terminalOps.createClaudeCli') return { success: true }
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    nextSession = makeSession()
+    setupStores()
+    vi.mocked(opencodeApi.connect).mockResolvedValue({
+      success: true,
+      value: { success: true, sessionId: 'opc-1' }
+    })
+    vi.mocked(opencodeApi.prompt).mockResolvedValue({
+      success: true,
+      value: { success: true }
+    })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+    useSessionStore.setState(initialSessionState, true)
+    useWorktreeStore.setState(initialWorktreeState, true)
+    useKanbanStore.setState(initialKanbanState, true)
+    useProjectStore.setState(initialProjectState, true)
+    useUsageStore.setState(initialUsageState, true)
+    useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
+  })
+
+  it('returns sessionId/worktreeId and stamps badge fields + extras on success', async () => {
+    const { updateTicket } = setupStores()
+
+    const result = await launchTicketWithModel(baseSpec())
+
+    expect(result).toEqual({ success: true, sessionId: 'session-1', worktreeId: 'worktree-1' })
+    expect(updateTicket).toHaveBeenCalledWith(
+      'ticket-1',
+      'project-1',
+      expect.objectContaining({
+        current_session_id: 'session-1',
+        worktree_id: 'worktree-1',
+        mode: 'build',
+        model_provider_id: 'anthropic',
+        model_id: 'opus',
+        model_variant: 'high',
+        pending_launch_config: null
+      })
+    )
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('returns {success:false} without creating a session when worktree creation fails', async () => {
+    const createWorktreeFromBranch = vi.fn(async () => ({
+      success: false,
+      error: 'disk full'
+    }))
+    const createSession = vi.fn(async () => ({ success: true, session: nextSession }))
+    useWorktreeStore.setState({ createWorktreeFromBranch })
+    useSessionStore.setState({ createSession })
+
+    const result = await launchTicketWithModel(
+      baseSpec({ worktree: { type: 'new', sourceBranch: 'main' } })
+    )
+
+    expect(result).toEqual({ success: false, error: 'disk full' })
+    expect(createSession).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('returns {success:false} when session creation fails', async () => {
+    const createSession = vi.fn(async () => ({ success: false, error: 'no provider' }))
+    useSessionStore.setState({ createSession })
+
+    const result = await launchTicketWithModel(baseSpec())
+
+    expect(result).toEqual({ success: false, error: 'no provider' })
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('returns {success:false} when the OpenCode connect fails', async () => {
+    nextSession = makeSession({ agent_sdk: 'opencode' })
+    setupStores()
+    vi.mocked(opencodeApi.connect).mockResolvedValue({
+      success: true,
+      value: { success: false, error: 'connect refused' }
+    })
+
+    const result = await launchTicketWithModel(
+      baseSpec({
+        modelConfig: { sdk: 'opencode', model: null, codexFastMode: false }
+      })
+    )
+
+    expect(result).toEqual({ success: false, error: 'connect refused' })
+    expect(opencodeApi.prompt).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('passes an explicit nameHint through to createWorktreeFromBranch', async () => {
+    const { createWorktreeFromBranch } = setupStores()
+
+    await launchTicketWithModel(
+      baseSpec({ worktree: { type: 'new', sourceBranch: 'main', nameHint: 'custom-slug' } })
+    )
+
+    expect(createWorktreeFromBranch).toHaveBeenCalledWith(
+      'project-1',
+      '/repo',
+      'Hive',
+      'main',
+      'custom-slug'
+    )
+  })
+
+  it('falls back to the canonicalized ticket title when no nameHint is given', async () => {
+    const { createWorktreeFromBranch } = setupStores()
+
+    await launchTicketWithModel(baseSpec({ worktree: { type: 'new', sourceBranch: 'main' } }))
+
+    expect(createWorktreeFromBranch).toHaveBeenCalledWith(
+      'project-1',
+      '/repo',
+      'Hive',
+      'main',
+      'my-ticket-title'
+    )
+  })
+
+  it('stamps badge from the session row when modelConfig.model is null', async () => {
+    nextSession = makeSession({
+      agent_sdk: 'opencode',
+      model_provider_id: 'openai',
+      model_id: 'gpt-5.5',
+      model_variant: null
+    })
+    const { updateTicket } = setupStores()
+
+    await launchTicketWithModel(
+      baseSpec({ modelConfig: { sdk: 'opencode', model: null, codexFastMode: false } })
+    )
+
+    expect(updateTicket).toHaveBeenCalledWith(
+      'ticket-1',
+      'project-1',
+      expect.objectContaining({
+        model_provider_id: 'openai',
+        model_id: 'gpt-5.5',
+        model_variant: null
+      })
+    )
+  })
+
+  it('stamps badge from the resolution fallback when session row and modelConfig.model are null', async () => {
+    // Session row carries no model, config carries no model → resolveModelForSdk
+    // (null under empty settings) → FALLBACK_MODELS['codex'].
+    useSettingsStore.setState({ selectedModel: null, selectedModelByProvider: {} })
+    nextSession = makeSession({
+      agent_sdk: 'codex',
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null
+    })
+    const { updateTicket } = setupStores()
+
+    await launchTicketWithModel(
+      baseSpec({ modelConfig: { sdk: 'codex', model: null, codexFastMode: false } })
+    )
+
+    expect(updateTicket).toHaveBeenCalledWith(
+      'ticket-1',
+      'project-1',
+      expect.objectContaining({
+        model_provider_id: 'codex',
+        model_id: 'gpt-5.5',
+        model_variant: null
+      })
+    )
+  })
+})

--- a/src/renderer/src/lib/ticket-launch.ts
+++ b/src/renderer/src/lib/ticket-launch.ts
@@ -1,0 +1,336 @@
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
+import { resolveModelForSdk } from '@/stores/useSettingsStore'
+import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
+import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
+import { snapshotTokenBaseline } from '@/lib/token-baselines'
+import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
+import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
+import { unwrapEnvelope } from '@/lib/ipc-envelope'
+import { opencodeApi } from '@/api/opencode-api'
+import { dbApi } from '@/api/db-api'
+import { terminalApi } from '@/api/terminal-api'
+import { startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
+import { createPlanFile, exceedsGoalPromptLimit, planFilePrompt } from '@/lib/goal-plan-file'
+import { FALLBACK_MODELS } from '@shared/model-resolution'
+import type { HandoffAgentSdk } from '@shared/types/agent-sdk'
+import type { KanbanTicketUpdate } from '../../../main/db/types'
+
+type LaunchMode = 'build' | 'plan' | 'super-plan'
+
+export interface LaunchModelConfig {
+  sdk: HandoffAgentSdk
+  model: { providerID: string; modelID: string; variant?: string } | null
+  codexFastMode: boolean
+}
+
+export interface TicketLaunchSpec {
+  ticketId: string
+  projectId: string
+  ticketTitle: string
+  worktree:
+    | { type: 'new'; sourceBranch: string; nameHint?: string }
+    | { type: 'existing'; worktreeId: string }
+  prompt: string
+  mode: LaunchMode
+  modelConfig: LaunchModelConfig
+  goalMode: boolean
+  goalSuccessCriteria: string | null
+  /** Extra fields merged into the success updateTicket call (e.g. { pending_launch_config: null }). */
+  ticketUpdateExtras?: Partial<KanbanTicketUpdate>
+}
+
+export interface TicketLaunchResult {
+  success: boolean
+  sessionId?: string
+  worktreeId?: string
+  error?: string
+}
+
+function wrapGoalPrompt(prompt: string, criteria: string): string {
+  const stripped = prompt.replace(/^\/goal\s+/, '')
+  return `/goal ${stripped}. Goal success criteria: ${criteria}`
+}
+
+function composeLaunchPrompt(
+  rawPrompt: string,
+  mode: LaunchMode,
+  sessionAgentSdk: string | null | undefined,
+  goalMode: boolean,
+  goalSuccessCriteria: string | null,
+  options: { claudeCli: boolean }
+): string | null {
+  const trimmedPrompt = rawPrompt.trim()
+  if (!trimmedPrompt) return null
+
+  const skipPrefix =
+    options.claudeCli ||
+    sessionAgentSdk === 'claude-code' ||
+    sessionAgentSdk === 'codex' ||
+    sessionAgentSdk === 'claude-code-cli'
+  const modePrefix =
+    mode === 'super-plan'
+      ? getSuperPlanModePrefix(sessionAgentSdk)
+      : mode === 'plan' && !skipPrefix
+        ? PLAN_MODE_PREFIX
+        : ''
+  const fullPrompt = modePrefix + trimmedPrompt
+
+  return goalMode && goalSuccessCriteria
+    ? wrapGoalPrompt(fullPrompt, goalSuccessCriteria)
+    : fullPrompt
+}
+
+/**
+ * Resolve the provider/model/variant to stamp on the ticket badge. Priority:
+ * (a) the resolved model persisted on the created session row, (b) the launch
+ * config's explicit model, (c) the renderer's per-SDK resolution then the hard
+ * SDK fallback. The last step guarantees non-null provider/model ids on every
+ * launch.
+ */
+function resolveBadgeModel(
+  modelConfig: LaunchModelConfig,
+  session: { model_provider_id: string | null; model_id: string | null; model_variant: string | null }
+): { providerID: string; modelID: string; variant: string | null } {
+  if (session.model_provider_id && session.model_id) {
+    return {
+      providerID: session.model_provider_id,
+      modelID: session.model_id,
+      variant: session.model_variant ?? null
+    }
+  }
+  if (modelConfig.model) {
+    return {
+      providerID: modelConfig.model.providerID,
+      modelID: modelConfig.model.modelID,
+      variant: modelConfig.model.variant ?? null
+    }
+  }
+  const resolved = resolveModelForSdk(modelConfig.sdk) ?? FALLBACK_MODELS[modelConfig.sdk]
+  return {
+    providerID: resolved.providerID,
+    modelID: resolved.modelID,
+    variant: resolved.variant ?? null
+  }
+}
+
+/**
+ * Headless ticket-launch pipeline shared by auto-launch (single model) and the
+ * multi-model orchestrator. Resolves/creates the worktree, creates the session,
+ * stamps status + ticket badge fields, and delivers the prompt per SDK. Every
+ * failure — worktree/session/connect or a thrown error — is returned as
+ * { success: false, error }; callers own all user-visible messaging.
+ */
+export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<TicketLaunchResult> {
+  const { sdk, model, codexFastMode } = spec.modelConfig
+  const goalMode = spec.goalMode === true
+  const goalSuccessCriteria = spec.goalSuccessCriteria?.trim() || null
+  // Working copy of the prompt — the goal-mode overflow branch may replace it
+  // with a short "Implement PLAN_{uuid}.md" pointer.
+  let prompt = spec.prompt
+
+  try {
+    // 1. Resolve worktree
+    let worktreeId: string
+    if (spec.worktree.type === 'new') {
+      const project = useProjectStore.getState().projects.find((p) => p.id === spec.projectId)
+      if (!project) {
+        return { success: false, error: 'Project not found' }
+      }
+      const nameHint = spec.worktree.nameHint ?? canonicalizeTicketTitle(spec.ticketTitle)
+      const result = await useWorktreeStore
+        .getState()
+        .createWorktreeFromBranch(
+          spec.projectId,
+          project.path,
+          project.name,
+          spec.worktree.sourceBranch,
+          nameHint || undefined
+        )
+      if (!result.success || !result.worktree?.id) {
+        return { success: false, error: result.error || 'Could not create worktree' }
+      }
+      worktreeId = result.worktree.id
+    } else {
+      worktreeId = spec.worktree.worktreeId
+    }
+
+    // Resolve the worktree record once — needed for plan-file creation and the
+    // OpenCode connect below. Newly created worktrees are already in the store.
+    const findWorktree = (): { path: string } | undefined =>
+      Array.from(useWorktreeStore.getState().worktreesByProject.values())
+        .flat()
+        .find((w) => w.id === worktreeId)
+    let worktree = findWorktree()
+    if (!worktree) {
+      // The project's worktrees may not be loaded yet (e.g. auto-launch firing
+      // from a store subscription shortly after startup)
+      await useWorktreeStore.getState().loadWorktrees(spec.projectId)
+      worktree = findWorktree()
+    }
+
+    // Oversized goal prompts get rejected by the CLI — persist the full ticket
+    // prompt as PLAN_{uuid}.md in the worktree root and send a short
+    // "Implement PLAN_{uuid}.md" goal prompt instead (the /goal wrapper stays).
+    if (goalMode && goalSuccessCriteria && worktree?.path) {
+      const composed = composeLaunchPrompt(prompt, spec.mode, sdk, goalMode, goalSuccessCriteria, {
+        claudeCli: sdk === 'claude-code-cli'
+      })
+      if (exceedsGoalPromptLimit(composed)) {
+        const fileName = await createPlanFile(worktree.path, prompt.trim())
+        prompt = planFilePrompt(fileName)
+      }
+    }
+
+    // 2. Create session
+    const modelOverride = model ? { ...model, agentSdk: sdk } : undefined
+    const cliPendingPrompt =
+      sdk === 'claude-code-cli'
+        ? composeLaunchPrompt(prompt, spec.mode, sdk, goalMode, goalSuccessCriteria, {
+            claudeCli: true
+          })
+        : null
+    const createOptions = {
+      autoFocus: false,
+      ...(modelOverride ? { modelOverride } : {}),
+      ...(cliPendingPrompt ? { pendingMessage: cliPendingPrompt } : {})
+    }
+    const sessionResult = await useSessionStore
+      .getState()
+      .createSession(worktreeId, spec.projectId, sdk, spec.mode, createOptions)
+    if (!sessionResult.success || !sessionResult.session) {
+      return { success: false, error: sessionResult.error || 'Could not create session' }
+    }
+
+    const session = sessionResult.session
+    const sessionId = session.id
+    const sessionAgentSdk = session.agent_sdk
+
+    // 3. Set status tracking
+    messageSendTimes.set(sessionId, Date.now())
+    userExplicitSendTimes.set(sessionId, Date.now())
+    snapshotTokenBaseline(sessionId)
+    lastSendMode.set(sessionId, isPlanLike(spec.mode) ? 'plan' : 'build')
+    useWorktreeStatusStore
+      .getState()
+      .setSessionStatus(sessionId, isPlanLike(spec.mode) ? 'planning' : 'working')
+
+    // 4. Apply model override
+    const effectiveModel = model ?? undefined
+    if (model) {
+      await useSessionStore.getState().setSessionModel(sessionId, model)
+    }
+
+    // 5. Update ticket: clear pending config (via extras), set session + worktree,
+    //    and stamp the model badge fields.
+    const badge = resolveBadgeModel(spec.modelConfig, session)
+    await useKanbanStore.getState().updateTicket(spec.ticketId, spec.projectId, {
+      current_session_id: sessionId,
+      worktree_id: worktreeId,
+      mode: spec.mode,
+      goal_mode: goalMode,
+      goal_success_criteria: goalMode ? goalSuccessCriteria : null,
+      model_provider_id: badge.providerID,
+      model_id: badge.modelID,
+      model_variant: badge.variant,
+      ...spec.ticketUpdateExtras
+    })
+
+    // 6. Trigger usage refresh
+    useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(sdk))
+
+    if (sessionAgentSdk === 'claude-code-cli') {
+      const outboundPrompt =
+        cliPendingPrompt ??
+        composeLaunchPrompt(prompt, spec.mode, sessionAgentSdk, goalMode, goalSuccessCriteria, {
+          claudeCli: true
+        })
+
+      if (spec.mode === 'super-plan') {
+        // Await so the persisted mode is committed before the main process
+        // reads it in buildClaudeCliPtySpawn (createClaudeCli).
+        await useSessionStore.getState().setSessionMode(sessionId, 'plan')
+      }
+
+      bumpWorktreeLastMessage({ worktreeId })
+      const result = unwrapEnvelope(
+        await terminalApi.createClaudeCli(sessionId, {
+          pendingPrompt: outboundPrompt
+        })
+      )
+      if (result.success && outboundPrompt) {
+        useSessionStore.getState().dequeuePendingMessage(sessionId)
+      }
+      return { success: true, sessionId, worktreeId }
+    }
+
+    // 7. Connect to OpenCode and send prompt
+    if (!worktree?.path) return { success: true, sessionId, worktreeId }
+
+    const connectResult = unwrapEnvelope(await opencodeApi.connect(worktree.path, sessionId))
+    if (!connectResult.success || !connectResult.sessionId) {
+      return { success: false, error: connectResult.error || 'Could not start session' }
+    }
+
+    useSessionStore.getState().setOpenCodeSessionId(sessionId, connectResult.sessionId)
+    await dbApi.session.update(sessionId, { opencode_session_id: connectResult.sessionId })
+
+    // 8. Send prompt
+    if (prompt.trim()) {
+      const outboundPrompt = composeLaunchPrompt(
+        prompt,
+        spec.mode,
+        sessionAgentSdk,
+        goalMode,
+        goalSuccessCriteria,
+        { claudeCli: false }
+      )
+      if (!outboundPrompt) return { success: true, sessionId, worktreeId }
+
+      const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
+
+      if (spec.mode === 'super-plan') {
+        useSessionStore.getState().setSessionMode(sessionId, 'plan')
+      }
+
+      bumpWorktreeLastMessage({ worktreeId })
+      startHivePromptTelemetry({
+        sessionId,
+        prompt: outboundPrompt,
+        worktreeId,
+        modelId: effectiveModel?.modelID,
+        providerId: effectiveModel?.providerID,
+        modelVariant: effectiveModel?.variant,
+        mode: spec.mode,
+        // Auto-launch is not an interactive send from a tab.
+        source: 'other'
+      })
+      unwrapEnvelope(
+        await opencodeApi.prompt(
+          worktree.path,
+          connectResult.sessionId,
+          [{ type: 'text', text: outboundPrompt }],
+          // Strip `agentSdk` — the prompt RPC model schema is .strict() and
+          // rejects it ("RPC parameters failed validation").
+          effectiveModel
+            ? {
+                providerID: effectiveModel.providerID,
+                modelID: effectiveModel.modelID,
+                variant: effectiveModel.variant
+              }
+            : undefined,
+          promptOptions
+        )
+      )
+    }
+
+    return { success: true, sessionId, worktreeId }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : null
+    return { success: false, error: detail || 'Could not launch session' }
+  }
+}

--- a/src/renderer/src/lib/ticket-launch.ts
+++ b/src/renderer/src/lib/ticket-launch.ts
@@ -90,9 +90,11 @@ function composeLaunchPrompt(
  * (a) the resolved model persisted on the created session row, (b) the launch
  * config's explicit model, (c) the renderer's per-SDK resolution then the hard
  * SDK fallback. The last step guarantees non-null provider/model ids on every
- * launch.
+ * launch. Exported: WorktreePickerModal's interactive launch paths stamp with
+ * the same priority — the session row records what ACTUALLY runs (session
+ * creation resolves through its own chain and can differ from the picker's).
  */
-function resolveBadgeModel(
+export function resolveBadgeModel(
   modelConfig: LaunchModelConfig,
   session: { model_provider_id: string | null; model_id: string | null; model_variant: string | null }
 ): { providerID: string; modelID: string; variant: string | null } {

--- a/src/renderer/src/lib/ticket-launch.ts
+++ b/src/renderer/src/lib/ticket-launch.ts
@@ -132,6 +132,11 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
   // Working copy of the prompt — the goal-mode overflow branch may replace it
   // with a short "Implement PLAN_{uuid}.md" pointer.
   let prompt = spec.prompt
+  // Snapshots of the worktree/session ids as soon as each is created, hoisted
+  // above the try so the catch fallback can still report them (Fix 5: avoids
+  // leaving a phantom "working" session the caller can't see/clean up).
+  let createdWorktreeId: string | undefined
+  let createdSessionId: string | undefined
 
   try {
     // 1. Resolve worktree
@@ -158,6 +163,7 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
     } else {
       worktreeId = spec.worktree.worktreeId
     }
+    createdWorktreeId = worktreeId
 
     // Resolve the worktree record once — needed for plan-file creation and the
     // OpenCode connect below. Newly created worktrees are already in the store.
@@ -209,6 +215,7 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
     const session = sessionResult.session
     const sessionId = session.id
     const sessionAgentSdk = session.agent_sdk
+    createdSessionId = sessionId
 
     // 3. Set status tracking
     messageSendTimes.set(sessionId, Date.now())
@@ -267,18 +274,33 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
           pendingPrompt: outboundPrompt
         })
       )
-      if (result.success && outboundPrompt) {
+      if (!result.success) {
+        return {
+          success: false,
+          error: result.error ?? 'Failed to start Claude CLI',
+          sessionId,
+          worktreeId
+        }
+      }
+      if (outboundPrompt) {
         useSessionStore.getState().dequeuePendingMessage(sessionId)
       }
       return { success: true, sessionId, worktreeId }
     }
 
     // 7. Connect to OpenCode and send prompt
-    if (!worktree?.path) return { success: true, sessionId, worktreeId }
+    if (!worktree?.path) {
+      return { success: false, error: 'Worktree path not found', sessionId, worktreeId }
+    }
 
     const connectResult = unwrapEnvelope(await opencodeApi.connect(worktree.path, sessionId))
     if (!connectResult.success || !connectResult.sessionId) {
-      return { success: false, error: connectResult.error || 'Could not start session' }
+      return {
+        success: false,
+        error: connectResult.error || 'Could not start session',
+        sessionId,
+        worktreeId
+      }
     }
 
     useSessionStore.getState().setOpenCodeSessionId(sessionId, connectResult.sessionId)
@@ -336,6 +358,11 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
     return { success: true, sessionId, worktreeId }
   } catch (err) {
     const detail = err instanceof Error ? err.message : null
-    return { success: false, error: detail || 'Could not launch session' }
+    return {
+      success: false,
+      error: detail || 'Could not launch session',
+      ...(createdSessionId ? { sessionId: createdSessionId } : {}),
+      ...(createdWorktreeId ? { worktreeId: createdWorktreeId } : {})
+    }
   }
 }

--- a/src/renderer/src/lib/ticket-launch.ts
+++ b/src/renderer/src/lib/ticket-launch.ts
@@ -226,7 +226,11 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
     }
 
     // 5. Update ticket: clear pending config (via extras), set session + worktree,
-    //    and stamp the model badge fields.
+    //    and stamp the model badge fields. variant_group_id defaults to null
+    //    here (a single-model (re)launch shouldn't keep claiming membership in
+    //    a stale multi-launch group) — the multi-model orchestrator overrides
+    //    it back via ticketUpdateExtras, which must win, hence the field
+    //    ordering below.
     const badge = resolveBadgeModel(spec.modelConfig, session)
     await useKanbanStore.getState().updateTicket(spec.ticketId, spec.projectId, {
       current_session_id: sessionId,
@@ -237,6 +241,7 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
       model_provider_id: badge.providerID,
       model_id: badge.modelID,
       model_variant: badge.variant,
+      variant_group_id: null,
       ...spec.ticketUpdateExtras
     })
 

--- a/src/renderer/src/lib/ticket-launch.ts
+++ b/src/renderer/src/lib/ticket-launch.ts
@@ -209,7 +209,14 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
       .getState()
       .createSession(worktreeId, spec.projectId, sdk, spec.mode, createOptions)
     if (!sessionResult.success || !sessionResult.session) {
-      return { success: false, error: sessionResult.error || 'Could not create session' }
+      // worktreeId is included so a just-created worktree stays visible to
+      // the caller — nothing else records it on this path (the ticket link
+      // is only stamped after session creation).
+      return {
+        success: false,
+        error: sessionResult.error || 'Could not create session',
+        worktreeId
+      }
     }
 
     const session = sessionResult.session
@@ -336,7 +343,7 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
         // Auto-launch is not an interactive send from a tab.
         source: 'other'
       })
-      unwrapEnvelope(
+      const promptResult = unwrapEnvelope(
         await opencodeApi.prompt(
           worktree.path,
           connectResult.sessionId,
@@ -353,6 +360,17 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
           promptOptions
         )
       )
+      if (!promptResult.success) {
+        // A rejected prompt (e.g. command bridge unavailable) means no agent
+        // is actually running — surface it so the caller's failure recovery
+        // runs instead of leaving the ticket linked to an idle session.
+        return {
+          success: false,
+          error: promptResult.error || 'Could not send prompt',
+          sessionId,
+          worktreeId
+        }
+      }
     }
 
     return { success: true, sessionId, worktreeId }

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -56,6 +56,10 @@ function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
     note: null,
     created_from_session: true,
     auto_approve_plan: false,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
     ...overrides
   }
 }

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -4,6 +4,7 @@ import type {
   KanbanTicket,
   KanbanTicketColumn,
   KanbanTicketCreate,
+  KanbanTicketDuplicateOverrides,
   KanbanTicketUpdate,
   MarkdownCardDiagnostic,
   TicketDependency
@@ -218,6 +219,11 @@ interface KanbanState {
   loadTicketsWithArchiveVisibility: (projectId: string, includeArchived: boolean) => Promise<void>
   reconcileFinishedSessions: (projectId: string) => void
   createTicket: (projectId: string, data: KanbanTicketCreate) => Promise<KanbanTicket>
+  duplicateTicket: (
+    projectId: string,
+    ticketId: string,
+    overrides?: KanbanTicketDuplicateOverrides
+  ) => Promise<KanbanTicket | null>
   convertMarkdownPlaceholder: (projectId: string, filePath: string) => Promise<KanbanTicket>
   updateTicket: (ticketId: string, projectId: string, data: KanbanTicketUpdate) => Promise<void>
   deleteTicket: (ticketId: string, projectId: string) => Promise<void>
@@ -476,6 +482,31 @@ export const useKanbanStore = create<KanbanState>()(
           return { tickets: next }
         })
         return ticket
+      },
+
+      // ── duplicateTicket ──────────────────────────────────────────
+      duplicateTicket: async (
+        projectId: string,
+        ticketId: string,
+        overrides?: KanbanTicketDuplicateOverrides
+      ) => {
+        try {
+          const ticket = await kanban.ticket.duplicate<KanbanTicket, KanbanTicketDuplicateOverrides>(
+            projectId,
+            ticketId,
+            overrides
+          )
+          set((state) => {
+            const next = new Map(state.tickets)
+            const existing = next.get(projectId) ?? []
+            next.set(projectId, [...existing, ticket])
+            return { tickets: next }
+          })
+          return ticket
+        } catch (err) {
+          console.error('Failed to duplicate ticket:', ticketId, err)
+          return null
+        }
       },
 
       convertMarkdownPlaceholder: async (projectId: string, filePath: string) => {

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -161,7 +161,11 @@ describe('rpc router', () => {
       goal_success_criteria: null,
       note: null,
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const calls: unknown[] = []
     const router = makeRpcRouter({
@@ -268,7 +272,11 @@ describe('rpc router', () => {
       goal_success_criteria: null,
       note: null,
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const secondTicket = {
       ...firstTicket,
@@ -400,7 +408,11 @@ describe('rpc router', () => {
       goal_success_criteria: null,
       note: null,
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const calls: Array<{ projectId: string; id: string }> = []
     const router = makeRpcRouter({
@@ -499,7 +511,11 @@ describe('rpc router', () => {
       goal_success_criteria: null,
       note: null,
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const calls: Array<{ projectId: string; includeArchived: boolean | undefined }> = []
     const router = makeRpcRouter({
@@ -599,7 +615,11 @@ describe('rpc router', () => {
       goal_success_criteria: 'Build passes',
       note: 'Keep private',
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const calls: Array<{ projectId: string; id: string; data: unknown }> = []
     const router = makeRpcRouter({
@@ -782,7 +802,11 @@ describe('rpc router', () => {
       goal_success_criteria: null,
       note: null,
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const calls: Array<{ projectId: string; id: string }> = []
     const router = makeRpcRouter({
@@ -953,7 +977,11 @@ describe('rpc router', () => {
       goal_success_criteria: null,
       note: null,
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const calls: Array<{ projectId: string; ticketId: string }> = []
     const router = makeRpcRouter({
@@ -1053,7 +1081,11 @@ describe('rpc router', () => {
       goal_success_criteria: null,
       note: null,
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const calls: Array<{ projectId: string; id: string; column: string; sortOrder: number }> = []
     const router = makeRpcRouter({
@@ -1328,7 +1360,11 @@ describe('rpc router', () => {
       goal_success_criteria: null,
       note: null,
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const calls: string[] = []
     const router = makeRpcRouter({
@@ -1430,7 +1466,11 @@ describe('rpc router', () => {
       goal_success_criteria: null,
       note: null,
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const calls: Array<{ projectId: string; id: string; tokens: number }> = []
     const router = makeRpcRouter({
@@ -2197,7 +2237,11 @@ describe('rpc router', () => {
       goal_success_criteria: null,
       note: null,
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const calls: string[] = []
     const router = makeRpcRouter({
@@ -2310,7 +2354,11 @@ describe('rpc router', () => {
       goal_success_criteria: null,
       note: null,
       created_from_session: false,
-      auto_approve_plan: false
+      auto_approve_plan: false,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
     }
     const calls: Array<{ projectId: string; ticketId: string }> = []
     const router = makeRpcRouter({

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -244,6 +244,90 @@ describe('rpc router', () => {
     })
   })
 
+  it('round-trips model fields and note through kanban.ticket.create', async () => {
+    const ticket = {
+      id: 'ticket-model-1',
+      project_id: project.id,
+      title: 'Ship HTTP migration',
+      description: null,
+      attachments: [],
+      column: 'todo' as const,
+      sort_order: 0,
+      current_session_id: null,
+      worktree_id: null,
+      mode: null,
+      plan_ready: false,
+      created_at: '2026-05-26T00:05:00.000Z',
+      updated_at: '2026-05-26T00:05:00.000Z',
+      archived_at: null,
+      external_provider: null,
+      external_id: null,
+      external_url: null,
+      github_pr_number: null,
+      github_pr_url: null,
+      mark: null,
+      total_tokens: 0,
+      pending_launch_config: null,
+      goal_mode: false,
+      goal_success_criteria: null,
+      note: 'Launched via multi-model',
+      created_from_session: false,
+      auto_approve_plan: false,
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-6',
+      model_variant: 'thinking',
+      variant_group_id: 'group-1'
+    }
+    const calls: unknown[] = []
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      kanban: {
+        createTicket: (projectId, data) =>
+          Effect.sync(() => {
+            calls.push({ projectId, data })
+            return ticket
+          }),
+        createTicketBatch: () => Effect.die(new Error('createTicketBatch should not run')),
+        getTicket: () => Effect.die(new Error('getTicket should not run')),
+        getTicketsByProject: () => Effect.die(new Error('getTicketsByProject should not run')),
+        updateTicket: () => Effect.die(new Error('updateTicket should not run')),
+        deleteTicket: () => Effect.die(new Error('deleteTicket should not run')),
+        archiveTicket: () => Effect.die(new Error('archiveTicket should not run')),
+        archiveAllDoneTickets: () => Effect.die(new Error('archiveAllDoneTickets should not run')),
+        unarchiveTicket: () => Effect.die(new Error('unarchiveTicket should not run')),
+        moveTicket: () => Effect.die(new Error('moveTicket should not run'))
+      }
+    })
+
+    const params = {
+      project_id: project.id,
+      title: 'Ship HTTP migration',
+      description: null,
+      attachments: [],
+      column: 'todo' as const,
+      plan_ready: false,
+      note: 'Launched via multi-model',
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-6',
+      model_variant: 'thinking',
+      variant_group_id: 'group-1'
+    }
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'kanban-ticket-create-model-1',
+        method: 'kanban.ticket.create',
+        params
+      })
+    )
+
+    expect(response).toEqual({
+      id: 'kanban-ticket-create-model-1',
+      ok: true,
+      value: ticket
+    })
+    expect(calls).toEqual([{ projectId: project.id, data: params }])
+  })
+
   it('handles kanban.ticket.duplicate through the kanban RPC domain', async () => {
     const ticket = {
       id: 'ticket-2',
@@ -830,6 +914,116 @@ describe('rpc router', () => {
       ok: false,
       error: { code: 'VALIDATION_FAILED' }
     })
+  })
+
+  it('round-trips model fields through kanban.ticket.update, then nulls them out', async () => {
+    const ticketWithModel = {
+      id: 'ticket-1',
+      project_id: project.id,
+      title: 'Ship HTTP migration',
+      description: null,
+      attachments: [],
+      column: 'in_progress' as const,
+      sort_order: 0,
+      current_session_id: null,
+      worktree_id: null,
+      mode: null,
+      plan_ready: false,
+      created_at: '2026-05-26T00:05:00.000Z',
+      updated_at: '2026-05-26T00:06:00.000Z',
+      archived_at: null,
+      external_provider: null,
+      external_id: null,
+      external_url: null,
+      github_pr_number: null,
+      github_pr_url: null,
+      mark: null,
+      total_tokens: 0,
+      pending_launch_config: null,
+      goal_mode: false,
+      goal_success_criteria: null,
+      note: null,
+      created_from_session: false,
+      auto_approve_plan: false,
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-6',
+      model_variant: 'thinking',
+      variant_group_id: 'group-1'
+    }
+    const ticketWithoutModel = {
+      ...ticketWithModel,
+      updated_at: '2026-05-26T00:07:00.000Z',
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
+    }
+    const calls: Array<{ projectId: string; id: string; data: unknown }> = []
+    const responses = [ticketWithModel, ticketWithoutModel]
+    let callIndex = 0
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      kanban: {
+        createTicket: () => Effect.die(new Error('createTicket should not run')),
+        createTicketBatch: () => Effect.die(new Error('createTicketBatch should not run')),
+        getTicket: () => Effect.die(new Error('getTicket should not run')),
+        getTicketsByProject: () => Effect.die(new Error('getTicketsByProject should not run')),
+        deleteTicket: () => Effect.die(new Error('deleteTicket should not run')),
+        archiveTicket: () => Effect.die(new Error('archiveTicket should not run')),
+        archiveAllDoneTickets: () => Effect.die(new Error('archiveAllDoneTickets should not run')),
+        unarchiveTicket: () => Effect.die(new Error('unarchiveTicket should not run')),
+        moveTicket: () => Effect.die(new Error('moveTicket should not run')),
+        updateTicket: (projectId, id, data) =>
+          Effect.sync(() => {
+            calls.push({ projectId, id, data })
+            return responses[callIndex++]
+          })
+      }
+    })
+
+    const setData = {
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-6',
+      model_variant: 'thinking',
+      variant_group_id: 'group-1'
+    }
+    const setResponse = await Effect.runPromise(
+      router.handle({
+        id: 'kanban-ticket-update-model-1',
+        method: 'kanban.ticket.update',
+        params: { projectId: project.id, id: 'ticket-1', data: setData }
+      })
+    )
+
+    expect(setResponse).toEqual({
+      id: 'kanban-ticket-update-model-1',
+      ok: true,
+      value: ticketWithModel
+    })
+
+    const nullData = {
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      variant_group_id: null
+    }
+    const nullResponse = await Effect.runPromise(
+      router.handle({
+        id: 'kanban-ticket-update-model-2',
+        method: 'kanban.ticket.update',
+        params: { projectId: project.id, id: 'ticket-1', data: nullData }
+      })
+    )
+
+    expect(nullResponse).toEqual({
+      id: 'kanban-ticket-update-model-2',
+      ok: true,
+      value: ticketWithoutModel
+    })
+    expect(calls).toEqual([
+      { projectId: project.id, id: 'ticket-1', data: setData },
+      { projectId: project.id, id: 'ticket-1', data: nullData }
+    ])
   })
 
   it('handles kanban.ticket.delete through the kanban RPC domain', async () => {

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -244,6 +244,134 @@ describe('rpc router', () => {
     })
   })
 
+  it('handles kanban.ticket.duplicate through the kanban RPC domain', async () => {
+    const ticket = {
+      id: 'ticket-2',
+      project_id: project.id,
+      title: 'Ship HTTP migration',
+      description: null,
+      attachments: [],
+      column: 'todo' as const,
+      sort_order: 0,
+      current_session_id: null,
+      worktree_id: null,
+      mode: null,
+      plan_ready: false,
+      created_at: '2026-05-26T00:05:00.000Z',
+      updated_at: '2026-05-26T00:05:00.000Z',
+      archived_at: null,
+      external_provider: null,
+      external_id: null,
+      external_url: null,
+      github_pr_number: null,
+      github_pr_url: null,
+      mark: null,
+      total_tokens: 0,
+      pending_launch_config: null,
+      goal_mode: false,
+      goal_success_criteria: null,
+      note: null,
+      created_from_session: false,
+      auto_approve_plan: false,
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-6',
+      model_variant: 'thinking',
+      variant_group_id: 'group-1'
+    }
+    const calls: unknown[] = []
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      kanban: {
+        createTicket: () => Effect.die(new Error('createTicket should not run')),
+        createTicketBatch: () => Effect.die(new Error('createTicketBatch should not run')),
+        getTicket: () => Effect.die(new Error('getTicket should not run')),
+        getTicketsByProject: () => Effect.die(new Error('getTicketsByProject should not run')),
+        updateTicket: () => Effect.die(new Error('updateTicket should not run')),
+        deleteTicket: () => Effect.die(new Error('deleteTicket should not run')),
+        archiveTicket: () => Effect.die(new Error('archiveTicket should not run')),
+        archiveAllDoneTickets: () => Effect.die(new Error('archiveAllDoneTickets should not run')),
+        unarchiveTicket: () => Effect.die(new Error('unarchiveTicket should not run')),
+        moveTicket: () => Effect.die(new Error('moveTicket should not run')),
+        duplicateTicket: (projectId, id, overrides) =>
+          Effect.sync(() => {
+            calls.push({ projectId, id, overrides })
+            return ticket
+          })
+      }
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'kanban-ticket-duplicate-1',
+        method: 'kanban.ticket.duplicate',
+        params: {
+          projectId: project.id,
+          id: 'ticket-1',
+          overrides: {
+            column: 'in_progress',
+            model_provider_id: 'anthropic',
+            model_id: 'claude-opus-4-6',
+            model_variant: 'thinking',
+            variant_group_id: 'group-1'
+          }
+        }
+      })
+    )
+
+    expect(response).toEqual({
+      id: 'kanban-ticket-duplicate-1',
+      ok: true,
+      value: ticket
+    })
+    expect(calls).toEqual([
+      {
+        projectId: project.id,
+        id: 'ticket-1',
+        overrides: {
+          column: 'in_progress',
+          model_provider_id: 'anthropic',
+          model_id: 'claude-opus-4-6',
+          model_variant: 'thinking',
+          variant_group_id: 'group-1'
+        }
+      }
+    ])
+  })
+
+  it('validates kanban.ticket.duplicate params', async () => {
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      kanban: {
+        createTicket: () => Effect.die(new Error('createTicket should not run')),
+        createTicketBatch: () => Effect.die(new Error('createTicketBatch should not run')),
+        getTicket: () => Effect.die(new Error('getTicket should not run')),
+        getTicketsByProject: () => Effect.die(new Error('getTicketsByProject should not run')),
+        updateTicket: () => Effect.die(new Error('updateTicket should not run')),
+        deleteTicket: () => Effect.die(new Error('deleteTicket should not run')),
+        archiveTicket: () => Effect.die(new Error('archiveTicket should not run')),
+        archiveAllDoneTickets: () => Effect.die(new Error('archiveAllDoneTickets should not run')),
+        unarchiveTicket: () => Effect.die(new Error('unarchiveTicket should not run')),
+        moveTicket: () => Effect.die(new Error('moveTicket should not run')),
+        duplicateTicket: () =>
+          Effect.die(new Error('duplicateTicket should not run for invalid params'))
+      }
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'kanban-ticket-duplicate-2',
+        method: 'kanban.ticket.duplicate',
+        params: { projectId: project.id, id: 'ticket-1', overrides: { unknownField: true } }
+      })
+    )
+
+    expect(response).toMatchObject({
+      id: 'kanban-ticket-duplicate-2',
+      ok: false,
+      error: { code: 'VALIDATION_FAILED' }
+    })
+  })
+
   it('handles kanban.ticket.createBatch through the kanban RPC domain', async () => {
     const firstTicket = {
       id: 'ticket-1',

--- a/src/server/rpc/domains/__tests__/backup-ops.test.ts
+++ b/src/server/rpc/domains/__tests__/backup-ops.test.ts
@@ -114,6 +114,10 @@ function ticket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
     note: null,
     created_from_session: false,
     auto_approve_plan: false,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
     ...overrides
   }
 }

--- a/src/server/rpc/domains/kanban.ts
+++ b/src/server/rpc/domains/kanban.ts
@@ -9,6 +9,7 @@ import type {
   KanbanTicketBatchCreate,
   KanbanTicketBatchCreateResult,
   KanbanTicketCreate,
+  KanbanTicketDuplicateOverrides,
   KanbanTicketUpdate,
   MarkdownCardDiagnostic,
   TicketDependency
@@ -86,6 +87,13 @@ export interface KanbanRpcService {
     column: KanbanTicket['column'],
     sortOrder: number
   ) => Effect.Effect<KanbanTicket | null, unknown, never>
+  // Optional (like the other ticket methods below) so the 50+ existing test
+  // mocks that construct a full `kanban:` service literal don't all need updating.
+  readonly duplicateTicket?: (
+    projectId: string,
+    id: string,
+    overrides?: KanbanTicketDuplicateOverrides
+  ) => Effect.Effect<KanbanTicket, unknown, never>
   readonly moveTicketToProject?: (
     projectId: string,
     id: string,
@@ -216,7 +224,12 @@ const kanbanTicketCreateSchema = z
     github_pr_number: z.number().nullable().optional(),
     github_pr_url: z.string().nullable().optional(),
     mark: ticketMarkSchema.nullable().optional(),
-    created_from_session: z.boolean().optional()
+    created_from_session: z.boolean().optional(),
+    note: z.string().nullable().optional(),
+    model_provider_id: z.string().nullable().optional(),
+    model_id: z.string().nullable().optional(),
+    model_variant: z.string().nullable().optional(),
+    variant_group_id: z.string().nullable().optional()
   })
   .strict() satisfies z.ZodType<KanbanTicketCreate>
 
@@ -240,6 +253,23 @@ const kanbanTicketBatchCreateParamsSchema = z
     data: kanbanTicketBatchCreateSchema
   })
   .strict()
+const kanbanTicketDuplicateOverridesSchema = z
+  .object({
+    column: ticketColumnSchema.optional(),
+    sort_order: z.number().optional(),
+    model_provider_id: z.string().nullable().optional(),
+    model_id: z.string().nullable().optional(),
+    model_variant: z.string().nullable().optional(),
+    variant_group_id: z.string().nullable().optional()
+  })
+  .strict() satisfies z.ZodType<KanbanTicketDuplicateOverrides>
+const kanbanTicketDuplicateParamsSchema = z
+  .object({
+    projectId: z.string(),
+    id: z.string(),
+    overrides: kanbanTicketDuplicateOverridesSchema.optional()
+  })
+  .strict()
 const kanbanTicketUpdateSchema = z
   .object({
     title: z.string().optional(),
@@ -259,7 +289,11 @@ const kanbanTicketUpdateSchema = z
     goal_success_criteria: z.string().nullable().optional(),
     note: z.string().nullable().optional(),
     archived_at: z.string().nullable().optional(),
-    auto_approve_plan: z.boolean().optional()
+    auto_approve_plan: z.boolean().optional(),
+    model_provider_id: z.string().nullable().optional(),
+    model_id: z.string().nullable().optional(),
+    model_variant: z.string().nullable().optional(),
+    variant_group_id: z.string().nullable().optional()
   })
   .strict() satisfies z.ZodType<KanbanTicketUpdate>
 const ticketIdProjectParamsSchema = z
@@ -479,6 +513,14 @@ export const makeLiveKanbanRpcService = (): KanbanRpcService => ({
       try: async () => {
         const { getKanbanBackendForProject } = await import('../../../main/services/kanban-backend')
         return getKanbanBackendForProject(projectId).create(projectId, data)
+      },
+      catch: (cause) => cause
+    }),
+  duplicateTicket: (projectId, id, overrides) =>
+    Effect.tryPromise({
+      try: async () => {
+        const { getKanbanBackendForProject } = await import('../../../main/services/kanban-backend')
+        return getKanbanBackendForProject(projectId).duplicate(projectId, id, overrides)
       },
       catch: (cause) => cause
     }),
@@ -1034,6 +1076,20 @@ export const makeKanbanRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.createTicket(data.project_id, data)
+        })
+    ],
+    [
+      'kanban.ticket.duplicate',
+      (params) =>
+        Effect.gen(function* () {
+          const { projectId, id, overrides } = yield* Effect.try({
+            try: () => kanbanTicketDuplicateParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          if (!service.duplicateTicket) {
+            return yield* Effect.die(new Error('kanban.ticket.duplicate service is not implemented'))
+          }
+          return yield* service.duplicateTicket(projectId, id, overrides)
         })
     ],
     [

--- a/src/shared/__tests__/branch-utils.test.ts
+++ b/src/shared/__tests__/branch-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeFilename } from '../types/branch-utils'
+import { canonicalizeModelSlug, normalizeFilename } from '../types/branch-utils'
 
 describe('normalizeFilename', () => {
   it('converts spaces to underscores', () => {
@@ -34,5 +34,43 @@ describe('normalizeFilename', () => {
   it('returns an empty string for all-unsafe input', () => {
     expect(normalizeFilename('!@#$%^&*()')).toBe('')
     expect(normalizeFilename('   ')).toBe('')
+  })
+})
+
+describe('canonicalizeModelSlug', () => {
+  it('drops a trailing segment that would push past the cap, instead of cutting mid-segment', () => {
+    expect(canonicalizeModelSlug('claude-opus-4-5-20251101')).toBe('claude-opus-4-5')
+  })
+
+  it('converts dots to dashes and lowercases', () => {
+    expect(canonicalizeModelSlug('gpt-5.5-codex')).toBe('gpt-5-5-codex')
+  })
+
+  it('leaves short slugs under the cap untouched', () => {
+    expect(canonicalizeModelSlug('sonnet')).toBe('sonnet')
+  })
+
+  it('uppercases and underscores are normalized like canonicalizeTicketTitle', () => {
+    expect(canonicalizeModelSlug('GPT_5_Turbo')).toBe('gpt-5-turbo')
+  })
+
+  it('keeps a whole segment that lands exactly at the cap', () => {
+    // "aaaaaaaaaa-bbbbb" is exactly 16 chars — must be kept whole.
+    expect(canonicalizeModelSlug('aaaaaaaaaa-bbbbb-cccccccc')).toBe('aaaaaaaaaa-bbbbb')
+  })
+
+  it('falls back to a raw sanitized prefix when a single segment alone exceeds the cap', () => {
+    const result = canonicalizeModelSlug('supercalifragilisticexpialidocious')
+    expect(result).toBe('supercalifragili')
+    expect(result.length).toBeLessThanOrEqual(16)
+  })
+
+  it('never cuts mid-word: no result ends mid-token relative to input segments', () => {
+    const result = canonicalizeModelSlug('claude-opus-4-5-20251101')
+    expect(['claude', 'opus', '4', '5', '20251101']).toContain(result.split('-').pop())
+  })
+
+  it('returns an empty string for empty input', () => {
+    expect(canonicalizeModelSlug('')).toBe('')
   })
 })

--- a/src/shared/__tests__/branch-utils.test.ts
+++ b/src/shared/__tests__/branch-utils.test.ts
@@ -73,4 +73,12 @@ describe('canonicalizeModelSlug', () => {
   it('returns an empty string for empty input', () => {
     expect(canonicalizeModelSlug('')).toBe('')
   })
+
+  it('falls back to "model" for symbol-only input that sanitizes to empty', () => {
+    expect(canonicalizeModelSlug('!!!___$$$')).toBe('model')
+  })
+
+  it('falls back to "model" for non-ASCII/unicode-only input that sanitizes to empty', () => {
+    expect(canonicalizeModelSlug('你好')).toBe('model')
+  })
 })

--- a/src/shared/types/branch-utils.ts
+++ b/src/shared/types/branch-utils.ts
@@ -33,7 +33,9 @@ const MODEL_SLUG_CAP = 16
  * would push past the cap is dropped instead of truncated, e.g.
  * `claude-opus-4-5-20251101` -> `claude-opus-4-5`. Never returns an empty
  * string for non-empty input — if even the first segment overflows the cap,
- * falls back to a raw prefix of the sanitized string.
+ * falls back to a raw prefix of the sanitized string; if sanitation strips
+ * the input down to nothing (symbol-only or non-ASCII modelIDs like `你好`),
+ * falls back to the literal `model`.
  */
 export function canonicalizeModelSlug(modelID: string): string {
   const sanitized = modelID
@@ -41,6 +43,8 @@ export function canonicalizeModelSlug(modelID: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-') // any run of non-alphanumeric chars → single dash
     .replace(/^-+|-+$/g, '') // strip leading/trailing dashes
+
+  if (sanitized.length === 0) return modelID.length > 0 ? 'model' : ''
 
   if (sanitized.length <= MODEL_SLUG_CAP) return sanitized
 

--- a/src/shared/types/branch-utils.ts
+++ b/src/shared/types/branch-utils.ts
@@ -22,6 +22,38 @@ export function canonicalizeTicketTitle(title: string): string {
     .replace(/-+$/, '') // strip trailing dashes after truncation
 }
 
+const MODEL_SLUG_CAP = 16
+
+/**
+ * Convert a model ID into a short, filesystem-safe slug for the multi-model
+ * worktree nameHint (`<ticket-slug>-<model-slug>`). Reuses
+ * canonicalizeTicketTitle's sanitation mechanics (lowercase, non-alphanumeric
+ * runs -> single dash, trim leading/trailing dashes) but caps at ~16 chars
+ * without cutting a dash-separated segment in half: a trailing segment that
+ * would push past the cap is dropped instead of truncated, e.g.
+ * `claude-opus-4-5-20251101` -> `claude-opus-4-5`. Never returns an empty
+ * string for non-empty input — if even the first segment overflows the cap,
+ * falls back to a raw prefix of the sanitized string.
+ */
+export function canonicalizeModelSlug(modelID: string): string {
+  const sanitized = modelID
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-') // any run of non-alphanumeric chars → single dash
+    .replace(/^-+|-+$/g, '') // strip leading/trailing dashes
+
+  if (sanitized.length <= MODEL_SLUG_CAP) return sanitized
+
+  let capped = ''
+  for (const segment of sanitized.split('-')) {
+    const candidate = capped ? `${capped}-${segment}` : segment
+    if (candidate.length > MODEL_SLUG_CAP) break
+    capped = candidate
+  }
+
+  return capped || sanitized.slice(0, MODEL_SLUG_CAP).replace(/-+$/, '')
+}
+
 /**
  * Convert a plan title into a filesystem-safe filename fragment.
  * Unlike canonicalizeTicketTitle (lowercase, 32-char cap for Windows


### PR DESCRIPTION
## Summary
- Added multi-model ticket launch support across the renderer, backend, and RPC layer.
- Stored and surfaced model metadata for tickets, including kanban badges and markdown-backed fields.
- Split launch orchestration into shared pipelines and multi-model-specific logic for better session handling.
- Added schema, type, and migration-safety updates for the new ticket model columns.
- Included extensive tests for duplicate RPCs, routing, UI behavior, launch flows, and model badge rendering.

## Testing
- Added and updated unit/integration tests for `kanban.ticket.duplicate` RPC behavior and renderer API routing.
- Added UI tests for `WorktreePickerModal`, `KanbanTicketCard`, `KanbanTicketModal`, and `TicketModelBadge`.
- Added launch-flow tests covering shared ticket launch logic and multi-model launch orchestration.
- Added backend coverage for markdown model field mirroring and duplicate ticket handling.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SQLite migrations and kanban launch state (sessions, worktrees, queued configs); regressions could mis-stamp badges or leave orphaned sessions, though coverage is extensive.
> 
> **Overview**
> Adds **multi-model launches** from the worktree picker: extra SDK/model rows on a new worktree, **Save & Queue** serialization via `pending_launch_config.models`, and **`runMultiModelLaunch`** (duplicate siblings, shared `variant_group_id`, sequential sessions). **Auto-launch** now delegates to **`launchTicketWithModel`** and routes multi-entry + new-worktree configs through the same orchestrator.
> 
> Persists **model badge metadata** on tickets (schema **v39**: `model_provider_id`, `model_id`, `model_variant`, `variant_group_id`) for SQLite and markdown runtime state, with create/update/batch/move/duplicate plumbing. **`kanban.ticket.duplicate`** plus renderer API support powers multi-launch copies. Launch paths stamp badges from **`resolveBadgeModel`** (session row wins), clear stale `variant_group_id` / `pending_launch_config` where appropriate, and show **`TicketModelBadge`** on cards and modals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66840e0cc966b46f13f79c9664e42680a07ae5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->