### PR TITLE
Fix Cancel button in sign-in banner

### DIFF
--- a/src/renderer/src/components/layout/LoginBanner.test.tsx
+++ b/src/renderer/src/components/layout/LoginBanner.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { useLoginStore } from '@/stores/useLoginStore'
+import { LoginBanner } from './LoginBanner'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn()
+  }
+}))
+
+describe('LoginBanner', () => {
+  beforeEach(() => {
+    useLoginStore.setState({
+      activeLogin: {
+        loginId: 'login-1',
+        provider: 'anthropic',
+        email: null,
+        state: 'waiting',
+        error: null
+      }
+    })
+    const request: ReturnType<typeof vi.fn> = vi.fn(async () => null)
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetRendererRpcClientForTests()
+    useLoginStore.setState({ activeLogin: null })
+  })
+
+  it('opts the banner out of the header drag region so Cancel is clickable', () => {
+    render(<LoginBanner />)
+
+    // The banner floats over the title-bar drag region; without no-drag,
+    // Electron swallows clicks before they reach the Cancel button.
+    const pill = screen.getByRole('button', { name: 'Cancel' }).parentElement as HTMLElement
+    expect(
+      (pill.style as CSSStyleDeclaration & { WebkitAppRegion?: string }).WebkitAppRegion
+    ).toBe('no-drag')
+  })
+
+  it('clears the active login when Cancel is clicked', () => {
+    render(<LoginBanner />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(useLoginStore.getState().activeLogin).toBeNull()
+  })
+})

--- a/src/renderer/src/components/layout/LoginBanner.tsx
+++ b/src/renderer/src/components/layout/LoginBanner.tsx
@@ -20,7 +20,10 @@ export function LoginBanner(): React.JSX.Element | null {
       className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-2"
       data-testid="login-banner"
     >
-      <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-border bg-background/95 px-3 py-1.5 text-xs shadow-lg backdrop-blur">
+      <div
+        className="pointer-events-auto flex items-center gap-2 rounded-full border border-border bg-background/95 px-3 py-1.5 text-xs shadow-lg backdrop-blur"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      >
         <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
         <span className="text-foreground">
           Signing in to {providerName} — complete the sign-in in Chrome…


### PR DESCRIPTION
## Summary
- Mark the login banner as `no-drag` so Electron does not intercept clicks on the Cancel button.
- Add regression coverage confirming the banner is excluded from the title-bar drag region.
- Add a behavior test that clicking Cancel clears the active login state.

## Testing
- `vitest src/renderer/src/components/layout/LoginBanner.test.tsx`
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small renderer styling fix and unit tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes **Cancel** on the floating sign-in banner being unclickable because the pill sat over the header’s Electron **drag** region.
> 
> The inner banner pill now sets **`WebkitAppRegion: 'no-drag'`**, matching other header overlays (e.g. Kanban dependency bar, header controls). New **`LoginBanner`** tests assert that style and that **Cancel** clears **`activeLogin`** in the login store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d00cc747c51ecded8bd6153f5b31711cc56d0c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->