### PR TITLE
Rename Claude CLI connections from ticket titles

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -6,6 +6,7 @@ import {
   AlertTriangle,
   Trash2,
   Archive,
+  Copy,
   ArchiveRestore,
   GitBranch,
   ExternalLink,
@@ -714,6 +715,34 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       toast.error('Failed to archive ticket')
     }
   }, [ticket.id, ticket.project_id])
+
+  const handleDuplicate = useCallback(async () => {
+    try {
+      const store = useKanbanStore.getState()
+      const created = await store.createTicket(ticket.project_id, {
+        project_id: ticket.project_id,
+        title: ticket.title,
+        description: ticket.description,
+        column: 'todo'
+      })
+      // Goal fields aren't part of the create payload — mirror them after creation
+      if (ticket.goal_mode || ticket.goal_success_criteria) {
+        await store.updateTicket(created.id, ticket.project_id, {
+          goal_mode: ticket.goal_mode,
+          goal_success_criteria: ticket.goal_success_criteria
+        })
+      }
+      toast.success('Ticket duplicated')
+    } catch {
+      toast.error('Failed to duplicate ticket')
+    }
+  }, [
+    ticket.project_id,
+    ticket.title,
+    ticket.description,
+    ticket.goal_mode,
+    ticket.goal_success_criteria
+  ])
 
   const handleMoveToProject = useCallback(
     async (project: { id: string; name: string }) => {
@@ -1558,6 +1587,15 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
               )}
             </ContextMenuSubContent>
           </ContextMenuSub>
