### PR TITLE
Fix Claude CLI handoff picker and status teardown

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.handoff.test.tsx
@@ -442,6 +442,13 @@ describe('KanbanTicketModal handoff from Claude CLI plan review', () => {
     })
     expect(setActiveSession).not.toHaveBeenCalledWith('handoff-session')
     expect(useKanbanStore.getState().isBoardViewActive).toBe(true)
+    // The handoff session was created with the picker's explicit model; the
+    // build-mode flip must not clobber it with the mode-default model.
+    expect(useSessionStore.getState().setSessionMode).toHaveBeenCalledWith(
+      'handoff-session',
+      'build',
+      { applyModeDefault: false }
+    )
   })
 
   it('shows terminal-backed followup and implement controls for Claude CLI plan review', async () => {

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -2342,7 +2342,9 @@ function PlanReviewModeContent({
           const handoffPrompt = buildHandoffPrompt(planContent, override)
           const newSession = result.session
           const newSessionId = newSession.id
-          const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
+          const setModePromise = sessionStore.setSessionMode(newSessionId, 'build', {
+            applyModeDefault: false
+          })
 
           prepareTicketBuildSession(newSessionId, handoffGoalMode)
           if (newSession.agent_sdk === 'claude-code-cli') {
@@ -2421,7 +2423,9 @@ function PlanReviewModeContent({
         const handoffPrompt = buildHandoffPrompt(planContent, override)
         const newSession = result.session
         const newSessionId = newSession.id
-        const setModePromise = sessionStore.setSessionMode(newSessionId, 'build')
+        const setModePromise = sessionStore.setSessionMode(newSessionId, 'build', {
+          applyModeDefault: false
+        })
         const localWorktreePath = findWorktreePathById(worktreeId)
         if (!localWorktreePath) {
           toast.error('Could not find worktree path')
@@ -2912,6 +2916,7 @@ function PlanReviewModeContent({
         <DialogFooter className="flex-shrink-0 gap-1.5 flex-wrap">
           <HandoffSplitButton
             worktreeId={sessionRecord?.worktree_id ?? undefined}
+            sessionId={ticket.current_session_id ?? undefined}
             onHandoff={handleHandoff}
             testIdPrefix="plan-review"
             disabled={isActioning || !hasWorkingContext}

--- a/src/renderer/src/components/layout/MainPane.test.tsx
+++ b/src/renderer/src/components/layout/MainPane.test.tsx
@@ -227,6 +227,21 @@ describe('MainPane terminal visibility', () => {
     expect(terminal.closest('.hidden')).not.toBeNull()
   })
 
+  it('keeps the active terminal laid out while a ghostty-suppressing overlay is open', () => {
+    // Popovers/dropdowns push ghostty suppression to hide the native NSView.
+    // The HTML container must stay visible: overlays anchored inside the
+    // session view (e.g. the handoff picker) lose their anchor geometry and
+    // teleport to the viewport corner if the container collapses.
+    setupMainPaneState()
+    useLayoutStore.setState({ ghosttyOverlaySuppressed: true })
+
+    renderMainPane()
+
+    const terminal = screen.getByTestId('session-view-session-1')
+    expect(terminal.getAttribute('data-visible')).toBe('true')
+    expect(terminal.closest('.hidden')).toBeNull()
+  })
+
   it('keeps a plain terminal session mounted but hidden during board view', () => {
     setupMainPaneState(makeSession({ id: 'terminal-1', agent_sdk: 'terminal' }))
     useKanbanStore.setState({ isBoardViewActive: true })

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -20,7 +20,6 @@ import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useSessionStore, BOARD_TAB_ID } from '@/stores/useSessionStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useFileViewerStore } from '@/stores/useFileViewerStore'
-import { useLayoutStore } from '@/stores/useLayoutStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { usePinnedStore } from '@/stores/usePinnedStore'
@@ -105,7 +104,6 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const activeDiff = useFileViewerStore((state) => state.activeDiff)
   const contextEditorWorktreeId = useFileViewerStore((state) => state.contextEditorWorktreeId)
   const closedTerminalSessionIds = useSessionStore((state) => state.closedTerminalSessionIds)
-  const ghosttyOverlaySuppressed = useLayoutStore((state) => state.ghosttyOverlaySuppressed)
   const activePinnedSessionId = useSessionStore((state) => state.activePinnedSessionId)
   const activeBoardAssistantProjectId = useSessionStore((state) => state.activeBoardAssistantProjectId)
   const isBoardViewActive = useKanbanStore((state) => state.isBoardViewActive)
@@ -211,9 +209,11 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   // Determine which terminal session is currently visible (if any).
   // A terminal is visible when it's the active session AND no diff/file/loading overlay is on top.
   const visibleTerminalId = useMemo(() => {
-    if (ghosttyOverlaySuppressed) {
-      return null
-    }
+    // Note: ghostty overlay suppression must NOT hide the terminal container
+    // here. Collapsing it zeroes out any overlay anchored inside the session
+    // view (e.g. the handoff picker popover, which itself pushes suppression),
+    // teleporting the overlay to the viewport corner. TerminalView hides the
+    // native ghostty surface via effectiveVisible instead.
 
     // When the board, pinned board, or board assistant is occupying the main
     // pane, hide all stateful terminal sessions — otherwise the always-mounted
@@ -248,7 +248,6 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     activeDiff,
     activeFilePath,
     getAgentSdk,
-    ghosttyOverlaySuppressed,
     isBoardViewActive,
     isPinnedBoardActive,
     activeBoardAssistantProjectId

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -130,6 +130,7 @@ function clampPlanCardPosition(
 interface ClaudeCliPlanReadyCardProps {
   planContent: string
   worktreeId?: string
+  sessionId: string
   onHandoff: (override: HandoffSelectionOverride) => void
   onSaveAsTicket: () => void
   onSaveAsFile: () => void
@@ -139,6 +140,7 @@ interface ClaudeCliPlanReadyCardProps {
 function ClaudeCliPlanReadyCard({
   planContent,
   worktreeId,
+  sessionId,
   onHandoff,
   onSaveAsTicket,
   onSaveAsFile,
@@ -261,6 +263,7 @@ function ClaudeCliPlanReadyCard({
         <div className="flex flex-wrap items-center gap-2">
           <HandoffSplitButton
             worktreeId={worktreeId}
+            sessionId={sessionId}
             onHandoff={onHandoff}
             testIdPrefix="claude-cli-plan-ready"
           />
@@ -400,7 +403,9 @@ export function ClaudeCliSessionView({
           return
         }
 
-        const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
+        const setModePromise = sessionStore.setSessionMode(result.session.id, 'build', {
+        applyModeDefault: false
+      })
         registerHivePromptHandoff(sessionId, result.session.id)
         sessionStore.setPendingMessage(result.session.id, handoffPrompt)
         await useKanbanStore
@@ -445,7 +450,9 @@ export function ClaudeCliSessionView({
         return
       }
 
-      const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
+      const setModePromise = sessionStore.setSessionMode(result.session.id, 'build', {
+        applyModeDefault: false
+      })
       registerHivePromptHandoff(sessionId, result.session.id)
       sessionStore.setPendingMessage(result.session.id, handoffPrompt)
       await useKanbanStore
@@ -588,6 +595,7 @@ export function ClaudeCliSessionView({
           <ClaudeCliPlanReadyCard
             planContent={pendingPlan.planContent}
             worktreeId={sessionRecord?.worktree_id ?? undefined}
+            sessionId={sessionId}
             onHandoff={handlePlanReadyHandoff}
             onSaveAsTicket={handlePlanReadySaveAsTicket}
             onSaveAsFile={handlePlanReadySaveAsFile}

--- a/src/renderer/src/components/sessions/HandoffModelPicker.test.tsx
+++ b/src/renderer/src/components/sessions/HandoffModelPicker.test.tsx
@@ -1,0 +1,209 @@
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { HandoffSplitButton } from './HandoffSplitButton'
+import { clearHandoffModelCatalogCache } from '@/lib/handoffSelection'
+import {
+  isHandoffPickerOpenForSession,
+  resetHandoffPickerState
+} from '@/lib/handoff-ui-state'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+
+const opencodeApiMocks = vi.hoisted(() => ({
+  listModels: vi.fn().mockResolvedValue({ success: true, value: { success: true, providers: [] } })
+}))
+
+vi.mock('@/api/opencode-api', () => ({
+  opencodeApi: opencodeApiMocks
+}))
+
+const initialSettingsState = useSettingsStore.getState()
+
+describe('HandoffModelPicker inside a modal dialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearHandoffModelCatalogCache()
+    opencodeApiMocks.listModels.mockResolvedValue({
+      success: true,
+      value: { success: true, providers: [] }
+    })
+    useSettingsStore.setState({
+      availableAgentSdks: { opencode: true, claude: true, codex: true },
+      defaultAgentSdk: 'claude-code-cli',
+      lastHandoffOverride: null,
+      selectedModel: null,
+      selectedModelByProvider: {},
+      defaultModels: null
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearHandoffModelCatalogCache()
+    resetHandoffPickerState()
+    useSettingsStore.setState(initialSettingsState, true)
+  })
+
+  function renderInDialog(): { onDialogOpenChange: ReturnType<typeof vi.fn> } {
+    const onDialogOpenChange = vi.fn()
+
+    render(
+      <Dialog open onOpenChange={onDialogOpenChange}>
+        <DialogContent data-testid="host-dialog">
+          <DialogHeader>
+            <DialogTitle>Ticket</DialogTitle>
+          </DialogHeader>
+          <HandoffSplitButton worktreeId="worktree-1" onHandoff={vi.fn()} testIdPrefix="plan-review" />
+        </DialogContent>
+      </Dialog>
+    )
+
+    return { onDialogOpenChange }
+  }
+
+  it('keeps the host dialog open while interacting with the picker popover', async () => {
+    // The ticket modal hosts this picker; the popover portals outside the
+    // dialog's DOM, so it must be modal — otherwise every click inside it
+    // registers as a pointer-down-outside on the dialog and closes the ticket.
+    const { onDialogOpenChange } = renderInDialog()
+    const user = userEvent.setup()
+
+    await user.click(screen.getByTestId('plan-review-handoff-chevron'))
+    const sdkTrigger = await screen.findByRole('button', { name: 'Select handoff SDK' })
+
+    await user.click(sdkTrigger)
+    const codexItem = await screen.findByRole('menuitem', { name: 'Codex' })
+
+    await user.click(codexItem)
+
+    expect(onDialogOpenChange).not.toHaveBeenCalledWith(false)
+    expect(screen.getByTestId('host-dialog')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Select handoff SDK' })).toHaveTextContent('Codex')
+  })
+
+  it('registers the session-scoped picker-open guard while the popover is open', async () => {
+    render(
+      <HandoffSplitButton
+        worktreeId="worktree-1"
+        sessionId="session-1"
+        onHandoff={vi.fn()}
+        testIdPrefix="plan-review"
+      />
+    )
+    const user = userEvent.setup()
+
+    expect(isHandoffPickerOpenForSession('session-1')).toBe(false)
+
+    await user.click(screen.getByTestId('plan-review-handoff-chevron'))
+    await screen.findByRole('button', { name: 'Select handoff SDK' })
+    expect(isHandoffPickerOpenForSession('session-1')).toBe(true)
+    expect(isHandoffPickerOpenForSession('other-session')).toBe(false)
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(isHandoffPickerOpenForSession('session-1')).toBe(false))
+  })
+
+  it('applies picker changes to the effective selection live, without pressing Handoff', async () => {
+    // Changing SDK/model/effort must take effect immediately: the user can
+    // close the picker and fire the main handoff button (or right-click goal
+    // mode) expecting the selection they just made — e.g. switch to xhigh,
+    // then send an xhigh goal prompt from the main button.
+    opencodeApiMocks.listModels.mockResolvedValue({
+      success: true,
+      value: {
+        success: true,
+        providers: [
+          {
+            id: 'codex',
+            name: 'Codex',
+            models: {
+              'gpt-x': { id: 'gpt-x', name: 'GPT X', variants: { low: {}, xhigh: {} } }
+            }
+          }
+        ]
+      }
+    })
+    render(
+      <HandoffSplitButton
+        worktreeId="worktree-1"
+        sessionId="session-1"
+        onHandoff={vi.fn()}
+        testIdPrefix="plan-review"
+      />
+    )
+    const user = userEvent.setup()
+
+    await user.click(screen.getByTestId('plan-review-handoff-chevron'))
+    await user.click(await screen.findByRole('button', { name: 'Select handoff SDK' }))
+    await user.click(await screen.findByRole('menuitem', { name: 'Codex' }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Select handoff model' })).toHaveTextContent(
+        'GPT X'
+      )
+    )
+
+    await user.click(screen.getByRole('button', { name: 'xhigh' }))
+
+    // Close WITHOUT confirming — the selection must stick.
+    await user.keyboard('{Escape}')
+
+    await waitFor(() =>
+      expect(useSettingsStore.getState().lastHandoffOverride).toEqual({
+        agentSdk: 'codex',
+        providerID: 'codex',
+        modelID: 'gpt-x',
+        variant: 'xhigh'
+      })
+    )
+    const mainButton = screen.getByTestId('plan-review-handoff-btn')
+    expect(mainButton).toHaveTextContent('Codex')
+    expect(mainButton).toHaveTextContent('GPT X')
+    expect(mainButton).toHaveTextContent('xhigh')
+  })
+
+  it('closes the picker instead of stranding it when the anchor collapses to zero size', async () => {
+    render(
+      <HandoffSplitButton
+        worktreeId="worktree-1"
+        sessionId="session-1"
+        onHandoff={vi.fn()}
+        testIdPrefix="plan-review"
+      />
+    )
+    const user = userEvent.setup()
+
+    const chevron = screen.getByTestId('plan-review-handoff-chevron')
+    // The chevron's parent is the split button's root container (the watcher's ref target).
+    const container = chevron.parentElement as HTMLElement
+    // jsdom has no layout; feed the watcher a real size first, then a collapse.
+    let collapsed = false
+    vi.spyOn(container, 'getBoundingClientRect').mockImplementation(
+      () =>
+        ({
+          x: 0,
+          y: 0,
+          width: collapsed ? 0 : 200,
+          height: collapsed ? 0 : 32,
+          top: 0,
+          left: 0,
+          right: collapsed ? 0 : 200,
+          bottom: collapsed ? 0 : 32,
+          toJSON: () => ({})
+        }) as DOMRect
+    )
+
+    await user.click(chevron)
+    await screen.findByRole('button', { name: 'Select handoff SDK' })
+
+    collapsed = true
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 450))
+    })
+
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Select handoff SDK' })).toBeNull()
+    )
+    expect(isHandoffPickerOpenForSession('session-1')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sessions/HandoffModelPicker.tsx
+++ b/src/renderer/src/components/sessions/HandoffModelPicker.tsx
@@ -90,6 +90,18 @@ export function HandoffModelPicker({
     return loaded
   }, [])
 
+  // Every explicit pick applies immediately (not just on Handoff): the user
+  // can close the picker and fire the main split button — or right-click it
+  // into goal mode — expecting exactly the SDK/model/effort they just chose.
+  const persistOverride = useCallback((agentSdk: HandoffAgentSdk, model: SelectedModel) => {
+    useSettingsStore.getState().setLastHandoffOverride({
+      agentSdk,
+      providerID: model.providerID,
+      modelID: model.modelID,
+      variant: model.variant
+    })
+  }, [])
+
   const resolveModelForCatalog = useCallback(
     (providers: ProviderModels[], model: SelectedModel): SelectedModel => {
       const info = findModelInfo(providers, model.providerID, model.modelID)
@@ -141,36 +153,45 @@ export function HandoffModelPicker({
         configuredDefault.modelID
       )
       const nextInfo = configuredInfo ?? getFirstModelInfo(providers)
-      setPickedModel(nextInfo ? buildModelFromInfo(nextInfo, configuredDefault.variant) : configuredDefault)
+      const nextModel = nextInfo
+        ? buildModelFromInfo(nextInfo, configuredDefault.variant)
+        : configuredDefault
+      setPickedModel(nextModel)
+      persistOverride(nextSdk, nextModel)
     },
-    [ensureProviders]
+    [ensureProviders, persistOverride]
   )
 
-  const handleSelectModel = useCallback((model: SelectedModel) => {
-    const info = findModelInfo(currentProviders, model.providerID, model.modelID)
-    setPickedModel(info ? buildModelFromInfo(info, model.variant) : model)
-  }, [currentProviders])
+  const handleSelectModel = useCallback(
+    (model: SelectedModel) => {
+      const info = findModelInfo(currentProviders, model.providerID, model.modelID)
+      const nextModel = info ? buildModelFromInfo(info, model.variant) : model
+      setPickedModel(nextModel)
+      persistOverride(pickedSdk, nextModel)
+    },
+    [currentProviders, persistOverride, pickedSdk]
+  )
 
   const handleConfirm = useCallback(() => {
     if (!pickedModel) return
 
-    const nextOverride = {
-      agentSdk: pickedSdk,
-      providerID: pickedModel.providerID,
-      modelID: pickedModel.modelID,
-      variant: pickedModel.variant
-    }
-    useSettingsStore.getState().setLastHandoffOverride(nextOverride)
+    persistOverride(pickedSdk, pickedModel)
     onConfirm({ agentSdk: pickedSdk, model: pickedModel })
     onOpenChange(false)
-  }, [onConfirm, onOpenChange, pickedModel, pickedSdk])
+  }, [onConfirm, onOpenChange, persistOverride, pickedModel, pickedSdk])
 
   const modelLabel = currentModelInfo
     ? getModelDisplayName(currentModelInfo)
     : pickedModel?.modelID ?? (loadingSdks[pickedSdk] ? 'Loading…' : 'Select model')
 
   return (
-    <Popover open={open} onOpenChange={onOpenChange}>
+    // modal: the picker can be anchored inside a React portal (the claude-cli
+    // plan card portalled into the ticket modal), where its portalled content
+    // is outside the host Dialog's React tree. A non-modal popover's clicks
+    // then count as pointer-down-outside on the Dialog and close the ticket
+    // modal mid-selection. Modal mode makes this popover the topmost
+    // pointer-events-disabled layer so the Dialog ignores them.
+    <Popover open={open} onOpenChange={onOpenChange} modal>
       <PopoverTrigger asChild>{anchor}</PopoverTrigger>
       <PopoverContent align="end" className="w-[360px] p-3">
         <div className="space-y-3">
@@ -266,7 +287,9 @@ export function HandoffModelPicker({
                     key={variant}
                     type="button"
                     onClick={() => {
-                      setPickedModel({ ...pickedModel, variant })
+                      const nextModel = { ...pickedModel, variant }
+                      setPickedModel(nextModel)
+                      persistOverride(pickedSdk, nextModel)
                     }}
                     className={cn(
                       'rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide transition-colors',

--- a/src/renderer/src/components/sessions/HandoffSplitButton.tsx
+++ b/src/renderer/src/components/sessions/HandoffSplitButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import {
   getAvailableHandoffAgentSdks,
@@ -6,6 +6,7 @@ import {
   loadHandoffModelCatalog,
   type HandoffSelectionOverride
 } from '@/lib/handoffSelection'
+import { setHandoffPickerOpen } from '@/lib/handoff-ui-state'
 import { cn } from '@/lib/utils'
 import { supportsGoalMode } from '@shared/types/agent-sdk'
 import { HandoffModelPicker } from './HandoffModelPicker'
@@ -28,6 +29,8 @@ function MnemonicLabel({ letter, label }: { letter: string; label: string }): Re
 
 interface HandoffSplitButtonProps {
   worktreeId?: string
+  /** Source session, when known — scopes the picker-open guard that keeps the plan card / ticket modal alive during selection. */
+  sessionId?: string
   onHandoff: (override: HandoffSelectionOverride) => void
   vimModeEnabled?: boolean
   testIdPrefix?: string
@@ -36,6 +39,7 @@ interface HandoffSplitButtonProps {
 
 export function HandoffSplitButton({
   worktreeId,
+  sessionId,
   onHandoff,
   vimModeEnabled = false,
   testIdPrefix = 'plan-ready',
@@ -50,6 +54,41 @@ export function HandoffSplitButton({
   const [pickerOpen, setPickerOpen] = useState(false)
   const [catalogVersion, setCatalogVersion] = useState(0)
   const [goalMode, setGoalMode] = useState(false)
+  const pickerId = useId()
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    setHandoffPickerOpen(pickerId, sessionId ?? null, pickerOpen)
+    return () => {
+      setHandoffPickerOpen(pickerId, sessionId ?? null, false)
+    }
+  }, [pickerId, sessionId, pickerOpen])
+
+  // If something still hides or unmounts this button while the picker popover
+  // is open (its content is portalled to <body>), the popover would survive
+  // with a zero-size anchor and teleport to the viewport corner. Close it
+  // instead. Only trip after the anchor has been measured with a real size so
+  // layout-less environments (jsdom) never see a false collapse.
+  useEffect(() => {
+    if (!pickerOpen) return
+    const el = containerRef.current
+    if (!el) return
+
+    let hadSize = false
+    const check = (): void => {
+      const rect = el.getBoundingClientRect()
+      const visible = rect.width > 0 && rect.height > 0
+      if (visible) {
+        hadSize = true
+      } else if (hadSize) {
+        setPickerOpen(false)
+      }
+    }
+
+    check()
+    const interval = window.setInterval(check, 200)
+    return () => window.clearInterval(interval)
+  }, [pickerOpen])
 
   const showChevron = getAvailableHandoffAgentSdks(availableAgentSdks).length > 1
   void availableAgentSdks
@@ -95,6 +134,7 @@ export function HandoffSplitButton({
 
   return (
     <div
+      ref={containerRef}
       className={cn(
         'inline-flex h-8 items-center rounded-full border text-foreground shadow-md transition-colors duration-200',
         isGoalModeActive ? 'relative border-primary/40 bg-primary/15' : 'border-border bg-muted/80',
@@ -149,6 +189,9 @@ export function HandoffSplitButton({
             }}
             worktreeId={worktreeId}
             onConfirm={(override) => {
+              // Unregister before dispatching so the handoff's own teardown
+              // (plan clear, ticket sync, modal close) isn't guarded away.
+              setHandoffPickerOpen(pickerId, sessionId ?? null, false)
               onHandoff(withGoalMode(override))
             }}
             anchor={

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -5107,7 +5107,9 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
           toast.error(result.error ?? 'Failed to create handoff session')
           return
         }
-        const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
+        const setModePromise = sessionStore.setSessionMode(result.session.id, 'build', {
+        applyModeDefault: false
+      })
         registerHivePromptHandoff(sessionId, result.session.id)
         sessionStore.setPendingMessage(result.session.id, handoffPrompt)
         await useKanbanStore
@@ -5140,7 +5142,9 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
         return
       }
 
-      const setModePromise = sessionStore.setSessionMode(result.session.id, 'build')
+      const setModePromise = sessionStore.setSessionMode(result.session.id, 'build', {
+        applyModeDefault: false
+      })
       registerHivePromptHandoff(sessionId, result.session.id)
       sessionStore.setPendingMessage(result.session.id, handoffPrompt)
       await useKanbanStore

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -97,6 +97,7 @@ type SubscribedPayload = {
 }
 
 import { useClaudeCliStatusListener } from '../useClaudeCliStatusListener'
+import { resetHandoffPickerState, setHandoffPickerOpen } from '@/lib/handoff-ui-state'
 
 describe('useClaudeCliStatusListener', () => {
   let subscribedCallback: ((payload: SubscribedPayload) => void) | null
@@ -128,6 +129,7 @@ describe('useClaudeCliStatusListener', () => {
 
   afterEach(() => {
     mocks.onClaudeCliStatus.mockReset()
+    resetHandoffPickerState()
   })
 
   it('subscribes to Claude CLI status events and writes payloads into the worktree status store', () => {
@@ -348,6 +350,74 @@ describe('useClaudeCliStatusListener', () => {
     })
 
     expect(mocks.setSelectedTicketId).toHaveBeenCalledWith(null)
+  })
+
+  it('defers plan-followup teardown while a handoff picker for the session is open', () => {
+    mocks.kanbanState = {
+      selectedTicketId: 'ticket-plan',
+      tickets: new Map([
+        ['project-1', [{ id: 'ticket-plan', current_session_id: 'hive-session-1' }]]
+      ])
+    }
+    setHandoffPickerOpen('picker-1', 'hive-session-1', true)
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'planning',
+      metadata: { reason: 'claude_cli_plan_followup' }
+    })
+
+    // The user is mid-handoff: keep the modal, plan card, and ticket state up.
+    expect(mocks.clearPendingPlan).not.toHaveBeenCalled()
+    expect(mocks.notifyKanbanSessionSync).not.toHaveBeenCalled()
+    expect(mocks.setSelectedTicketId).not.toHaveBeenCalled()
+    // Status bookkeeping still proceeds.
+    expect(mocks.setSessionStatus).toHaveBeenCalledWith('hive-session-1', 'planning', {
+      reason: 'claude_cli_plan_followup'
+    })
+  })
+
+  it('defers terminal plan-approval teardown while a handoff picker for the session is open', () => {
+    mocks.kanbanState = {
+      selectedTicketId: 'ticket-plan',
+      tickets: new Map([
+        ['project-1', [{ id: 'ticket-plan', current_session_id: 'hive-session-1' }]]
+      ])
+    }
+    setHandoffPickerOpen('picker-1', 'hive-session-1', true)
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'working',
+      metadata: { hookEventName: 'PostToolUse', hookPath: 'tool', toolName: 'ExitPlanMode' }
+    })
+
+    expect(mocks.clearPendingPlan).not.toHaveBeenCalled()
+    expect(mocks.notifyKanbanSessionSync).not.toHaveBeenCalled()
+    expect(mocks.setSelectedTicketId).not.toHaveBeenCalled()
+    expect(mocks.setSessionStatus).toHaveBeenCalledWith('hive-session-1', 'working', {
+      hookEventName: 'PostToolUse',
+      hookPath: 'tool',
+      toolName: 'ExitPlanMode'
+    })
+  })
+
+  it('tears down normally when the open handoff picker belongs to another session', () => {
+    setHandoffPickerOpen('picker-1', 'other-session', true)
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'planning',
+      metadata: { reason: 'claude_cli_plan_followup' }
+    })
+
+    expect(mocks.clearPendingPlan).toHaveBeenCalledWith('hive-session-1')
+    expect(mocks.notifyKanbanSessionSync).toHaveBeenCalledWith('hive-session-1', {
+      type: 'plan_followup'
+    })
   })
 
   it('does not close the selected ticket modal for a different session followup', () => {

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -6,6 +6,7 @@ import { useKanbanStore } from '@/stores/useKanbanStore'
 import { lastSendMode } from '@/lib/message-send-times'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { isPlanLike } from '@/lib/constants'
+import { isHandoffPickerOpenForSession } from '@/lib/handoff-ui-state'
 
 type ClaudeCliStatusMetadata = {
   reason?: string
@@ -55,9 +56,16 @@ export function useClaudeCliStatusListener(): void {
         reason: 'claude_cli_plan_followup'
       }
     ): void => {
-      useSessionStore.getState().clearPendingPlan(sessionId)
-      notifyKanbanSessionSync(sessionId, { type: 'plan_followup' })
-      closeLinkedTicketModal(sessionId)
+      // While the user has a handoff picker open for this session, keep the
+      // plan card, ticket state, and modal alive — tearing them down strands
+      // the picker popover (its anchor collapses). Status still updates; the
+      // handoff confirm path unregisters the picker before dispatching, so a
+      // real handoff's teardown is unaffected.
+      if (!isHandoffPickerOpenForSession(sessionId)) {
+        useSessionStore.getState().clearPendingPlan(sessionId)
+        notifyKanbanSessionSync(sessionId, { type: 'plan_followup' })
+        closeLinkedTicketModal(sessionId)
+      }
       lastSendMode.set(sessionId, 'plan')
       useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'planning', metadata)
     }
@@ -92,15 +100,19 @@ export function useClaudeCliStatusListener(): void {
         // Any approval consumes the one-shot auto-approve arm (no-op if the hook
         // server already consumed it when auto-approving).
         void terminalApi.setClaudeCliPlanAutoApprove(sessionId, false).catch(() => undefined)
-        sessionStore.clearPendingPlan(sessionId)
         if (isPlanLike(currentMode)) {
           // Persist the session itself to build mode so a later --resume respawn
           // doesn't pass --permission-mode plan. Claude already left plan mode
           // when the dialog was approved, so skip the Shift+Tab PTY sync.
           void sessionStore.setSessionMode(sessionId, 'build', { syncCliPermissionMode: false })
         }
-        notifyKanbanSessionSync(sessionId, { type: 'implement' })
-        closeLinkedTicketModal(sessionId)
+        // Same handoff-picker guard as handlePlanFollowup: don't rip the plan
+        // card / ticket modal out from under an open picker.
+        if (!isHandoffPickerOpenForSession(sessionId)) {
+          sessionStore.clearPendingPlan(sessionId)
+          notifyKanbanSessionSync(sessionId, { type: 'implement' })
+          closeLinkedTicketModal(sessionId)
+        }
         lastSendMode.set(sessionId, 'build')
         worktreeStatus.setSessionStatus(sessionId, 'working', metadata)
         return

--- a/src/renderer/src/lib/handoff-ui-state.ts
+++ b/src/renderer/src/lib/handoff-ui-state.ts
@@ -1,0 +1,34 @@
+/**
+ * Tracks handoff pickers that are currently open so background claude-cli
+ * status transitions (plan followup, terminal plan approval) don't tear down
+ * the UI the user is actively interacting with — closing the ticket modal or
+ * unmounting the plan card mid-selection strands the picker popover at the
+ * viewport corner. Teardown is skipped while a picker for that session (or an
+ * unscoped picker) is open; the handoff confirm path unregisters synchronously
+ * before dispatching so its own teardown still runs.
+ */
+const openHandoffPickers = new Map<string, string | null>()
+
+export function setHandoffPickerOpen(
+  pickerId: string,
+  sessionId: string | null,
+  open: boolean
+): void {
+  if (open) {
+    openHandoffPickers.set(pickerId, sessionId)
+  } else {
+    openHandoffPickers.delete(pickerId)
+  }
+}
+
+/** True when a handoff picker scoped to this session — or an unscoped one — is open. */
+export function isHandoffPickerOpenForSession(sessionId: string): boolean {
+  for (const scope of openHandoffPickers.values()) {
+    if (scope === null || scope === sessionId) return true
+  }
+  return false
+}
+
+export function resetHandoffPickerState(): void {
+  openHandoffPickers.clear()
+}

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -184,7 +184,7 @@ interface SessionState {
   setSessionMode: (
     sessionId: string,
     mode: SessionMode,
-    options?: { syncCliPermissionMode?: boolean }
+    options?: { syncCliPermissionMode?: boolean; applyModeDefault?: boolean }
   ) => Promise<void>
   setSessionModel: (
     sessionId: string,
@@ -1317,7 +1317,7 @@ export const useSessionStore = create<SessionState>()(
       setSessionMode: async (
         sessionId: string,
         mode: SessionMode,
-        options?: { syncCliPermissionMode?: boolean }
+        options?: { syncCliPermissionMode?: boolean; applyModeDefault?: boolean }
       ) => {
         const previousMode = get().modeBySession.get(sessionId) || 'build'
         if (options?.syncCliPermissionMode !== false) {
@@ -1336,8 +1336,12 @@ export const useSessionStore = create<SessionState>()(
           console.error('Failed to persist session mode:', error)
         }
 
-        // Apply mode-specific default model (same as toggleSessionMode)
-        await get().applyModeDefaultModel(sessionId, mode)
+        // Apply mode-specific default model (same as toggleSessionMode).
+        // Handoff paths opt out: they just created the session with an
+        // explicitly picked model/variant that the default must not clobber.
+        if (options?.applyModeDefault !== false) {
+          await get().applyModeDefaultModel(sessionId, mode)
+        }
 
         // Notify Kanban board of mode change
         notifyKanbanSessionSync(sessionId, { type: 'mode_change', sessionMode: mode })


### PR DESCRIPTION
## Summary
- Prevent handoff sessions from being overwritten by mode-default model selection when switching them to `build`.
- Keep the handoff picker usable inside ticket modal and session overlays by making the popover modal and preserving its anchor container while open.
- Add session-scoped picker tracking so Claude CLI status transitions do not tear down the plan card or close the ticket modal mid-selection.
- Persist explicit SDK/model/effort choices immediately and add coverage for the picker, modal interaction, terminal visibility, and status-listener guards.

## Testing
- Not run
- Added/updated unit tests for handoff picker behavior, modal containment, and session status teardown guards
- Added layout regression coverage for terminal container visibility while overlay suppression is active

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session mode/model application, main-pane terminal visibility, and Claude CLI status teardown paths; behavior is well covered by new tests but spans several UI coordination layers.
> 
> **Overview**
> Fixes **plan handoff** from the ticket modal and Claude CLI plan card so SDK/model selection and UI teardown behave correctly.
> 
> **Handoff model preservation:** `setSessionMode(..., 'build')` on new handoff sessions now passes `{ applyModeDefault: false }` so build-mode defaults do not overwrite the model chosen in the picker.
> 
> **Handoff picker UX:** The model picker popover is **modal** (so clicks do not dismiss the host ticket dialog), applies SDK/model/effort to `lastHandoffOverride` **immediately** on change, and `HandoffSplitButton` takes an optional **`sessionId`** to register open state and auto-close if the anchor collapses.
> 
> **Layout / teardown guards:** `MainPane` no longer hides the terminal container when `ghosttyOverlaySuppressed` is true (native surface hiding stays in `TerminalView`). **`handoff-ui-state`** defers Claude CLI status-driven plan followup / `ExitPlanMode` teardown (clear plan, kanban sync, close ticket) while a picker for that session is open.
> 
> Tests cover picker-in-dialog behavior, terminal visibility under overlay suppression, handoff `applyModeDefault`, and status-listener deferral.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0813bb81bfe9ec8861e059477469d4e7b9704461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->