### PR TITLE
Show queued branch target on kanban tickets

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.queued-branch.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.queued-branch.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { KanbanTicketCard } from './KanbanTicketCard'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket } from '../../../../main/db/types'
+
+const initialWorktreeState = useWorktreeStore.getState()
+
+const now = '2026-01-01T00:00:00.000Z'
+
+const existingWorktree = {
+  id: 'worktree-1',
+  project_id: 'project-1',
+  name: 'atlanta',
+  branch_name: 'feature/login-flow',
+  path: '/tmp/worktree-1',
+  status: 'active' as const,
+  is_default: false,
+  branch_renamed: 1,
+  last_message_at: null,
+  session_titles: '[]',
+  last_model_provider_id: null,
+  last_model_id: null,
+  last_model_variant: null,
+  attachments: '[]',
+  created_at: now,
+  last_accessed_at: now,
+  github_pr_number: null,
+  github_pr_url: null
+}
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'project-1',
+    title: 'Queued ticket',
+    description: null,
+    attachments: [],
+    column: 'in_progress',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: null,
+    mode: 'build',
+    plan_ready: false,
+    created_at: now,
+    updated_at: now,
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
+    created_from_session: false,
+    auto_approve_plan: false,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
+    ...overrides
+  }
+}
+
+function makePendingConfig(
+  worktree:
+    | { type: 'new'; sourceBranch: string }
+    | { type: 'existing'; worktreeId: string }
+): string {
+  return JSON.stringify({
+    worktree,
+    prompt: 'do the thing',
+    mode: 'build',
+    model: null,
+    sdk: 'claude-code',
+    codexFastMode: false,
+    goalMode: false,
+    goalSuccessCriteria: null
+  })
+}
+
+describe('KanbanTicketCard queued branch badge', () => {
+  afterEach(() => {
+    cleanup()
+    useWorktreeStore.setState(initialWorktreeState, true)
+  })
+
+  it('shows the target branch name when queued on an existing worktree', () => {
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([['project-1', [existingWorktree]]])
+    })
+
+    render(
+      <KanbanTicketCard
+        ticket={makeTicket({
+          pending_launch_config: makePendingConfig({ type: 'existing', worktreeId: 'worktree-1' })
+        })}
+      />
+    )
+
+    expect(screen.getByTestId('ticket-queued-branch')).toHaveTextContent('feature/login-flow')
+  })
+
+  it('shows (new-worktree) when queued to launch on a new worktree', () => {
+    render(
+      <KanbanTicketCard
+        ticket={makeTicket({
+          pending_launch_config: makePendingConfig({ type: 'new', sourceBranch: 'main' })
+        })}
+      />
+    )
+
+    expect(screen.getByTestId('ticket-queued-branch')).toHaveTextContent('(new-worktree)')
+  })
+
+  it('renders no badge when the ticket has no pending launch config', () => {
+    render(<KanbanTicketCard ticket={makeTicket()} />)
+
+    expect(screen.queryByTestId('ticket-queued-branch')).not.toBeInTheDocument()
+  })
+
+  it('renders no badge when the pending config is malformed JSON', () => {
+    render(
+      <KanbanTicketCard ticket={makeTicket({ pending_launch_config: 'not-json{' })} />
+    )
+
+    expect(screen.queryByTestId('ticket-queued-branch')).not.toBeInTheDocument()
+  })
+
+  it('renders no badge when the queued worktree no longer exists in the store', () => {
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([['project-1', [existingWorktree]]])
+    })
+
+    render(
+      <KanbanTicketCard
+        ticket={makeTicket({
+          pending_launch_config: makePendingConfig({ type: 'existing', worktreeId: 'gone' })
+        })}
+      />
+    )
+
+    expect(screen.queryByTestId('ticket-queued-branch')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -237,6 +237,34 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
 
   const isBlocked = !isSimpleMode && unresolvedBlockerCount > 0
 
+  // ── Queued launch target (branch it will run on, or new worktree) ──
+  const queuedWorktree = useMemo(() => {
+    if (!ticket.pending_launch_config) return null
+    try {
+      const config = JSON.parse(ticket.pending_launch_config) as {
+        worktree?: { type: 'new'; sourceBranch: string } | { type: 'existing'; worktreeId: string }
+      }
+      return config.worktree ?? null
+    } catch {
+      return null
+    }
+  }, [ticket.pending_launch_config])
+
+  const queuedBranchLabel = useWorktreeStore(
+    useCallback(
+      (state) => {
+        if (!queuedWorktree) return null
+        if (queuedWorktree.type === 'new') return '(new-worktree)'
+        for (const worktrees of state.worktreesByProject.values()) {
+          const found = worktrees.find((w) => w.id === queuedWorktree.worktreeId)
+          if (found) return found.branch_name || found.name
+        }
+        return null
+      },
+      [queuedWorktree]
+    )
+  )
+
   // ── Lookup worktree name ────────────────────────────────────────
   const worktreeName = useWorktreeStore(
     useCallback(
@@ -1039,7 +1067,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || hasNote || worktreeName || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || blockingDiagnostic || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode || ticket.auto_approve_plan || activeRemoteLaunch || showModelBadge) && (
+            {(hasAttachments || hasNote || worktreeName || queuedBranchLabel || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || blockingDiagnostic || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode || ticket.auto_approve_plan || activeRemoteLaunch || showModelBadge) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
@@ -1077,6 +1105,16 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                   <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 border border-amber-500/30 px-2 py-0.5 text-[11px] font-medium text-amber-500">
                     <Lock className="h-3 w-3" />
                     {unresolvedBlockerCount}
+                  </span>
+                )}
+                {/* Queued launch target badge — branch the queued ticket will run on */}
+                {queuedBranchLabel && (
+                  <span
+                    data-testid="ticket-queued-branch"
+                    className="inline-flex items-center gap-1 rounded-full bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+                  >
+                    <GitBranch className="h-3 w-3" />
+                    {queuedBranchLabel}
                   </span>
                 )}
                 {/* Attachment badge */}

--- a/src/renderer/src/components/kanban/WorktreePickerModal.goal-prefill.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.goal-prefill.test.tsx
@@ -1,0 +1,425 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorktreePickerModal, _resetLastSourceBranch } from './WorktreePickerModal'
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { opencodeApi } from '@/api/opencode-api'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useUsageStore } from '@/stores/useUsageStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket, Session, Worktree } from '../../../../main/db/types'
+
+vi.mock('@/api/hive-enterprise/client', () => ({
+  isHiveTelemetryEnabled: vi.fn(() => false),
+  recordHivePromptStart: vi.fn(),
+  recordHivePromptIdle: vi.fn(),
+  recordHiveQuestionsAnswered: vi.fn()
+}))
+
+vi.mock('@/components/sessions/ModelSelector', () => ({
+  ModelSelector: () => <div data-testid="model-selector" />
+}))
+
+vi.mock('@/components/sessions/CodexFastToggle', () => ({
+  CodexFastToggle: () => <div data-testid="codex-fast-toggle" />
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@/api/settings-api', () => ({
+  settingsApi: {
+    detectEditors: vi.fn(),
+    detectTerminals: vi.fn(),
+    loadCustomCommandsFile: vi.fn().mockResolvedValue({ commands: [] }),
+    onSettingsUpdated: vi.fn(() => vi.fn()),
+    openWithTerminal: vi.fn()
+  }
+}))
+
+vi.mock('@/api/pet-api', () => ({
+  petApi: {
+    updateSettings: vi.fn().mockResolvedValue({
+      success: true,
+      value: { enabled: true, size: 'md', position: { x: 0, y: 0 }, hatched: true }
+    })
+  }
+}))
+
+vi.mock('@/api/opencode-api', () => ({
+  opencodeApi: {
+    connect: vi.fn(),
+    prompt: vi.fn()
+  }
+}))
+
+const initialSettingsState = useSettingsStore.getState()
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+const initialConnectionState = useConnectionStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialUsageState = useUsageStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
+
+const STORED_GOAL = 'All tests green and feature verified'
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'project-1',
+    title: 'Goal ticket',
+    description: 'Short description',
+    column: 'todo',
+    sort_order: 0,
+    worktree_id: null,
+    current_session_id: null,
+    mode: 'build',
+    plan_ready: false,
+    goal_mode: false,
+    goal_success_criteria: null,
+    pending_launch_config: null,
+    created_from_session: false,
+    auto_approve_plan: false,
+    attachments: [],
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    note: null,
+    total_tokens: 0,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+function makeGoalTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return makeTicket({ goal_mode: true, goal_success_criteria: STORED_GOAL, ...overrides })
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'worktree-1',
+    project_id: 'project-1',
+    name: 'Feature',
+    branch_name: 'feature',
+    path: '/repo/feature',
+    status: 'active',
+    is_default: false,
+    branch_renamed: 0,
+    last_message_at: null,
+    session_titles: '[]',
+    last_model_provider_id: null,
+    last_model_id: null,
+    last_model_variant: null,
+    attachments: '[]',
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_accessed_at: '2026-01-01T00:00:00.000Z',
+    github_pr_number: null,
+    github_pr_url: null,
+    ...overrides
+  } as Worktree
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    remote_launch: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    pinned_to_board: false,
+    ...overrides
+  }
+}
+
+function setupStores(): void {
+  const createSession = vi.fn(
+    async (
+      worktreeId: string,
+      projectId: string,
+      sdk: Session['agent_sdk'] = 'opencode',
+      mode: Session['mode'] = 'build'
+    ) => ({
+      success: true,
+      session: makeSession({
+        worktree_id: worktreeId,
+        project_id: projectId,
+        agent_sdk: sdk,
+        mode: mode === 'super-plan' ? 'plan' : mode
+      })
+    })
+  )
+
+  useSettingsStore.setState({
+    availableAgentSdks: { opencode: true, claude: true, codex: true },
+    defaultAgentSdk: 'opencode',
+    selectedModel: null,
+    selectedModelByProvider: {},
+    defaultModels: null,
+    codexFastMode: false,
+    codexFastModeAccepted: true,
+    boardMode: 'toggle'
+  })
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '/repo',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        worktree_create_script: null,
+        custom_commands: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        last_accessed_at: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([['project-1', [makeWorktree()]]]),
+    worktreeOrderByProject: new Map(),
+    syncWorktrees: vi.fn(),
+    createWorktreeFromBranch: vi.fn()
+  })
+  useConnectionStore.setState({ connections: [], loaded: true })
+  useKanbanStore.setState({
+    tickets: new Map([['project-1', []]]),
+    updateTicket: vi.fn(async () => undefined),
+    computeSortOrder: vi.fn(() => 1),
+    getTicketsByColumn: vi.fn(() => []),
+    getTicketsByColumnForConnection: vi.fn(() => [])
+  })
+  useSessionStore.setState({
+    sessionsByWorktree: new Map(),
+    sessionsByConnection: new Map(),
+    modeBySession: new Map(),
+    createSession,
+    setSessionModel: vi.fn(async () => undefined),
+    setSessionMode: vi.fn(async () => undefined),
+    setOpenCodeSessionId: vi.fn(),
+    setActiveSession: vi.fn(),
+    dequeuePendingMessage: vi.fn()
+  })
+  useWorktreeStatusStore.setState({
+    setSessionStatus: vi.fn(),
+    setLastMessageTime: vi.fn()
+  })
+  useUsageStore.setState({
+    fetchUsageForProvider: vi.fn()
+  })
+}
+
+function findRpcCall(request: ReturnType<typeof vi.fn>, method: string): unknown[] | undefined {
+  return request.mock.calls.find(([m]) => m === method)
+}
+
+describe('WorktreePickerModal goal pre-fill from ticket', () => {
+  let request: ReturnType<typeof vi.fn>
+
+  beforeAll(async () => {
+    // useSettingsStore schedules a one-shot 200ms timer on module import that
+    // reloads settings and re-detects agent SDKs; with the mocked RPC client it
+    // sets availableAgentSdks to null, unmounting the SDK toggle mid-test. Let
+    // it fire (against a mock client) before any test renders.
+    const bootRequest: ReturnType<typeof vi.fn> = vi.fn(async () => null)
+    setRendererRpcClient({ request: bootRequest, subscribe: vi.fn() })
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    resetRendererRpcClientForTests()
+  })
+
+  beforeEach(() => {
+    _resetLastSourceBranch()
+    vi.clearAllMocks()
+    resetRendererRpcClientForTests()
+    request = vi.fn(async (method: string) => {
+      if (method === 'terminalOps.createClaudeCli') return { success: true }
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    setupStores()
+    vi.mocked(opencodeApi.connect).mockResolvedValue({
+      success: true,
+      value: { success: true, sessionId: 'opc-1' }
+    })
+    vi.mocked(opencodeApi.prompt).mockResolvedValue({
+      success: true,
+      value: { success: true }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useSettingsStore.setState(initialSettingsState, true)
+    useSessionStore.setState(initialSessionState, true)
+    useWorktreeStore.setState(initialWorktreeState, true)
+    useConnectionStore.setState(initialConnectionState, true)
+    useKanbanStore.setState(initialKanbanState, true)
+    useProjectStore.setState(initialProjectState, true)
+    useUsageStore.setState(initialUsageState, true)
+    useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
+    resetRendererRpcClientForTests()
+  })
+
+  it('checks the goal switch and pre-fills the criteria when the default SDK supports goals', async () => {
+    useSettingsStore.setState({ defaultAgentSdk: 'codex' })
+
+    render(
+      <WorktreePickerModal
+        ticket={makeGoalTicket()}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('goal-mode-toggle')).toHaveAttribute('aria-checked', 'true')
+    )
+    expect(screen.getByTestId('goal-success-criteria')).toHaveValue(STORED_GOAL)
+  })
+
+  it('pre-fills once the user switches to a goal-capable SDK', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={makeGoalTicket()}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    // Default SDK is opencode — no goal switch yet, and nothing pre-applied
+    expect(screen.queryByTestId('goal-mode-toggle')).toBeNull()
+
+    await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+
+    expect(screen.getByTestId('goal-mode-toggle')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('goal-success-criteria')).toHaveValue(STORED_GOAL)
+  })
+
+  it('leaves the goal switch unchecked when the ticket has no stored goal', async () => {
+    useSettingsStore.setState({ defaultAgentSdk: 'codex' })
+
+    render(
+      <WorktreePickerModal
+        ticket={makeTicket()}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('goal-mode-toggle')).toHaveAttribute('aria-checked', 'false')
+    expect(screen.queryByTestId('goal-success-criteria')).toBeNull()
+  })
+
+  it('lets the user deactivate the pre-filled goal, and the uncheck sticks across SDK switches', async () => {
+    useSettingsStore.setState({ defaultAgentSdk: 'codex' })
+
+    render(
+      <WorktreePickerModal
+        ticket={makeGoalTicket()}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('goal-mode-toggle')).toHaveAttribute('aria-checked', 'true')
+    )
+    await userEvent.click(screen.getByTestId('goal-mode-toggle'))
+    expect(screen.getByTestId('goal-mode-toggle')).toHaveAttribute('aria-checked', 'false')
+
+    // Switching to another goal-capable SDK must not resurrect the pre-fill
+    await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+    expect(screen.getByTestId('goal-mode-toggle')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('sends the pre-filled goal prompt without further input (Claude CLI)', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={makeGoalTicket()}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('sdk-toggle-claude-code-cli'))
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('terminalOps.createClaudeCli', expect.any(Object))
+    )
+    const cliCall = findRpcCall(request, 'terminalOps.createClaudeCli')
+    const pendingPrompt = (cliCall![1] as { opts: { pendingPrompt: string } }).opts.pendingPrompt
+    expect(pendingPrompt).toMatch(/^\/goal /)
+    expect(pendingPrompt).toContain(`Goal success criteria: ${STORED_GOAL}`)
+  })
+
+  it('never applies the stored goal while the SDK cannot run goal mode', async () => {
+    render(
+      <WorktreePickerModal
+        ticket={makeGoalTicket()}
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+        onSendComplete={vi.fn()}
+      />
+    )
+
+    // Default SDK is opencode — send straight away
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await userEvent.click(screen.getByTestId('wt-picker-send-btn'))
+
+    await waitFor(() => expect(opencodeApi.prompt).toHaveBeenCalled())
+    const [, , parts] = vi.mocked(opencodeApi.prompt).mock.calls[0]
+    const text = (parts as Array<{ type: string; text: string }>)
+      .map((p) => p.text)
+      .join('\n')
+    expect(text).not.toContain('/goal')
+    expect(text).not.toContain('Goal success criteria')
+  })
+})

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -405,6 +405,11 @@ export function WorktreePickerModal({
   const [isSending, setIsSending] = useState(false)
   const [goalMode, setGoalMode] = useState(false)
   const [goalCriteria, setGoalCriteria] = useState('')
+  // A ticket that already carries a goal re-arms the switch on open. The
+  // stored criteria waits here until the goal switch is actually available
+  // (build mode + a goal-capable SDK) and is applied once per open, so a
+  // manual uncheck is never overridden.
+  const goalPrefillRef = useRef<string | null>(null)
   const promptRef = useRef<HTMLTextAreaElement>(null)
   const [sourceBranch, setSourceBranch] = useState<string | null>(null) // null = default
   const [branchPopoverOpen, setBranchPopoverOpen] = useState(false)
@@ -586,6 +591,10 @@ export function WorktreePickerModal({
       setIsSending(false)
       setGoalMode(false)
       setGoalCriteria('')
+      goalPrefillRef.current =
+        ticket.goal_mode && ticket.goal_success_criteria?.trim()
+          ? ticket.goal_success_criteria
+          : null
       setSelectedModel(null)
       setSelectedSdk(null)
       setExtraModelRows([])
@@ -609,6 +618,26 @@ export function WorktreePickerModal({
       }
     }
   }, [open, ticket, projectId, project?.path, syncWorktrees])
+
+  // ── Apply the ticket's stored goal once the switch is available ──
+  // Fires immediately when the default SDK supports goal mode, or later when
+  // the user switches to a goal-capable SDK. One-shot per open.
+  useEffect(() => {
+    if (!open || !goalAvailable || goalPrefillRef.current === null) return
+    setGoalMode(true)
+    setGoalCriteria(goalPrefillRef.current)
+    goalPrefillRef.current = null
+  }, [open, goalAvailable])
+
+  // Backstop: goal mode must never stay on while the switch is hidden — the
+  // send path wraps the outgoing prompt with /goal whenever goalMode is set,
+  // which a non-goal SDK can't parse. (The first render after `open` flips can
+  // briefly see stale availability from a previous open of a mounted modal.)
+  useEffect(() => {
+    if (!goalMode || goalAvailable) return
+    setGoalMode(false)
+    setGoalCriteria('')
+  }, [goalMode, goalAvailable])
 
   // ── Reset remote state + unsubscribe when the modal closes ───────
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add a queued-launch branch badge to `KanbanTicketCard` so tickets with `pending_launch_config` show the branch they will run on.
- Support both existing worktree launches and new-worktree launches, with a fallback label of `(new-worktree)`.
- Keep the badge hidden when the config is missing, malformed, or the referenced worktree can no longer be found.
- Add focused tests covering the queued branch badge behavior and error/absence cases.

## Testing
- Added `KanbanTicketCard.queued-branch.test.tsx` to verify branch label rendering for existing worktrees.
- Added coverage for new-worktree labels, missing config, malformed JSON, and missing worktree references.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only kanban badges and launch-modal pre-fill; malformed `pending_launch_config` is handled safely with no badge.
> 
> **Overview**
> **Kanban cards** now show where a **queued** launch will run: tickets with `pending_launch_config` get a branch badge (`ticket-queued-branch`)—existing worktree branch name, `(new-worktree)` for a new worktree, or nothing if config is missing, invalid JSON, or the worktree id is gone.
> 
> **Worktree picker** pre-fills **goal mode** from the ticket when you open launch: stored `goal_success_criteria` applies once build mode and a goal-capable SDK are available (including after switching SDK). Manual uncheck is not overwritten; goal mode is cleared if the UI hides goal support so non-goal SDKs never get a `/goal` prompt.
> 
> Tests cover queued-branch badge cases and goal pre-fill / send behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1ff688fa9c5853a09dc118d4c8564ff6a98e059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->