+
+          <ContextMenuItem
+            data-testid="ctx-duplicate-ticket"
+            onClick={() => void handleDuplicate()}
+            className="gap-2"
+          >
+            <Copy className="h-3.5 w-3.5" />
+            Duplicate
+          </ContextMenuItem>
 
           {!isExternalTicket && (
             <ContextMenuItem

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -156,6 +156,7 @@ function setupStores(): {
   setSessionModel: ReturnType<typeof vi.fn>
   setSessionMode: ReturnType<typeof vi.fn>
   updateTicket: ReturnType<typeof vi.fn>
+  renameConnection: ReturnType<typeof vi.fn>
 } {
   const createSession = vi.fn(
     async (
@@ -195,6 +196,7 @@ function setupStores(): {
   const setSessionModel = vi.fn(async () => undefined)
   const setSessionMode = vi.fn(async () => undefined)
   const updateTicket = vi.fn(async () => undefined)
+  const renameConnection = vi.fn(async () => undefined)
 
   useSettingsStore.setState({
     availableAgentSdks: { opencode: true, claude: true, codex: true },
@@ -275,7 +277,8 @@ function setupStores(): {
         members: []
       }
     ],
-    loaded: true
+    loaded: true,
+    renameConnection
   })
   useKanbanStore.setState({
     tickets: new Map([['project-1', [baseTicket]]]),
@@ -303,7 +306,14 @@ function setupStores(): {
     fetchUsageForProvider: vi.fn()
   })
 
-  return { createSession, createConnectionSession, setSessionModel, setSessionMode, updateTicket }
+  return {
+    createSession,
+    createConnectionSession,
+    setSessionModel,
+    setSessionMode,
+    updateTicket,
+    renameConnection
+  }
 }
 
 async function renderAndSelectClaudeCli(ticket: KanbanTicket = baseTicket): Promise<void> {
@@ -461,6 +471,36 @@ describe('WorktreePickerModal Claude CLI launch', () => {
       sessionId: 'connection-session-1',
       opts: { pendingPrompt: expect.stringContaining('Please implement the following ticket.') }
     })
+  })
+
+  it('renames the connection after the ticket title when it has no custom name', async () => {
+    const { renameConnection } = setupStores()
+    await renderAndSelectClaudeCliForConnection()
+
+    await userEvent.click(screen.getByTestId('model-selector-pick-opus'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() =>
+      expect(renameConnection).toHaveBeenCalledWith('connection-1', 'Launch Claude CLI')
+    )
+  })
+
+  it('does not rename a connection that already has a custom name', async () => {
+    const { renameConnection } = setupStores()
+    useConnectionStore.setState((state) => ({
+      connections: state.connections.map((c) =>
+        c.id === 'connection-1' ? { ...c, custom_name: 'My connection' } : c
+      )
+    }))
+    await renderAndSelectClaudeCliForConnection()
+
+    await userEvent.click(screen.getByTestId('model-selector-pick-opus'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', expect.any(Object))
+    )
+    expect(renameConnection).not.toHaveBeenCalled()
   })
 
   it('omits the synthetic plan prefix for Claude CLI plan launches', async () => {

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -476,9 +476,10 @@ export function WorktreePickerModal({
     // ── Connection mode path ──────────────────────────────────────
     if (isConnectionMode && connectionId) {
       try {
-        const connectionPath = useConnectionStore
+        const connection = useConnectionStore
           .getState()
-          .connections.find((c) => c.id === connectionId)?.path
+          .connections.find((c) => c.id === connectionId)
+        const connectionPath = connection?.path
         const effectivePromptText = await convertOversizedGoalPrompt(
           promptText,
           composedGoalPrompt,
@@ -544,6 +545,12 @@ export function WorktreePickerModal({
           goal_mode: goalMode,
           goal_success_criteria: goalMode ? goalCriteria.trim() : null
         })
+
+        // Name the connection after the ticket unless the user already renamed it
+        const ticketTitle = ticket.title.trim()
+        if (connection && !connection.custom_name && ticketTitle) {
+          void useConnectionStore.getState().renameConnection(connectionId, ticketTitle)
+        }
 
         void autoPinBaseWorktree(ticket.project_id)
 

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -524,6 +524,21 @@ function ProviderUsageBlock({
     return membersByAccount?.get(`${provider}:${rowEmail?.toLowerCase() ?? ''}`) ?? []
   }
 
+  // The active account sorts last, so open the popover scrolled to the bottom
+  // to keep it in view when many accounts overflow the max height.
+  const popoverRef = useRef<HTMLDivElement | null>(null)
+  const scrollPopoverToBottom = useCallback((node: HTMLDivElement | null): void => {
+    popoverRef.current = node
+    if (node) node.scrollTop = node.scrollHeight
+  }, [])
+
+  // Saved accounts load async on hover and can land after the popover mounts,
+  // growing the content past the initial scroll position.
+  useEffect(() => {
+    const node = popoverRef.current
+    if (node) node.scrollTop = node.scrollHeight
+  }, [savedAccounts.length])
+
   useEffect(() => {
     loadSavedAccounts(provider).catch(() => {})
   }, [loadSavedAccounts, provider])
@@ -661,6 +676,7 @@ function ProviderUsageBlock({
         </div>
       </HoverCardTrigger>
       <HoverCardContent
+        ref={scrollPopoverToBottom}
         side="top"
         sideOffset={8}
         collisionPadding={8}


### PR DESCRIPTION
## Summary
- Renames the active connection to match the ticket title after a successful Claude CLI ticket send, but only when the connection has no existing custom name.
- Leaves user-customized connection names unchanged.
- Updates the Claude CLI modal tests to cover both rename and no-rename cases.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only kanban/usage tweaks plus a fire-and-forget connection rename; no auth or data-migration changes.
> 
> **Overview**
> Adds **Duplicate** on kanban ticket context menus: creates a new **todo** ticket with the same title, description, and goal fields (goal copied via a follow-up `updateTicket`).
> 
> After a successful **connection-mode** send from `WorktreePickerModal`, the active connection is renamed to the trimmed ticket title when it has no `custom_name`; user-set `custom_name` is left alone. Claude CLI modal tests cover both paths.
> 
> The usage indicator hover popover now **scrolls to the bottom** on open and when saved accounts load, so the active account (sorted last) stays visible in long account lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c1654879045f7a349245d487819825436a68ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->