### PR TITLE
Fix Codex session lifecycle handling

### DIFF
--- a/src/main/services/__tests__/codex-app-server-manager.test.ts
+++ b/src/main/services/__tests__/codex-app-server-manager.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import type { ChildProcess } from 'node:child_process'
+import type readline from 'node:readline'
+import {
+  CodexAppServerManager,
+  type CodexManagerEvent,
+  type CodexProviderSession,
+  type CodexSessionContext
+} from '../codex-app-server-manager'
+
+function createContext(overrides: Partial<CodexProviderSession> = {}): CodexSessionContext {
+  return {
+    session: {
+      provider: 'codex',
+      status: 'ready',
+      threadId: 'T',
+      cwd: '/repo',
+      model: null,
+      activeTurnId: null,
+      resumeCursor: 'T',
+      goalStatus: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides
+    },
+    child: {} as ChildProcess,
+    output: {} as readline.Interface,
+    pending: new Map(),
+    pendingApprovals: new Map(),
+    pendingUserInputs: new Map(),
+    collabReceiverTurns: new Map(),
+    nextRequestId: 1,
+    stopping: false
+  }
+}
+
+function notify(
+  manager: CodexAppServerManager,
+  context: CodexSessionContext,
+  method: string,
+  params: Record<string, unknown>
+): void {
+  manager.handleStdoutLine(context, JSON.stringify({ jsonrpc: '2.0', method, params }))
+}
+
+describe('CodexAppServerManager turn lifecycle guards', () => {
+  let manager: CodexAppServerManager
+  let context: CodexSessionContext
+  let events: CodexManagerEvent[]
+
+  const eventsFor = (method: string): CodexManagerEvent[] =>
+    events.filter((event) => event.method === method)
+
+  beforeEach(() => {
+    manager = new CodexAppServerManager()
+    context = createContext()
+    events = []
+    manager.on('event', (event) => events.push(event))
+  })
+
+  it('marks the session ready on the active turn matching turn/completed', () => {
+    notify(manager, context, 'turn/started', { threadId: 'T', turn: { id: 't1', status: 'inProgress' } })
+    expect(context.session.status).toBe('running')
+    expect(context.session.activeTurnId).toBe('t1')
+
+    notify(manager, context, 'turn/completed', { threadId: 'T', turn: { id: 't1', status: 'completed' } })
+    expect(context.session.status).toBe('ready')
+    expect(context.session.activeTurnId).toBeNull()
+    expect(eventsFor('turn/completed')).toHaveLength(1)
+  })
+
+  it('ignores turn/completed from an unregistered child thread', () => {
+    notify(manager, context, 'turn/started', { threadId: 'T', turn: { id: 't1', status: 'inProgress' } })
+
+    notify(manager, context, 'turn/completed', {
+      threadId: 'C-unregistered',
+      turn: { id: 'c9', status: 'completed' }
+    })
+
+    expect(context.session.status).toBe('running')
+    expect(context.session.activeTurnId).toBe('t1')
+    expect(eventsFor('turn/completed')).toHaveLength(0)
+  })
+
+  it('ignores turn/started from an unregistered child thread', () => {
+    notify(manager, context, 'turn/started', { threadId: 'C-unregistered', turn: { id: 'c1', status: 'inProgress' } })
+
+    expect(context.session.status).toBe('ready')
+    expect(context.session.activeTurnId).toBeNull()
+    expect(eventsFor('turn/started')).toHaveLength(0)
+  })
+
+  it('still suppresses turn/completed from a registered collab child thread', () => {
+    notify(manager, context, 'turn/started', { threadId: 'T', turn: { id: 't1', status: 'inProgress' } })
+    notify(manager, context, 'item/started', {
+      threadId: 'T',
+      turnId: 't1',
+      item: { id: 'i1', type: 'collabAgentToolCall', receiverThreadIds: ['C'] }
+    })
+
+    notify(manager, context, 'turn/completed', { threadId: 'C', turn: { id: 'c9', status: 'completed' } })
+
+    expect(context.session.status).toBe('running')
+    expect(context.session.activeTurnId).toBe('t1')
+    expect(eventsFor('turn/completed')).toHaveLength(0)
+  })
+
+  it('drops a stale turn/completed whose turn id does not match the active turn', () => {
+    notify(manager, context, 'turn/started', { threadId: 'T', turn: { id: 't2', status: 'inProgress' } })
+
+    notify(manager, context, 'turn/completed', { threadId: 'T', turn: { id: 't1', status: 'completed' } })
+    expect(context.session.status).toBe('running')
+    expect(context.session.activeTurnId).toBe('t2')
+    expect(eventsFor('turn/completed')).toHaveLength(0)
+
+    notify(manager, context, 'turn/completed', { threadId: 'T', turn: { id: 't2', status: 'completed' } })
+    expect(context.session.status).toBe('ready')
+    expect(context.session.activeTurnId).toBeNull()
+    expect(eventsFor('turn/completed')).toHaveLength(1)
+  })
+
+  it('accepts turn/completed when no active turn is tracked (interrupt flow)', () => {
+    context = createContext({ status: 'running', activeTurnId: null })
+
+    notify(manager, context, 'turn/completed', { threadId: 'T', turn: { id: 't1', status: 'interrupted' } })
+
+    expect(context.session.status).toBe('ready')
+    expect(eventsFor('turn/completed')).toHaveLength(1)
+  })
+
+  it('marks the session as error on a matching failed turn/completed', () => {
+    notify(manager, context, 'turn/started', { threadId: 'T', turn: { id: 't1', status: 'inProgress' } })
+
+    notify(manager, context, 'turn/completed', { threadId: 'T', turn: { id: 't1', status: 'failed' } })
+
+    expect(context.session.status).toBe('error')
+    expect(context.session.activeTurnId).toBeNull()
+    expect(eventsFor('turn/completed')).toHaveLength(1)
+  })
+
+  it('tracks goal status from thread/goal/updated and clears it on thread/goal/cleared', () => {
+    notify(manager, context, 'thread/goal/updated', {
+      threadId: 'T',
+      turnId: 't1',
+      goal: {
+        threadId: 'T',
+        objective: 'ship it',
+        status: 'active',
+        tokenBudget: null,
+        tokensUsed: 0,
+        timeUsedSeconds: 0,
+        createdAt: 0,
+        updatedAt: 0
+      }
+    })
+
+    expect(context.session.goalStatus).toBe('active')
+    expect(eventsFor('thread/goal/updated')).toHaveLength(1)
+
+    notify(manager, context, 'thread/goal/cleared', { threadId: 'T' })
+    expect(context.session.goalStatus).toBeNull()
+  })
+
+  it('ignores goal updates from foreign threads', () => {
+    notify(manager, context, 'thread/goal/updated', {
+      threadId: 'C-foreign',
+      turnId: null,
+      goal: {
+        threadId: 'C-foreign',
+        objective: 'child goal',
+        status: 'active',
+        tokenBudget: null,
+        tokensUsed: 0,
+        timeUsedSeconds: 0,
+        createdAt: 0,
+        updatedAt: 0
+      }
+    })
+
+    expect(context.session.goalStatus).toBeNull()
+  })
+
+  it('tracks goal status through the thread goal RPC helpers', async () => {
+    ;(manager as unknown as { sessions: Map<string, CodexSessionContext> }).sessions.set(
+      'T',
+      context
+    )
+    const sendRequest = vi
+      .fn()
+      .mockResolvedValueOnce({ goal: { status: 'active' } })
+      .mockResolvedValueOnce({ goal: { status: 'complete' } })
+      .mockResolvedValueOnce({ cleared: true })
+    ;(manager as unknown as { sendRequest: typeof sendRequest }).sendRequest = sendRequest
+
+    await manager.setThreadGoal('T', { objective: 'ship it' })
+    expect(context.session.goalStatus).toBe('active')
+
+    await manager.getThreadGoal('T')
+    expect(context.session.goalStatus).toBe('complete')
+
+    await manager.clearThreadGoal('T')
+    expect(context.session.goalStatus).toBeNull()
+  })
+
+  it('still forwards non-lifecycle notifications from foreign threads, stamped as child events', () => {
+    notify(manager, context, 'turn/started', { threadId: 'T', turn: { id: 't1', status: 'inProgress' } })
+
+    notify(manager, context, 'item/agentMessage/delta', { threadId: 'C', itemId: 'i1', delta: 'hi' })
+
+    const deltas = eventsFor('item/agentMessage/delta')
+    expect(deltas).toHaveLength(1)
+    expect(deltas[0].childThreadId).toBe('C')
+    expect(context.session.status).toBe('running')
+  })
+})

