### PR TITLE
Lower toast z-index below popup menus

### DIFF
--- a/src/renderer/src/components/ui/sonner.tsx
+++ b/src/renderer/src/components/ui/sonner.tsx
@@ -6,6 +6,9 @@ function Toaster({ ...props }: ToasterProps) {
       position="bottom-left"
       theme="dark"
       className="toaster group"
+      // Below the z-50 popup layer (context/dropdown menus, dialogs) so toasts
+      // never intercept clicks on menu items that overlap them
+      style={{ zIndex: 40 }}
       toastOptions={{
         classNames: {
           toast:


### PR DESCRIPTION
## Summary
- Lower the Sonner toaster z-index so toasts render beneath the app's popup layer.
- Prevent toasts from intercepting clicks on overlapping context menu and dropdown items.
- Keep dialog and menu interactions clickable even when a toast is present.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single styling change on the toast wrapper with no auth, data, or business-logic impact; only stacking order vs. existing popups.
> 
> **Overview**
> Sets an explicit **`zIndex: 40`** on the shared Sonner `Toaster` so notifications stack **below** the app’s **`z-50`** popup layer (context menus, dropdowns, dialogs).
> 
> This fixes cases where a bottom-left toast could sit on top of overlapping menu items and **steal pointer events**, making those items hard or impossible to click.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca3b50f0915265556f0092a69ac344604f3ac63b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->