### PR TITLE
Fix abort to interrupt subagents

### DIFF
--- a/src/main/services/__tests__/codex-app-server-manager-abort.test.ts
+++ b/src/main/services/__tests__/codex-app-server-manager-abort.test.ts
@@ -1,0 +1,325 @@
+import type { ChildProcess } from 'node:child_process'
+import type readline from 'node:readline'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('../codex-debug-logger', () => ({
+  logCodexMessage: vi.fn(),
+  logCodexLifecycleEvent: vi.fn(),
+  resetSession: vi.fn()
+}))
+
+import { CodexAppServerManager, type CodexSessionContext } from '../codex-app-server-manager'
+
+const PARENT_THREAD_ID = 'thread-parent'
+const PARENT_TURN_ID = 'turn-1'
+
+interface OutgoingMessage {
+  jsonrpc: string
+  id?: number
+  method?: string
+  params?: Record<string, unknown>
+}
+
+interface Harness {
+  manager: CodexAppServerManager
+  context: CodexSessionContext
+  written: OutgoingMessage[]
+  /** Called for every outgoing request; return false to skip the default ok-response. */
+  onRequest: (handler: (msg: OutgoingMessage) => boolean | void) => void
+  notify: (method: string, params: Record<string, unknown>) => void
+  respond: (msg: OutgoingMessage, result?: unknown) => void
+  respondError: (msg: OutgoingMessage, message: string) => void
+  interrupts: () => Array<{ threadId: string; turnId: string }>
+}
+
+function createHarness(): Harness {
+  const manager = new CodexAppServerManager()
+  const written: OutgoingMessage[] = []
+  const handlers: Array<(msg: OutgoingMessage) => boolean | void> = []
+
+  const child = {
+    killed: false,
+    stdin: {
+      writable: true,
+      write: (line: string): boolean => {
+        const msg = JSON.parse(line) as OutgoingMessage
+        written.push(msg)
+        // Defer so the promise machinery in sendRequest settles like real IO.
+        queueMicrotask(() => {
+          for (const handler of handlers) {
+            if (handler(msg) === false) return
+          }
+          respond(msg)
+        })
+        return true
+      }
+    }
+  }
+
+  const context: CodexSessionContext = {
+    session: {
+      provider: 'codex',
+      status: 'running',
+      threadId: PARENT_THREAD_ID,
+      cwd: '/repo',
+      model: null,
+      activeTurnId: PARENT_TURN_ID,
+      resumeCursor: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    },
+    child: child as unknown as ChildProcess,
+    output: { close: vi.fn() } as unknown as readline.Interface,
+    pending: new Map(),
+    pendingApprovals: new Map(),
+    pendingUserInputs: new Map(),
+    collabReceiverTurns: new Map(),
+    subagentThreadIds: new Set(),
+    nextRequestId: 1,
+    stopping: false,
+    abortRequested: false,
+    abortReinterruptsRemaining: 0
+  }
+
+  ;(manager as unknown as { sessions: Map<string, CodexSessionContext> }).sessions.set(
+    PARENT_THREAD_ID,
+    context
+  )
+
+  function respond(msg: OutgoingMessage, result: unknown = {}): void {
+    if (msg.id === undefined) return
+    manager.handleStdoutLine(context, JSON.stringify({ jsonrpc: '2.0', id: msg.id, result }))
+  }
+
+  function respondError(msg: OutgoingMessage, message: string): void {
+    if (msg.id === undefined) return
+    manager.handleStdoutLine(
+      context,
+      JSON.stringify({ jsonrpc: '2.0', id: msg.id, error: { code: -32600, message } })
+    )
+  }
+
+  function notify(method: string, params: Record<string, unknown>): void {
+    manager.handleStdoutLine(context, JSON.stringify({ jsonrpc: '2.0', method, params }))
+  }
+
+  return {
+    manager,
+    context,
+    written,
+    onRequest: (handler) => handlers.push(handler),
+    notify,
+    respond,
+    respondError,
+    interrupts: () =>
+      written
+        .filter((msg) => msg.method === 'turn/interrupt')
+        .map((msg) => msg.params as { threadId: string; turnId: string })
+  }
+}
+
+function registerCollabChildren(harness: Harness, childThreadIds: string[]): void {
+  harness.notify('item/started', {
+    threadId: PARENT_THREAD_ID,
+    turnId: PARENT_TURN_ID,
+    item: {
+      id: 'item-collab-1',
+      type: 'collabAgentToolCall',
+      receiverThreadIds: childThreadIds
+    }
+  })
+}
+
+describe('CodexAppServerManager abort', () => {
+  it('interrupts the parent turn and every known subagent thread', async () => {
+    const harness = createHarness()
+    registerCollabChildren(harness, ['child-1', 'child-2'])
+
+    await harness.manager.interruptTurn(PARENT_THREAD_ID)
+
+    expect(harness.interrupts()).toEqual([
+      { threadId: PARENT_THREAD_ID, turnId: PARENT_TURN_ID },
+      { threadId: 'child-1', turnId: '' },
+      { threadId: 'child-2', turnId: '' }
+    ])
+    expect(harness.context.session.status).toBe('ready')
+    expect(harness.context.session.activeTurnId).toBeNull()
+    expect(harness.context.abortRequested).toBe(true)
+  })
+
+  it('still interrupts subagents when the collab map is cleared mid-abort', async () => {
+    const harness = createHarness()
+    registerCollabChildren(harness, ['child-1'])
+
+    harness.onRequest((msg) => {
+      if (msg.method === 'turn/interrupt' && msg.params?.threadId === PARENT_THREAD_ID) {
+        // A non-interrupted turn/completed clears collabReceiverTurns before
+        // the deferred interrupt response resolves.
+        harness.notify('turn/completed', {
+          threadId: PARENT_THREAD_ID,
+          turn: { id: PARENT_TURN_ID, status: 'completed' }
+        })
+      }
+    })
+
+    await harness.manager.interruptTurn(PARENT_THREAD_ID)
+
+    expect(harness.context.collabReceiverTurns.size).toBe(0)
+    expect(harness.interrupts()).toContainEqual({ threadId: 'child-1', turnId: '' })
+  })
+
+  it('interrupts subagents even when the parent interrupt fails', async () => {
+    const harness = createHarness()
+    registerCollabChildren(harness, ['child-1', 'child-2'])
+
+    harness.onRequest((msg) => {
+      if (msg.method === 'turn/interrupt' && msg.params?.threadId === PARENT_THREAD_ID) {
+        harness.respondError(msg, 'no active turn to interrupt')
+        return false
+      }
+      return undefined
+    })
+
+    await expect(harness.manager.interruptTurn(PARENT_THREAD_ID)).resolves.toBeUndefined()
+
+    expect(harness.interrupts().slice(1)).toEqual([
+      { threadId: 'child-1', turnId: '' },
+      { threadId: 'child-2', turnId: '' }
+    ])
+    expect(harness.context.session.status).toBe('ready')
+  })
+
+  it('tolerates individual subagent interrupt failures', async () => {
+    const harness = createHarness()
+    registerCollabChildren(harness, ['child-1', 'child-2'])
+
+    harness.onRequest((msg) => {
+      if (msg.method === 'turn/interrupt' && msg.params?.threadId === 'child-1') {
+        harness.respondError(msg, 'no active turn to interrupt')
+        return false
+      }
+      return undefined
+    })
+
+    await expect(harness.manager.interruptTurn(PARENT_THREAD_ID)).resolves.toBeUndefined()
+    expect(harness.interrupts()).toHaveLength(3)
+  })
+
+  it('re-interrupts turns that start while an abort is in flight', async () => {
+    const harness = createHarness()
+    await harness.manager.interruptTurn(PARENT_THREAD_ID)
+    harness.written.length = 0
+
+    // A subagent thread we never saw in a collab item restarts from queued mail.
+    harness.notify('turn/started', { threadId: 'child-9', turn: { id: 'turn-9' } })
+    // The parent thread restarts too.
+    harness.notify('turn/started', { threadId: PARENT_THREAD_ID, turn: { id: 'turn-2' } })
+    await vi.waitFor(() => expect(harness.interrupts()).toHaveLength(2))
+
+    expect(harness.interrupts()).toEqual([
+      { threadId: 'child-9', turnId: 'turn-9' },
+      { threadId: PARENT_THREAD_ID, turnId: 'turn-2' }
+    ])
+    // The restarted parent turn must not revive the session.
+    expect(harness.context.session.status).toBe('ready')
+    expect(harness.context.session.activeTurnId).toBeNull()
+  })
+
+  it('caps post-abort re-interrupts', async () => {
+    const harness = createHarness()
+    await harness.manager.interruptTurn(PARENT_THREAD_ID)
+    harness.written.length = 0
+    harness.context.abortReinterruptsRemaining = 2
+
+    for (let i = 0; i < 4; i += 1) {
+      harness.notify('turn/started', { threadId: `child-${i}`, turn: { id: `turn-${i}` } })
+    }
+    await vi.waitFor(() => expect(harness.interrupts()).toHaveLength(2))
+
+    expect(harness.context.abortReinterruptsRemaining).toBe(0)
+  })
+
+  it('does not re-interrupt turns once a new prompt is sent', async () => {
+    const harness = createHarness()
+    registerCollabChildren(harness, ['child-1'])
+    await harness.manager.interruptTurn(PARENT_THREAD_ID)
+    expect(harness.context.abortRequested).toBe(true)
+
+    harness.onRequest((msg) => {
+      if (msg.method === 'turn/start') {
+        harness.respond(msg, { turn: { id: 'turn-2' } })
+        return false
+      }
+      return undefined
+    })
+    await harness.manager.sendTurn(PARENT_THREAD_ID, { text: 'go again' })
+
+    expect(harness.context.abortRequested).toBe(false)
+    expect(harness.context.abortReinterruptsRemaining).toBe(0)
+    expect(harness.context.collabReceiverTurns.size).toBe(0)
+
+    harness.written.length = 0
+    harness.notify('turn/started', { threadId: PARENT_THREAD_ID, turn: { id: 'turn-2' } })
+    expect(harness.interrupts()).toHaveLength(0)
+    expect(harness.context.session.status).toBe('running')
+  })
+
+  // Newer codex builds emit collab items with empty receiverThreadIds; child
+  // threads are only recognizable by their thread id differing from the root.
+  it('detects subagent threads by thread id when receiverThreadIds is empty', async () => {
+    const harness = createHarness()
+
+    harness.notify('turn/started', { threadId: 'child-a', turn: { id: 'turn-a' } })
+    harness.notify('turn/started', { threadId: 'child-b', turn: { id: 'turn-b' } })
+
+    // Child turn lifecycle must not clobber the parent session state.
+    expect(harness.context.session.activeTurnId).toBe(PARENT_TURN_ID)
+    expect(harness.context.session.status).toBe('running')
+
+    await harness.manager.interruptTurn(PARENT_THREAD_ID)
+
+    expect(harness.interrupts()).toEqual([
+      { threadId: PARENT_THREAD_ID, turnId: PARENT_TURN_ID },
+      { threadId: 'child-a', turnId: '' },
+      { threadId: 'child-b', turnId: '' }
+    ])
+  })
+
+  it('does not let subagent turn completions flip the parent session state', async () => {
+    const harness = createHarness()
+
+    harness.notify('turn/started', { threadId: 'child-a', turn: { id: 'turn-a' } })
+    harness.notify('turn/completed', {
+      threadId: 'child-a',
+      turn: { id: 'turn-a', status: 'failed' }
+    })
+
+    expect(harness.context.session.status).toBe('running')
+    expect(harness.context.session.activeTurnId).toBe(PARENT_TURN_ID)
+  })
+
+  it('keeps suppressing straggler subagent notifications after an abort', async () => {
+    const harness = createHarness()
+    registerCollabChildren(harness, ['child-1'])
+
+    await harness.manager.interruptTurn(PARENT_THREAD_ID)
+
+    // Parent turn reports interrupted — the collab map must survive.
+    harness.notify('turn/completed', {
+      threadId: PARENT_THREAD_ID,
+      turn: { id: PARENT_TURN_ID, status: 'interrupted' }
+    })
+    expect(harness.context.collabReceiverTurns.size).toBe(1)
+
+    // A straggler child failure must not flip the parent session to error.
+    harness.notify('turn/completed', {
+      threadId: 'child-1',
+      turn: { id: 'child-turn-1', status: 'failed' }
+    })
+    expect(harness.context.session.status).toBe('ready')
+  })
+})

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -41,6 +41,13 @@ import { getRuntime } from '../effect/spawn/runtime'
 
 const log = createLogger({ component: 'CodexAppServerManager' })
 
