### PR TITLE
Add Codex CLI session support and hook translation

### DIFF
--- a/src/main/services/__tests__/codex-cli-hooks.test.ts
+++ b/src/main/services/__tests__/codex-cli-hooks.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../db', () => ({
   getDatabase: () => ({ getSession: getSessionMock })
 }))
 
+import { CODEX_PLAN_MODE_PREFIX } from '@shared/agent-mode-prefixes'
 import {
   buildCodexCliHookArgs,
   clearAllCodexSessionTracking,
@@ -124,15 +125,16 @@ describe('translateCodexHook', () => {
     expect(post).toMatchObject({ hook_event_name: 'PostToolUse', tool_name: 'AskUserQuestion' })
   })
 
-  it('injects permission_mode plan on UserPromptSubmit while the Hive session is plan-like', () => {
+  it('injects permission_mode plan on UserPromptSubmit for a Hive plan-prefixed prompt', () => {
     setHiveMode('plan')
+    const prompt = CODEX_PLAN_MODE_PREFIX + 'Design the feature'
     const hook = translateCodexHook(HIVE_ID, {
       hook_event_name: 'UserPromptSubmit',
-      prompt: 'Design the feature'
+      prompt
     })
     expect(hook).toMatchObject({
       hook_event_name: 'UserPromptSubmit',
-      prompt: 'Design the feature',
+      prompt,
       permission_mode: 'plan'
     })
 
@@ -142,6 +144,21 @@ describe('translateCodexHook', () => {
       prompt: 'Implement it'
     })
     expect(buildHook?.permission_mode).toBeUndefined()
+  })
+
+  it('does NOT mark a raw TUI prompt as plan mode even when the session is persisted as plan', () => {
+    // The user typed straight into the yolo codex TUI, so the prompt lacks the
+    // codex plan convention; codex can mutate, so it must not report as planning.
+    setHiveMode('plan')
+    const hook = translateCodexHook(HIVE_ID, {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'just fix the bug directly'
+    })
+    expect(hook).toMatchObject({
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'just fix the bug directly'
+    })
+    expect(hook?.permission_mode).toBeUndefined()
   })
 
   it("translates the 'Implement the plan.' approval into PostToolUse(ExitPlanMode) — only in plan mode", () => {

--- a/src/main/services/__tests__/codex-cli-hooks.test.ts
+++ b/src/main/services/__tests__/codex-cli-hooks.test.ts
@@ -140,18 +140,21 @@ describe('translateCodexHook', () => {
     expect(buildHook?.permission_mode).toBeUndefined()
   })
 
-  it("translates the plan popup's canned prompts into PostToolUse(ExitPlanMode)", () => {
+  it("translates the 'Implement the plan.' approval into PostToolUse(ExitPlanMode) — only in plan mode", () => {
     setHiveMode('plan')
-    for (const prompt of [
-      'Implement the plan.',
-      'A previous agent produced the plan below to accomplish the task…'
-    ]) {
-      const hook = translateCodexHook(HIVE_ID, {
-        hook_event_name: 'UserPromptSubmit',
-        prompt
-      })
-      expect(hook).toMatchObject({ hook_event_name: 'PostToolUse', tool_name: 'ExitPlanMode' })
-    }
+    expect(
+      translateCodexHook(HIVE_ID, { hook_event_name: 'UserPromptSubmit', prompt: 'Implement the plan.' })
+    ).toMatchObject({ hook_event_name: 'PostToolUse', tool_name: 'ExitPlanMode' })
+  })
+
+  it("does NOT convert a literal 'Implement the plan.' typed in build mode (no spurious plan-approved event)", () => {
+    setHiveMode('build')
+    const hook = translateCodexHook(HIVE_ID, {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'Implement the plan.'
+    })
+    expect(hook).toMatchObject({ hook_event_name: 'UserPromptSubmit', prompt: 'Implement the plan.' })
+    expect(hook?.permission_mode).toBeUndefined()
   })
 
   it('latches plan_ready from a plan-mode Stop only when a <proposed_plan> block is present', () => {

--- a/src/main/services/__tests__/codex-cli-hooks.test.ts
+++ b/src/main/services/__tests__/codex-cli-hooks.test.ts
@@ -55,10 +55,14 @@ describe('buildCodexCliHookArgs', () => {
       'hooks.Stop',
       'hooks.UserPromptSubmit'
     ])
-    // Each override curls the payload to the per-session codex-hook route.
+    // Each override curls the payload to the per-session codex-hook route, with
+    // both a POSIX command and a cmd.exe-compatible commandWindows override.
     for (const override of overrides) {
       expect(override).toContain(`http://127.0.0.1:4242/codex-hook/${HIVE_ID}/`)
       expect(override).toContain("type=\"command\"")
+      expect(override).toContain('commandWindows=')
+      expect(override).toContain('2>nul') // Windows null redirect + bare echo
+      expect(override).toContain("|| echo {}")
     }
     // Questions are the only PreToolUse we need.
     const preToolUse = overrides.find((o) => o.startsWith('hooks.PreToolUse'))

--- a/src/main/services/__tests__/codex-cli-hooks.test.ts
+++ b/src/main/services/__tests__/codex-cli-hooks.test.ts
@@ -1,0 +1,236 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getSessionMock = vi.fn()
+vi.mock('../../db', () => ({
+  getDatabase: () => ({ getSession: getSessionMock })
+}))
+
+import {
+  buildCodexCliHookArgs,
+  clearAllCodexSessionTracking,
+  extractProposedPlanText,
+  seedCodexSessionTracking,
+  setCodexSessionIdSink,
+  translateCodexHook
+} from '../codex-cli-hooks'
+
+const HIVE_ID = 'hive-1'
+const THREAD = '019f0000-0000-7000-8000-000000000001'
+
+let sessionDir: string
+let transcriptPath: string
+
+function setHiveMode(mode: string): void {
+  getSessionMock.mockReturnValue({ mode })
+}
+
+beforeEach(() => {
+  clearAllCodexSessionTracking()
+  setCodexSessionIdSink(null)
+  getSessionMock.mockReset()
+  setHiveMode('build')
+  sessionDir = mkdtempSync(path.join(tmpdir(), 'codex-hooks-test-'))
+  transcriptPath = path.join(sessionDir, 'rollout.jsonl')
+})
+
+afterEach(() => {
+  clearAllCodexSessionTracking()
+  setCodexSessionIdSink(null)
+  rmSync(sessionDir, { recursive: true, force: true })
+})
+
+describe('buildCodexCliHookArgs', () => {
+  it('enables hooks, bypasses hook trust, and wires every pipeline event as -c overrides', () => {
+    const args = buildCodexCliHookArgs(4242, HIVE_ID)
+    expect(args.slice(0, 3)).toEqual(['--enable', 'hooks', '--dangerously-bypass-hook-trust'])
+    const overrides = args.filter((arg) => arg.startsWith('hooks.'))
+    expect(overrides.map((o) => o.split('=')[0]).sort()).toEqual([
+      'hooks.PermissionRequest',
+      'hooks.PostToolUse',
+      'hooks.PreToolUse',
+      'hooks.SessionStart',
+      'hooks.Stop',
+      'hooks.UserPromptSubmit'
+    ])
+    // Each override curls the payload to the per-session codex-hook route.
+    for (const override of overrides) {
+      expect(override).toContain(`http://127.0.0.1:4242/codex-hook/${HIVE_ID}/`)
+      expect(override).toContain("type=\"command\"")
+    }
+    // Questions are the only PreToolUse we need.
+    const preToolUse = overrides.find((o) => o.startsWith('hooks.PreToolUse'))
+    expect(preToolUse).toContain('matcher="request_user_input"')
+  })
+})
+
+describe('translateCodexHook', () => {
+  it('passes SessionStart through and reports the thread id via the sink', () => {
+    const sink = vi.fn()
+    setCodexSessionIdSink(sink)
+    seedCodexSessionTracking(HIVE_ID, null)
+
+    const hook = translateCodexHook(HIVE_ID, {
+      hook_event_name: 'SessionStart',
+      session_id: THREAD,
+      transcript_path: transcriptPath
+    })
+    expect(hook).toMatchObject({ hook_event_name: 'SessionStart' })
+    expect(sink).toHaveBeenCalledWith(HIVE_ID, THREAD)
+
+    // Unchanged id on later hooks is not re-reported…
+    translateCodexHook(HIVE_ID, { hook_event_name: 'Stop', session_id: THREAD })
+    expect(sink).toHaveBeenCalledTimes(1)
+
+    // …but a new thread id (e.g. /clear) is.
+    translateCodexHook(HIVE_ID, { hook_event_name: 'SessionStart', session_id: 'new-thread' })
+    expect(sink).toHaveBeenCalledWith(HIVE_ID, 'new-thread')
+  })
+
+  it('drops subagent-scoped hooks entirely', () => {
+    expect(
+      translateCodexHook(HIVE_ID, {
+        hook_event_name: 'Stop',
+        session_id: THREAD,
+        agent_id: 'collab-1'
+      })
+    ).toBeNull()
+  })
+
+  it('maps request_user_input to AskUserQuestion so the question pipeline latches', () => {
+    const pre = translateCodexHook(HIVE_ID, {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'request_user_input',
+      tool_use_id: 'call-1',
+      tool_input: { questions: [{ question: 'Which flavor?' }] }
+    })
+    expect(pre).toMatchObject({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion',
+      tool_use_id: 'call-1'
+    })
+
+    const post = translateCodexHook(HIVE_ID, {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'request_user_input',
+      tool_use_id: 'call-1'
+    })
+    expect(post).toMatchObject({ hook_event_name: 'PostToolUse', tool_name: 'AskUserQuestion' })
+  })
+
+  it('injects permission_mode plan on UserPromptSubmit while the Hive session is plan-like', () => {
+    setHiveMode('plan')
+    const hook = translateCodexHook(HIVE_ID, {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'Design the feature'
+    })
+    expect(hook).toMatchObject({
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'Design the feature',
+      permission_mode: 'plan'
+    })
+
+    setHiveMode('build')
+    const buildHook = translateCodexHook(HIVE_ID, {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'Implement it'
+    })
+    expect(buildHook?.permission_mode).toBeUndefined()
+  })
+
+  it("translates the plan popup's canned prompts into PostToolUse(ExitPlanMode)", () => {
+    setHiveMode('plan')
+    for (const prompt of [
+      'Implement the plan.',
+      'A previous agent produced the plan below to accomplish the task…'
+    ]) {
+      const hook = translateCodexHook(HIVE_ID, {
+        hook_event_name: 'UserPromptSubmit',
+        prompt
+      })
+      expect(hook).toMatchObject({ hook_event_name: 'PostToolUse', tool_name: 'ExitPlanMode' })
+    }
+  })
+
+  it('latches plan_ready from a plan-mode Stop only when a <proposed_plan> block is present', () => {
+    setHiveMode('plan')
+    const hook = translateCodexHook(HIVE_ID, {
+      hook_event_name: 'Stop',
+      session_id: THREAD,
+      transcript_path: transcriptPath,
+      last_assistant_message:
+        'Here is my plan.\n<proposed_plan>\n1. Add --version to main.py\n2. Add a test\n</proposed_plan>'
+    })
+    expect(hook).toMatchObject({
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'ExitPlanMode',
+      tool_input: { plan: '1. Add --version to main.py\n2. Add a test' }
+    })
+  })
+
+  it('keeps a plan-mode Stop as Stop when the message has no <proposed_plan> (e.g. only a question was asked)', () => {
+    setHiveMode('plan')
+    expect(
+      translateCodexHook(HIVE_ID, {
+        hook_event_name: 'Stop',
+        session_id: THREAD,
+        last_assistant_message: 'Which database should we target?'
+      })
+    ).toMatchObject({ hook_event_name: 'Stop', last_assistant_message: 'Which database should we target?' })
+
+    expect(
+      translateCodexHook(HIVE_ID, { hook_event_name: 'Stop', session_id: THREAD })
+    ).toMatchObject({ hook_event_name: 'Stop' })
+  })
+
+  it('never latches plan_ready in build mode, even with a <proposed_plan> block', () => {
+    setHiveMode('build')
+    expect(
+      translateCodexHook(HIVE_ID, {
+        hook_event_name: 'Stop',
+        session_id: THREAD,
+        last_assistant_message: 'done <proposed_plan>x</proposed_plan>'
+      })
+    ).toMatchObject({ hook_event_name: 'Stop' })
+  })
+
+  it('returns null for events the pipeline must not see', () => {
+    expect(
+      translateCodexHook(HIVE_ID, { hook_event_name: 'SubagentStop', session_id: THREAD })
+    ).toBeNull()
+    expect(translateCodexHook(HIVE_ID, { hook_event_name: 'PreCompact' })).toBeNull()
+  })
+})
+
+describe('extractProposedPlanText', () => {
+  it('extracts the trimmed markdown inside a <proposed_plan> block', () => {
+    expect(
+      extractProposedPlanText('intro\n<proposed_plan>\n  # Plan\n  - step 1\n</proposed_plan>\noutro')
+    ).toBe('# Plan\n  - step 1')
+  })
+
+  it('is case-insensitive on the tag', () => {
+    expect(extractProposedPlanText('<PROPOSED_PLAN>hi</PROPOSED_PLAN>')).toBe('hi')
+  })
+
+  it('returns null when there is no complete block or the block is empty', () => {
+    expect(extractProposedPlanText('just a plan, no tags')).toBeNull()
+    expect(extractProposedPlanText('<proposed_plan>only an open tag')).toBeNull()
+    expect(extractProposedPlanText('<proposed_plan>   </proposed_plan>')).toBeNull()
+    expect(extractProposedPlanText(null)).toBeNull()
+    expect(extractProposedPlanText(undefined)).toBeNull()
+  })
+
+  it('skips an earlier empty or narrated block and returns the first block with content', () => {
+    expect(
+      extractProposedPlanText(
+        "I'll wrap it in <proposed_plan></proposed_plan> tags.\n<proposed_plan>1. real step</proposed_plan>"
+      )
+    ).toBe('1. real step')
+    expect(
+      extractProposedPlanText('<proposed_plan>  </proposed_plan> then <proposed_plan>the plan</proposed_plan>')
+    ).toBe('the plan')
+  })
+})

--- a/src/main/services/__tests__/codex-cli-spawner.test.ts
+++ b/src/main/services/__tests__/codex-cli-spawner.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import type { Session } from '../../db/types'
+import { buildCodexCliPtySpawn, normalizeCodexCliEffort } from '../codex-cli-spawner'
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'hive-session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'codex-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: 'codex',
+    model_id: 'gpt-5.5',
+    model_variant: null,
+    remote_launch: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    pinned_to_board: false,
+    ...overrides
+  }
+}
+
+describe('normalizeCodexCliEffort', () => {
+  it('accepts codex reasoning efforts and rejects anything else', () => {
+    expect(normalizeCodexCliEffort('high')).toBe('high')
+    expect(normalizeCodexCliEffort('ULTRA')).toBe('ultra')
+    expect(normalizeCodexCliEffort('ultracode')).toBeNull()
+    expect(normalizeCodexCliEffort(null)).toBeNull()
+    expect(normalizeCodexCliEffort(undefined)).toBeNull()
+  })
+})
+
+describe('buildCodexCliPtySpawn', () => {
+  it('spawns yolo with update-check suppression and worktree trust in every mode', () => {
+    const spawn = buildCodexCliPtySpawn({
+      session: makeSession({ model_id: null }),
+      worktreePath: '/repo/feature'
+    })
+    expect(spawn.command).toBe('codex')
+    expect(spawn.cwd).toBe('/repo/feature')
+    expect(spawn.args).toEqual([
+      '--dangerously-bypass-approvals-and-sandbox',
+      '-c',
+      'check_for_update_on_startup=false',
+      '-c',
+      'projects={"/repo/feature"={trust_level="trusted"}}'
+    ])
+  })
+
+  it('plan mode uses the same args (plan is activated in the TUI, not via flags)', () => {
+    const spawn = buildCodexCliPtySpawn({
+      session: makeSession({ mode: 'plan', model_id: null }),
+      worktreePath: '/repo/feature'
+    })
+    expect(spawn.args[0]).toBe('--dangerously-bypass-approvals-and-sandbox')
+    expect(spawn.args).not.toContain('--permission-mode')
+  })
+
+  it('passes model and reasoning effort as codex flags', () => {
+    const spawn = buildCodexCliPtySpawn({
+      session: makeSession({ model_id: 'gpt-5.6-sol', model_variant: 'xhigh' }),
+      worktreePath: '/repo/feature'
+    })
+    expect(spawn.args).toContain('-m')
+    expect(spawn.args[spawn.args.indexOf('-m') + 1]).toBe('gpt-5.6-sol')
+    expect(spawn.args).toContain('model_reasoning_effort="xhigh"')
+  })
+
+  it('resumes via the resume subcommand with the persisted thread id', () => {
+    const spawn = buildCodexCliPtySpawn({
+      session: makeSession({ claude_session_id: '019f-thread' }),
+      worktreePath: '/repo/feature'
+    })
+    expect(spawn.args.slice(0, 2)).toEqual(['resume', '019f-thread'])
+  })
+
+  it('appends hook args and the prompt as the final positional arg', () => {
+    const spawn = buildCodexCliPtySpawn({
+      session: makeSession({ model_id: null }),
+      worktreePath: '/repo/feature',
+      hookArgs: ['--enable', 'hooks'],
+      pendingPrompt: 'Fix the bug'
+    })
+    expect(spawn.args.slice(-3)).toEqual(['--enable', 'hooks', 'Fix the bug'])
+  })
+
+  it('escapes quotes and backslashes in the trust override path', () => {
+    const spawn = buildCodexCliPtySpawn({
+      session: makeSession({ model_id: null }),
+      worktreePath: '/repo/we"ird\\path'
+    })
+    expect(spawn.args).toContain(
+      'projects={"/repo/we\\"ird\\\\path"={trust_level="trusted"}}'
+    )
+  })
+})

--- a/src/main/services/__tests__/codex-cli-spawner.test.ts
+++ b/src/main/services/__tests__/codex-cli-spawner.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import type { Session } from '../../db/types'
-import { buildCodexCliPtySpawn, normalizeCodexCliEffort } from '../codex-cli-spawner'
+import {
+  buildCodexCliPtySpawn,
+  isWindowsShimBinary,
+  normalizeCodexCliEffort
+} from '../codex-cli-spawner'
 
 function makeSession(overrides: Partial<Session> = {}): Session {
   return {
@@ -43,6 +47,28 @@ describe('normalizeCodexCliEffort', () => {
     expect(normalizeCodexCliEffort('ultracode')).toBeNull()
     expect(normalizeCodexCliEffort(null)).toBeNull()
     expect(normalizeCodexCliEffort(undefined)).toBeNull()
+  })
+})
+
+describe('isWindowsShimBinary', () => {
+  const realPlatform = process.platform
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: realPlatform })
+  })
+
+  it('flags .cmd/.bat/.com shims only on win32 (drives shell wrapping for text generation)', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    expect(isWindowsShimBinary('C:/npm/codex.cmd')).toBe(true)
+    expect(isWindowsShimBinary('C:/npm/codex.BAT')).toBe(true)
+    expect(isWindowsShimBinary('C:/npm/codex.com')).toBe(true)
+    expect(isWindowsShimBinary('C:/bun/codex.exe')).toBe(false)
+    expect(isWindowsShimBinary('C:/bun/codex')).toBe(false)
+  })
+
+  it('is always false off win32 (POSIX runs the binary directly)', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    expect(isWindowsShimBinary('/usr/local/bin/codex.cmd')).toBe(false)
+    expect(isWindowsShimBinary('/usr/local/bin/codex')).toBe(false)
   })
 })
 

--- a/src/main/services/__tests__/codex-cli-spawner.test.ts
+++ b/src/main/services/__tests__/codex-cli-spawner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import type { Session } from '../../db/types'
 import { buildCodexCliPtySpawn, normalizeCodexCliEffort } from '../codex-cli-spawner'
 
@@ -99,5 +99,44 @@ describe('buildCodexCliPtySpawn', () => {
     expect(spawn.args).toContain(
       'projects={"/repo/we\\"ird\\\\path"={trust_level="trusted"}}'
     )
+  })
+
+  describe('Windows shim binaries', () => {
+    const realPlatform = process.platform
+    const realComspec = process.env.COMSPEC
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: realPlatform })
+      if (realComspec === undefined) delete process.env.COMSPEC
+      else process.env.COMSPEC = realComspec
+    })
+
+    it('wraps a .cmd shim through the command processor on Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+      process.env.COMSPEC = 'C:\\Windows\\System32\\cmd.exe'
+
+      const spawn = buildCodexCliPtySpawn({
+        session: makeSession({ model_id: null }),
+        worktreePath: 'C:/repo',
+        codexBinary: 'C:/Users/x/AppData/npm/codex.cmd',
+        pendingPrompt: 'do it'
+      })
+
+      expect(spawn.command).toBe('C:\\Windows\\System32\\cmd.exe')
+      expect(spawn.args.slice(0, 2)).toEqual(['/c', 'C:/Users/x/AppData/npm/codex.cmd'])
+      expect(spawn.args).toContain('--dangerously-bypass-approvals-and-sandbox')
+      expect(spawn.args[spawn.args.length - 1]).toBe('do it')
+    })
+
+    it('spawns a real .exe directly (no wrapper) on Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+      const spawn = buildCodexCliPtySpawn({
+        session: makeSession({ model_id: null }),
+        worktreePath: 'C:/repo',
+        codexBinary: 'C:/Users/x/.bun/bin/codex.exe'
+      })
+      expect(spawn.command).toBe('C:/Users/x/.bun/bin/codex.exe')
+      expect(spawn.args[0]).toBe('--dangerously-bypass-approvals-and-sandbox')
+    })
   })
 })

