### PR TITLE
Show model badge only for multi-model duplicate cards

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.test.tsx
@@ -44,18 +44,34 @@ describe('KanbanTicketCard model badge', () => {
     cleanup()
   })
 
-  it('renders the model badge when the ticket has model fields, even with no other badges', () => {
+  it('renders the model badge for a multi-model duplicate, even with no other badges', () => {
     const ticket: KanbanTicket = {
       ...baseTicket,
       model_provider_id: 'anthropic',
       model_id: 'claude-opus-4-5-20251101',
-      model_variant: null
+      model_variant: null,
+      variant_group_id: 'group-1'
     }
 
     render(<KanbanTicketCard ticket={ticket} />)
 
     expect(screen.getByText('claude-opus-4-5-20251101')).toBeInTheDocument()
     expect(screen.getByRole('img', { name: 'Claude' })).toBeInTheDocument()
+  })
+
+  it('does not render a model badge for a single-model launch (no variant_group_id)', () => {
+    const ticket: KanbanTicket = {
+      ...baseTicket,
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-5-20251101',
+      model_variant: null,
+      variant_group_id: null
+    }
+
+    render(<KanbanTicketCard ticket={ticket} />)
+
+    expect(screen.queryByText('claude-opus-4-5-20251101')).toBeNull()
+    expect(screen.queryByRole('img', { name: 'Claude' })).toBeNull()
   })
 
   it('does not render a model badge when the ticket has no model_id', () => {

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -556,6 +556,9 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
 
   const isError = sessionStatus === 'error'
   const hasAttachments = ticket.attachments.length > 0
+  // Only surface the model on cards that are part of a multi-model duplicate
+  // group — for single-model launches the name is noise.
+  const showModelBadge = !!ticket.model_id && !!ticket.variant_group_id
   const isForwardedToTelegram = useTelegramStore(
     useCallback(
       (state) => !!ticket.current_session_id && state.activeForwardingSessionId === ticket.current_session_id,
@@ -1036,7 +1039,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || blockingDiagnostic || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode || ticket.auto_approve_plan || activeRemoteLaunch || ticket.model_id) && (
+            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || blockingDiagnostic || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode || ticket.auto_approve_plan || activeRemoteLaunch || showModelBadge) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
@@ -1103,8 +1106,8 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                   </Tooltip>
                 )}
 
-                {/* Model badge */}
-                <TicketModelBadge ticket={ticket} />
+                {/* Model badge — only for multi-model duplicate groups */}
+                {showModelBadge && <TicketModelBadge ticket={ticket} />}
 
                 {/* Project tag (connection mode) or worktree name badge */}
                 {projectTag ? (


### PR DESCRIPTION
## Summary
- Limit the ticket model badge to cards that belong to a `variant_group_id`, so single-model launches do not show the model name.
- Update the Kanban card rendering logic to use a `showModelBadge` flag instead of checking `model_id` alone.
- Add regression coverage for both multi-model duplicate cards and single-model launches.

## Testing
- `Not run`
- Added/updated unit tests in `KanbanTicketCard.test.tsx` to verify the badge appears only for multi-model duplicate tickets.
- Added a unit test confirming the badge is hidden when `variant_group_id` is `null`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Kanban badge visibility with targeted unit tests; no auth, data, or launch logic changes.
> 
> **Overview**
> Kanban ticket cards no longer show the model name/provider badge for ordinary single-model launches. The badge appears only when a ticket has both **`model_id`** and **`variant_group_id`**, i.e. cards in a multi-model duplicate group.
> 
> **`KanbanTicketCard`** introduces a **`showModelBadge`** flag and uses it for the badges row and **`TicketModelBadge`** rendering instead of treating any **`model_id`** as enough to show the badge.
> 
> Unit tests in **`KanbanTicketCard.test.tsx`** assert the badge shows for grouped duplicates and stays hidden when **`variant_group_id`** is null or **`model_id`** is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ba5b55f669a39ca2db1c4c3d812641f44641b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->