### PR TITLE
Remember last project directory in create dialog

### DIFF
--- a/src/renderer/src/components/projects/AddProjectButton.test.tsx
+++ b/src/renderer/src/components/projects/AddProjectButton.test.tsx
@@ -9,6 +9,16 @@ const mocks = vi.hoisted(() => ({
   addProject: vi.fn()
 }))
 
+const settingsMocks = vi.hoisted(() => {
+  const state = {
+    lastProjectDirectory: null as string | null,
+    updateSetting: vi.fn()
+  }
+  const useSettingsStore = (selector: (s: typeof state) => unknown): unknown => selector(state)
+  useSettingsStore.getState = () => state
+  return { state, useSettingsStore }
+})
+
 const projectApiMocks = vi.hoisted(() => ({
   openDirectoryDialog: vi.fn(),
   initRepository: vi.fn(),
@@ -30,7 +40,8 @@ const toastMocks = vi.hoisted(() => ({
 vi.mock('@/stores', () => ({
   useProjectStore: () => ({
     addProject: mocks.addProject
-  })
+  }),
+  useSettingsStore: settingsMocks.useSettingsStore
 }))
 
 vi.mock('@/api/project-api', () => ({

--- a/src/renderer/src/components/projects/CreateProjectDialog.test.tsx
+++ b/src/renderer/src/components/projects/CreateProjectDialog.test.tsx
@@ -9,6 +9,16 @@ const mocks = vi.hoisted(() => ({
   addProject: vi.fn()
 }))
 
+const settingsMocks = vi.hoisted(() => {
+  const state = {
+    lastProjectDirectory: null as string | null,
+    updateSetting: vi.fn()
+  }
+  const useSettingsStore = (selector: (s: typeof state) => unknown): unknown => selector(state)
+  useSettingsStore.getState = () => state
+  return { state, useSettingsStore }
+})
+
 const projectApiMocks = vi.hoisted(() => ({
   openDirectoryDialog: vi.fn(),
   createProjectFolder: vi.fn()
@@ -22,7 +32,8 @@ const toastMocks = vi.hoisted(() => ({
 vi.mock('@/stores', () => ({
   useProjectStore: () => ({
     addProject: mocks.addProject
-  })
+  }),
+  useSettingsStore: settingsMocks.useSettingsStore
 }))
 
 vi.mock('@/api/project-api', () => ({
@@ -33,6 +44,8 @@ vi.mock('@/lib/toast', () => toastMocks)
 
 beforeEach(() => {
   vi.clearAllMocks()
+  settingsMocks.state.lastProjectDirectory = null
+  settingsMocks.state.updateSetting.mockResolvedValue(undefined)
   mocks.addProject.mockResolvedValue({ success: true })
   projectApiMocks.openDirectoryDialog.mockResolvedValue('/tmp/parent')
   projectApiMocks.createProjectFolder.mockResolvedValue({
@@ -81,6 +94,66 @@ describe('CreateProjectDialog', () => {
     expect(await screen.findByTestId('create-project-error')).toHaveTextContent('already exists')
     expect(mocks.addProject).not.toHaveBeenCalled()
     expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('prefills the location from the last remembered directory', async () => {
+    settingsMocks.state.lastProjectDirectory = '/tmp/remembered'
+    render(<CreateProjectDialog open onOpenChange={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-project-location')).toHaveValue('/tmp/remembered')
+    })
+
+    await userEvent.type(screen.getByTestId('create-project-name-input'), 'my-app')
+    await waitFor(() => {
+      expect(screen.getByTestId('create-project-confirm')).toBeEnabled()
+    })
+    await userEvent.click(screen.getByTestId('create-project-confirm'))
+
+    await waitFor(() => {
+      expect(projectApiMocks.createProjectFolder).toHaveBeenCalledWith('/tmp/remembered', 'my-app')
+    })
+    expect(projectApiMocks.openDirectoryDialog).not.toHaveBeenCalled()
+  })
+
+  it('lets browsing override the remembered directory', async () => {
+    settingsMocks.state.lastProjectDirectory = '/tmp/remembered'
+    render(<CreateProjectDialog open onOpenChange={vi.fn()} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Browse…' }))
+    await waitFor(() => {
+      expect(screen.getByTestId('create-project-location')).toHaveValue('/tmp/parent')
+    })
+  })
+
+  it('remembers the selected directory after a successful create', async () => {
+    render(<CreateProjectDialog open onOpenChange={vi.fn()} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Browse…' }))
+    await userEvent.type(screen.getByTestId('create-project-name-input'), 'my-app')
+    await userEvent.click(screen.getByTestId('create-project-confirm'))
+
+    await waitFor(() => {
+      expect(settingsMocks.state.updateSetting).toHaveBeenCalledWith(
+        'lastProjectDirectory',
+        '/tmp/parent'
+      )
+    })
+  })
+
+  it('does not remember the directory when creation fails', async () => {
+    projectApiMocks.createProjectFolder.mockResolvedValue({
+      success: false,
+      error: 'nope'
+    })
+    render(<CreateProjectDialog open onOpenChange={vi.fn()} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Browse…' }))
+    await userEvent.type(screen.getByTestId('create-project-name-input'), 'my-app')
+    await userEvent.click(screen.getByTestId('create-project-confirm'))
+
+    await screen.findByTestId('create-project-error')
+    expect(settingsMocks.state.updateSetting).not.toHaveBeenCalled()
   })
 
   it('disables Create until both location and name are set', async () => {

--- a/src/renderer/src/components/projects/CreateProjectDialog.tsx
+++ b/src/renderer/src/components/projects/CreateProjectDialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { useProjectStore } from '@/stores'
+import { useProjectStore, useSettingsStore } from '@/stores'
 import { projectToast } from '@/lib/toast'
 import { projectApi } from '@/api/project-api'
 
@@ -31,6 +31,7 @@ export function CreateProjectDialog({
 
   useEffect(() => {
     if (open) {
+      setLocation((prev) => prev ?? useSettingsStore.getState().lastProjectDirectory)
       setName('')
       setError(null)
       setIsCreating(false)
@@ -60,6 +61,8 @@ export function CreateProjectDialog({
         setError(result.error || 'Failed to create project folder.')
         return
       }
+
+      void useSettingsStore.getState().updateSetting('lastProjectDirectory', location)
 
       const addResult = await addProject(result.path)
       if (!addResult.success) {

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -111,6 +111,10 @@ export interface AppSettings {
   // Quick Actions
   lastOpenAction: QuickActionType | null
 
+  // Projects
+  /** Root directory picked the last time a project was created via the plus button. */
+  lastProjectDirectory: string | null
+
   // Favorites
   favoriteModels: string[] // Array of "providerID::modelID" keys
 
@@ -215,6 +219,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   defaultModels: null,
   lastHandoffOverride: null,
   lastOpenAction: null,
+  lastProjectDirectory: null,
   favoriteModels: [],
   customChromeCommand: '',
   modelVariantDefaults: {},
@@ -437,6 +442,7 @@ function extractSettings(state: SettingsState): AppSettings {
     defaultModels: state.defaultModels,
     lastHandoffOverride: state.lastHandoffOverride,
     lastOpenAction: state.lastOpenAction,
+    lastProjectDirectory: state.lastProjectDirectory,
     favoriteModels: state.favoriteModels,
     customChromeCommand: state.customChromeCommand,
     modelVariantDefaults: state.modelVariantDefaults,
@@ -802,6 +808,7 @@ export const useSettingsStore = create<SettingsState>()(
         defaultModels: state.defaultModels,
         lastHandoffOverride: state.lastHandoffOverride,
         lastOpenAction: state.lastOpenAction,
+        lastProjectDirectory: state.lastProjectDirectory,
         favoriteModels: state.favoriteModels,
         customChromeCommand: state.customChromeCommand,
         modelVariantDefaults: state.modelVariantDefaults,


### PR DESCRIPTION
## Summary
- Store the last selected project directory in settings and hydrate it into the create-project dialog when it opens.
- Persist the chosen directory after a successful project creation so the next new project starts from the same location.
- Add tests covering prefill, browse override, successful persistence, and the no-save-on-failure case.

## Testing
- Added/updated Vitest coverage in `CreateProjectDialog.test.tsx` and `AddProjectButton.test.tsx`.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX preference stored in existing settings persistence; no auth or project lifecycle logic beyond the create dialog.
> 
> **Overview**
> Adds a persisted **`lastProjectDirectory`** setting and wires it into the **Create New Project** flow so repeat creates start from the same parent folder.
> 
> When the dialog opens, the location field is hydrated from `useSettingsStore.getState().lastProjectDirectory` (browse still replaces it). After **`createProjectFolder`** succeeds, the chosen parent path is saved via **`updateSetting('lastProjectDirectory', location)`** before the project is added to Hive.
> 
> Vitest mocks **`useSettingsStore`** in **`AddProjectButton.test.tsx`** and **`CreateProjectDialog.test.tsx`**, with new cases for prefill, browse override, save on success, and no save when folder creation fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ecfca60034535db33cd0addd107cf976d600ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->