+// Codex's turn interrupt is not tree-aware: collab subagents run as sibling
+// threads inside the app-server and each needs its own turn/interrupt.
+const SUBAGENT_INTERRUPT_TIMEOUT_MS = 5_000
+// After an interrupt, codex auto-starts new turns from queued trigger-turn
+// mail; cap how many of those we re-interrupt per abort.
+const MAX_ABORT_REINTERRUPTS = 5
+
 // ── JSON-RPC protocol types ───────────────────────────────────────
 
 export interface JsonRpcError {
@@ -117,8 +124,13 @@ export interface CodexSessionContext {
   pendingApprovals: Map<string, PendingApprovalRequest>
   pendingUserInputs: Map<string, PendingUserInputRequest>
   collabReceiverTurns: Map<string, string> // childThreadId → parentTurnId
+  // Subagent threads observed on this app-server (any thread id ≠ the root
+  // thread). Needed because newer codex builds emit empty receiverThreadIds.
+  subagentThreadIds: Set<string>
   nextRequestId: number
   stopping: boolean
+  abortRequested: boolean
+  abortReinterruptsRemaining: number
 }
 
 // ── Start session input ───────────────────────────────────────────
@@ -483,8 +495,11 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         pendingApprovals: new Map(),
         pendingUserInputs: new Map(),
         collabReceiverTurns: new Map(),
+        subagentThreadIds: new Set(),
         nextRequestId: 1,
-        stopping: false
+        stopping: false,
+        abortRequested: false,
+        abortReinterruptsRemaining: 0
       }
 
       this.sessions.set(tempThreadId, context)
