### PR TITLE
Pin selected project combos in Recent Connections

### DIFF
--- a/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
+++ b/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
@@ -464,8 +464,8 @@ export function RecentConnectionsDialog({
                     <button
                       className={cn(
                         'flex flex-col w-full px-3 py-2 text-sm text-left',
-                        'hover:bg-accent/50 transition-colors',
-                        selectedId === SELECTED_COMBO_ID && 'bg-accent/30'
+                        'bg-primary/10 hover:bg-primary/15 transition-colors',
+                        selectedId === SELECTED_COMBO_ID && 'bg-primary/20'
                       )}
                       onClick={() => setSelectedId(SELECTED_COMBO_ID)}
                       data-testid="recent-connection-row-selected-combo"
@@ -507,7 +507,13 @@ export function RecentConnectionsDialog({
                             className={cn(
                               'flex flex-col w-full px-3 py-2 text-sm text-left',
                               'hover:bg-accent/50 transition-colors',
-                              selectedId === entry.id && 'bg-accent/30'
+                              selectedId === entry.id && 'bg-accent/30',
+                              // The pinned exact-selection entry is special in the
+                              // same way as the synthetic row -- tint it to match
+                              entry.id === exactSelectionEntry?.id &&
+                                (selectedId === entry.id
+                                  ? 'bg-primary/20 hover:bg-primary/20'
+                                  : 'bg-primary/10 hover:bg-primary/15')
                             )}
                             onClick={() => setSelectedId(entry.id)}
                             data-testid={`recent-connection-row-${entry.id}`}

--- a/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
+++ b/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
@@ -30,6 +30,10 @@ interface RecentConnectionsDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
+// Row id for the pinned "create from selected projects" row, which has no
+// backing recent-connection entry.
+const SELECTED_COMBO_ID = '__selected-projects__'
+
 export function RecentConnectionsDialog({
   open,
   onOpenChange
@@ -149,13 +153,43 @@ export function RecentConnectionsDialog({
     )
   }, [entries, filter, selectedProjectIds])
 
+  // The recent connection whose project set is exactly the selection, if any
+  const exactSelectionEntry = useMemo(() => {
+    if (selectedProjects.length < 2) return null
+    return (
+      entries.find(
+        (entry) =>
+          entry.projects.length === selectedProjects.length &&
+          entry.projects.every((p) => selectedProjectIds.has(p.id))
+      ) ?? null
+    )
+  }, [entries, selectedProjects, selectedProjectIds])
+
+  // With 2+ projects selected, the first row is always exactly that combination:
+  // the matching recent entry pinned to the top (exempt from the text filter),
+  // or a synthetic row that creates a brand-new connection from the selection.
+  const showSelectionRow = selectedProjects.length >= 2 && !exactSelectionEntry
+
+  const displayEntries = useMemo(() => {
+    if (!exactSelectionEntry) return filteredEntries
+    return [
+      exactSelectionEntry,
+      ...filteredEntries.filter((entry) => entry.id !== exactSelectionEntry.id)
+    ]
+  }, [filteredEntries, exactSelectionEntry])
+
   // The Create handler resolves against `entries`, so a selected row hidden by
   // the filter would still be creatable invisibly -- drop the selection instead.
   useEffect(() => {
-    if (selectedId && !filteredEntries.some((entry) => entry.id === selectedId)) {
+    if (!selectedId) return
+    if (selectedId === SELECTED_COMBO_ID) {
+      if (!showSelectionRow) setSelectedId(null)
+      return
+    }
+    if (!displayEntries.some((entry) => entry.id === selectedId)) {
       setSelectedId(null)
     }
-  }, [filteredEntries, selectedId])
+  }, [displayEntries, selectedId, showSelectionRow])
 
   // Focus the note input when it appears (deferred to run after the context menu closes)
   useEffect(() => {
@@ -175,19 +209,22 @@ export function RecentConnectionsDialog({
   }, [])
 
   const handleCreate = useCallback(async () => {
-    const entry = entries.find((e) => e.id === selectedId)
-    if (!entry) return
+    const projects =
+      selectedId === SELECTED_COMBO_ID
+        ? selectedProjects
+        : entries.find((e) => e.id === selectedId)?.projects
+    if (!projects || projects.length === 0) return
 
     setIsCreating(true)
     try {
-      const id = await quickCreateConnection(entry.projects)
+      const id = await quickCreateConnection(projects)
       if (id) {
         onOpenChange(false)
       }
     } finally {
       setIsCreating(false)
     }
-  }, [entries, selectedId, quickCreateConnection, onOpenChange])
+  }, [entries, selectedId, selectedProjects, quickCreateConnection, onOpenChange])
 
   const persistNote = useCallback(async (entryId: string, raw: string | null) => {
     const normalized = raw && raw.trim() ? raw.trim() : null
@@ -414,7 +451,7 @@ export function RecentConnectionsDialog({
                   No recent connections yet. Create one by right-clicking a worktree and choosing
                   Connect to…
                 </div>
-              ) : filteredEntries.length === 0 ? (
+              ) : displayEntries.length === 0 && !showSelectionRow ? (
                 <div
                   className="px-4 py-8 text-center text-sm text-muted-foreground"
                   data-testid="recent-connections-no-match"
@@ -423,7 +460,25 @@ export function RecentConnectionsDialog({
                 </div>
               ) : (
                 <div className="py-1">
-                  {filteredEntries.map((entry) =>
+                  {showSelectionRow && (
+                    <button
+                      className={cn(
+                        'flex flex-col w-full px-3 py-2 text-sm text-left',
+                        'hover:bg-accent/50 transition-colors',
+                        selectedId === SELECTED_COMBO_ID && 'bg-accent/30'
+                      )}
+                      onClick={() => setSelectedId(SELECTED_COMBO_ID)}
+                      data-testid="recent-connection-row-selected-combo"
+                    >
+                      <span className="truncate">
+                        {selectedProjects.map((p) => p.name).join(' + ')}
+                      </span>
+                      <span className="text-xs text-muted-foreground truncate">
+                        New connection from selected projects
+                      </span>
+                    </button>
+                  )}
+                  {displayEntries.map((entry) =>
                     editingNoteId === entry.id ? (
                       <div
                         key={entry.id}

--- a/src/renderer/src/components/connections/__tests__/RecentConnectionsDialog.test.tsx
+++ b/src/renderer/src/components/connections/__tests__/RecentConnectionsDialog.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { RecentConnectionsDialog } from '../RecentConnectionsDialog'
+import { useConnectionStore } from '@/stores/useConnectionStore'
 import type { RecentConnectionEntry } from '@shared/types/connection'
 
 vi.mock('@/api/connection-api', () => ({
@@ -151,5 +152,95 @@ describe('RecentConnectionsDialog project filter panel', () => {
     expect(screen.getByTestId('recent-connection-row-e5')).toBeInTheDocument()
     expect(screen.queryByTestId('recent-connection-row-e1')).not.toBeInTheDocument()
     expect(screen.queryByTestId('recent-connection-row-e2')).not.toBeInTheDocument()
+  })
+})
+
+describe('RecentConnectionsDialog pinned selection row', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not show the selection row with fewer than 2 projects selected', async () => {
+    await renderDialog()
+
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-a'))
+
+    expect(screen.queryByTestId('recent-connection-row-selected-combo')).not.toBeInTheDocument()
+  })
+
+  it('pins a synthetic row with exactly the selected projects when no entry matches', async () => {
+    // alpha+beta+gamma exists in no entry
+    await renderDialog()
+
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-a'))
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-b'))
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-c'))
+
+    const combo = screen.getByTestId('recent-connection-row-selected-combo')
+    expect(combo).toHaveTextContent('alpha-service + beta-web + gamma-api')
+    expect(combo).toHaveTextContent('New connection from selected projects')
+    // No entry contains all three, but the no-match empty state must not replace the row
+    expect(screen.queryByTestId('recent-connections-no-match')).not.toBeInTheDocument()
+  })
+
+  it('creates a new connection from the synthetic selection row', async () => {
+    const quickCreateConnection = vi.fn().mockResolvedValue('conn-1')
+    useConnectionStore.setState({ quickCreateConnection } as never)
+    const onOpenChange = vi.fn()
+
+    vi.mocked(connectionApi.getRecentConnections).mockResolvedValue({
+      success: true,
+      entries
+    })
+    render(<RecentConnectionsDialog open onOpenChange={onOpenChange} />)
+    await waitFor(() =>
+      expect(screen.queryByTestId('recent-connections-loading')).not.toBeInTheDocument()
+    )
+
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-a'))
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-b'))
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-c'))
+    await userEvent.click(screen.getByTestId('recent-connection-row-selected-combo'))
+    await userEvent.click(screen.getByTestId('recent-connections-create-button'))
+
+    await waitFor(() => expect(quickCreateConnection).toHaveBeenCalledWith([alpha, beta, gamma]))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('pins the exact matching entry first instead of a synthetic row', async () => {
+    await renderDialog()
+
+    // beta+gamma matches e3, which normally sorts last
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-b'))
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-c'))
+
+    expect(screen.queryByTestId('recent-connection-row-selected-combo')).not.toBeInTheDocument()
+    const rows = screen.getAllByTestId(/^recent-connection-row-/)
+    expect(rows[0]).toHaveAttribute('data-testid', 'recent-connection-row-e3')
+  })
+
+  it('keeps the pinned exact match visible even when the text filter excludes it', async () => {
+    await renderDialog()
+
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-b'))
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-c'))
+    await userEvent.type(screen.getByTestId('recent-connections-filter'), 'zzz-no-match')
+
+    expect(screen.getByTestId('recent-connection-row-e3')).toBeInTheDocument()
+  })
+
+  it('drops the synthetic selection when the combination gains an exact match', async () => {
+    await renderDialog()
+
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-a'))
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-b'))
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-c'))
+    await userEvent.click(screen.getByTestId('recent-connection-row-selected-combo'))
+
+    // Deselect gamma: alpha+beta matches e1 exactly, so the synthetic row vanishes
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-c'))
+
+    expect(screen.queryByTestId('recent-connection-row-selected-combo')).not.toBeInTheDocument()
+    expect(screen.getByTestId('recent-connections-create-button')).toBeDisabled()
   })
 })


### PR DESCRIPTION
## Summary
- Pin the currently selected project combination to the top of Recent Connections when 2+ projects are selected.
- Show a synthetic “new connection from selected projects” row when no exact recent entry matches the selection.
- Keep an exact matching recent connection row visible even when the text filter would otherwise hide it.
- Add coverage for selection-row visibility, create behavior, exact-match pinning, and filter interactions.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in the recent-connections dialog with existing `quickCreateConnection`; behavior is covered by new unit tests.
> 
> **Overview**
> When **two or more projects** are selected in Recent Connections, the dialog **pins that exact combination at the top** of the list.
> 
> If there is **no matching recent entry**, it shows a **synthetic row** (“New connection from selected projects”) that **Create** uses to call `quickCreateConnection` with the current selection. If a **recent entry matches exactly**, that row is **pinned first** (with matching highlight) **instead of** the synthetic row, and it **stays visible even when the text filter would hide it**.
> 
> Selection is **cleared** when the pinned/synthetic row is no longer valid (e.g. deselecting projects so an exact match appears and the synthetic row goes away). Tests cover visibility, create flow, exact-match pinning, filter behavior, and selection cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e7f976d94d074cc2d3cf44cb18fc33784ab02e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->