### PR TITLE
Sort Done by updated_at and disable drag reordering

### DIFF
--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -400,6 +400,18 @@ export function KanbanColumn({
 
   const handleDragOver = useCallback(
     (e: React.DragEvent) => {
+      // Done is date-sorted (newest first): reordering within it is disabled,
+      // and cross-column drops always land at the top regardless of cursor position
+      if (isDoneColumn) {
+        if (getKanbanDragData()?.sourceColumn === 'done') return
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'move'
+        setIsDragOver(true)
+        dropIndexRef.current = 0
+        setDropIndex(0)
+        return
+      }
+
       e.preventDefault()
       e.dataTransfer.dropEffect = 'move'
       setIsDragOver(true)
@@ -421,7 +433,7 @@ export function KanbanColumn({
       dropIndexRef.current = index
       setDropIndex(index)
     },
-    [tickets.length]
+    [tickets.length, isDoneColumn]
   )
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
@@ -584,6 +596,8 @@ export function KanbanColumn({
         }
       } else {
         // ── Same-column reorder ───────────────────────────────
+        // Done is always date-sorted — manual reordering is disabled
+        if (isDoneColumn) return
         const ticketProjectId = findTicketProjectId(ticketId, draggedProjectId)
         const draggedKey = ticketKey(ticketProjectId, ticketId)
         const projectTickets = projectTicketsForColumn(ticketProjectId)
@@ -607,6 +621,7 @@ export function KanbanColumn({
       tickets.length,
       isInProgressColumn,
       isTodoColumn,
+      isDoneColumn,
       isMultiProjectMode,
       projectId,
       findTicketProjectId,

--- a/src/renderer/src/stores/useKanbanStore.done-sort.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.done-sort.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KanbanTicket } from '../../../main/db/types'
+
+// Mock the kanban RPC API so moveTicket doesn't hit a real client.
+vi.mock('@/api/kanban-api', () => ({
+  kanbanApi: {
+    ticket: {
+      move: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(null),
+      reorder: vi.fn().mockResolvedValue(undefined)
+    }
+  }
+}))
+
+// moveTicket dynamically imports useSettingsStore for the follow-up trigger.
+vi.mock('./useSettingsStore', () => ({
+  useSettingsStore: { getState: () => ({ followUpTriggerColumn: 'done' }) }
+}))
+
+import { useKanbanStore } from './useKanbanStore'
+
+const PROJECT_ID = 'proj-1'
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: PROJECT_ID,
+    title: 'A ticket',
+    description: null,
+    attachments: [],
+    column: 'done',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: null,
+    mode: 'build',
+    plan_ready: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
+    created_from_session: false,
+    auto_approve_plan: false,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
+    ...overrides
+  }
+}
+
+function seed(tickets: KanbanTicket[]): void {
+  useKanbanStore.setState({ tickets: new Map([[PROJECT_ID, tickets]]) })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useKanbanStore.setState({ tickets: new Map() })
+})
+
+afterEach(() => {
+  useKanbanStore.setState({ tickets: new Map() })
+})
+
+describe('getTicketsByColumn — done column is date-sorted', () => {
+  it('sorts done tickets by updated_at descending, ignoring sort_order', () => {
+    seed([
+      makeTicket({ id: 'old', sort_order: 0, updated_at: '2026-01-01T00:00:00.000Z' }),
+      makeTicket({ id: 'newest', sort_order: 99, updated_at: '2026-03-01T00:00:00.000Z' }),
+      makeTicket({ id: 'middle', sort_order: 50, updated_at: '2026-02-01T00:00:00.000Z' })
+    ])
+
+    const ids = useKanbanStore
+      .getState()
+      .getTicketsByColumn(PROJECT_ID, 'done')
+      .map((t) => t.id)
+    expect(ids).toEqual(['newest', 'middle', 'old'])
+  })
+
+  it('still sorts other columns by sort_order', () => {
+    seed([
+      makeTicket({ id: 'b', column: 'todo', sort_order: 1, updated_at: '2026-03-01T00:00:00.000Z' }),
+      makeTicket({ id: 'a', column: 'todo', sort_order: 0, updated_at: '2026-01-01T00:00:00.000Z' })
+    ])
+
+    const ids = useKanbanStore
+      .getState()
+      .getTicketsByColumn(PROJECT_ID, 'todo')
+      .map((t) => t.id)
+    expect(ids).toEqual(['a', 'b'])
+  })
+
+  it('excludes archived tickets from the active done list', () => {
+    seed([
+      makeTicket({ id: 'active', updated_at: '2026-01-01T00:00:00.000Z' }),
+      makeTicket({
+        id: 'archived',
+        updated_at: '2026-03-01T00:00:00.000Z',
+        archived_at: '2026-03-02T00:00:00.000Z'
+      })
+    ])
+
+    const ids = useKanbanStore
+      .getState()
+      .getTicketsByColumn(PROJECT_ID, 'done')
+      .map((t) => t.id)
+    expect(ids).toEqual(['active'])
+  })
+})
+
+describe('moveTicket — done placement', () => {
+  it('bumps updated_at optimistically so a ticket moved to done sorts to the top', async () => {
+    seed([
+      makeTicket({ id: 'existing-done', updated_at: '2026-05-01T00:00:00.000Z' }),
+      makeTicket({ id: 'moving', column: 'review', updated_at: '2026-01-01T00:00:00.000Z' })
+    ])
+
+    await useKanbanStore.getState().moveTicket('moving', PROJECT_ID, 'done', 5)
+
+    const ids = useKanbanStore
+      .getState()
+      .getTicketsByColumn(PROJECT_ID, 'done')
+      .map((t) => t.id)
+    expect(ids).toEqual(['moving', 'existing-done'])
+  })
+})

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -125,6 +125,11 @@ const COLUMN_ORDER: Record<KanbanTicketColumn, number> = {
   done: 3
 }
 
+// Done ignores manual sort_order — always newest first (updated_at ≈ when the
+// ticket entered Done, since moving a ticket bumps updated_at)
+const byUpdatedAtDesc = (a: KanbanTicket, b: KanbanTicket): number =>
+  b.updated_at.localeCompare(a.updated_at)
+
 function findTicketByRef(
   ticketsByProject: Map<string, KanbanTicket[]>,
   ref: TicketRef
@@ -826,11 +831,13 @@ export const useKanbanStore = create<KanbanState>()(
         const prev = get().tickets.get(projectId) ?? []
         const snapshot = prev.map((t) => ({ ...t }))
 
-        // Optimistic local update
+        // Optimistic local update (updated_at mirrors the backend bump so the
+        // date-sorted Done column places the ticket correctly right away)
+        const movedAt = new Date().toISOString()
         set((state) => {
           const next = new Map(state.tickets)
           const tickets = (next.get(projectId) ?? []).map((t) =>
-            t.id === ticketId ? { ...t, column, sort_order: sortOrder } : t
+            t.id === ticketId ? { ...t, column, sort_order: sortOrder, updated_at: movedAt } : t
           )
           next.set(projectId, tickets)
           return { tickets: next }
@@ -1206,7 +1213,7 @@ export const useKanbanStore = create<KanbanState>()(
         const tickets = get().tickets.get(projectId) ?? []
         return tickets
           .filter((t) => t.column === column && !t.archived_at)
-          .sort((a, b) => a.sort_order - b.sort_order)
+          .sort(column === 'done' ? byUpdatedAtDesc : (a, b) => a.sort_order - b.sort_order)
       },
 
       // ── getArchivedTicketsByColumn ─────────────────────────────────
@@ -1310,7 +1317,7 @@ export const useKanbanStore = create<KanbanState>()(
       ): KanbanTicket[] => {
         const projectIds = get().getConnectionProjectIds(connectionId)
         const merged = projectIds.flatMap((pid) => get().getTicketsByColumn(pid, column))
-        merged.sort((a, b) => a.sort_order - b.sort_order)
+        merged.sort(column === 'done' ? byUpdatedAtDesc : (a, b) => a.sort_order - b.sort_order)
         return merged
       },
 
@@ -1392,7 +1399,7 @@ export const useKanbanStore = create<KanbanState>()(
       getTicketsByColumnForPinned: (column: KanbanTicketColumn): KanbanTicket[] => {
         const projectIds = [...usePinnedStore.getState().pinnedProjectIds]
         const merged = projectIds.flatMap((pid) => get().getTicketsByColumn(pid, column))
-        merged.sort((a, b) => a.sort_order - b.sort_order)
+        merged.sort(column === 'done' ? byUpdatedAtDesc : (a, b) => a.sort_order - b.sort_order)
         return merged
       },
 


### PR DESCRIPTION
## Summary
- Make the `Done` kanban column always sort by `updated_at` descending instead of `sort_order`.
- Prevent manual reordering inside `Done`; cross-column drops into `Done` always land at the top.
- Update optimistic `moveTicket` behavior so a ticket moved into `Done` gets a fresh `updated_at` immediately.
- Add tests covering `Done` sorting, archived ticket filtering, and optimistic placement when moving into `Done`.

## Testing
- `Not run`
- Added unit coverage in `useKanbanStore.done-sort.test.ts` for `Done` ordering and move behavior.
- Verified the column drag logic now blocks same-column reordering in `Done` and forces incoming drops to index `0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI ordering and drag rules for Done only; other columns unchanged. Optimistic `updated_at` on every column move is a minor behavioral nuance but low impact.
> 
> **Overview**
> The **Done** column now lists tickets **newest first** by `updated_at` instead of `sort_order`, including single-project, connection, and pinned board views.
> 
> **Drag-and-drop** in `KanbanColumn` no longer allows reordering within Done; drops from other columns into Done always target the **top** (index `0`). Optimistic **`moveTicket`** sets a fresh `updated_at` so newly completed items appear at the top immediately.
> 
> Unit tests in `useKanbanStore.done-sort.test.ts` cover Done ordering, non-Done `sort_order` behavior, archived filtering, and optimistic placement after a move to Done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 792010bb22243f8745aa62340c476d9e1af90802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->