@@ -683,8 +698,11 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       throw new Error('sendTurn: session has no threadId')
     }
 
-    // Reset child tracking for new turn
+    // Reset child tracking and any in-flight abort for new turn
     context.collabReceiverTurns.clear()
+    context.subagentThreadIds.clear()
+    context.abortRequested = false
+    context.abortReinterruptsRemaining = 0
 
     // Build the turn input array
     const turnInput =
@@ -785,6 +803,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       input: turnInput,
       expectedTurnId
     }
+
+    // Steering means the user wants the turn to continue — cancel any in-flight abort.
+    context.abortRequested = false
+    context.abortReinterruptsRemaining = 0
 
     const response = await this.sendRequest<TurnSteerResponse>(context, 'turn/steer', params)
 
@@ -962,12 +984,55 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
     const targetTurnId = turnId ?? context.session.activeTurnId
 
+    // Snapshot known subagent thread ids before any await: the parent's
+    // turn/completed (status "interrupted") clears the tracking at the same
+    // moment the deferred interrupt response resolves.
+    const childThreadIds = [
+      ...new Set([...context.collabReceiverTurns.keys(), ...context.subagentThreadIds])
+    ]
+
+    context.abortRequested = true
+    context.abortReinterruptsRemaining = MAX_ABORT_REINTERRUPTS
+
     const params: TurnInterruptParams = {
       threadId: context.session.threadId!,
       turnId: targetTurnId ?? ''
     }
 