--- a/src/main/services/__tests__/codex-event-mapper.test.ts
+++ b/src/main/services/__tests__/codex-event-mapper.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CodexManagerEvent } from '../codex-app-server-manager'
+import { mapCodexEventToStreamEvents } from '../codex-event-mapper'
+
+function makeEvent(overrides: Partial<CodexManagerEvent>): CodexManagerEvent {
+  return {
+    id: 'evt-1',
+    kind: 'notification',
+    provider: 'codex',
+    threadId: 'T',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    method: 'turn/completed',
+    ...overrides
+  }
+}
+
+const statusTypes = (events: ReturnType<typeof mapCodexEventToStreamEvents>): string[] =>
+  events
+    .filter((event) => event.type === 'session.status')
+    .map((event) => event.statusPayload?.type ?? '')
+
+describe('mapCodexEventToStreamEvents turn lifecycle thread scoping', () => {
+  it('emits idle for turn/completed on the session thread', () => {
+    const events = mapCodexEventToStreamEvents(
+      makeEvent({ payload: { threadId: 'T', turn: { id: 't1', status: 'completed' } } }),
+      'hive-1'
+    )
+
+    expect(statusTypes(events)).toEqual(['idle'])
+  })
+
+  it('emits nothing for turn/completed from a foreign thread', () => {
+    const events = mapCodexEventToStreamEvents(
+      makeEvent({ payload: { threadId: 'C', turn: { id: 'c1', status: 'completed' } } }),
+      'hive-1'
+    )
+
+    expect(events).toEqual([])
+  })
+
+  it('still emits idle when the payload carries no threadId (legacy shape)', () => {
+    const events = mapCodexEventToStreamEvents(
+      makeEvent({ payload: { turn: { id: 't1', status: 'completed' } } }),
+      'hive-1'
+    )
+
+    expect(statusTypes(events)).toEqual(['idle'])
+  })
+
+  it('emits busy for turn/started on the session thread', () => {
+    const events = mapCodexEventToStreamEvents(
+      makeEvent({
+        method: 'turn/started',
+        payload: { threadId: 'T', turn: { id: 't1', status: 'inProgress' } }
+      }),
+      'hive-1'
+    )
+
+    expect(statusTypes(events)).toEqual(['busy'])
+  })
+
+  it('emits nothing for turn/started from a foreign thread', () => {
+    const events = mapCodexEventToStreamEvents(
+      makeEvent({
+        method: 'turn/started',
+        payload: { threadId: 'C', turn: { id: 'c1', status: 'inProgress' } }
+      }),
+      'hive-1'
+    )
+
+    expect(events).toEqual([])
+  })
+
+  it('emits session.error plus idle for a failed turn on the session thread', () => {
+    const events = mapCodexEventToStreamEvents(
+      makeEvent({
+        payload: {
+          threadId: 'T',
+          turn: { id: 't1', status: 'failed', error: { message: 'boom' } }
+        }
+      }),
+      'hive-1'
+    )
+
+    expect(events.some((event) => event.type === 'session.error')).toBe(true)
+    expect(statusTypes(events)).toEqual(['idle'])
+  })
+})

