### PR TITLE
Add create-worktree action to connection worktree dialog

### DIFF
--- a/src/renderer/src/components/connections/ManageConnectionWorktreesDialog.tsx
+++ b/src/renderer/src/components/connections/ManageConnectionWorktreesDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
-import { Loader2, Search, Settings2, GitBranch } from 'lucide-react'
+import { Loader2, Search, Settings2, GitBranch, Plus } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { toast } from '@/lib/toast'
 import {
   Dialog,
   DialogContent,
@@ -31,6 +32,7 @@ interface WorktreeOption {
 interface ProjectGroup {
   projectId: string
   projectName: string
+  projectPath: string
   worktrees: WorktreeOption[]
 }
 
@@ -41,6 +43,8 @@ export function ManageConnectionWorktreesDialog({
 }: ManageConnectionWorktreesDialogProps): React.JSX.Element {
   const projects = useProjectStore((s) => s.projects)
   const worktreesByProject = useWorktreeStore((s) => s.worktreesByProject)
+  const createWorktree = useWorktreeStore((s) => s.createWorktree)
+  const creatingForProjectId = useWorktreeStore((s) => s.creatingForProjectId)
   const connections = useConnectionStore((s) => s.connections)
   const updateConnectionMembers = useConnectionStore((s) => s.updateConnectionMembers)
 
@@ -73,6 +77,7 @@ export function ManageConnectionWorktreesDialog({
       groups.push({
         projectId: project.id,
         projectName: project.name,
+        projectPath: project.path,
         worktrees: activeWorktrees.map((w) => ({
           id: w.id,
           name: w.name,
@@ -140,6 +145,21 @@ export function ManageConnectionWorktreesDialog({
     })
   }, [])
 
+  const handleCreateWorktree = useCallback(
+    async (group: ProjectGroup) => {
+      if (creatingForProjectId) return
+
+      const result = await createWorktree(group.projectId, group.projectPath, group.projectName)
+      if (result.success && result.worktree) {
+        setSelectedIds((prev) => new Set(prev).add(result.worktree!.id))
+        setFilter('')
+      } else {
+        toast.error(`Failed to create worktree: ${result.error || 'Unknown error'}`)
+      }
+    },
+    [creatingForProjectId, createWorktree]
+  )
+
   const handleSave = useCallback(async () => {
     if (selectedIds.size === 0 || !hasChanges) return
     setIsSubmitting(true)
@@ -195,8 +215,23 @@ export function ManageConnectionWorktreesDialog({
               {filteredGroups.map((group) => (
                 <div key={group.projectId}>
                   {/* Project group header */}
-                  <div className="px-3 py-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider bg-muted/30 sticky top-0">
-                    {group.projectName}
+                  <div className="flex items-center justify-between px-3 py-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider bg-muted/30 sticky top-0">
+                    <span className="truncate">{group.projectName}</span>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-5 w-5 p-0 cursor-pointer hover:bg-accent shrink-0"
+                      onClick={() => handleCreateWorktree(group)}
+                      disabled={creatingForProjectId !== null}
+                      title={`Create worktree in ${group.projectName}`}
+                      data-testid={`manage-worktrees-create-${group.projectId}`}
+                    >
+                      {creatingForProjectId === group.projectId ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Plus className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
                   </div>
                   {/* Worktrees in this project */}
                   {group.worktrees.map((wt) => (

--- a/src/renderer/src/components/connections/__tests__/ManageConnectionWorktreesDialog.test.tsx
+++ b/src/renderer/src/components/connections/__tests__/ManageConnectionWorktreesDialog.test.tsx
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('@/api/worktree-api', () => ({
+  worktreeApi: {
+    create: vi.fn()
+  }
+}))
+
+import { worktreeApi } from '@/api/worktree-api'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { ManageConnectionWorktreesDialog } from '../ManageConnectionWorktreesDialog'
+
+function worktree(id: string, projectId: string, name: string): Record<string, unknown> {
+  return {
+    id,
+    project_id: projectId,
+    name,
+    branch_name: `branch-${name}`,
+    path: `/worktrees/${name}`,
+    status: 'active',
+    is_default: false,
+    branch_renamed: 0,
+    last_message_at: null,
+    session_titles: '[]',
+    last_model_provider_id: null,
+    last_model_id: null,
+    last_model_variant: null,
+    attachments: '[]',
+    created_at: '',
+    last_accessed_at: '',
+    github_pr_number: null,
+    github_pr_url: null
+  }
+}
+
+const connection = {
+  id: 'conn-1',
+  name: 'alpha + beta',
+  custom_name: null,
+  status: 'active' as const,
+  path: '/connections/conn-1',
+  color: null,
+  created_at: '',
+  updated_at: '',
+  members: [
+    {
+      id: 'cm-1',
+      connection_id: 'conn-1',
+      worktree_id: 'wt-a1',
+      project_id: 'proj-a',
+      symlink_name: 'alpha',
+      added_at: '',
+      worktree_name: 'wt-a1',
+      worktree_branch: 'branch-wt-a1',
+      worktree_path: '/worktrees/wt-a1',
+      project_name: 'alpha'
+    }
+  ]
+}
+
+describe('ManageConnectionWorktreesDialog create worktree button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useProjectStore.setState({
+      projects: [
+        { id: 'proj-a', name: 'alpha', path: '/proj/a' },
+        { id: 'proj-b', name: 'beta', path: '/proj/b' }
+      ]
+    } as never)
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        ['proj-a', [worktree('wt-a1', 'proj-a', 'wt-a1')]],
+        ['proj-b', [worktree('wt-b1', 'proj-b', 'wt-b1')]]
+      ]),
+      creatingForProjectId: null
+    } as never)
+    useConnectionStore.setState({ connections: [connection] } as never)
+  })
+
+  it('renders a + button next to each project group', () => {
+    render(<ManageConnectionWorktreesDialog connectionId="conn-1" open onOpenChange={() => {}} />)
+
+    expect(screen.getByTestId('manage-worktrees-create-proj-a')).toBeInTheDocument()
+    expect(screen.getByTestId('manage-worktrees-create-proj-b')).toBeInTheDocument()
+  })
+
+  it('creates a worktree for the project, shows it in the list, and checks it', async () => {
+    vi.mocked(worktreeApi.create).mockResolvedValue({
+      success: true,
+      worktree: worktree('wt-new', 'proj-b', 'fresh-worktree')
+    } as never)
+
+    render(<ManageConnectionWorktreesDialog connectionId="conn-1" open onOpenChange={() => {}} />)
+
+    await userEvent.click(screen.getByTestId('manage-worktrees-create-proj-b'))
+
+    expect(worktreeApi.create).toHaveBeenCalledWith({
+      projectId: 'proj-b',
+      projectPath: '/proj/b',
+      projectName: 'beta'
+    })
+
+    // New worktree appears in the list and is selected
+    await waitFor(() =>
+      expect(screen.getByTestId('manage-worktree-option-wt-new')).toBeInTheDocument()
+    )
+    expect(screen.getByTestId('manage-worktree-checkbox-wt-new')).toHaveAttribute(
+      'aria-checked',
+      'true'
+    )
+    // Existing selection is preserved
+    expect(screen.getByTestId('manage-worktree-checkbox-wt-a1')).toHaveAttribute(
+      'aria-checked',
+      'true'
+    )
+  })
+
+  it('does not add a selection when creation fails', async () => {
+    vi.mocked(worktreeApi.create).mockResolvedValue({
+      success: false,
+      error: 'boom'
+    } as never)
+
+    render(<ManageConnectionWorktreesDialog connectionId="conn-1" open onOpenChange={() => {}} />)
+
+    await userEvent.click(screen.getByTestId('manage-worktrees-create-proj-b'))
+
+    await waitFor(() => expect(worktreeApi.create).toHaveBeenCalled())
+    expect(screen.queryByTestId('manage-worktree-option-wt-new')).not.toBeInTheDocument()
+    // Only the original member remains selected
+    expect(screen.getByText('1 worktree selected')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a per-project create-worktree button to the connection worktrees dialog.
- Creates a new worktree from the project path/name, then auto-selects it and clears the filter on success.
- Shows inline loading state while a worktree is being created and surfaces errors with a toast.
- Adds coverage for rendering, successful creation, and failure handling.

## Testing
- Ran/added unit tests for the dialog create-worktree flow.
- Verified the create button renders for each project group.
- Verified a successful create call inserts the new worktree and selects it.
- Verified a failed create call does not add a selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only flow reusing existing worktree creation store logic; no auth or persistence changes beyond normal create/select behavior.
> 
> **Overview**
> **Manage Connection Worktrees** now lets users spin up a worktree for a project without leaving the dialog. Each project group header gets a **+** control that calls `useWorktreeStore.createWorktree` with that project’s id, path, and name.
> 
> On success, the new worktree is **auto-selected** for the connection (existing selections stay), and the filter is cleared so the new row is visible. While creation runs, the matching header shows a spinner and all create buttons are disabled via `creatingForProjectId`. Failures surface through **`toast.error`**.
> 
> `ProjectGroup` now carries **`projectPath`** for the create API. New unit tests cover the + buttons, happy path (list + checkbox), and failed create (no extra selection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b012701031c845dd2d46b62e74caf2d81405304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->