### PR TITLE
Add Discord transport for Claude CLI sessions

### DIFF
--- a/src/main/desktop/backend-manager.ts
+++ b/src/main/desktop/backend-manager.ts
@@ -64,6 +64,7 @@ import {
 } from '../services/terminal-pty-bridge'
 import { launchClaudeCliInTmux } from '../services/remote-tmux-launcher'
 import { claudeCliTelegramBridge } from '../services/claude-cli-telegram-bridge'
+import { claudeCliDiscordBridge } from '../services/claude-cli-discord-bridge'
 import { setClaudeCliPlanAutoApprove } from '../services/claude-cli-plan-auto-approve'
 import { openPathWithEditor, openPathWithTerminal } from '../services/settings-openers'
 import {
@@ -801,6 +802,49 @@ const handleDesktopBackendCommand = (
     const success = claudeCliTelegramBridge.hasPendingPlan(message.payload.requestId)
     if (success) {
       claudeCliTelegramBridge.resolvePlan(
+        message.payload.requestId,
+        message.payload.approve,
+        message.payload.feedback
+      )
+    }
+    sendDesktopBackendCommandResult(
+      child,
+      makeDesktopCommandResult(message.id, { ok: true, value: { success } }),
+      log
+    )
+    return
+  }
+
+  if (message.command === 'discordClaudeCliQuestionReply') {
+    const success = claudeCliDiscordBridge.hasPendingQuestion(message.payload.requestId)
+    if (success) {
+      claudeCliDiscordBridge.resolveQuestion(message.payload.requestId, message.payload.answers)
+    }
+    sendDesktopBackendCommandResult(
+      child,
+      makeDesktopCommandResult(message.id, { ok: true, value: { success } }),
+      log
+    )
+    return
+  }
+
+  if (message.command === 'discordClaudeCliQuestionReject') {
+    const success = claudeCliDiscordBridge.hasPendingQuestion(message.payload.requestId)
+    if (success) {
+      claudeCliDiscordBridge.rejectQuestion(message.payload.requestId)
+    }
+    sendDesktopBackendCommandResult(
+      child,
+      makeDesktopCommandResult(message.id, { ok: true, value: { success } }),
+      log
+    )
+    return
+  }
+
+  if (message.command === 'discordClaudeCliPlanReply') {
+    const success = claudeCliDiscordBridge.hasPendingPlan(message.payload.requestId)
+    if (success) {
+      claudeCliDiscordBridge.resolvePlan(
         message.payload.requestId,
         message.payload.approve,
         message.payload.feedback

--- a/src/main/services/claude-cli-discord-bridge.test.ts
+++ b/src/main/services/claude-cli-discord-bridge.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ServerResponse } from 'node:http'
+import { DISCORD_CLAUDE_CLI_EVENT_CHANNEL } from '@shared/discord-events'
+
+vi.mock('../desktop/backend-event-publisher', () => ({
+  publishDesktopBackendEvent: vi.fn(async () => true)
+}))
+
+import { publishDesktopBackendEvent } from '../desktop/backend-event-publisher'
+import { claudeCliDiscordBridge } from './claude-cli-discord-bridge'
+
+const DISCORD_CONFIG = JSON.stringify({
+  botToken: 'token',
+  guildId: 'guild-1',
+  guildName: 'Guild',
+  enabled: true,
+  selectedProjectIds: ['project-1']
+})
+
+class FakeDb {
+  settings = new Map<string, string>()
+  sessions = new Map<string, { id: string; agent_sdk: string; worktree_id: string | null }>()
+  channelWorktrees = new Set<string>()
+
+  getSetting(key: string): string | null {
+    return this.settings.get(key) ?? null
+  }
+
+  getSession(id: string): { id: string; agent_sdk: string; worktree_id: string | null } | null {
+    return this.sessions.get(id) ?? null
+  }
+
+  getDiscordChannelResourceByWorktree(worktreeId: string): { discord_id: string } | null {
+    return this.channelWorktrees.has(worktreeId) ? { discord_id: 'channel-1' } : null
+  }
+}
+
+const makeRes = (): ServerResponse => {
+  const res = {
+    writableEnded: false,
+    setTimeout: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    writeHead: vi.fn(),
+    end: vi.fn(function (this: { writableEnded: boolean }) {
+      res.writableEnded = true
+    })
+  }
+  return res as unknown as ServerResponse
+}
+
+let sessionCounter = 0
+const makeCliSession = (db: FakeDb, worktreeId = 'worktree-1'): string => {
+  const id = `session-${++sessionCounter}`
+  db.sessions.set(id, { id, agent_sdk: 'claude-code-cli', worktree_id: worktreeId })
+  return id
+}
+
+describe('claudeCliDiscordBridge dynamic ownership', () => {
+  let db: FakeDb
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    claudeCliDiscordBridge.cancelAll()
+    db = new FakeDb()
+    claudeCliDiscordBridge.setDatabase(db as never)
+  })
+
+  it('owns a claude-cli session whose worktree has a provisioned channel while Discord is enabled', () => {
+    db.settings.set('discord_config', DISCORD_CONFIG)
+    db.channelWorktrees.add('worktree-1')
+    const sessionId = makeCliSession(db)
+
+    expect(claudeCliDiscordBridge.isRegistered(sessionId)).toBe(true)
+  })
+
+  it('does not own sessions when Discord mode is disabled', () => {
+    db.settings.set(
+      'discord_config',
+      JSON.stringify({ ...JSON.parse(DISCORD_CONFIG), enabled: false })
+    )
+    db.channelWorktrees.add('worktree-1')
+    const sessionId = makeCliSession(db)
+
+    expect(claudeCliDiscordBridge.isRegistered(sessionId)).toBe(false)
+  })
+
+  it('does not own sessions whose worktree has no channel', () => {
+    db.settings.set('discord_config', DISCORD_CONFIG)
+    const sessionId = makeCliSession(db, 'worktree-without-channel')
+
+    expect(claudeCliDiscordBridge.isRegistered(sessionId)).toBe(false)
+  })
+
+  it('holds an AskUserQuestion hook for an owned session and relays the event to the backend', () => {
+    db.settings.set('discord_config', DISCORD_CONFIG)
+    db.channelWorktrees.add('worktree-1')
+    const sessionId = makeCliSession(db)
+    expect(claudeCliDiscordBridge.isRegistered(sessionId)).toBe(true)
+
+    const res = makeRes()
+    const owned = claudeCliDiscordBridge.onHook(
+      sessionId,
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'AskUserQuestion',
+        tool_input: {
+          questions: [{ question: 'Pick one', options: ['a', 'b'] }]
+        }
+      },
+      res
+    )
+
+    expect(owned).toBe(true)
+    expect(res.writableEnded).toBe(false)
+    expect(publishDesktopBackendEvent).toHaveBeenCalledWith(
+      DISCORD_CLAUDE_CLI_EVENT_CHANNEL,
+      expect.objectContaining({ type: 'question.asked', sessionId })
+    )
+  })
+
+  it('relays idle transport events to the backend channel', () => {
+    db.settings.set('discord_config', DISCORD_CONFIG)
+    db.channelWorktrees.add('worktree-1')
+    const sessionId = makeCliSession(db)
+    expect(claudeCliDiscordBridge.isRegistered(sessionId)).toBe(true)
+
+    claudeCliDiscordBridge.notifySessionIdle(sessionId, 'final message')
+
+    expect(publishDesktopBackendEvent).toHaveBeenCalledWith(
+      DISCORD_CLAUDE_CLI_EVENT_CHANNEL,
+      expect.objectContaining({ type: 'message.updated', sessionId })
+    )
+    expect(publishDesktopBackendEvent).toHaveBeenCalledWith(
+      DISCORD_CLAUDE_CLI_EVENT_CHANNEL,
+      expect.objectContaining({ type: 'session.idle', sessionId })
+    )
+  })
+})