-    await this.sendRequest(context, 'turn/interrupt', params)
+    // Parent first: interrupting children first wakes the parent's wait_agent
+    // with completion mail, letting the parent model keep acting meanwhile.
+    try {
+      await this.sendRequest(context, 'turn/interrupt', params)
+    } catch (error) {
+      log.warn('interruptTurn: parent interrupt failed, continuing with subagents', {
+        threadId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+
+    // Interrupt each subagent thread. Empty turnId skips codex's active-turn
+    // validation and still aborts whatever the thread is running.
+    const results = await Promise.allSettled(
+      childThreadIds.map((childThreadId) => {
+        const childParams: TurnInterruptParams = { threadId: childThreadId, turnId: '' }
+        return this.sendRequest(
+          context,
+          'turn/interrupt',
+          childParams,
+          SUBAGENT_INTERRUPT_TIMEOUT_MS
+        )
+      })
+    )
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        log.warn('interruptTurn: subagent interrupt failed', {
+          threadId,
+          childThreadId: childThreadIds[index],
+          error:
+            result.reason instanceof Error ? result.reason.message : String(result.reason)
+        })
+      }
+    })
 
     this.updateSession(context, {
       status: 'ready',
@@ -1172,8 +1237,27 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     this.rememberCollabReceiverTurns(context, notification.params, route.turnId)
 
     // Detect if this notification is from a child thread
+    const providerConversationId = this.readProviderConversationId(notification.params)
     const childParentTurnId = this.readChildParentTurnId(context, notification.params)
-    const isChildConversation = childParentTurnId !== undefined
+    const isChildConversation = this.isChildThread(
+      context,
+      providerConversationId,
+      childParentTurnId
+    )
+    if (isChildConversation && providerConversationId) {
+      context.subagentThreadIds.add(providerConversationId)
+    }
+
+    // While an abort is in flight, codex auto-starts new turns from queued
+    // trigger-turn mail (on the parent or any subagent thread). Re-interrupt
+    // them, and keep a restarted parent turn from flipping the session back
+    // to running or reaching the renderer.
+    if (notification.method === 'turn/started' && context.abortRequested) {
+      this.reinterruptStartedTurn(context, notification.params)
+      if (!isChildConversation) {
+        return
+      }
+    }
 
     // Suppress lifecycle notifications from child threads
     if (isChildConversation && this.shouldSuppressChildConversationNotification(notification.method)) {
@@ -1185,8 +1269,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       notification.method === 'item/agentMessage/delta'
         ? asString(asObject(notification.params)?.delta)
         : undefined
-
-    const providerConversationId = this.readProviderConversationId(notification.params)
 
     // Emit event — child events get parent's turnId for proper attribution
     this.emitEvent({
@@ -1218,8 +1300,13 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
     if (notification.method === 'turn/completed') {
       if (isChildConversation) return
-      context.collabReceiverTurns.clear()
       const status = notification.params.turn.status
+      // Subagents outlive an interrupted parent turn; keep the mappings so
+      // their trailing notifications stay suppressed/attributed.
+      if (status !== 'interrupted') {
+        context.collabReceiverTurns.clear()
+        context.subagentThreadIds.clear()
+      }
       this.updateSession(context, {
         status: status === 'failed' ? 'error' : 'ready',
         activeTurnId: null
@@ -1236,7 +1323,14 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     const childParentTurnId = this.readChildParentTurnId(context, request.params)
     const effectiveTurnId = childParentTurnId ?? route.turnId
     const providerConversationId = this.readProviderConversationId(request.params)
-    const isChildConversation = childParentTurnId !== undefined
+    const isChildConversation = this.isChildThread(
+      context,
+      providerConversationId,
+      childParentTurnId
+    )
+    if (isChildConversation && providerConversationId) {
+      context.subagentThreadIds.add(providerConversationId)
+    }
 
     // Track approval requests
     if (
@@ -1417,6 +1511,22 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     return context.collabReceiverTurns.get(providerConversationId)
   }
 
+  private isChildThread(
+    context: CodexSessionContext,
+    providerConversationId: string | undefined,
+    childParentTurnId: string | undefined
+  ): boolean {
+    if (childParentTurnId !== undefined) return true
+    // Newer codex builds emit collab items with empty receiverThreadIds, so
+    // fall back to the thread id itself: this app-server hosts exactly one
+    // root thread — any other thread id belongs to a subagent.
+    return (
+      providerConversationId !== undefined &&
+      context.session.threadId !== null &&
+      providerConversationId !== context.session.threadId
+    )
+  }
+
   private rememberCollabReceiverTurns(
     context: CodexSessionContext,
     params: unknown,
@@ -1435,6 +1545,36 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         context.collabReceiverTurns.set(id, parentTurnId)
       }
     }
+  }
+
+  private reinterruptStartedTurn(context: CodexSessionContext, params: unknown): void {
+    if (context.abortReinterruptsRemaining <= 0) return
+
+    const payload = asObject(params)
+    // Use the notification's own thread id — it also covers subagent threads
+    // that never registered in collabReceiverTurns.
+    const startedThreadId = this.readProviderConversationId(params)
+    const startedTurnId = asString(asObject(payload?.turn)?.id)
+    if (!startedThreadId) return
+
+    context.abortReinterruptsRemaining -= 1
+
+    const interruptParams: TurnInterruptParams = {
+      threadId: startedThreadId,
+      turnId: startedTurnId ?? ''
+    }
+    void this.sendRequest(
+      context,
+      'turn/interrupt',
+      interruptParams,
+      SUBAGENT_INTERRUPT_TIMEOUT_MS
+    ).catch((error) => {
+      log.warn('reinterruptStartedTurn: interrupt failed', {
+        threadId: startedThreadId,
+        turnId: startedTurnId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    })
   }
 
   private shouldSuppressChildConversationNotification(method: string): boolean {


### PR DESCRIPTION
## Summary
- Interrupts the parent turn and all known subagent threads when an execution abort is requested.
- Tracks subagent thread IDs separately so abort handling still works when Codex emits empty `receiverThreadIds`.
- Re-interrupts turns that start during an in-flight abort, with a cap to avoid runaway retries.
- Preserves child-thread suppression across interrupted parent completion events so straggler notifications do not flip session state.

## Testing
- Added unit coverage for interrupting parent plus subagents.
- Added coverage for abort behavior when collab mappings are cleared mid-abort.
- Added coverage for parent interrupt failures and individual subagent interrupt failures.
- Added coverage for re-interrupting restarted turns during abort, including the retry cap.
- Added coverage for clearing abort state when a new prompt is sent.
- Added coverage for detecting subagents via thread ID fallback and keeping child lifecycle events from mutating the parent session.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Codex session/abort orchestration and notification handling; mistakes could leave agents running after abort or mis-report session status, but behavior is heavily unit-tested.
> 
> **Overview**
> **Abort now stops collab subagents**, not only the root turn. `interruptTurn` snapshots known child thread IDs, interrupts the parent first, then issues `turn/interrupt` for each subagent (empty `turnId`), tolerating per-thread failures without failing the whole abort.
> 
> Session context gains **`subagentThreadIds`**, **`abortRequested`**, and a capped **`abortReinterruptsRemaining`** so abort still works when Codex sends empty `receiverThreadIds` (children inferred as any thread id ≠ root). While abort is in flight, **`turn/started`** triggers re-interrupts (max 5) and blocks the parent from going back to **running**; **`sendTurn`** / **`steerTurn`** clear abort state.
> 
> **`turn/completed`** no longer always clears collab maps: on **interrupted** parent completion, mappings stay so late subagent events stay suppressed and do not flip the parent session to **error**. **`isChildThread`** centralizes child detection for notifications and requests.
> 
> Adds **`codex-app-server-manager-abort.test.ts`** with harness coverage for multi-thread interrupt, mid-abort races, re-interrupt caps, and new-prompt reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be8183d70e5d944580fd002fa5f53bf15d630ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->