### PR TITLE
Add declared-model support for custom providers

### DIFF
--- a/src/main/services/__tests__/claude-cli-spawner.test.ts
+++ b/src/main/services/__tests__/claude-cli-spawner.test.ts
@@ -315,6 +315,136 @@ describe('buildClaudeCliPtySpawn', () => {
       expect(spawn.args).not.toContain('--effort')
     })
 
+    it('passes a provider-declared model slug and effort verbatim', () => {
+      process.env.SHELL = '/bin/zsh'
+      const spawn = buildClaudeCliPtySpawn({
+        session: makeSession({
+          custom_provider_id: 'prov-1',
+          model_provider_id: 'custom',
+          model_id: 'glm-4.6',
+          model_variant: 'high'
+        }),
+        worktreePath: '/repo/worktree',
+        pendingPrompt: 'Do the thing',
+        claudeBinary: 'claude',
+        customProviderCommand: 'claudex',
+        customProviderModels: [
+          { id: 'm1', name: 'GLM 4.6', slug: 'glm-4.6', efforts: ['low', 'high'] }
+        ]
+      })
+
+      // Positional params ride after the command's own flags, so the picked
+      // model wins over an alias-baked --model (last-flag-wins).
+      expect(spawn.args.slice(0, 3)).toEqual(['-ilc', 'claudex "$@"', 'claudex'])
+      const modelIndex = spawn.args.indexOf('--model')
+      expect(spawn.args[modelIndex + 1]).toBe('glm-4.6')
+      const effortIndex = spawn.args.indexOf('--effort')
+      expect(spawn.args[effortIndex + 1]).toBe('high')
+      expect(spawn.args[spawn.args.length - 1]).toBe('Do the thing')
+    })
+
+    it('omits --effort when the session variant is not declared for the model', () => {
+      const spawn = buildClaudeCliPtySpawn({
+        session: makeSession({
+          custom_provider_id: 'prov-1',
+          model_provider_id: 'custom',
+          model_id: 'glm-4.6',
+          model_variant: 'max'
+        }),
+        worktreePath: '/repo/worktree',
+        pendingPrompt: null,
+        claudeBinary: 'claude',
+        customProviderCommand: 'claudex',
+        customProviderModels: [{ id: 'm1', name: 'GLM 4.6', slug: 'glm-4.6', efforts: ['low'] }]
+      })
+
+      expect(spawn.args).toContain('--model')
+      expect(spawn.args).not.toContain('--effort')
+    })
+
+    it('keeps suppressing --model when the session model matches no declared slug', () => {
+      // Stale stock-claude values (pre-feature sessions) must never reach the
+      // provider's command.
+      const spawn = buildClaudeCliPtySpawn({
+        session: makeSession({
+          custom_provider_id: 'prov-1',
+          model_id: 'sonnet',
+          model_variant: 'high'
+        }),
+        worktreePath: '/repo/worktree',
+        pendingPrompt: null,
+        claudeBinary: 'claude',
+        customProviderCommand: 'claudex',
+        customProviderModels: [
+          { id: 'm1', name: 'GLM 4.6', slug: 'glm-4.6', efforts: ['low', 'high'] }
+        ]
+      })
+
+      expect(spawn.args).not.toContain('--model')
+      expect(spawn.args).not.toContain('--effort')
+    })
+
+    it('suppresses --model/--effort when a custom-model session degrades to plain claude', () => {
+      // Provider deleted → bridge passes no customProviderCommand, but the row
+      // still carries the proxy slug. Substring normalization would turn
+      // 'kimi-sonnet' into --model sonnet on stock claude — must stay out.
+      const spawn = buildClaudeCliPtySpawn({
+        session: makeSession({
+          custom_provider_id: 'prov-deleted',
+          model_provider_id: 'custom',
+          model_id: 'kimi-sonnet',
+          model_variant: 'high'
+        }),
+        worktreePath: '/repo/worktree',
+        pendingPrompt: null,
+        claudeBinary: '/usr/local/bin/claude'
+      })
+
+      expect(spawn.command).toBe('/usr/local/bin/claude')
+      expect(spawn.args).not.toContain('--model')
+      expect(spawn.args).not.toContain('--effort')
+    })
+
+    it('ignores declared models whose slug is blank', () => {
+      const spawn = buildClaudeCliPtySpawn({
+        session: makeSession({ model_id: '', model_variant: 'high' }),
+        worktreePath: '/repo/worktree',
+        pendingPrompt: null,
+        claudeBinary: 'claude',
+        customProviderCommand: 'claudex',
+        customProviderModels: [{ id: 'm1', name: 'Unfinished row', slug: '  ', efforts: ['high'] }]
+      })
+
+      expect(spawn.args).not.toContain('--model')
+      expect(spawn.args).not.toContain('--effort')
+    })
+
+    it('still suppresses the ultracode settings merge for declared provider models', () => {
+      const hookSettingsJson = '{"hooks":{"Stop":[{"id":1}]}}'
+      const spawn = buildClaudeCliPtySpawn({
+        session: makeSession({
+          custom_provider_id: 'prov-1',
+          model_provider_id: 'custom',
+          model_id: 'glm-4.6',
+          model_variant: 'ultracode'
+        }),
+        worktreePath: '/repo/worktree',
+        pendingPrompt: null,
+        claudeBinary: 'claude',
+        hookSettingsJson,
+        customProviderCommand: 'claudex',
+        customProviderModels: [
+          { id: 'm1', name: 'GLM 4.6', slug: 'glm-4.6', efforts: ['low', 'high'] }
+        ]
+      })
+
+      const settingsIndex = spawn.args.indexOf('--settings')
+      expect(spawn.args[settingsIndex + 1]).toBe(hookSettingsJson)
+      expect(spawn.args).not.toContain('--effort')
+      // The declared model itself still rides along.
+      expect(spawn.args).toContain('--model')
+    })
+
     it('keeps plan-mode permission flags for custom provider spawns', () => {
       process.env.SHELL = '/bin/zsh'
       const spawn = buildClaudeCliPtySpawn({

--- a/src/main/services/__tests__/claude-cli-spawner.test.ts
+++ b/src/main/services/__tests__/claude-cli-spawner.test.ts
@@ -362,6 +362,28 @@ describe('buildClaudeCliPtySpawn', () => {
       expect(spawn.args).not.toContain('--effort')
     })
 
+    it('requires the custom marker — a legacy stock stamp never matches a declared slug', () => {
+      // Legacy custom-provider sessions carry stock stamps (anthropic/sonnet).
+      // A provider later declaring a slug named like a stock alias must not
+      // start overriding the alias-baked model on their respawn.
+      const spawn = buildClaudeCliPtySpawn({
+        session: makeSession({
+          custom_provider_id: 'prov-1',
+          model_provider_id: 'anthropic',
+          model_id: 'sonnet',
+          model_variant: 'high'
+        }),
+        worktreePath: '/repo/worktree',
+        pendingPrompt: null,
+        claudeBinary: 'claude',
+        customProviderCommand: 'claudex',
+        customProviderModels: [{ id: 'm1', name: 'Sonnet proxy', slug: 'sonnet', efforts: ['high'] }]
+      })
+
+      expect(spawn.args).not.toContain('--model')
+      expect(spawn.args).not.toContain('--effort')
+    })
+
     it('keeps suppressing --model when the session model matches no declared slug', () => {
       // Stale stock-claude values (pre-feature sessions) must never reach the
       // provider's command.

--- a/src/main/services/claude-cli-spawner.ts
+++ b/src/main/services/claude-cli-spawner.ts
@@ -111,9 +111,14 @@ export function buildClaudeCliPtySpawn(input: ClaudeCliPtySpawnInput): ClaudeCli
   // explicitly picked it, so pass it verbatim (last-flag-wins is now desired).
   // Stale stock-claude values in model_id (pre-feature sessions) never match a
   // declared slug and stay suppressed.
-  const customModel = customCommand
-    ? matchCustomProviderModel(input.customProviderModels, input.session.model_id)
-    : null
+  // The slug match additionally requires the 'custom' marker: legacy sessions
+  // carry stock stamps (model_provider_id 'anthropic', model_id 'sonnet'), and
+  // a provider later declaring a slug named like a stock alias must not start
+  // overriding the alias-baked model on their respawn.
+  const customModel =
+    customCommand && input.session.model_provider_id === CUSTOM_MODEL_PROVIDER_ID
+      ? matchCustomProviderModel(input.customProviderModels, input.session.model_id)
+      : null
   // A custom-provider session whose provider was deleted/blanked degrades to
   // plain claude with its proxy slug still in model_id — never let that slug
   // reach normalizeClaudeCliModel, whose substring matching could turn e.g.

--- a/src/main/services/claude-cli-spawner.ts
+++ b/src/main/services/claude-cli-spawner.ts
@@ -1,11 +1,17 @@
 import type { Session } from '../db/types'
+import {
+  CUSTOM_MODEL_PROVIDER_ID,
+  matchCustomProviderModel,
+  resolveCustomProviderEffort,
+  type CustomProviderModel
+} from '@shared/types/custom-provider'
 import { getUserEnvironmentVariables } from './env-vars'
 import type { DatabaseService } from '../db/database'
 
 export interface ClaudeCliPtySpawnInput {
   session: Pick<
     Session,
-    'mode' | 'model_id' | 'model_variant' | 'claude_session_id'
+    'mode' | 'model_provider_id' | 'model_id' | 'model_variant' | 'claude_session_id'
   >
   worktreePath: string
   pendingPrompt?: string | null
@@ -17,9 +23,17 @@ export interface ClaudeCliPtySpawnInput {
    * A custom provider's launch command (may be a shell alias or a full command
    * line with env prefixes). When set, the spawn runs through the user's
    * interactive login shell so aliases resolve, and Hive's --model/--effort
-   * flags are suppressed — the command itself decides the model.
+   * flags are suppressed — the command itself decides the model — unless the
+   * session's model matches one the provider declares (customProviderModels).
    */
   customProviderCommand?: string | null
+  /**
+   * The custom provider's declared models. When the session's `model_id`
+   * matches a declared slug, that slug is passed verbatim as `--model` (and the
+   * declared effort as `--effort`) after the command, overriding alias-baked
+   * flags via claude's last-flag-wins semantics.
+   */
+  customProviderModels?: CustomProviderModel[] | null
 }
 
 export interface ClaudeCliPtySpawn {
@@ -92,17 +106,41 @@ export function buildClaudeCliPtySpawn(input: ClaudeCliPtySpawnInput): ClaudeCli
 
   // Custom providers own their model selection (often baked into the command
   // as an alias flag) — a Hive-side --model/--effort appended after the alias's
-  // own flags would win and silently override it.
-  const model = customCommand ? null : normalizeClaudeCliModel(input.session.model_id)
+  // own flags would win and silently override it. Exception: when the provider
+  // declares models and this session carries one of their slugs, the user
+  // explicitly picked it, so pass it verbatim (last-flag-wins is now desired).
+  // Stale stock-claude values in model_id (pre-feature sessions) never match a
+  // declared slug and stay suppressed.
+  const customModel = customCommand
+    ? matchCustomProviderModel(input.customProviderModels, input.session.model_id)
+    : null
+  // A custom-provider session whose provider was deleted/blanked degrades to
+  // plain claude with its proxy slug still in model_id — never let that slug
+  // reach normalizeClaudeCliModel, whose substring matching could turn e.g.
+  // 'kimi-sonnet' into a real --model sonnet on stock claude.
+  const orphanedCustomModel =
+    !customCommand && input.session.model_provider_id === CUSTOM_MODEL_PROVIDER_ID
+  const model = customCommand
+    ? (customModel?.slug.trim() ?? null)
+    : orphanedCustomModel
+      ? null
+      : normalizeClaudeCliModel(input.session.model_id)
   if (model) {
     args.push('--model', model)
   }
 
   // Ultracode is Hive-injected claude settings — suppress it for custom
-  // providers along with --model/--effort; the model picker is hidden for
-  // them, so a remembered ultracode variant would ride along invisibly.
-  const ultracode = customCommand ? false : isUltracodeEffort(input.session.model_variant)
-  const effort = customCommand ? null : normalizeClaudeCliEffort(input.session.model_variant)
+  // providers along with --model/--effort; it is never offered for provider
+  // models, so a remembered ultracode variant would ride along invisibly.
+  const ultracode =
+    customCommand || orphanedCustomModel ? false : isUltracodeEffort(input.session.model_variant)
+  const effort = customCommand
+    ? customModel
+      ? normalizeClaudeCliEffort(resolveCustomProviderEffort(customModel, input.session.model_variant))
+      : null
+    : orphanedCustomModel
+      ? null
+      : normalizeClaudeCliEffort(input.session.model_variant)
   if (effort) {
     args.push('--effort', effort)
   }

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -20,6 +20,7 @@ import { setClaudeCliPlanAutoApprove } from './claude-cli-plan-auto-approve'
 import { logClaudeBinaryVersion, resolveClaudeBinaryPath } from './claude-binary-resolver'
 import { buildClaudeCliPtySpawn } from './claude-cli-spawner'
 import { getCustomProviderById } from './custom-providers'
+import type { CustomProviderModel } from '@shared/types/custom-provider'
 import { externalizeGoalHandoffPlan } from './claude-cli-plan-handoff'
 import { reassertClaudeCliPromptSubmit, writeClaudeCliPrompt } from './claude-cli-pty-prompt'
 import { watchForClaudeSessionId, type ClaudeSessionWatchHandle } from './claude-session-watcher'
@@ -277,6 +278,7 @@ export async function createClaudeCliTerminal(
     // paths) rather than permanently bricking the session's resumable
     // transcript behind a hard error.
     let customProviderCommand: string | null = null
+    let customProviderModels: CustomProviderModel[] | null = null
     if (session.custom_provider_id) {
       // The wrapper spawns through a POSIX login shell ($SHELL -ilc) — Windows
       // GUI apps have no SHELL and no /bin/zsh, so fail with a clear message
@@ -290,6 +292,7 @@ export async function createClaudeCliTerminal(
       const provider = getCustomProviderById(db, session.custom_provider_id)
       if (provider?.command.trim()) {
         customProviderCommand = provider.command
+        customProviderModels = provider.models ?? null
       } else {
         log.warn('Custom provider missing or blank; falling back to plain claude', {
           sessionId,
@@ -318,7 +321,8 @@ export async function createClaudeCliTerminal(
       claudeBinary,
       hookSettingsJson,
       db,
-      customProviderCommand
+      customProviderCommand,
+      customProviderModels
     })
 
     log.info('Creating Claude CLI PTY', {

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -37,6 +37,7 @@ import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
 import { useRemoteLaunchStore } from '@/stores/useRemoteLaunchStore'
 import { ModelSelector } from '@/components/sessions/ModelSelector'
+import { CustomProviderModelSelector } from '@/components/sessions/CustomProviderModelSelector'
 import { CodexFastToggle } from '@/components/sessions/CodexFastToggle'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
@@ -69,7 +70,8 @@ import {
   type LaunchModelConfig
 } from '@/lib/ticket-launch'
 import type { AvailableAgentSdks } from '@/lib/agent-sdk-availability'
-import type { CustomClaudeProvider } from '@shared/types/custom-provider'
+import { findCustomProvider, type CustomClaudeProvider } from '@shared/types/custom-provider'
+import { resolveCustomProviderSelectedModel } from '@/lib/handoffSelection'
 
 // Stable empty array to avoid referential-inequality loops in Zustand selectors
 const EMPTY_ARRAY: readonly never[] = []
@@ -560,6 +562,17 @@ export function WorktreePickerModal({
     !runOnRemote && !isConnectionMode && agentSdk === 'claude-code-cli'
       ? selectedCustomProviderId
       : null
+
+  // Row 1's custom-provider selection: the picked model validated against the
+  // provider's declared models (stale/foreign picks degrade to the provider
+  // default), null when the provider declares none — then no model rides the
+  // launch and the provider's command keeps owning it.
+  const selectedCustomProvider = effectiveCustomProviderId
+    ? findCustomProvider(customProviders, effectiveCustomProviderId)
+    : undefined
+  const customProviderModel = selectedCustomProvider
+    ? resolveCustomProviderSelectedModel(selectedCustomProvider, selectedModel)
+    : null
 
   // ── Remote section visibility + preflight ─────────────────────────
   const remoteSectionVisible =
@@ -1278,16 +1291,26 @@ export function WorktreePickerModal({
       const entries: LaunchModelConfig[] = [
         {
           sdk: agentSdk,
-          model: selectedModel ?? autoResolvedModel ?? null,
+          model: effectiveCustomProviderId
+            ? customProviderModel
+            : (selectedModel ?? autoResolvedModel ?? null),
           codexFastMode,
           customProviderId: effectiveCustomProviderId
         },
-        ...extraModelRows.map((r) => ({
-          sdk: r.sdk,
-          model: r.model ?? resolveRowDefaultModel(r.sdk, mode),
-          codexFastMode: r.codexFastMode,
-          customProviderId: r.sdk === 'claude-code-cli' ? r.customProviderId : null
-        }))
+        ...extraModelRows.map((r) => {
+          const rowProvider =
+            r.sdk === 'claude-code-cli'
+              ? findCustomProvider(customProviders, r.customProviderId)
+              : undefined
+          return {
+            sdk: r.sdk,
+            model: rowProvider
+              ? resolveCustomProviderSelectedModel(rowProvider, r.model)
+              : (r.model ?? resolveRowDefaultModel(r.sdk, mode)),
+            codexFastMode: r.codexFastMode,
+            customProviderId: r.sdk === 'claude-code-cli' ? r.customProviderId : null
+          }
+        })
       ]
 
       // ── Save config only path: serialize config, don't create session ─
@@ -1298,7 +1321,7 @@ export function WorktreePickerModal({
             : { type: 'existing' as const, worktreeId: worktreeId! },
           prompt: promptText.trim() || buildPrompt(mode, ticket),
           mode,
-          model: selectedModel ?? null,
+          model: effectiveCustomProviderId ? customProviderModel : (selectedModel ?? null),
           sdk: agentSdk,
           codexFastMode,
           goalMode,
@@ -1461,7 +1484,9 @@ export function WorktreePickerModal({
       )
 
       // Create session in the selected worktree
-      const effectiveModel = selectedModel ?? autoResolvedModel ?? undefined
+      const effectiveModel = effectiveCustomProviderId
+        ? (customProviderModel ?? undefined)
+        : (selectedModel ?? autoResolvedModel ?? undefined)
       const modelOverride = effectiveModel ? { ...effectiveModel, agentSdk } : undefined
       const cliPendingPrompt =
         agentSdk === 'claude-code-cli'
@@ -1503,9 +1528,13 @@ export function WorktreePickerModal({
         .getState()
         .setSessionStatus(sessionId, isPlanLike(mode) ? 'planning' : 'working')
 
-      // Apply user's model override to the session if they explicitly picked one
+      // Apply user's model override to the session if they explicitly picked
+      // one (custom-provider picks apply as their validated selection)
       if (selectedModel) {
-        await useSessionStore.getState().setSessionModel(sessionId, selectedModel)
+        const explicitModel = effectiveCustomProviderId ? customProviderModel : selectedModel
+        if (explicitModel) {
+          await useSessionStore.getState().setSessionModel(sessionId, explicitModel)
+        }
       }
 
       // Update the ticket with session info and move to in_progress
@@ -1518,7 +1547,7 @@ export function WorktreePickerModal({
       // resolves independently and can differ), then the picked/auto model,
       // then the per-SDK resolution + hard fallback (never null).
       const badgeModel =
-        resolveCustomProviderBadge(effectiveCustomProviderId) ??
+        resolveCustomProviderBadge(effectiveCustomProviderId, effectiveModel) ??
         resolveBadgeModel(
           { sdk: agentSdk, model: effectiveModel ?? null, codexFastMode },
           sessionResult.session
@@ -2110,8 +2139,19 @@ export function WorktreePickerModal({
                 </div>
               )}
               <div className="flex items-center gap-2 flex-wrap">
-                {/* Custom providers own their model (baked into the command) — no model picker */}
-                {!effectiveCustomProviderId && (
+                {/* Custom providers: picker over their declared models; without
+                    any, the command owns the model (no picker, as before) */}
+                {effectiveCustomProviderId ? (
+                  selectedCustomProvider && (
+                    <div className="min-w-0">
+                      <CustomProviderModelSelector
+                        provider={selectedCustomProvider}
+                        value={selectedModel}
+                        onChange={setSelectedModel}
+                      />
+                    </div>
+                  )
+                ) : (
                   <div className="min-w-0">
                     <ModelSelector
                       value={selectedModel ?? autoResolvedModel}
@@ -2159,7 +2199,24 @@ export function WorktreePickerModal({
                           idPrefix={`extra-model-row-${rowIndex}-sdk`}
                         />
                         <div className="flex items-center gap-2 flex-wrap">
-                          {!(row.sdk === 'claude-code-cli' && row.customProviderId) && (
+                          {row.sdk === 'claude-code-cli' && row.customProviderId ? (
+                            (() => {
+                              const rowProvider = findCustomProvider(
+                                customProviders,
+                                row.customProviderId
+                              )
+                              return rowProvider ? (
+                                <div className="min-w-0">
+                                  <CustomProviderModelSelector
+                                    provider={rowProvider}
+                                    value={row.model}
+                                    onChange={(model) => updateRowModel(row.key, model)}
+                                    testIdPrefix={`extra-model-row-${rowIndex}-custom-model`}
+                                  />
+                                </div>
+                              ) : null
+                            })()
+                          ) : (
                             <div className="min-w-0">
                               <ModelSelector
                                 value={rowModelValue}

--- a/src/renderer/src/components/sessions/CustomProviderModelSelector.tsx
+++ b/src/renderer/src/components/sessions/CustomProviderModelSelector.tsx
@@ -1,0 +1,126 @@
+import { Check, ChevronDown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  CUSTOM_MODEL_PROVIDER_ID,
+  getCustomProviderModelDisplayName,
+  getLaunchableCustomProviderModels,
+  resolveCustomProviderModelSelection,
+  type CustomClaudeProvider
+} from '@shared/types/custom-provider'
+import type { SelectedModel } from '@/stores/useSettingsStore'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+
+interface CustomProviderModelSelectorProps {
+  provider: CustomClaudeProvider
+  /** Candidate selection; invalid/absent values display the provider default. */
+  value: SelectedModel | null
+  onChange: (model: SelectedModel) => void
+  testIdPrefix?: string
+}
+
+/**
+ * Model + effort picker for a custom provider's declared models — the
+ * stock ModelSelector is SDK-catalog based and would offer ultracode, so
+ * custom providers get this dedicated pill. Renders nothing when the provider
+ * declares no launchable models (the command owns the model then).
+ */
+export function CustomProviderModelSelector({
+  provider,
+  value,
+  onChange,
+  testIdPrefix = 'custom-provider-model-selector'
+}: CustomProviderModelSelectorProps): React.JSX.Element | null {
+  const models = getLaunchableCustomProviderModels(provider.models)
+  const selection = resolveCustomProviderModelSelection(provider, value?.modelID, value?.variant)
+  if (!selection) return null
+
+  const { model: currentModel, effort: currentEffort } = selection
+
+  const selectModel = (slug: string, variant?: string | null): void => {
+    const next = resolveCustomProviderModelSelection(provider, slug, variant)
+    if (!next) return
+    onChange({
+      providerID: CUSTOM_MODEL_PROVIDER_ID,
+      modelID: next.model.slug.trim(),
+      variant: next.effort ?? undefined
+    })
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={cn(
+            'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
+            'border select-none',
+            'bg-muted/50 border-border text-muted-foreground hover:bg-muted hover:text-foreground'
+          )}
+          title="Select model"
+          aria-label={`Current model: ${getCustomProviderModelDisplayName(currentModel)}. Click to change model`}
+          data-testid={testIdPrefix}
+        >
+          <span className="truncate max-w-[140px]">
+            {getCustomProviderModelDisplayName(currentModel)}
+          </span>
+          {currentEffort && (
+            <span className="text-[10px] font-semibold uppercase text-primary">
+              {currentEffort}
+            </span>
+          )}
+          <ChevronDown className="h-3 w-3 shrink-0 opacity-50" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-72 max-h-80 overflow-y-auto">
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          {provider.name || 'Custom Provider'}
+        </DropdownMenuLabel>
+        {models.map((model) => {
+          const active = model.slug.trim() === currentModel.slug.trim()
+          return (
+            <div key={model.id}>
+              <DropdownMenuItem
+                onClick={() => selectModel(model.slug)}
+                className="flex items-center justify-between gap-2 cursor-pointer"
+                data-testid={`${testIdPrefix}-model-${model.slug.trim()}`}
+              >
+                <span className="truncate text-sm">{getCustomProviderModelDisplayName(model)}</span>
+                {active && <Check className="h-4 w-4 shrink-0 text-primary" />}
+              </DropdownMenuItem>
+              {model.efforts.length > 0 && (
+                <div className="flex flex-wrap gap-1 pl-6 pb-1">
+                  {model.efforts.map((effort) => {
+                    const activeEffort = active && currentEffort === effort
+                    return (
+                      <button
+                        key={effort}
+                        className={cn(
+                          'text-[10px] px-1.5 py-0.5 rounded',
+                          activeEffort
+                            ? 'bg-primary text-primary-foreground'
+                            : 'bg-muted text-muted-foreground hover:bg-accent'
+                        )}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          selectModel(model.slug, effort)
+                        }}
+                        data-testid={`${testIdPrefix}-effort-${model.slug.trim()}-${effort}`}
+                      >
+                        {effort.toUpperCase()}
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/renderer/src/components/sessions/HandoffModelPicker.tsx
+++ b/src/renderer/src/components/sessions/HandoffModelPicker.tsx
@@ -10,12 +10,14 @@ import {
   type HandoffSelectionOverride
 } from '@/lib/handoffSelection'
 import {
+  buildCustomProviderCatalog,
   findModelInfo,
   getFirstModelInfo,
   getModelDisplayName,
   getModelVariantKeys,
   type ProviderModels
 } from '@/lib/parseProviders'
+import { findCustomProvider } from '@shared/types/custom-provider'
 import { cn } from '@/lib/utils'
 import { isWindows } from '@/lib/platform'
 import { Button } from '@/components/ui/button'
@@ -136,7 +138,9 @@ export function HandoffModelPicker({
     setPickedCustomProviderId(effective.customProviderId ?? null)
     setPickedModel(effective.model)
 
-    if (effective.customProviderId) return // custom providers have no model catalog
+    // Custom providers have no SDK model catalog to load — their declared
+    // models (already resolved into effective.model) come from settings.
+    if (effective.customProviderId) return
 
     void ensureProviders(effective.agentSdk).then((providers) => {
       if (!active) return
@@ -148,9 +152,19 @@ export function HandoffModelPicker({
     }
   }, [open, worktreeId, ensureProviders, resolveModelForCatalog])
 
+  // The picked custom provider's declared models, synthesized into the same
+  // catalog shape the SDK dropdown/chips consume. Empty when the provider
+  // declares none — then the command owns the model (legacy pill below).
+  const customProviderCatalog = useMemo(() => {
+    if (!pickedCustomProviderId) return null
+    const provider = findCustomProvider(customProviders, pickedCustomProviderId)
+    return provider ? buildCustomProviderCatalog(provider) : []
+  }, [pickedCustomProviderId, customProviders])
+
   const currentProviders = useMemo(
-    () => providersBySdk[pickedSdk] ?? getCachedModelCatalog(pickedSdk) ?? [],
-    [pickedSdk, providersBySdk]
+    () =>
+      customProviderCatalog ?? providersBySdk[pickedSdk] ?? getCachedModelCatalog(pickedSdk) ?? [],
+    [customProviderCatalog, pickedSdk, providersBySdk]
   )
   const currentModelInfo = pickedModel
     ? findModelInfo(currentProviders, pickedModel.providerID, pickedModel.modelID)
@@ -184,13 +198,19 @@ export function HandoffModelPicker({
     (customProviderId: string) => {
       setPickedSdk('claude-code-cli')
       setPickedCustomProviderId(customProviderId)
-      // The provider's command decides the real model — persist the cli default
-      // only to satisfy the override's model shape.
-      const model = resolveModelForSdkDefault('claude-code-cli')
+      const provider = findCustomProvider(customProviders, customProviderId)
+      const catalog = provider ? buildCustomProviderCatalog(provider) : []
+      const firstDeclared = getFirstModelInfo(catalog)
+      // Providers with declared models default to the first one (honoring a
+      // remembered effort); without any, the command decides the real model —
+      // persist the cli default only to satisfy the override's model shape.
+      const model = firstDeclared
+        ? buildModelFromInfo(firstDeclared)
+        : resolveModelForSdkDefault('claude-code-cli')
       setPickedModel(model)
       persistOverride('claude-code-cli', model, customProviderId)
     },
-    [persistOverride]
+    [customProviders, persistOverride]
   )
 
   const handleSelectModel = useCallback(
@@ -198,9 +218,9 @@ export function HandoffModelPicker({
       const info = findModelInfo(currentProviders, model.providerID, model.modelID)
       const nextModel = info ? buildModelFromInfo(info, model.variant) : model
       setPickedModel(nextModel)
-      persistOverride(pickedSdk, nextModel)
+      persistOverride(pickedSdk, nextModel, pickedCustomProviderId)
     },
-    [currentProviders, persistOverride, pickedSdk]
+    [currentProviders, persistOverride, pickedSdk, pickedCustomProviderId]
   )
 
   const handleConfirm = useCallback(() => {
@@ -285,7 +305,7 @@ export function HandoffModelPicker({
               </DropdownMenuContent>
             </DropdownMenu>
 
-            {pickedCustomProviderId ? (
+            {pickedCustomProviderId && currentProviders.length === 0 ? (
               <div
                 className="flex h-8 items-center rounded-full border border-border bg-muted/30 px-3 text-xs text-muted-foreground"
                 title="The provider's command decides the model"
@@ -342,7 +362,7 @@ export function HandoffModelPicker({
             )}
           </div>
 
-          {variantKeys.length > 0 && pickedModel && !pickedCustomProviderId && (
+          {variantKeys.length > 0 && pickedModel && (
             <div className="flex flex-wrap gap-1.5">
               {variantKeys.map((variant) => {
                 const active = pickedModel.variant === variant
@@ -353,7 +373,7 @@ export function HandoffModelPicker({
                     onClick={() => {
                       const nextModel = { ...pickedModel, variant }
                       setPickedModel(nextModel)
-                      persistOverride(pickedSdk, nextModel)
+                      persistOverride(pickedSdk, nextModel, pickedCustomProviderId)
                     }}
                     className={cn(
                       'rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide transition-colors',

--- a/src/renderer/src/components/sessions/HandoffSplitButton.tsx
+++ b/src/renderer/src/components/sessions/HandoffSplitButton.tsx
@@ -136,7 +136,12 @@ export function HandoffSplitButton({
     return { ...override, goalMode: finalGoalMode }
   }
 
-  const labelTitle = effective.customProviderId
+  // A custom provider without declared models shows only its name (the command
+  // decides the model — modelName mirrors sdkName then); with a declared model
+  // picked it reads like any SDK: "Provider / Model EFFORT".
+  const customNameOnly =
+    !!effective.customProviderId && effective.display.modelName === effective.display.sdkName
+  const labelTitle = customNameOnly
     ? `Handoff · ${effective.display.sdkName}`
     : `Handoff · ${effective.display.sdkName} / ${effective.display.modelName}${
         effective.display.variant ? ` ${effective.display.variant.toUpperCase()}` : ''
@@ -189,7 +194,7 @@ export function HandoffSplitButton({
           {vimModeEnabled ? <MnemonicLabel letter="a" label="Handoff" /> : 'Handoff'}
         </span>
         <span className="text-muted-foreground">·</span>
-        {effective.customProviderId ? (
+        {customNameOnly ? (
           <span className="max-w-[180px] truncate">{effective.display.sdkName}</span>
         ) : (
           <>

--- a/src/renderer/src/components/settings/SettingsCustomProviders.test.tsx
+++ b/src/renderer/src/components/settings/SettingsCustomProviders.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import type { CustomClaudeProvider } from '@shared/types/custom-provider'
+import { SettingsCustomProviders } from './SettingsCustomProviders'
+
+const initialSettingsState = useSettingsStore.getState()
+
+function seedProvider(overrides: Partial<CustomClaudeProvider> = {}): CustomClaudeProvider {
+  const provider: CustomClaudeProvider = {
+    id: 'prov-1',
+    name: 'Proxy',
+    command: 'claudex',
+    usageProvider: 'none',
+    models: [],
+    ...overrides
+  }
+  useSettingsStore.setState({ customProviders: [provider] })
+  return provider
+}
+
+function currentModels(): NonNullable<CustomClaudeProvider['models']> {
+  return useSettingsStore.getState().customProviders?.[0]?.models ?? []
+}
+
+describe('SettingsCustomProviders models editor', () => {
+  beforeEach(() => {
+    useSettingsStore.setState(initialSettingsState, true)
+  })
+
+  it('adds a model row with empty name/slug and no efforts', async () => {
+    const user = userEvent.setup()
+    seedProvider()
+    render(<SettingsCustomProviders />)
+
+    await user.click(screen.getByTestId('custom-provider-model-add'))
+
+    const models = currentModels()
+    expect(models).toHaveLength(1)
+    expect(models[0]).toMatchObject({ name: '', slug: '', efforts: [] })
+    expect(models[0].id).toBeTruthy()
+  })
+
+  it('persists typed name and slug into the settings store', async () => {
+    const user = userEvent.setup()
+    seedProvider({ models: [{ id: 'm1', name: '', slug: '', efforts: [] }] })
+    render(<SettingsCustomProviders />)
+
+    await user.type(screen.getByTestId('custom-provider-model-name'), 'GLM 4.6')
+    await user.type(screen.getByTestId('custom-provider-model-slug'), 'glm-4.6')
+
+    expect(currentModels()[0]).toMatchObject({ name: 'GLM 4.6', slug: 'glm-4.6' })
+  })
+
+  it('toggles effort chips and stores them in canonical order', async () => {
+    const user = userEvent.setup()
+    seedProvider({ models: [{ id: 'm1', name: 'GLM', slug: 'glm-4.6', efforts: [] }] })
+    render(<SettingsCustomProviders />)
+
+    await user.click(screen.getByTestId('custom-provider-model-effort-high'))
+    await user.click(screen.getByTestId('custom-provider-model-effort-low'))
+    expect(currentModels()[0].efforts).toEqual(['low', 'high'])
+
+    await user.click(screen.getByTestId('custom-provider-model-effort-high'))
+    expect(currentModels()[0].efforts).toEqual(['low'])
+  })
+
+  it('removes a model row', async () => {
+    const user = userEvent.setup()
+    seedProvider({
+      models: [
+        { id: 'm1', name: 'A', slug: 'a', efforts: [] },
+        { id: 'm2', name: 'B', slug: 'b', efforts: [] }
+      ]
+    })
+    render(<SettingsCustomProviders />)
+
+    const removeButtons = screen.getAllByTestId('custom-provider-model-remove')
+    await user.click(removeButtons[0])
+
+    const models = currentModels()
+    expect(models).toHaveLength(1)
+    expect(models[0].id).toBe('m2')
+  })
+
+  it('flags blank and duplicate slugs without blocking the save', () => {
+    seedProvider({
+      models: [
+        { id: 'm1', name: 'Blank', slug: '', efforts: [] },
+        { id: 'm2', name: 'One', slug: 'dup', efforts: [] },
+        { id: 'm3', name: 'Two', slug: 'dup', efforts: [] }
+      ]
+    })
+    render(<SettingsCustomProviders />)
+
+    expect(screen.getAllByText(/Slug required/)).toHaveLength(1)
+    expect(screen.getAllByText(/Duplicate slug/)).toHaveLength(2)
+    // All rows are still persisted — validation is presentational only.
+    expect(currentModels()).toHaveLength(3)
+  })
+})

--- a/src/renderer/src/components/settings/SettingsCustomProviders.test.tsx
+++ b/src/renderer/src/components/settings/SettingsCustomProviders.test.tsx
@@ -43,15 +43,21 @@ describe('SettingsCustomProviders models editor', () => {
     expect(models[0].id).toBeTruthy()
   })
 
-  it('persists typed name and slug into the settings store', async () => {
+  it('persists typed name and slug into the settings store (row-scoped testids)', async () => {
     const user = userEvent.setup()
-    seedProvider({ models: [{ id: 'm1', name: '', slug: '', efforts: [] }] })
+    seedProvider({
+      models: [
+        { id: 'm1', name: '', slug: '', efforts: [] },
+        { id: 'm2', name: 'Other', slug: 'other', efforts: [] }
+      ]
+    })
     render(<SettingsCustomProviders />)
 
-    await user.type(screen.getByTestId('custom-provider-model-name'), 'GLM 4.6')
-    await user.type(screen.getByTestId('custom-provider-model-slug'), 'glm-4.6')
+    await user.type(screen.getByTestId('custom-provider-model-name-m1'), 'GLM 4.6')
+    await user.type(screen.getByTestId('custom-provider-model-slug-m1'), 'glm-4.6')
 
     expect(currentModels()[0]).toMatchObject({ name: 'GLM 4.6', slug: 'glm-4.6' })
+    expect(currentModels()[1]).toMatchObject({ name: 'Other', slug: 'other' })
   })
 
   it('toggles effort chips and stores them in canonical order', async () => {
@@ -59,11 +65,11 @@ describe('SettingsCustomProviders models editor', () => {
     seedProvider({ models: [{ id: 'm1', name: 'GLM', slug: 'glm-4.6', efforts: [] }] })
     render(<SettingsCustomProviders />)
 
-    await user.click(screen.getByTestId('custom-provider-model-effort-high'))
-    await user.click(screen.getByTestId('custom-provider-model-effort-low'))
+    await user.click(screen.getByTestId('custom-provider-model-effort-m1-high'))
+    await user.click(screen.getByTestId('custom-provider-model-effort-m1-low'))
     expect(currentModels()[0].efforts).toEqual(['low', 'high'])
 
-    await user.click(screen.getByTestId('custom-provider-model-effort-high'))
+    await user.click(screen.getByTestId('custom-provider-model-effort-m1-high'))
     expect(currentModels()[0].efforts).toEqual(['low'])
   })
 
@@ -77,8 +83,7 @@ describe('SettingsCustomProviders models editor', () => {
     })
     render(<SettingsCustomProviders />)
 
-    const removeButtons = screen.getAllByTestId('custom-provider-model-remove')
-    await user.click(removeButtons[0])
+    await user.click(screen.getByTestId('custom-provider-model-remove-m1'))
 
     const models = currentModels()
     expect(models).toHaveLength(1)

--- a/src/renderer/src/components/settings/SettingsCustomProviders.tsx
+++ b/src/renderer/src/components/settings/SettingsCustomProviders.tsx
@@ -1,6 +1,11 @@
 import { Plus, Trash2 } from 'lucide-react'
 import { useSettingsStore } from '@/stores/useSettingsStore'
-import type { CustomClaudeProvider, CustomProviderUsage } from '@shared/types/custom-provider'
+import {
+  CUSTOM_PROVIDER_EFFORTS,
+  type CustomClaudeProvider,
+  type CustomProviderModel,
+  type CustomProviderUsage
+} from '@shared/types/custom-provider'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
@@ -21,7 +26,8 @@ export function SettingsCustomProviders(): React.JSX.Element {
       id: crypto.randomUUID(),
       name: '',
       command: '',
-      usageProvider: 'none'
+      usageProvider: 'none',
+      models: []
     }
     updateSetting('customProviders', [...providers, provider])
   }
@@ -39,6 +45,31 @@ export function SettingsCustomProviders(): React.JSX.Element {
       'customProviders',
       providers.map((p) => (p.id === id ? { ...p, ...patch } : p))
     )
+  }
+
+  const handleModelAdd = (provider: CustomClaudeProvider): void => {
+    handleChange(provider.id, {
+      models: [
+        ...(provider.models ?? []),
+        { id: crypto.randomUUID(), name: '', slug: '', efforts: [] }
+      ]
+    })
+  }
+
+  const handleModelChange = (
+    provider: CustomClaudeProvider,
+    modelId: string,
+    patch: Partial<CustomProviderModel>
+  ): void => {
+    handleChange(provider.id, {
+      models: (provider.models ?? []).map((m) => (m.id === modelId ? { ...m, ...patch } : m))
+    })
+  }
+
+  const handleModelRemove = (provider: CustomClaudeProvider, modelId: string): void => {
+    handleChange(provider.id, {
+      models: (provider.models ?? []).filter((m) => m.id !== modelId)
+    })
   }
 
   return (
@@ -115,6 +146,115 @@ export function SettingsCustomProviders(): React.JSX.Element {
                   <p className="text-xs text-muted-foreground mt-1">
                     Which account&apos;s usage to refresh when this provider finishes a turn.
                   </p>
+                </div>
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground">Models</label>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Optional. Declare the models this provider serves — session pickers then offer
+                    them, and Hive passes the selection as{' '}
+                    <span className="font-mono">--model</span> /{' '}
+                    <span className="font-mono">--effort</span> after the command. Leave empty to
+                    let the command decide the model.
+                  </p>
+                  <div className="space-y-2 mt-2">
+                    {(provider.models ?? []).map((model) => {
+                      const slugValue = model.slug.trim()
+                      const duplicateSlug =
+                        slugValue !== '' &&
+                        (provider.models ?? []).some(
+                          (other) => other.id !== model.id && other.slug.trim() === slugValue
+                        )
+                      return (
+                        <div
+                          key={model.id}
+                          className="rounded-md border p-2 space-y-2"
+                          data-testid={`custom-provider-model-${model.id}`}
+                        >
+                          <div className="flex items-center gap-2">
+                            <Input
+                              value={model.name}
+                              onChange={(e) =>
+                                handleModelChange(provider, model.id, { name: e.target.value })
+                              }
+                              placeholder="Name — e.g. GLM 4.6"
+                              className="h-8"
+                              data-testid="custom-provider-model-name"
+                            />
+                            <Input
+                              value={model.slug}
+                              onChange={(e) =>
+                                handleModelChange(provider, model.id, { slug: e.target.value })
+                              }
+                              placeholder="Slug — e.g. glm-4.6"
+                              className="h-8 font-mono"
+                              data-testid="custom-provider-model-slug"
+                            />
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => handleModelRemove(provider, model.id)}
+                              className="text-muted-foreground hover:text-destructive shrink-0 h-8 w-8"
+                              data-testid="custom-provider-model-remove"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                          {slugValue === '' && (
+                            <p className="text-xs text-destructive">
+                              Slug required — the model is ignored until one is set. It is passed
+                              verbatim as <span className="font-mono">--model</span>.
+                            </p>
+                          )}
+                          {duplicateSlug && (
+                            <p className="text-xs text-destructive">
+                              Duplicate slug — another model of this provider already uses it.
+                            </p>
+                          )}
+                          <div className="flex items-center gap-1 flex-wrap">
+                            <span className="text-[10px] uppercase tracking-wide text-muted-foreground mr-1">
+                              Efforts
+                            </span>
+                            {CUSTOM_PROVIDER_EFFORTS.map((effort) => {
+                              const active = model.efforts.includes(effort)
+                              return (
+                                <button
+                                  key={effort}
+                                  role="checkbox"
+                                  aria-checked={active}
+                                  onClick={() => {
+                                    const next = new Set(model.efforts)
+                                    if (active) next.delete(effort)
+                                    else next.add(effort)
+                                    handleModelChange(provider, model.id, {
+                                      efforts: CUSTOM_PROVIDER_EFFORTS.filter((e) => next.has(e))
+                                    })
+                                  }}
+                                  className={cn(
+                                    'px-2 py-0.5 rounded-md text-xs border transition-colors',
+                                    active
+                                      ? 'bg-accent text-accent-foreground border-accent'
+                                      : 'text-muted-foreground hover:bg-accent/50'
+                                  )}
+                                  data-testid={`custom-provider-model-effort-${effort}`}
+                                >
+                                  {effort}
+                                </button>
+                              )
+                            })}
+                          </div>
+                        </div>
+                      )
+                    })}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleModelAdd(provider)}
+                      data-testid="custom-provider-model-add"
+                    >
+                      <Plus className="h-4 w-4 mr-1" />
+                      Add Model
+                    </Button>
+                  </div>
                 </div>
               </div>
               <Button

--- a/src/renderer/src/components/settings/SettingsCustomProviders.tsx
+++ b/src/renderer/src/components/settings/SettingsCustomProviders.tsx
@@ -178,7 +178,7 @@ export function SettingsCustomProviders(): React.JSX.Element {
                               }
                               placeholder="Name — e.g. GLM 4.6"
                               className="h-8"
-                              data-testid="custom-provider-model-name"
+                              data-testid={`custom-provider-model-name-${model.id}`}
                             />
                             <Input
                               value={model.slug}
@@ -187,14 +187,14 @@ export function SettingsCustomProviders(): React.JSX.Element {
                               }
                               placeholder="Slug — e.g. glm-4.6"
                               className="h-8 font-mono"
-                              data-testid="custom-provider-model-slug"
+                              data-testid={`custom-provider-model-slug-${model.id}`}
                             />
                             <Button
                               variant="ghost"
                               size="icon"
                               onClick={() => handleModelRemove(provider, model.id)}
                               className="text-muted-foreground hover:text-destructive shrink-0 h-8 w-8"
-                              data-testid="custom-provider-model-remove"
+                              data-testid={`custom-provider-model-remove-${model.id}`}
                             >
                               <Trash2 className="h-3.5 w-3.5" />
                             </Button>
@@ -235,7 +235,7 @@ export function SettingsCustomProviders(): React.JSX.Element {
                                       ? 'bg-accent text-accent-foreground border-accent'
                                       : 'text-muted-foreground hover:bg-accent/50'
                                   )}
-                                  data-testid={`custom-provider-model-effort-${effort}`}
+                                  data-testid={`custom-provider-model-effort-${model.id}-${effort}`}
                                 >
                                   {effort}
                                 </button>

--- a/src/renderer/src/lib/handoffSelection.custom-models.test.ts
+++ b/src/renderer/src/lib/handoffSelection.custom-models.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  getEffectiveHandoffSelection,
+  resolveCustomProviderSelectedModel
+} from '@/lib/handoffSelection'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import type { CustomClaudeProvider } from '@shared/types/custom-provider'
+
+const initialSettingsState = useSettingsStore.getState()
+
+// Second model's slug deliberately collides with a stock alias name: a legacy
+// override's stock stamp must never accidentally "pick" it.
+const provider: CustomClaudeProvider = {
+  id: 'p1',
+  name: 'Proxy',
+  command: 'claudex',
+  usageProvider: 'none',
+  models: [
+    { id: 'm1', name: 'GLM 4.6', slug: 'glm-4.6', efforts: ['low', 'high'] },
+    { id: 'm2', name: 'Proxy Sonnet', slug: 'sonnet', efforts: ['high'] }
+  ]
+}
+
+describe('custom provider model resolution vs legacy stock stamps', () => {
+  beforeEach(() => {
+    useSettingsStore.setState(initialSettingsState, true)
+  })
+
+  it('ignores a legacy handoff override whose stock modelID collides with a declared slug', () => {
+    useSettingsStore.setState({
+      customProviders: [provider],
+      lastHandoffOverride: {
+        agentSdk: 'claude-code-cli',
+        customProviderId: 'p1',
+        providerID: 'anthropic',
+        modelID: 'sonnet',
+        variant: 'high'
+      }
+    })
+
+    const effective = getEffectiveHandoffSelection({})
+    // Degrades to the provider default (first declared model), not 'sonnet'.
+    expect(effective.customProviderId).toBe('p1')
+    expect(effective.model).toEqual({ providerID: 'custom', modelID: 'glm-4.6', variant: 'low' })
+    expect(effective.display.modelName).toBe('GLM 4.6')
+  })
+
+  it('honors an override that already carries the custom marker', () => {
+    useSettingsStore.setState({
+      customProviders: [provider],
+      lastHandoffOverride: {
+        agentSdk: 'claude-code-cli',
+        customProviderId: 'p1',
+        providerID: 'custom',
+        modelID: 'sonnet',
+        variant: 'high'
+      }
+    })
+
+    const effective = getEffectiveHandoffSelection({})
+    expect(effective.model).toEqual({ providerID: 'custom', modelID: 'sonnet', variant: 'high' })
+    expect(effective.display.modelName).toBe('Proxy Sonnet')
+  })
+
+  it('resolveCustomProviderSelectedModel treats non-custom candidates as no pick', () => {
+    expect(
+      resolveCustomProviderSelectedModel(provider, {
+        providerID: 'anthropic',
+        modelID: 'sonnet',
+        variant: 'high'
+      })
+    ).toEqual({ providerID: 'custom', modelID: 'glm-4.6', variant: 'low' })
+
+    expect(
+      resolveCustomProviderSelectedModel(provider, {
+        providerID: 'custom',
+        modelID: 'sonnet',
+        variant: 'high'
+      })
+    ).toEqual({ providerID: 'custom', modelID: 'sonnet', variant: 'high' })
+  })
+})

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -1,6 +1,12 @@
 import { isAgentSdkAvailable, type AvailableAgentSdks } from './agent-sdk-availability'
 import { type AgentSdk, supportsGoalMode, toModelCatalogSdk } from '@shared/types/agent-sdk'
-import { findCustomProvider } from '@shared/types/custom-provider'
+import {
+  CUSTOM_MODEL_PROVIDER_ID,
+  findCustomProvider,
+  getCustomProviderModelDisplayName,
+  resolveCustomProviderModelSelection,
+  type CustomClaudeProvider
+} from '@shared/types/custom-provider'
 import { HANDOFF_PLAN_PROMPT_HEADER } from '@shared/agent-mode-prefixes'
 import {
   findModelInfo,
@@ -175,6 +181,31 @@ function getModelInfoFromCache(
   return findModelInfo(providers, model.providerID, model.modelID)
 }
 
+/**
+ * Resolve a candidate model/effort against a custom provider's declared models
+ * into the `SelectedModel` shape that rides overrides, launch configs, and the
+ * session row (`providerID: 'custom'`, `modelID: <slug>`, `variant: <effort>`).
+ * An invalid candidate degrades to the provider's default (first model/effort);
+ * null when the provider declares no launchable models — the command keeps
+ * owning the model, as before this feature.
+ */
+export function resolveCustomProviderSelectedModel(
+  provider: CustomClaudeProvider,
+  candidate?: { modelID?: string | null; variant?: string | null } | null
+): SelectedModel | null {
+  const selection = resolveCustomProviderModelSelection(
+    provider,
+    candidate?.modelID,
+    candidate?.variant
+  )
+  if (!selection) return null
+  return {
+    providerID: CUSTOM_MODEL_PROVIDER_ID,
+    modelID: selection.model.slug.trim(),
+    variant: selection.effort ?? undefined
+  }
+}
+
 export function getHandoffSdkDisplayName(
   agentSdk: HandoffAgentSdk,
   customProviderId?: string | null
@@ -268,6 +299,31 @@ export function getEffectiveHandoffSelection(opts: {
   if (override.customProviderId) {
     const provider = findCustomProvider(settings.customProviders, override.customProviderId)
     if (!provider || !provider.command.trim()) return fallback
+    const providerName = provider.name || 'Custom Provider'
+    // Resolve the remembered model/effort against the provider's declared
+    // models — a slug/effort the user has since removed degrades to the
+    // provider default rather than riding along stale.
+    const selection = resolveCustomProviderModelSelection(
+      provider,
+      override.modelID,
+      override.variant
+    )
+    if (selection) {
+      return {
+        agentSdk: override.agentSdk,
+        customProviderId: provider.id,
+        model: {
+          providerID: CUSTOM_MODEL_PROVIDER_ID,
+          modelID: selection.model.slug.trim(),
+          variant: selection.effort ?? undefined
+        },
+        display: {
+          sdkName: providerName,
+          modelName: getCustomProviderModelDisplayName(selection.model),
+          variant: selection.effort ?? undefined
+        }
+      }
+    }
     const model: SelectedModel = {
       providerID: override.providerID,
       modelID: override.modelID,
@@ -278,9 +334,10 @@ export function getEffectiveHandoffSelection(opts: {
       customProviderId: provider.id,
       model,
       display: {
-        // The provider's command decides the real model — show only the name.
-        sdkName: provider.name || 'Custom Provider',
-        modelName: provider.name || 'Custom Provider',
+        // No declared models: the provider's command decides the real model —
+        // show only the name.
+        sdkName: providerName,
+        modelName: providerName,
         variant: undefined
       }
     }
@@ -316,6 +373,8 @@ export function resolveSessionCreationSelection(opts: {
   agentSdkOverride?: AgentSdk
   initialMode?: 'build' | 'plan' | 'super-plan'
   modelOverride?: SelectedModel
+  /** claude-code-cli only: resolve the model from this provider's declared list. */
+  customProviderId?: string | null
 }): {
   agentSdk: AgentSdk
   model: SelectedModel | null
@@ -328,8 +387,29 @@ export function resolveSessionCreationSelection(opts: {
     return { agentSdk, model: null }
   }
 
-  if (opts.modelOverride) {
-    return { agentSdk, model: opts.modelOverride }
+  // Custom-provider sessions must never be stamped with a stock-claude model:
+  // once the spawner passes --model for declared models, a stale claude value
+  // would only be dead weight (it can't match a declared slug), and a declared
+  // provider needs its default model stamped even when no override rides in.
+  if (opts.customProviderId && agentSdk === 'claude-code-cli') {
+    const provider = findCustomProvider(settings.customProviders, opts.customProviderId)
+    if (provider) {
+      const model = resolveCustomProviderSelectedModel(provider, opts.modelOverride)
+      return { agentSdk, model }
+    }
+  }
+  // A custom-shaped override that reaches here has lost its provider (deleted,
+  // degraded, or a dangling id) — never leak the proxy slug into stock-claude
+  // resolution. Scoped to claude-code-cli: 'custom' is also a legal opencode
+  // catalog provider id and must pass through untouched for other SDKs.
+  const modelOverride =
+    agentSdk === 'claude-code-cli' &&
+    opts.modelOverride?.providerID === CUSTOM_MODEL_PROVIDER_ID
+      ? undefined
+      : opts.modelOverride
+
+  if (modelOverride) {
+    return { agentSdk, model: modelOverride }
   }
 
   if (opts.agentSdkOverride) {

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -185,18 +185,22 @@ function getModelInfoFromCache(
  * Resolve a candidate model/effort against a custom provider's declared models
  * into the `SelectedModel` shape that rides overrides, launch configs, and the
  * session row (`providerID: 'custom'`, `modelID: <slug>`, `variant: <effort>`).
- * An invalid candidate degrades to the provider's default (first model/effort);
- * null when the provider declares no launchable models — the command keeps
- * owning the model, as before this feature.
+ * Only candidates already carrying the 'custom' marker count — a legacy stock
+ * stamp like anthropic/sonnet must not accidentally match a declared slug
+ * named after a stock alias. Invalid or non-custom candidates degrade to the
+ * provider's default (first model/effort); null when the provider declares no
+ * launchable models — the command keeps owning the model, as before this
+ * feature.
  */
 export function resolveCustomProviderSelectedModel(
   provider: CustomClaudeProvider,
-  candidate?: { modelID?: string | null; variant?: string | null } | null
+  candidate?: { providerID?: string; modelID?: string | null; variant?: string | null } | null
 ): SelectedModel | null {
+  const isCustomCandidate = candidate?.providerID === CUSTOM_MODEL_PROVIDER_ID
   const selection = resolveCustomProviderModelSelection(
     provider,
-    candidate?.modelID,
-    candidate?.variant
+    isCustomCandidate ? candidate?.modelID : null,
+    isCustomCandidate ? candidate?.variant : null
   )
   if (!selection) return null
   return {
@@ -302,11 +306,15 @@ export function getEffectiveHandoffSelection(opts: {
     const providerName = provider.name || 'Custom Provider'
     // Resolve the remembered model/effort against the provider's declared
     // models — a slug/effort the user has since removed degrades to the
-    // provider default rather than riding along stale.
+    // provider default rather than riding along stale. Only overrides already
+    // carrying the 'custom' marker count as a remembered pick: a legacy
+    // override's stock stamp (anthropic/sonnet) must not accidentally match a
+    // declared slug named after a stock alias.
+    const isCustomOverrideModel = override.providerID === CUSTOM_MODEL_PROVIDER_ID
     const selection = resolveCustomProviderModelSelection(
       provider,
-      override.modelID,
-      override.variant
+      isCustomOverrideModel ? override.modelID : null,
+      isCustomOverrideModel ? override.variant : null
     )
     if (selection) {
       return {

--- a/src/renderer/src/lib/multi-model-launch.ts
+++ b/src/renderer/src/lib/multi-model-launch.ts
@@ -39,9 +39,9 @@ interface EffectiveModel {
  * yet: explicit config model -> per-SDK resolution -> hard SDK fallback.
  */
 function resolveEffectiveModel(entry: LaunchModelConfig): EffectiveModel {
-  // Custom providers own their model (baked into the command) — badge with the
-  // provider's display name rather than a claude model that won't actually run.
-  const customBadge = resolveCustomProviderBadge(entry.customProviderId)
+  // Custom providers: badge with the chosen declared model when there is one,
+  // else the provider's display name — never a claude model that won't run.
+  const customBadge = resolveCustomProviderBadge(entry.customProviderId, entry.model)
   if (customBadge) return customBadge
   const resolved = entry.model ?? resolveModelForSdk(entry.sdk) ?? FALLBACK_MODELS[entry.sdk]
   return {

--- a/src/renderer/src/lib/parseProviders.ts
+++ b/src/renderer/src/lib/parseProviders.ts
@@ -1,3 +1,10 @@
+import {
+  CUSTOM_MODEL_PROVIDER_ID,
+  getCustomProviderModelDisplayName,
+  getLaunchableCustomProviderModels,
+  type CustomClaudeProvider
+} from '@shared/types/custom-provider'
+
 export interface ModelInfo {
   id: string
   name?: string
@@ -101,6 +108,30 @@ export function getVariantKeysForSdk(
     return [...base, ULTRACODE_VARIANT]
   }
   return base
+}
+
+/**
+ * Synthesize a picker catalog from a custom provider's declared models so the
+ * existing model-dropdown + variant-chip machinery works unchanged. Efforts map
+ * onto variants; `getVariantKeysForSdk`'s ultracode append must NOT be used on
+ * this catalog (ultracode is a stock-claude `--settings` mode, not an effort).
+ * Empty when the provider declares no launchable models.
+ */
+export function buildCustomProviderCatalog(provider: CustomClaudeProvider): ProviderModels[] {
+  const models = getLaunchableCustomProviderModels(provider.models)
+  if (models.length === 0) return []
+  return [
+    {
+      providerID: CUSTOM_MODEL_PROVIDER_ID,
+      providerName: provider.name || 'Custom Provider',
+      models: models.map((model) => ({
+        id: model.slug.trim(),
+        name: getCustomProviderModelDisplayName(model),
+        providerID: CUSTOM_MODEL_PROVIDER_ID,
+        variants: Object.fromEntries(model.efforts.map((effort) => [effort, {}]))
+      }))
+    }
+  ]
 }
 
 export function findModelInfo(

--- a/src/renderer/src/lib/ticket-launch.ts
+++ b/src/renderer/src/lib/ticket-launch.ts
@@ -5,7 +5,13 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
 import { resolveModelForSdk, useSettingsStore } from '@/stores/useSettingsStore'
-import { findCustomProvider } from '@shared/types/custom-provider'
+import {
+  CUSTOM_MODEL_PROVIDER_ID,
+  findCustomProvider,
+  getCustomProviderModelDisplayName,
+  matchCustomProviderModel
+} from '@shared/types/custom-provider'
+import { resolveCustomProviderSelectedModel } from '@/lib/handoffSelection'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
@@ -124,20 +130,34 @@ export function resolveBadgeModel(
 }
 
 /**
- * Badge for a custom-provider launch: the provider's command decides the real
- * model (often via alias flags), so the session row's resolved claude model
- * would mislead — stamp the provider's display name instead. Returns null when
- * the id doesn't reference a known provider.
+ * Badge for a custom-provider launch. With a chosen declared model, stamp its
+ * display name (+ effort) — that is what actually runs. Otherwise the
+ * provider's command decides the real model (often via alias flags), so the
+ * session row's resolved claude model would mislead — stamp the provider's
+ * display name instead. Returns null when the id doesn't reference a known
+ * provider.
  */
 export function resolveCustomProviderBadge(
-  customProviderId: string | null | undefined
-): { providerID: string; modelID: string; variant: null } | null {
+  customProviderId: string | null | undefined,
+  model?: { providerID: string; modelID: string; variant?: string | null } | null
+): { providerID: string; modelID: string; variant: string | null } | null {
   if (!customProviderId) return null
   const provider = findCustomProvider(
     useSettingsStore.getState().customProviders,
     customProviderId
   )
   if (!provider) return null
+  const declaredModel =
+    model?.providerID === CUSTOM_MODEL_PROVIDER_ID
+      ? matchCustomProviderModel(provider.models, model.modelID)
+      : null
+  if (declaredModel) {
+    return {
+      providerID: CUSTOM_MODEL_PROVIDER_ID,
+      modelID: getCustomProviderModelDisplayName(declaredModel),
+      variant: model?.variant ?? null
+    }
+  }
   return { providerID: 'custom', modelID: provider.name || 'Custom Provider', variant: null }
 }
 
@@ -235,7 +255,23 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
 
     // 2. Create session
     const customProviderId = resolveLaunchCustomProviderId(sdk, spec.modelConfig.customProviderId)
-    const modelOverride = model ? { ...model, agentSdk: sdk } : undefined
+    // Custom-provider models can go stale between queueing and launch: a
+    // deleted provider degrades to plain claude and must drop the model too (a
+    // proxy slug could fuzzy-match a wrong --model on stock claude), and a
+    // renamed slug re-resolves to the provider's current default. Scoped to
+    // claude-code-cli — 'custom' is also a legal opencode catalog provider id.
+    let effectiveConfigModel: { providerID: string; modelID: string; variant?: string } | null =
+      model
+    if (sdk === 'claude-code-cli' && model?.providerID === CUSTOM_MODEL_PROVIDER_ID) {
+      const provider = findCustomProvider(
+        useSettingsStore.getState().customProviders,
+        customProviderId
+      )
+      effectiveConfigModel = provider ? resolveCustomProviderSelectedModel(provider, model) : null
+    }
+    const modelOverride = effectiveConfigModel
+      ? { ...effectiveConfigModel, agentSdk: sdk }
+      : undefined
     const cliPendingPrompt =
       sdk === 'claude-code-cli'
         ? composeLaunchPrompt(prompt, spec.mode, sdk, goalMode, goalSuccessCriteria, {
@@ -277,9 +313,9 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
       .setSessionStatus(sessionId, isPlanLike(spec.mode) ? 'planning' : 'working')
 
     // 4. Apply model override
-    const effectiveModel = model ?? undefined
-    if (model) {
-      await useSessionStore.getState().setSessionModel(sessionId, model)
+    const effectiveModel = effectiveConfigModel ?? undefined
+    if (effectiveConfigModel) {
+      await useSessionStore.getState().setSessionModel(sessionId, effectiveConfigModel)
     }
 
     // 5. Update ticket: clear pending config (via extras), set session + worktree,
@@ -288,7 +324,9 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
     //    a stale multi-launch group) — the multi-model orchestrator overrides
     //    it back via ticketUpdateExtras, which must win, hence the field
     //    ordering below.
-    const badge = resolveCustomProviderBadge(customProviderId) ?? resolveBadgeModel(spec.modelConfig, session)
+    const badge =
+      resolveCustomProviderBadge(customProviderId, effectiveConfigModel) ??
+      resolveBadgeModel(spec.modelConfig, session)
     await useKanbanStore.getState().updateTicket(spec.ticketId, spec.projectId, {
       current_session_id: sessionId,
       worktree_id: worktreeId,

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -18,6 +18,7 @@ import { connectionApi } from '@/api/connection-api'
 import { terminalApi } from '@/api/terminal-api'
 import { opencodeApi } from '@/api/opencode-api'
 import { type AgentSdk, isTerminalBacked } from '@shared/types/agent-sdk'
+import { CUSTOM_MODEL_PROVIDER_ID } from '@shared/types/custom-provider'
 
 /**
  * Push the follow-up-message queue state for a session into the backend.
@@ -518,7 +519,8 @@ export const useSessionStore = create<SessionState>()(
               worktreeId,
               agentSdkOverride,
               initialMode,
-              modelOverride: options?.modelOverride
+              modelOverride: options?.modelOverride,
+              customProviderId: options?.customProviderId
             })
           // Custom providers run their own command through the login shell —
           // stock-claude detection (`which claude` in the Electron process) is
@@ -1474,9 +1476,15 @@ export const useSessionStore = create<SessionState>()(
           console.error('Failed to push model to agent backend:', error)
         }
 
-        // Update per-provider last-used model so new worktrees inherit it
-        // Skip when auto-applying mode defaults — those shouldn't rewrite global preferences
-        if (!options?.skipGlobalUpdate) {
+        // Update per-provider last-used model so new worktrees inherit it.
+        // Skip when auto-applying mode defaults — those shouldn't rewrite global
+        // preferences — and for custom-provider models ('custom' marker on a
+        // cli session): a proxy slug must never become the stock claude-code-cli
+        // default. Other SDKs pass through — 'custom' is also a legal opencode
+        // catalog provider id.
+        const isCustomProviderModel =
+          model.providerID === CUSTOM_MODEL_PROVIDER_ID && agentSdk === 'claude-code-cli'
+        if (!options?.skipGlobalUpdate && !isCustomProviderModel) {
           try {
             const { useSettingsStore } = await import('./useSettingsStore')
             useSettingsStore
@@ -1487,9 +1495,10 @@ export const useSessionStore = create<SessionState>()(
           }
         }
 
-        // Also persist as the worktree's last-used model (only for worktree sessions)
+        // Also persist as the worktree's last-used model (only for worktree
+        // sessions; custom-provider slugs would leak into stock fallback chains)
         const scope = findSessionScope(get(), sessionId)
-        if (scope?.type === 'worktree') {
+        if (scope?.type === 'worktree' && !isCustomProviderModel) {
           try {
             await dbApi.worktree.updateModel({
               worktreeId: scope.scopeId,
@@ -1513,6 +1522,10 @@ export const useSessionStore = create<SessionState>()(
         const settings = useSettingsStore.getState()
         const sessionSdk = session?.agent_sdk ?? settings.defaultAgentSdk ?? 'opencode'
         if (sessionSdk === 'terminal') return
+        // Custom-provider sessions carry a provider-declared model (or none) —
+        // mode defaults always resolve to STOCK claude models, which would
+        // clobber the declared slug and silently un-pass --model on respawn.
+        if (session?.custom_provider_id) return
 
         const modeDefault = settings.getModelForMode(newMode)
         // Cross-SDK mode default on a live session is impossible to apply because the
@@ -2104,7 +2117,8 @@ export const useSessionStore = create<SessionState>()(
             resolveSessionCreationSelection({
               agentSdkOverride,
               initialMode,
-              modelOverride: opts?.modelOverride
+              modelOverride: opts?.modelOverride,
+              customProviderId: opts?.customProviderId
             })
           // Same gating as createSession: custom providers don't need
           // stock-claude detection but are blocked up front on Windows.

--- a/src/shared/types/custom-provider.test.ts
+++ b/src/shared/types/custom-provider.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getLaunchableCustomProviderModels,
+  matchCustomProviderModel,
+  resolveCustomProviderEffort,
+  resolveCustomProviderModelSelection,
+  sanitizeCustomProviders,
+  type CustomProviderModel
+} from './custom-provider'
+
+const MODEL: CustomProviderModel = {
+  id: 'm1',
+  name: 'GLM 4.6',
+  slug: 'glm-4.6',
+  efforts: ['low', 'high']
+}
+
+describe('sanitizeCustomProviders', () => {
+  it('keeps legacy providers without models and defaults models to []', () => {
+    const result = sanitizeCustomProviders([
+      { id: 'p1', name: 'Proxy', command: 'claudex', usageProvider: 'claude' }
+    ])
+    expect(result).toEqual([
+      { id: 'p1', name: 'Proxy', command: 'claudex', usageProvider: 'claude', models: [] }
+    ])
+  })
+
+  it('round-trips declared models and drops unknown effort values', () => {
+    const result = sanitizeCustomProviders([
+      {
+        id: 'p1',
+        name: 'Proxy',
+        command: 'claudex',
+        usageProvider: 'none',
+        models: [
+          { id: 'm1', name: 'GLM 4.6', slug: 'glm-4.6', efforts: ['high', 'ultracode', 'low', 'nope'] }
+        ]
+      }
+    ])
+    // Canonical order (low → max), unknown values dropped — ultracode is not an effort.
+    expect(result[0].models).toEqual([
+      { id: 'm1', name: 'GLM 4.6', slug: 'glm-4.6', efforts: ['low', 'high'] }
+    ])
+  })
+
+  it('drops malformed model rows but keeps the provider', () => {
+    const result = sanitizeCustomProviders([
+      {
+        id: 'p1',
+        name: 'Proxy',
+        command: 'claudex',
+        usageProvider: 'none',
+        models: [
+          { id: 'm1', name: 'ok', slug: 'ok', efforts: [] },
+          { id: '', name: 'no id', slug: 'x', efforts: [] },
+          { id: 'm3', name: 42, slug: 'x', efforts: [] },
+          'not-an-object'
+        ]
+      }
+    ])
+    expect(result[0].models).toEqual([{ id: 'm1', name: 'ok', slug: 'ok', efforts: [] }])
+  })
+
+  it('treats a non-array models value as no models', () => {
+    const result = sanitizeCustomProviders([
+      { id: 'p1', name: 'Proxy', command: 'claudex', usageProvider: 'none', models: 'nope' }
+    ])
+    expect(result[0].models).toEqual([])
+  })
+})
+
+describe('model matching and resolution', () => {
+  it('ignores models with blank slugs', () => {
+    expect(
+      getLaunchableCustomProviderModels([MODEL, { id: 'm2', name: 'Draft', slug: '  ', efforts: [] }])
+    ).toEqual([MODEL])
+  })
+
+  it('matches by trimmed slug only', () => {
+    expect(matchCustomProviderModel([MODEL], 'glm-4.6')).toEqual(MODEL)
+    expect(matchCustomProviderModel([MODEL], ' glm-4.6 ')).toEqual(MODEL)
+    expect(matchCustomProviderModel([MODEL], 'sonnet')).toBeNull()
+    expect(matchCustomProviderModel([MODEL], null)).toBeNull()
+    expect(matchCustomProviderModel(undefined, 'glm-4.6')).toBeNull()
+  })
+
+  it('resolves declared efforts and rejects undeclared ones', () => {
+    expect(resolveCustomProviderEffort(MODEL, 'high')).toBe('high')
+    expect(resolveCustomProviderEffort(MODEL, 'max')).toBeNull()
+    expect(resolveCustomProviderEffort(MODEL, 'ultracode')).toBeNull()
+    expect(resolveCustomProviderEffort(MODEL, null)).toBeNull()
+  })
+
+  it('resolveCustomProviderModelSelection honors a valid candidate', () => {
+    const provider = { models: [MODEL, { id: 'm2', name: 'Air', slug: 'glm-air', efforts: [] }] }
+    expect(resolveCustomProviderModelSelection(provider, 'glm-air', 'high')).toEqual({
+      model: provider.models[1],
+      effort: null
+    })
+  })
+
+  it('falls back to the first model and first effort for invalid candidates', () => {
+    const provider = { models: [MODEL] }
+    expect(resolveCustomProviderModelSelection(provider, 'sonnet', 'ultracode')).toEqual({
+      model: MODEL,
+      effort: 'low'
+    })
+  })
+
+  it('returns null when the provider declares no launchable models', () => {
+    expect(resolveCustomProviderModelSelection({ models: [] }, 'x', 'low')).toBeNull()
+    expect(resolveCustomProviderModelSelection({ models: undefined }, 'x', 'low')).toBeNull()
+    expect(
+      resolveCustomProviderModelSelection({ models: [{ id: 'm', name: 'n', slug: ' ', efforts: [] }] })
+    ).toBeNull()
+  })
+})

--- a/src/shared/types/custom-provider.ts
+++ b/src/shared/types/custom-provider.ts
@@ -16,6 +16,27 @@
 /** Where a custom provider's turns should be counted for account usage. */
 export type CustomProviderUsage = 'none' | 'claude' | 'openai'
 
+/**
+ * Effort levels the claude CLI accepts for `--effort`. Provider models may only
+ * declare a subset of these — commander rejects anything else, which would kill
+ * the whole spawn. Note `ultracode` is NOT an effort (it rides in `--settings`)
+ * and is never offered for custom providers.
+ */
+export const CUSTOM_PROVIDER_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'] as const
+export type CustomProviderEffort = (typeof CUSTOM_PROVIDER_EFFORTS)[number]
+
+/** A model a custom provider serves, selectable when launching its sessions. */
+export interface CustomProviderModel {
+  /** Stable uuid — React row key and patch identity in the settings editor. */
+  id: string
+  /** Display name shown in pickers; falls back to the slug when blank. */
+  name: string
+  /** Passed verbatim as `--model <slug>` to the provider's command. */
+  slug: string
+  /** Efforts offered for this model; empty = never pass `--effort`. */
+  efforts: CustomProviderEffort[]
+}
+
 export interface CustomClaudeProvider {
   id: string
   /** Display name shown in pickers ("New <name> Session", SDK toggle, handoff). */
@@ -27,7 +48,20 @@ export interface CustomClaudeProvider {
    */
   command: string
   usageProvider: CustomProviderUsage
+  /**
+   * Models this provider serves. When non-empty (and a model has a slug), the
+   * session pickers offer them and the chosen slug/effort is appended as
+   * `--model`/`--effort` after the command — overriding any alias-baked model.
+   * When absent/empty the command keeps owning the model (legacy behavior).
+   */
+  models?: CustomProviderModel[]
 }
+
+/**
+ * `SelectedModel.providerID` / `sessions.model_provider_id` marker for a model
+ * chosen from a custom provider's list (matches the ticket-badge convention).
+ */
+export const CUSTOM_MODEL_PROVIDER_ID = 'custom'
 
 /**
  * Map a provider's usage attribution onto the account-usage provider union
@@ -54,13 +88,92 @@ export function findCustomProvider(
   return providers.find((p) => p.id === id)
 }
 
+/**
+ * Models that can actually launch: a blank slug has nothing to pass as
+ * `--model`, so half-typed settings rows are ignored (mirrors how providers
+ * with a blank command are hidden from pickers).
+ */
+export function getLaunchableCustomProviderModels(
+  models: CustomProviderModel[] | null | undefined
+): CustomProviderModel[] {
+  return (models ?? []).filter((m) => m.slug.trim() !== '')
+}
+
+/**
+ * Strict slug match against the provider's declared models. Sessions persist
+ * the slug in `model_id`; anything that doesn't match a declared model (stale
+ * stock-claude values like 'sonnet', or a slug the user has since renamed)
+ * must NOT be forwarded to the provider's command.
+ */
+export function matchCustomProviderModel(
+  models: CustomProviderModel[] | null | undefined,
+  slug: string | null | undefined
+): CustomProviderModel | null {
+  const trimmed = slug?.trim()
+  if (!trimmed) return null
+  return getLaunchableCustomProviderModels(models).find((m) => m.slug.trim() === trimmed) ?? null
+}
+
+/** The stored effort when the model declares it, else null (no `--effort`). */
+export function resolveCustomProviderEffort(
+  model: CustomProviderModel,
+  variant: string | null | undefined
+): CustomProviderEffort | null {
+  if (!variant) return null
+  return model.efforts.find((effort) => effort === variant) ?? null
+}
+
+/**
+ * Resolve what a custom-provider session should run: the candidate model/effort
+ * when it matches the provider's declarations, else the provider's default
+ * (first declared model, first declared effort). Null when the provider
+ * declares no launchable models — the command keeps owning the model.
+ */
+export function resolveCustomProviderModelSelection(
+  provider: Pick<CustomClaudeProvider, 'models'> | null | undefined,
+  candidateModelId?: string | null,
+  candidateVariant?: string | null
+): { model: CustomProviderModel; effort: CustomProviderEffort | null } | null {
+  const launchable = getLaunchableCustomProviderModels(provider?.models)
+  if (launchable.length === 0) return null
+  const model = matchCustomProviderModel(launchable, candidateModelId) ?? launchable[0]
+  const effort = resolveCustomProviderEffort(model, candidateVariant) ?? model.efforts[0] ?? null
+  return { model, effort }
+}
+
+/** Display name for a provider model (slug fallback for blank names). */
+export function getCustomProviderModelDisplayName(model: CustomProviderModel): string {
+  return model.name.trim() || model.slug.trim()
+}
+
+function sanitizeCustomProviderModels(value: unknown): CustomProviderModel[] {
+  if (!Array.isArray(value)) return []
+  const result: CustomProviderModel[] = []
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue
+    const { id, name, slug, efforts } = entry as Record<string, unknown>
+    if (typeof id !== 'string' || !id) continue
+    if (typeof name !== 'string' || typeof slug !== 'string') continue
+    // Intersect with the known set in canonical order — the claude CLI rejects
+    // unknown --effort values, which would kill the whole spawn.
+    const effortSet = new Set(Array.isArray(efforts) ? efforts : [])
+    result.push({
+      id,
+      name,
+      slug,
+      efforts: CUSTOM_PROVIDER_EFFORTS.filter((effort) => effortSet.has(effort))
+    })
+  }
+  return result
+}
+
 /** Sanitize a value parsed from the settings JSON blob into a valid provider list. */
 export function sanitizeCustomProviders(value: unknown): CustomClaudeProvider[] {
   if (!Array.isArray(value)) return []
   const result: CustomClaudeProvider[] = []
   for (const entry of value) {
     if (!entry || typeof entry !== 'object') continue
-    const { id, name, command, usageProvider } = entry as Record<string, unknown>
+    const { id, name, command, usageProvider, models } = entry as Record<string, unknown>
     if (typeof id !== 'string' || !id) continue
     if (typeof name !== 'string' || typeof command !== 'string') continue
     result.push({
@@ -70,7 +183,8 @@ export function sanitizeCustomProviders(value: unknown): CustomClaudeProvider[] 
       usageProvider:
         usageProvider === 'openai' || usageProvider === 'none' || usageProvider === 'claude'
           ? usageProvider
-          : 'none'
+          : 'none',
+      models: sanitizeCustomProviderModels(models)
     })
   }
   return result

--- a/test/phase-22/session-11/apply-mode-default-model.test.ts
+++ b/test/phase-22/session-11/apply-mode-default-model.test.ts
@@ -153,6 +153,41 @@ describe('applyModeDefaultModel', () => {
     })
   })
 
+  test('does not clobber a custom-provider session model with a stock mode default', async () => {
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([
+        [
+          'wt-1',
+          [
+            {
+              ...baseSession,
+              agent_sdk: 'claude-code-cli' as const,
+              custom_provider_id: 'prov-1',
+              model_provider_id: 'custom',
+              model_id: 'glm-4.6',
+              model_variant: 'high'
+            }
+          ]
+        ]
+      ]),
+      sessionsByConnection: new Map(),
+      boardAssistantByProject: new Map()
+    })
+    seedSettings({
+      agentSdk: 'claude-code-cli',
+      providerID: 'anthropic',
+      modelID: 'sonnet',
+      variant: 'xhigh'
+    })
+    const setSessionModel = vi
+      .spyOn(useSessionStore.getState(), 'setSessionModel')
+      .mockResolvedValue(undefined)
+
+    await useSessionStore.getState().applyModeDefaultModel('session-1', 'plan')
+
+    expect(setSessionModel).not.toHaveBeenCalled()
+  })
+
   test('does not change terminal session models', async () => {
     seedSession('terminal')
     seedSettings(claudePlanDefault)


### PR DESCRIPTION
## Summary
- Added custom provider model declarations and effort metadata, with validation helpers shared across main and renderer code.
- Updated Claude CLI spawning to pass provider-declared `--model` and `--effort` only when the session matches a declared slug, while preserving legacy custom-provider behavior.
- Added UI support for selecting custom provider models in worktree launches, handoff flows, and settings, including per-model effort chips and inline validation.
- Expanded tests across spawn logic, custom provider settings, and shared type helpers to cover declared models, blank slugs, duplicates, and orphaned provider sessions.

## Testing
- `vitest src/main/services/__tests__/claude-cli-spawner.test.ts`
- `vitest src/renderer/src/components/settings/SettingsCustomProviders.test.tsx`
- `vitest src/shared/types/custom-provider.test.ts`
- `vitest src/renderer/src/components/session-11/apply-mode-default-model.test.ts`
- Not run: full app test suite or manual UI verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude CLI spawn argv and session model stamping for custom-provider sessions; edge-case guards are extensive but wrong slug/effort handling could still mis-route spawns or badges.
> 
> **Overview**
> Custom Claude providers can now declare **models** (name, slug, optional efforts) in settings. When a session uses a declared slug with `providerID: 'custom'`, Hive appends **`--model`** and **`--effort`** after the provider command so user picks override alias-baked flags; legacy behavior remains when no models are declared or the session still carries stock Anthropic stamps.
> 
> **Spawn & main:** `buildClaudeCliPtySpawn` and the PTY bridge load `customProviderModels` and only forward flags when the session matches a declared slug; orphaned custom sessions (deleted provider) and proxy slugs are blocked from leaking into stock Claude normalization.
> 
> **UI & launch:** New `CustomProviderModelSelector`, settings model editor with effort chips and slug validation, and wiring through worktree picker, handoff, ticket launch, and badges so launches and handoffs resolve against declared lists instead of hiding the model picker entirely.
> 
> **Session safety:** Handoff overrides, session creation, mode defaults, and global/worktree model persistence ignore or degrade stale stock stamps and custom slugs so proxy models do not become default Claude settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad947dac91890ff0fd1fbe67bd44868c27f01b9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->