--- a/src/main/services/claude-cli-discord-bridge.ts
+++ b/src/main/services/claude-cli-discord-bridge.ts
@@ -1,24 +1,51 @@
 import { EventEmitter } from 'node:events'
 import type { ServerResponse } from 'node:http'
 import type { OpenCodeStreamEvent } from '@shared/types/opencode'
+import { DISCORD_CLAUDE_CLI_EVENT_CHANNEL } from '@shared/discord-events'
 import { agentEventBus } from './agent-event-bus'
+import { publishDesktopBackendEvent } from '../desktop/backend-event-publisher'
+import { getDatabase } from '../db'
+import type { DatabaseService } from '../db/database'
+import { isDiscordModeEnabled } from './discord-config'
 import {
   CliHookHoldCore,
   type ClaudeHookBody,
   type CliHookRouteContext
 } from './cli-hook-hold-core'
 
+// How long a session's "does Discord own this session?" DB answer is reused
+// before re-querying. Hooks fire on every tool use, so the lookup must not hit
+// SQLite each time; the TTL bounds how long a Discord enable/disable flip takes
+// to affect an already-running session.
+const OWNERSHIP_CACHE_TTL_MS = 3000
+
 class ClaudeCliDiscordBridge {
   readonly name = 'discord'
   private readonly emitter = new EventEmitter()
+  private db: DatabaseService | null = null
+  private ownershipCache = new Map<string, { owned: boolean; expiresAt: number }>()
+  // Sessions registered by the dynamic ownership check (vs an explicit
+  // register() call); these are revoked when Discord mode turns off.
+  private readonly autoRegistered = new Set<string>()
   private readonly core = new CliHookHoldCore({
     name: 'Discord',
-    emitShared: (event) => agentEventBus.publish(event),
-    emitTransport: (event) => this.emitter.emit('event', event)
+    emitShared: (event) => {
+      agentEventBus.publish(event)
+      this.relayToBackend(event)
+    },
+    emitTransport: (event) => {
+      this.emitter.emit('event', event)
+      this.relayToBackend(event)
+    }
   })
 
   constructor() {
     this.emitter.setMaxListeners(0)
+  }
+
+  setDatabase(db: DatabaseService | null): void {
+    this.db = db
+    this.ownershipCache.clear()
   }
 
   register(sessionId: string): void {
@@ -26,6 +53,22 @@ class ClaudeCliDiscordBridge {
   }
 
   isRegistered(sessionId: string): boolean {
+    // Sessions started outside Discord (app UI, kanban tickets) are owned
+    // dynamically: any claude-cli session whose worktree has a provisioned
+    // Discord channel routes its hooks here while Discord mode is enabled.
+    const owned = this.isDiscordOwnedSession(sessionId)
+    if (owned) {
+      if (!this.core.isRegistered(sessionId)) {
+        this.core.register(sessionId)
+        this.autoRegistered.add(sessionId)
+      }
+      return true
+    }
+    if (this.autoRegistered.has(sessionId)) {
+      this.autoRegistered.delete(sessionId)
+      this.core.cancelSession(sessionId)
+      return false
+    }
     return this.core.isRegistered(sessionId)
   }
 
@@ -73,10 +116,49 @@ class ClaudeCliDiscordBridge {
 
   cancelSession(sessionId: string): void {
     this.core.cancelSession(sessionId)
+    this.ownershipCache.delete(sessionId)
+    this.autoRegistered.delete(sessionId)
   }
 
   cancelAll(): void {
     this.core.cancelAll()
+    this.ownershipCache.clear()
+    this.autoRegistered.clear()
+  }
+
+  private relayToBackend(event: OpenCodeStreamEvent): void {
+    // No-op in the backend server process (no desktop backend attached); in the
+    // Electron main process this hands the event to the server child, where the
+    // Discord session bridge posts to channels.
+    void publishDesktopBackendEvent(DISCORD_CLAUDE_CLI_EVENT_CHANNEL, event)
+  }
+
+  private isDiscordOwnedSession(sessionId: string): boolean {
+    const cached = this.ownershipCache.get(sessionId)
+    if (cached && cached.expiresAt > Date.now()) return cached.owned
+
+    let owned = false
+    try {
+      const db = this.getDb()
+      const session = db.getSession(sessionId)
+      if (session?.agent_sdk === 'claude-code-cli' && session.worktree_id) {
+        owned =
+          !!db.getDiscordChannelResourceByWorktree(session.worktree_id) &&
+          isDiscordModeEnabled(db)
+      }
+    } catch {
+      owned = false
+    }
+
+    this.ownershipCache.set(sessionId, { owned, expiresAt: Date.now() + OWNERSHIP_CACHE_TTL_MS })
+    return owned
+  }
+
+  private getDb(): DatabaseService {
+    if (!this.db) {
+      this.db = getDatabase()
+    }
+    return this.db
   }
 }
 

--- a/src/main/services/cli-hook-transport-router.ts
+++ b/src/main/services/cli-hook-transport-router.ts
@@ -45,7 +45,10 @@ export class CliHookTransportRouter {
   }
 }
 
+// Telegram first: forwarding a session to Telegram is an explicit per-session
+// action, while Discord claims sessions ambiently (any session in a worktree
+// with a provisioned channel), so the explicit choice must win.
 export const cliHookTransportRouter = new CliHookTransportRouter([
-  claudeCliDiscordBridge,
-  claudeCliTelegramBridge
+  claudeCliTelegramBridge,
+  claudeCliDiscordBridge
 ])

--- a/src/main/services/discord-claude-cli-command.ts
+++ b/src/main/services/discord-claude-cli-command.ts
@@ -1,0 +1,83 @@
+import {
+  isDesktopCommandResult,
+  makeDesktopCommandRequest,
+  type DiscordClaudeCliPlanReplyPayload,
+  type DiscordClaudeCliQuestionRejectPayload,
+  type DiscordClaudeCliQuestionReplyPayload,
+  type DiscordClaudeCliReplyResult
+} from '@shared/desktop-command'
+
+type DiscordClaudeCliCommandName =
+  | 'discordClaudeCliQuestionReply'
+  | 'discordClaudeCliQuestionReject'
+  | 'discordClaudeCliPlanReply'
+
+type DiscordClaudeCliCommandPayload =
+  | DiscordClaudeCliQuestionReplyPayload
+  | DiscordClaudeCliQuestionRejectPayload
+  | DiscordClaudeCliPlanReplyPayload
+
+type ProcessWithIpc = NodeJS.Process & {
+  send?: (message: unknown, callback?: (error: Error | null) => void) => boolean
+}
+
+function makeRequest(
+  id: string,
+  command: DiscordClaudeCliCommandName,
+  payload: DiscordClaudeCliCommandPayload
+) {
+  if (command === 'discordClaudeCliQuestionReply') {
+    return makeDesktopCommandRequest(id, command, payload as DiscordClaudeCliQuestionReplyPayload)
+  }
+  if (command === 'discordClaudeCliQuestionReject') {
+    return makeDesktopCommandRequest(id, command, payload as DiscordClaudeCliQuestionRejectPayload)
+  }
+  return makeDesktopCommandRequest(id, command, payload as DiscordClaudeCliPlanReplyPayload)
+}
+
+/**
+ * Forward a Discord-held Claude CLI reply from the backend server process to
+ * the Electron main process, where the PTY + hook server (and thus the held
+ * hook response) live. Returns null when not running as a desktop backend
+ * child (no IPC channel), so callers can fall through to in-process handling.
+ */
+export async function requestDiscordClaudeCliCommand(
+  command: DiscordClaudeCliCommandName,
+  payload: DiscordClaudeCliCommandPayload
+): Promise<DiscordClaudeCliReplyResult | null> {
+  if (process.env.HIVE_SERVER_MODE !== 'desktop' || !process.env.HIVE_DESKTOP_BOOTSTRAP_TOKEN) {
+    return null
+  }
+  const ipcProcess = process as ProcessWithIpc
+  const send = ipcProcess.send
+  if (typeof send !== 'function') return null
+
+  const id = `discord-claude-cli-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  return await new Promise<DiscordClaudeCliReplyResult>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error(`${command} timed out`))
+    }, 5_000)
+    const cleanup = (): void => {
+      clearTimeout(timeout)
+      process.off('message', onMessage)
+    }
+    const onMessage = (message: unknown): void => {
+      if (!isDesktopCommandResult(message) || message.id !== id) return
+      cleanup()
+      if (!message.ok) {
+        reject(new Error(message.error))
+        return
+      }
+      resolve((message.value ?? { success: true }) as DiscordClaudeCliReplyResult)
+    }
+
+    process.on('message', onMessage)
+    const request = makeRequest(id, command, payload)
+    send.call(process, request, (error) => {
+      if (!error) return
+      cleanup()
+      reject(error)
+    })
+  })
+}

--- a/src/main/services/discord-config.ts
+++ b/src/main/services/discord-config.ts
@@ -1,0 +1,76 @@
+import type { DiscordConfig } from '@shared/types/discord'
+
+export const DISCORD_CONFIG_KEY = 'discord_config'
+
+interface SettingsReader {
+  getSetting(key: string): string | null
+}
+
+export const isConfigured = (config: DiscordConfig | null): config is DiscordConfig =>
+  !!config?.botToken.trim() && !!config.guildId.trim()
+
+export const parseConfig = (raw: string | null): DiscordConfig | null => {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Partial<DiscordConfig>
+    return {
+      botToken: typeof parsed.botToken === 'string' ? parsed.botToken : '',
+      guildId: typeof parsed.guildId === 'string' ? parsed.guildId : '',
+      guildName: typeof parsed.guildName === 'string' ? parsed.guildName : '',
+      enabled: parsed.enabled === true,
+      selectedProjectIds: Array.isArray(parsed.selectedProjectIds)
+        ? parsed.selectedProjectIds.filter((id): id is string => typeof id === 'string')
+        : []
+    }
+  } catch {
+    return null
+  }
+}
+
+const parseEnvBoolean = (raw: string | undefined, fallback: boolean): boolean => {
+  if (raw === undefined) return fallback
+  const normalized = raw.trim().toLowerCase()
+  if (!normalized) return fallback
+  return !['0', 'false', 'no', 'off'].includes(normalized)
+}
+
+const parseEnvProjectIds = (raw: string | undefined): string[] => {
+  if (!raw?.trim()) return []
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (Array.isArray(parsed)) {
+      return Array.from(
+        new Set(parsed.filter((id): id is string => typeof id === 'string').map((id) => id.trim()))
+      ).filter((id) => id.length > 0)
+    }
+  } catch {
+    // Fall back to comma-separated values.
+  }
+  return Array.from(new Set(raw.split(',').map((id) => id.trim()))).filter((id) => id.length > 0)
+}
+
+export const getEnvConfig = (env: NodeJS.ProcessEnv = process.env): DiscordConfig | null => {
+  const botToken = env.HIVE_DISCORD_BOT_TOKEN?.trim() ?? ''
+  const guildId = env.HIVE_DISCORD_GUILD_ID?.trim() ?? ''
+  if (!botToken || !guildId) return null
+  return {
+    botToken,
+    guildId,
+    guildName: env.HIVE_DISCORD_GUILD_NAME?.trim() || guildId,
+    enabled: parseEnvBoolean(env.HIVE_DISCORD_ENABLED, true),
+    selectedProjectIds: parseEnvProjectIds(env.HIVE_DISCORD_SELECTED_PROJECT_IDS)
+  }
+}
+
+export const isBlankConfig = (config: DiscordConfig | null): boolean =>
+  !config || (!config.botToken.trim() && !config.guildId.trim())
+
+export const getDiscordConfig = (db: SettingsReader): DiscordConfig | null => {
+  const savedConfig = parseConfig(db.getSetting(DISCORD_CONFIG_KEY))
+  return isBlankConfig(savedConfig) ? getEnvConfig() : savedConfig
+}
+
+export const isDiscordModeEnabled = (db: SettingsReader): boolean => {
+  const config = getDiscordConfig(db)
+  return isConfigured(config) && config.enabled === true
+}

--- a/src/main/services/discord-service.ts
+++ b/src/main/services/discord-service.ts
@@ -45,11 +45,17 @@ import {
 } from './project-ops'
 import { cloneRepository, deriveProjectNameFromGitUrl, isSafeGitRemoteUrl } from './git-repository'
 import { discordSessionBridge, type DiscordSessionBridge } from './discord-session-bridge'
+import {
+  DISCORD_CONFIG_KEY,
+  getEnvConfig,
+  isBlankConfig,
+  isConfigured,
+  parseConfig
+} from './discord-config'
 import type { AgentSdkManager } from './agent-sdk-manager'
 import { createPrFromWorktree } from './discord-pr-creator'
 import { pushWorktree } from './discord-push'
 
-const DISCORD_CONFIG_KEY = 'discord_config'
 const log = createLogger({ component: 'Discord' })
 type DiscordCommand = {
   name: string
@@ -177,67 +183,6 @@ class DiscordJsGateway implements DiscordGateway {
     this.client = null
   }
 }
-
-const isConfigured = (config: DiscordConfig | null): config is DiscordConfig =>
-  !!config?.botToken.trim() && !!config.guildId.trim()
-
-const parseConfig = (raw: string | null): DiscordConfig | null => {
-  if (!raw) return null
-  try {
-    const parsed = JSON.parse(raw) as Partial<DiscordConfig>
-    return {
-      botToken: typeof parsed.botToken === 'string' ? parsed.botToken : '',
-      guildId: typeof parsed.guildId === 'string' ? parsed.guildId : '',
-      guildName: typeof parsed.guildName === 'string' ? parsed.guildName : '',
-      enabled: parsed.enabled === true,
-      selectedProjectIds: Array.isArray(parsed.selectedProjectIds)
-        ? parsed.selectedProjectIds.filter((id): id is string => typeof id === 'string')
-        : []
-    }
-  } catch {
-    return null
-  }
-}
-
-const parseEnvBoolean = (raw: string | undefined, fallback: boolean): boolean => {
-  if (raw === undefined) return fallback
-  const normalized = raw.trim().toLowerCase()
-  if (!normalized) return fallback
-  return !['0', 'false', 'no', 'off'].includes(normalized)
-}
-
-const parseEnvProjectIds = (raw: string | undefined): string[] => {
-  if (!raw?.trim()) return []
-  try {
-    const parsed = JSON.parse(raw) as unknown
-    if (Array.isArray(parsed)) {
-      return Array.from(
-        new Set(parsed.filter((id): id is string => typeof id === 'string').map((id) => id.trim()))
-      ).filter((id) => id.length > 0)
-    }
-  } catch {
-    // Fall back to comma-separated values.
-  }
-  return Array.from(new Set(raw.split(',').map((id) => id.trim()))).filter(
-    (id) => id.length > 0
-  )
-}
-
-const getEnvConfig = (env: NodeJS.ProcessEnv = process.env): DiscordConfig | null => {
-  const botToken = env.HIVE_DISCORD_BOT_TOKEN?.trim() ?? ''
-  const guildId = env.HIVE_DISCORD_GUILD_ID?.trim() ?? ''
-  if (!botToken || !guildId) return null
-  return {
-    botToken,
-    guildId,
-    guildName: env.HIVE_DISCORD_GUILD_NAME?.trim() || guildId,
-    enabled: parseEnvBoolean(env.HIVE_DISCORD_ENABLED, true),
-    selectedProjectIds: parseEnvProjectIds(env.HIVE_DISCORD_SELECTED_PROJECT_IDS)
-  }
-}
-
-const isBlankConfig = (config: DiscordConfig | null): boolean =>
-  !config || (!config.botToken.trim() && !config.guildId.trim())
 
 const parseSessionTitles = (raw: string): string[] => {
   try {

--- a/src/main/services/discord-session-bridge.test.ts
+++ b/src/main/services/discord-session-bridge.test.ts
@@ -62,6 +62,10 @@ class FakeBridgeDatabase {
     return this.sessions.find((session) => session.id === id) ?? null
   }
 
+  getWorktree(id: string): Worktree | null {
+    return this.worktrees.find((worktree) => worktree.id === id) ?? null
+  }
+
   getAgentSdkForSession(agentSessionId: string): string | null {
     return (
       this.sessions.find((session) => session.opencode_session_id === agentSessionId)?.agent_sdk ??
@@ -1175,6 +1179,167 @@ describe('DiscordSessionBridge stream delivery', () => {
         content: expect.stringContaining('Handoff started')
       })
     )
+  })
+})
+
+describe('DiscordSessionBridge relayed CLI sessions', () => {
+  const makeWorktree = (overrides: Partial<Worktree> = {}): Worktree => ({
+    id: 'worktree-1',
+    project_id: 'project-1',
+    name: 'worktree',
+    branch_name: 'feature/worktree',
+    path: '/repo/project/worktree',
+    status: 'active',
+    is_default: false,
+    branch_renamed: 0,
+    last_message_at: null,
+    session_titles: '[]',
+    last_model_provider_id: null,
+    last_model_id: null,
+    last_model_variant: null,
+    attachments: '[]',
+    pinned: 0,
+    context: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    base_branch: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_accessed_at: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  })
+
+  const setupRelayedCliSession = (overrides: { replyRouter?: unknown } = {}) => {
+    const setup = setupBridge({ replyRouter: overrides.replyRouter })
+    const { channel, messages } = makeInteractiveChannel()
+    // The session was started from the app (kanban ticket), so it is NOT the
+    // resource's managed session.
+    setup.db.resources = [makeResource({ managed_session_id: 'some-other-session' })]
+    setup.db.sessions.push(
+      makeSession({
+        id: 'ticket-session',
+        agent_sdk: 'claude-code-cli',
+        opencode_session_id: null
+      })
+    )
+    setup.db.worktrees.push(makeWorktree())
+    setup.bridge.setChannelResolver(async (channelId) =>
+      channelId === 'channel-1' ? (channel as never) : null
+    )
+    return { ...setup, channel, messages }
+  }
+
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('forwards a relayed question for a session that is not the managed session', async () => {
+    const { bridge, channel, messages } = setupRelayedCliSession()
+
+    bridge.handleBackendAgentEvent({
+      type: 'question.asked',
+      sessionId: 'ticket-session',
+      data: {
+        requestId: 'req-cli-1',
+        questions: [
+          {
+            question: 'Which color?',
+            header: 'Color',
+            options: [{ label: 'Red' }, { label: 'Blue' }],
+            multiple: false
+          }
+        ]
+      }
+    })
+    await flushPromises()
+
+    expect(channel.send).toHaveBeenCalled()
+    expect(messages[0].content).toContain('Which color?')
+    expect(messages[0].components).toBeTruthy()
+  })
+
+  it('routes a question answer through the reply router with the claude-code-cli sdk', async () => {
+    const replyRouter = {
+      setAgentSdkManager: vi.fn(),
+      replyQuestion: vi.fn(async () => undefined),
+      rejectQuestion: vi.fn(async () => undefined),
+      replyPermission: vi.fn(async () => undefined),
+      replyCommandApproval: vi.fn(async () => undefined),
+      replyPlan: vi.fn(async () => undefined)
+    }
+    const { bridge } = setupRelayedCliSession({ replyRouter })
+
+    bridge.handleBackendAgentEvent({
+      type: 'question.asked',
+      sessionId: 'ticket-session',
+      data: {
+        requestId: 'req-cli-2',
+        questions: [
+          {
+            question: 'Which color?',
+            options: [{ label: 'Red' }, { label: 'Blue' }],
+            multiple: false
+          }
+        ]
+      }
+    })
+    await flushPromises()
+
+    await bridge.handleComponentInteraction({
+      isButton: () => false,
+      isStringSelectMenu: () => true,
+      customId: 'question:req-cli-2:select:0',
+      values: ['1'],
+      deferUpdate: vi.fn(async () => undefined)
+    })
+    await bridge.handleComponentInteraction({
+      isButton: () => true,
+      isStringSelectMenu: () => false,
+      customId: 'question:req-cli-2:submit',
+      deferUpdate: vi.fn(async () => undefined)
+    })
+    await flushPromises()
+
+    expect(replyRouter.replyQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 'req-cli-2',
+        answers: [['Blue']],
+        agentSdk: 'claude-code-cli'
+      })
+    )
+  })
+
+  it('posts the final assistant message when a relayed CLI session goes idle', async () => {
+    const { bridge, channel } = setupRelayedCliSession()
+
+    bridge.handleBackendAgentEvent({
+      type: 'message.updated',
+      sessionId: 'ticket-session',
+      data: { role: 'assistant', content: 'All done here.' }
+    })
+    await flushPromises()
+    bridge.handleBackendAgentEvent({
+      type: 'session.idle',
+      sessionId: 'ticket-session',
+      data: {}
+    })
+    await flushPromises()
+
+    expect(channel.send).toHaveBeenCalledWith('All done here.')
+  })
+
+  it('forwards a relayed plan for a non-managed session', async () => {
+    const { bridge, messages } = setupRelayedCliSession()
+
+    bridge.handleBackendAgentEvent({
+      type: 'plan.ready',
+      sessionId: 'ticket-session',
+      data: { requestId: 'req-plan-1', plan: '1. Do the thing' }
+    })
+    await flushPromises()
+
+    expect(messages[0].content).toContain('Plan ready')
+    expect(messages[0].content).toContain('1. Do the thing')
+    expect(messages[0].components).toBeTruthy()
   })
 })
 

--- a/src/main/services/discord-session-bridge.ts
+++ b/src/main/services/discord-session-bridge.ts
@@ -362,6 +362,66 @@ export class DiscordSessionBridge {
     this.discordPending.clear()
   }
 
+  /**
+   * Entry point for Claude CLI hook events relayed from the Electron main
+   * process (where the PTY + hook server live). Sessions started outside
+   * Discord (app UI, kanban tickets) have no runtime yet, so one is created
+   * lazily from the session's worktree channel mapping before the event is
+   * processed — that lets busy/idle/final-message events reach the channel too.
+   */
+  handleBackendAgentEvent(payload: unknown): void {
+    const event = asRecord(payload)
+    if (!event || typeof event.type !== 'string' || typeof event.sessionId !== 'string') return
+    void this.processRelayedCliEvent(payload as OpenCodeStreamEvent)
+  }
+
+  private async processRelayedCliEvent(event: OpenCodeStreamEvent): Promise<void> {
+    if (!this.runtimesBySessionId.has(event.sessionId)) {
+      await this.ensureRuntimeForSession(event.sessionId).catch((error) => {
+        log.warn('Failed to create Discord runtime for relayed CLI session', {
+          sessionId: event.sessionId,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      })
+    }
+    // Relayed events are not re-broadcast to the renderer: the shared ones
+    // (question.asked, question.replied) already reached it via the main
+    // process's own agent event bus relay.
+    this.onStreamEvent(event, { republish: false })
+  }
+
+  private async ensureRuntimeForSession(sessionId: string): Promise<void> {
+    const db = this.getDb()
+    const session = db.getSession(sessionId)
+    if (!session?.worktree_id) return
+    const resource = db.getDiscordChannelResourceByWorktree(session.worktree_id)
+    if (!resource) return
+    const channel = await this.resolveChannel?.(resource.discord_id)
+    if (!channel) return
+    const worktree = db.getWorktree?.(session.worktree_id)
+    if (!worktree?.path) return
+    if (this.runtimesBySessionId.has(sessionId)) return
+
+    this.runtimesBySessionId.set(session.id, {
+      channelId: resource.discord_id,
+      channel,
+      hiveSessionId: session.id,
+      worktreePath: worktree.path,
+      opencodeSessionId: session.opencode_session_id ?? session.id,
+      model: this.getSessionModel(session),
+      mode: session.mode,
+      agentSdk: session.agent_sdk,
+      busy: false,
+      currentAssistantMessageId: null,
+      textBuffer: '',
+      pendingUserEchoText: null,
+      postedToolIds: new Set(),
+      typingInterval: null,
+      queue: [],
+      sendChain: Promise.resolve()
+    })
+  }
+
   async handleUserMessage(input: DiscordUserMessageInput): Promise<void> {
     const { resource, session } = await this.resolveManagedSession(input)
     const runtime = this.registerRuntime(input, session, resource)
@@ -603,7 +663,7 @@ export class DiscordSessionBridge {
     }
   }
 
-  private onStreamEvent(event: OpenCodeStreamEvent): void {
+  private onStreamEvent(event: OpenCodeStreamEvent, opts?: { republish?: boolean }): void {
     const runtime = this.runtimesBySessionId.get(event.sessionId)
 
     if (this.isInteractiveResolutionEvent(event.type)) {
@@ -618,9 +678,17 @@ export class DiscordSessionBridge {
 
     if (!runtime) return
 
-    this.publishEvent?.(OPENCODE_STREAM_CHANNEL, event)
+    if (opts?.republish !== false) {
+      this.publishEvent?.(OPENCODE_STREAM_CHANNEL, event)
+    }
 
     if (event.childSessionId) return
+
+    if (event.type === 'session.busy') {
+      runtime.busy = true
+      this.startTyping(runtime)
+      return
+    }
 
     if (event.type === 'message.part.updated') {
       this.handlePartUpdated(runtime, event)
@@ -1275,8 +1343,11 @@ export class DiscordSessionBridge {
 
     const session = this.getDb().getSession(event.sessionId)
     if (!session?.worktree_id) return null
+    // Any session in a worktree with a provisioned channel forwards its
+    // interactive prompts there — not only the Discord-managed session — so
+    // sessions started from the app (kanban tickets) surface in Discord too.
     const resource = this.getDb().getDiscordChannelResourceByWorktree(session.worktree_id)
-    if (!resource || resource.managed_session_id !== session.id) return null
+    if (!resource) return null
     const channel = await this.resolveChannel?.(resource.discord_id)
     if (!channel) return null
     const worktree = this.getDb().getWorktree?.(session.worktree_id)

--- a/src/main/services/interactive-reply-router.ts
+++ b/src/main/services/interactive-reply-router.ts
@@ -7,6 +7,7 @@ import { openCodeService } from './opencode-service'
 import { getDatabase } from '../db'
 import type { DatabaseService } from '../db/database'
 import { claudeCliDiscordBridge } from './claude-cli-discord-bridge'
+import { requestDiscordClaudeCliCommand } from './discord-claude-cli-command'
 
 type PermissionDecision = 'once' | 'always' | 'reject'
 
@@ -142,6 +143,16 @@ export class InteractiveReplyRouter {
       return
     }
 
+    // Claude CLI hooks are held in the Electron main process (where the PTY
+    // lives); reach them over the desktop IPC channel.
+    if (input.agentSdk === 'claude-code-cli') {
+      const forwarded = await requestDiscordClaudeCliCommand('discordClaudeCliQuestionReply', {
+        requestId: input.requestId,
+        answers: input.answers
+      }).catch(() => null)
+      if (forwarded?.success) return
+    }
+
     const claudeImpl = getImplementer<QuestionImplementer>(this.sdkManager, 'claude-code')
     if (claudeImpl?.hasPendingQuestion?.(input.requestId)) {
       await claudeImpl.questionReply?.(input.requestId, input.answers, input.worktreePath)
@@ -161,6 +172,13 @@ export class InteractiveReplyRouter {
     if (this.cliBridge.hasPendingQuestion(input.requestId)) {
       this.cliBridge.rejectQuestion(input.requestId)
       return
+    }
+
+    if (input.agentSdk === 'claude-code-cli') {
+      const forwarded = await requestDiscordClaudeCliCommand('discordClaudeCliQuestionReject', {
+        requestId: input.requestId
+      }).catch(() => null)
+      if (forwarded?.success) return
     }
 
     const claudeImpl = getImplementer<QuestionImplementer>(this.sdkManager, 'claude-code')
@@ -217,6 +235,13 @@ export class InteractiveReplyRouter {
       this.cliBridge.resolvePlan(input.requestId, input.approve, input.feedback)
       return
     }
+
+    const forwarded = await requestDiscordClaudeCliCommand('discordClaudeCliPlanReply', {
+      requestId: input.requestId,
+      approve: input.approve,
+      ...(input.feedback !== undefined ? { feedback: input.feedback } : {})
+    }).catch(() => null)
+    if (forwarded?.success) return
 
     const claudeImpl = getImplementer<ClaudePlanImplementer>(this.sdkManager, 'claude-code')
     const hasPending =

--- a/src/main/services/opencode-session-commands.ts
+++ b/src/main/services/opencode-session-commands.ts
@@ -7,6 +7,7 @@ import type { AgentSdkCapabilities, AgentSdkId, PromptOptions } from './agent-sd
 import { ClaudeCodeImplementer } from './claude-code-implementer'
 import { CodexImplementer } from './codex-implementer'
 import { claudeCliTelegramBridge } from './claude-cli-telegram-bridge'
+import { claudeCliDiscordBridge } from './claude-cli-discord-bridge'
 import { toError } from './error-utils'
 import { isClaudeCli, isTerminalBacked } from '@shared/types/agent-sdk'
 
@@ -504,6 +505,11 @@ export async function replyOpenCodeQuestion(
       return { success: true }
     }
 
+    if (claudeCliDiscordBridge.hasPendingQuestion(requestId)) {
+      claudeCliDiscordBridge.resolveQuestion(requestId, answers)
+      return { success: true }
+    }
+
     if (sdkManager) {
       const claudeImpl = sdkManager.getImplementer('claude-code') as ClaudeCodeImplementer
       if (claudeImpl.hasPendingQuestion(requestId)) {
@@ -545,6 +551,11 @@ export async function rejectOpenCodeQuestion(
       return { success: true }
     }
 
+    if (claudeCliDiscordBridge.hasPendingQuestion(requestId)) {
+      claudeCliDiscordBridge.rejectQuestion(requestId)
+      return { success: true }
+    }
+
     if (sdkManager) {
       const claudeImpl = sdkManager.getImplementer('claude-code') as ClaudeCodeImplementer
       if (claudeImpl.hasPendingQuestion(requestId)) {
@@ -582,6 +593,10 @@ export async function approveOpenCodePlan(
 ): Promise<{ success: boolean; error?: string }> {
   log.info('OpenCode session plan:approve', { hiveSessionId, requestId })
   try {
+    if (requestId && claudeCliDiscordBridge.hasPendingPlan(requestId)) {
+      claudeCliDiscordBridge.resolvePlan(requestId, true)
+      return { success: true }
+    }
     // TODO(codex): Generalize when Codex implements this HITL flow
     if (sdkManager) {
       const claudeImpl = sdkManager.getImplementer('claude-code') as ClaudeCodeImplementer
@@ -616,6 +631,10 @@ export async function rejectOpenCodePlan(
     feedbackLength: feedback.length
   })
   try {
+    if (requestId && claudeCliDiscordBridge.hasPendingPlan(requestId)) {
+      claudeCliDiscordBridge.resolvePlan(requestId, false, feedback)
+      return { success: true }
+    }
     // TODO(codex): Generalize when Codex implements this HITL flow
     if (sdkManager) {
       const claudeImpl = sdkManager.getImplementer('claude-code') as ClaudeCodeImplementer

--- a/src/server/rpc/domains/discord-ops.ts
+++ b/src/server/rpc/domains/discord-ops.ts
@@ -5,6 +5,7 @@ import type {
   DiscordProvisionSummary,
   DiscordVerifyResult
 } from '@shared/types/discord'
+import { DISCORD_CLAUDE_CLI_EVENT_CHANNEL } from '@shared/discord-events'
 import type { EventBus } from '../../events/event-bus'
 import type { RpcHandler } from '../router'
 import type { AgentSdkManager } from '../../../main/services/agent-sdk-manager'
@@ -84,6 +85,18 @@ export const makeLiveDiscordOpsRpcService = (eventBus?: EventBus): DiscordOpsRpc
     bootedEventBuses.add(eventBus)
     void importDiscordService(eventBus)
       .then((service) => service.startListening())
+      .catch(() => undefined)
+    // Claude CLI hook events (questions, plans, idle/busy) are held in the
+    // Electron main process and relayed here over the desktop event channel;
+    // hand them to the session bridge so they post to Discord channels.
+    void import('../../../main/services/discord-session-bridge')
+      .then(({ discordSessionBridge }) => {
+        Effect.runSync(
+          eventBus.subscribe(DISCORD_CLAUDE_CLI_EVENT_CHANNEL, ({ payload }) => {
+            discordSessionBridge.handleBackendAgentEvent(payload)
+          })
+        )
+      })
       .catch(() => undefined)
   }
 

--- a/src/shared/desktop-command.ts
+++ b/src/shared/desktop-command.ts
@@ -109,6 +109,9 @@ export type DesktopCommandName =
   | 'telegramClaudeCliQuestionReply'
   | 'telegramClaudeCliQuestionReject'
   | 'telegramClaudeCliPlanReply'
+  | 'discordClaudeCliQuestionReply'
+  | 'discordClaudeCliQuestionReject'
+  | 'discordClaudeCliPlanReply'
   | 'terminalSetClaudeCliPlanAutoApprove'
 
 export interface OpenInAppPayload {
@@ -399,6 +402,13 @@ export interface TelegramClaudeCliPlanReplyPayload {
 export interface TelegramClaudeCliReplyResult {
   readonly success: boolean
 }
+
+// Discord reuses the Telegram claude-cli payload shapes: both transports hold
+// the same CLI hooks and resolve them with the same request/answer data.
+export type DiscordClaudeCliQuestionReplyPayload = TelegramClaudeCliQuestionReplyPayload
+export type DiscordClaudeCliQuestionRejectPayload = TelegramClaudeCliQuestionRejectPayload
+export type DiscordClaudeCliPlanReplyPayload = TelegramClaudeCliPlanReplyPayload
+export type DiscordClaudeCliReplyResult = TelegramClaudeCliReplyResult
 
 export interface TerminalGhosttyAvailabilityResult {
   readonly available: boolean
@@ -981,6 +991,9 @@ export type DesktopCommandRequest =
   | TelegramClaudeCliQuestionReplyDesktopCommandRequest
   | TelegramClaudeCliQuestionRejectDesktopCommandRequest
   | TelegramClaudeCliPlanReplyDesktopCommandRequest
+  | DiscordClaudeCliQuestionReplyDesktopCommandRequest
+  | DiscordClaudeCliQuestionRejectDesktopCommandRequest
+  | DiscordClaudeCliPlanReplyDesktopCommandRequest
   | TerminalSetClaudeCliPlanAutoApproveDesktopCommandRequest
 
 export interface QuitAppDesktopCommandRequest {
@@ -1688,6 +1701,27 @@ export interface TelegramClaudeCliQuestionRejectDesktopCommandRequest {
   readonly payload: TelegramClaudeCliQuestionRejectPayload
 }
 
+export interface DiscordClaudeCliQuestionReplyDesktopCommandRequest {
+  readonly type: typeof DESKTOP_COMMAND_REQUEST_TYPE
+  readonly id: string
+  readonly command: 'discordClaudeCliQuestionReply'
+  readonly payload: DiscordClaudeCliQuestionReplyPayload
+}
+
+export interface DiscordClaudeCliQuestionRejectDesktopCommandRequest {
+  readonly type: typeof DESKTOP_COMMAND_REQUEST_TYPE
+  readonly id: string
+  readonly command: 'discordClaudeCliQuestionReject'
+  readonly payload: DiscordClaudeCliQuestionRejectPayload
+}
+
+export interface DiscordClaudeCliPlanReplyDesktopCommandRequest {
+  readonly type: typeof DESKTOP_COMMAND_REQUEST_TYPE
+  readonly id: string
+  readonly command: 'discordClaudeCliPlanReply'
+  readonly payload: DiscordClaudeCliPlanReplyPayload
+}
+
 export interface TelegramClaudeCliPlanReplyDesktopCommandRequest {
   readonly type: typeof DESKTOP_COMMAND_REQUEST_TYPE
   readonly id: string
@@ -2200,6 +2234,21 @@ export function makeDesktopCommandRequest(
   command: 'telegramClaudeCliPlanReply',
   payload: TelegramClaudeCliPlanReplyPayload
 ): TelegramClaudeCliPlanReplyDesktopCommandRequest
+export function makeDesktopCommandRequest(
+  id: string,
+  command: 'discordClaudeCliQuestionReply',
+  payload: DiscordClaudeCliQuestionReplyPayload
+): DiscordClaudeCliQuestionReplyDesktopCommandRequest
+export function makeDesktopCommandRequest(
+  id: string,
+  command: 'discordClaudeCliQuestionReject',
+  payload: DiscordClaudeCliQuestionRejectPayload
+): DiscordClaudeCliQuestionRejectDesktopCommandRequest
+export function makeDesktopCommandRequest(
+  id: string,
+  command: 'discordClaudeCliPlanReply',
+  payload: DiscordClaudeCliPlanReplyPayload
+): DiscordClaudeCliPlanReplyDesktopCommandRequest
 export function makeDesktopCommandRequest(
   id: string,
   command: 'terminalSetClaudeCliPlanAutoApprove',
@@ -3409,6 +3458,26 @@ export function makeDesktopCommandRequest(
     } as TelegramClaudeCliPlanReplyDesktopCommandRequest
   }
 
+  if (
+    command === 'discordClaudeCliQuestionReply' ||
+    command === 'discordClaudeCliQuestionReject' ||
+    command === 'discordClaudeCliPlanReply'
+  ) {
+    if (!payload) {
+      throw new Error(`Missing ${command} payload`)
+    }
+
+    return {
+      type: DESKTOP_COMMAND_REQUEST_TYPE,
+      id,
+      command,
+      payload
+    } as
+      | DiscordClaudeCliQuestionReplyDesktopCommandRequest
+      | DiscordClaudeCliQuestionRejectDesktopCommandRequest
+      | DiscordClaudeCliPlanReplyDesktopCommandRequest
+  }
+
   if (command === 'terminalSetClaudeCliPlanAutoApprove') {
     if (!payload) {
       throw new Error('Missing terminalSetClaudeCliPlanAutoApprove payload')
@@ -3581,6 +3650,12 @@ export const isDesktopCommandRequest = (value: unknown): value is DesktopCommand
       (value.command === 'telegramClaudeCliQuestionReject' &&
         isTelegramClaudeCliQuestionRejectPayload(value.payload)) ||
       (value.command === 'telegramClaudeCliPlanReply' &&
+        isTelegramClaudeCliPlanReplyPayload(value.payload)) ||
+      (value.command === 'discordClaudeCliQuestionReply' &&
+        isTelegramClaudeCliQuestionReplyPayload(value.payload)) ||
+      (value.command === 'discordClaudeCliQuestionReject' &&
+        isTelegramClaudeCliQuestionRejectPayload(value.payload)) ||
+      (value.command === 'discordClaudeCliPlanReply' &&
         isTelegramClaudeCliPlanReplyPayload(value.payload)) ||
       (value.command === 'terminalSetClaudeCliPlanAutoApprove' &&
         isTerminalClaudeCliPlanAutoApprovePayload(value.payload)))

--- a/src/shared/discord-events.ts
+++ b/src/shared/discord-events.ts
@@ -2,6 +2,10 @@ import type { DiscordProvisionProgress, DiscordStatusChangedPayload } from './ty
 
 export const DISCORD_PROVISION_PROGRESS_CHANNEL = 'discord:provisionProgress'
 export const DISCORD_STATUS_CHANGED_CHANNEL = 'discord:statusChanged'
+// Claude CLI hook events relayed from the process that holds the hook (the
+// Electron main process, where the PTY + hook server live) to the backend
+// server process, where the Discord session bridge posts to channels.
+export const DISCORD_CLAUDE_CLI_EVENT_CHANNEL = 'discord:claudeCliEvent'
 
 export type DiscordProvisionProgressPayload = DiscordProvisionProgress
 export type DiscordStatusChangedEventPayload = DiscordStatusChangedPayload


### PR DESCRIPTION
## Summary
- Add Discord-specific Claude CLI command handling so held question and plan replies can round-trip from the backend server to Electron main.
- Route Discord-owned Claude CLI sessions dynamically based on worktree channel provisioning and Discord mode state, instead of only explicit registration.
- Relay Claude CLI hook events and idle/busy updates into the Discord session bridge so relayed app sessions can post questions, plans, and final assistant messages to Discord.
- Extract Discord config parsing and environment fallback logic into a shared service and reorder transport routing so explicit Telegram forwarding still wins.
- Expand unit coverage for Discord CLI ownership detection, hook relaying, and session bridge behavior.

## Testing
- `Not run`
- Added/updated Vitest coverage for Discord CLI bridge ownership and event relay flows.
- Added/updated Vitest coverage for relayed Discord session bridge question, plan, and idle handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cross-process hook holding and routing affect agent HITL flows; mistakes could drop or misroute questions/plans, though behavior mirrors the existing Telegram CLI bridge pattern.
> 
> **Overview**
> Adds **Discord transport for Claude CLI** so sessions started in the app (e.g. kanban) can surface questions, plans, busy/idle, and final assistant text in provisioned worktree channels—not only Discord-managed sessions.
> 
> **`claudeCliDiscordBridge`** now **claims sessions dynamically** when Discord mode is on and the session’s worktree has a mapped channel (`claude-code-cli` + cached DB lookup), relays hook/stream events to the backend via `DISCORD_CLAUDE_CLI_EVENT_CHANNEL`, and **desktop IPC commands** (`discordClaudeCliQuestionReply` / `Reject` / `PlanReply`) resolve held hooks in Electron main where the PTY lives.
> 
> The **Discord session bridge** lazily creates runtimes for relayed sessions, forwards interactive events for any session in a linked worktree (not just `managed_session_id`), and handles `session.busy` typing. **Transport routing** puts Telegram before Discord so explicit Telegram forwarding wins over ambient Discord ownership.
> 
> Discord **config parsing** moves to `discord-config.ts` (shared `isDiscordModeEnabled`). **Tests** cover ownership, hook relay, and relayed bridge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b54b8bde45e89d8d42f5cba3eb52037f2721e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->