--- a/src/main/services/__tests__/codex-implementer-goal-idle.test.ts
+++ b/src/main/services/__tests__/codex-implementer-goal-idle.test.ts
@@ -1,0 +1,380 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockAgentPublish } = vi.hoisted(() => ({
+  mockAgentPublish: vi.fn()
+}))
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('../agent-event-bus', () => ({
+  agentEventBus: { publish: mockAgentPublish }
+}))
+
+vi.mock('../codex-app-server-manager', () => ({
+  CodexAppServerManager: class {
+    on = vi.fn()
+  }
+}))
+
+vi.mock('../notification-service', () => ({
+  notificationService: { shouldNotifyWhenWindowUnfocused: vi.fn(() => false) }
+}))
+
+vi.mock('../codex-session-title', () => ({
+  generateCodexSessionTitle: vi.fn()
+}))
+
+vi.mock('../git-service', () => ({
+  autoRenameWorktreeBranch: vi.fn()
+}))
+
+vi.mock('../worktree-events', () => ({
+  emitWorktreeBranchRenamed: vi.fn()
+}))
+
+import { CodexImplementer, type CodexSessionState } from '../codex-implementer'
+import type { CodexManagerEvent, CodexProviderSession } from '../codex-app-server-manager'
+import type { OpenCodeStreamEvent } from '@shared/types/opencode'
+
+function createSession(overrides: Partial<CodexSessionState> = {}): CodexSessionState {
+  return {
+    threadId: 'thread-1',
+    hiveSessionId: 'hive-session-1',
+    worktreePath: '/repo',
+    status: 'ready',
+    messages: [],
+    pendingHitlRequestIds: new Set(),
+    liveAssistantDraft: null,
+    currentTurnId: null,
+    currentAssistantMessageId: null,
+    revertMessageID: null,
+    revertDiff: null,
+    titleGenerated: true,
+    titleGenerationStarted: true,
+    persistDebounceTimer: null,
+    goalIdleFallbackTimer: null,
+    ...overrides
+  }
+}
+
+function installSession(impl: CodexImplementer, session: CodexSessionState): void {
+  ;(impl as unknown as { sessions: Map<string, CodexSessionState> }).sessions.set(
+    `${session.worktreePath}::${session.threadId}`,
+    session
+  )
+}
+
+interface ManagerMock {
+  session: Partial<CodexProviderSession>
+  listeners: Array<(event: CodexManagerEvent) => void>
+  sendTurn: ReturnType<typeof vi.fn>
+}
+
+function installManager(
+  impl: CodexImplementer,
+  session: Partial<CodexProviderSession>
+): ManagerMock {
+  const mock: ManagerMock = {
+    session,
+    listeners: [],
+    sendTurn: vi.fn(async () => ({ turnId: 't1', threadId: 'thread-1' }))
+  }
+  ;(impl as unknown as { manager: unknown }).manager = {
+    getSession: vi.fn(() => mock.session),
+    on: vi.fn((_event: string, listener: (event: CodexManagerEvent) => void) => {
+      mock.listeners.push(listener)
+    }),
+    removeListener: vi.fn(),
+    sendTurn: mock.sendTurn
+  }
+  return mock
+}
+
+function makeManagerEvent(overrides: Partial<CodexManagerEvent> = {}): CodexManagerEvent {
+  return {
+    id: `evt-${Math.random().toString(36).slice(2)}`,
+    kind: 'notification',
+    provider: 'codex',
+    threadId: 'thread-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    method: 'turn/completed',
+    payload: { threadId: 'thread-1', turn: { id: 't1', status: 'completed' } },
+    ...overrides
+  }
+}
+
+function forward(impl: CodexImplementer, session: CodexSessionState, event: CodexManagerEvent): boolean {
+  return (
+    impl as unknown as {
+      forwardAutonomousStreamEvent: (s: CodexSessionState, e: CodexManagerEvent) => boolean
+    }
+  ).forwardAutonomousStreamEvent(session, event)
+}
+
+function handleManagerEvent(impl: CodexImplementer, event: CodexManagerEvent): void {
+  ;(impl as unknown as { handleManagerEvent: (e: CodexManagerEvent) => void }).handleManagerEvent(
+    event
+  )
+}
+
+const publishedEvents = (): OpenCodeStreamEvent[] =>
+  mockAgentPublish.mock.calls.map(([event]) => event as OpenCodeStreamEvent)
+
+const publishedStatuses = (type: string): OpenCodeStreamEvent[] =>
+  publishedEvents().filter(
+    (event) => event.type === 'session.status' && event.statusPayload?.type === type
+  )
+
+describe('CodexImplementer goal-aware idle suppression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('forwards idle for an autonomous turn/completed when no goal is active', () => {
+    const impl = new CodexImplementer()
+    const session = createSession()
+    installManager(impl, { status: 'ready', goalStatus: null })
+
+    forward(impl, session, makeManagerEvent())
+
+    expect(publishedStatuses('idle')).toHaveLength(1)
+    expect(session.goalIdleFallbackTimer).toBeNull()
+  })
+
+  it('suppresses idle while a goal is active but still forwards usage, and arms the fallback', () => {
+    const impl = new CodexImplementer()
+    const session = createSession()
+    installManager(impl, { status: 'ready', goalStatus: 'active' })
+
+    forward(
+      impl,
+      session,
+      makeManagerEvent({
+        payload: {
+          threadId: 'thread-1',
+          turn: { id: 't1', status: 'completed' },
+          usage: { inputTokens: 10, outputTokens: 5 }
+        }
+      })
+    )
+
+    expect(publishedStatuses('idle')).toHaveLength(0)
+    expect(publishedEvents().some((event) => event.type === 'message.updated')).toBe(true)
+    expect(session.goalIdleFallbackTimer).not.toBeNull()
+  })
+
+  it('does not suppress idle for a failed turn under an active goal', () => {
+    const impl = new CodexImplementer()
+    const session = createSession()
+    installManager(impl, { status: 'ready', goalStatus: 'active' })
+
+    forward(
+      impl,
+      session,
+      makeManagerEvent({
+        payload: {
+          threadId: 'thread-1',
+          turn: { id: 't1', status: 'failed', error: { message: 'boom' } }
+        }
+      })
+    )
+
+    expect(publishedEvents().some((event) => event.type === 'session.error')).toBe(true)
+    expect(publishedStatuses('idle')).toHaveLength(1)
+    expect(session.goalIdleFallbackTimer).toBeNull()
+  })
+
+  it('cancels the fallback when a continuation turn starts', () => {
+    const impl = new CodexImplementer()
+    const session = createSession()
+    installManager(impl, { status: 'ready', goalStatus: 'active' })
+
+    forward(impl, session, makeManagerEvent())
+    expect(session.goalIdleFallbackTimer).not.toBeNull()
+
+    forward(
+      impl,
+      session,
+      makeManagerEvent({
+        method: 'turn/started',
+        payload: { threadId: 'thread-1', turn: { id: 't2', status: 'inProgress' } }
+      })
+    )
+
+    expect(session.goalIdleFallbackTimer).toBeNull()
+    expect(publishedStatuses('busy')).toHaveLength(1)
+
+    vi.advanceTimersByTime(60_000)
+    expect(publishedStatuses('idle')).toHaveLength(0)
+  })
+
+  it('emits idle from the fallback when no continuation turn arrives and the session is ready', () => {
+    const impl = new CodexImplementer()
+    const session = createSession()
+    installManager(impl, { status: 'ready', goalStatus: 'active' })
+
+    forward(impl, session, makeManagerEvent())
+    expect(publishedStatuses('idle')).toHaveLength(0)
+
+    vi.advanceTimersByTime(15_000)
+
+    expect(publishedStatuses('idle')).toHaveLength(1)
+    expect(session.status).toBe('ready')
+  })
+
+  it('does not emit idle from the fallback while the manager session is still running', () => {
+    const impl = new CodexImplementer()
+    const session = createSession()
+    const manager = installManager(impl, { status: 'ready', goalStatus: 'active' })
+
+    forward(impl, session, makeManagerEvent())
+    manager.session = { status: 'running', goalStatus: 'active' }
+
+    vi.advanceTimersByTime(60_000)
+
+    expect(publishedStatuses('idle')).toHaveLength(0)
+  })
+
+  it('emits idle exactly once when a terminal goal update lands after a suppressed completion', () => {
+    const impl = new CodexImplementer()
+    const session = createSession()
+    installSession(impl, session)
+    installManager(impl, { status: 'ready', goalStatus: 'active' })
+
+    forward(impl, session, makeManagerEvent())
+    expect(publishedStatuses('idle')).toHaveLength(0)
+
+    handleManagerEvent(
+      impl,
+      makeManagerEvent({
+        method: 'thread/goal/updated',
+        payload: {
+          threadId: 'thread-1',
+          turnId: 't1',
+          goal: {
+            threadId: 'thread-1',
+            objective: 'ship it',
+            status: 'complete',
+            tokenBudget: null,
+            tokensUsed: 0,
+            timeUsedSeconds: 0,
+            createdAt: 0,
+            updatedAt: 0
+          }
+        }
+      })
+    )
+
+    expect(publishedStatuses('idle')).toHaveLength(1)
+    expect(session.goalIdleFallbackTimer).toBeNull()
+
+    vi.advanceTimersByTime(60_000)
+    expect(publishedStatuses('idle')).toHaveLength(1)
+  })
+
+  it('defers idle in the prompt path while a goal is active', async () => {
+    const impl = new CodexImplementer()
+    const session = createSession()
+    installSession(impl, session)
+    const manager = installManager(impl, { status: 'ready', goalStatus: 'active' })
+
+    await (
+      impl as unknown as {
+        runUserTurn: (
+          s: CodexSessionState,
+          worktreePath: string,
+          agentSessionId: string,
+          text: string,
+          turnInput: unknown[]
+        ) => Promise<void>
+      }
+    ).runUserTurn(session, '/repo', 'thread-1', 'do it', [
+      { type: 'text', text: 'do it', text_elements: [] }
+    ])
+
+    const completion = makeManagerEvent()
+    for (const listener of [...manager.listeners]) {
+      listener(completion)
+    }
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(publishedStatuses('idle')).toHaveLength(0)
+    expect(session.goalIdleFallbackTimer).not.toBeNull()
+  })
+
+  it('ignores a turn/completed whose payload belongs to another thread in the prompt path', async () => {
+    const impl = new CodexImplementer()
+    const session = createSession()
+    installSession(impl, session)
+    const manager = installManager(impl, { status: 'running', goalStatus: null })
+
+    await (
+      impl as unknown as {
+        runUserTurn: (
+          s: CodexSessionState,
+          worktreePath: string,
+          agentSessionId: string,
+          text: string,
+          turnInput: unknown[]
+        ) => Promise<void>
+      }
+    ).runUserTurn(session, '/repo', 'thread-1', 'do it', [
+      { type: 'text', text: 'do it', text_elements: [] }
+    ])
+
+    const foreignCompletion = makeManagerEvent({
+      payload: { threadId: 'C-child', turn: { id: 'c1', status: 'completed' } }
+    })
+    for (const listener of [...manager.listeners]) {
+      listener(foreignCompletion)
+    }
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(publishedStatuses('idle')).toHaveLength(0)
+    expect(session.status).toBe('running')
+
+    const completion = makeManagerEvent()
+    for (const listener of [...manager.listeners]) {
+      listener(completion)
+    }
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(publishedStatuses('idle')).toHaveLength(1)
+  })
+
+  it('emits idle in the prompt path when no goal is active', async () => {
+    const impl = new CodexImplementer()
+    const session = createSession()
+    installSession(impl, session)
+    const manager = installManager(impl, { status: 'ready', goalStatus: null })
+
+    await (
+      impl as unknown as {
+        runUserTurn: (
+          s: CodexSessionState,
+          worktreePath: string,
+          agentSessionId: string,
+          text: string,
+          turnInput: unknown[]
+        ) => Promise<void>
+      }
+    ).runUserTurn(session, '/repo', 'thread-1', 'do it', [
+      { type: 'text', text: 'do it', text_elements: [] }
+    ])
+
+    const completion = makeManagerEvent()
+    for (const listener of [...manager.listeners]) {
+      listener(completion)
+    }
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(publishedStatuses('idle')).toHaveLength(1)
+  })
+})

