### PR TITLE
Add scheduled account switching by time and usage

### DIFF
--- a/src/renderer/src/components/accounts/ScheduleSwitchControls.tsx
+++ b/src/renderer/src/components/accounts/ScheduleSwitchControls.tsx
@@ -152,7 +152,7 @@ export function ScheduleSwitchForm({
       <div className="text-[9px] text-muted-foreground/70">
         {mode === 'time'
           ? 'Switch to this account after the time elapses.'
-          : 'Switch when the active account crosses this usage.'}
+          : 'Switch when any usage bar of the active account crosses this percent.'}
         {replacesOther && (
           <span className="text-amber-500"> Replaces the pending {existing?.email} schedule.</span>
         )}

--- a/src/renderer/src/components/accounts/ScheduleSwitchControls.tsx
+++ b/src/renderer/src/components/accounts/ScheduleSwitchControls.tsx
@@ -65,7 +65,7 @@ export function ScheduleSwitchForm({
     const value = Number(customValue)
     if (!Number.isFinite(value) || value <= 0) return
     if (mode === 'time') submitTime(value * 60_000)
-    else submitUsage(value)
+    else if (value <= 100) submitUsage(value)
   }
 
   return (
@@ -126,6 +126,7 @@ export function ScheduleSwitchForm({
           <input
             type="number"
             min={1}
+            max={mode === 'usage' ? 100 : undefined}
             value={customValue}
             onChange={(e) => setCustomValue(e.target.value)}
             onKeyDown={(e) => {
@@ -154,7 +155,10 @@ export function ScheduleSwitchForm({
           ? 'Switch to this account after the time elapses.'
           : 'Switch when any usage bar of the active account crosses this percent.'}
         {replacesOther && (
-          <span className="text-amber-500"> Replaces the pending {existing?.email} schedule.</span>
+          <span className="text-amber-500">
+            {' '}
+            Replaces the pending {existing?.email ?? 'account'} schedule.
+          </span>
         )}
       </div>
     </div>

--- a/src/renderer/src/components/accounts/ScheduleSwitchControls.tsx
+++ b/src/renderer/src/components/accounts/ScheduleSwitchControls.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from 'react'
+import { Clock, Gauge, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useTimerTickStore } from '@/stores/useTimerTickStore'
+import {
+  useAccountScheduleStore,
+  describeSchedule,
+  getActiveUsagePercent,
+  type ScheduledSwitch,
+  type ScheduleMode
+} from '@/stores/useAccountScheduleStore'
+import type { UsageProvider } from '@shared/types/usage'
+
+const TIME_PRESETS = [
+  { label: '30m', ms: 30 * 60_000 },
+  { label: '1h', ms: 60 * 60_000 },
+  { label: '2h', ms: 2 * 60 * 60_000 },
+  { label: '4h', ms: 4 * 60 * 60_000 }
+]
+
+const USAGE_PRESETS = [50, 70, 90]
+
+const presetButtonClass =
+  'rounded-sm border border-border/60 px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground'
+
+interface ScheduleSwitchFormProps {
+  provider: UsageProvider
+  accountId: string
+  email: string | null
+  onDone?: () => void
+  className?: string
+}
+
+/**
+ * Compact "schedule a switch to this account" form: by time (switch after a
+ * delay) or by usage (switch once the active account's usage bar crosses a
+ * percentage). One schedule per provider — setting a new one replaces it.
+ */
+export function ScheduleSwitchForm({
+  provider,
+  accountId,
+  email,
+  onDone,
+  className
+}: ScheduleSwitchFormProps): React.JSX.Element {
+  const scheduleByTime = useAccountScheduleStore((s) => s.scheduleByTime)
+  const scheduleByUsage = useAccountScheduleStore((s) => s.scheduleByUsage)
+  const existing = useAccountScheduleStore((s) => s.schedules[provider])
+  const [mode, setMode] = useState<ScheduleMode>('time')
+  const [customValue, setCustomValue] = useState('')
+
+  const replacesOther = existing !== undefined && existing.accountId !== accountId
+
+  const submitTime = (ms: number): void => {
+    scheduleByTime(provider, accountId, email, ms)
+    onDone?.()
+  }
+
+  const submitUsage = (percent: number): void => {
+    scheduleByUsage(provider, accountId, email, percent)
+    onDone?.()
+  }
+
+  const submitCustom = (): void => {
+    const value = Number(customValue)
+    if (!Number.isFinite(value) || value <= 0) return
+    if (mode === 'time') submitTime(value * 60_000)
+    else submitUsage(value)
+  }
+
+  return (
+    <div className={cn('space-y-1.5', className)} data-testid="schedule-switch-form">
+      <div className="inline-flex items-center gap-0.5 rounded-sm border border-border/60 p-0.5">
+        {(
+          [
+            { key: 'time', label: 'By time', icon: Clock },
+            { key: 'usage', label: 'By usage', icon: Gauge }
+          ] as const
+        ).map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => {
+              setMode(key)
+              setCustomValue('')
+            }}
+            aria-pressed={mode === key}
+            className={cn(
+              'inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[9px] font-medium transition-colors',
+              mode === key
+                ? 'bg-accent text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <Icon className="h-2.5 w-2.5" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1">
+        {mode === 'time'
+          ? TIME_PRESETS.map((preset) => (
+              <button
+                key={preset.label}
+                type="button"
+                onClick={() => submitTime(preset.ms)}
+                className={presetButtonClass}
+                aria-label={`Switch in ${preset.label}`}
+              >
+                {preset.label}
+              </button>
+            ))
+          : USAGE_PRESETS.map((percent) => (
+              <button
+                key={percent}
+                type="button"
+                onClick={() => submitUsage(percent)}
+                className={presetButtonClass}
+                aria-label={`Switch at ${percent}% usage`}
+              >
+                {percent}%
+              </button>
+            ))}
+        <div className="flex items-center gap-1">
+          <input
+            type="number"
+            min={1}
+            value={customValue}
+            onChange={(e) => setCustomValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                submitCustom()
+              }
+            }}
+            placeholder={mode === 'time' ? 'min' : '%'}
+            aria-label={mode === 'time' ? 'Custom minutes' : 'Custom usage percent'}
+            className="h-5 w-11 rounded-sm border border-border/60 bg-transparent px-1 text-[9px] text-foreground outline-none focus:border-border [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          />
+          <button
+            type="button"
+            onClick={submitCustom}
+            disabled={!customValue}
+            className={cn(presetButtonClass, 'disabled:cursor-not-allowed disabled:opacity-50')}
+          >
+            Set
+          </button>
+        </div>
+      </div>
+
+      <div className="text-[9px] text-muted-foreground/70">
+        {mode === 'time'
+          ? 'Switch to this account after the time elapses.'
+          : 'Switch when the active account crosses this usage.'}
+        {replacesOther && (
+          <span className="text-amber-500"> Replaces the pending {existing?.email} schedule.</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface SchedulePendingSummaryProps {
+  schedule: ScheduledSwitch
+  onCancel: () => void
+  className?: string
+}
+
+/** Live "auto-switch pending" line with a cancel button. */
+export function SchedulePendingSummary({
+  schedule,
+  onCancel,
+  className
+}: SchedulePendingSummaryProps): React.JSX.Element {
+  const tickMs = useTimerTickStore((s) => s.tickMs)
+  const currentPercent = schedule.mode === 'usage' ? getActiveUsagePercent(schedule.provider) : null
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-1 rounded-sm border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[9px] text-amber-600 dark:text-amber-400',
+        className
+      )}
+      data-testid="schedule-pending-summary"
+    >
+      <Clock className="h-2.5 w-2.5 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">
+        Auto-switch {describeSchedule(schedule, tickMs)}
+        {schedule.mode === 'usage' && currentPercent !== null && (
+          <span className="opacity-70"> (now {Math.round(currentPercent)}%)</span>
+        )}
+      </span>
+      <button
+        type="button"
+        onClick={onCancel}
+        aria-label="Cancel scheduled switch"
+        className="shrink-0 rounded-sm p-0.5 transition-colors hover:bg-amber-500/20"
+      >
+        <X className="h-2.5 w-2.5" />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -23,6 +23,7 @@ import { useConnectionWatcher } from '@/hooks/useConnectionWatcher'
 import { useAutoUpdate } from '@/hooks/useAutoUpdate'
 import { useKeepAwake } from '@/hooks/useKeepAwake'
 import { useSleepWhenIdle } from '@/hooks/useSleepWhenIdle'
+import { useAccountScheduleRunner } from '@/hooks/useAccountScheduleRunner'
 import { ErrorBoundary, ErrorFallback } from '@/components/error'
 import { CreatePRModal } from '@/components/pr/CreatePRModal'
 import { ConnectionPRModal } from '@/components/pr/ConnectionPRModal'
@@ -151,6 +152,8 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
   useKeepAwake()
   // One-shot sleep after all sessions have been idle for a continuous minute.
   useSleepWhenIdle()
+  // Scheduled account switches + mid-session 5-minute usage refresh
+  useAccountScheduleRunner()
 
   // Drag-and-drop from Finder
   const activeSessionId = useSessionStore((s) => s.activeSessionId)

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -14,7 +14,12 @@ import { reportActiveAccountsSnapshot } from '@/lib/hive-account-report'
 import { fetchHiveAccountMembers, isHiveTelemetryEnabled } from '@/api/hive-enterprise/client'
 import { MemberAvatarStack, type AccountMemberInfo } from './MemberAvatarStack'
 import { cn } from '@/lib/utils'
-import { Loader2, RefreshCw } from 'lucide-react'
+import { Loader2, RefreshCw, Timer } from 'lucide-react'
+import { useAccountScheduleStore } from '@/stores/useAccountScheduleStore'
+import {
+  ScheduleSwitchForm,
+  SchedulePendingSummary
+} from '@/components/accounts/ScheduleSwitchControls'
 import claudeIcon from '@/assets/model-icons/claude.svg'
 import openaiIcon from '@/assets/model-icons/openai.svg'
 import type {
@@ -208,6 +213,7 @@ function usageFromSavedAccount(
 
 export interface UsageAccountRowProps {
   row: AccountRowData
+  provider?: UsageProvider
   isSwitching?: boolean
   isLoginActive?: boolean
   highlightActive?: boolean
@@ -220,6 +226,7 @@ export interface UsageAccountRowProps {
 
 export function UsageAccountRow({
   row,
+  provider,
   isSwitching = false,
   isLoginActive = false,
   highlightActive = false,
@@ -232,6 +239,12 @@ export function UsageAccountRow({
   const fiveHour = usageWindowDisplay(row.usage?.five_hour, 'five_hour')
   const sevenDay = usageWindowDisplay(row.usage?.seven_day, 'seven_day')
   const scoped = row.usage?.scoped ?? []
+
+  const schedule = useAccountScheduleStore((s) => (provider ? s.schedules[provider] : undefined))
+  const cancelSchedule = useAccountScheduleStore((s) => s.cancelSchedule)
+  const [showScheduleForm, setShowScheduleForm] = useState(false)
+  const scheduleTargetsRow = schedule !== undefined && schedule.accountId === row.id
+  const canSchedule = provider !== undefined && !row.isActive && onSwitch !== undefined
 
   return (
     <div
@@ -314,6 +327,23 @@ export function UsageAccountRow({
               Refresh
             </button>
           )}
+          {canSchedule && (
+            <button
+              type="button"
+              onClick={() => setShowScheduleForm((v) => !v)}
+              aria-label={`Schedule switch to ${row.email ?? 'this account'}`}
+              aria-expanded={showScheduleForm}
+              className={cn(
+                'inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[9px] font-medium transition-colors',
+                scheduleTargetsRow
+                  ? 'border-amber-500/50 text-amber-600 hover:bg-amber-500/10 dark:text-amber-400'
+                  : 'border-border/60 text-muted-foreground hover:bg-accent/60 hover:text-foreground'
+              )}
+            >
+              <Timer className="h-2.5 w-2.5" />
+              Schedule
+            </button>
+          )}
           {row.status === 'stale' && onSignInAgain && (
             <button
               type="button"
@@ -326,6 +356,23 @@ export function UsageAccountRow({
             </button>
           )}
         </div>
+      )}
+
+      {scheduleTargetsRow && provider && schedule && (
+        <SchedulePendingSummary
+          schedule={schedule}
+          onCancel={() => cancelSchedule(provider)}
+          className="mt-1.5"
+        />
+      )}
+      {!scheduleTargetsRow && showScheduleForm && canSchedule && provider && (
+        <ScheduleSwitchForm
+          provider={provider}
+          accountId={row.id}
+          email={row.email}
+          onDone={() => setShowScheduleForm(false)}
+          className="mt-1.5 border-t border-border/40 pt-1.5"
+        />
       )}
 
       {row.isRefreshing && (
@@ -563,6 +610,7 @@ function ProviderUsagePopoverBody({ provider }: { provider: UsageProvider }): Re
           <UsageAccountRow
             key={row.id}
             row={row}
+            provider={provider}
             isSwitching={switchingAccountIds.has(row.id)}
             isLoginActive={isLoginActive}
             highlightActive={highlightActive}
@@ -633,6 +681,7 @@ export function ProviderUsageBlock({
     provider === 'anthropic' ? s.anthropicIsLoading : s.openaiIsLoading
   )
   const fetchEmail = useAccountStore((s) => s.fetchEmail)
+  const hasPendingSchedule = useAccountScheduleStore((s) => s.schedules[provider] !== undefined)
 
   // Which provider the popover shows. The bottom toggle can point it at a
   // different provider than the hovered trigger; each open snaps it back.
@@ -739,6 +788,12 @@ export function ProviderUsageBlock({
                 )}
               />
             </button>
+            {hasPendingSchedule && (
+              <Timer
+                className="h-2.5 w-2.5 shrink-0 text-amber-500"
+                aria-label="Account switch scheduled"
+              />
+            )}
             <div className="flex-1 space-y-0.5">
               <UsageRow
                 label="5h"

--- a/src/renderer/src/components/settings/SettingsAccounts.test.tsx
+++ b/src/renderer/src/components/settings/SettingsAccounts.test.tsx
@@ -95,9 +95,9 @@ describe('SettingsAccounts', () => {
   it('hides Switch on the active account and shows it on others', async () => {
     await renderSettingsAccounts()
 
-    expect(screen.queryByRole('button', { name: /switch to active@example.com/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /^switch to active@example.com$/i })).toBeNull()
     expect(
-      screen.getByRole('button', { name: /switch to expired@example.com/i })
+      screen.getByRole('button', { name: /^switch to expired@example.com$/i })
     ).not.toBeNull()
   })
 

--- a/src/renderer/src/components/settings/SettingsAccounts.tsx
+++ b/src/renderer/src/components/settings/SettingsAccounts.tsx
@@ -1,9 +1,15 @@
 import { useEffect, useState } from 'react'
-import { Loader2, Plus, RefreshCw, Repeat, Trash2 } from 'lucide-react'
+import { Loader2, Plus, RefreshCw, Repeat, Timer, Trash2 } from 'lucide-react'
 import { useAccountStore, useUsageStore } from '@/stores'
 import { useLoginStore } from '@/stores/useLoginStore'
+import { useAccountScheduleStore } from '@/stores/useAccountScheduleStore'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  ScheduleSwitchForm,
+  SchedulePendingSummary
+} from '@/components/accounts/ScheduleSwitchControls'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -35,6 +41,8 @@ function ProviderAccountsCard({ provider }: { provider: UsageProvider }): React.
   )
   const startLogin = useLoginStore((s) => s.startLogin)
   const isLoginActive = useLoginStore((s) => s.activeLogin !== null)
+  const schedule = useAccountScheduleStore((s) => s.schedules[provider])
+  const cancelSchedule = useAccountScheduleStore((s) => s.cancelSchedule)
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null)
 
   const icon = provider === 'anthropic' ? claudeIcon : openaiIcon
@@ -162,6 +170,39 @@ function ProviderAccountsCard({ provider }: { provider: UsageProvider }): React.
                         <Repeat className="h-3.5 w-3.5" />
                       )}
                     </Button>
+                  )}
+                  {!isActive && (
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className={cn(
+                            'h-7 w-7',
+                            schedule?.accountId === account.id
+                              ? 'text-amber-500 hover:text-amber-400'
+                              : 'text-muted-foreground hover:text-foreground'
+                          )}
+                          aria-label={`Schedule switch to ${account.email}`}
+                        >
+                          <Timer className="h-3.5 w-3.5" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent align="end" className="w-64 p-3">
+                        {schedule?.accountId === account.id ? (
+                          <SchedulePendingSummary
+                            schedule={schedule}
+                            onCancel={() => cancelSchedule(provider)}
+                          />
+                        ) : (
+                          <ScheduleSwitchForm
+                            provider={provider}
+                            accountId={account.id}
+                            email={account.email}
+                          />
+                        )}
+                      </PopoverContent>
+                    </Popover>
                   )}
                   {isExpired && (
                     <Button

--- a/src/renderer/src/hooks/useAccountScheduleRunner.ts
+++ b/src/renderer/src/hooks/useAccountScheduleRunner.ts
@@ -1,0 +1,81 @@
+import { useEffect } from 'react'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useUsageStore, resolveUsageProvider } from '@/stores/useUsageStore'
+import { useAccountScheduleStore } from '@/stores/useAccountScheduleStore'
+import type { UsageProvider } from '@shared/types/usage'
+
+const CHECK_INTERVAL_MS = 30_000
+// While a session is actively running, keep usage fresh even when no prompt
+// completes — long runs can burn through a window without ever going idle,
+// and usage-based scheduled switches need current numbers to fire mid-session.
+const SESSION_USAGE_REFRESH_MS = 5 * 60_000
+
+function providersWithRunningSessions(): Set<UsageProvider> {
+  const providers = new Set<UsageProvider>()
+  const { sessionStatuses } = useWorktreeStatusStore.getState()
+  const runningIds = Object.entries(sessionStatuses)
+    .filter(([, entry]) => entry?.status === 'working' || entry?.status === 'planning')
+    .map(([sessionId]) => sessionId)
+  if (runningIds.length === 0) return providers
+
+  const sessionStore = useSessionStore.getState()
+  const allSessions = [
+    ...[...sessionStore.sessionsByWorktree.values()].flat(),
+    ...[...sessionStore.sessionsByConnection.values()].flat()
+  ]
+  for (const id of runningIds) {
+    const session = allSessions.find((s) => s.id === id)
+    if (session) providers.add(resolveUsageProvider(session))
+  }
+  return providers
+}
+
+/**
+ * Drives scheduled account switches (see useAccountScheduleStore) and the
+ * mid-session usage refresh. Mount once at the app root.
+ */
+export function useAccountScheduleRunner(): void {
+  useEffect(() => {
+    const tick = (): void => {
+      const usageStore = useUsageStore.getState()
+      for (const provider of providersWithRunningSessions()) {
+        const lastFetchedAt =
+          provider === 'anthropic'
+            ? usageStore.anthropicLastFetchedAt
+            : usageStore.openaiLastFetchedAt
+        if (!lastFetchedAt || Date.now() - lastFetchedAt >= SESSION_USAGE_REFRESH_MS) {
+          // fetchUsageForProvider is silent on failure and debounce-safe, so a
+          // flaky refresh never toasts every 5 minutes.
+          usageStore.fetchUsageForProvider(provider).catch(() => {})
+        }
+      }
+      useAccountScheduleStore
+        .getState()
+        .checkSchedules()
+        .catch(() => {})
+    }
+
+    tick()
+    const interval = setInterval(tick, CHECK_INTERVAL_MS)
+
+    // Evaluate usage-based schedules the moment fresh usage data lands instead
+    // of waiting for the next tick.
+    const unsubscribe = useUsageStore.subscribe((state, prevState) => {
+      if (
+        state.anthropicUsage !== prevState.anthropicUsage ||
+        state.openaiUsage !== prevState.openaiUsage
+      ) {
+        useAccountScheduleStore
+          .getState()
+          .checkSchedules()
+          .catch(() => {})
+      }
+    })
+
+    return () => {
+      clearInterval(interval)
+      unsubscribe()
+    }
+  }, [])
+}

--- a/src/renderer/src/hooks/useAccountScheduleRunner.ts
+++ b/src/renderer/src/hooks/useAccountScheduleRunner.ts
@@ -37,6 +37,11 @@ function providersWithRunningSessions(): Set<UsageProvider> {
  */
 export function useAccountScheduleRunner(): void {
   useEffect(() => {
+    // Failed fetches don't advance lastFetchedAt, so gate on our own attempt
+    // time too — otherwise a flaky network turns the 5-minute refresh into
+    // polling on every tick.
+    const lastAttemptAt: Partial<Record<UsageProvider, number>> = {}
+
     const tick = (): void => {
       const usageStore = useUsageStore.getState()
       for (const provider of providersWithRunningSessions()) {
@@ -44,7 +49,9 @@ export function useAccountScheduleRunner(): void {
           provider === 'anthropic'
             ? usageStore.anthropicLastFetchedAt
             : usageStore.openaiLastFetchedAt
-        if (!lastFetchedAt || Date.now() - lastFetchedAt >= SESSION_USAGE_REFRESH_MS) {
+        const lastActivity = Math.max(lastFetchedAt ?? 0, lastAttemptAt[provider] ?? 0)
+        if (Date.now() - lastActivity >= SESSION_USAGE_REFRESH_MS) {
+          lastAttemptAt[provider] = Date.now()
           // fetchUsageForProvider is silent on failure and debounce-safe, so a
           // flaky refresh never toasts every 5 minutes.
           usageStore.fetchUsageForProvider(provider).catch(() => {})

--- a/src/renderer/src/hooks/useAccountScheduleRunner.ts
+++ b/src/renderer/src/hooks/useAccountScheduleRunner.ts
@@ -66,12 +66,14 @@ export function useAccountScheduleRunner(): void {
     tick()
     const interval = setInterval(tick, CHECK_INTERVAL_MS)
 
-    // Evaluate usage-based schedules the moment fresh usage data lands instead
-    // of waiting for the next tick.
+    // Evaluate schedules the moment fresh usage data or account-list changes
+    // land (e.g. the target of a pending schedule was removed) instead of
+    // waiting for the next tick.
     const unsubscribe = useUsageStore.subscribe((state, prevState) => {
       if (
         state.anthropicUsage !== prevState.anthropicUsage ||
-        state.openaiUsage !== prevState.openaiUsage
+        state.openaiUsage !== prevState.openaiUsage ||
+        state.savedAccounts !== prevState.savedAccounts
       ) {
         useAccountScheduleStore
           .getState()

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { useAccountScheduleStore, describeSchedule } from '../useAccountScheduleStore'
+import { useUsageStore } from '../useUsageStore'
+import { useAccountStore } from '../useAccountStore'
+import { toast } from '@/lib/toast'
+import type { SavedAccountDTO, UsageData } from '@shared/types/usage'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn()
+  }
+}))
+
+function makeAccount(id: string, email: string): SavedAccountDTO {
+  return {
+    id,
+    provider: 'anthropic',
+    email,
+    last_usage: null,
+    last_fetched_at: null,
+    status: 'ok',
+    last_error: null,
+    created_at: new Date().toISOString(),
+    plan: null
+  }
+}
+
+function makeUsage(fiveHour: number, sevenDay: number, resetsAt?: string): UsageData {
+  const futureReset = resetsAt ?? new Date(Date.now() + 3_600_000).toISOString()
+  return {
+    five_hour: { utilization: fiveHour, resets_at: futureReset },
+    seven_day: { utilization: sevenDay, resets_at: futureReset }
+  }
+}
+
+describe('useAccountScheduleStore', () => {
+  let request: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-16T10:00:00.000Z'))
+    vi.clearAllMocks()
+
+    useAccountScheduleStore.setState({ schedules: {} })
+    useAccountStore.setState({ anthropicEmail: 'current@x.com', openaiEmail: null })
+    useUsageStore.setState({
+      anthropicUsage: null,
+      anthropicLastFetchedAt: null,
+      anthropicIsLoading: false,
+      anthropicLastError: null,
+      anthropicLastRetryAfter: null,
+      openaiUsage: null,
+      openaiIsLoading: false,
+      savedAccounts: {
+        anthropic: [makeAccount('acc-1', 'current@x.com'), makeAccount('acc-2', 'target@x.com')],
+        openai: []
+      },
+      refreshingProviders: { anthropic: false, openai: false },
+      switchingAccountIds: new Set<string>()
+    })
+
+    request = vi.fn(async (method: string) => {
+      if (method === 'accountOps.switchAccount') return { success: true }
+      if (method === 'accountOps.listSaved') return []
+      if (method === 'accountOps.getClaudeEmail') return 'target@x.com'
+      if (method === 'accountOps.getOpenAIEmail') return null
+      if (method === 'usageOps.fetch') return { success: true, data: undefined }
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+    vi.useRealTimers()
+  })
+
+  const switchCalls = (): unknown[][] =>
+    request.mock.calls.filter(([method]) => method === 'accountOps.switchAccount')
+
+  it('does not fire a time schedule before it is due, fires it after', async () => {
+    useAccountScheduleStore
+      .getState()
+      .scheduleByTime('anthropic', 'acc-2', 'target@x.com', 30 * 60_000)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+    expect(switchCalls()).toHaveLength(0)
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeDefined()
+
+    vi.setSystemTime(Date.now() + 31 * 60_000)
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(1)
+    expect(switchCalls()[0][1]).toEqual({ accountId: 'acc-2' })
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
+  })
+
+  it('fires a usage schedule only once the active usage crosses the threshold', async () => {
+    useAccountScheduleStore.getState().scheduleByUsage('anthropic', 'acc-2', 'target@x.com', 80)
+
+    useUsageStore.setState({ anthropicUsage: makeUsage(60, 20) })
+    await useAccountScheduleStore.getState().checkSchedules()
+    expect(switchCalls()).toHaveLength(0)
+
+    useUsageStore.setState({ anthropicUsage: makeUsage(85, 20) })
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(1)
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
+  })
+
+  it('uses the max across usage windows (7d bar can trigger too)', async () => {
+    useAccountScheduleStore.getState().scheduleByUsage('anthropic', 'acc-2', 'target@x.com', 80)
+
+    useUsageStore.setState({ anthropicUsage: makeUsage(10, 91) })
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(1)
+  })
+
+  it('ignores stale usage whose reset time is in the past', async () => {
+    useAccountScheduleStore.getState().scheduleByUsage('anthropic', 'acc-2', 'target@x.com', 80)
+
+    const pastReset = new Date(Date.now() - 3_600_000).toISOString()
+    useUsageStore.setState({ anthropicUsage: makeUsage(95, 95, pastReset) })
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(0)
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeDefined()
+  })
+
+  it('drops the schedule without switching when the target account is already active', async () => {
+    useAccountScheduleStore.getState().scheduleByTime('anthropic', 'acc-2', 'target@x.com', 1_000)
+    useAccountStore.setState({ anthropicEmail: 'target@x.com' })
+
+    vi.setSystemTime(Date.now() + 2_000)
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(0)
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
+  })
+
+  it('cancels with an error toast when the target account no longer exists', async () => {
+    useAccountScheduleStore.getState().scheduleByTime('anthropic', 'gone-id', 'gone@x.com', 1_000)
+
+    vi.setSystemTime(Date.now() + 2_000)
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(0)
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('gone@x.com'))
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
+  })
+
+  it('replaces an existing schedule for the provider and supports cancel', () => {
+    const store = useAccountScheduleStore.getState()
+    store.scheduleByTime('anthropic', 'acc-2', 'target@x.com', 60_000)
+    store.scheduleByUsage('anthropic', 'acc-1', 'current@x.com', 70)
+
+    const schedule = useAccountScheduleStore.getState().schedules.anthropic
+    expect(schedule?.mode).toBe('usage')
+    expect(schedule?.accountId).toBe('acc-1')
+    expect(schedule?.thresholdPercent).toBe(70)
+
+    useAccountScheduleStore.getState().cancelSchedule('anthropic')
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
+  })
+
+  it('describeSchedule renders time countdowns and usage thresholds', () => {
+    const now = Date.now()
+    expect(
+      describeSchedule(
+        {
+          provider: 'anthropic',
+          accountId: 'a',
+          email: null,
+          mode: 'time',
+          executeAt: now + 90 * 60_000,
+          thresholdPercent: null,
+          createdAt: now
+        },
+        now
+      )
+    ).toBe('in 1h 30m')
+    expect(
+      describeSchedule(
+        {
+          provider: 'anthropic',
+          accountId: 'a',
+          email: null,
+          mode: 'usage',
+          executeAt: null,
+          thresholdPercent: 85,
+          createdAt: now
+        },
+        now
+      )
+    ).toBe('at 85% usage')
+  })
+})

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
@@ -284,6 +284,36 @@ describe('useAccountScheduleStore', () => {
     expect(remaining?.accountId).toBe('acc-1')
   })
 
+  it('does not switch when the schedule is canceled during an in-flight account reload', async () => {
+    // Target not in the seeded savedAccounts, forcing the reload path.
+    useAccountScheduleStore
+      .getState()
+      .scheduleByTime('anthropic', 'acc-new', 'new@x.com', 1_000)
+
+    const pendingList: { resolve?: (value: SavedAccountDTO[]) => void } = {}
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.listSaved')
+        return new Promise((resolve) => {
+          pendingList.resolve = resolve
+        })
+      if (method === 'accountOps.switchAccount') return { success: true }
+      return null
+    })
+
+    vi.setSystemTime(Date.now() + 2_000)
+    const checking = useAccountScheduleStore.getState().checkSchedules()
+    while (!pendingList.resolve) await Promise.resolve()
+
+    // User cancels while the reload IPC is still in flight.
+    useAccountScheduleStore.getState().cancelSchedule('anthropic')
+
+    pendingList.resolve([makeAccount('acc-new', 'new@x.com')])
+    await checking
+
+    expect(switchCalls()).toHaveLength(0)
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
+  })
+
   it('replaces an existing schedule for the provider and supports cancel', () => {
     const store = useAccountScheduleStore.getState()
     store.scheduleByTime('anthropic', 'acc-2', 'target@x.com', 60_000)

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
-import { useAccountScheduleStore, describeSchedule } from '../useAccountScheduleStore'
+import {
+  useAccountScheduleStore,
+  describeSchedule,
+  resetExecutingProvidersForTests
+} from '../useAccountScheduleStore'
 import { useUsageStore } from '../useUsageStore'
 import { useAccountStore } from '../useAccountStore'
 import { toast } from '@/lib/toast'
@@ -59,6 +63,7 @@ describe('useAccountScheduleStore', () => {
     vi.clearAllMocks()
 
     useAccountScheduleStore.setState({ schedules: {} })
+    resetExecutingProvidersForTests()
     useAccountStore.setState({ anthropicEmail: 'current@x.com', openaiEmail: null })
     useUsageStore.setState({
       anthropicUsage: null,
@@ -194,6 +199,56 @@ describe('useAccountScheduleStore', () => {
     expect(switchCalls()).toHaveLength(0)
     expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('gone@x.com'))
     expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
+  })
+
+  it('keeps the schedule and backs off when the switch attempt fails', async () => {
+    useAccountScheduleStore.getState().scheduleByTime('anthropic', 'acc-2', 'target@x.com', 1_000)
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.switchAccount') return { success: false, error: 'network down' }
+      if (method === 'accountOps.listSaved') return []
+      return null
+    })
+
+    vi.setSystemTime(Date.now() + 2_000)
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(1)
+    const kept = useAccountScheduleStore.getState().schedules.anthropic
+    expect(kept).toBeDefined()
+    expect(kept?.notBefore).toBe(Date.now() + 5 * 60_000)
+
+    // Still backing off — no second attempt yet.
+    await useAccountScheduleStore.getState().checkSchedules()
+    expect(switchCalls()).toHaveLength(1)
+
+    // After the retry delay it fires again; this time the switch succeeds.
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.switchAccount') return { success: true }
+      if (method === 'accountOps.listSaved') return []
+      if (method === 'accountOps.getClaudeEmail') return 'target@x.com'
+      if (method === 'usageOps.fetch') return { success: true, data: undefined }
+      return null
+    })
+    vi.setSystemTime(Date.now() + 5 * 60_000 + 1_000)
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(2)
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
+  })
+
+  it('keeps the schedule when the saved-accounts reload fails', async () => {
+    useAccountScheduleStore.getState().scheduleByTime('anthropic', 'gone-id', 'gone@x.com', 1_000)
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.listSaved') throw new Error('rpc down')
+      return null
+    })
+
+    vi.setSystemTime(Date.now() + 2_000)
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(0)
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeDefined()
   })
 
   it('replaces an existing schedule for the provider and supports cancel', () => {

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
@@ -28,11 +28,25 @@ function makeAccount(id: string, email: string): SavedAccountDTO {
   }
 }
 
-function makeUsage(fiveHour: number, sevenDay: number, resetsAt?: string): UsageData {
+function makeUsage(
+  fiveHour: number,
+  sevenDay: number,
+  resetsAt?: string,
+  scoped?: { label: string; used_percent: number; resets_at?: string | null }[]
+): UsageData {
   const futureReset = resetsAt ?? new Date(Date.now() + 3_600_000).toISOString()
   return {
     five_hour: { utilization: fiveHour, resets_at: futureReset },
-    seven_day: { utilization: sevenDay, resets_at: futureReset }
+    seven_day: { utilization: sevenDay, resets_at: futureReset },
+    ...(scoped
+      ? {
+          scoped: scoped.map((s) => ({
+            label: s.label,
+            used_percent: s.used_percent,
+            resets_at: s.resets_at === undefined ? futureReset : s.resets_at
+          }))
+        }
+      : {})
   }
 }
 
@@ -119,6 +133,34 @@ describe('useAccountScheduleStore', () => {
     await useAccountScheduleStore.getState().checkSchedules()
 
     expect(switchCalls()).toHaveLength(1)
+  })
+
+  it('includes scoped bars (e.g. Fable) when finding the highest usage', async () => {
+    useAccountScheduleStore.getState().scheduleByUsage('anthropic', 'acc-2', 'target@x.com', 80)
+
+    // 5h and 7d are below the threshold; only the scoped model bar is above.
+    useUsageStore.setState({
+      anthropicUsage: makeUsage(50, 60, undefined, [{ label: 'Fable', used_percent: 85 }])
+    })
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(1)
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
+  })
+
+  it('ignores a stale scoped bar whose reset time is in the past', async () => {
+    useAccountScheduleStore.getState().scheduleByUsage('anthropic', 'acc-2', 'target@x.com', 80)
+
+    const pastReset = new Date(Date.now() - 3_600_000).toISOString()
+    useUsageStore.setState({
+      anthropicUsage: makeUsage(50, 60, undefined, [
+        { label: 'Fable', used_percent: 95, resets_at: pastReset }
+      ])
+    })
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(0)
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeDefined()
   })
 
   it('ignores stale usage whose reset time is in the past', async () => {

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
@@ -190,7 +190,10 @@ describe('useAccountScheduleStore', () => {
     expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
   })
 
-  it('cancels with an error toast when the target account no longer exists', async () => {
+  it('cancels with an error toast when the target account no longer exists at due time', async () => {
+    // Empty list = "maybe not loaded yet", so the pre-due prune stays out of
+    // the way and the due-time reload path decides.
+    useUsageStore.setState({ savedAccounts: { anthropic: [], openai: [] } })
     useAccountScheduleStore.getState().scheduleByTime('anthropic', 'gone-id', 'gone@x.com', 1_000)
 
     vi.setSystemTime(Date.now() + 2_000)
@@ -198,6 +201,22 @@ describe('useAccountScheduleStore', () => {
 
     expect(switchCalls()).toHaveLength(0)
     expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('gone@x.com'))
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
+  })
+
+  it('cancels a pending (not yet due) schedule once its target vanishes from the loaded accounts', async () => {
+    useAccountScheduleStore
+      .getState()
+      .scheduleByTime('anthropic', 'acc-2', 'target@x.com', 60 * 60_000)
+
+    // Still due in an hour, but the target gets removed from the account list.
+    useUsageStore.setState({
+      savedAccounts: { anthropic: [makeAccount('acc-1', 'current@x.com')], openai: [] }
+    })
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(0)
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('target@x.com'))
     expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
   })
 
@@ -237,6 +256,7 @@ describe('useAccountScheduleStore', () => {
   })
 
   it('keeps the schedule when the saved-accounts reload fails', async () => {
+    useUsageStore.setState({ savedAccounts: { anthropic: [], openai: [] } })
     useAccountScheduleStore.getState().scheduleByTime('anthropic', 'gone-id', 'gone@x.com', 1_000)
     request.mockImplementation(async (method: string) => {
       if (method === 'accountOps.listSaved') throw new Error('rpc down')
@@ -285,7 +305,8 @@ describe('useAccountScheduleStore', () => {
   })
 
   it('does not switch when the schedule is canceled during an in-flight account reload', async () => {
-    // Target not in the seeded savedAccounts, forcing the reload path.
+    // Empty list forces the due-time reload path (pre-due prune skips it).
+    useUsageStore.setState({ savedAccounts: { anthropic: [], openai: [] } })
     useAccountScheduleStore
       .getState()
       .scheduleByTime('anthropic', 'acc-new', 'new@x.com', 1_000)

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
@@ -251,6 +251,39 @@ describe('useAccountScheduleStore', () => {
     expect(useAccountScheduleStore.getState().schedules.anthropic).toBeDefined()
   })
 
+  it('does not drop a replacement schedule created during an in-flight switch', async () => {
+    useAccountScheduleStore.getState().scheduleByTime('anthropic', 'acc-2', 'target@x.com', 1_000)
+
+    const pendingSwitch: { resolve?: (value: { success: boolean }) => void } = {}
+    request.mockImplementation(async (method: string) => {
+      if (method === 'accountOps.switchAccount')
+        return new Promise((resolve) => {
+          pendingSwitch.resolve = resolve
+        })
+      if (method === 'accountOps.listSaved') return []
+      if (method === 'accountOps.getClaudeEmail') return 'other@x.com'
+      if (method === 'usageOps.fetch') return { success: true, data: undefined }
+      return null
+    })
+
+    vi.setSystemTime(Date.now() + 2_000)
+    const checking = useAccountScheduleStore.getState().checkSchedules()
+    // Flush microtasks until the switch RPC is actually in flight.
+    while (!pendingSwitch.resolve) await Promise.resolve()
+    expect(switchCalls()).toHaveLength(1)
+
+    // User replaces the schedule while the switch is still awaiting.
+    useAccountScheduleStore.getState().scheduleByUsage('anthropic', 'acc-1', 'current@x.com', 70)
+
+    pendingSwitch.resolve({ success: true })
+    await checking
+
+    const remaining = useAccountScheduleStore.getState().schedules.anthropic
+    expect(remaining).toBeDefined()
+    expect(remaining?.mode).toBe('usage')
+    expect(remaining?.accountId).toBe('acc-1')
+  })
+
   it('replaces an existing schedule for the provider and supports cancel', () => {
     const store = useAccountScheduleStore.getState()
     store.scheduleByTime('anthropic', 'acc-2', 'target@x.com', 60_000)

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.test.ts
@@ -77,6 +77,7 @@ describe('useAccountScheduleStore', () => {
         anthropic: [makeAccount('acc-1', 'current@x.com'), makeAccount('acc-2', 'target@x.com')],
         openai: []
       },
+      savedAccountsLoaded: { anthropic: true, openai: false },
       refreshingProviders: { anthropic: false, openai: false },
       switchingAccountIds: new Set<string>()
     })
@@ -191,9 +192,12 @@ describe('useAccountScheduleStore', () => {
   })
 
   it('cancels with an error toast when the target account no longer exists at due time', async () => {
-    // Empty list = "maybe not loaded yet", so the pre-due prune stays out of
-    // the way and the due-time reload path decides.
-    useUsageStore.setState({ savedAccounts: { anthropic: [], openai: [] } })
+    // Not loaded yet, so the pre-due prune stays out of the way and the
+    // due-time reload path decides.
+    useUsageStore.setState({
+      savedAccounts: { anthropic: [], openai: [] },
+      savedAccountsLoaded: { anthropic: false, openai: false }
+    })
     useAccountScheduleStore.getState().scheduleByTime('anthropic', 'gone-id', 'gone@x.com', 1_000)
 
     vi.setSystemTime(Date.now() + 2_000)
@@ -212,6 +216,21 @@ describe('useAccountScheduleStore', () => {
     // Still due in an hour, but the target gets removed from the account list.
     useUsageStore.setState({
       savedAccounts: { anthropic: [makeAccount('acc-1', 'current@x.com')], openai: [] }
+    })
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(0)
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('target@x.com'))
+    expect(useAccountScheduleStore.getState().schedules.anthropic).toBeUndefined()
+  })
+
+  it('cancels a pending usage schedule when the LAST saved account is removed (loaded empty list)', async () => {
+    useAccountScheduleStore.getState().scheduleByUsage('anthropic', 'acc-2', 'target@x.com', 99)
+
+    // Removing the final account leaves a successfully loaded, empty list.
+    useUsageStore.setState({
+      savedAccounts: { anthropic: [], openai: [] },
+      savedAccountsLoaded: { anthropic: true, openai: false }
     })
     await useAccountScheduleStore.getState().checkSchedules()
 
@@ -256,7 +275,10 @@ describe('useAccountScheduleStore', () => {
   })
 
   it('keeps the schedule when the saved-accounts reload fails', async () => {
-    useUsageStore.setState({ savedAccounts: { anthropic: [], openai: [] } })
+    useUsageStore.setState({
+      savedAccounts: { anthropic: [], openai: [] },
+      savedAccountsLoaded: { anthropic: false, openai: false }
+    })
     useAccountScheduleStore.getState().scheduleByTime('anthropic', 'gone-id', 'gone@x.com', 1_000)
     request.mockImplementation(async (method: string) => {
       if (method === 'accountOps.listSaved') throw new Error('rpc down')
@@ -305,8 +327,11 @@ describe('useAccountScheduleStore', () => {
   })
 
   it('does not switch when the schedule is canceled during an in-flight account reload', async () => {
-    // Empty list forces the due-time reload path (pre-due prune skips it).
-    useUsageStore.setState({ savedAccounts: { anthropic: [], openai: [] } })
+    // Not-yet-loaded state forces the due-time reload path (pre-due prune skips it).
+    useUsageStore.setState({
+      savedAccounts: { anthropic: [], openai: [] },
+      savedAccountsLoaded: { anthropic: false, openai: false }
+    })
     useAccountScheduleStore
       .getState()
       .scheduleByTime('anthropic', 'acc-new', 'new@x.com', 1_000)

--- a/src/renderer/src/stores/index.ts
+++ b/src/renderer/src/stores/index.ts
@@ -61,6 +61,13 @@ export {
   normalizeUsage
 } from './useUsageStore'
 export { useAccountStore } from './useAccountStore'
+export {
+  useAccountScheduleStore,
+  describeSchedule,
+  getActiveUsagePercent,
+  type ScheduledSwitch,
+  type ScheduleMode
+} from './useAccountScheduleStore'
 export { useLoginStore, type ActiveLogin, type LoginState } from './useLoginStore'
 export { useHintStore } from './useHintStore'
 export { useVimModeStore } from './useVimModeStore'

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -186,10 +186,17 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
               continue
             }
 
-            // switchAccount toasts success/failure itself.
+            // switchAccount toasts success/failure itself. Both outcome paths
+            // guard on createdAt: the user may have replaced the schedule
+            // while the switch was in flight, and the replacement must survive.
             const switched = await useUsageStore.getState().switchAccount(schedule.accountId)
             if (switched) {
-              get().cancelSchedule(provider)
+              set((state) => {
+                const current = state.schedules[provider]
+                if (!current || current.createdAt !== schedule.createdAt) return state
+                const { [provider]: _, ...rest } = state.schedules
+                return { schedules: rest }
+              })
             } else {
               // Keep the schedule but back off so a persistent failure doesn't
               // retry (and toast) on every tick.

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -148,6 +148,24 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
             continue
           }
 
+          // Target removed while still pending (e.g. via the remove-account
+          // UI): cancel right away rather than at due time — a usage schedule
+          // that never fires would otherwise linger with no row to cancel it
+          // from. An empty list is ambiguous (may simply not be loaded yet),
+          // so only a non-empty list is treated as authoritative here; the
+          // empty case is resolved by the reload below once the schedule is due.
+          const knownAccounts = useUsageStore.getState().savedAccounts[provider]
+          if (
+            knownAccounts.length > 0 &&
+            !knownAccounts.some((a) => a.id === schedule.accountId)
+          ) {
+            get().cancelSchedule(provider)
+            toast.error(
+              `Scheduled switch canceled: ${schedule.email ?? 'account'} is no longer saved`
+            )
+            continue
+          }
+
           let due = false
           if (schedule.mode === 'time') {
             due = schedule.executeAt !== null && Date.now() >= schedule.executeAt

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -176,6 +176,11 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
                 continue
               }
               accounts = useUsageStore.getState().savedAccounts[provider]
+
+              // The reload awaited an IPC round-trip — the user may have
+              // canceled or replaced the schedule in the meantime.
+              const latest = get().schedules[provider]
+              if (!latest || latest.createdAt !== schedule.createdAt) continue
             }
 
             if (!accounts.some((a) => a.id === schedule.accountId)) {

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -151,12 +151,13 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
           // Target removed while still pending (e.g. via the remove-account
           // UI): cancel right away rather than at due time — a usage schedule
           // that never fires would otherwise linger with no row to cancel it
-          // from. An empty list is ambiguous (may simply not be loaded yet),
-          // so only a non-empty list is treated as authoritative here; the
-          // empty case is resolved by the reload below once the schedule is due.
-          const knownAccounts = useUsageStore.getState().savedAccounts[provider]
+          // from. Only a successfully loaded list is authoritative (even when
+          // empty, e.g. the last account was removed); before the first load
+          // the check is deferred to the due-time reload below.
+          const usageState = useUsageStore.getState()
+          const knownAccounts = usageState.savedAccounts[provider]
           if (
-            knownAccounts.length > 0 &&
+            usageState.savedAccountsLoaded[provider] &&
             !knownAccounts.some((a) => a.id === schedule.accountId)
           ) {
             get().cancelSchedule(provider)

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -17,6 +17,8 @@ export interface ScheduledSwitch {
   /** Utilization percent (0-100) at or above which a 'usage' schedule fires */
   thresholdPercent: number | null
   createdAt: number
+  /** Set after a failed switch attempt — don't retry before this time */
+  notBefore?: number
 }
 
 interface AccountScheduleState {
@@ -73,9 +75,18 @@ function activeEmailFor(provider: UsageProvider): string | null {
   return provider === 'anthropic' ? state.anthropicEmail : state.openaiEmail
 }
 
+// A due schedule whose switch attempt failed is retried, but not more often
+// than this — a persistently failing switch shouldn't toast every tick.
+const RETRY_DELAY_MS = 5 * 60_000
+
 // Re-entrancy guard: checkSchedules can be triggered by both the interval
 // tick and usage-store updates while a switch is still in flight.
 const executingProviders = new Set<UsageProvider>()
+
+/** Test hook: the guard lives outside the store, so setState can't reset it. */
+export function resetExecutingProvidersForTests(): void {
+  executingProviders.clear()
+}
 
 export const useAccountScheduleStore = create<AccountScheduleState>()(
   persist(
@@ -127,6 +138,7 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
         for (const provider of PROVIDERS) {
           const schedule = get().schedules[provider]
           if (!schedule || executingProviders.has(provider)) continue
+          if (schedule.notBefore !== undefined && Date.now() < schedule.notBefore) continue
 
           // Already on the target account (e.g. the user switched manually) —
           // the schedule is moot, drop it silently.
@@ -148,22 +160,26 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
           }
           if (!due) continue
 
+          // Re-entrancy during the awaits below is blocked by executingProviders,
+          // so the schedule can stay in place until the switch outcome is known —
+          // a transient failure must not silently drop the user's schedule.
           executingProviders.add(provider)
           try {
             // Make sure the target account still exists before switching.
             let accounts = useUsageStore.getState().savedAccounts[provider]
             if (!accounts.some((a) => a.id === schedule.accountId)) {
-              await useUsageStore
-                .getState()
-                .loadSavedAccounts(provider)
-                .catch(() => {})
+              try {
+                await useUsageStore.getState().loadSavedAccounts(provider)
+              } catch {
+                // Can't tell whether the account is gone — keep the schedule
+                // and let a later check retry.
+                continue
+              }
               accounts = useUsageStore.getState().savedAccounts[provider]
             }
 
-            // Clear before switching so a re-entrant check can't double-fire.
-            get().cancelSchedule(provider)
-
             if (!accounts.some((a) => a.id === schedule.accountId)) {
+              get().cancelSchedule(provider)
               toast.error(
                 `Scheduled switch canceled: ${schedule.email ?? 'account'} is no longer saved`
               )
@@ -171,7 +187,23 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
             }
 
             // switchAccount toasts success/failure itself.
-            await useUsageStore.getState().switchAccount(schedule.accountId)
+            const switched = await useUsageStore.getState().switchAccount(schedule.accountId)
+            if (switched) {
+              get().cancelSchedule(provider)
+            } else {
+              // Keep the schedule but back off so a persistent failure doesn't
+              // retry (and toast) on every tick.
+              set((state) => {
+                const current = state.schedules[provider]
+                if (!current || current.createdAt !== schedule.createdAt) return state
+                return {
+                  schedules: {
+                    ...state.schedules,
+                    [provider]: { ...current, notBefore: Date.now() + RETRY_DELAY_MS }
+                  }
+                }
+              })
+            }
           } finally {
             executingProviders.delete(provider)
           }

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -1,0 +1,198 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import type { UsageProvider } from '@shared/types/usage'
+import { toast } from '@/lib/toast'
+import { useUsageStore, normalizeUsage } from './useUsageStore'
+import { useAccountStore } from './useAccountStore'
+
+export type ScheduleMode = 'time' | 'usage'
+
+export interface ScheduledSwitch {
+  provider: UsageProvider
+  accountId: string
+  email: string | null
+  mode: ScheduleMode
+  /** Epoch ms at which a 'time' schedule fires */
+  executeAt: number | null
+  /** Utilization percent (0-100) at or above which a 'usage' schedule fires */
+  thresholdPercent: number | null
+  createdAt: number
+}
+
+interface AccountScheduleState {
+  schedules: Partial<Record<UsageProvider, ScheduledSwitch>>
+
+  scheduleByTime: (
+    provider: UsageProvider,
+    accountId: string,
+    email: string | null,
+    delayMs: number
+  ) => void
+  scheduleByUsage: (
+    provider: UsageProvider,
+    accountId: string,
+    email: string | null,
+    thresholdPercent: number
+  ) => void
+  cancelSchedule: (provider: UsageProvider) => void
+  checkSchedules: () => Promise<void>
+}
+
+const PROVIDERS: UsageProvider[] = ['anthropic', 'openai']
+
+// A reset time in the past means the cached utilization predates the window's
+// reset and no longer reflects reality (mirrors UsageIndicator's staleness
+// rule). null is NOT stale: it means "no active window".
+function isResetInPast(resetsAt: string | null | undefined): boolean {
+  if (!resetsAt) return false
+  const time = new Date(resetsAt).getTime()
+  return !isNaN(time) && time < Date.now()
+}
+
+/**
+ * Highest current utilization across the active account's usage windows for
+ * the provider — the number a 'usage' schedule is compared against. Returns
+ * null when no fresh usage data is available.
+ */
+export function getActiveUsagePercent(provider: UsageProvider): number | null {
+  const state = useUsageStore.getState()
+  const usage = normalizeUsage(provider, state.anthropicUsage, state.openaiUsage)
+  if (!usage) return null
+  const windows = [usage.five_hour, usage.seven_day].filter(
+    (w) => w && !isResetInPast(w.resets_at)
+  )
+  if (windows.length === 0) return null
+  return Math.max(...windows.map((w) => w.utilization))
+}
+
+function activeEmailFor(provider: UsageProvider): string | null {
+  const state = useAccountStore.getState()
+  return provider === 'anthropic' ? state.anthropicEmail : state.openaiEmail
+}
+
+// Re-entrancy guard: checkSchedules can be triggered by both the interval
+// tick and usage-store updates while a switch is still in flight.
+const executingProviders = new Set<UsageProvider>()
+
+export const useAccountScheduleStore = create<AccountScheduleState>()(
+  persist(
+    (set, get) => ({
+      schedules: {},
+
+      scheduleByTime: (provider, accountId, email, delayMs) => {
+        set((state) => ({
+          schedules: {
+            ...state.schedules,
+            [provider]: {
+              provider,
+              accountId,
+              email,
+              mode: 'time' as const,
+              executeAt: Date.now() + delayMs,
+              thresholdPercent: null,
+              createdAt: Date.now()
+            }
+          }
+        }))
+      },
+
+      scheduleByUsage: (provider, accountId, email, thresholdPercent) => {
+        set((state) => ({
+          schedules: {
+            ...state.schedules,
+            [provider]: {
+              provider,
+              accountId,
+              email,
+              mode: 'usage' as const,
+              executeAt: null,
+              thresholdPercent: Math.min(100, Math.max(1, Math.round(thresholdPercent))),
+              createdAt: Date.now()
+            }
+          }
+        }))
+      },
+
+      cancelSchedule: (provider) => {
+        set((state) => {
+          const { [provider]: _, ...rest } = state.schedules
+          return { schedules: rest }
+        })
+      },
+
+      checkSchedules: async () => {
+        for (const provider of PROVIDERS) {
+          const schedule = get().schedules[provider]
+          if (!schedule || executingProviders.has(provider)) continue
+
+          // Already on the target account (e.g. the user switched manually) —
+          // the schedule is moot, drop it silently.
+          const activeEmail = activeEmailFor(provider)
+          if (schedule.email !== null && activeEmail !== null && schedule.email === activeEmail) {
+            get().cancelSchedule(provider)
+            continue
+          }
+
+          let due = false
+          if (schedule.mode === 'time') {
+            due = schedule.executeAt !== null && Date.now() >= schedule.executeAt
+          } else {
+            const percent = getActiveUsagePercent(provider)
+            due =
+              percent !== null &&
+              schedule.thresholdPercent !== null &&
+              percent >= schedule.thresholdPercent
+          }
+          if (!due) continue
+
+          executingProviders.add(provider)
+          try {
+            // Make sure the target account still exists before switching.
+            let accounts = useUsageStore.getState().savedAccounts[provider]
+            if (!accounts.some((a) => a.id === schedule.accountId)) {
+              await useUsageStore
+                .getState()
+                .loadSavedAccounts(provider)
+                .catch(() => {})
+              accounts = useUsageStore.getState().savedAccounts[provider]
+            }
+
+            // Clear before switching so a re-entrant check can't double-fire.
+            get().cancelSchedule(provider)
+
+            if (!accounts.some((a) => a.id === schedule.accountId)) {
+              toast.error(
+                `Scheduled switch canceled: ${schedule.email ?? 'account'} is no longer saved`
+              )
+              continue
+            }
+
+            // switchAccount toasts success/failure itself.
+            await useUsageStore.getState().switchAccount(schedule.accountId)
+          } finally {
+            executingProviders.delete(provider)
+          }
+        }
+      }
+    }),
+    {
+      name: 'hive-account-switch-schedules',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ schedules: state.schedules })
+    }
+  )
+)
+
+/** Human-readable description of a pending schedule, e.g. "in 42m" / "at 80% usage". */
+export function describeSchedule(schedule: ScheduledSwitch, nowMs: number): string {
+  if (schedule.mode === 'usage') {
+    return `at ${schedule.thresholdPercent}% usage`
+  }
+  const remainingMs = Math.max(0, (schedule.executeAt ?? nowMs) - nowMs)
+  const totalMinutes = Math.ceil(remainingMs / 60_000)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  if (hours > 0) return `in ${hours}h ${String(minutes).padStart(2, '0')}m`
+  if (totalMinutes > 0) return `in ${totalMinutes}m`
+  return 'in <1m'
+}

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -50,17 +50,20 @@ function isResetInPast(resetsAt: string | null | undefined): boolean {
 }
 
 /**
- * Highest current utilization across the active account's usage windows for
- * the provider — the number a 'usage' schedule is compared against. Returns
- * null when no fresh usage data is available.
+ * Highest current utilization across ALL of the active account's usage bars
+ * for the provider — 5h, 7d, and any scoped windows (Fable, etc.) — the
+ * number a 'usage' schedule is compared against. Returns null when no fresh
+ * usage data is available.
  */
 export function getActiveUsagePercent(provider: UsageProvider): number | null {
   const state = useUsageStore.getState()
   const usage = normalizeUsage(provider, state.anthropicUsage, state.openaiUsage)
   if (!usage) return null
-  const windows = [usage.five_hour, usage.seven_day].filter(
-    (w) => w && !isResetInPast(w.resets_at)
-  )
+  const windows = [
+    usage.five_hour,
+    usage.seven_day,
+    ...(usage.scoped ?? []).map((s) => ({ utilization: s.used_percent, resets_at: s.resets_at }))
+  ].filter((w) => w && !isResetInPast(w.resets_at))
   if (windows.length === 0) return null
   return Math.max(...windows.map((w) => w.utilization))
 }

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -42,7 +42,8 @@ interface UsageState {
   refreshAllForProvider: (provider: UsageProvider) => Promise<void>
   refreshSavedAccount: (id: string, opts?: { userInitiated?: boolean }) => Promise<void>
   removeSavedAccount: (id: string) => Promise<void>
-  switchAccount: (id: string) => Promise<void>
+  /** Resolves true when the switch op succeeded (failures also toast). */
+  switchAccount: (id: string) => Promise<boolean>
   fetchUsageForProvider: (provider: UsageProvider) => Promise<void>
   forceRefreshProvider: (provider: UsageProvider) => Promise<void>
   setActiveProvider: (provider: UsageProvider) => void
@@ -245,6 +246,7 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
             .forceRefreshProvider(provider)
             .catch(() => {})
         }
+        return true
       } else {
         toast.error(`Switch failed: ${result.error ?? 'Unknown error'}`)
       }
@@ -257,6 +259,7 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
         return { switchingAccountIds: nextIds }
       })
     }
+    return false
   },
 
   fetchUsageForProvider: async (provider: UsageProvider) => {

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -32,6 +32,9 @@ interface UsageState {
 
   activeProvider: UsageProvider
   savedAccounts: Record<UsageProvider, SavedAccountDTO[]>
+  /** True once savedAccounts[provider] reflects a successful load — an empty
+   * list is only meaningful (e.g. "the account really is gone") when set. */
+  savedAccountsLoaded: Record<UsageProvider, boolean>
   savedAccountLoadErrors: Record<UsageProvider, string | null>
   refreshingProviders: Record<UsageProvider, boolean>
   refreshingAccountIds: Set<string>
@@ -80,6 +83,7 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
 
   activeProvider: 'anthropic',
   savedAccounts: { anthropic: [], openai: [] },
+  savedAccountsLoaded: { anthropic: false, openai: false },
   savedAccountLoadErrors: { anthropic: null, openai: null },
   refreshingProviders: { anthropic: false, openai: false },
   refreshingAccountIds: new Set<string>(),
@@ -92,6 +96,7 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
       if (provider) {
         set((state) => ({
           savedAccounts: { ...state.savedAccounts, [provider]: accounts },
+          savedAccountsLoaded: { ...state.savedAccountsLoaded, [provider]: true },
           savedAccountLoadErrors: { ...state.savedAccountLoadErrors, [provider]: null }
         }))
         return
@@ -102,6 +107,7 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
           anthropic: accounts.filter((account) => account.provider === 'anthropic'),
           openai: accounts.filter((account) => account.provider === 'openai')
         },
+        savedAccountsLoaded: { anthropic: true, openai: true },
         savedAccountLoadErrors: { anthropic: null, openai: null }
       })
     } catch (error) {


### PR DESCRIPTION
## Summary
- Adds a persisted account schedule store that can switch providers by delay or by usage threshold.
- Introduces UI controls in usage popovers and Settings Accounts to create, view, and cancel pending switches.
- Runs scheduled switches from the app layout and refreshes usage periodically during active sessions so usage-based triggers can fire mid-session.
- Expands usage threshold logic to consider scoped usage bars, with tests covering time-based, usage-based, stale-data, and cancel/replace behavior.

## Testing
- `Not run`
- Added unit coverage for schedule firing, stale reset handling, scoped usage bars, and schedule replacement/cancel behavior.
- Updated the Settings Accounts test to match the refined switch button labels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automated account switches run in the background and call existing switch RPC; logic is well-tested but wrong timing or usage reads could switch accounts unexpectedly during active work.
> 
> **Overview**
> Adds **scheduled auto-switching** between saved Claude/OpenAI accounts: one pending schedule per provider, persisted in localStorage, either after a delay or when the **active** account’s usage (max across 5h, 7d, and scoped bars, ignoring stale resets) crosses a threshold.
> 
> A new **`useAccountScheduleStore`** drives execution via **`useAccountScheduleRunner`** at app root (30s ticks plus immediate checks on usage/account-list updates). While sessions are working/planning, usage is refreshed about every 5 minutes so usage-based schedules can fire mid-session. Failed switches retry with a 5-minute backoff; removed targets, cancel/replace during async work, and already-active targets are handled explicitly.
> 
> **UI:** `ScheduleSwitchForm` / `SchedulePendingSummary` in the usage popover account rows and Settings Accounts (timer popover); amber pending indicator on the usage bar. **`switchAccount`** now returns **`Promise<boolean>`**; **`savedAccountsLoaded`** tracks whether an empty saved list is authoritative for canceling stale schedules.
> 
> Broad unit tests cover time/usage firing, scoped bars, staleness, cancel/replace, and failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f28e49895bea5bf816fda947c3da93925154adca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->