### PR TITLE
Show model icons on kanban tickets via setting

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { KanbanTicketCard } from './KanbanTicketCard'
+import { useSettingsStore } from '@/stores/useSettingsStore'
 import type { KanbanTicket } from '../../../../main/db/types'
 
 const now = '2026-01-01T00:00:00.000Z'
@@ -42,6 +43,7 @@ const baseTicket: KanbanTicket = {
 describe('KanbanTicketCard model badge', () => {
   afterEach(() => {
     cleanup()
+    useSettingsStore.setState({ showModelIcons: false })
   })
 
   it('renders the model badge for a multi-model duplicate, even with no other badges', () => {
@@ -72,6 +74,30 @@ describe('KanbanTicketCard model badge', () => {
 
     expect(screen.queryByText('claude-opus-4-5-20251101')).toBeNull()
     expect(screen.queryByRole('img', { name: 'Claude' })).toBeNull()
+  })
+
+  it('renders the model badge for a single-model launch when showModelIcons is on', () => {
+    useSettingsStore.setState({ showModelIcons: true })
+    const ticket: KanbanTicket = {
+      ...baseTicket,
+      model_provider_id: 'anthropic',
+      model_id: 'claude-opus-4-5-20251101',
+      model_variant: null,
+      variant_group_id: null
+    }
+
+    render(<KanbanTicketCard ticket={ticket} />)
+
+    expect(screen.getByText('claude-opus-4-5-20251101')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Claude' })).toBeInTheDocument()
+  })
+
+  it('does not render a model badge when showModelIcons is on but the ticket has no model_id', () => {
+    useSettingsStore.setState({ showModelIcons: true })
+    render(<KanbanTicketCard ticket={baseTicket} />)
+
+    expect(screen.queryByRole('img', { name: 'Claude' })).toBeNull()
+    expect(screen.queryByRole('img', { name: 'OpenAI' })).toBeNull()
   })
 
   it('does not render a model badge when the ticket has no model_id', () => {

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -584,9 +584,11 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
 
   const isError = sessionStatus === 'error'
   const hasAttachments = ticket.attachments.length > 0
-  // Only surface the model on cards that are part of a multi-model duplicate
-  // group — for single-model launches the name is noise.
-  const showModelBadge = !!ticket.model_id && !!ticket.variant_group_id
+  // Surface the model on cards that are part of a multi-model duplicate
+  // group — for single-model launches the name is noise, unless the user
+  // opted in via the "show model icons" setting.
+  const showModelIcons = useSettingsStore((s) => s.showModelIcons)
+  const showModelBadge = !!ticket.model_id && (showModelIcons || !!ticket.variant_group_id)
   const isForwardedToTelegram = useTelegramStore(
     useCallback(
       (state) => !!ticket.current_session_id && state.activeForwardingSessionId === ticket.current_session_id,

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -405,7 +405,7 @@ export function SettingsGeneral(): React.JSX.Element {
         <div>
           <label className="text-sm font-medium">Model icons</label>
           <p className="text-xs text-muted-foreground">
-            Show the model icon (Claude, OpenAI) next to the worktree status
+            Show the model icon (Claude, OpenAI) next to the worktree status and on kanban tickets
           </p>
         </div>
         <button


### PR DESCRIPTION
## Summary
- Adds an opt-in `showModelIcons` setting to display model badges on single-model kanban tickets.
- Preserves the existing behavior for multi-model duplicate groups while expanding badge visibility when the setting is enabled.
- Updates the General settings copy to reflect that model icons now appear on kanban tickets as well as worktree status.
- Adds tests covering the new enabled and disabled cases for model badge rendering.

## Testing
- Added unit tests in `KanbanTicketCard.test.tsx` for single-model tickets with `showModelIcons` enabled.
- Added unit tests verifying no badge is shown when `showModelIcons` is enabled but `model_id` is missing.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display logic behind an existing user setting, with added unit tests and no backend or auth changes.
> 
> **Overview**
> Extends the existing **Model icons** preference so kanban ticket cards—not only worktree status—can show provider/model badges.
> 
> **`KanbanTicketCard`** now reads `showModelIcons` from settings: badges still always appear for multi-model duplicate groups (`variant_group_id`), and also appear on single-model tickets when the user turns the setting on. General settings copy now mentions kanban tickets. Unit tests cover the enabled/disabled paths and reset `showModelIcons` after each run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e48f18c7da6fd7be439e3afcee85ce9dc20f55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->