--- a/src/main/services/__tests__/codex-implementer-refresh.test.ts
+++ b/src/main/services/__tests__/codex-implementer-refresh.test.ts
@@ -47,6 +47,7 @@ function createSession(overrides: Partial<CodexSessionState> = {}): CodexSession
     titleGenerated: true,
     titleGenerationStarted: true,
     persistDebounceTimer: null,
+    goalIdleFallbackTimer: null,
     ...overrides
   }
 }

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -104,6 +104,7 @@ export interface CodexProviderSession {
   model: string | null
   activeTurnId: string | null
   resumeCursor: string | null
+  goalStatus: ThreadGoalStatus | null
   createdAt: string
   updatedAt: string
   error?: string
@@ -443,6 +444,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         model: options.model ?? null,
         activeTurnId: null,
         resumeCursor: null,
+        goalStatus: null,
         createdAt: now,
         updatedAt: now
       }
@@ -813,21 +815,35 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       params.tokenBudget = input.tokenBudget ?? null
     }
 
-    return this.sendRequest<CodexThreadGoalSetResponse>(context, 'thread/goal/set', params)
+    const response = await this.sendRequest<CodexThreadGoalSetResponse>(
+      context,
+      'thread/goal/set',
+      params
+    )
+    this.updateSession(context, { goalStatus: response.goal.status })
+    return response
   }
 
   async getThreadGoal(threadId: string): Promise<CodexThreadGoalGetResponse> {
     const context = this.getSessionContextForThreadRpc(threadId, 'getThreadGoal')
-    return this.sendRequest<CodexThreadGoalGetResponse>(context, 'thread/goal/get', {
-      threadId: context.session.threadId
-    })
+    const response = await this.sendRequest<CodexThreadGoalGetResponse>(
+      context,
+      'thread/goal/get',
+      { threadId: context.session.threadId }
+    )
+    this.updateSession(context, { goalStatus: response.goal?.status ?? null })
+    return response
   }
 
   async clearThreadGoal(threadId: string): Promise<CodexThreadGoalClearResponse> {
     const context = this.getSessionContextForThreadRpc(threadId, 'clearThreadGoal')
-    return this.sendRequest<CodexThreadGoalClearResponse>(context, 'thread/goal/clear', {
-      threadId: context.session.threadId
-    })
+    const response = await this.sendRequest<CodexThreadGoalClearResponse>(
+      context,
+      'thread/goal/clear',
+      { threadId: context.session.threadId }
+    )
+    this.updateSession(context, { goalStatus: null })
+    return response
   }
 
   async getGoalsFeatureStatus(threadId: string): Promise<CodexGoalsFeatureStatus> {
@@ -1171,13 +1187,35 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     // Track collab subagent spawns (must run before child detection)
     this.rememberCollabReceiverTurns(context, notification.params, route.turnId)
 
-    // Detect if this notification is from a child thread
+    // Detect if this notification is from a child thread. Registered collab
+    // subagents are known via collabReceiverTurns, but registration can race
+    // the child's own lifecycle notifications — so any notification carrying a
+    // threadId other than the session's parent thread is also treated as child.
+    const providerConversationId = this.readProviderConversationId(notification.params)
+    const parentThreadId = context.session.threadId
+    const isForeignThread =
+      parentThreadId !== null &&
+      providerConversationId !== undefined &&
+      providerConversationId !== parentThreadId
+
     const childParentTurnId = this.readChildParentTurnId(context, notification.params)
-    const isChildConversation = childParentTurnId !== undefined
+    const isChildConversation = childParentTurnId !== undefined || isForeignThread
 
     // Suppress lifecycle notifications from child threads
     if (isChildConversation && this.shouldSuppressChildConversationNotification(notification.method)) {
       return
+    }
+
+    // Drop stale completions: only the active turn may settle the session.
+    // A missing activeTurnId (interrupt/resume) accepts any completion.
+    if (notification.method === 'turn/completed' && !isChildConversation) {
+      const completedTurnId = notification.params.turn.id
+      const activeTurnId = context.session.activeTurnId
+      if (activeTurnId !== null && completedTurnId !== activeTurnId) {
+        log.warn('Dropping stale turn/completed', { completedTurnId, activeTurnId })
+        logCodexLifecycleEvent('turn/completed/stale', { completedTurnId, activeTurnId })
+        return
+      }
     }
 
     // Extract textDelta for streaming text notifications (matches t3code pattern)
@@ -1185,8 +1223,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       notification.method === 'item/agentMessage/delta'
         ? asString(asObject(notification.params)?.delta)
         : undefined
-
-    const providerConversationId = this.readProviderConversationId(notification.params)
 
     // Emit event — child events get parent's turnId for proper attribution
     this.emitEvent({
@@ -1224,6 +1260,18 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         status: status === 'failed' ? 'error' : 'ready',
         activeTurnId: null
       })
+      return
+    }
+
+    if (notification.method === 'thread/goal/updated') {
+      if (isChildConversation) return
+      this.updateSession(context, { goalStatus: notification.params.goal.status })
+      return
+    }
+
+    if (notification.method === 'thread/goal/cleared') {
+      if (isChildConversation) return
+      this.updateSession(context, { goalStatus: null })
       return
     }
   }