--- a/src/main/services/__tests__/codex-cli-spawner.test.ts
+++ b/src/main/services/__tests__/codex-cli-spawner.test.ts
@@ -32,19 +32,21 @@ function makeSession(overrides: Partial<Session> = {}): Session {
 }
 
 describe('normalizeCodexCliEffort', () => {
-  it('accepts every canonical ReasoningEffort value (case-insensitively)', () => {
-    for (const effort of ['none', 'minimal', 'low', 'medium', 'high', 'xhigh']) {
+  it('accepts every codex catalog effort plus the schema low-tier values (case-insensitively)', () => {
+    for (const effort of ['ultra', 'max', 'xhigh', 'high', 'medium', 'low', 'none', 'minimal']) {
       expect(normalizeCodexCliEffort(effort)).toBe(effort)
       expect(normalizeCodexCliEffort(effort.toUpperCase())).toBe(effort)
     }
   })
 
-  it('rejects values outside the Codex effort enum', () => {
-    // `ultra`/`max` are not part of the codex schema — passing them would make
-    // codex fall back to its default effort, so they must normalize to null.
-    expect(normalizeCodexCliEffort('ultra')).toBeNull()
-    expect(normalizeCodexCliEffort('max')).toBeNull()
+  it('passes gpt-5.6 max/ultra through (codex wire values, even though the generated schema is stale)', () => {
+    expect(normalizeCodexCliEffort('max')).toBe('max')
+    expect(normalizeCodexCliEffort('ultra')).toBe('ultra')
+  })
+
+  it('rejects non-codex efforts (e.g. claude-cli ultracode) and empty input', () => {
     expect(normalizeCodexCliEffort('ultracode')).toBeNull()
+    expect(normalizeCodexCliEffort('turbo')).toBeNull()
     expect(normalizeCodexCliEffort(null)).toBeNull()
     expect(normalizeCodexCliEffort(undefined)).toBeNull()
   })

--- a/src/main/services/__tests__/codex-cli-spawner.test.ts
+++ b/src/main/services/__tests__/codex-cli-spawner.test.ts
@@ -28,9 +28,18 @@ function makeSession(overrides: Partial<Session> = {}): Session {
 }
 
 describe('normalizeCodexCliEffort', () => {
-  it('accepts codex reasoning efforts and rejects anything else', () => {
-    expect(normalizeCodexCliEffort('high')).toBe('high')
-    expect(normalizeCodexCliEffort('ULTRA')).toBe('ultra')
+  it('accepts every canonical ReasoningEffort value (case-insensitively)', () => {
+    for (const effort of ['none', 'minimal', 'low', 'medium', 'high', 'xhigh']) {
+      expect(normalizeCodexCliEffort(effort)).toBe(effort)
+      expect(normalizeCodexCliEffort(effort.toUpperCase())).toBe(effort)
+    }
+  })
+
+  it('rejects values outside the Codex effort enum', () => {
+    // `ultra`/`max` are not part of the codex schema — passing them would make
+    // codex fall back to its default effort, so they must normalize to null.
+    expect(normalizeCodexCliEffort('ultra')).toBeNull()
+    expect(normalizeCodexCliEffort('max')).toBeNull()
     expect(normalizeCodexCliEffort('ultracode')).toBeNull()
     expect(normalizeCodexCliEffort(null)).toBeNull()
     expect(normalizeCodexCliEffort(undefined)).toBeNull()

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -24,12 +24,22 @@ import {
   isClaudeCliPlanAutoApproveArmed,
   setClaudeCliPlanAutoApprove
 } from './claude-cli-plan-auto-approve'
+// Runtime import is one-way: codex-cli-hooks only type-imports from this module.
+import { translateCodexHook, type CodexHookBody } from './codex-cli-hooks'
+import { writeClaudeCliPrompt } from './claude-cli-pty-prompt'
 import { ptyService } from './pty-service'
+
+type CliHookProvider = 'claude' | 'codex'
 
 // Delay between replying to the ExitPlanMode PermissionRequest hook and
 // pressing "1" on the PTY: claude renders its plan dialog only after the hook
 // response lands, and the keypress must hit the dialog, not the composer.
 const PLAN_AUTO_APPROVE_KEYSTROKE_DELAY_MS = 500
+// The codex implement follow-up (matches buildSdkPlanImplementationPrompt and
+// the approval prompt translateCodexHook recognizes). codex-cli plans have no
+// dialog and stay in Default collaboration mode, so implementing is just
+// sending this prompt — no keystroke/mode toggle.
+const CODEX_IMPLEMENT_PROMPT = 'Implement the plan.'
 
 export interface ParsedClaudeHook {
   hook_event_name?: string
@@ -240,17 +250,23 @@ export function subscribeClaudeCliStatus(
   }
 }
 
-function parseHookPath(url: string | undefined): { sessionId: string; hookPath: string } | null {
+function parseHookPath(
+  url: string | undefined
+): { sessionId: string; hookPath: string; provider: CliHookProvider } | null {
   if (!url) return null
 
   try {
     const parsed = new URL(url, `http://${host}`)
     const segments = parsed.pathname.split('/').filter(Boolean)
-    if (segments.length !== 3 || segments[0] !== 'hook') return null
+    if (segments.length !== 3) return null
+    const provider: CliHookProvider | null =
+      segments[0] === 'hook' ? 'claude' : segments[0] === 'codex-hook' ? 'codex' : null
+    if (!provider) return null
 
     return {
       sessionId: decodeURIComponent(segments[1]),
-      hookPath: segments[2]
+      hookPath: segments[2],
+      provider
     }
   } catch {
     return null
@@ -291,8 +307,17 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
   let owned = false
   try {
     const rawBody = await readRequestBody(req)
-    const body = JSON.parse(rawBody || '{}') as ParsedClaudeHook
-    if (route) {
+    const parsedBody: unknown = JSON.parse(rawBody || '{}')
+    // Codex payloads are near-claude-shaped already; translation maps codex
+    // tool names and synthesizes the ExitPlanMode plan flow (codex has no plan
+    // tool — see codex-cli-hooks.ts) so the rest of this pipeline is
+    // provider-agnostic. A null translation means the event is noise for the
+    // pipeline (subagent-scoped hooks, unknown events).
+    const body =
+      route?.provider === 'codex'
+        ? translateCodexHook(route.sessionId, parsedBody as CodexHookBody)
+        : (parsedBody as ParsedClaudeHook)
+    if (route && body) {
       const status = mapHookEventToStatus(body)
       const mapped: ClaudeCliStatusPayload | null = status
         ? {
@@ -316,7 +341,11 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
         for (const payload of processClaudeCliHook(route.sessionId, body, mapped)) {
           publishClaudeCliStatus(payload)
         }
-        void handleClaudeCliHiveTelemetryHook(route.sessionId, body)
+        // Telemetry parses claude-format transcript JSONL; codex rollout files
+        // have a different schema, so codex sessions skip it.
+        if (route.provider === 'claude') {
+          void handleClaudeCliHiveTelemetryHook(route.sessionId, body)
+        }
       }
       // First user prompt of this CLI session → tell the renderer so it can
       // auto-create a kanban ticket (if the setting is on). Fires for prompts
@@ -357,7 +386,10 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
       // response (held open until answered). Otherwise behavior is unchanged.
       // suppressIdle keeps a deferred/subagent-scoped Stop from telling the
       // transport the session went idle while background work is in flight.
-      if (!bypassTransport) {
+      // Codex sessions skip transports: held hook responses can't answer the
+      // codex TUI (questions/plan popups are keyboard-driven there), so
+      // forwarding would strand the phone-side reply.
+      if (!bypassTransport && route.provider === 'claude') {
         owned = cliHookTransportRouter.routeHook(route.sessionId, body, res, {
           suppressIdle: gate.kind !== 'pass'
         })
@@ -368,24 +400,33 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
         body.hook_event_name === 'PermissionRequest' &&
         !res.writableEnded
       ) {
-        // Hook responses cannot approve the plan dialog: on claude v2.1.201 a
-        // PermissionRequest hookSpecificOutput.decision (allow + setMode) is
-        // accepted but the interactive dialog is shown anyway (verified
-        // empirically — claude-playground keeps a keystroke fallback for the
-        // same reason). So reply '{}' to let the dialog render, then press "1"
-        // ("Yes, and bypass permissions") on the PTY — approval and
-        // bypassPermissions in the same stroke, exactly like a manual approve.
         const approvedSessionId = route.sessionId
+        const approvedProvider = route.provider
         consumeClaudeCliPlanAutoApprove(approvedSessionId)
         res.writeHead(200, { 'content-type': 'application/json' })
         res.end('{}')
         setTimeout(() => {
           if (!ptyService.has(approvedSessionId)) {
-            log.warn('Plan auto-approve keystroke skipped: PTY is gone', {
+            log.warn('Plan auto-approve action skipped: PTY is gone', {
               sessionId: approvedSessionId
             })
             return
           }
+          if (approvedProvider === 'codex') {
+            // Codex has no plan dialog (the plan is a `<proposed_plan>` block)
+            // and stays in Default collaboration mode, so implementing is just
+            // sending the implement follow-up. The renderer flips the Hive
+            // session mode to build off the resulting UserPromptSubmit.
+            writeClaudeCliPrompt(approvedSessionId, CODEX_IMPLEMENT_PROMPT)
+            log.info('Auto-implemented codex plan', { sessionId: approvedSessionId })
+            return
+          }
+          // Claude: hook responses cannot approve the plan dialog (on
+          // v2.1.201 a PermissionRequest decision is accepted but the dialog
+          // renders anyway — claude-playground keeps a keystroke fallback for
+          // the same reason). Reply '{}' (above) to let the dialog render,
+          // then press "1" ("Yes, and bypass permissions") — approval and
+          // bypassPermissions in one stroke, exactly like a manual approve.
           ptyService.write(approvedSessionId, '1')
           log.info('Auto-approved ExitPlanMode plan', { sessionId: approvedSessionId })
         }, PLAN_AUTO_APPROVE_KEYSTROKE_DELAY_MS)

--- a/src/main/services/codex-binary-resolver.ts
+++ b/src/main/services/codex-binary-resolver.ts
@@ -66,6 +66,52 @@ function hasCodexHookTrustFlag(output: string): boolean {
   return /--dangerously-bypass-hook-trust\b/.test(output)
 }
 
+/**
+ * Minimum codex version whose non-interactive hook-trust bypass actually works.
+ * `--dangerously-bypass-hook-trust` first shipped in 0.131.0 but was
+ * parsed-but-ignored through 0.133.0 (openai/codex#24093 — the TUI still shows
+ * the blocking "Hooks need review" prompt), and it is absent before 0.131.0.
+ * Since every codex-cli spawn relies on that bypass, 0.134.0 is the first
+ * usable version. A help-text flag check alone can't distinguish the broken
+ * 0.131–0.133 builds, so we gate on the parsed version.
+ */
+const MIN_CODEX_CLI_HOOK_VERSION: readonly [number, number, number] = [0, 134, 0]
+
+/** Parse the first `X.Y.Z` triple from `codex --version` output (e.g. "codex-cli 0.144.0"). */
+function parseCodexVersion(output: string): [number, number, number] | null {
+  const m = output.match(/(\d+)\.(\d+)\.(\d+)/)
+  if (!m) return null
+  return [Number(m[1]), Number(m[2]), Number(m[3])]
+}
+
+function versionAtLeast(
+  actual: readonly [number, number, number],
+  min: readonly [number, number, number]
+): boolean {
+  for (let i = 0; i < 3; i++) {
+    if (actual[i] > min[i]) return true
+    if (actual[i] < min[i]) return false
+  }
+  return true
+}
+
+function readCodexVersionOutput(binaryPath: string): string | null {
+  try {
+    return execFileSync(binaryPath, ['--version'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      env: process.env,
+      shell: usesShellForCodexBinary(binaryPath)
+    })
+  } catch (error) {
+    const output = [
+      stringifyProbeOutput((error as { stdout?: unknown }).stdout),
+      stringifyProbeOutput((error as { stderr?: unknown }).stderr)
+    ].join('\n')
+    return output.trim() ? output : null
+  }
+}
+
 function firstExistingPath(paths: string[]): string | null {
   return paths.find((candidate) => existsSync(candidate)) ?? null
 }
@@ -194,6 +240,21 @@ export function supportsCodexCliHooks(binaryPath: string): boolean {
     return cached
   }
 
+  // Primary gate: version. The bypass Hive relies on only works >= 0.134.0
+  // (see MIN_CODEX_CLI_HOOK_VERSION); a help-text flag check would wrongly
+  // accept the broken 0.131–0.133 builds.
+  const versionOutput = readCodexVersionOutput(binaryPath)
+  const version = versionOutput ? parseCodexVersion(versionOutput) : null
+  if (version) {
+    const supported = versionAtLeast(version, MIN_CODEX_CLI_HOOK_VERSION)
+    if (supported || !isBareCommand(binaryPath)) {
+      codexHookSupportCache.set(binaryPath, supported)
+    }
+    return supported
+  }
+
+  // Fallback (version unparseable — e.g. a forked/patched build): best-effort
+  // help-text check for the flag.
   try {
     const output = execFileSync(binaryPath, ['--help'], {
       encoding: 'utf-8',

--- a/src/main/services/codex-binary-resolver.ts
+++ b/src/main/services/codex-binary-resolver.ts
@@ -6,6 +6,7 @@ import { createLogger } from './logger'
 
 const log = createLogger({ component: 'CodexBinaryResolver' })
 const codexAppServerSupportCache = new Map<string, boolean>()
+const codexHookSupportCache = new Map<string, boolean>()
 
 function splitResolvedPaths(result: string): string[] {
   return result
@@ -53,6 +54,16 @@ function stringifyProbeOutput(output: unknown): string {
 
 function hasCodexAppServerUsage(output: string): boolean {
   return /Usage:\s*codex\s+app-server\b/i.test(output)
+}
+
+/**
+ * The codex-cli provider injects `--dangerously-bypass-hook-trust` (and the
+ * `--enable hooks` / `-c hooks.*` overrides) on every spawn. An older codex
+ * that predates the hooks surface rejects those flags and the session fails to
+ * start, so hook-trust support is the capability gate for offering codex-cli.
+ */
+function hasCodexHookTrustFlag(output: string): boolean {
+  return /--dangerously-bypass-hook-trust\b/.test(output)
 }
 
 function firstExistingPath(paths: string[]): string | null {
@@ -166,6 +177,47 @@ export function supportsCodexAppServer(binaryPath: string): boolean {
     }
     if (!isBareCommand(binaryPath)) {
       codexAppServerSupportCache.set(binaryPath, false)
+    }
+    return false
+  }
+}
+
+/**
+ * Whether this codex binary supports the hook flags the codex-cli provider
+ * injects (see hasCodexHookTrustFlag). Probes `codex --help` and looks for
+ * `--dangerously-bypass-hook-trust`. Same caching/shell/error-output handling
+ * as supportsCodexAppServer.
+ */
+export function supportsCodexCliHooks(binaryPath: string): boolean {
+  const cached = codexHookSupportCache.get(binaryPath)
+  if (cached !== undefined) {
+    return cached
+  }
+
+  try {
+    const output = execFileSync(binaryPath, ['--help'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      env: process.env,
+      shell: usesShellForCodexBinary(binaryPath)
+    })
+    const supported = hasCodexHookTrustFlag(output)
+    if (supported || !isBareCommand(binaryPath)) {
+      codexHookSupportCache.set(binaryPath, supported)
+    }
+    return supported
+  } catch (error) {
+    const output = [
+      stringifyProbeOutput((error as { stdout?: unknown }).stdout),
+      stringifyProbeOutput((error as { stderr?: unknown }).stderr)
+    ].join('\n')
+    const supported = hasCodexHookTrustFlag(output)
+    if (supported) {
+      codexHookSupportCache.set(binaryPath, true)
+      return true
+    }
+    if (!isBareCommand(binaryPath)) {
+      codexHookSupportCache.set(binaryPath, false)
     }
     return false
   }

--- a/src/main/services/codex-cli-hooks.ts
+++ b/src/main/services/codex-cli-hooks.ts
@@ -89,14 +89,25 @@ function codexHookUrl(port: number, hiveSessionId: string, path: string): string
 }
 
 /**
- * One hook command. Runs via `sh -c`; codex writes the payload JSON to stdin
- * and parses stdout for a decision. The hook server always replies `{}` ("no
- * verdict"); on a bridge outage (server down / curl timeout) we must STILL emit
- * a valid `{}` — codex's Stop hook treats empty stdout on exit 0 as invalid, so
- * a `|| echo '{}'` fallback keeps a transient outage from erroring every turn.
+ * The POSIX hook command. Codex runs it via `sh -c`; it writes the payload JSON
+ * to stdin and parses stdout for a decision. The hook server always replies
+ * `{}` ("no verdict"); on a bridge outage (server down / curl timeout) we must
+ * STILL emit a valid `{}` — codex's Stop hook treats empty stdout on exit 0 as
+ * invalid, so the `|| echo '{}'` fallback keeps a transient outage from
+ * erroring every turn.
  */
-function curlHookCommand(url: string, maxTimeSeconds: number): string {
+function curlHookCommandPosix(url: string, maxTimeSeconds: number): string {
   return `curl -s -m ${maxTimeSeconds} -X POST -H 'Content-Type: application/json' --data-binary @- '${url}' 2>/dev/null || echo '{}'`
+}
+
+/**
+ * The Windows hook command. Codex runs it via `cmd.exe /C`, so it needs
+ * double-quoted args, `2>nul`, and a bare `echo {}` (cmd.exe's echo keeps the
+ * quotes of `echo '{}'`). Supplied via codex's `commandWindows` override so the
+ * hooks still POST after the .cmd/.bat shim is wrapped for the PTY.
+ */
+function curlHookCommandWindows(url: string, maxTimeSeconds: number): string {
+  return `curl -s -m ${maxTimeSeconds} -X POST -H "Content-Type: application/json" --data-binary @- "${url}" 2>nul || echo {}`
 }
 
 function hookOverride(
@@ -104,11 +115,13 @@ function hookOverride(
   url: string,
   opts: { timeoutSeconds: number; matcher?: string }
 ): string[] {
-  const command = curlHookCommand(url, Math.max(5, opts.timeoutSeconds - 10))
+  const maxTime = Math.max(5, opts.timeoutSeconds - 10)
+  const command = curlHookCommandPosix(url, maxTime)
+  const commandWindows = curlHookCommandWindows(url, maxTime)
   const matcher = opts.matcher ? `matcher="${opts.matcher}",` : ''
-  // TOML inline value; the command is a triple-quoted literal string so no
-  // escaping is needed inside (it must simply never contain three quotes).
-  const value = `hooks.${event}=[{${matcher}hooks=[{type="command",command='''${command}''',timeout=${opts.timeoutSeconds}}]}]`
+  // TOML inline value; the commands are triple-quoted literal strings so no
+  // escaping is needed inside (they must simply never contain three quotes).
+  const value = `hooks.${event}=[{${matcher}hooks=[{type="command",command='''${command}''',commandWindows='''${commandWindows}''',timeout=${opts.timeoutSeconds}}]}]`
   return ['-c', value]
 }
 

--- a/src/main/services/codex-cli-hooks.ts
+++ b/src/main/services/codex-cli-hooks.ts
@@ -1,5 +1,6 @@
 import { getDatabase } from '../db'
 import { createLogger } from './logger'
+import { CODEX_PROPOSED_PLAN_FINALIZATION } from '@shared/agent-mode-prefixes'
 import type { ParsedClaudeHook } from './claude-hook-server'
 
 const log = createLogger({ component: 'CodexCliHooks' })
@@ -218,6 +219,23 @@ function isCodexPlanApprovalPrompt(prompt: unknown): boolean {
 }
 
 /**
+ * Whether a submitted prompt is a Hive-orchestrated codex-cli plan prompt (vs a
+ * raw prompt the user typed directly into the codex TUI). Both codex-cli plan
+ * prefixes — CODEX_PLAN_MODE_PREFIX and CODEX_CLI_SUPER_PLAN_MODE_PREFIX — embed
+ * CODEX_PROPOSED_PLAN_FINALIZATION (the `<proposed_plan>` instruction), which a
+ * raw TUI prompt never carries. We match on `includes` rather than a prefix
+ * check because goal mode wraps the whole thing as `/goal … Goal success
+ * criteria: …`, so the plan prefix is not at position 0.
+ *
+ * This gates plan-mode status: codex is spawned in bypass/yolo mode, so a raw
+ * TUI prompt in a plan-persisted session can mutate files and is NOT a read-only
+ * planning turn — only prefixed prompts actually instruct codex to plan.
+ */
+function isCodexPlanPrefixedPrompt(prompt: unknown): boolean {
+  return typeof prompt === 'string' && prompt.includes(CODEX_PROPOSED_PLAN_FINALIZATION)
+}
+
+/**
  * Extract the markdown inside a `<proposed_plan>…</proposed_plan>` block — the
  * codex plan convention (there is no ExitPlanMode tool). We ask codex to emit
  * this block via CODEX_PLAN_MODE_PREFIX / CODEX_SUPER_PLAN_MODE_PREFIX, exactly
@@ -289,7 +307,12 @@ export function translateCodexHook(
         prompt: raw.prompt,
         transcript_path: transcriptPath
       }
-      if (planLike) {
+      // Only report a plan turn when the prompt actually carries the codex plan
+      // convention. A raw prompt typed straight into the yolo-mode codex TUI
+      // while the session is persisted as plan/super-plan is NOT read-only
+      // planning — treating it as such would mislabel a mutating turn as
+      // "planning" (see isCodexPlanPrefixedPrompt).
+      if (planLike && isCodexPlanPrefixedPrompt(raw.prompt)) {
         hook.permission_mode = 'plan'
       }
       return hook

--- a/src/main/services/codex-cli-hooks.ts
+++ b/src/main/services/codex-cli-hooks.ts
@@ -55,10 +55,10 @@ const log = createLogger({ component: 'CodexCliHooks' })
  */
 export const CODEX_QUESTION_TOOL = 'request_user_input'
 
-// Canned prompts submitted by the codex TUI's "Implement this plan?" popup
-// (plan_implementation.rs) — the machine-readable "plan approved" signal.
+// The implement follow-up Hive sends to approve a plan (buildSdkPlanImplementationPrompt
+// + the hook-server auto-approve). Recognized only while the session is still
+// plan-like (see below), so it's the "plan approved → go to build" signal.
 const CODEX_PLAN_IMPLEMENT_MESSAGE = 'Implement the plan.'
-const CODEX_PLAN_CLEAR_CONTEXT_PREFIX = 'A previous agent produced the plan below'
 
 const TOOL_MAP: Record<string, string> = {
   [CODEX_QUESTION_TOOL]: 'AskUserQuestion'
@@ -199,12 +199,7 @@ function isPlanLikeHiveMode(hiveSessionId: string): boolean {
 }
 
 function isCodexPlanApprovalPrompt(prompt: unknown): boolean {
-  if (typeof prompt !== 'string') return false
-  const trimmed = prompt.trim()
-  return (
-    trimmed === CODEX_PLAN_IMPLEMENT_MESSAGE ||
-    trimmed.startsWith(CODEX_PLAN_CLEAR_CONTEXT_PREFIX)
-  )
+  return typeof prompt === 'string' && prompt.trim() === CODEX_PLAN_IMPLEMENT_MESSAGE
 }
 
 /**
@@ -256,12 +251,18 @@ export function translateCodexHook(
       return { hook_event_name: 'SessionStart', transcript_path: transcriptPath }
 
     case 'UserPromptSubmit': {
-      if (isCodexPlanApprovalPrompt(raw.prompt)) {
-        // The "Implement this plan?" popup's canned follow-up: codex switched
-        // itself to Default mode and is implementing. Synthesized
-        // PostToolUse(ExitPlanMode) releases the plan_ready latch and drives
-        // the renderer's existing "plan approved" handling (session → build,
-        // no Shift+Tab sync).
+      // Codex never reports plan mode itself; plan-driven handling is keyed off
+      // Hive's persisted session mode.
+      const planLike = isPlanLikeHiveMode(hiveSessionId)
+      // The "Implement the plan." follow-up is the plan-approval signal ONLY
+      // while the session is still plan-like (auto-approve fires before the
+      // renderer flips the mode; the manual implement path flips to build
+      // first, so it falls through to a normal working prompt here). Gating on
+      // planLike keeps a literal "Implement the plan." typed in a build-mode
+      // session from emitting a spurious plan-approved event.
+      if (planLike && isCodexPlanApprovalPrompt(raw.prompt)) {
+        // Synthesized PostToolUse(ExitPlanMode) releases the plan_ready latch
+        // and drives the renderer's "plan approved → build" handling.
         return {
           hook_event_name: 'PostToolUse',
           tool_name: 'ExitPlanMode',
@@ -273,9 +274,7 @@ export function translateCodexHook(
         prompt: raw.prompt,
         transcript_path: transcriptPath
       }
-      // Codex never reports plan mode itself; UserPromptSubmit→planning is
-      // driven off Hive's persisted session mode instead.
-      if (isPlanLikeHiveMode(hiveSessionId)) {
+      if (planLike) {
         hook.permission_mode = 'plan'
       }
       return hook

--- a/src/main/services/codex-cli-hooks.ts
+++ b/src/main/services/codex-cli-hooks.ts
@@ -90,11 +90,13 @@ function codexHookUrl(port: number, hiveSessionId: string, path: string): string
 
 /**
  * One hook command. Runs via `sh -c`; codex writes the payload JSON to stdin
- * and parses stdout for a decision — `{}` (or a curl failure swallowed by
- * `|| true`) means "no verdict" and codex proceeds normally.
+ * and parses stdout for a decision. The hook server always replies `{}` ("no
+ * verdict"); on a bridge outage (server down / curl timeout) we must STILL emit
+ * a valid `{}` — codex's Stop hook treats empty stdout on exit 0 as invalid, so
+ * a `|| echo '{}'` fallback keeps a transient outage from erroring every turn.
  */
 function curlHookCommand(url: string, maxTimeSeconds: number): string {
-  return `curl -s -m ${maxTimeSeconds} -X POST -H 'Content-Type: application/json' --data-binary @- '${url}' 2>/dev/null || true`
+  return `curl -s -m ${maxTimeSeconds} -X POST -H 'Content-Type: application/json' --data-binary @- '${url}' 2>/dev/null || echo '{}'`
 }
 
 function hookOverride(

--- a/src/main/services/codex-cli-hooks.ts
+++ b/src/main/services/codex-cli-hooks.ts
@@ -1,0 +1,335 @@
+import { getDatabase } from '../db'
+import { createLogger } from './logger'
+import type { ParsedClaudeHook } from './claude-hook-server'
+
+const log = createLogger({ component: 'CodexCliHooks' })
+
+/**
+ * Codex CLI integration: per-spawn hook injection + payload translation.
+ *
+ * Codex (>=0.129, verified on 0.144) ships a Claude-compatible hooks engine.
+ * Unlike grok there is no global-file requirement: hook config rides the spawn
+ * args as `-c hooks.<Event>=[…]` TOML overrides (with
+ * `--dangerously-bypass-hook-trust` so the injected hooks skip the persisted
+ * trust prompt), each command a `curl` that POSTs the stdin payload to the
+ * shared hook server on `/codex-hook/<hiveSessionId>/<path>`. Nothing under
+ * ~/.codex is ever written.
+ *
+ * Payloads are translated into the ParsedClaudeHook shape so the entire
+ * claude-cli control plane — interaction ledger, subagent gate, status
+ * pipeline, plan auto-approve, renderer state machine — is reused unchanged
+ * (the same architecture as grok-cli-hooks). Codex specifics:
+ * - Payload keys are already snake_case with claude event names; only tool
+ *   names need mapping (`request_user_input` is codex's AskUserQuestion).
+ * - `permission_mode` reflects the approval policy (always "bypassPermissions"
+ *   under Hive's yolo spawn), never plan mode — planning is derived from
+ *   Hive's own session.mode and injected on UserPromptSubmit.
+ * - Plans follow the CODEX convention, not claude's: codex has no ExitPlanMode
+ *   tool, and codex-cli deliberately stays in codex's Default collaboration
+ *   mode (entering native Plan mode would pop codex's own interactive
+ *   "Implement this plan?" dialog — the claude-style plan dialog we avoid).
+ *   Instead we ASK for a plan via CODEX_PLAN_MODE_PREFIX / the super-plan
+ *   prefix (the same instruction the `codex` SDK injects out-of-band): codex
+ *   reads/reasons without mutating and emits its finished plan wrapped in
+ *   `<proposed_plan>…</proposed_plan>`. On a plan-mode Stop we extract that
+ *   block (extractProposedPlanText) and, only if present, latch plan_ready. The
+ *   synthesized `ExitPlanMode` tool_name is purely Hive's internal plan-ready
+ *   status label (shared with claude-cli) so the block routes into the same
+ *   plan-card pipeline — it is never a codex tool call.
+ * - Implementing sends the canned "Implement the plan." follow-up (the codex
+ *   SDK's implementation prompt); codex is already in Default mode, so this
+ *   just starts an implementing turn. That UserPromptSubmit is translated into
+ *   a synthesized PostToolUse(ExitPlanMode), which the renderer treats as
+ *   "plan approved → flip the Hive session to build".
+ * - The codex thread id (`session_id`) and rollout path arrive on every hook,
+ *   so there is no transcript-dir watcher: the id is reported through a sink
+ *   (registered by terminal-pty-bridge) and persisted for `codex resume`.
+ */
+
+/**
+ * codex's AskUserQuestion equivalent. Only available to the model in codex's
+ * native Plan collaboration mode, which codex-cli does not enter — so this hook
+ * is wired (→ 'answering') for completeness/future-proofing but does not fire
+ * in the prompt-driven plan flow; codex asks any clarifying questions as inline
+ * terminal text instead.
+ */
+export const CODEX_QUESTION_TOOL = 'request_user_input'
+
+// Canned prompts submitted by the codex TUI's "Implement this plan?" popup
+// (plan_implementation.rs) — the machine-readable "plan approved" signal.
+const CODEX_PLAN_IMPLEMENT_MESSAGE = 'Implement the plan.'
+const CODEX_PLAN_CLEAR_CONTEXT_PREFIX = 'A previous agent produced the plan below'
+
+const TOOL_MAP: Record<string, string> = {
+  [CODEX_QUESTION_TOOL]: 'AskUserQuestion'
+}
+
+export interface CodexHookBody {
+  hook_event_name?: string
+  session_id?: string
+  turn_id?: string
+  transcript_path?: string | null
+  cwd?: string
+  model?: string
+  permission_mode?: string
+  tool_name?: string
+  tool_input?: unknown
+  tool_use_id?: string
+  tool_response?: unknown
+  prompt?: string
+  stop_hook_active?: boolean
+  last_assistant_message?: string | null
+  agent_id?: string
+  agent_type?: string
+  source?: string
+}
+
+function codexHookUrl(port: number, hiveSessionId: string, path: string): string {
+  return `http://127.0.0.1:${port}/codex-hook/${encodeURIComponent(hiveSessionId)}/${path}`
+}
+
+/**
+ * One hook command. Runs via `sh -c`; codex writes the payload JSON to stdin
+ * and parses stdout for a decision — `{}` (or a curl failure swallowed by
+ * `|| true`) means "no verdict" and codex proceeds normally.
+ */
+function curlHookCommand(url: string, maxTimeSeconds: number): string {
+  return `curl -s -m ${maxTimeSeconds} -X POST -H 'Content-Type: application/json' --data-binary @- '${url}' 2>/dev/null || true`
+}
+
+function hookOverride(
+  event: string,
+  url: string,
+  opts: { timeoutSeconds: number; matcher?: string }
+): string[] {
+  const command = curlHookCommand(url, Math.max(5, opts.timeoutSeconds - 10))
+  const matcher = opts.matcher ? `matcher="${opts.matcher}",` : ''
+  // TOML inline value; the command is a triple-quoted literal string so no
+  // escaping is needed inside (it must simply never contain three quotes).
+  const value = `hooks.${event}=[{${matcher}hooks=[{type="command",command='''${command}''',timeout=${opts.timeoutSeconds}}]}]`
+  return ['-c', value]
+}
+
+/**
+ * Per-invocation hook wiring for a codex-cli spawn. `--enable hooks` covers
+ * configs where the feature was explicitly disabled;
+ * `--dangerously-bypass-hook-trust` skips the persisted-trust prompt for these
+ * Hive-injected overrides.
+ */
+export function buildCodexCliHookArgs(port: number, hiveSessionId: string): string[] {
+  const url = (path: string): string => codexHookUrl(port, hiveSessionId, path)
+  return [
+    '--enable',
+    'hooks',
+    '--dangerously-bypass-hook-trust',
+    ...hookOverride('SessionStart', url('session'), { timeoutSeconds: 20 }),
+    ...hookOverride('UserPromptSubmit', url('start'), { timeoutSeconds: 20 }),
+    ...hookOverride('Stop', url('stop'), { timeoutSeconds: 20 }),
+    // Questions only; the generous timeout is a ceiling for hooks a transport
+    // may one day hold open, not a delay.
+    ...hookOverride('PreToolUse', url('tool'), {
+      timeoutSeconds: 600,
+      matcher: CODEX_QUESTION_TOOL
+    }),
+    ...hookOverride('PostToolUse', url('tool'), { timeoutSeconds: 20 }),
+    ...hookOverride('PermissionRequest', url('permission'), { timeoutSeconds: 600 })
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Session tracking + thread-id sink
+// ---------------------------------------------------------------------------
+
+interface CodexSessionTracking {
+  /** Last thread id reported through the sink (dedupes per-hook reporting). */
+  reportedThreadId: string | null
+}
+
+const tracking = new Map<string, CodexSessionTracking>()
+
+type CodexSessionIdSink = (hiveSessionId: string, codexThreadId: string) => void
+let codexSessionIdSink: CodexSessionIdSink | null = null
+
+/** Registered once by terminal-pty-bridge to persist detected codex thread ids. */
+export function setCodexSessionIdSink(sink: CodexSessionIdSink | null): void {
+  codexSessionIdSink = sink
+}
+
+/**
+ * Seed tracking at spawn time with the thread id we are resuming (or null for
+ * a fresh session, in which case the first hook's session_id is reported
+ * through the sink). `/clear` starts a new thread mid-PTY; the changed id is
+ * reported again so resume stays fresh.
+ */
+export function seedCodexSessionTracking(
+  hiveSessionId: string,
+  codexThreadId: string | null
+): void {
+  tracking.set(hiveSessionId, { reportedThreadId: codexThreadId })
+}
+
+export function clearCodexSessionTracking(hiveSessionId: string): void {
+  tracking.delete(hiveSessionId)
+}
+
+export function clearAllCodexSessionTracking(): void {
+  tracking.clear()
+}
+
+function getOrCreateTracking(hiveSessionId: string): CodexSessionTracking {
+  let state = tracking.get(hiveSessionId)
+  if (!state) {
+    state = { reportedThreadId: null }
+    tracking.set(hiveSessionId, state)
+  }
+  return state
+}
+
+// ---------------------------------------------------------------------------
+// Payload translation
+// ---------------------------------------------------------------------------
+
+function isPlanLikeHiveMode(hiveSessionId: string): boolean {
+  try {
+    const mode = getDatabase().getSession(hiveSessionId)?.mode
+    return mode === 'plan' || mode === 'super-plan'
+  } catch {
+    return false
+  }
+}
+
+function isCodexPlanApprovalPrompt(prompt: unknown): boolean {
+  if (typeof prompt !== 'string') return false
+  const trimmed = prompt.trim()
+  return (
+    trimmed === CODEX_PLAN_IMPLEMENT_MESSAGE ||
+    trimmed.startsWith(CODEX_PLAN_CLEAR_CONTEXT_PREFIX)
+  )
+}
+
+/**
+ * Extract the markdown inside a `<proposed_plan>…</proposed_plan>` block — the
+ * codex plan convention (there is no ExitPlanMode tool). We ask codex to emit
+ * this block via CODEX_PLAN_MODE_PREFIX / CODEX_SUPER_PLAN_MODE_PREFIX, exactly
+ * as the `codex` app-server SDK does; the block IS the "plan ready" signal.
+ * Mirrors extractProposedPlanMarkdown in codex-implementer.ts. Returns the
+ * trimmed inner content, or null when the text carries no complete block (e.g.
+ * a plan turn that only asked a request_user_input question).
+ */
+export function extractProposedPlanText(text: string | null | undefined): string | null {
+  if (typeof text !== 'string') return null
+  // Scan ALL blocks and return the first with non-empty content: the model may
+  // narrate the tag name or emit an empty/example block before the real plan
+  // (a lazy first-match would then lock onto the empty one and drop the plan).
+  for (const match of text.matchAll(/<proposed_plan>\s*([\s\S]*?)\s*<\/proposed_plan>/gi)) {
+    const inner = match[1]?.trim()
+    if (inner) return inner
+  }
+  return null
+}
+
+/**
+ * Translate a codex hook payload for `hiveSessionId` into the ParsedClaudeHook
+ * shape the claude-cli pipeline consumes. Returns null for events the pipeline
+ * must not see (subagent-scoped hooks, unknown events).
+ */
+export function translateCodexHook(
+  hiveSessionId: string,
+  raw: CodexHookBody
+): ParsedClaudeHook | null {
+  // Subagent-scoped hooks (collab agents) carry agent_id; they must not drive
+  // the main session's status or thread-id tracking.
+  if (raw.agent_id) return null
+
+  const state = getOrCreateTracking(hiveSessionId)
+  if (typeof raw.session_id === 'string' && raw.session_id && raw.session_id !== state.reportedThreadId) {
+    state.reportedThreadId = raw.session_id
+    codexSessionIdSink?.(hiveSessionId, raw.session_id)
+  }
+
+  const event = raw.hook_event_name ?? ''
+  const transcriptPath =
+    typeof raw.transcript_path === 'string' && raw.transcript_path ? raw.transcript_path : undefined
+
+  switch (event) {
+    case 'SessionStart':
+      return { hook_event_name: 'SessionStart', transcript_path: transcriptPath }
+
+    case 'UserPromptSubmit': {
+      if (isCodexPlanApprovalPrompt(raw.prompt)) {
+        // The "Implement this plan?" popup's canned follow-up: codex switched
+        // itself to Default mode and is implementing. Synthesized
+        // PostToolUse(ExitPlanMode) releases the plan_ready latch and drives
+        // the renderer's existing "plan approved" handling (session → build,
+        // no Shift+Tab sync).
+        return {
+          hook_event_name: 'PostToolUse',
+          tool_name: 'ExitPlanMode',
+          transcript_path: transcriptPath
+        }
+      }
+      const hook: ParsedClaudeHook = {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: raw.prompt,
+        transcript_path: transcriptPath
+      }
+      // Codex never reports plan mode itself; UserPromptSubmit→planning is
+      // driven off Hive's persisted session mode instead.
+      if (isPlanLikeHiveMode(hiveSessionId)) {
+        hook.permission_mode = 'plan'
+      }
+      return hook
+    }
+
+    case 'PreToolUse':
+    case 'PostToolUse':
+    case 'PermissionRequest': {
+      const toolName = raw.tool_name ? (TOOL_MAP[raw.tool_name] ?? raw.tool_name) : undefined
+      const hook: ParsedClaudeHook = {
+        hook_event_name: event,
+        transcript_path: transcriptPath
+      }
+      if (toolName) hook.tool_name = toolName
+      if (raw.tool_use_id) hook.tool_use_id = raw.tool_use_id
+      if (raw.tool_input && typeof raw.tool_input === 'object') {
+        hook.tool_input = raw.tool_input as ParsedClaudeHook['tool_input']
+      }
+      return hook
+    }
+
+    case 'Stop': {
+      const lastAssistantMessage =
+        typeof raw.last_assistant_message === 'string' && raw.last_assistant_message.trim()
+          ? raw.last_assistant_message
+          : undefined
+      // In plan mode, a completed `<proposed_plan>` block in the final message
+      // is codex's "plan ready" signal. Only then do we latch plan_ready; a
+      // plan turn that merely asked a question (request_user_input) has no
+      // block and stays a normal Stop. `ExitPlanMode` here is Hive's internal
+      // plan-ready status name shared with claude-cli — NOT a codex tool call
+      // (codex has none) — it just routes into the shared plan-card pipeline.
+      if (isPlanLikeHiveMode(hiveSessionId)) {
+        const planText = extractProposedPlanText(lastAssistantMessage)
+        if (planText) {
+          log.info('Codex <proposed_plan> received; latching plan_ready', {
+            sessionId: hiveSessionId
+          })
+          return {
+            hook_event_name: 'PermissionRequest',
+            tool_name: 'ExitPlanMode',
+            tool_input: { plan: planText },
+            transcript_path: transcriptPath
+          }
+        }
+      }
+      return {
+        hook_event_name: 'Stop',
+        transcript_path: transcriptPath,
+        last_assistant_message: lastAssistantMessage
+      }
+    }
+
+    default:
+      return null
+  }
+}

--- a/src/main/services/codex-cli-spawner.ts
+++ b/src/main/services/codex-cli-spawner.ts
@@ -1,0 +1,102 @@
+import type { Session } from '../db/types'
+import { getUserEnvironmentVariables } from './env-vars'
+import type { DatabaseService } from '../db/database'
+
+/**
+ * Builds the PTY spawn spec for a `codex-cli` session — the codex TUI running
+ * in a terminal, mirroring claude-cli-spawner.ts for the codex binary.
+ *
+ * Codex differences that shape the args (verified against codex 0.144):
+ * - Yolo is `--dangerously-bypass-approvals-and-sandbox` (the counterpart of
+ *   claude's `--dangerously-skip-permissions`, passed in every mode so the
+ *   session never blocks on approvals — plan-mode restraint comes from the
+ *   collaboration mode, not the approval policy).
+ * - There is NO CLI flag for plan mode: the TUI always boots in the Default
+ *   collaboration mode. Plan mode is entered post-boot via a Shift+Tab
+ *   keystroke driven by the SessionStart hook (see codex-cli-boot-actions.ts),
+ *   which is also why a plan-mode prompt must NOT be passed as a positional
+ *   arg (it would auto-submit before the mode flip) — the caller withholds it.
+ * - Resume is a subcommand (`codex resume <thread-uuid>`), not a flag. The
+ *   thread id is captured from the SessionStart hook payload and persisted in
+ *   the session's claude_session_id column (generic "CLI session id").
+ * - `-c check_for_update_on_startup=false` is always passed: a promptless
+ *   `codex resume <id>` otherwise blocks on the interactive "Update
+ *   available!" picker (cmux ships the same suppression).
+ * - The worktree is stamped trusted via a `projects` config override so a
+ *   fresh worktree never blocks on the trust dialog. The override is
+ *   per-invocation only — it never touches ~/.codex/config.toml.
+ */
+export interface CodexCliPtySpawnInput {
+  session: Pick<Session, 'mode' | 'model_id' | 'model_variant' | 'claude_session_id'>
+  worktreePath: string
+  pendingPrompt?: string | null
+  codexBinary?: string | null
+  codexSessionId?: string | null
+  /** Extra `-c hooks.*` args from buildCodexCliHookArgs. */
+  hookArgs?: string[] | null
+  db?: DatabaseService | null
+}
+
+export interface CodexCliPtySpawn {
+  command: string
+  args: string[]
+  cwd: string
+  env: Record<string, string>
+}
+
+const VALID_EFFORTS = new Set(['ultra', 'max', 'xhigh', 'high', 'medium', 'low'])
+
+export function normalizeCodexCliEffort(variant: string | null | undefined): string | null {
+  if (!variant) return null
+  const lower = variant.toLowerCase()
+  return VALID_EFFORTS.has(lower) ? lower : null
+}
+
+/**
+ * TOML inline-table override marking the worktree trusted for this invocation.
+ * The path is embedded in a TOML basic string; escape backslashes and quotes
+ * (Windows paths, exotic worktree names).
+ */
+function trustProjectOverride(worktreePath: string): string {
+  const escaped = worktreePath.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  return `projects={"${escaped}"={trust_level="trusted"}}`
+}
+
+export function buildCodexCliPtySpawn(input: CodexCliPtySpawnInput): CodexCliPtySpawn {
+  const resumeId = input.codexSessionId ?? input.session.claude_session_id
+
+  const args: string[] = resumeId ? ['resume', resumeId] : []
+
+  args.push(
+    '--dangerously-bypass-approvals-and-sandbox',
+    '-c',
+    'check_for_update_on_startup=false',
+    '-c',
+    trustProjectOverride(input.worktreePath)
+  )
+
+  if (input.session.model_id) {
+    args.push('-m', input.session.model_id)
+  }
+
+  const effort = normalizeCodexCliEffort(input.session.model_variant)
+  if (effort) {
+    args.push('-c', `model_reasoning_effort="${effort}"`)
+  }
+
+  if (input.hookArgs?.length) {
+    args.push(...input.hookArgs)
+  }
+
+  const prompt = input.pendingPrompt?.trim()
+  if (prompt) {
+    args.push(prompt)
+  }
+
+  return {
+    command: input.codexBinary || 'codex',
+    args,
+    cwd: input.worktreePath,
+    env: getUserEnvironmentVariables(input.db ?? null)
+  }
+}

--- a/src/main/services/codex-cli-spawner.ts
+++ b/src/main/services/codex-cli-spawner.ts
@@ -9,7 +9,7 @@ import type { DatabaseService } from '../db/database'
  * must go through the command processor. Detection already runs these shims
  * with `shell: true` for the same reason.
  */
-function isWindowsShimBinary(binaryPath: string): boolean {
+export function isWindowsShimBinary(binaryPath: string): boolean {
   if (process.platform !== 'win32') return false
   const ext = extname(binaryPath).toLowerCase()
   return ext === '.cmd' || ext === '.bat' || ext === '.com'

--- a/src/main/services/codex-cli-spawner.ts
+++ b/src/main/services/codex-cli-spawner.ts
@@ -88,6 +88,12 @@ export function buildCodexCliPtySpawn(input: CodexCliPtySpawnInput): CodexCliPty
     args.push(...input.hookArgs)
   }
 
+  // Final positional arg = the initial prompt, which auto-submits. This is
+  // valid for BOTH a fresh launch (`codex [PROMPT]`) and a resume: the
+  // interactive `codex resume [SESSION_ID] [PROMPT]` explicitly accepts an
+  // "Optional user prompt to start the session" (verified via `codex resume
+  // --help` on the >= 0.134 binaries we gate on — the `exec resume` variant is
+  // a separate, non-interactive command we don't use).
   const prompt = input.pendingPrompt?.trim()
   if (prompt) {
     args.push(prompt)

--- a/src/main/services/codex-cli-spawner.ts
+++ b/src/main/services/codex-cli-spawner.ts
@@ -1,6 +1,7 @@
 import { extname } from 'node:path'
 import type { Session } from '../db/types'
 import { getUserEnvironmentVariables } from './env-vars'
+import { CODEX_REASONING_EFFORTS } from './codex-models'
 import type { DatabaseService } from '../db/database'
 
 /**
@@ -57,10 +58,15 @@ export interface CodexCliPtySpawn {
   env: Record<string, string>
 }
 
-// Must match the canonical Codex `ReasoningEffort` enum
-// (src/shared/codex-schemas/ReasoningEffort.ts) — codex rejects anything else
-// passed to `-c model_reasoning_effort=...` and would fall back to its default.
-const VALID_EFFORTS = new Set(['none', 'minimal', 'low', 'medium', 'high', 'xhigh'])
+// Efforts codex accepts for `-c model_reasoning_effort=...`. codex-cli shares
+// codex's model catalog, so a codex-cli model_variant is always one of the
+// catalog's wire values (CODEX_REASONING_EFFORTS — includes gpt-5.6's `max`/
+// `ultra`, which the generated ReasoningEffort.ts schema is simply stale on; the
+// working SDK codex passes these straight through unfiltered). `none`/`minimal`
+// are added from that schema for completeness. Anything else — notably
+// claude-cli's `ultracode` — normalizes to null so we omit the flag and let
+// codex pick its default rather than passing a value codex would reject.
+const VALID_EFFORTS = new Set<string>([...CODEX_REASONING_EFFORTS, 'none', 'minimal'])
 
 export function normalizeCodexCliEffort(variant: string | null | undefined): string | null {
   if (!variant) return null

--- a/src/main/services/codex-cli-spawner.ts
+++ b/src/main/services/codex-cli-spawner.ts
@@ -57,7 +57,10 @@ export interface CodexCliPtySpawn {
   env: Record<string, string>
 }
 
-const VALID_EFFORTS = new Set(['ultra', 'max', 'xhigh', 'high', 'medium', 'low'])
+// Must match the canonical Codex `ReasoningEffort` enum
+// (src/shared/codex-schemas/ReasoningEffort.ts) — codex rejects anything else
+// passed to `-c model_reasoning_effort=...` and would fall back to its default.
+const VALID_EFFORTS = new Set(['none', 'minimal', 'low', 'medium', 'high', 'xhigh'])
 
 export function normalizeCodexCliEffort(variant: string | null | undefined): string | null {
   if (!variant) return null

--- a/src/main/services/codex-cli-spawner.ts
+++ b/src/main/services/codex-cli-spawner.ts
@@ -1,6 +1,19 @@
+import { extname } from 'node:path'
 import type { Session } from '../db/types'
 import { getUserEnvironmentVariables } from './env-vars'
 import type { DatabaseService } from '../db/database'
+
+/**
+ * On Windows the resolved codex binary can be a `.cmd`/`.bat`/`.com` shim
+ * (npm/bun globals install these), which node-pty cannot spawn directly — it
+ * must go through the command processor. Detection already runs these shims
+ * with `shell: true` for the same reason.
+ */
+function isWindowsShimBinary(binaryPath: string): boolean {
+  if (process.platform !== 'win32') return false
+  const ext = extname(binaryPath).toLowerCase()
+  return ext === '.cmd' || ext === '.bat' || ext === '.com'
+}
 
 /**
  * Builds the PTY spawn spec for a `codex-cli` session — the codex TUI running
@@ -99,10 +112,26 @@ export function buildCodexCliPtySpawn(input: CodexCliPtySpawnInput): CodexCliPty
     args.push(prompt)
   }
 
+  const binary = input.codexBinary || 'codex'
+  const env = getUserEnvironmentVariables(input.db ?? null)
+  const cwd = input.worktreePath
+
+  if (isWindowsShimBinary(binary)) {
+    // node-pty can't launch a .cmd/.bat shim directly — run it through the
+    // command processor (`cmd.exe /c <shim> …`), or the PTY never starts even
+    // though detection reported codex-cli available.
+    return {
+      command: process.env.COMSPEC || 'cmd.exe',
+      args: ['/c', binary, ...args],
+      cwd,
+      env
+    }
+  }
+
   return {
-    command: input.codexBinary || 'codex',
+    command: binary,
     args,
-    cwd: input.worktreePath,
-    env: getUserEnvironmentVariables(input.db ?? null)
+    cwd,
+    env
   }
 }

--- a/src/main/services/discord-session-bridge.test.ts
+++ b/src/main/services/discord-session-bridge.test.ts
@@ -310,6 +310,26 @@ describe('DiscordSessionBridge managed sessions', () => {
     )
   })
 
+  it('normalizes a codex-cli default to the codex SDK for the managed session', async () => {
+    // codex-cli has no Discord terminal bridge; it must be persisted/dispatched
+    // as codex or the prompt path rejects it as terminal-only.
+    const { db, bridge, openCode } = setupBridge()
+    setAppSettings(db, {
+      defaultAgentSdk: 'codex-cli',
+      selectedModelByProvider: {
+        'codex-cli': { providerID: 'codex', modelID: 'gpt-5.5' }
+      }
+    })
+
+    await bridge.handleUserMessage(userMessage(makeChannel(), 'codex cli default'))
+
+    expect(db.createdSessions[0]).toEqual(
+      expect.objectContaining({ agent_sdk: 'codex' })
+    )
+    // The prompt is dispatched (not rejected as a terminal-only CLI session).
+    expect(openCode.prompt).toHaveBeenCalled()
+  })
+
   it('reuses the same managed session for later messages without creating another one', async () => {
     const { db, bridge, openCode, emit } = setupBridge()
     const channel = makeChannel()

--- a/src/main/services/discord-session-bridge.test.ts
+++ b/src/main/services/discord-session-bridge.test.ts
@@ -5,6 +5,19 @@ import { DiscordSessionBridge, splitDiscordMessage } from './discord-session-bri
 import type { DiscordResource, Session, Worktree } from '../db/types'
 import type { OpenCodeStreamEvent } from '@shared/types/opencode'
 
+// codex-cli is only coerced to the codex app-server SDK when the binary supports
+// app-server. Default the probe to available; the codex-cli-only fallback test
+// flips it off.
+const codexResolverMocks = vi.hoisted(() => ({
+  resolveCodexBinaryPath: vi.fn(() => 'codex'),
+  supportsCodexAppServer: vi.fn(() => true)
+}))
+vi.mock('./codex-binary-resolver', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./codex-binary-resolver')>()),
+  resolveCodexBinaryPath: codexResolverMocks.resolveCodexBinaryPath,
+  supportsCodexAppServer: codexResolverMocks.supportsCodexAppServer
+}))
+
 const PLAN_MODE_PREFIX =
   '[Mode: Plan] You are in planning mode. Focus on designing, analyzing, and outlining an approach. Do NOT make code changes - instead describe what changes should be made and why.\n\n'
 
@@ -247,6 +260,8 @@ const flushPromises = async (): Promise<void> => {
 describe('DiscordSessionBridge managed sessions', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    codexResolverMocks.resolveCodexBinaryPath.mockReturnValue('codex')
+    codexResolverMocks.supportsCodexAppServer.mockReturnValue(true)
   })
 
   it('creates a managed OpenCode build session on the first message and persists both ids', async () => {
@@ -327,6 +342,25 @@ describe('DiscordSessionBridge managed sessions', () => {
       expect.objectContaining({ agent_sdk: 'codex' })
     )
     // The prompt is dispatched (not rejected as a terminal-only CLI session).
+    expect(openCode.prompt).toHaveBeenCalled()
+  })
+
+  it('falls back to OpenCode for a codex-cli default when the binary lacks app-server support', async () => {
+    // codex:false, codexCli:true — the codex implementer is registered but the
+    // binary can't run app-server, so persist opencode instead of a codex
+    // session that would throw at startSession().
+    codexResolverMocks.supportsCodexAppServer.mockReturnValue(false)
+    const { db, bridge, openCode } = setupBridge()
+    setAppSettings(db, {
+      defaultAgentSdk: 'codex-cli',
+      selectedModelByProvider: {
+        'codex-cli': { providerID: 'codex', modelID: 'gpt-5.5' }
+      }
+    })
+
+    await bridge.handleUserMessage(userMessage(makeChannel(), 'codex cli no app-server'))
+
+    expect(db.createdSessions[0]).toEqual(expect.objectContaining({ agent_sdk: 'opencode' }))
     expect(openCode.prompt).toHaveBeenCalled()
   })
 

--- a/src/main/services/discord-session-bridge.ts
+++ b/src/main/services/discord-session-bridge.ts
@@ -17,6 +17,7 @@ import { getDatabase } from '../db'
 import type { DiscordResource, Session, SessionMode } from '../db/types'
 import { agentEventBus } from './agent-event-bus'
 import type { AgentSdkManager } from './agent-sdk-manager'
+import { resolveCodexBinaryPath, supportsCodexAppServer } from './codex-binary-resolver'
 import { createLogger } from './logger'
 import {
   abortOpenCodeSession,
@@ -185,15 +186,29 @@ function getImplementerSdk(sdk: AgentSdk): AgentSdk {
   return sdk
 }
 
+/** Whether the installed codex binary supports the app-server (not just the CLI). */
+function codexAppServerAvailable(): boolean {
+  const binary = resolveCodexBinaryPath()
+  return !!binary && supportsCodexAppServer(binary)
+}
+
 /**
  * The SDK to PERSIST for a Discord-managed session. claude-code-cli keeps its
  * id (it has a Discord terminal bridge that mirrors its PTY hooks), but
  * codex-cli has no such bridge and Discord has no PTY, so it must run as the
  * codex SDK provider. Persisting the CLI id would make promptOpenCodeSession
  * reject every Discord prompt as terminal-only.
+ *
+ * A codex build can support the CLI/hooks yet not the app-server (detection
+ * reports codex:false, codexCli:true). The codex implementer stays registered
+ * regardless, so resolveCreation's getImplementer check can't catch this — we
+ * must verify the binary actually supports app-server before coercing, or
+ * CodexAppServerManager.startSession() throws at connect time. Fall back to
+ * OpenCode when codex can't run.
  */
 function toDiscordManagedSdk(sdk: AgentSdk): AgentSdk {
-  return sdk === 'codex-cli' ? 'codex' : sdk
+  if (sdk !== 'codex-cli') return sdk
+  return codexAppServerAvailable() ? 'codex' : 'opencode'
 }
 
 function displayToolName(name: string): string {

--- a/src/main/services/discord-session-bridge.ts
+++ b/src/main/services/discord-session-bridge.ts
@@ -185,6 +185,17 @@ function getImplementerSdk(sdk: AgentSdk): AgentSdk {
   return sdk
 }
 
+/**
+ * The SDK to PERSIST for a Discord-managed session. claude-code-cli keeps its
+ * id (it has a Discord terminal bridge that mirrors its PTY hooks), but
+ * codex-cli has no such bridge and Discord has no PTY, so it must run as the
+ * codex SDK provider. Persisting the CLI id would make promptOpenCodeSession
+ * reject every Discord prompt as terminal-only.
+ */
+function toDiscordManagedSdk(sdk: AgentSdk): AgentSdk {
+  return sdk === 'codex-cli' ? 'codex' : sdk
+}
+
 function displayToolName(name: string): string {
   const lower = name.toLowerCase()
   if (lower.includes('bash') || lower.includes('shell') || lower.includes('exec')) return 'Bash'
@@ -1267,7 +1278,7 @@ export class DiscordSessionBridge {
     const newSession = db.createSession({
       worktree_id: sourceSession.worktree_id,
       project_id: sourceSession.project_id ?? resource.project_id,
-      agent_sdk: selection.agentSdk,
+      agent_sdk: toDiscordManagedSdk(selection.agentSdk),
       mode: 'build',
       session_type: 'default',
       model_provider_id: selection.model.providerID,
@@ -1657,17 +1668,22 @@ export class DiscordSessionBridge {
       settings: this.readModelSettings(),
       mode
     })
-    if (resolved.agentSdk === 'opencode' || !this.sdkManager) return resolved
+    // Persist the Discord-runnable SDK (codex-cli -> codex), then validate an
+    // implementer exists — otherwise the created session is dispatched through
+    // a provider it can't run.
+    const agentSdk = toDiscordManagedSdk(resolved.agentSdk)
+    const model = resolved.model
+    if (agentSdk === 'opencode' || !this.sdkManager) return { agentSdk, model }
 
     try {
-      this.sdkManager.getImplementer(getImplementerSdk(resolved.agentSdk))
-      return resolved
+      this.sdkManager.getImplementer(getImplementerSdk(agentSdk))
+      return { agentSdk, model }
     } catch (error) {
       log.warn('Falling back to OpenCode for unregistered Discord agent SDK', {
-        requestedSdk: resolved.agentSdk,
+        requestedSdk: agentSdk,
         error: error instanceof Error ? error.message : String(error)
       })
-      return { agentSdk: 'opencode', model: resolved.model }
+      return { agentSdk: 'opencode', model }
     }
   }
 

--- a/src/main/services/discord-session-bridge.ts
+++ b/src/main/services/discord-session-bridge.ts
@@ -176,7 +176,13 @@ function normalizeToolStatus(status: unknown): 'running' | 'success' | 'error' {
 }
 
 function getImplementerSdk(sdk: AgentSdk): AgentSdk {
-  return sdk === 'claude-code-cli' ? 'claude-code' : sdk
+  // The terminal-backed CLIs have no Discord/streaming implementer of their
+  // own — dispatch to their SDK sibling (Discord runs the streaming provider,
+  // there is no PTY). Without this, getImplementer('codex-cli') misses and the
+  // bridge silently falls back to OpenCode with the Codex model.
+  if (sdk === 'claude-code-cli') return 'claude-code'
+  if (sdk === 'codex-cli') return 'codex'
+  return sdk
 }
 
 function displayToolName(name: string): string {

--- a/src/main/services/opencode-session-commands.ts
+++ b/src/main/services/opencode-session-commands.ts
@@ -9,7 +9,7 @@ import { CodexImplementer } from './codex-implementer'
 import { claudeCliTelegramBridge } from './claude-cli-telegram-bridge'
 import { claudeCliDiscordBridge } from './claude-cli-discord-bridge'
 import { toError } from './error-utils'
-import { isClaudeCli, isTerminalBacked } from '@shared/types/agent-sdk'
+import { isCliAgentSdk, isTerminalBacked } from '@shared/types/agent-sdk'
 
 const log = createLogger({ component: 'OpenCodeSessionCommands' })
 type PromptMessage =
@@ -29,7 +29,7 @@ const injectedWorktrees = new Set<string>()
 function resolveSdkId(
   dbService: DatabaseService,
   sessionId: string
-): 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal' | null {
+): 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'codex-cli' | 'terminal' | null {
   return (
     dbService.getAgentSdkForSession(sessionId) ?? dbService.getSession(sessionId)?.agent_sdk ?? null
   )
@@ -40,7 +40,9 @@ function resolveAgentSessionId(dbService: DatabaseService, sessionId: string): s
 }
 
 function toImplementerSdk(sdkId: AgentSdkId): AgentSdkId {
-  return sdkId === 'claude-code-cli' ? 'claude-code' : sdkId
+  if (sdkId === 'claude-code-cli') return 'claude-code'
+  if (sdkId === 'codex-cli') return 'codex'
+  return sdkId
 }
 
 export async function connectOpenCodeSession(
@@ -196,13 +198,13 @@ export async function promptOpenCodeSession(
         sdkId,
         route: sdkId && sdkId !== 'opencode' && !isTerminalBacked(sdkId) ? 'sdk' : 'opencode'
       })
-      if (isClaudeCli(sdkId)) {
-        // Terminal-backed Claude: prompts go through the PTY (bracketed paste /
-        // pending-prompt spawn), never the SDK implementer. Routing it there
-        // would corrupt the claude-code implementer's session state.
+      if (isCliAgentSdk(sdkId)) {
+        // Terminal-backed CLI agents: prompts go through the PTY (bracketed
+        // paste / pending-prompt spawn), never an SDK implementer. Routing
+        // one there would corrupt the implementer's session state.
         return {
           success: false,
-          error: 'claude-code-cli sessions receive prompts via the terminal, not the prompt API'
+          error: 'CLI agent sessions receive prompts via the terminal, not the prompt API'
         }
       }
       if (sdkId && sdkId !== 'opencode' && !isTerminalBacked(sdkId)) {
@@ -387,13 +389,13 @@ export async function refreshOpenCodeSessionFromThread(
 
 export async function listOpenCodeModels(
   opts?: {
-    agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+    agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'codex-cli' | 'terminal'
   },
   sdkManager?: AgentSdkManager
 ): Promise<{ success: boolean; providers: unknown; error?: string }> {
   log.info('OpenCode session models', { agentSdk: opts?.agentSdk })
   try {
-    const requestedSdk = opts?.agentSdk === 'claude-code-cli' ? 'claude-code' : opts?.agentSdk
+    const requestedSdk = opts?.agentSdk ? toImplementerSdk(opts.agentSdk) : opts?.agentSdk
     if (requestedSdk && requestedSdk !== 'opencode' && requestedSdk !== 'terminal' && sdkManager) {
       const impl = sdkManager.getImplementer(requestedSdk)
       if (impl) {
@@ -419,7 +421,7 @@ export async function setOpenCodeSelectedModel(
     providerID: string
     modelID: string
     variant?: string
-    agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+    agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'codex-cli' | 'terminal'
   } | null,
   sdkManager?: AgentSdkManager
 ): Promise<{ success: boolean; error?: string }> {
@@ -457,7 +459,7 @@ export async function setOpenCodeSelectedModel(
 export async function getOpenCodeModelInfo(
   worktreePath: string,
   modelId: string,
-  agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal',
+  agentSdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'codex-cli' | 'terminal',
   sdkManager?: AgentSdkManager
 ): Promise<{
   success: boolean
@@ -466,7 +468,7 @@ export async function getOpenCodeModelInfo(
 }> {
   log.info('OpenCode session modelInfo', { worktreePath, modelId, agentSdk })
   try {
-    const requestedSdk = agentSdk === 'claude-code-cli' ? 'claude-code' : agentSdk
+    const requestedSdk = agentSdk ? toImplementerSdk(agentSdk) : agentSdk
     if (requestedSdk && requestedSdk !== 'opencode' && requestedSdk !== 'terminal' && sdkManager) {
       const impl = sdkManager.getImplementer(requestedSdk)
       if (impl) {

--- a/src/main/services/system-info.ts
+++ b/src/main/services/system-info.ts
@@ -10,6 +10,12 @@ export interface AgentSdkDetection {
   opencode: boolean
   claude: boolean
   codex: boolean
+  /**
+   * The terminal-backed codex-cli provider only needs the binary to exist —
+   * unlike the SDK-driven `codex`, which additionally requires app-server
+   * support in the installed version.
+   */
+  codexCli: boolean
 }
 
 export interface AppPaths {
@@ -39,7 +45,8 @@ export function detectAgentSdks(openCodeLaunchSpec: OpenCodeLaunchSpec | null): 
   return {
     opencode: openCodeLaunchSpec !== null,
     claude: check('claude'),
-    codex: !!resolvedCodexBinary && supportsCodexAppServer(resolvedCodexBinary)
+    codex: !!resolvedCodexBinary && supportsCodexAppServer(resolvedCodexBinary),
+    codexCli: !!resolvedCodexBinary
   }
 }
 

--- a/src/main/services/system-info.ts
+++ b/src/main/services/system-info.ts
@@ -2,7 +2,11 @@ import { execFileSync } from 'child_process'
 import { existsSync } from 'fs'
 import { homedir } from 'os'
 import { getLogDir } from './logger'
-import { resolveCodexBinaryPath, supportsCodexAppServer } from './codex-binary-resolver'
+import {
+  resolveCodexBinaryPath,
+  supportsCodexAppServer,
+  supportsCodexCliHooks
+} from './codex-binary-resolver'
 import { resolveOpenCodeLaunchSpec } from './opencode-binary-resolver'
 import type { OpenCodeLaunchSpec } from './opencode-binary-resolver'
 
@@ -46,7 +50,10 @@ export function detectAgentSdks(openCodeLaunchSpec: OpenCodeLaunchSpec | null): 
     opencode: openCodeLaunchSpec !== null,
     claude: check('claude'),
     codex: !!resolvedCodexBinary && supportsCodexAppServer(resolvedCodexBinary),
-    codexCli: !!resolvedCodexBinary
+    // codex-cli only needs the binary (no app-server), but the binary MUST
+    // support the hook flags every spawn injects — an older codex without them
+    // would fail to start, so gate on hook capability rather than mere presence.
+    codexCli: !!resolvedCodexBinary && supportsCodexCliHooks(resolvedCodexBinary)
   }
 }
 

--- a/src/main/services/telegram-forwarding-service.test.ts
+++ b/src/main/services/telegram-forwarding-service.test.ts
@@ -8,12 +8,8 @@ import {
   DESKTOP_COMMAND_RESULT_TYPE,
   type DesktopCommandRequest
 } from '../../shared/desktop-command'
-import {
-  CODEX_CLI_SUPER_PLAN_MODE_PREFIX,
-  CODEX_PLAN_MODE_PREFIX
-} from '../../shared/agent-mode-prefixes'
 import { writeClaudeCliPrompt } from './claude-cli-pty-prompt'
-import { applyCodexCliPlanPrefix, TelegramForwardingService } from './telegram-forwarding-service'
+import { TelegramForwardingService } from './telegram-forwarding-service'
 
 vi.mock('./claude-cli-pty-prompt', () => ({
   writeClaudeCliPrompt: vi.fn(() => ({ delivered: true }))
@@ -148,45 +144,8 @@ describe('TelegramForwardingService backend events', () => {
   })
 })
 
-describe('applyCodexCliPlanPrefix', () => {
-  it('prefixes codex-cli plan / super-plan prompts with the codex plan prefix', () => {
-    expect(applyCodexCliPlanPrefix('codex-cli', 'plan', 'do X')).toBe(
-      CODEX_PLAN_MODE_PREFIX + 'do X'
-    )
-    expect(applyCodexCliPlanPrefix('codex-cli', 'super-plan', 'do X')).toBe(
-      CODEX_CLI_SUPER_PLAN_MODE_PREFIX + 'do X'
-    )
-  })
-
-  it('leaves codex-cli build/ask prompts and null mode verbatim', () => {
-    expect(applyCodexCliPlanPrefix('codex-cli', 'build', 'do X')).toBe('do X')
-    expect(applyCodexCliPlanPrefix('codex-cli', 'ask', 'do X')).toBe('do X')
-    expect(applyCodexCliPlanPrefix('codex-cli', null, 'do X')).toBe('do X')
-  })
-
-  it('never prefixes claude-code-cli (permission-mode drives its plan) or non-CLI SDKs', () => {
-    expect(applyCodexCliPlanPrefix('claude-code-cli', 'plan', 'do X')).toBe('do X')
-    expect(applyCodexCliPlanPrefix('codex', 'plan', 'do X')).toBe('do X')
-    expect(applyCodexCliPlanPrefix('opencode', 'super-plan', 'do X')).toBe('do X')
-  })
-})
-
 describe('TelegramForwardingService.sendPrompt CLI routing', () => {
-  it('injects a codex-cli plan follow-up into the PTY with the codex plan prefix', async () => {
-    vi.mocked(writeClaudeCliPrompt).mockClear()
-    const service = new TelegramForwardingService()
-    seedForwardingState(service)
-    Reflect.set(service, 'db', {
-      getSession: () => ({ agent_sdk: 'codex-cli', mode: 'plan', opencode_session_id: null })
-    })
-
-    const sendPrompt = Reflect.get(service, 'sendPrompt') as (text: string) => Promise<void>
-    await sendPrompt.call(service, 'add a test')
-
-    expect(writeClaudeCliPrompt).toHaveBeenCalledWith('s1', CODEX_PLAN_MODE_PREFIX + 'add a test')
-  })
-
-  it('injects a claude-code-cli follow-up into the PTY verbatim (no plan prefix)', async () => {
+  it('injects a claude-code-cli follow-up into the PTY verbatim', async () => {
     vi.mocked(writeClaudeCliPrompt).mockClear()
     const service = new TelegramForwardingService()
     seedForwardingState(service)
@@ -198,6 +157,36 @@ describe('TelegramForwardingService.sendPrompt CLI routing', () => {
     await sendPrompt.call(service, 'add a test')
 
     expect(writeClaudeCliPrompt).toHaveBeenCalledWith('s1', 'add a test')
+  })
+})
+
+describe('TelegramForwardingService.startForwarding SDK gating', () => {
+  it('rejects Telegram forwarding for codex-cli sessions (keyboard-driven TUI, no transport)', async () => {
+    const service = new TelegramForwardingService()
+    service.initialize({
+      db: {
+        getSetting: () =>
+          JSON.stringify({ botToken: 'token', chatId: 123, chatName: 'me', contextSize: 3 }),
+        getSession: () => ({
+          agent_sdk: 'codex-cli',
+          worktree_id: 'w1',
+          opencode_session_id: null
+        }),
+        getWorktree: () => ({ path: '/repo', branch_name: 'branch' }),
+        getProject: () => ({ name: 'Project' }),
+        setSetting: vi.fn(),
+        deleteSetting: vi.fn()
+      } as never
+    })
+
+    await expect(
+      service.startForwarding({
+        sessionId: 'cx1',
+        worktreeId: 'w1',
+        connectionId: null,
+        mode: 'all'
+      })
+    ).rejects.toThrow(/not supported for Codex CLI/i)
   })
 })
 

--- a/src/main/services/telegram-forwarding-service.test.ts
+++ b/src/main/services/telegram-forwarding-service.test.ts
@@ -8,7 +8,16 @@ import {
   DESKTOP_COMMAND_RESULT_TYPE,
   type DesktopCommandRequest
 } from '../../shared/desktop-command'
-import { TelegramForwardingService } from './telegram-forwarding-service'
+import {
+  CODEX_CLI_SUPER_PLAN_MODE_PREFIX,
+  CODEX_PLAN_MODE_PREFIX
+} from '../../shared/agent-mode-prefixes'
+import { writeClaudeCliPrompt } from './claude-cli-pty-prompt'
+import { applyCodexCliPlanPrefix, TelegramForwardingService } from './telegram-forwarding-service'
+
+vi.mock('./claude-cli-pty-prompt', () => ({
+  writeClaudeCliPrompt: vi.fn(() => ({ delivered: true }))
+}))
 
 vi.mock('./logger', () => ({
   createLogger: () => ({
@@ -136,6 +145,59 @@ describe('TelegramForwardingService backend events', () => {
       requestId: 'codex-plan:thread-1',
       plan: 'Do the work.'
     })
+  })
+})
+
+describe('applyCodexCliPlanPrefix', () => {
+  it('prefixes codex-cli plan / super-plan prompts with the codex plan prefix', () => {
+    expect(applyCodexCliPlanPrefix('codex-cli', 'plan', 'do X')).toBe(
+      CODEX_PLAN_MODE_PREFIX + 'do X'
+    )
+    expect(applyCodexCliPlanPrefix('codex-cli', 'super-plan', 'do X')).toBe(
+      CODEX_CLI_SUPER_PLAN_MODE_PREFIX + 'do X'
+    )
+  })
+
+  it('leaves codex-cli build/ask prompts and null mode verbatim', () => {
+    expect(applyCodexCliPlanPrefix('codex-cli', 'build', 'do X')).toBe('do X')
+    expect(applyCodexCliPlanPrefix('codex-cli', 'ask', 'do X')).toBe('do X')
+    expect(applyCodexCliPlanPrefix('codex-cli', null, 'do X')).toBe('do X')
+  })
+
+  it('never prefixes claude-code-cli (permission-mode drives its plan) or non-CLI SDKs', () => {
+    expect(applyCodexCliPlanPrefix('claude-code-cli', 'plan', 'do X')).toBe('do X')
+    expect(applyCodexCliPlanPrefix('codex', 'plan', 'do X')).toBe('do X')
+    expect(applyCodexCliPlanPrefix('opencode', 'super-plan', 'do X')).toBe('do X')
+  })
+})
+
+describe('TelegramForwardingService.sendPrompt CLI routing', () => {
+  it('injects a codex-cli plan follow-up into the PTY with the codex plan prefix', async () => {
+    vi.mocked(writeClaudeCliPrompt).mockClear()
+    const service = new TelegramForwardingService()
+    seedForwardingState(service)
+    Reflect.set(service, 'db', {
+      getSession: () => ({ agent_sdk: 'codex-cli', mode: 'plan', opencode_session_id: null })
+    })
+
+    const sendPrompt = Reflect.get(service, 'sendPrompt') as (text: string) => Promise<void>
+    await sendPrompt.call(service, 'add a test')
+
+    expect(writeClaudeCliPrompt).toHaveBeenCalledWith('s1', CODEX_PLAN_MODE_PREFIX + 'add a test')
+  })
+
+  it('injects a claude-code-cli follow-up into the PTY verbatim (no plan prefix)', async () => {
+    vi.mocked(writeClaudeCliPrompt).mockClear()
+    const service = new TelegramForwardingService()
+    seedForwardingState(service)
+    Reflect.set(service, 'db', {
+      getSession: () => ({ agent_sdk: 'claude-code-cli', mode: 'plan', opencode_session_id: null })
+    })
+
+    const sendPrompt = Reflect.get(service, 'sendPrompt') as (text: string) => Promise<void>
+    await sendPrompt.call(service, 'add a test')
+
+    expect(writeClaudeCliPrompt).toHaveBeenCalledWith('s1', 'add a test')
   })
 })
 

--- a/src/main/services/telegram-forwarding-service.ts
+++ b/src/main/services/telegram-forwarding-service.ts
@@ -19,7 +19,8 @@ import {
   type TelegramClaudeCliReplyResult,
   type TelegramClaudeCliSessionPayload
 } from '@shared/desktop-command'
-import { isClaudeCli, isCliAgentSdk } from '@shared/types/agent-sdk'
+import { isClaudeCli, isCliAgentSdk, isCodexCli } from '@shared/types/agent-sdk'
+import { getPlanModePrefix, getSuperPlanModePrefix } from '@shared/agent-mode-prefixes'
 import { openCodeService } from './opencode-service'
 import { ClaudeCodeImplementer } from './claude-code-implementer'
 import { CodexImplementer } from './codex-implementer'
@@ -251,6 +252,24 @@ export function isTrackedInteractionStale(
   requestId: string
 ): boolean {
   return !tracked.has(requestId)
+}
+
+/**
+ * Prepend codex-cli's plan-mode prompt prefix when a forwarded prompt targets a
+ * codex-cli session in plan/super-plan mode. Only codex-cli is prefixed:
+ * claude-code-cli drives plan mode via `--permission-mode` out-of-band, and the
+ * non-CLI SDKs handle plan mode entirely off the prompt text — so both are left
+ * verbatim. Mirrors the prefixing the renderer send paths apply (composePromptForSdk).
+ */
+export function applyCodexCliPlanPrefix(
+  agentSdk: string | null | undefined,
+  mode: string | null | undefined,
+  text: string
+): string {
+  if (!isCodexCli(agentSdk)) return text
+  if (mode === 'super-plan') return getSuperPlanModePrefix('codex-cli') + text
+  if (mode === 'plan') return getPlanModePrefix('codex-cli') + text
+  return text
 }
 
 export class TelegramForwardingService {
@@ -1187,8 +1206,16 @@ export class TelegramForwardingService {
     // claude-hook-server), so its questions/plans stay keyboard-driven in the
     // TUI — but plain forwarded prompts must still reach the terminal here.
     if (isCliAgentSdk(session.agent_sdk)) {
-      const { delivered } = writeClaudeCliPrompt(state.sessionId, text)
-      // No live PTY yet — keep it queued for the next idle flush (best-effort).
+      // codex-cli plan mode is enforced purely by the prompt prefix (it has no
+      // out-of-band permission-mode toggle like claude-cli), so a forwarded
+      // plan/super-plan follow-up must carry CODEX_PLAN_MODE_PREFIX or codex
+      // runs it as a default/build turn and never emits the <proposed_plan>
+      // block that drives plan_ready. claude-code-cli needs no prefix here.
+      const outbound = applyCodexCliPlanPrefix(session.agent_sdk, session.mode, text)
+      const { delivered } = writeClaudeCliPrompt(state.sessionId, outbound)
+      // No live PTY yet — queue the RAW text so the next idle flush re-derives
+      // the prefix from the (possibly changed) session mode rather than
+      // double-prefixing an already-prefixed prompt.
       if (!delivered) state.pendingQueuedPrompt = text
       return
     }

--- a/src/main/services/telegram-forwarding-service.ts
+++ b/src/main/services/telegram-forwarding-service.ts
@@ -19,8 +19,7 @@ import {
   type TelegramClaudeCliReplyResult,
   type TelegramClaudeCliSessionPayload
 } from '@shared/desktop-command'
-import { isClaudeCli, isCliAgentSdk, isCodexCli } from '@shared/types/agent-sdk'
-import { getPlanModePrefix, getSuperPlanModePrefix } from '@shared/agent-mode-prefixes'
+import { isClaudeCli, isCodexCli } from '@shared/types/agent-sdk'
 import { openCodeService } from './opencode-service'
 import { ClaudeCodeImplementer } from './claude-code-implementer'
 import { CodexImplementer } from './codex-implementer'
@@ -254,24 +253,6 @@ export function isTrackedInteractionStale(
   return !tracked.has(requestId)
 }
 
-/**
- * Prepend codex-cli's plan-mode prompt prefix when a forwarded prompt targets a
- * codex-cli session in plan/super-plan mode. Only codex-cli is prefixed:
- * claude-code-cli drives plan mode via `--permission-mode` out-of-band, and the
- * non-CLI SDKs handle plan mode entirely off the prompt text — so both are left
- * verbatim. Mirrors the prefixing the renderer send paths apply (composePromptForSdk).
- */
-export function applyCodexCliPlanPrefix(
-  agentSdk: string | null | undefined,
-  mode: string | null | undefined,
-  text: string
-): string {
-  if (!isCodexCli(agentSdk)) return text
-  if (mode === 'super-plan') return getSuperPlanModePrefix('codex-cli') + text
-  if (mode === 'plan') return getPlanModePrefix('codex-cli') + text
-  return text
-}
-
 export class TelegramForwardingService {
   private db: DatabaseService | null = null
   private sdkManager: AgentSdkManager | null = null
@@ -403,6 +384,18 @@ export class TelegramForwardingService {
     }
     if (!!params.worktreeId === !!params.connectionId) {
       throw new Error('Telegram forwarding requires exactly one target')
+    }
+
+    // codex-cli is not Telegram-forwardable — same stance as Discord, which also
+    // excludes it. Its questions and plan approvals are keyboard-driven in the
+    // codex TUI, and its hooks deliberately skip transports (claude-hook-server),
+    // so a forwarded codex-cli session could accept an inbound prompt but never
+    // emit responses / busy / idle / plan.ready back to Telegram (and queued
+    // prompts, which flush on idle, would strand). Block it up-front rather than
+    // half-forwarding.
+    const targetSession = this.db?.getSession(params.sessionId)
+    if (targetSession && isCodexCli(targetSession.agent_sdk)) {
+      throw new Error('Telegram forwarding is not supported for Codex CLI sessions')
     }
 
     const previous = this.state
@@ -1199,23 +1192,13 @@ export class TelegramForwardingService {
     const session = this.db?.getSession(state.sessionId)
     if (!session) throw new Error('Active session not found')
 
-    // CLI sessions (claude-code-cli and codex-cli) have no SDK implementer to
-    // route a prompt to; inject it straight into the PTY, exactly like the
-    // in-app terminal follow-up path (terminal-pty-bridge → writeClaudeCliPrompt,
-    // also gated by isCliAgentSdk). Note codex-cli hooks skip transports (see
-    // claude-hook-server), so its questions/plans stay keyboard-driven in the
-    // TUI — but plain forwarded prompts must still reach the terminal here.
-    if (isCliAgentSdk(session.agent_sdk)) {
-      // codex-cli plan mode is enforced purely by the prompt prefix (it has no
-      // out-of-band permission-mode toggle like claude-cli), so a forwarded
-      // plan/super-plan follow-up must carry CODEX_PLAN_MODE_PREFIX or codex
-      // runs it as a default/build turn and never emits the <proposed_plan>
-      // block that drives plan_ready. claude-code-cli needs no prefix here.
-      const outbound = applyCodexCliPlanPrefix(session.agent_sdk, session.mode, text)
-      const { delivered } = writeClaudeCliPrompt(state.sessionId, outbound)
-      // No live PTY yet — queue the RAW text so the next idle flush re-derives
-      // the prefix from the (possibly changed) session mode rather than
-      // double-prefixing an already-prefixed prompt.
+    // Claude CLI sessions have no SDK implementer; inject the prompt straight
+    // into the PTY. codex-cli is intentionally NOT handled here: it's blocked
+    // from Telegram forwarding up-front (see startForwarding), so a codex-cli
+    // session never reaches this path.
+    if (isClaudeCli(session.agent_sdk)) {
+      const { delivered } = writeClaudeCliPrompt(state.sessionId, text)
+      // No live PTY yet — keep it queued for the next idle flush (best-effort).
       if (!delivered) state.pendingQueuedPrompt = text
       return
     }

--- a/src/main/services/telegram-forwarding-service.ts
+++ b/src/main/services/telegram-forwarding-service.ts
@@ -19,7 +19,7 @@ import {
   type TelegramClaudeCliReplyResult,
   type TelegramClaudeCliSessionPayload
 } from '@shared/desktop-command'
-import { isClaudeCli } from '@shared/types/agent-sdk'
+import { isClaudeCli, isCliAgentSdk } from '@shared/types/agent-sdk'
 import { openCodeService } from './opencode-service'
 import { ClaudeCodeImplementer } from './claude-code-implementer'
 import { CodexImplementer } from './codex-implementer'
@@ -1180,8 +1180,13 @@ export class TelegramForwardingService {
     const session = this.db?.getSession(state.sessionId)
     if (!session) throw new Error('Active session not found')
 
-    // CLI sessions have no implementer; inject the prompt straight into the PTY.
-    if (isClaudeCli(session.agent_sdk)) {
+    // CLI sessions (claude-code-cli and codex-cli) have no SDK implementer to
+    // route a prompt to; inject it straight into the PTY, exactly like the
+    // in-app terminal follow-up path (terminal-pty-bridge → writeClaudeCliPrompt,
+    // also gated by isCliAgentSdk). Note codex-cli hooks skip transports (see
+    // claude-hook-server), so its questions/plans stay keyboard-driven in the
+    // TUI — but plain forwarded prompts must still reach the terminal here.
+    if (isCliAgentSdk(session.agent_sdk)) {
       const { delivered } = writeClaudeCliPrompt(state.sessionId, text)
       // No live PTY yet — keep it queued for the next idle flush (best-effort).
       if (!delivered) state.pendingQueuedPrompt = text

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -18,7 +18,17 @@ import {
 } from './claude-cli-subagent-tracker'
 import { setClaudeCliPlanAutoApprove } from './claude-cli-plan-auto-approve'
 import { logClaudeBinaryVersion, resolveClaudeBinaryPath } from './claude-binary-resolver'
-import { buildClaudeCliPtySpawn } from './claude-cli-spawner'
+import { buildClaudeCliPtySpawn, type ClaudeCliPtySpawn } from './claude-cli-spawner'
+import { buildCodexCliPtySpawn } from './codex-cli-spawner'
+import {
+  buildCodexCliHookArgs,
+  clearAllCodexSessionTracking,
+  clearCodexSessionTracking,
+  seedCodexSessionTracking,
+  setCodexSessionIdSink
+} from './codex-cli-hooks'
+import { resolveCodexBinaryPath } from './codex-binary-resolver'
+import { isCliAgentSdk, isCodexCli } from '@shared/types/agent-sdk'
 import { externalizeGoalHandoffPlan } from './claude-cli-plan-handoff'
 import { reassertClaudeCliPromptSubmit, writeClaudeCliPrompt } from './claude-cli-pty-prompt'
 import { watchForClaudeSessionId, type ClaudeSessionWatchHandle } from './claude-session-watcher'
@@ -75,6 +85,41 @@ function armClaudePlanFollowupWatcher(sessionId: string): void {
       })
     })
   )
+}
+
+
+let codexSessionIdSinkRegistered = false
+
+/**
+ * Persist codex thread ids reported by the hook translation layer (the codex
+ * analog of watchForClaudeSessionId — the id arrives on every hook payload):
+ * store on the session row (the claude_session_id column holds the CLI-native
+ * session id for every CLI provider) and notify the renderer over the same
+ * channel. Unlike claude, the id is refreshed on change so `/clear` (which
+ * starts a new codex thread) keeps resume pointing at the live thread.
+ */
+function ensureCodexSessionIdSink(): void {
+  if (codexSessionIdSinkRegistered) return
+  codexSessionIdSinkRegistered = true
+
+  setCodexSessionIdSink((sessionId, codexThreadId) => {
+    try {
+      const db = getDatabase()
+      if (db.getSession(sessionId)?.claude_session_id !== codexThreadId) {
+        db.updateSession(sessionId, { claude_session_id: codexThreadId })
+      }
+    } catch (error) {
+      log.warn('Failed to persist Codex CLI thread id', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+    void import('../desktop/backend-event-publisher')
+      .then(({ publishDesktopBackendEvent }) =>
+        publishDesktopBackendEvent(`terminal:claude-session-id:${sessionId}`, codexThreadId)
+      )
+      .catch(() => undefined)
+  })
 }
 
 function ensureClaudeCliStatusSubscription(): void {
@@ -152,6 +197,7 @@ export function destroyNodePtyTerminal(terminalId: string): void {
   closeClaudePlanFollowupWatcher(terminalId)
   clearClaudeCliInteractions(terminalId)
   clearClaudeCliSubagentTracking(terminalId)
+  clearCodexSessionTracking(terminalId)
   claudeCliSessions.delete(terminalId)
   claudeCliWorktreeBasenames.delete(terminalId)
   claudeCliTranscriptSources.delete(terminalId)
@@ -219,6 +265,7 @@ function attachNodePtyListeners(terminalId: string): void {
     if (claudeCliSessions.has(terminalId)) {
       clearClaudeCliInteractions(terminalId)
       clearClaudeCliSubagentTracking(terminalId)
+      clearCodexSessionTracking(terminalId)
       setClaudeCliPlanAutoApprove(terminalId, false)
       publishClaudeCliStatus({
         sessionId: terminalId,
@@ -248,9 +295,10 @@ export async function createClaudeCliTerminal(
     if (!session) {
       return { success: false, error: 'Session not found' }
     }
-    if (session.agent_sdk !== 'claude-code-cli') {
-      return { success: false, error: 'Session is not a Claude Code CLI session' }
+    if (!isCliAgentSdk(session.agent_sdk)) {
+      return { success: false, error: 'Session is not a CLI agent session' }
     }
+    const isCodex = isCodexCli(session.agent_sdk)
 
     let worktreePath: string | null = null
     if (session.worktree_id) {
@@ -269,24 +317,51 @@ export async function createClaudeCliTerminal(
       pendingPrompt = externalizeGoalHandoffPlan(pendingPrompt, worktreePath)
     }
 
-    const claudeBinary = resolveClaudeBinaryPath()
-    if (!claudeBinary) {
-      return { success: false, error: 'Claude binary not found on PATH' }
-    }
-    logClaudeBinaryVersion(claudeBinary)
-
     const alreadyExists = ptyService.has(sessionId)
     const { port } = await getClaudeHookServer()
     ensureClaudeCliStatusSubscription()
-    const hookSettingsJson = buildClaudeCliHookSettings(port, sessionId)
-    const spawn = buildClaudeCliPtySpawn({
-      session,
-      worktreePath,
-      pendingPrompt,
-      claudeBinary,
-      hookSettingsJson,
-      db
-    })
+
+    let spawn: ClaudeCliPtySpawn
+    if (isCodex) {
+      const codexBinary = resolveCodexBinaryPath()
+      if (!codexBinary) {
+        return { success: false, error: 'Codex binary not found on PATH' }
+      }
+      // Thread ids arrive on hook payloads (via the sink); hooks themselves
+      // ride the spawn args as -c overrides — nothing global is written.
+      ensureCodexSessionIdSink()
+      seedCodexSessionTracking(sessionId, session.claude_session_id)
+      // Plan mode is a PROMPT convention for codex-cli (CODEX_PLAN_MODE_PREFIX
+      // asks for a `<proposed_plan>` block and forbids mutation) — codex stays
+      // in its Default collaboration mode, so the plan prompt is delivered as a
+      // normal auto-submitting arg exactly like build mode. We deliberately do
+      // NOT flip codex into its native Plan collaboration mode: that mode shows
+      // codex's own interactive "Implement this plan?" popup, which is the
+      // claude-style plan dialog we want to avoid (see codex-cli-hooks.ts).
+      spawn = buildCodexCliPtySpawn({
+        session,
+        worktreePath,
+        pendingPrompt,
+        codexBinary,
+        hookArgs: buildCodexCliHookArgs(port, sessionId),
+        db
+      })
+    } else {
+      const claudeBinary = resolveClaudeBinaryPath()
+      if (!claudeBinary) {
+        return { success: false, error: 'Claude binary not found on PATH' }
+      }
+      logClaudeBinaryVersion(claudeBinary)
+      const hookSettingsJson = buildClaudeCliHookSettings(port, sessionId)
+      spawn = buildClaudeCliPtySpawn({
+        session,
+        worktreePath,
+        pendingPrompt,
+        claudeBinary,
+        hookSettingsJson,
+        db
+      })
+    }
 
     log.info('Creating Claude CLI PTY', {
       sessionId,
@@ -296,7 +371,9 @@ export async function createClaudeCliTerminal(
       )
     })
 
-    if (!session.claude_session_id) {
+    // Codex thread ids arrive on hook payloads (via the sink registered
+    // above); the filesystem watcher below is claude-transcript-specific.
+    if (!session.claude_session_id && !isCodex) {
       claudeWatchers.get(sessionId)?.close()
       claudeWatchers.set(
         sessionId,
@@ -322,10 +399,15 @@ export async function createClaudeCliTerminal(
         })
       )
     }
-    claudeCliTranscriptSources.set(sessionId, {
-      worktreePath,
-      claudeSessionId: session.claude_session_id
-    })
+    if (!isCodex) {
+      // Feeds the plan-followup watcher, which reads claude transcript files;
+      // codex plan followups arrive through hooks instead (UserPromptSubmit in
+      // plan mode → planning), so codex sessions never register a source.
+      claudeCliTranscriptSources.set(sessionId, {
+        worktreePath,
+        claudeSessionId: session.claude_session_id
+      })
+    }
 
     const { cols, rows } = ptyService.create(sessionId, {
       cwd: spawn.cwd,
@@ -335,11 +417,13 @@ export async function createClaudeCliTerminal(
     })
     if (alreadyExists && pendingPrompt) {
       // ptyService.create reused the live PTY, so the spawn args (and the
-      // prompt riding on them) never reached claude. Inject it as a paste so
-      // a racing promptless create call can't strand the prompt.
+      // prompt riding on them) never reached the CLI. Inject it as a paste so
+      // a racing promptless create call can't strand the prompt. (codex-cli
+      // plan prompts carry their instruction inline and need no mode toggle,
+      // so this path is identical for both CLIs.)
       const { delivered } = writeClaudeCliPrompt(sessionId, pendingPrompt)
       if (delivered) {
-        // The paste can land before claude's TUI is input-ready, which buffers
+        // The paste can land before the TUI is input-ready, which buffers
         // the text but drops the submitting CR — leaving the prompt sitting
         // unsent. Re-assert Enter across the boot window so it actually submits.
         reassertClaudeCliPromptSubmit(sessionId)
@@ -405,6 +489,7 @@ export function cleanupTerminals(): void {
   claudeCliLastStatus.clear()
   clearAllClaudeCliInteractions()
   clearAllClaudeCliSubagentTracking()
+  clearAllCodexSessionTracking()
   unsubscribeClaudeCliStatus?.()
   unsubscribeClaudeCliStatus = null
   resetAllClaudeCliTitleState()

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -54,6 +54,12 @@ const flushScheduled = new Set<string>()
 const claudeWatchers = new Map<string, ClaudeSessionWatchHandle>()
 const claudePlanFollowupWatchers = new Map<string, ClaudePlanFollowupWatchHandle>()
 const claudeCliSessions = new Set<string>()
+// Sessions eligible for OSC terminal-title auto-naming. Only claude-code-cli:
+// claude emits a task-summary title, whereas codex's title is a configurable
+// status line (app name · project · branch · tokens), which would make a poor
+// session name / branch rename. So codex-cli is deliberately excluded from the
+// title-parse path (not merely dropped at persist time).
+const claudeCliTitleSessions = new Set<string>()
 const claudeCliWorktreeBasenames = new Map<string, string>()
 const claudeCliTranscriptSources = new Map<
   string,
@@ -199,6 +205,7 @@ export function destroyNodePtyTerminal(terminalId: string): void {
   clearClaudeCliSubagentTracking(terminalId)
   clearCodexSessionTracking(terminalId)
   claudeCliSessions.delete(terminalId)
+  claudeCliTitleSessions.delete(terminalId)
   claudeCliWorktreeBasenames.delete(terminalId)
   claudeCliTranscriptSources.delete(terminalId)
   claudeCliLastStatus.delete(terminalId)
@@ -218,7 +225,7 @@ function attachNodePtyListeners(terminalId: string): void {
     const existing = dataBuffers.get(terminalId)
     dataBuffers.set(terminalId, existing ? existing + data : data)
 
-    if (claudeCliSessions.has(terminalId)) {
+    if (claudeCliTitleSessions.has(terminalId)) {
       const title = processClaudeCliPtyData(terminalId, data, {
         worktreeBasename: claudeCliWorktreeBasenames.get(terminalId)
       })
@@ -274,6 +281,7 @@ function attachNodePtyListeners(terminalId: string): void {
       })
       claudeCliSessions.delete(terminalId)
     }
+    claudeCliTitleSessions.delete(terminalId)
     claudeCliWorktreeBasenames.delete(terminalId)
     claudeCliTranscriptSources.delete(terminalId)
     claudeCliLastStatus.delete(terminalId)
@@ -434,6 +442,13 @@ export async function createClaudeCliTerminal(
       })
     }
     claudeCliSessions.add(sessionId)
+    // Only claude-code-cli emits summary titles worth persisting (see
+    // claudeCliTitleSessions); codex-cli is excluded from title parsing.
+    if (isCodex) {
+      claudeCliTitleSessions.delete(sessionId)
+    } else {
+      claudeCliTitleSessions.add(sessionId)
+    }
     // A restarted session must never inherit a stale interaction latch.
     clearClaudeCliInteractions(sessionId)
     // ...nor a stale subagent deferral/pending-notification set, which could
@@ -484,6 +499,7 @@ export function cleanupTerminals(): void {
   }
   claudePlanFollowupWatchers.clear()
   claudeCliSessions.clear()
+  claudeCliTitleSessions.clear()
   claudeCliWorktreeBasenames.clear()
   claudeCliTranscriptSources.clear()
   claudeCliLastStatus.clear()

--- a/src/main/services/text-generation-router.ts
+++ b/src/main/services/text-generation-router.ts
@@ -178,7 +178,9 @@ function resolveProvider(provider: AgentSdkId): TextGenProvider | null {
   const sdks = getCachedSdkDetection()
   const providerAvailable: Record<TextGenProvider, boolean> = {
     'claude-code': sdks.claude,
-    codex: sdks.codex,
+    // Text generation spawns `codex exec`, which needs only the codex binary
+    // (no app-server) — available whenever either codex signal is set.
+    codex: sdks.codex || sdks.codexCli,
     opencode: sdks.opencode
   }
 

--- a/src/main/services/text-generation-router.ts
+++ b/src/main/services/text-generation-router.ts
@@ -142,24 +142,49 @@ export async function generateText(
 }
 
 /**
- * Resolve to an available provider, falling back if the requested one is unavailable.
+ * The providers that have an actual text-generation implementation. The
+ * terminal-backed CLI providers (`claude-code-cli`, `codex-cli`) have none —
+ * text generation runs through their SDK sibling's exec/app-server route — so
+ * they are normalized to that sibling before dispatch.
+ */
+type TextGenProvider = 'claude-code' | 'codex' | 'opencode'
+
+function toTextGenProvider(provider: AgentSdkId): TextGenProvider | null {
+  switch (provider) {
+    case 'claude-code':
+    case 'claude-code-cli':
+      return 'claude-code'
+    case 'codex':
+    case 'codex-cli':
+      return 'codex'
+    case 'opencode':
+      return 'opencode'
+    case 'terminal':
+      return null
+  }
+}
+
+/**
+ * Resolve to an available text-generation provider, falling back if the
+ * requested one is unavailable. CLI providers are normalized to their SDK
+ * sibling first, so the returned id always has a `generateWithProvider` branch
+ * (a bare CLI id would otherwise fall through the switch to `undefined`).
  * Fallback order: claude-code -> codex -> opencode.
  */
-function resolveProvider(provider: AgentSdkId): AgentSdkId | null {
-  if (provider === 'terminal') return null
+function resolveProvider(provider: AgentSdkId): TextGenProvider | null {
+  const normalized = toTextGenProvider(provider)
+  if (!normalized) return null
 
   const sdks = getCachedSdkDetection()
-  const providerAvailable: Record<Exclude<AgentSdkId, 'terminal'>, boolean> = {
+  const providerAvailable: Record<TextGenProvider, boolean> = {
     'claude-code': sdks.claude,
-    'claude-code-cli': sdks.claude,
     codex: sdks.codex,
-    'codex-cli': sdks.codexCli,
     opencode: sdks.opencode
   }
 
-  if (providerAvailable[provider]) return provider
+  if (providerAvailable[normalized]) return normalized
 
-  const fallbackOrder: Exclude<AgentSdkId, 'terminal'>[] = ['claude-code', 'codex', 'opencode']
+  const fallbackOrder: TextGenProvider[] = ['claude-code', 'codex', 'opencode']
   for (const fallback of fallbackOrder) {
     if (providerAvailable[fallback]) return fallback
   }
@@ -171,7 +196,7 @@ function resolveProvider(provider: AgentSdkId): AgentSdkId | null {
  * Dispatch to the correct provider implementation.
  */
 function generateWithProvider(
-  provider: AgentSdkId,
+  provider: TextGenProvider,
   prompt: string,
   systemPrompt: string,
   modelOverride?: string,
@@ -185,8 +210,6 @@ function generateWithProvider(
       return generateWithCodex(prompt, systemPrompt, modelOverride, outputSchema, cwd)
     case 'opencode':
       return generateWithOpenCode(prompt, systemPrompt, modelOverride, cwd)
-    case 'terminal':
-      return Promise.resolve(null)
   }
 }
 

--- a/src/main/services/text-generation-router.ts
+++ b/src/main/services/text-generation-router.ts
@@ -7,6 +7,7 @@ import { Effect } from 'effect'
 import { loadClaudeSDK } from './claude-sdk-loader'
 import { resolveCodexBinaryPath } from './codex-binary-resolver'
 import { getCodexCliEnv } from './codex-cli-env'
+import { isWindowsShimBinary } from './codex-cli-spawner'
 import { detectAgentSdks } from './system-info'
 import type { AgentSdkDetection } from './system-info'
 import type { OpenCodeLaunchSpec } from './opencode-binary-resolver'
@@ -342,12 +343,21 @@ async function generateWithCodex(
     }
     args.push('--output-last-message', outputFile, '-')
 
+    // A Windows npm/bun global install resolves codex to a `.cmd`/`.bat` shim,
+    // which child_process can't launch directly — run it through the shell, the
+    // same way codex-app-server-manager and codex-cli-spawner handle the shim.
+    // Without this, `codexCli` would advertise Codex text generation (see
+    // toTextGenProvider) and then fail every `codex exec` here instead of the
+    // caller getting a chance to fall back.
+    const useShell = isWindowsShimBinary(binary)
+
     await spawnWithStdin(
       binary,
       args,
       fullPrompt,
       cwd,
-      spawnEnv
+      spawnEnv,
+      useShell
     )
     const output = await readFile(outputFile, 'utf-8')
     return output.trim() || null
@@ -416,7 +426,8 @@ function spawnWithStdin(
   args: string[],
   input: string,
   cwd?: string,
-  env?: NodeJS.ProcessEnv
+  env?: NodeJS.ProcessEnv,
+  shell?: boolean
 ): Promise<string> {
   return getRuntime()
     .runPromise(
@@ -429,7 +440,8 @@ function spawnWithStdin(
           maxOutputBytes: MAX_OUTPUT_SIZE,
           collectStderr: true,
           env: env ?? process.env,
-          cwd
+          cwd,
+          shell
         })
       )
     )

--- a/src/main/services/text-generation-router.ts
+++ b/src/main/services/text-generation-router.ts
@@ -151,7 +151,9 @@ function resolveProvider(provider: AgentSdkId): AgentSdkId | null {
   const sdks = getCachedSdkDetection()
   const providerAvailable: Record<Exclude<AgentSdkId, 'terminal'>, boolean> = {
     'claude-code': sdks.claude,
+    'claude-code-cli': sdks.claude,
     codex: sdks.codex,
+    'codex-cli': sdks.codexCli,
     opencode: sdks.opencode
   }
 

--- a/src/renderer/src/api/db-api.ts
+++ b/src/renderer/src/api/db-api.ts
@@ -74,7 +74,7 @@ type SessionCreateData = {
   name?: string | null
   opencode_session_id?: string | null
   claude_session_id?: string | null
-  agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'codex-cli' | 'terminal'
   mode?: 'build' | 'plan' | 'super-plan'
   session_type?: 'default' | 'board-assistant'
   model_provider_id?: string | null
@@ -88,7 +88,7 @@ type SessionUpdateData = {
   status?: 'active' | 'completed' | 'error'
   opencode_session_id?: string | null
   claude_session_id?: string | null
-  agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+  agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'codex-cli' | 'terminal'
   mode?: 'build' | 'plan' | 'super-plan'
   session_type?: 'default' | 'board-assistant'
   model_provider_id?: string | null

--- a/src/renderer/src/api/opencode-api.ts
+++ b/src/renderer/src/api/opencode-api.ts
@@ -4,7 +4,7 @@ import { OPENCODE_STREAM_CHANNEL } from '@shared/opencode-events'
 import type { OpenCodeStreamEvent } from '@shared/types/opencode'
 import { getRendererRpcClient } from './rpc-client'
 
-type OpenCodeAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+type OpenCodeAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'codex-cli' | 'terminal'
 
 export type OpenCodeSetModelInput = {
   readonly providerID: string

--- a/src/renderer/src/api/system-api.ts
+++ b/src/renderer/src/api/system-api.ts
@@ -30,6 +30,7 @@ interface AgentSdkDetectionResult {
   readonly opencode: boolean
   readonly claude: boolean
   readonly codex: boolean
+  readonly codexCli?: boolean
 }
 
 interface MenuStatePayload {

--- a/src/renderer/src/components/kanban/BoardAssistantView.tsx
+++ b/src/renderer/src/components/kanban/BoardAssistantView.tsx
@@ -243,7 +243,14 @@ async function ensureRuntimeSession(
     currentState.selectedAgentSdkOverride ?? resolveBoardChatAgentSdk(settings.defaultAgentSdk)
   const selectedModel =
     currentState.selectedModelOverride ?? resolveBoardChatDefaultModel(settings, baseAgentSdk)
-  const agentSdk = currentState.selectedAgentSdkOverride ?? selectedModel?.agentSdk ?? baseAgentSdk
+  // Coerce away terminal-backed CLI SDKs (codex-cli / claude-code-cli): a saved
+  // `/ask` default or model override can carry one via selectedModel.agentSdk,
+  // but the board assistant is a streaming PTY-less session, so persisting a CLI
+  // agent_sdk here makes later prompts fail promptOpenCodeSession's isCliAgentSdk
+  // guard. Mirrors the coercion in useBoardChatStore.ensureRuntime.
+  const agentSdk =
+    currentState.selectedAgentSdkOverride ??
+    resolveBoardChatAgentSdk(selectedModel?.agentSdk ?? baseAgentSdk)
 
   let runtimePath: string | null = null
   let worktreeId: string | null = null

--- a/src/renderer/src/components/kanban/BoardAssistantView.tsx
+++ b/src/renderer/src/components/kanban/BoardAssistantView.tsx
@@ -240,17 +240,20 @@ async function ensureRuntimeSession(
 
   const settings = useSettingsStore.getState()
   const baseAgentSdk =
-    currentState.selectedAgentSdkOverride ?? resolveBoardChatAgentSdk(settings.defaultAgentSdk)
+    currentState.selectedAgentSdkOverride ??
+    resolveBoardChatAgentSdk(settings.defaultAgentSdk, settings.availableAgentSdks)
   const selectedModel =
     currentState.selectedModelOverride ?? resolveBoardChatDefaultModel(settings, baseAgentSdk)
   // Coerce away terminal-backed CLI SDKs (codex-cli / claude-code-cli): a saved
   // `/ask` default or model override can carry one via selectedModel.agentSdk,
   // but the board assistant is a streaming PTY-less session, so persisting a CLI
   // agent_sdk here makes later prompts fail promptOpenCodeSession's isCliAgentSdk
-  // guard. Mirrors the coercion in useBoardChatStore.ensureRuntime.
+  // guard. Mirrors the coercion in useBoardChatStore.ensureRuntime. Also falls
+  // back to opencode when the coerced streaming provider (e.g. codex app-server)
+  // isn't actually available.
   const agentSdk =
     currentState.selectedAgentSdkOverride ??
-    resolveBoardChatAgentSdk(selectedModel?.agentSdk ?? baseAgentSdk)
+    resolveBoardChatAgentSdk(selectedModel?.agentSdk ?? baseAgentSdk, settings.availableAgentSdks)
 
   let runtimePath: string | null = null
   let worktreeId: string | null = null

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -105,7 +105,7 @@ import { useConflictFixFlow } from '@/hooks/useConflictFixFlow'
 import { useTicketRemoteLaunch } from '@/hooks/useTicketRemoteLaunch'
 import { formatTokenCount } from '@/lib/format-utils'
 import { canToggleAutoApprovePlan } from '@/lib/plan-auto-approve'
-import { isClaudeCli } from '@shared/types/agent-sdk'
+import { isCliAgentSdk } from '@shared/types/agent-sdk'
 import { terminalApi } from '@/api/terminal-api'
 import type { KanbanTicket, TicketMark } from '../../../../main/db/types'
 
@@ -972,7 +972,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       // Mirror the durable flag into the hook server's in-memory armed registry
       // when a claude-cli session is already live; sessions armed before they
       // exist are registered by the status listener on their first planning turn.
-      if (ticket.current_session_id && isClaudeCli(linkedSessionAgentSdk)) {
+      if (ticket.current_session_id && isCliAgentSdk(linkedSessionAgentSdk)) {
         await terminalApi.setClaudeCliPlanAutoApprove(ticket.current_session_id, next)
       }
     } catch {

--- a/src/renderer/src/components/kanban/KanbanTicketModal.review-tab.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.review-tab.test.tsx
@@ -349,4 +349,25 @@ describe('KanbanTicketModal review mode Tab handling', () => {
     expect(tabNotPrevented).toBe(true)
     expect(shiftTabNotPrevented).toBe(true)
   })
+
+  it('keeps the mode chip and intercepts Tab for codex-cli sessions (no in-terminal toggle)', async () => {
+    // codex-cli has no in-terminal permission-mode toggle — its plan/super-plan
+    // is driven from followUpMode via CODEX_PLAN_MODE_PREFIX — so unlike claude-cli
+    // the modal must keep the mode toggle and own Tab/Shift+Tab.
+    const session = makeSession('codex-cli')
+    dbApiMocks.session.get.mockResolvedValue(session)
+    setupStores(session)
+
+    renderModal()
+
+    const textarea = await screen.findByTestId('review-followup-input')
+    const chip = await screen.findByTestId('review-mode-toggle')
+    expect(chip).toHaveAttribute('data-mode', 'build')
+
+    textarea.focus()
+    const notPrevented = fireEvent.keyDown(textarea, { key: 'Tab' })
+
+    expect(notPrevented).toBe(false)
+    expect(chip).toHaveAttribute('data-mode', 'plan')
+  })
 })

--- a/src/renderer/src/components/kanban/KanbanTicketModal.review-tab.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.review-tab.test.tsx
@@ -140,7 +140,7 @@ const worktree: Worktree = {
   last_accessed_at: now
 }
 
-function makeSession(agentSdk: string): Session {
+function makeSession(agentSdk: Session['agent_sdk']): Session {
   return {
     id: 'session-1',
     worktree_id: 'worktree-1',

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -2009,6 +2009,13 @@ function PlanReviewModeContent({
 
   const isConnectionSession = !!sessionRecord?.connection_id
   const isClaudeCliPlanSession = isCliAgentSdk(sessionRecord?.agent_sdk)
+  // Only claude-cli hides the modal mode toggle / cedes Tab+Shift+Tab to its
+  // terminal (its plan mode IS the in-terminal permission-mode toggle). codex-cli
+  // has no in-terminal toggle — plan/super-plan is driven from followUpMode via
+  // CODEX_PLAN_MODE_PREFIX — so it keeps the modal toggle. (Dropzone/superpowers
+  // below stay gated on isClaudeCliPlanSession: both CLI terminals hide those.)
+  const terminalOwnsModeToggle =
+    isClaudeCliPlanSession && !isCodexCli(sessionRecord?.agent_sdk)
   const hasWorkingContext = !!(sessionRecord?.worktree_id || sessionRecord?.connection_id)
 
   const [slashCommands, setSlashCommands] = useState<{ name: string }[]>([])
@@ -2096,7 +2103,7 @@ function PlanReviewModeContent({
 
   // Tab key toggles mode, Shift+Tab toggles super-plan
   useEffect(() => {
-    if (isClaudeCliPlanSession) return
+    if (terminalOwnsModeToggle) return
     const handler = (e: KeyboardEvent): void => {
       if (e.key === 'Tab' && !e.ctrlKey && !e.metaKey && !e.altKey) {
         const modal = document.querySelector('[data-testid="kanban-ticket-modal"]')
@@ -2113,7 +2120,7 @@ function PlanReviewModeContent({
     }
     window.addEventListener('keydown', handler, true)
     return () => window.removeEventListener('keydown', handler, true)
-  }, [isClaudeCliPlanSession, toggleMode, toggleSuperMode])
+  }, [terminalOwnsModeToggle, toggleMode, toggleSuperMode])
 
   // ── Send followup (reject pending plan + iterate) ────────────────
   const handleSendFollowup = useCallback(async () => {
@@ -2911,7 +2918,7 @@ function PlanReviewModeContent({
         placeholder="Iterate on the plan... (Enter to send)"
         testIdPrefix="plan-review"
         showInlineSendButton
-        hideModeToggle={isClaudeCliPlanSession}
+        hideModeToggle={terminalOwnsModeToggle}
         textareaRef={textareaRef}
       />
 
@@ -3015,7 +3022,13 @@ function ReviewModeContent({
     () => (ticket.worktree_id ? findWorktreeById(ticket.worktree_id) : null),
     [ticket.worktree_id]
   )
-  const isClaudeCliSession = isCliAgentSdk(sessionRecord?.agent_sdk)
+  // Hide the modal's follow-up mode toggle (and let Tab/Shift+Tab reach the
+  // embedded terminal) ONLY for claude-cli, whose plan mode IS the in-terminal
+  // permission-mode toggle. codex-cli has no in-terminal toggle — its
+  // plan/super-plan comes from followUpMode → CODEX_PLAN_MODE_PREFIX in
+  // sendFollowupToSession — so it must keep the modal toggle selectable.
+  const isClaudeCliSession =
+    isCliAgentSdk(sessionRecord?.agent_sdk) && !isCodexCli(sessionRecord?.agent_sdk)
   const [followUpText, setFollowUpText] = useState('')
   const [followUpMode, setFollowUpMode] = useState<FollowUpMode>('build')
   const [isSending, setIsSending] = useState(false)

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
+import { isCliAgentSdk, isCodexCli } from '@shared/types/agent-sdk'
 import { useShallow } from 'zustand/react/shallow'
 import {
   Eye,
@@ -75,7 +76,12 @@ import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/mes
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
 import { markClaudeCliPromptStarted } from '@/lib/claude-cli-send-tracking'
-import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
+import {
+  CODEX_PLAN_MODE_PREFIX,
+  PLAN_MODE_PREFIX,
+  getSuperPlanModePrefix,
+  isPlanLike
+} from '@/lib/constants'
 import { buildSdkPlanImplementationPrompt } from '@/lib/proposedPlan'
 import { toast } from '@/lib/toast'
 import {
@@ -424,13 +430,24 @@ async function sendFollowupToSession(opts: {
   // This updates modeBySession, persists to DB, and applies mode-specific default model.
   await useSessionStore.getState().setSessionMode(opts.sessionId, opts.followUpMode)
 
-  // Claude Code & Codex handle plan mode via the SDK — don't prepend the text prefix
-  const skipPrefix = session.agent_sdk === 'claude-code' || session.agent_sdk === 'codex'
+  // Claude Code & Codex SDKs handle plan mode out-of-band (no text prefix), and
+  // claude-cli drives it via --permission-mode plan (also no prefix). codex-cli
+  // is the exception: it carries codex's `<proposed_plan>` convention as a
+  // prompt prefix (CODEX_PLAN_MODE_PREFIX), so plan followups keep asking codex
+  // for a plan the codex way rather than the claude way.
+  const skipPrefix =
+    session.agent_sdk === 'claude-code' ||
+    session.agent_sdk === 'codex' ||
+    session.agent_sdk === 'claude-code-cli'
   const modePrefix =
     opts.followUpMode === 'super-plan'
       ? getSuperPlanModePrefix(session.agent_sdk)
-      : opts.followUpMode === 'plan' && !skipPrefix
-        ? PLAN_MODE_PREFIX
+      : opts.followUpMode === 'plan'
+        ? isCodexCli(session.agent_sdk)
+          ? CODEX_PLAN_MODE_PREFIX
+          : skipPrefix
+            ? ''
+            : PLAN_MODE_PREFIX
         : ''
   const fullPrompt = modePrefix + opts.prompt
 
@@ -455,7 +472,7 @@ async function sendFollowupToSession(opts: {
   // Resolve model AFTER setSessionMode (which may have applied a mode-specific default)
   const model = resolveSessionModel(opts.sessionId, result.session)
 
-  if (session.agent_sdk === 'claude-code-cli') {
+  if (isCliAgentSdk(session.agent_sdk)) {
     const delivery = unwrapEnvelope(
       await terminalApi.sendClaudeCliPrompt(opts.sessionId, fullPrompt)
     )
@@ -922,7 +939,7 @@ function KanbanTicketModalContent({
   }, [sessionRecord?.worktree_id])
 
   const effectiveSession = sessionRecord ?? dbSessionInfo?.session ?? null
-  const isClaudeCli = effectiveSession?.agent_sdk === 'claude-code-cli'
+  const isClaudeCli = isCliAgentSdk(effectiveSession?.agent_sdk)
   const currentWorktreeSessionStatus = useWorktreeStatusStore(
     useCallback(
       (state) =>
@@ -1991,7 +2008,7 @@ function PlanReviewModeContent({
   const dropZoneRef = useRef<HTMLDivElement>(null)
 
   const isConnectionSession = !!sessionRecord?.connection_id
-  const isClaudeCliPlanSession = sessionRecord?.agent_sdk === 'claude-code-cli'
+  const isClaudeCliPlanSession = isCliAgentSdk(sessionRecord?.agent_sdk)
   const hasWorkingContext = !!(sessionRecord?.worktree_id || sessionRecord?.connection_id)
 
   const [slashCommands, setSlashCommands] = useState<{ name: string }[]>([])
@@ -2348,7 +2365,7 @@ function PlanReviewModeContent({
           })
 
           prepareTicketBuildSession(newSessionId, handoffGoalMode)
-          if (newSession.agent_sdk === 'claude-code-cli') {
+          if (isCliAgentSdk(newSession.agent_sdk)) {
             registerHivePromptHandoff(sessionId, newSessionId)
             sessionStore.setPendingMessage(newSessionId, handoffPrompt)
           }
@@ -2356,7 +2373,7 @@ function PlanReviewModeContent({
           const boardMode = useSettingsStore.getState().boardMode
           if (boardMode === 'sticky-tab') {
             sessionStore.setActiveSession(BOARD_TAB_ID)
-          } else if (newSession.agent_sdk !== 'claude-code-cli') {
+          } else if (!isCliAgentSdk(newSession.agent_sdk)) {
             sessionStore.setActiveConnection(sessionRecord.connection_id)
             sessionStore.setActiveConnectionSession(newSessionId)
           }
@@ -2364,7 +2381,7 @@ function PlanReviewModeContent({
           onClose()
           void (async () => {
             await setModePromise
-            if (newSession.agent_sdk === 'claude-code-cli') {
+            if (isCliAgentSdk(newSession.agent_sdk)) {
               bumpWorktreeLastMessage({ connectionId: sessionRecord.connection_id })
               const cliResult = unwrapEnvelope(
                 await terminalApi.createClaudeCli(newSessionId, {
@@ -2434,7 +2451,7 @@ function PlanReviewModeContent({
         }
 
         prepareTicketBuildSession(newSessionId, handoffGoalMode)
-        if (newSession.agent_sdk === 'claude-code-cli') {
+        if (isCliAgentSdk(newSession.agent_sdk)) {
           registerHivePromptHandoff(sessionId, newSessionId)
           sessionStore.setPendingMessage(newSessionId, handoffPrompt)
         }
@@ -2442,7 +2459,7 @@ function PlanReviewModeContent({
         const boardMode = useSettingsStore.getState().boardMode
         if (boardMode === 'sticky-tab') {
           sessionStore.setActiveSession(BOARD_TAB_ID)
-        } else if (newSession.agent_sdk !== 'claude-code-cli') {
+        } else if (!isCliAgentSdk(newSession.agent_sdk)) {
           sessionStore.setActiveWorktree(worktreeId)
           sessionStore.setActiveSession(newSessionId)
         }
@@ -2450,7 +2467,7 @@ function PlanReviewModeContent({
         onClose()
         void (async () => {
           await setModePromise
-          if (newSession.agent_sdk === 'claude-code-cli') {
+          if (isCliAgentSdk(newSession.agent_sdk)) {
             bumpWorktreeLastMessage({ worktreeId })
             const cliResult = unwrapEnvelope(
               await terminalApi.createClaudeCli(newSessionId, {
@@ -2994,7 +3011,7 @@ function ReviewModeContent({
     () => (ticket.worktree_id ? findWorktreeById(ticket.worktree_id) : null),
     [ticket.worktree_id]
   )
-  const isClaudeCliSession = sessionRecord?.agent_sdk === 'claude-code-cli'
+  const isClaudeCliSession = isCliAgentSdk(sessionRecord?.agent_sdk)
   const [followUpText, setFollowUpText] = useState('')
   const [followUpMode, setFollowUpMode] = useState<FollowUpMode>('build')
   const [isSending, setIsSending] = useState(false)

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
-import { isCliAgentSdk, isCodexCli } from '@shared/types/agent-sdk'
+import { isCliAgentSdk, isCodexCli, supportsGoalMode } from '@shared/types/agent-sdk'
 import { useShallow } from 'zustand/react/shallow'
 import {
   Eye,
@@ -2327,7 +2327,11 @@ function PlanReviewModeContent({
 
       try {
         const sessionId = ticket.current_session_id
-        const handoffGoalMode = override?.goalMode === true && override?.agentSdk === 'codex'
+        // Any goal-capable target (codex, codex-cli, claude-code-cli) must keep
+        // goal_mode when relinked — buildHandoffPrompt already emits `/goal` for
+        // them, so `=== 'codex'` alone would drop goal tracking for the CLIs.
+        const handoffGoalMode =
+          override?.goalMode === true && supportsGoalMode(override?.agentSdk)
         useSessionStore.getState().clearPendingPlan(sessionId)
         useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
         lastSendMode.delete(sessionId)

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -93,7 +93,13 @@ const initialProjectState = useProjectStore.getState()
 const initialUsageState = useUsageStore.getState()
 const initialWorktreeStatusState = useWorktreeStatusStore.getState()
 
-type TestAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+type TestAgentSdk =
+  | 'opencode'
+  | 'claude-code'
+  | 'claude-code-cli'
+  | 'codex'
+  | 'codex-cli'
+  | 'terminal'
 type TestSessionMode = 'build' | 'plan' | 'super-plan'
 
 const baseTicket: KanbanTicket = {

--- a/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
@@ -102,7 +102,13 @@ const initialProjectState = useProjectStore.getState()
 const initialUsageState = useUsageStore.getState()
 const initialWorktreeStatusState = useWorktreeStatusStore.getState()
 
-type TestAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+type TestAgentSdk =
+  | 'opencode'
+  | 'claude-code'
+  | 'claude-code-cli'
+  | 'codex'
+  | 'codex-cli'
+  | 'terminal'
 type TestSessionMode = 'build' | 'plan' | 'super-plan'
 
 const baseTicket: KanbanTicket = {

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -41,7 +41,12 @@ import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/mes
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
 import { autoPinBaseWorktree } from '@/lib/auto-pin'
-import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
+import {
+  CODEX_PLAN_MODE_PREFIX,
+  PLAN_MODE_PREFIX,
+  getSuperPlanModePrefix,
+  isPlanLike
+} from '@/lib/constants'
 import { toast } from '@/lib/toast'
 import { opencodeApi } from '@/api/opencode-api'
 import { dbApi } from '@/api/db-api'
@@ -51,7 +56,7 @@ import { remoteLaunchApi } from '@/api/remote-launch-api'
 import { startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
 import type { KanbanTicket, Session } from '../../../../main/db/types'
 import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
-import { supportsGoalMode } from '@shared/types/agent-sdk'
+import { isCliAgentSdk, isCodexCli, supportsGoalMode } from '@shared/types/agent-sdk'
 import { createPlanFile, exceedsGoalPromptLimit, planFilePrompt } from '@/lib/goal-plan-file'
 import {
   REMOTE_LAUNCH_STEPS,
@@ -70,7 +75,7 @@ const EMPTY_ARRAY: readonly never[] = []
 
 // ── Types ───────────────────────────────────────────────────────────
 type PickerMode = 'build' | 'plan' | 'super-plan'
-type PickerAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex'
+type PickerAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'codex-cli'
 
 function completionSendMode(mode: PickerMode): 'build' | 'plan' {
   return isPlanLike(mode) ? 'plan' : 'build'
@@ -192,16 +197,23 @@ function composePromptForSdk(
   const trimmedPrompt = prompt.trim()
   if (!trimmedPrompt) return null
 
+  // See composeLaunchPrompt (ticket-launch.ts): codex-cli carries codex's plan
+  // convention (`<proposed_plan>`) as a prompt prefix; claude-cli and the SDKs
+  // skip the text prefix.
   const skipPrefix =
     options.claudeCli ||
     sessionAgentSdk === 'claude-code' ||
     sessionAgentSdk === 'codex' ||
-    sessionAgentSdk === 'claude-code-cli'
+    isCliAgentSdk(sessionAgentSdk)
   const modePrefix =
     mode === 'super-plan'
       ? getSuperPlanModePrefix(sessionAgentSdk)
-      : mode === 'plan' && !skipPrefix
-        ? PLAN_MODE_PREFIX
+      : mode === 'plan'
+        ? isCodexCli(sessionAgentSdk)
+          ? CODEX_PLAN_MODE_PREFIX
+          : skipPrefix
+            ? ''
+            : PLAN_MODE_PREFIX
         : ''
   const fullPrompt = modePrefix + trimmedPrompt
 
@@ -312,7 +324,8 @@ function SdkToggleGroup({
         availableAgentSdks.opencode,
         availableAgentSdks.claude,
         availableAgentSdks.codex,
-        availableAgentSdks.claude
+        availableAgentSdks.claude,
+        availableAgentSdks.codexCli
       ].filter(Boolean).length
     : 0
   if (!availableAgentSdks || buttonCount < 2) return null
@@ -379,6 +392,19 @@ function SdkToggleGroup({
           className={buttonClass(value === 'claude-code-cli')}
         >
           Claude CLI
+        </button>
+      )}
+      {availableAgentSdks.codexCli && (
+        <button
+          type="button"
+          data-testid={`${idPrefix}-codex-cli`}
+          onClick={() => onChange('codex-cli')}
+          disabled={disabled}
+          aria-pressed={value === 'codex-cli'}
+          title={buttonTitle}
+          className={buttonClass(value === 'codex-cli')}
+        >
+          Codex CLI
         </button>
       )}
     </div>
@@ -867,7 +893,7 @@ export function WorktreePickerModal({
   const composedGoalPrompt = useMemo(() => {
     if (!goalMode || !goalAvailable) return null
     return composePromptForSdk(mode, agentSdk, promptText, goalMode, goalCriteria, {
-      claudeCli: agentSdk === 'claude-code-cli'
+      claudeCli: isCliAgentSdk(agentSdk)
     })
   }, [goalMode, goalAvailable, mode, agentSdk, promptText, goalCriteria])
   const willUsePlanFile = exceedsGoalPromptLimit(composedGoalPrompt)
@@ -1014,12 +1040,11 @@ export function WorktreePickerModal({
         const createConnectionSession = useSessionStore.getState().createConnectionSession
         const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
         const modelOverride = effectiveModel ? { ...effectiveModel, agentSdk } : undefined
-        const cliPendingPrompt =
-          agentSdk === 'claude-code-cli'
-            ? composePromptForSdk(mode, agentSdk, effectivePromptText, goalMode, goalCriteria, {
-                claudeCli: true
-              })
-            : null
+        const cliPendingPrompt = isCliAgentSdk(agentSdk)
+          ? composePromptForSdk(mode, agentSdk, effectivePromptText, goalMode, goalCriteria, {
+              claudeCli: true
+            })
+          : null
         const createOptions = {
           ...(modelOverride ? { modelOverride } : {}),
           ...(cliPendingPrompt ? { pendingMessage: cliPendingPrompt } : {})
@@ -1109,7 +1134,7 @@ export function WorktreePickerModal({
         onOpenChange(false)
         toast.success('Session started')
 
-        if (sessionAgentSdk === 'claude-code-cli') {
+        if (isCliAgentSdk(sessionAgentSdk)) {
           const outboundPrompt =
             cliPendingPrompt ??
             composePromptForSdk(mode, sessionAgentSdk, effectivePromptText, goalMode, goalCriteria, {
@@ -1386,12 +1411,11 @@ export function WorktreePickerModal({
       // Create session in the selected worktree
       const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
       const modelOverride = effectiveModel ? { ...effectiveModel, agentSdk } : undefined
-      const cliPendingPrompt =
-        agentSdk === 'claude-code-cli'
-          ? composePromptForSdk(mode, agentSdk, effectivePromptText, goalMode, goalCriteria, {
-              claudeCli: true
-            })
-          : null
+      const cliPendingPrompt = isCliAgentSdk(agentSdk)
+        ? composePromptForSdk(mode, agentSdk, effectivePromptText, goalMode, goalCriteria, {
+            claudeCli: true
+          })
+        : null
       const createOptions = {
         ...(modelOverride ? { modelOverride } : {}),
         ...(cliPendingPrompt ? { pendingMessage: cliPendingPrompt } : {})

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -1501,7 +1501,10 @@ export function WorktreePickerModal({
       onOpenChange(false)
       toast.success('Session started')
 
-      if (sessionAgentSdk === 'claude-code-cli') {
+      // Both CLI-backed agents (claude-code-cli, codex-cli) start their PTY via
+      // createClaudeCli (which routes codex-cli to createCodexCli); only the
+      // OpenCode/SDK providers fall through to opencodeApi.connect below.
+      if (isCliAgentSdk(sessionAgentSdk)) {
         const outboundPrompt =
           cliPendingPrompt ??
           composePromptForSdk(mode, sessionAgentSdk, effectivePromptText, goalMode, goalCriteria, {

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -1512,8 +1512,14 @@ export function WorktreePickerModal({
           })
 
         if (mode === 'super-plan') {
-          // Await so the persisted mode is committed before the main process
-          // reads it in buildClaudeCliPtySpawn (createClaudeCli).
+          // Auto-revert super-plan → plan (one-shot mode), applied for BOTH CLI
+          // agents — same as every other send/launch path (SessionView,
+          // KanbanTicketModal, ticket-launch) and the codex SDK branch below.
+          // The one-shot super-plan prefix is already baked into outboundPrompt
+          // above; this only persists the follow-up mode. It is NOT a claude-cli
+          // permission-mode artifact (codex-cli must revert too, to stay
+          // consistent with the codex SDK). Awaited so the persisted mode is
+          // committed before the main process reads it (createClaudeCli).
           await useSessionStore.getState().setSessionMode(sessionId, 'plan')
         }
 

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -15,7 +15,7 @@ import { SessionTerminalView } from '@/components/sessions/SessionTerminalView'
 import { FileViewer } from '@/components/file-viewer'
 import { ImageDiffView } from '@/components/diff'
 import { isImageFile } from '@shared/types/file-utils'
-import { isTerminalBacked } from '@shared/types/agent-sdk'
+import { isCliAgentSdk, isTerminalBacked } from '@shared/types/agent-sdk'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useSessionStore, BOARD_TAB_ID } from '@/stores/useSessionStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -147,7 +147,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     }
 
     for (const [sessionId, count] of sessionMountRequests.entries()) {
-      if (count > 0 && getAgentSdk(sessionId) === 'claude-code-cli') {
+      if (count > 0 && isCliAgentSdk(getAgentSdk(sessionId))) {
         terminals.add(sessionId)
       }
     }
@@ -468,7 +468,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
             <div key={sessionId} className={isActive ? 'flex-1 flex flex-col min-h-0' : 'hidden'}>
               {agentSdk === 'terminal' ? (
                 <SessionTerminalView sessionId={sessionId} isVisible={isActive} />
-              ) : agentSdk === 'claude-code-cli' ? (
+              ) : isCliAgentSdk(agentSdk) ? (
                 <ClaudeCliSessionPortal sessionId={sessionId} isActive={isActive} />
               ) : (
                 <SessionView sessionId={sessionId} isVisible={isActive} />

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -29,7 +29,7 @@ import {
 import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 import { extractPlanTitle, normalizeFilename } from '@shared/types/branch-utils'
-import { supportsGoalMode } from '@shared/types/agent-sdk'
+import { isCliAgentSdk, supportsGoalMode } from '@shared/types/agent-sdk'
 import '@xterm/xterm/css/xterm.css'
 import '@/styles/xterm.css'
 
@@ -81,7 +81,7 @@ async function startTicketModalHandoffSession(opts: {
   connectionId?: string | null
   worktreePath?: string | null
 }): Promise<void> {
-  if (opts.agentSdk === 'claude-code-cli') {
+  if (isCliAgentSdk(opts.agentSdk)) {
     bumpWorktreeLastMessage({
       worktreeId: opts.worktreeId,
       connectionId: opts.connectionId

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -42,7 +42,7 @@ interface ModelSelectorProps {
   value?: SelectedModel | null
   onChange?: (model: SelectedModel) => void
   // Override the SDK used for model listing (e.g. force 'opencode' in settings when defaultAgentSdk is 'terminal')
-  agentSdkOverride?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex'
+  agentSdkOverride?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'codex-cli'
   disableTitleTooltip?: boolean
   hideProviderPrefix?: boolean
   allowAgentSdkSelection?: boolean

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -1401,9 +1401,15 @@ export function SessionTabs(): React.JSX.Element | null {
                     New Codex Session
                   </ContextMenuItem>
                 )}
+                {availableAgentSdks?.codexCli && (
+                  <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('codex-cli')}>
+                    New Codex CLI Session
+                  </ContextMenuItem>
+                )}
                 {(availableAgentSdks?.opencode ||
                   availableAgentSdks?.claude ||
-                  availableAgentSdks?.codex) && <ContextMenuSeparator />}
+                  availableAgentSdks?.codex ||
+                  availableAgentSdks?.codexCli) && <ContextMenuSeparator />}
                 <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('terminal')}>
                   <TerminalSquare className="h-4 w-4 mr-2 text-emerald-500" />
                   New Terminal

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -64,7 +64,7 @@ import {
   extractPlanTitle,
   normalizeFilename
 } from '@shared/types/branch-utils'
-import { supportsGoalMode } from '@shared/types/agent-sdk'
+import { isCliAgentSdk, supportsGoalMode } from '@shared/types/agent-sdk'
 import type { TokenInfo, SessionModelRef } from '@/stores/useContextStore'
 import {
   extractTokens,
@@ -6528,7 +6528,7 @@ export function SessionView({ sessionId, isVisible = true }: SessionViewProps): 
   // session updates no longer re-render this wrapper with a new object identity.
   const agentSdk = useSessionStore((state) => state.getSessionById(sessionId)?.agent_sdk ?? null)
 
-  if (agentSdk === 'claude-code-cli') {
+  if (isCliAgentSdk(agentSdk)) {
     return <ClaudeCliSessionView sessionId={sessionId} isVisible={isVisible} />
   }
 

--- a/src/renderer/src/components/sessions/SuperToggle.tsx
+++ b/src/renderer/src/components/sessions/SuperToggle.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react'
+import { isCliAgentSdk } from '@shared/types/agent-sdk'
 import { cn } from '@/lib/utils'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { Tip } from '@/components/ui/Tip'
@@ -16,7 +17,7 @@ export const SuperToggle = memo(function SuperToggle({
   const hasPendingPrompt = useSessionStore((state) => state.pendingMessages.has(sessionId))
 
   const visible = mode === 'plan' || mode === 'super-plan'
-  const disabled = session?.agent_sdk === 'claude-code-cli' && !hasPendingPrompt
+  const disabled = isCliAgentSdk(session?.agent_sdk) && !hasPendingPrompt
   const isOn = mode === 'super-plan'
 
   return (

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -58,6 +58,7 @@ export function SettingsGeneral(): React.JSX.Element {
   const claudeAvailable = isAgentSdkAvailable('claude-code', availableAgentSdks)
   const claudeCliAvailable = isAgentSdkAvailable('claude-code-cli', availableAgentSdks)
   const codexAvailable = isAgentSdkAvailable('codex', availableAgentSdks)
+  const codexCliAvailable = isAgentSdkAvailable('codex-cli', availableAgentSdks)
 
   return (
     <div className="space-y-6">
@@ -615,9 +616,27 @@ export function SettingsGeneral(): React.JSX.Element {
           >
             Claude Code (CLI)
           </button>
+          <button
+            onClick={() => updateSetting('defaultAgentSdk', 'codex-cli')}
+            disabled={!codexCliAvailable}
+            className={cn(
+              'px-3 py-1.5 rounded-md text-sm border transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+              defaultAgentSdk === 'codex-cli'
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50'
+            )}
+            data-testid="agent-sdk-codex-cli"
+            title={!codexCliAvailable ? 'Codex CLI is not currently available' : undefined}
+          >
+            Codex (CLI)
+          </button>
         </div>
         {availableAgentSdks &&
-          (!opencodeAvailable || !claudeAvailable || !claudeCliAvailable || !codexAvailable) && (
+          (!opencodeAvailable ||
+            !claudeAvailable ||
+            !claudeCliAvailable ||
+            !codexAvailable ||
+            !codexCliAvailable) && (
             <p className="text-xs text-muted-foreground/70 italic">
               Unavailable providers are disabled until their CLI is installed and launchable from
               Hive.

--- a/src/renderer/src/components/setup/AgentPickerDialog.tsx
+++ b/src/renderer/src/components/setup/AgentPickerDialog.tsx
@@ -9,8 +9,8 @@ import {
 } from '@/components/ui/alert-dialog'
 
 interface AgentPickerDialogProps {
-  onSelect: (sdk: 'opencode' | 'claude-code' | 'codex') => void
-  availableSdks: { opencode: boolean; claude: boolean; codex: boolean }
+  onSelect: (sdk: 'opencode' | 'claude-code' | 'codex' | 'codex-cli') => void
+  availableSdks: { opencode: boolean; claude: boolean; codex: boolean; codexCli?: boolean }
 }
 
 export function AgentPickerDialog({
@@ -70,6 +70,19 @@ export function AgentPickerDialog({
             >
               <div className="text-sm font-medium">Codex</div>
               <div className="text-xs text-muted-foreground mt-1">OpenAI&apos;s coding agent</div>
+            </button>
+          )}
+          {availableSdks.codexCli && (
+            <button
+              onClick={() => onSelect('codex-cli')}
+              className={cn(
+                'flex-1 px-4 py-3 rounded-lg border-2 border-border',
+                'hover:border-primary hover:bg-accent/50 transition-colors',
+                'text-center cursor-pointer'
+              )}
+            >
+              <div className="text-sm font-medium">Codex (CLI)</div>
+              <div className="text-xs text-muted-foreground mt-1">OpenAI&apos;s Codex terminal</div>
             </button>
           )}
         </div>

--- a/src/renderer/src/components/setup/AgentSetupGuard.tsx
+++ b/src/renderer/src/components/setup/AgentSetupGuard.tsx
@@ -17,6 +17,7 @@ export function AgentSetupGuard(): React.JSX.Element | null {
     opencode: boolean
     claude: boolean
     codex: boolean
+    codexCli: boolean
   } | null>(null)
 
   useEffect(() => {
@@ -29,13 +30,17 @@ export function AgentSetupGuard(): React.JSX.Element | null {
       .then((result) => {
         if (cancelled) return
 
-        setDetectedSdks(result)
+        setDetectedSdks({ ...result, codexCli: result.codexCli ?? false })
 
-        const { opencode, claude, codex } = result
-        const found: Array<'opencode' | 'claude-code' | 'codex'> = []
+        const { opencode, claude, codex, codexCli } = result
+        const found: Array<'opencode' | 'claude-code' | 'codex' | 'codex-cli'> = []
         if (opencode) found.push('opencode')
         if (claude) found.push('claude-code')
         if (codex) found.push('codex')
+        // The codex binary can be present without app-server support (codex
+        // false, codexCli true) — then only the terminal Codex CLI is usable.
+        // Offer it so a codex-cli-only machine isn't wrongly shown "no agent".
+        else if (codexCli) found.push('codex-cli')
 
         if (found.length === 0) {
           setStatus('none-found')
@@ -77,7 +82,9 @@ export function AgentSetupGuard(): React.JSX.Element | null {
   if (status === 'choose' && detectedSdks) {
     return (
       <AgentPickerDialog
-        availableSdks={detectedSdks}
+        // Only offer the terminal Codex CLI as a distinct choice when the
+        // app-server-backed Codex isn't available (else they'd double up).
+        availableSdks={{ ...detectedSdks, codexCli: detectedSdks.codexCli && !detectedSdks.codex }}
         onSelect={(sdk) => {
           updateSetting('defaultAgentSdk', sdk)
           updateSetting('initialSetupComplete', true)

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   setSelectedTicketId: vi.fn(),
   lastSendMode: new Map<string, 'plan' | 'build'>(),
   modeBySession: new Map<string, 'build' | 'plan' | 'super-plan'>(),
+  sessionAgentSdk: new Map<string, string>(),
   sessionStatuses: {} as Record<string, { status: string } | null>,
   kanbanState: {
     selectedTicketId: null as string | null,
@@ -43,7 +44,12 @@ vi.mock('@/stores/useSessionStore', () => ({
       modeBySession: mocks.modeBySession,
       setPendingPlan: mocks.setPendingPlan,
       clearPendingPlan: mocks.clearPendingPlan,
-      setSessionMode: mocks.setSessionMode
+      setSessionMode: mocks.setSessionMode,
+      // Defaults to claude-code-cli so the plan-mode Stop→plan_ready fallback
+      // stays active for the existing claude tests; a codex-cli case overrides it.
+      getSessionById: (id: string) => ({
+        agent_sdk: mocks.sessionAgentSdk.get(id) ?? 'claude-code-cli'
+      })
     })
   }
 }))
@@ -120,6 +126,7 @@ describe('useClaudeCliStatusListener', () => {
     mocks.notifyKanbanSessionSync.mockClear()
     mocks.lastSendMode.clear()
     mocks.modeBySession.clear()
+    mocks.sessionAgentSdk.clear()
     mocks.sessionStatuses = {}
     mocks.kanbanState = {
       selectedTicketId: null,
@@ -284,6 +291,31 @@ describe('useClaudeCliStatusListener', () => {
       hookEventName: 'Stop',
       hookPath: 'stop'
     })
+  })
+
+  it('does NOT re-derive plan_ready from a tagless plan-mode Stop for codex-cli', () => {
+    // codex-cli plan_ready is authoritative from <proposed_plan> detection; a
+    // plain Stop (no plan block — e.g. it asked a question) must stay completed.
+    mocks.modeBySession.set('hive-session-1', 'plan')
+    mocks.lastSendMode.set('hive-session-1', 'plan')
+    mocks.sessionAgentSdk.set('hive-session-1', 'codex-cli')
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'completed',
+      metadata: { hookEventName: 'Stop', hookPath: 'stop' }
+    })
+
+    expect(mocks.setSessionStatus).toHaveBeenLastCalledWith('hive-session-1', 'completed', {
+      hookEventName: 'Stop',
+      hookPath: 'stop'
+    })
+    expect(mocks.setSessionStatus).not.toHaveBeenCalledWith(
+      'hive-session-1',
+      'plan_ready',
+      expect.anything()
+    )
   })
 
   it('treats a prompt submitted while plan_ready as plan approval work', () => {

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -318,6 +318,32 @@ describe('useClaudeCliStatusListener', () => {
     )
   })
 
+  it('does NOT re-derive planning from a working UserPromptSubmit for codex-cli (raw yolo TUI prompt)', () => {
+    // codex-cli status is authoritative upstream: a 'working' UserPromptSubmit
+    // means the prompt lacked the codex plan prefix (a raw TUI prompt that can
+    // mutate), so it must stay working rather than be relabeled read-only planning.
+    // claude-cli still derives planning here (see the plan-mode sequence test).
+    mocks.modeBySession.set('hive-session-1', 'plan')
+    mocks.sessionAgentSdk.set('hive-session-1', 'codex-cli')
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedCallback?.({
+      sessionId: 'hive-session-1',
+      status: 'working',
+      metadata: { hookEventName: 'UserPromptSubmit', hookPath: 'start' }
+    })
+
+    expect(mocks.setSessionStatus).toHaveBeenLastCalledWith('hive-session-1', 'working', {
+      hookEventName: 'UserPromptSubmit',
+      hookPath: 'start'
+    })
+    expect(mocks.setSessionStatus).not.toHaveBeenCalledWith(
+      'hive-session-1',
+      'planning',
+      expect.anything()
+    )
+  })
+
   it('treats a prompt submitted while plan_ready as plan approval work', () => {
     mocks.modeBySession.set('hive-session-1', 'plan')
     mocks.sessionStatuses = { 'hive-session-1': { status: 'plan_ready' } }

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -7,6 +7,7 @@ import { lastSendMode } from '@/lib/message-send-times'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { isPlanLike } from '@/lib/constants'
 import { isHandoffPickerOpenForSession } from '@/lib/handoff-ui-state'
+import { isCodexCli } from '@shared/types/agent-sdk'
 
 type ClaudeCliStatusMetadata = {
   reason?: string
@@ -166,7 +167,13 @@ export function useClaudeCliStatusListener(): void {
       if (
         status === 'completed' &&
         metadata?.hookEventName === 'Stop' &&
-        lastSendMode.get(sessionId) === 'plan'
+        lastSendMode.get(sessionId) === 'plan' &&
+        // codex-cli plan_ready is authoritative from the `<proposed_plan>`
+        // detection (a plan-turn Stop WITH a block is already translated to a
+        // plan_ready event upstream). A plain Stop here means the plan turn
+        // ended WITHOUT a plan (e.g. it asked a clarifying question), so it must
+        // NOT be re-derived to plan_ready — that's a claude-only fallback.
+        !isCodexCli(sessionStore.getSessionById(sessionId)?.agent_sdk)
       ) {
         worktreeStatus.setSessionStatus(sessionId, 'plan_ready', metadata)
         return

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -156,7 +156,16 @@ export function useClaudeCliStatusListener(): void {
       if (
         status === 'working' &&
         metadata?.hookEventName === 'UserPromptSubmit' &&
-        isPlanLike(currentMode)
+        isPlanLike(currentMode) &&
+        // codex-cli's planning status is authoritative from upstream: the hook
+        // translator only sets permission_mode:'plan' (→ status 'planning') for
+        // prompts that actually carry the codex plan prefix. A 'working'
+        // UserPromptSubmit for a codex-cli session is therefore a raw yolo TUI
+        // prompt that can mutate and must NOT be re-derived to a read-only
+        // planning turn (mirrors the Stop→plan_ready guard below). claude-cli
+        // drives plan mode via its in-terminal permission mode, so its plan
+        // prompts arrive as 'working' and still need this fallback.
+        !isCodexCli(sessionStore.getSessionById(sessionId)?.agent_sdk)
       ) {
         reassertPlanAutoApprove(sessionId)
         lastSendMode.set(sessionId, 'plan')

--- a/src/renderer/src/hooks/useLifecycleActions.ts
+++ b/src/renderer/src/hooks/useLifecycleActions.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { isCliAgentSdk } from '@shared/types/agent-sdk'
 import { useGitStore } from '@/stores/useGitStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useSessionStore } from '@/stores/useSessionStore'
@@ -232,7 +233,7 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
         {
           autoFocus: false,
           modelOverride: reviewDefaultModel,
-          ...(effectiveSelection.agentSdk === 'claude-code-cli' ? { pendingMessage: prompt } : {})
+          ...(isCliAgentSdk(effectiveSelection.agentSdk) ? { pendingMessage: prompt } : {})
         }
       )
       if (!result.success || !result.session) {
@@ -263,7 +264,7 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
 
       void (async () => {
         try {
-          if (agentSdk === 'claude-code-cli') {
+          if (isCliAgentSdk(agentSdk)) {
             messageSendTimes.set(sessionId, Date.now())
             userExplicitSendTimes.set(sessionId, Date.now())
             snapshotTokenBaseline(sessionId)

--- a/src/renderer/src/lib/__tests__/codex-cli-plan-convention.test.ts
+++ b/src/renderer/src/lib/__tests__/codex-cli-plan-convention.test.ts
@@ -35,6 +35,16 @@ describe('codex-cli plan convention', () => {
     expect(prefix).not.toContain('<proposed_plan>')
   })
 
+  it('carries the read-only restraint in every codex-cli planning prefix (yolo has no other guard)', () => {
+    // codex-cli spawns in yolo mode, so the prompt is the only thing keeping a
+    // planning turn from mutating the worktree.
+    expect(getPlanModePrefix('codex-cli')).toContain('Do NOT modify files')
+    expect(getSuperPlanModePrefix('codex-cli')).toContain('Do NOT modify files')
+    // The SDK codex enforces plan restraint out-of-band (collaboration mode), so
+    // its super-plan prompt deliberately does NOT carry the text restraint.
+    expect(getSuperPlanModePrefix('codex')).not.toContain('Do NOT modify files')
+  })
+
   it('implements the codex way — a bare "Implement the plan." (no re-sent plan markdown)', () => {
     expect(buildSdkPlanImplementationPrompt('codex-cli', '# some plan\n- a\n- b')).toBe(
       'Implement the plan.'

--- a/src/renderer/src/lib/__tests__/codex-cli-plan-convention.test.ts
+++ b/src/renderer/src/lib/__tests__/codex-cli-plan-convention.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CODEX_PLAN_MODE_PREFIX,
+  PLAN_MODE_PREFIX,
+  getPlanModePrefix,
+  getSuperPlanModePrefix,
+  stripModePrefix
+} from '@/lib/constants'
+import { buildSdkPlanImplementationPrompt } from '@/lib/proposedPlan'
+
+/**
+ * codex-cli asks for a plan the codex way — a `<proposed_plan>` block — rather
+ * than the claude way (--permission-mode plan + an ExitPlanMode tool call).
+ */
+describe('codex-cli plan convention', () => {
+  it('gives codex-cli the <proposed_plan> plan prefix, and claude-cli/others the claude prefix', () => {
+    expect(getPlanModePrefix('codex-cli')).toBe(CODEX_PLAN_MODE_PREFIX)
+    expect(CODEX_PLAN_MODE_PREFIX).toContain('<proposed_plan>')
+    expect(CODEX_PLAN_MODE_PREFIX).not.toContain('ExitPlanMode')
+
+    expect(getPlanModePrefix('claude-code-cli')).toBe(PLAN_MODE_PREFIX)
+    expect(getPlanModePrefix('opencode')).toBe(PLAN_MODE_PREFIX)
+    expect(getPlanModePrefix(null)).toBe(PLAN_MODE_PREFIX)
+  })
+
+  it('gives codex-cli super-plan the request_user_input interview + <proposed_plan> finalization', () => {
+    const prefix = getSuperPlanModePrefix('codex-cli')
+    expect(prefix).toContain('request_user_input')
+    expect(prefix).toContain('<proposed_plan>')
+  })
+
+  it('leaves the SDK codex super-plan prefix byte-identical (finalization injected out-of-band there)', () => {
+    const prefix = getSuperPlanModePrefix('codex')
+    expect(prefix).toContain('request_user_input')
+    expect(prefix).not.toContain('<proposed_plan>')
+  })
+
+  it('implements the codex way — a bare "Implement the plan." (no re-sent plan markdown)', () => {
+    expect(buildSdkPlanImplementationPrompt('codex-cli', '# some plan\n- a\n- b')).toBe(
+      'Implement the plan.'
+    )
+    // claude-cli still re-sends the plan text.
+    expect(buildSdkPlanImplementationPrompt('claude-code-cli', '# some plan')).toContain(
+      '# some plan'
+    )
+  })
+
+  it('strips the codex plan prefix (so display/goal-file logic sees the raw prompt)', () => {
+    expect(stripModePrefix(CODEX_PLAN_MODE_PREFIX + 'do the thing')).toBe('do the thing')
+    expect(stripModePrefix(getSuperPlanModePrefix('codex-cli') + 'do the thing')).toBe('do the thing')
+  })
+})

--- a/src/renderer/src/lib/agent-sdk-availability.ts
+++ b/src/renderer/src/lib/agent-sdk-availability.ts
@@ -4,6 +4,8 @@ export interface AvailableAgentSdks {
   opencode: boolean
   claude: boolean
   codex: boolean
+  /** codex binary present (no app-server requirement) — gates the terminal-backed codex-cli. */
+  codexCli?: boolean
 }
 
 /** Alias of the shared {@link AgentSdk} union, kept for this module's selection-focused naming. */
@@ -19,6 +21,8 @@ function getAgentSdkLabel(sdk: Exclude<SelectableAgentSdk, 'terminal'>): string 
       return 'Claude Code (CLI)'
     case 'codex':
       return 'Codex'
+    case 'codex-cli':
+      return 'Codex (CLI)'
   }
 }
 
@@ -36,8 +40,8 @@ export function isAgentSdkAvailable(
       return availableAgentSdks.claude
     case 'codex':
       return availableAgentSdks.codex
-    case 'terminal':
-      return true
+    case 'codex-cli':
+      return availableAgentSdks.codexCli ?? false
   }
 }
 

--- a/src/renderer/src/lib/backgroundSessionStart.claude-cli.test.ts
+++ b/src/renderer/src/lib/backgroundSessionStart.claude-cli.test.ts
@@ -6,6 +6,7 @@ import { startBackgroundSessionPrompt } from './backgroundSessionStart'
 
 const terminalApiMocks = vi.hoisted(() => ({
   sendClaudeCliPrompt: vi.fn(),
+  createClaudeCli: vi.fn(),
   startHivePromptTelemetry: vi.fn()
 }))
 
@@ -48,6 +49,8 @@ function mockSendClaudeCliPrompt(delivered: boolean): ReturnType<typeof vi.fn> {
 describe('startBackgroundSessionPrompt — claude-code-cli follow-up delivery', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default: starting the background PTY succeeds (used by the no-live-PTY path).
+    terminalApiMocks.createClaudeCli.mockResolvedValue({ success: true, value: { success: true } })
     seedClaudeCliSession()
     messageSendTimes.delete('s1')
     userExplicitSendTimes.delete('s1')
@@ -86,7 +89,9 @@ describe('startBackgroundSessionPrompt — claude-code-cli follow-up delivery', 
     expect(useWorktreeStatusStore.getState().sessionStatuses['s1']?.status).toBe('working')
   })
 
-  it('queues the prompt for the next spawn when no live PTY exists', async () => {
+  it('starts the CLI PTY with the prompt when no live PTY exists (background handoff)', async () => {
+    // A background-created session (autoFocus:false) has no view to mount and
+    // spawn it, so the helper must start the PTY itself rather than just queue.
     const sendClaudeCliPrompt = mockSendClaudeCliPrompt(false)
 
     await startBackgroundSessionPrompt({
@@ -97,12 +102,56 @@ describe('startBackgroundSessionPrompt — claude-code-cli follow-up delivery', 
     })
 
     expect(sendClaudeCliPrompt).toHaveBeenCalledWith('s1', 'follow-up question')
-    expect(useSessionStore.getState().pendingMessages.get('s1')).toBe('follow-up question')
+    expect(terminalApiMocks.createClaudeCli).toHaveBeenCalledWith('s1', {
+      pendingPrompt: 'follow-up question'
+    })
+    // Started, not left queued.
+    expect(useSessionStore.getState().pendingMessages.get('s1')).toBeUndefined()
     expect(terminalApiMocks.startHivePromptTelemetry).not.toHaveBeenCalled()
   })
 
-  it('does not record send times or working status when the prompt was only queued', async () => {
+  it('falls back to queuing when starting the background CLI PTY fails', async () => {
     mockSendClaudeCliPrompt(false)
+    terminalApiMocks.createClaudeCli.mockResolvedValue({
+      success: true,
+      value: { success: false, error: 'spawn failed' }
+    })
+
+    await startBackgroundSessionPrompt({
+      worktreePath: '/repo',
+      sessionId: 's1',
+      prompt: 'follow-up question',
+      bumpTarget: {}
+    })
+
+    expect(terminalApiMocks.createClaudeCli).toHaveBeenCalled()
+    expect(useSessionStore.getState().pendingMessages.get('s1')).toBe('follow-up question')
+  })
+
+  it('records send tracking and working status when it starts a background CLI session', async () => {
+    // Starting the background handoff should run the ticket timer just like a
+    // live-PTY delivery, so the session shows as working rather than idle.
+    mockSendClaudeCliPrompt(false)
+
+    await startBackgroundSessionPrompt({
+      worktreePath: '/repo',
+      sessionId: 's1',
+      prompt: 'follow-up question',
+      bumpTarget: {}
+    })
+
+    expect(userExplicitSendTimes.get('s1')).toBeTypeOf('number')
+    expect(messageSendTimes.get('s1')).toBeTypeOf('number')
+    expect(lastSendMode.get('s1')).toBe('build')
+    expect(useWorktreeStatusStore.getState().sessionStatuses['s1']?.status).toBe('working')
+  })
+
+  it('does not record send tracking or status when it only queues after a failed start', async () => {
+    mockSendClaudeCliPrompt(false)
+    terminalApiMocks.createClaudeCli.mockResolvedValue({
+      success: true,
+      value: { success: false, error: 'spawn failed' }
+    })
 
     await startBackgroundSessionPrompt({
       worktreePath: '/repo',

--- a/src/renderer/src/lib/backgroundSessionStart.ts
+++ b/src/renderer/src/lib/backgroundSessionStart.ts
@@ -59,17 +59,32 @@ export async function startBackgroundSessionPrompt(opts: {
 }): Promise<void> {
   const session = findSessionModelSource(opts.sessionId)
   if (isCliAgentSdk(session?.agent_sdk)) {
-    // Deliver straight to the live PTY if the session is already running;
-    // otherwise queue it so the next spawn picks it up as the prompt argument
-    // (createClaudeTerminal -> dequeuePendingMessage). Without the live-PTY path
-    // a follow-up to a running CLI session would be silently dropped.
+    // If the session already has a live PTY, deliver straight into it (a
+    // follow-up to a running CLI session).
     const { delivered } = unwrapEnvelope(
       await terminalApi.sendClaudeCliPrompt(opts.sessionId, opts.prompt)
     )
-    if (!delivered) {
+    if (delivered) {
+      markClaudeCliPromptStarted(opts.sessionId)
+      bumpWorktreeLastMessage(opts.bumpTarget)
+      return
+    }
+    // No live PTY yet. This helper *starts* background-created sessions (e.g. a
+    // Telegram plan handoff, created with autoFocus:false) — and unlike a
+    // foreground launch there is no terminal view that will mount and spawn the
+    // CLI. So start the PTY ourselves with the prompt as its initial argument,
+    // mirroring the ticket-modal CLI handoff (ClaudeCliSessionView). Merely
+    // queuing would leave the handoff idle until the user manually opened its
+    // tab, even though a "handoff started" toast was already shown.
+    const result = unwrapEnvelope(
+      await terminalApi.createClaudeCli(opts.sessionId, { pendingPrompt: opts.prompt })
+    )
+    if (!result.success) {
+      // Spawn failed — fall back to queuing so a later manual open still delivers it.
       useSessionStore.getState().setPendingMessage(opts.sessionId, opts.prompt)
       return
     }
+    useSessionStore.getState().dequeuePendingMessage(opts.sessionId)
     markClaudeCliPromptStarted(opts.sessionId)
     bumpWorktreeLastMessage(opts.bumpTarget)
     return

--- a/src/renderer/src/lib/backgroundSessionStart.ts
+++ b/src/renderer/src/lib/backgroundSessionStart.ts
@@ -1,5 +1,5 @@
 import type { SelectedModel } from '@/stores/useSettingsStore'
-import { type AgentSdk, isClaudeCli } from '@shared/types/agent-sdk'
+import { type AgentSdk, isCliAgentSdk } from '@shared/types/agent-sdk'
 import { resolveModelForSdk } from '@/stores/useSettingsStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
@@ -58,7 +58,7 @@ export async function startBackgroundSessionPrompt(opts: {
   bumpTarget: { worktreeId?: string | null; connectionId?: string | null }
 }): Promise<void> {
   const session = findSessionModelSource(opts.sessionId)
-  if (isClaudeCli(session?.agent_sdk)) {
+  if (isCliAgentSdk(session?.agent_sdk)) {
     // Deliver straight to the live PTY if the session is already running;
     // otherwise queue it so the next spawn picks it up as the prompt argument
     // (createClaudeTerminal -> dequeuePendingMessage). Without the live-PTY path

--- a/src/renderer/src/lib/constants.ts
+++ b/src/renderer/src/lib/constants.ts
@@ -1,20 +1,32 @@
 import {
+  CODEX_CLI_SUPER_PLAN_MODE_PREFIX,
+  CODEX_PLAN_MODE_PREFIX,
   CODEX_SUPER_PLAN_MODE_PREFIX,
   PLAN_MODE_PREFIX,
   SUPER_PLAN_MODE_PREFIX
 } from '@shared/agent-mode-prefixes'
 
 export {
+  CODEX_CLI_SUPER_PLAN_MODE_PREFIX,
+  CODEX_PLAN_MODE_PREFIX,
   CODEX_SUPER_PLAN_MODE_PREFIX,
   PLAN_MODE_PREFIX,
   SUPER_PLAN_MODE_PREFIX,
+  getPlanModePrefix,
   getSuperPlanModePrefix
 } from '@shared/agent-mode-prefixes'
 
 export const ASK_MODE_PREFIX =
   '[Mode: Ask] You are in question-answering mode. The user wants information only. Do NOT make any code changes, do NOT use file editing tools, do NOT modify any files. Simply answer the question directly and concisely.\n\n'
 
-const SUPER_PLAN_MODE_PREFIXES = [CODEX_SUPER_PLAN_MODE_PREFIX, SUPER_PLAN_MODE_PREFIX]
+// Longest-first: CODEX_CLI_SUPER_PLAN_MODE_PREFIX starts with
+// CODEX_SUPER_PLAN_MODE_PREFIX, so it must be tried before it to strip the
+// trailing `<proposed_plan>` finalization too.
+const SUPER_PLAN_MODE_PREFIXES = [
+  CODEX_CLI_SUPER_PLAN_MODE_PREFIX,
+  CODEX_SUPER_PLAN_MODE_PREFIX,
+  SUPER_PLAN_MODE_PREFIX
+]
 
 export function stripSuperPlanModePrefix(value: string): string | null {
   for (const prefix of SUPER_PLAN_MODE_PREFIXES) {
@@ -30,6 +42,9 @@ export function stripModePrefix(value: string): string {
   const superPlanStripped = stripSuperPlanModePrefix(value)
   if (superPlanStripped !== null) {
     return superPlanStripped
+  }
+  if (value.startsWith(CODEX_PLAN_MODE_PREFIX)) {
+    return value.slice(CODEX_PLAN_MODE_PREFIX.length)
   }
   if (value.startsWith(PLAN_MODE_PREFIX)) {
     return value.slice(PLAN_MODE_PREFIX.length)

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -50,23 +50,25 @@ const SDK_DISPLAY_NAMES: Record<HandoffAgentSdk, string> = {
   opencode: 'OpenCode',
   'claude-code': 'Claude Code',
   'claude-code-cli': 'Claude Code (CLI)',
-  codex: 'Codex'
+  codex: 'Codex',
+  'codex-cli': 'Codex (CLI)'
 }
 
 const FALLBACK_MODELS: Record<HandoffAgentSdk, SelectedModel> = {
   opencode: { providerID: 'anthropic', modelID: 'claude-opus-4-5-20251101' },
   'claude-code': { providerID: 'anthropic', modelID: 'claude-opus-4-5-20251101' },
   'claude-code-cli': { providerID: 'anthropic', modelID: 'sonnet', variant: 'high' },
-  codex: { providerID: 'codex', modelID: 'gpt-5.5' }
+  codex: { providerID: 'codex', modelID: 'gpt-5.5' },
+  'codex-cli': { providerID: 'codex', modelID: 'gpt-5.5', variant: 'high' }
 }
 
 const modelCatalogCache = new Map<HandoffAgentSdk, ProviderModels[]>()
 const inflightModelCatalogRequests = new Map<HandoffAgentSdk, Promise<ProviderModels[]>>()
 
-function normalizeHandoffSdk(
-  sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal' | null | undefined
-): HandoffAgentSdk {
-  if (sdk === 'claude-code' || sdk === 'claude-code-cli' || sdk === 'codex') return sdk
+function normalizeHandoffSdk(sdk: AgentSdk | null | undefined): HandoffAgentSdk {
+  if (sdk === 'claude-code' || sdk === 'claude-code-cli' || sdk === 'codex' || sdk === 'codex-cli') {
+    return sdk
+  }
   return 'opencode'
 }
 
@@ -177,7 +179,13 @@ export function getHandoffSdkDisplayName(agentSdk: HandoffAgentSdk): string {
 export function getAvailableHandoffAgentSdks(
   availableAgentSdks?: AvailableAgentSdks | null
 ): HandoffAgentSdk[] {
-  const orderedSdks: HandoffAgentSdk[] = ['opencode', 'claude-code', 'codex', 'claude-code-cli']
+  const orderedSdks: HandoffAgentSdk[] = [
+    'opencode',
+    'claude-code',
+    'codex',
+    'claude-code-cli',
+    'codex-cli'
+  ]
   return orderedSdks.filter((sdk) => isAgentSdkAvailable(sdk, availableAgentSdks))
 }
 

--- a/src/renderer/src/lib/hive-enterprise-telemetry-metadata.test.ts
+++ b/src/renderer/src/lib/hive-enterprise-telemetry-metadata.test.ts
@@ -52,6 +52,10 @@ describe('resolveHivePromptAccountProvider', () => {
     expect(resolveHivePromptAccountProvider('codex')).toBe('openai')
   })
 
+  it('maps codex-cli sessions to openai too (same OpenAI account family)', () => {
+    expect(resolveHivePromptAccountProvider('codex-cli')).toBe('openai')
+  })
+
   it('maps opencode, terminal, unknown, and missing SDKs to null', () => {
     expect(resolveHivePromptAccountProvider('opencode')).toBeNull()
     expect(resolveHivePromptAccountProvider('terminal')).toBeNull()

--- a/src/renderer/src/lib/hive-enterprise-telemetry.ts
+++ b/src/renderer/src/lib/hive-enterprise-telemetry.ts
@@ -8,7 +8,7 @@ import {
 import { reportActiveAccountsSnapshot } from '@/lib/hive-account-report'
 import { currentPromptIdBySession } from '@/lib/message-send-times'
 import { computeTokenFieldDelta } from '@/lib/token-baselines'
-import { isClaudeFamily } from '@shared/types/agent-sdk'
+import { isClaudeFamily, isCodexFamily } from '@shared/types/agent-sdk'
 import { useAccountStore } from '@/stores/useAccountStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useContextStore } from '@/stores/useContextStore'
@@ -101,7 +101,7 @@ export function resolveHivePromptAccountProvider(
   agentSdk: string | null | undefined
 ): HiveAccountProvider | null {
   if (isClaudeFamily(agentSdk)) return 'anthropic'
-  if (agentSdk === 'codex') return 'openai'
+  if (isCodexFamily(agentSdk)) return 'openai'
   return null
 }
 

--- a/src/renderer/src/lib/plan-auto-approve.ts
+++ b/src/renderer/src/lib/plan-auto-approve.ts
@@ -1,4 +1,4 @@
-import { isClaudeCli } from '@shared/types/agent-sdk'
+import { isCliAgentSdk } from '@shared/types/agent-sdk'
 import { isPlanLike } from './constants'
 import type { KanbanTicket } from '../../../main/db/types'
 
@@ -15,6 +15,6 @@ export function canToggleAutoApprovePlan(
   if (!isPlanLike(ticket.mode)) return false
   if (ticket.goal_mode) return false
   if (ticket.plan_ready) return false
-  if (ticket.current_session_id && !isClaudeCli(linkedSessionAgentSdk)) return false
+  if (ticket.current_session_id && !isCliAgentSdk(linkedSessionAgentSdk)) return false
   return true
 }

--- a/src/renderer/src/lib/pr-content-provider.ts
+++ b/src/renderer/src/lib/pr-content-provider.ts
@@ -1,26 +1,60 @@
 export type PRContentProvider = 'opencode' | 'claude-code' | 'codex'
-export type AgentSdkPreference = PRContentProvider | 'terminal'
+/**
+ * Any SDK the caller might hold, including the terminal-backed CLIs (which
+ * generate PR content through their SDK sibling's exec path) and the bare
+ * terminal (which has no text-generation provider).
+ */
+export type AgentSdkPreference =
+  | 'opencode'
+  | 'claude-code'
+  | 'claude-code-cli'
+  | 'codex'
+  | 'codex-cli'
+  | 'terminal'
 
 export interface AvailableAgentSdks {
   opencode: boolean
   claude: boolean
   codex: boolean
+  /** codex binary present (may lack app-server); enough for `codex exec` text generation. */
+  codexCli?: boolean
 }
 
 const PROVIDER_ORDER: PRContentProvider[] = ['claude-code', 'codex', 'opencode']
+
+/**
+ * Map any SDK to the provider that actually generates PR content. The terminal
+ * CLIs share their SDK sibling's `codex exec` / claude route; `terminal` has
+ * none.
+ */
+function toPRContentProvider(sdk: AgentSdkPreference): PRContentProvider | null {
+  switch (sdk) {
+    case 'claude-code':
+    case 'claude-code-cli':
+      return 'claude-code'
+    case 'codex':
+    case 'codex-cli':
+      return 'codex'
+    case 'opencode':
+      return 'opencode'
+    case 'terminal':
+      return null
+  }
+}
 
 export function resolvePRContentProvider(
   preferredSdk: AgentSdkPreference,
   availableSdks?: AvailableAgentSdks | null
 ): PRContentProvider | null {
-  if (preferredSdk !== 'terminal') {
-    if (!availableSdks || isProviderAvailable(preferredSdk, availableSdks)) {
-      return preferredSdk
+  const preferred = toPRContentProvider(preferredSdk)
+  if (preferred) {
+    if (!availableSdks || isProviderAvailable(preferred, availableSdks)) {
+      return preferred
     }
   }
 
   if (!availableSdks) {
-    return preferredSdk === 'terminal' ? 'claude-code' : preferredSdk
+    return preferred ?? 'claude-code'
   }
 
   for (const provider of PROVIDER_ORDER) {
@@ -37,7 +71,10 @@ function isProviderAvailable(provider: PRContentProvider, availableSdks: Availab
     case 'claude-code':
       return availableSdks.claude
     case 'codex':
-      return availableSdks.codex
+      // PR content generation spawns `codex exec`, which needs only the codex
+      // binary — available whenever either codex signal is set (app-server
+      // `codex`, or the terminal CLI `codexCli`).
+      return availableSdks.codex || (availableSdks.codexCli ?? false)
     case 'opencode':
       return availableSdks.opencode
   }

--- a/src/renderer/src/lib/proposedPlan.ts
+++ b/src/renderer/src/lib/proposedPlan.ts
@@ -22,7 +22,9 @@ export function buildSdkPlanImplementationPrompt(
   agentSdk: string | null | undefined,
   planMarkdown: string
 ): string {
-  return agentSdk === 'codex'
+  // Both codex providers keep the just-produced <proposed_plan> in context, so
+  // "Implement the plan." is enough — no need to re-send the plan markdown.
+  return agentSdk === 'codex' || agentSdk === 'codex-cli'
     ? 'Implement the plan.'
     : buildPlanImplementationPrompt(planMarkdown)
 }

--- a/src/renderer/src/lib/ticket-launch.ts
+++ b/src/renderer/src/lib/ticket-launch.ts
@@ -8,7 +8,12 @@ import { resolveModelForSdk } from '@/stores/useSettingsStore'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
-import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
+import {
+  CODEX_PLAN_MODE_PREFIX,
+  PLAN_MODE_PREFIX,
+  getSuperPlanModePrefix,
+  isPlanLike
+} from '@/lib/constants'
 import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { opencodeApi } from '@/api/opencode-api'
@@ -17,7 +22,7 @@ import { terminalApi } from '@/api/terminal-api'
 import { startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
 import { createPlanFile, exceedsGoalPromptLimit, planFilePrompt } from '@/lib/goal-plan-file'
 import { FALLBACK_MODELS } from '@shared/model-resolution'
-import type { HandoffAgentSdk } from '@shared/types/agent-sdk'
+import { isCliAgentSdk, isCodexCli, type HandoffAgentSdk } from '@shared/types/agent-sdk'
 import type { KanbanTicketUpdate } from '../../../main/db/types'
 
 type LaunchMode = 'build' | 'plan' | 'super-plan'
@@ -67,16 +72,25 @@ function composeLaunchPrompt(
   const trimmedPrompt = rawPrompt.trim()
   if (!trimmedPrompt) return null
 
+  // claude-cli skips the text prefix (it drives plan mode via --permission-mode
+  // plan); the SDKs skip it too (they inject plan instructions out-of-band).
+  // codex-cli is the exception: it has no such channel, so it carries codex's
+  // plan convention (`<proposed_plan>`) as a prompt prefix — see
+  // CODEX_PLAN_MODE_PREFIX.
   const skipPrefix =
     options.claudeCli ||
     sessionAgentSdk === 'claude-code' ||
     sessionAgentSdk === 'codex' ||
-    sessionAgentSdk === 'claude-code-cli'
+    isCliAgentSdk(sessionAgentSdk)
   const modePrefix =
     mode === 'super-plan'
       ? getSuperPlanModePrefix(sessionAgentSdk)
-      : mode === 'plan' && !skipPrefix
-        ? PLAN_MODE_PREFIX
+      : mode === 'plan'
+        ? isCodexCli(sessionAgentSdk)
+          ? CODEX_PLAN_MODE_PREFIX
+          : skipPrefix
+            ? ''
+            : PLAN_MODE_PREFIX
         : ''
   const fullPrompt = modePrefix + trimmedPrompt
 
@@ -186,7 +200,7 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
     // "Implement PLAN_{uuid}.md" goal prompt instead (the /goal wrapper stays).
     if (goalMode && goalSuccessCriteria && worktree?.path) {
       const composed = composeLaunchPrompt(prompt, spec.mode, sdk, goalMode, goalSuccessCriteria, {
-        claudeCli: sdk === 'claude-code-cli'
+        claudeCli: isCliAgentSdk(sdk)
       })
       if (exceedsGoalPromptLimit(composed)) {
         const fileName = await createPlanFile(worktree.path, prompt.trim())
@@ -196,12 +210,11 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
 
     // 2. Create session
     const modelOverride = model ? { ...model, agentSdk: sdk } : undefined
-    const cliPendingPrompt =
-      sdk === 'claude-code-cli'
-        ? composeLaunchPrompt(prompt, spec.mode, sdk, goalMode, goalSuccessCriteria, {
-            claudeCli: true
-          })
-        : null
+    const cliPendingPrompt = isCliAgentSdk(sdk)
+      ? composeLaunchPrompt(prompt, spec.mode, sdk, goalMode, goalSuccessCriteria, {
+          claudeCli: true
+        })
+      : null
     const createOptions = {
       autoFocus: false,
       ...(modelOverride ? { modelOverride } : {}),
@@ -264,7 +277,7 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
     // 6. Trigger usage refresh
     useUsageStore.getState().fetchUsageForProvider(resolveDefaultUsageProvider(sdk))
 
-    if (sessionAgentSdk === 'claude-code-cli') {
+    if (isCliAgentSdk(sessionAgentSdk)) {
       const outboundPrompt =
         cliPendingPrompt ??
         composeLaunchPrompt(prompt, spec.mode, sessionAgentSdk, goalMode, goalSuccessCriteria, {

--- a/src/renderer/src/stores/useBoardChatStore.test.ts
+++ b/src/renderer/src/stores/useBoardChatStore.test.ts
@@ -22,4 +22,28 @@ describe('resolveBoardChatAgentSdk', () => {
     expect(resolveBoardChatAgentSdk(null)).toBe('opencode')
     expect(resolveBoardChatAgentSdk(undefined)).toBe('opencode')
   })
+
+  it('falls back to opencode when the coerced streaming provider is unavailable', () => {
+    // codex build with CLI/hooks but no app-server (codex:false, codexCli:true):
+    // codex-cli (and a direct codex) must not be persisted, since the codex
+    // implementer's startSession() would throw.
+    const noCodex = { opencode: true, claude: true, codex: false, codexCli: true }
+    expect(resolveBoardChatAgentSdk('codex-cli', noCodex)).toBe('opencode')
+    expect(resolveBoardChatAgentSdk('codex', noCodex)).toBe('opencode')
+    // claude-code missing → claude-code-cli / claude-code also fall back.
+    const noClaude = { opencode: true, claude: false, codex: true }
+    expect(resolveBoardChatAgentSdk('claude-code-cli', noClaude)).toBe('opencode')
+    expect(resolveBoardChatAgentSdk('claude-code', noClaude)).toBe('opencode')
+  })
+
+  it('still coerces to the streaming sibling when the provider IS available', () => {
+    const all = { opencode: true, claude: true, codex: true, codexCli: true }
+    expect(resolveBoardChatAgentSdk('codex-cli', all)).toBe('codex')
+    expect(resolveBoardChatAgentSdk('claude-code-cli', all)).toBe('claude-code')
+  })
+
+  it('stays optimistic when availability is unknown (null)', () => {
+    expect(resolveBoardChatAgentSdk('codex-cli', null)).toBe('codex')
+    expect(resolveBoardChatAgentSdk('codex-cli', undefined)).toBe('codex')
+  })
 })

--- a/src/renderer/src/stores/useBoardChatStore.test.ts
+++ b/src/renderer/src/stores/useBoardChatStore.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { resolveBoardChatAgentSdk } from './useBoardChatStore'
+
+describe('resolveBoardChatAgentSdk', () => {
+  // The board assistant is a streaming OpenCode-style session with no PTY, so
+  // terminal-backed CLI SDKs must be coerced to their streaming sibling before
+  // being persisted as the session agent_sdk — otherwise later prompts fail the
+  // isCliAgentSdk guard in promptOpenCodeSession.
+  it('coerces terminal-backed CLI SDKs to their streaming implementer', () => {
+    expect(resolveBoardChatAgentSdk('codex-cli')).toBe('codex')
+    expect(resolveBoardChatAgentSdk('claude-code-cli')).toBe('claude-code')
+    expect(resolveBoardChatAgentSdk('terminal')).toBe('opencode')
+  })
+
+  it('passes streaming SDKs through unchanged (idempotent)', () => {
+    expect(resolveBoardChatAgentSdk('opencode')).toBe('opencode')
+    expect(resolveBoardChatAgentSdk('claude-code')).toBe('claude-code')
+    expect(resolveBoardChatAgentSdk('codex')).toBe('codex')
+  })
+
+  it('defaults to opencode for null / undefined', () => {
+    expect(resolveBoardChatAgentSdk(null)).toBe('opencode')
+    expect(resolveBoardChatAgentSdk(undefined)).toBe('opencode')
+  })
+})

--- a/src/renderer/src/stores/useBoardChatStore.ts
+++ b/src/renderer/src/stores/useBoardChatStore.ts
@@ -557,7 +557,15 @@ async function ensureRuntime(): Promise<{
   const baseAgentSdk =
     state.selectedAgentSdkOverride ?? resolveBoardChatAgentSdk(settings.defaultAgentSdk)
   const model = state.selectedModelOverride ?? resolveBoardChatDefaultModel(settings, baseAgentSdk)
-  const agentSdk = state.selectedAgentSdkOverride ?? model?.agentSdk ?? baseAgentSdk
+  // Coerce the persisted agent_sdk to a streaming implementer. `model.agentSdk`
+  // can carry a terminal-backed CLI SDK (codex-cli / claude-code-cli) — e.g. a
+  // saved `/ask` command default or a board-chat model override — but the board
+  // assistant is a streaming OpenCode-style session with no PTY, so persisting a
+  // CLI agent_sdk here makes later prompts fail the isCliAgentSdk guard in
+  // promptOpenCodeSession. resolveBoardChatAgentSdk maps codex-cli→codex,
+  // claude-code-cli→claude-code (idempotent on the streaming SDKs).
+  const agentSdk =
+    state.selectedAgentSdkOverride ?? resolveBoardChatAgentSdk(model?.agentSdk ?? baseAgentSdk)
 
   const projectId = scope.kind === 'project' ? scope.projectId : state.selectedTargetProjectId
 

--- a/src/renderer/src/stores/useBoardChatStore.ts
+++ b/src/renderer/src/stores/useBoardChatStore.ts
@@ -135,6 +135,9 @@ export function resolveBoardChatAgentSdk(
   const sdk = defaultAgentSdk ?? 'opencode'
   if (sdk === 'terminal') return 'opencode'
   if (sdk === 'claude-code-cli') return 'claude-code'
+  // codex-cli is terminal-backed; board chat needs a streaming implementer,
+  // so use its SDK sibling.
+  if (sdk === 'codex-cli') return 'codex'
   return sdk
 }
 

--- a/src/renderer/src/stores/useBoardChatStore.ts
+++ b/src/renderer/src/stores/useBoardChatStore.ts
@@ -130,25 +130,43 @@ export function resolveBoardChatAgentSdk(
   defaultAgentSdk:
     | ReturnType<typeof useSettingsStore.getState>['defaultAgentSdk']
     | null
-    | undefined
+    | undefined,
+  availableAgentSdks?: ReturnType<typeof useSettingsStore.getState>['availableAgentSdks']
 ): 'opencode' | 'claude-code' | 'codex' {
   const sdk = defaultAgentSdk ?? 'opencode'
-  if (sdk === 'terminal') return 'opencode'
-  if (sdk === 'claude-code-cli') return 'claude-code'
-  // codex-cli is terminal-backed; board chat needs a streaming implementer,
-  // so use its SDK sibling.
-  if (sdk === 'codex-cli') return 'codex'
-  return sdk
+  // Board chat runs a streaming implementer with no PTY, so map the
+  // terminal-backed CLIs to their streaming sibling.
+  const streaming =
+    sdk === 'terminal'
+      ? 'opencode'
+      : sdk === 'claude-code-cli'
+        ? 'claude-code'
+        : sdk === 'codex-cli'
+          ? 'codex'
+          : sdk
+  // …but only if that streaming provider is actually available. A codex build
+  // can support the CLI/hooks yet not the app-server (detection reports
+  // codex:false, codexCli:true), where CodexAppServerManager.startSession()
+  // throws; likewise claude-code may be absent. Fall back to opencode (always
+  // available) rather than persisting an agent_sdk the runtime can't start.
+  if (streaming === 'codex' && availableAgentSdks?.codex === false) return 'opencode'
+  if (streaming === 'claude-code' && availableAgentSdks?.claude === false) return 'opencode'
+  return streaming
 }
 
 export function resolveBoardChatDefaultModel(
   settings: Pick<
     ReturnType<typeof useSettingsStore.getState>,
-    'defaultAgentSdk' | 'selectedModel' | 'selectedModelByProvider' | 'getModelForMode'
+    | 'defaultAgentSdk'
+    | 'selectedModel'
+    | 'selectedModelByProvider'
+    | 'getModelForMode'
+    | 'availableAgentSdks'
   >,
   agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | null
 ): SelectedModel | null {
-  const agentSdk = agentSdkOverride ?? resolveBoardChatAgentSdk(settings.defaultAgentSdk)
+  const agentSdk =
+    agentSdkOverride ?? resolveBoardChatAgentSdk(settings.defaultAgentSdk, settings.availableAgentSdks)
   return (
     settings.getModelForMode('ask') ??
     resolveModelForSdk(agentSdk, settings) ??
@@ -555,7 +573,8 @@ async function ensureRuntime(): Promise<{
 
   const settings = useSettingsStore.getState()
   const baseAgentSdk =
-    state.selectedAgentSdkOverride ?? resolveBoardChatAgentSdk(settings.defaultAgentSdk)
+    state.selectedAgentSdkOverride ??
+    resolveBoardChatAgentSdk(settings.defaultAgentSdk, settings.availableAgentSdks)
   const model = state.selectedModelOverride ?? resolveBoardChatDefaultModel(settings, baseAgentSdk)
   // Coerce the persisted agent_sdk to a streaming implementer. `model.agentSdk`
   // can carry a terminal-backed CLI SDK (codex-cli / claude-code-cli) — e.g. a
@@ -565,7 +584,8 @@ async function ensureRuntime(): Promise<{
   // promptOpenCodeSession. resolveBoardChatAgentSdk maps codex-cli→codex,
   // claude-code-cli→claude-code (idempotent on the streaming SDKs).
   const agentSdk =
-    state.selectedAgentSdkOverride ?? resolveBoardChatAgentSdk(model?.agentSdk ?? baseAgentSdk)
+    state.selectedAgentSdkOverride ??
+    resolveBoardChatAgentSdk(model?.agentSdk ?? baseAgentSdk, settings.availableAgentSdks)
 
   const projectId = scope.kind === 'project' ? scope.projectId : state.selectedTargetProjectId
 

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -287,6 +287,13 @@ function findSessionInState(state: SessionState, sessionId: string): Session | n
 // therefore takes two presses, while returning from plan takes one. The
 // previous code sent a single press in both directions, which landed on
 // accept-edits (not plan) when entering plan mode.
+//
+// codex-cli is intentionally NOT handled here: it drives plan mode purely
+// through a prompt convention (CODEX_PLAN_MODE_PREFIX → a `<proposed_plan>`
+// block), staying in codex's Default collaboration mode the whole time, so
+// there is no keystroke to sync. (Flipping it into native Plan mode would
+// surface codex's own "Implement this plan?" popup — the very claude-style
+// dialog the codex convention avoids.)
 export function syncClaudeCliPermissionModeIfNeeded(
   state: SessionState,
   sessionId: string,

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -287,7 +287,12 @@ interface SettingsState extends AppSettings {
   customCommandsFileMtime: number | null
 
   // Cached SDK availability (non-persisted, re-detected each launch)
-  availableAgentSdks: { opencode: boolean; claude: boolean; codex: boolean } | null
+  availableAgentSdks: {
+    opencode: boolean
+    claude: boolean
+    codex: boolean
+    codexCli?: boolean
+  } | null
 
   // Actions
   openSettings: (section?: string) => void
@@ -645,6 +650,7 @@ export const useSettingsStore = create<SettingsState>()(
         if (
           agentSdk !== 'terminal' &&
           agentSdk !== 'claude-code-cli' &&
+          agentSdk !== 'codex-cli' &&
           !options?.skipBackendPush
         ) {
           try {

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { type AgentSdk, isClaudeFamily } from '@shared/types/agent-sdk'
+import { type AgentSdk, isClaudeFamily, isCodexFamily } from '@shared/types/agent-sdk'
 import type {
   UsageData,
   AnthropicRateLimitInfo,
@@ -483,7 +483,7 @@ export function resolveUsageProvider(session: SessionLike): UsageProvider {
 export function resolveDefaultUsageProvider(
   agentSdk: AgentSdk
 ): UsageProvider {
-  if (agentSdk === 'codex') return 'openai'
+  if (isCodexFamily(agentSdk)) return 'openai'
   return 'anthropic'
 }
 

--- a/src/server/rpc/domains/db.ts
+++ b/src/server/rpc/domains/db.ts
@@ -290,7 +290,14 @@ const worktreeIdParamsSchema = z.object({ worktreeId: z.string() }).strict()
 const worktreePinnedParamsSchema = z
   .object({ worktreeId: z.string(), pinned: z.boolean() })
   .strict()
-const agentSdkSchema = z.enum(['opencode', 'claude-code', 'claude-code-cli', 'codex', 'terminal'])
+const agentSdkSchema = z.enum([
+  'opencode',
+  'claude-code',
+  'claude-code-cli',
+  'codex',
+  'codex-cli',
+  'terminal'
+])
 const sessionModeSchema = z.enum(['build', 'plan', 'super-plan'])
 const sessionTypeSchema = z.enum(['default', 'board-assistant'])
 const sessionCreateParamsSchema = z.object({

--- a/src/server/rpc/domains/system-ops.ts
+++ b/src/server/rpc/domains/system-ops.ts
@@ -59,6 +59,8 @@ export interface AgentSdkDetectionResult {
   readonly opencode: boolean
   readonly claude: boolean
   readonly codex: boolean
+  /** Optional so pre-existing service stubs remain assignable; the live detector always sets it. */
+  readonly codexCli?: boolean
 }
 
 const emptyParamsSchema = z.union([z.object({}).strict(), z.undefined(), z.null()])

--- a/src/shared/agent-mode-prefixes.ts
+++ b/src/shared/agent-mode-prefixes.ts
@@ -1,11 +1,48 @@
 export const PLAN_MODE_PREFIX =
   '[Mode: Plan] You are in planning mode. Focus on designing, analyzing, and outlining an approach. Do NOT make code changes - instead describe what changes should be made and why.\n\n'
 
+/**
+ * Codex's plan convention (shared by the `codex` app-server SDK and the
+ * `codex-cli` terminal provider): codex has no ExitPlanMode tool — the model
+ * signals "plan is ready" by emitting a `<proposed_plan>…</proposed_plan>`
+ * block. The SDK injects this as `collaborationMode` developer_instructions;
+ * codex-cli, having no developer-instruction channel, injects it as a prompt
+ * prefix instead. Detection extracts the block (extractProposedPlanText in
+ * codex-cli-hooks.ts / extractProposedPlanMarkdown in codex-implementer.ts).
+ */
+export const CODEX_PROPOSED_PLAN_FINALIZATION =
+  'When your plan is complete, output it wrapped in `<proposed_plan>` and `</proposed_plan>` tags, with the implementation steps as markdown inside the block. Producing that block IS the signal that you are done — do NOT ask "should I proceed?" and do NOT implement anything after it.\n\n'
+
+/**
+ * Plan-mode prompt prefix for the codex-cli terminal provider. Mirrors the
+ * restraint + finalization rules of the SDK's plan collaboration instructions,
+ * so codex-cli asks for a plan the codex way (a `<proposed_plan>` block) rather
+ * than the claude way (`--permission-mode plan` + an ExitPlanMode tool call).
+ */
+export const CODEX_PLAN_MODE_PREFIX =
+  '[Mode: Plan] Investigate and design an approach. Do NOT modify files or run mutating commands — only read, explore, search, and reason about the codebase. ' +
+  CODEX_PROPOSED_PLAN_FINALIZATION
+
 export const SUPER_PLAN_MODE_PREFIX =
   'Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.\n\nIf a question can be answered by exploring the codebase, explore the codebase instead.\nAll questions should be asked using the AskUserQuestion tool if possible\n\n'
 
+// Unchanged from before the codex-cli work — used by the `codex` app-server
+// SDK, which supplies the `<proposed_plan>` finalization out-of-band via
+// developer_instructions. Kept byte-identical so stripping of already-persisted
+// codex super-plan messages still matches (the constant doubles as the strip
+// key — see stripSuperPlanModePrefix).
 export const CODEX_SUPER_PLAN_MODE_PREFIX =
   'Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.\n\nIf a question can be answered by exploring the codebase, explore the codebase instead.\nAll questions should be asked using the request_user_input tool if possible\n\n'
+
+/**
+ * codex-cli's super-plan prefix: the same interview instruction plus the
+ * `<proposed_plan>` finalization (codex-cli has no developer-instruction
+ * channel, so the finalization rides the prompt). This is a NEW constant, so
+ * there are no pre-existing persisted messages to break; the strip list picks
+ * it up alongside the plain codex prefix.
+ */
+export const CODEX_CLI_SUPER_PLAN_MODE_PREFIX =
+  CODEX_SUPER_PLAN_MODE_PREFIX + CODEX_PROPOSED_PLAN_FINALIZATION
 
 // Header that introduces the raw plan in a plan→implementor handoff prompt. Shared so the
 // renderer (which writes it in buildHandoffPrompt) and the main process (which detects and
@@ -13,7 +50,23 @@ export const CODEX_SUPER_PLAN_MODE_PREFIX =
 export const HANDOFF_PLAN_PROMPT_HEADER = 'Implement the following plan\n'
 
 export function getSuperPlanModePrefix(agentSdk: string | null | undefined): string {
-  return agentSdk === 'codex' ? CODEX_SUPER_PLAN_MODE_PREFIX : SUPER_PLAN_MODE_PREFIX
+  // Both codex providers interview via request_user_input; only codex-cli also
+  // needs the `<proposed_plan>` finalization inline (the SDK injects it
+  // out-of-band).
+  if (agentSdk === 'codex-cli') return CODEX_CLI_SUPER_PLAN_MODE_PREFIX
+  if (agentSdk === 'codex') return CODEX_SUPER_PLAN_MODE_PREFIX
+  return SUPER_PLAN_MODE_PREFIX
+}
+
+/**
+ * The plain plan-mode prompt prefix for an SDK. Only the codex-cli terminal
+ * provider uses a codex-style (`<proposed_plan>`) prefix here — the `codex`
+ * SDK injects its plan instructions out-of-band (developer_instructions) and
+ * so is not covered by this prompt-prefix helper.
+ */
+export function getPlanModePrefix(agentSdk: string | null | undefined): string {
+  if (agentSdk === 'codex-cli') return CODEX_PLAN_MODE_PREFIX
+  return PLAN_MODE_PREFIX
 }
 
 export function applyModePrefix(

--- a/src/shared/agent-mode-prefixes.ts
+++ b/src/shared/agent-mode-prefixes.ts
@@ -14,13 +14,26 @@ export const CODEX_PROPOSED_PLAN_FINALIZATION =
   'When your plan is complete, output it wrapped in `<proposed_plan>` and `</proposed_plan>` tags, with the implementation steps as markdown inside the block. Producing that block IS the signal that you are done — do NOT ask "should I proceed?" and do NOT implement anything after it.\n\n'
 
 /**
+ * The read-only restraint every codex-cli planning prefix must carry. codex-cli
+ * always spawns in yolo mode (`--dangerously-bypass-approvals-and-sandbox`, no
+ * sandbox), so — unlike the `codex` app-server SDK, which enforces plan
+ * restraint out-of-band via its collaboration mode — the prompt text is the
+ * ONLY thing stopping the agent from mutating the worktree while the UI still
+ * treats the turn as planning. Shared by the plain plan and super-plan prefixes
+ * so they can't drift.
+ */
+export const CODEX_READ_ONLY_RESTRAINT =
+  'Do NOT modify files or run mutating commands — only read, explore, search, and reason about the codebase. '
+
+/**
  * Plan-mode prompt prefix for the codex-cli terminal provider. Mirrors the
  * restraint + finalization rules of the SDK's plan collaboration instructions,
  * so codex-cli asks for a plan the codex way (a `<proposed_plan>` block) rather
  * than the claude way (`--permission-mode plan` + an ExitPlanMode tool call).
  */
 export const CODEX_PLAN_MODE_PREFIX =
-  '[Mode: Plan] Investigate and design an approach. Do NOT modify files or run mutating commands — only read, explore, search, and reason about the codebase. ' +
+  '[Mode: Plan] Investigate and design an approach. ' +
+  CODEX_READ_ONLY_RESTRAINT +
   CODEX_PROPOSED_PLAN_FINALIZATION
 
 export const SUPER_PLAN_MODE_PREFIX =
@@ -35,14 +48,18 @@ export const CODEX_SUPER_PLAN_MODE_PREFIX =
   'Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.\n\nIf a question can be answered by exploring the codebase, explore the codebase instead.\nAll questions should be asked using the request_user_input tool if possible\n\n'
 
 /**
- * codex-cli's super-plan prefix: the same interview instruction plus the
- * `<proposed_plan>` finalization (codex-cli has no developer-instruction
- * channel, so the finalization rides the prompt). This is a NEW constant, so
+ * codex-cli's super-plan prefix: the interview instruction, the same read-only
+ * restraint the plain codex-cli plan prefix carries, plus the `<proposed_plan>`
+ * finalization (codex-cli has no developer-instruction channel, so both ride
+ * the prompt). The restraint is essential here because codex-cli super-plan
+ * launches still spawn in yolo mode — without it the interview could mutate the
+ * worktree while the ticket is treated as planning. This is a NEW constant, so
  * there are no pre-existing persisted messages to break; the strip list picks
- * it up alongside the plain codex prefix.
+ * it up alongside the plain codex prefix (it still starts with
+ * CODEX_SUPER_PLAN_MODE_PREFIX, so longest-first stripping is unaffected).
  */
 export const CODEX_CLI_SUPER_PLAN_MODE_PREFIX =
-  CODEX_SUPER_PLAN_MODE_PREFIX + CODEX_PROPOSED_PLAN_FINALIZATION
+  CODEX_SUPER_PLAN_MODE_PREFIX + CODEX_READ_ONLY_RESTRAINT + CODEX_PROPOSED_PLAN_FINALIZATION
 
 // Header that introduces the raw plan in a plan→implementor handoff prompt. Shared so the
 // renderer (which writes it in buildHandoffPrompt) and the main process (which detects and

--- a/src/shared/desktop-command.ts
+++ b/src/shared/desktop-command.ts
@@ -634,7 +634,13 @@ export interface OpenCodeRefreshFromThreadResult {
   readonly error?: string
 }
 
-export type OpenCodeAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
+export type OpenCodeAgentSdk =
+  | 'opencode'
+  | 'claude-code'
+  | 'claude-code-cli'
+  | 'codex'
+  | 'codex-cli'
+  | 'terminal'
 
 export interface OpenCodeListModelsPayload {
   readonly agentSdk?: OpenCodeAgentSdk
@@ -4059,6 +4065,7 @@ const isOpenCodeAgentSdk = (value: unknown): value is OpenCodeAgentSdk =>
   value === 'claude-code' ||
   value === 'claude-code-cli' ||
   value === 'codex' ||
+  value === 'codex-cli' ||
   value === 'terminal'
 
 const isOpenCodeListModelsPayload = (value: unknown): value is OpenCodeListModelsPayload =>

--- a/src/shared/model-resolution.ts
+++ b/src/shared/model-resolution.ts
@@ -22,7 +22,8 @@ export const FALLBACK_MODELS: Record<HandoffAgentSdk, SharedSelectedModel> = {
   opencode: { providerID: 'anthropic', modelID: 'claude-opus-4-5-20251101' },
   'claude-code': { providerID: 'anthropic', modelID: 'claude-opus-4-5-20251101' },
   'claude-code-cli': { providerID: 'anthropic', modelID: 'sonnet', variant: 'high' },
-  codex: { providerID: 'codex', modelID: 'gpt-5.5' }
+  codex: { providerID: 'codex', modelID: 'gpt-5.5' },
+  'codex-cli': { providerID: 'codex', modelID: 'gpt-5.5', variant: 'high' }
 }
 
 export function getModeDefaultKey(mode: string | null | undefined): ModeDefaultKey {
@@ -33,7 +34,9 @@ export function getModeDefaultKey(mode: string | null | undefined): ModeDefaultK
 }
 
 export function normalizeAgentSdk(sdk: AgentSdk | string | null | undefined): HandoffAgentSdk {
-  if (sdk === 'claude-code' || sdk === 'claude-code-cli' || sdk === 'codex') return sdk
+  if (sdk === 'claude-code' || sdk === 'claude-code-cli' || sdk === 'codex' || sdk === 'codex-cli') {
+    return sdk
+  }
   return 'opencode'
 }
 

--- a/src/shared/types/__tests__/agent-sdk.test.ts
+++ b/src/shared/types/__tests__/agent-sdk.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_SDK_VALUES,
+  isClaudeCli,
+  isClaudeFamily,
+  isCliAgentSdk,
+  isCodexCli,
+  isCodexFamily,
+  isTerminalBacked,
+  supportsGoalMode,
+  toModelCatalogSdk
+} from '../agent-sdk'
+
+describe('agent-sdk predicates', () => {
+  it('exposes codex-cli as a canonical SDK value', () => {
+    expect(AGENT_SDK_VALUES).toContain('codex-cli')
+  })
+
+  it('isClaudeCli / isCodexCli identify only their exact CLI variant', () => {
+    expect(isClaudeCli('claude-code-cli')).toBe(true)
+    expect(isClaudeCli('codex-cli')).toBe(false)
+    expect(isCodexCli('codex-cli')).toBe(true)
+    expect(isCodexCli('codex')).toBe(false)
+    expect(isCodexCli('claude-code-cli')).toBe(false)
+  })
+
+  it('isCliAgentSdk covers both terminal-backed CLI agents (anchors PTY prompt routing)', () => {
+    // Telegram forwarding + the in-app terminal follow-up path both inject
+    // prompts straight into the PTY for these, since neither has an SDK
+    // implementer to route through.
+    expect(isCliAgentSdk('claude-code-cli')).toBe(true)
+    expect(isCliAgentSdk('codex-cli')).toBe(true)
+    expect(isCliAgentSdk('codex')).toBe(false)
+    expect(isCliAgentSdk('claude-code')).toBe(false)
+    expect(isCliAgentSdk('terminal')).toBe(false)
+    expect(isCliAgentSdk('opencode')).toBe(false)
+  })
+
+  it('isTerminalBacked adds the bare terminal to the CLI agents', () => {
+    expect(isTerminalBacked('terminal')).toBe(true)
+    expect(isTerminalBacked('codex-cli')).toBe(true)
+    expect(isTerminalBacked('claude-code-cli')).toBe(true)
+    expect(isTerminalBacked('codex')).toBe(false)
+    expect(isTerminalBacked('opencode')).toBe(false)
+  })
+
+  it('family predicates group each SDK with its CLI sibling', () => {
+    expect(isClaudeFamily('claude-code')).toBe(true)
+    expect(isClaudeFamily('claude-code-cli')).toBe(true)
+    expect(isClaudeFamily('codex-cli')).toBe(false)
+
+    expect(isCodexFamily('codex')).toBe(true)
+    expect(isCodexFamily('codex-cli')).toBe(true)
+    expect(isCodexFamily('claude-code-cli')).toBe(false)
+  })
+
+  it('supportsGoalMode includes both codex variants and the claude CLI', () => {
+    expect(supportsGoalMode('codex')).toBe(true)
+    expect(supportsGoalMode('codex-cli')).toBe(true)
+    expect(supportsGoalMode('claude-code-cli')).toBe(true)
+    expect(supportsGoalMode('claude-code')).toBe(false)
+    expect(supportsGoalMode('opencode')).toBe(false)
+  })
+
+  it('toModelCatalogSdk resolves the CLI variants to their catalog sibling', () => {
+    expect(toModelCatalogSdk('codex-cli')).toBe('codex')
+    expect(toModelCatalogSdk('claude-code-cli')).toBe('claude-code')
+    expect(toModelCatalogSdk('codex')).toBe('codex')
+    expect(toModelCatalogSdk(null)).toBeNull()
+    expect(toModelCatalogSdk(undefined)).toBeUndefined()
+  })
+
+  it('all predicates tolerate null / undefined / unknown strings', () => {
+    for (const sdk of [null, undefined, 'some-future-sdk']) {
+      expect(isCliAgentSdk(sdk)).toBe(false)
+      expect(isCodexFamily(sdk)).toBe(false)
+      expect(isTerminalBacked(sdk)).toBe(false)
+      expect(supportsGoalMode(sdk)).toBe(false)
+    }
+  })
+})

--- a/src/shared/types/agent-sdk.ts
+++ b/src/shared/types/agent-sdk.ts
@@ -71,6 +71,15 @@ export function isClaudeFamily(sdk: MaybeSdk): boolean {
   return sdk === 'claude-code' || sdk === 'claude-code-cli'
 }
 
+/**
+ * Either Codex variant — the app-server SDK `codex` or the terminal-backed
+ * `codex-cli`. Both bill to an OpenAI account, so usage/telemetry attribution
+ * should treat them the same.
+ */
+export function isCodexFamily(sdk: MaybeSdk): boolean {
+  return sdk === 'codex' || sdk === 'codex-cli'
+}
+
 /** SDKs whose CLI understands the `/goal` prompt prefix (persistent goal mode). */
 export function supportsGoalMode(sdk: MaybeSdk): boolean {
   return sdk === 'codex' || sdk === 'claude-code-cli' || sdk === 'codex-cli'

--- a/src/shared/types/agent-sdk.ts
+++ b/src/shared/types/agent-sdk.ts
@@ -26,6 +26,7 @@ export const AGENT_SDK_VALUES = [
   'claude-code',
   'claude-code-cli',
   'codex',
+  'codex-cli',
   'terminal'
 ] as const
 
@@ -41,13 +42,28 @@ export function isClaudeCli(sdk: MaybeSdk): boolean {
   return sdk === 'claude-code-cli'
 }
 
+/** The Codex CLI session type (terminal-backed Codex TUI, distinct from the app-server-driven `codex`). */
+export function isCodexCli(sdk: MaybeSdk): boolean {
+  return sdk === 'codex-cli'
+}
+
+/**
+ * Terminal-backed sessions driven by an agent CLI (claude / codex TUIs in a
+ * PTY). These share the CLI status pipeline (hook server → status events),
+ * plan-card flow, and the always-mounted terminal portal — unlike the bare
+ * `terminal` SDK, which is a plain shell.
+ */
+export function isCliAgentSdk(sdk: MaybeSdk): boolean {
+  return sdk === 'claude-code-cli' || sdk === 'codex-cli'
+}
+
 /**
  * Sessions whose UI is a live terminal surface rather than the OpenCode-style
- * streaming view: the bare `terminal` SDK and `claude-code-cli`. These share
- * mount/teardown handling and must NOT be routed through the OpenCode IPC.
+ * streaming view: the bare `terminal` SDK and the CLI-backed agents. These
+ * share mount/teardown handling and must NOT be routed through the OpenCode IPC.
  */
 export function isTerminalBacked(sdk: MaybeSdk): boolean {
-  return sdk === 'terminal' || sdk === 'claude-code-cli'
+  return sdk === 'terminal' || isCliAgentSdk(sdk)
 }
 
 /** Either Claude variant — the SDK-driven `claude-code` or the terminal-backed `claude-code-cli`. */
@@ -57,18 +73,21 @@ export function isClaudeFamily(sdk: MaybeSdk): boolean {
 
 /** SDKs whose CLI understands the `/goal` prompt prefix (persistent goal mode). */
 export function supportsGoalMode(sdk: MaybeSdk): boolean {
-  return sdk === 'codex' || sdk === 'claude-code-cli'
+  return sdk === 'codex' || sdk === 'claude-code-cli' || sdk === 'codex-cli'
 }
 
 /**
- * Map an SDK to the one whose model catalog it uses. `claude-code-cli` has no
- * catalog of its own — it shares `claude-code`'s — so model-listing/selection
- * code should resolve through this rather than special-casing the CLI inline.
+ * Map an SDK to the one whose model catalog it uses. The CLI variants have no
+ * catalog of their own — `claude-code-cli` shares `claude-code`'s and
+ * `codex-cli` shares `codex`'s — so model-listing/selection code should
+ * resolve through this rather than special-casing the CLIs inline.
  * Overloaded so nullable inputs (optional IPC payload fields) pass `null` /
  * `undefined` through unchanged.
  */
 export function toModelCatalogSdk(sdk: AgentSdk): AgentSdk
 export function toModelCatalogSdk(sdk: AgentSdk | null | undefined): AgentSdk | null | undefined
 export function toModelCatalogSdk(sdk: AgentSdk | null | undefined): AgentSdk | null | undefined {
-  return sdk === 'claude-code-cli' ? 'claude-code' : sdk
+  if (sdk === 'claude-code-cli') return 'claude-code'
+  if (sdk === 'codex-cli') return 'codex'
+  return sdk
 }

--- a/test/phase-20/session-11/pr-content-provider-resolution.test.ts
+++ b/test/phase-20/session-11/pr-content-provider-resolution.test.ts
@@ -36,4 +36,37 @@ describe('resolvePRContentProvider', () => {
       })
     ).toBeNull()
   })
+
+  it('resolves codex-cli to the codex provider when only the CLI is available', () => {
+    // codex false (no app-server) but codexCli true — `codex exec` still works.
+    expect(
+      resolvePRContentProvider('codex-cli', {
+        opencode: false,
+        claude: false,
+        codex: false,
+        codexCli: true
+      })
+    ).toBe('codex')
+  })
+
+  it('maps claude-code-cli to claude-code for PR content', () => {
+    expect(
+      resolvePRContentProvider('claude-code-cli', {
+        opencode: false,
+        claude: true,
+        codex: false
+      })
+    ).toBe('claude-code')
+  })
+
+  it('treats codex as available for PR content when only codexCli is set (falling back from terminal)', () => {
+    expect(
+      resolvePRContentProvider('terminal', {
+        opencode: false,
+        claude: false,
+        codex: false,
+        codexCli: true
+      })
+    ).toBe('codex')
+  })
 })

--- a/test/phase-22/session-2/agent-setup-guard-codex.test.tsx
+++ b/test/phase-22/session-2/agent-setup-guard-codex.test.tsx
@@ -50,9 +50,14 @@ vi.mock('@/components/setup/AgentPickerDialog', () => ({
     availableSdks
   }: {
     onSelect: (sdk: string) => void
-    availableSdks: { opencode: boolean; claude: boolean; codex: boolean }
+    availableSdks: { opencode: boolean; claude: boolean; codex: boolean; codexCli?: boolean }
   }) => (
     <div data-testid="agent-picker-dialog">
+      {availableSdks.codexCli && (
+        <button data-testid="pick-codex-cli" onClick={() => onSelect('codex-cli')}>
+          Codex (CLI)
+        </button>
+      )}
       {availableSdks.opencode && (
         <button data-testid="pick-opencode" onClick={() => onSelect('opencode')}>
           OpenCode
@@ -151,6 +156,65 @@ describe('AgentSetupGuard with Codex support', () => {
     await waitFor(() => {
       expect(screen.getByTestId('agent-not-found-dialog')).toBeInTheDocument()
     })
+  })
+
+  it('auto-selects codex-cli when the codex binary is present but app-server is unavailable', async () => {
+    // codex false (no app-server), codexCli true (binary present) — the only usable provider.
+    mockDetectAgentSdks.mockResolvedValue({
+      opencode: false,
+      claude: false,
+      codex: false,
+      codexCli: true
+    })
+
+    const { AgentSetupGuard } = await import('@/components/setup/AgentSetupGuard')
+    render(<AgentSetupGuard />)
+
+    await waitFor(() => {
+      expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('defaultAgentSdk', 'codex-cli')
+      expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('initialSetupComplete', true)
+    })
+    // Must NOT be treated as "no agent found".
+    expect(screen.queryByTestId('agent-not-found-dialog')).not.toBeInTheDocument()
+  })
+
+  it('offers Codex (CLI) as a distinct pick when combined with another provider', async () => {
+    mockDetectAgentSdks.mockResolvedValue({
+      opencode: true,
+      claude: false,
+      codex: false,
+      codexCli: true
+    })
+
+    const { AgentSetupGuard } = await import('@/components/setup/AgentSetupGuard')
+    render(<AgentSetupGuard />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-picker-dialog')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('pick-opencode')).toBeInTheDocument()
+    expect(screen.getByTestId('pick-codex-cli')).toBeInTheDocument()
+    // The SDK-backed Codex isn't available, so it must not be offered.
+    expect(screen.queryByTestId('pick-codex')).not.toBeInTheDocument()
+  })
+
+  it('does not double up Codex and Codex (CLI) when both flags are set', async () => {
+    // codex true implies codexCli true; only the richer SDK Codex should show.
+    mockDetectAgentSdks.mockResolvedValue({
+      opencode: true,
+      claude: false,
+      codex: true,
+      codexCli: true
+    })
+
+    const { AgentSetupGuard } = await import('@/components/setup/AgentSetupGuard')
+    render(<AgentSetupGuard />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-picker-dialog')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('pick-codex')).toBeInTheDocument()
+    expect(screen.queryByTestId('pick-codex-cli')).not.toBeInTheDocument()
   })
 
   it('auto-selects opencode when only opencode is installed (codex false)', async () => {

--- a/test/phase-22/session-2/settings-codex-provider.test.tsx
+++ b/test/phase-22/session-2/settings-codex-provider.test.tsx
@@ -92,7 +92,8 @@ describe('SettingsGeneral: Codex provider button', () => {
       'Claude Code',
       'Codex',
       'Terminal',
-      'Claude Code (CLI)'
+      'Claude Code (CLI)',
+      'Codex (CLI)'
     ])
   })
 

--- a/test/phase-22/session-2/system-info-opencode-detection.test.ts
+++ b/test/phase-22/session-2/system-info-opencode-detection.test.ts
@@ -30,9 +30,9 @@ describe('system-info: detectAgentSdks opencode launchability', () => {
       if (_cmd === '/usr/local/bin/codex' && args.join(' ') === 'app-server --help') {
         return 'Usage: codex app-server\n'
       }
-      // codex-cli hook-capability probe: `codex --help` advertises the flag.
-      if (_cmd === '/usr/local/bin/codex' && args.join(' ') === '--help') {
-        return 'Usage: codex [OPTIONS]\n      --dangerously-bypass-hook-trust\n'
+      // codex-cli hook-capability probe: `codex --version` >= 0.134.0.
+      if (_cmd === '/usr/local/bin/codex' && args.join(' ') === '--version') {
+        return 'codex-cli 0.144.0\n'
       }
       throw new Error('not found')
     })
@@ -49,13 +49,12 @@ describe('system-info: detectAgentSdks opencode launchability', () => {
     })
   })
 
-  it('does not offer codex-cli when the binary lacks the hook flags', async () => {
-    // Binary resolves (known-location existsSync) but its --help omits the
-    // hook-trust flag, so codex-cli must be reported unavailable.
+  it('does not offer codex-cli for a version with a broken hook-trust bypass (0.131-0.133)', async () => {
+    // The flag is present but ignored in these versions (openai/codex#24093).
     mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
       if (args?.[0] === 'codex') return '/usr/local/bin/codex\n'
-      if (_cmd === '/usr/local/bin/codex' && args.join(' ') === '--help') {
-        return 'Usage: codex [OPTIONS]\n  (an old build without hook support)\n'
+      if (_cmd === '/usr/local/bin/codex' && args.join(' ') === '--version') {
+        return 'codex-cli 0.132.0\n'
       }
       throw new Error('not found')
     })
@@ -64,6 +63,21 @@ describe('system-info: detectAgentSdks opencode launchability', () => {
 
     const result = detectAgentSdks({ command: '/usr/local/bin/opencode', shell: false })
     expect(result.codexCli).toBe(false)
+  })
+
+  it('offers codex-cli for the first fixed version (0.134.0)', async () => {
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args?.[0] === 'codex') return '/usr/local/bin/codex\n'
+      if (_cmd === '/usr/local/bin/codex' && args.join(' ') === '--version') {
+        return 'codex-cli 0.134.0\n'
+      }
+      throw new Error('not found')
+    })
+
+    const { detectAgentSdks } = await import('../../../src/main/services/system-info')
+
+    const result = detectAgentSdks({ command: '/usr/local/bin/opencode', shell: false })
+    expect(result.codexCli).toBe(true)
   })
 
   it('returns opencode false when the launch spec is null', async () => {

--- a/test/phase-22/session-2/system-info-opencode-detection.test.ts
+++ b/test/phase-22/session-2/system-info-opencode-detection.test.ts
@@ -40,7 +40,8 @@ describe('system-info: detectAgentSdks opencode launchability', () => {
     ).toEqual({
       opencode: true,
       claude: true,
-      codex: true
+      codex: true,
+      codexCli: true
     })
   })
 
@@ -54,7 +55,8 @@ describe('system-info: detectAgentSdks opencode launchability', () => {
     expect(detectAgentSdks(null)).toEqual({
       opencode: false,
       claude: false,
-      codex: false
+      codex: false,
+      codexCli: true
     })
   })
 })

--- a/test/phase-22/session-2/system-info-opencode-detection.test.ts
+++ b/test/phase-22/session-2/system-info-opencode-detection.test.ts
@@ -30,6 +30,10 @@ describe('system-info: detectAgentSdks opencode launchability', () => {
       if (_cmd === '/usr/local/bin/codex' && args.join(' ') === 'app-server --help') {
         return 'Usage: codex app-server\n'
       }
+      // codex-cli hook-capability probe: `codex --help` advertises the flag.
+      if (_cmd === '/usr/local/bin/codex' && args.join(' ') === '--help') {
+        return 'Usage: codex [OPTIONS]\n      --dangerously-bypass-hook-trust\n'
+      }
       throw new Error('not found')
     })
 
@@ -45,6 +49,23 @@ describe('system-info: detectAgentSdks opencode launchability', () => {
     })
   })
 
+  it('does not offer codex-cli when the binary lacks the hook flags', async () => {
+    // Binary resolves (known-location existsSync) but its --help omits the
+    // hook-trust flag, so codex-cli must be reported unavailable.
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args?.[0] === 'codex') return '/usr/local/bin/codex\n'
+      if (_cmd === '/usr/local/bin/codex' && args.join(' ') === '--help') {
+        return 'Usage: codex [OPTIONS]\n  (an old build without hook support)\n'
+      }
+      throw new Error('not found')
+    })
+
+    const { detectAgentSdks } = await import('../../../src/main/services/system-info')
+
+    const result = detectAgentSdks({ command: '/usr/local/bin/opencode', shell: false })
+    expect(result.codexCli).toBe(false)
+  })
+
   it('returns opencode false when the launch spec is null', async () => {
     mockExecFileSync.mockImplementation(() => {
       throw new Error('not found')
@@ -52,11 +73,13 @@ describe('system-info: detectAgentSdks opencode launchability', () => {
 
     const { detectAgentSdks } = await import('../../../src/main/services/system-info')
 
+    // Every probe throws with no output, so hook support can't be confirmed
+    // → codex-cli is not offered.
     expect(detectAgentSdks(null)).toEqual({
       opencode: false,
       claude: false,
       codex: false,
-      codexCli: true
+      codexCli: false
     })
   })
 })


### PR DESCRIPTION
## Summary
- Adds Codex CLI spawning, hook injection, and session-thread tracking so Codex sessions can run through the existing terminal-backed pipeline.
- Translates Codex hook payloads into the shared Claude-compatible hook shape, including `request_user_input` mapping and plan-handling via `<proposed_plan>` blocks.
- Updates the shared hook server and session routing so Codex and Claude CLI sessions are handled separately where their runtimes differ.
- Extends renderer/server models, agent SDK types, and session UI flows to recognize `codex-cli` alongside existing terminal-backed agents.
- Adds unit and component coverage for Codex hook translation, PTY spawn args, plan conventions, and worktree/session wiring.

## Testing
- Not run
- Added/updated Vitest coverage for Codex hook translation and PTY spawn behavior.
- Added/updated renderer tests for Codex plan conventions and worktree picker/session flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared hook server, PTY lifecycle, and plan/status state machine across main and renderer; incorrect translation or routing could mislabel plans or strand remote sessions, though behavior is heavily tested.
> 
> **Overview**
> Introduces **`codex-cli`** as a terminal-backed agent alongside `claude-code-cli`: new **PTY spawn** (`buildCodexCliPtySpawn`), **per-invocation hook args** POSTing to `/codex-hook/...`, and **`translateCodexHook`** so Codex events reuse the existing Claude-style status/plan pipeline (`request_user_input` → questions, `<proposed_plan>` → plan ready, `"Implement the plan."` → approval).
> 
> The **shared hook server** now distinguishes Claude vs Codex routes; Codex skips Claude-only telemetry/transports, and plan auto-approve for Codex **writes the implement prompt** to the PTY instead of keystrokes. **Binary detection** adds `codexCli` gated on hook support (≥0.134.0). **Discord/Telegram/board chat** coerce or block `codex-cli` where there is no streaming bridge or keyboard-driven TUI.
> 
> The **renderer** exposes Codex CLI in pickers/settings, uses **`CODEX_PLAN_MODE_PREFIX`** for plan turns (modal Tab toggle kept unlike Claude CLI), and generalizes many `claude-code-cli` checks to **`isCliAgentSdk`**. Substantial **Vitest** coverage for hooks, spawner, and plan conventions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acfbfaaca49b52876649cb32e306bb98a7a27415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->