--- a/src/main/services/codex-event-mapper.ts
+++ b/src/main/services/codex-event-mapper.ts
@@ -181,6 +181,14 @@ interface TurnCompletedInfo {
   cost?: number
 }
 
+// Busy/idle must never leak across threads: a turn lifecycle notification
+// whose own threadId differs from the session's parent thread (stamped on the
+// manager event) belongs to a collab subagent, not this session.
+function isForeignTurnLifecycleEvent(event: CodexManagerEvent): boolean {
+  const payloadThreadId = asString(asObject(event.payload)?.threadId)
+  return Boolean(payloadThreadId && event.threadId && payloadThreadId !== event.threadId)
+}
+
 function extractTurnCompletedInfo(event: CodexManagerEvent): TurnCompletedInfo {
   // ── Typed path: TurnCompletedNotification with Turn object ──
   const typed = event.payload as TurnCompletedNotification | undefined
@@ -668,6 +676,7 @@ function mapCodexEventToStreamEventsInner(
 
   // ── Turn started ──────────────────────────────────────────────
   if (method === 'turn/started') {
+    if (isForeignTurnLifecycleEvent(event)) return []
     return [
       {
         type: 'session.status',
@@ -706,6 +715,7 @@ function mapCodexEventToStreamEventsInner(
 
   // ── Turn completed ────────────────────────────────────────────
   if (method === 'turn/completed') {
+    if (isForeignTurnLifecycleEvent(event)) return []
     const info = extractTurnCompletedInfo(event)
     const events: OpenCodeStreamEvent[] = []
 

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -44,6 +44,9 @@ const log = createLogger({ component: 'CodexImplementer' })
 // Balances write coalescing during rapid streaming against data freshness for crash recovery.
 const PERSIST_DEBOUNCE_MS = 2000
 const CODEX_TURN_TIMEOUT_MS = 7 * 24 * 60 * 60 * 1000
+// Safety net for goal runs: if a suppressed turn/completed is never followed by
+// a continuation turn/started or a terminal goal update, emit idle anyway.
+const CODEX_GOAL_IDLE_FALLBACK_MS = 15_000
 const CODEX_GOAL_COMMAND = {
   name: 'goal',
   description: 'Set or manage a persistent Codex goal',
@@ -94,6 +97,7 @@ export interface CodexSessionState {
   titleGenerated: boolean
   titleGenerationStarted: boolean
   persistDebounceTimer: ReturnType<typeof setTimeout> | null
+  goalIdleFallbackTimer: ReturnType<typeof setTimeout> | null
 }
 
 interface CodexLiveToolState {
@@ -441,6 +445,31 @@ export class CodexImplementer implements AgentSdkImplementer {
       return
     }
 
+    // A terminal goal update resolves a previously suppressed idle: the goal
+    // run is over, so no continuation turn will arrive to cancel the fallback.
+    // Read the status from the event payload — the manager emits events before
+    // updating its own session state, so getSession() would still be stale here.
+    if (
+      targetSession &&
+      event.kind === 'notification' &&
+      (event.method === 'thread/goal/updated' || event.method === 'thread/goal/cleared')
+    ) {
+      const goalStatus = asString(asObject(asObject(event.payload)?.goal)?.status)
+      const goalRunOver =
+        event.method === 'thread/goal/cleared' ||
+        (goalStatus !== undefined && goalStatus !== 'active')
+      if (
+        goalRunOver &&
+        targetSession.goalIdleFallbackTimer &&
+        this.manager.getSession(targetSession.threadId)?.status !== 'running'
+      ) {
+        this.clearGoalIdleFallback(targetSession)
+        targetSession.status = 'ready'
+        this.emitStatus(targetSession.hiveSessionId, 'idle')
+      }
+      // Fall through — the goal event still forwards to the renderer below.
+    }
+
     // Goal continuation turns are started internally by the Codex app-server,
     // so they do not pass through prompt()'s scoped streaming listener.
     // Forward those global notifications through the same renderer/canonical
@@ -594,7 +623,8 @@ export class CodexImplementer implements AgentSdkImplementer {
       revertDiff: null,
       titleGenerated: false,
       titleGenerationStarted: false,
-      persistDebounceTimer: null
+      persistDebounceTimer: null,
+      goalIdleFallbackTimer: null
     }
     this.sessions.set(key, state)
 
@@ -668,7 +698,8 @@ export class CodexImplementer implements AgentSdkImplementer {
         revertDiff: null,
         titleGenerated: true,
         titleGenerationStarted: true,
-        persistDebounceTimer: null
+        persistDebounceTimer: null,
+        goalIdleFallbackTimer: null
       }
       this.sessions.set(newKey, state)
 
@@ -677,6 +708,10 @@ export class CodexImplementer implements AgentSdkImplementer {
       // Fire-and-forget: hydrate token usage so the context bar shows
       // accumulated usage from previous turns, not 0/200k.
       this.hydrateTokenUsageFromThread(state).catch(() => {})
+
+      // Fire-and-forget: hydrate goal status (updates the manager session as a
+      // side effect) so idle suppression works for resumed goal threads.
+      this.manager.getThreadGoal(threadId).catch(() => {})
 
       return {
         success: true,
@@ -706,6 +741,7 @@ export class CodexImplementer implements AgentSdkImplementer {
 
     // Flush any pending debounced persist before removing the session
     this.flushPendingPersist(session)
+    this.clearGoalIdleFallback(session)
 
     // Clean up local state
     this.sessions.delete(key)
@@ -727,6 +763,7 @@ export class CodexImplementer implements AgentSdkImplementer {
         clearTimeout(session.persistDebounceTimer)
         session.persistDebounceTimer = null
       }
+      this.clearGoalIdleFallback(session)
     }
 
     // Clear local state
@@ -861,6 +898,7 @@ export class CodexImplementer implements AgentSdkImplementer {
 
     // Emit busy status
     session.status = 'running'
+    this.clearGoalIdleFallback(session)
     this.emitStatus(session.hiveSessionId, 'busy')
 
     log.info('Prompt: starting', {
@@ -1025,16 +1063,20 @@ export class CodexImplementer implements AgentSdkImplementer {
         }
       }
 
-      // Detect turn completion and whether it failed
+      // Detect turn completion and whether it failed. A completion whose own
+      // threadId belongs to another thread (collab subagent) must not settle
+      // this session's turn.
       if (event.method === 'turn/completed') {
-        turnCompleted = true
         const typed = event.payload as TurnCompletedNotification | undefined
-        completedTurnId = event.turnId ?? typed?.turn?.id
-        const status: string | undefined =
-          typed?.turn?.status ??
-          ((event.payload as Record<string, unknown> | undefined)?.state as string | undefined)
-        if (status === 'failed') {
-          turnFailed = true
+        if (!typed?.threadId || typed.threadId === session.threadId) {
+          turnCompleted = true
+          completedTurnId = event.turnId ?? typed?.turn?.id
+          const status: string | undefined =
+            typed?.turn?.status ??
+            ((event.payload as Record<string, unknown> | undefined)?.state as string | undefined)
+          if (status === 'failed') {
+            turnFailed = true
+          }
         }
       }
 
@@ -1188,7 +1230,13 @@ export class CodexImplementer implements AgentSdkImplementer {
           }
 
           session.status = turnFailed ? 'error' : 'ready'
-          this.emitStatus(session.hiveSessionId, 'idle')
+          if (!turnFailed && this.manager.getSession(session.threadId)?.goalStatus === 'active') {
+            // A goal continuation turn is expected; defer idle to the fallback
+            // (cancelled by the next turn/started) or a terminal goal update.
+            this.armGoalIdleFallback(session)
+          } else {
+            this.emitStatus(session.hiveSessionId, 'idle')
+          }
 
           log.info('Prompt: completed', {
             worktreePath,
@@ -1333,6 +1381,7 @@ export class CodexImplementer implements AgentSdkImplementer {
     session.liveAssistantDraft = null
     session.currentTurnId = null
     session.currentAssistantMessageId = null
+    this.clearGoalIdleFallback(session)
     this.flushPendingPersist(session)
     this.persistCanonicalMessages(session)
     this.emitStatus(session.hiveSessionId, 'idle')
@@ -2472,6 +2521,27 @@ export class CodexImplementer implements AgentSdkImplementer {
     })
   }
 
+  // A goal-continuation turn is expected after this suppressed completion; if
+  // it never starts and no terminal goal update arrives, this timer ends the
+  // run so the session cannot stay "working" forever.
+  private armGoalIdleFallback(session: CodexSessionState): void {
+    this.clearGoalIdleFallback(session)
+    session.goalIdleFallbackTimer = setTimeout(() => {
+      session.goalIdleFallbackTimer = null
+      if (this.manager.getSession(session.threadId)?.status !== 'running') {
+        session.status = 'ready'
+        this.emitStatus(session.hiveSessionId, 'idle')
+      }
+    }, CODEX_GOAL_IDLE_FALLBACK_MS)
+  }
+
+  private clearGoalIdleFallback(session: CodexSessionState): void {
+    if (session.goalIdleFallbackTimer) {
+      clearTimeout(session.goalIdleFallbackTimer)
+      session.goalIdleFallbackTimer = null
+    }
+  }
+
   private forwardAutonomousStreamEvent(
     session: CodexSessionState,
     event: CodexManagerEvent
@@ -2495,8 +2565,21 @@ export class CodexImplementer implements AgentSdkImplementer {
 
     if (event.method === 'turn/started') {
       session.status = 'running'
+      this.clearGoalIdleFallback(session)
       this.resetLiveAssistantDraft(session)
     }
+
+    // Intermediate goal-continuation turns complete while the goal is still
+    // active; suppress their idle so the session doesn't read as finished.
+    const turnStatus: string | undefined =
+      event.method === 'turn/completed'
+        ? ((event.payload as TurnCompletedNotification | undefined)?.turn?.status ??
+          ((event.payload as Record<string, unknown> | undefined)?.state as string | undefined))
+        : undefined
+    const suppressIdle =
+      event.method === 'turn/completed' &&
+      turnStatus !== 'failed' &&
+      this.manager.getSession(session.threadId)?.goalStatus === 'active'
 
     if (
       contentStreamKindFromMethod(event.method) ||
@@ -2519,6 +2602,13 @@ export class CodexImplementer implements AgentSdkImplementer {
     }
 
     for (const streamEvent of streamEvents) {
+      if (
+        suppressIdle &&
+        streamEvent.type === 'session.status' &&
+        streamEvent.statusPayload?.type === 'idle'
+      ) {
+        continue
+      }
       const streamData = asObject(streamEvent.data)
       const part = asObject(streamData?.part)
       const state = asObject(part?.state)
@@ -2547,11 +2637,6 @@ export class CodexImplementer implements AgentSdkImplementer {
     }
 
     if (event.method === 'turn/completed') {
-      const typed = event.payload as TurnCompletedNotification | undefined
-      const status: string | undefined =
-        typed?.turn?.status ??
-        ((event.payload as Record<string, unknown> | undefined)?.state as string | undefined)
-
       this.flushPendingPersist(session)
       if (session.currentAssistantMessageId) {
         this.persistCanonicalMessages(session)
@@ -2559,7 +2644,10 @@ export class CodexImplementer implements AgentSdkImplementer {
       session.liveAssistantDraft = null
       session.currentTurnId = null
       session.currentAssistantMessageId = null
-      session.status = status === 'failed' ? 'error' : 'ready'
+      session.status = turnStatus === 'failed' ? 'error' : 'ready'
+      if (suppressIdle) {
+        this.armGoalIdleFallback(session)
+      }
     }
 
     return true
@@ -3444,9 +3532,12 @@ export class CodexImplementer implements AgentSdkImplementer {
         resetTimer()
 
         if (event.method === 'turn/completed') {
-          cleanup()
-          resolve()
-          return
+          const payloadThreadId = asString(asObject(event.payload)?.threadId)
+          if (!payloadThreadId || payloadThreadId === session.threadId) {
+            cleanup()
+            resolve()
+            return
+          }
         }
 
         // Only reject on truly fatal errors — not stderr warnings.
@@ -3598,7 +3689,8 @@ export class CodexImplementer implements AgentSdkImplementer {
         revertDiff: null,
         titleGenerated: true,
         titleGenerationStarted: true,
-        persistDebounceTimer: null
+        persistDebounceTimer: null,
+        goalIdleFallbackTimer: null
       }
 
       this.sessions.set(this.getSessionKey(worktreePath, threadId), recovered)


### PR DESCRIPTION
## Summary
- Tighten Codex turn lifecycle handling so busy/idle state is scoped to the active session thread and stale or foreign completions are ignored.
- Track Codex goal status in the app-server manager and propagate goal updates through the implementer to support idle suppression during goal-driven continuation turns.
- Add a fallback idle timer so suppressed goal completions still resolve cleanly if no follow-up turn or terminal goal update arrives.
- Expand test coverage for child-thread filtering, stale completion handling, goal status tracking, and goal-aware idle behavior.

## Testing
- Added Vitest coverage for `CodexAppServerManager` lifecycle guards and goal RPC/session updates.
- Added Vitest coverage for event mapping thread scoping and failed-turn handling.
- Added Vitest coverage for goal-aware idle suppression, fallback timing, and prompt-path behavior in `CodexImplementer`.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent session state and UI busy/idle signaling across collab and goal flows; behavior is heavily tested but regressions could leave sessions stuck busy or flip idle too early.
> 
> **Overview**
> Fixes Codex sessions incorrectly flipping to **idle** or **ready** when collab child threads complete turns, stale completions arrive, or intermediate goal-continuation turns finish while a goal is still **active**.
> 
> **`CodexAppServerManager`** now treats notifications whose `threadId` differs from the parent session as child traffic (including registration races), drops `turn/completed` when the turn id does not match `activeTurnId`, and keeps **`goalStatus`** in sync from goal RPCs and `thread/goal/*` notifications.
> 
> **`mapCodexEventToStreamEvents`** skips busy/idle for foreign-thread `turn/started` / `turn/completed` (legacy payloads without `threadId` still emit idle).
> 
> **`CodexImplementer`** ignores foreign-thread completions in the prompt and wait paths, **suppresses idle** after successful turns when a goal is active, arms a **15s fallback** if no continuation or terminal goal update arrives, and emits idle when goals complete or clear. Resumed threads hydrate goal status via `getThreadGoal`.
> 
> Vitest coverage added for manager lifecycle guards, event mapper thread scoping, and goal-aware idle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffc1ca3dd32c8b8ac52f3eba6db6e33fa6cbf904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->