### PR TITLE
Add one-time Hive account sharing via deep links

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -7,6 +7,12 @@ files:
   - out/**/*
   - resources/**/*
 
+# hive:// deep links (account share links etc.)
+protocols:
+  - name: Hive
+    schemes:
+      - hive
+
 # Native .node binaries cannot be loaded from inside an ASAR archive.
 # This extracts them to app.asar.unpacked/ at build time.
 asarUnpack:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -136,8 +136,12 @@ import {
   readWarnBeforeQuitting
 } from './quit-confirmation'
 import { emitSettingsUpdated } from './services/settings-events'
+import { markDeepLinksReady, registerDeepLinkHandling } from './services/deep-link-service'
 
 const log = createLogger({ component: 'Main' })
+
+// Must be wired before app 'ready' so cold-start hive:// links are captured.
+registerDeepLinkHandling()
 
 // Track custom commands file mtime for change detection
 let lastKnownMtime: number | null = null
@@ -789,6 +793,9 @@ app
       // Initialize auto-updater after backend event publishing is available.
       updaterService.init()
     }
+
+    // Backend is up — deep links can now import accounts and publish events.
+    markDeepLinksReady()
 
     app.on('activate', function () {
       ensureDockVisible('activate')

--- a/src/main/services/__tests__/account-share-service.test.ts
+++ b/src/main/services/__tests__/account-share-service.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decryptSharePayload,
+  encryptSharePayload,
+  isShareAccountLink
+} from '../account-share-service'
+import { buildShareAccountLink } from '../../../shared/account-share-link'
+
+describe('share payload crypto', () => {
+  it('round-trips a payload', () => {
+    const plaintext = JSON.stringify({ v: 1, provider: 'anthropic', email: 'a@b.com' })
+    const { key, ciphertext } = encryptSharePayload(plaintext)
+    expect(decryptSharePayload(key, ciphertext)).toBe(plaintext)
+  })
+
+  it('produces a different key and ciphertext every time', () => {
+    const a = encryptSharePayload('same input')
+    const b = encryptSharePayload('same input')
+    expect(a.key).not.toBe(b.key)
+    expect(a.ciphertext).not.toBe(b.ciphertext)
+  })
+
+  it('rejects a wrong key', () => {
+    const { ciphertext } = encryptSharePayload('secret')
+    const { key: otherKey } = encryptSharePayload('other')
+    expect(() => decryptSharePayload(otherKey, ciphertext)).toThrow()
+  })
+
+  it('rejects tampered ciphertext', () => {
+    const { key, ciphertext } = encryptSharePayload('secret')
+    const raw = Buffer.from(ciphertext, 'base64')
+    raw[raw.length - 1] ^= 0xff
+    expect(() => decryptSharePayload(key, raw.toString('base64'))).toThrow()
+  })
+
+  it('rejects a malformed key', () => {
+    const { ciphertext } = encryptSharePayload('secret')
+    expect(() => decryptSharePayload('short', ciphertext)).toThrow(
+      'Share link has an invalid encryption key'
+    )
+  })
+})
+
+describe('share account links', () => {
+  it('builds a link that parses back with the same parameters', () => {
+    const link = buildShareAccountLink({
+      serverUrl: 'https://hive.example.com/',
+      token: 'tok_123',
+      key: 'a-b_c'
+    })
+    expect(isShareAccountLink(link)).toBe(true)
+    const parsed = new URL(link)
+    expect(parsed.searchParams.get('server')).toBe('https://hive.example.com')
+    expect(parsed.searchParams.get('token')).toBe('tok_123')
+    expect(parsed.searchParams.get('key')).toBe('a-b_c')
+  })
+
+  it('rejects non-share links', () => {
+    expect(isShareAccountLink('https://example.com')).toBe(false)
+    expect(isShareAccountLink('hive://something-else?token=x')).toBe(false)
+    expect(isShareAccountLink('not a url')).toBe(false)
+  })
+})

--- a/src/main/services/__tests__/account-share-service.test.ts
+++ b/src/main/services/__tests__/account-share-service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   decryptSharePayload,
   encryptSharePayload,
+  importAccountShareFromLink,
   isShareAccountLink
 } from '../account-share-service'
 import { buildShareAccountLink } from '../../../shared/account-share-link'
@@ -59,5 +60,16 @@ describe('share account links', () => {
     expect(isShareAccountLink('https://example.com')).toBe(false)
     expect(isShareAccountLink('hive://something-else?token=x')).toBe(false)
     expect(isShareAccountLink('not a url')).toBe(false)
+  })
+
+  it('rejects a truncated key before claiming (the claim burns the one-time token)', async () => {
+    const link = buildShareAccountLink({
+      serverUrl: 'https://hive.example.com',
+      token: 'tok_123',
+      key: 'too-short'
+    })
+    await expect(importAccountShareFromLink(link)).rejects.toThrow(
+      'Share link has an invalid encryption key'
+    )
   })
 })

--- a/src/main/services/account-share-service.ts
+++ b/src/main/services/account-share-service.ts
@@ -28,6 +28,7 @@ import {
   type CodexAuth
 } from './account-store-codex'
 import { createLogger } from './logger'
+import { emitSettingsUpdated } from './settings-events'
 import { SHARE_ACCOUNT_LINK_HOST } from '../../shared/account-share-link'
 import { APP_SETTINGS_DB_KEY } from '../../shared/types/settings'
 import type { UsageProvider } from '@shared/types/usage'
@@ -114,6 +115,13 @@ export async function exportAccountShare(accountId: string): Promise<ExportedAcc
 export interface ImportedAccountShare {
   provider: UsageProvider
   email: string
+  /**
+   * Rotated Hive Enterprise token from the claim response, if the server
+   * issued one. Already persisted to the DB; the renderer must also apply it
+   * to its in-memory settings store (its full-blob saves would otherwise
+   * write the stale token back).
+   */
+  refreshedAuthToken?: string
 }
 
 export function isShareAccountLink(url: string): boolean {
@@ -165,11 +173,34 @@ const CLAIM_ACCOUNT_SHARE_MUTATION = /* GraphQL */ `
   }
 `
 
+/**
+ * Mirror requestWithRefresh in the renderer's hive-enterprise client: the
+ * server may rotate an about-to-expire token on any authenticated call via
+ * the `x-hive-refreshed-token` response header, and dropping it would leave
+ * a stale token that fails later requests. Persisted straight to the
+ * settings blob (this runs outside the renderer), then pushed to a live
+ * renderer via the settings-updated channel.
+ */
+function persistRefreshedHiveAuthToken(refreshedToken: string): void {
+  try {
+    const db = getDatabase()
+    const raw = db.getSetting(APP_SETTINGS_DB_KEY)
+    const settings = raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
+    settings.hiveAuthToken = refreshedToken
+    db.setSetting(APP_SETTINGS_DB_KEY, JSON.stringify(settings))
+    emitSettingsUpdated({ hiveAuthToken: refreshedToken })
+  } catch (error) {
+    log.warn('Failed to persist refreshed Hive Enterprise token', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
 async function claimFromServer(
   serverUrl: string,
   token: string,
   authToken: string
-): Promise<string> {
+): Promise<{ encryptedPayload: string; refreshedAuthToken: string | null }> {
   const endpoint = `${serverUrl.replace(/\/+$/, '')}/api/graphql`
   let response: Response
   try {
@@ -200,7 +231,11 @@ async function claimFromServer(
   if (!claimed) {
     throw new Error('This share link was already used or has expired')
   }
-  return claimed.encryptedPayload
+  const refreshedAuthToken = response.headers.get('x-hive-refreshed-token')
+  return {
+    encryptedPayload: claimed.encryptedPayload,
+    refreshedAuthToken: refreshedAuthToken && refreshedAuthToken !== authToken ? refreshedAuthToken : null
+  }
 }
 
 function parseSharePayload(json: string): SharePayloadV1 {
@@ -252,8 +287,11 @@ export async function importAccountShareFromLink(url: string): Promise<ImportedA
     )
   }
 
-  const encryptedPayload = await claimFromServer(connection.serverUrl, token, connection.authToken)
-  const payload = parseSharePayload(decryptSharePayload(key, encryptedPayload))
+  const claimed = await claimFromServer(connection.serverUrl, token, connection.authToken)
+  if (claimed.refreshedAuthToken) {
+    persistRefreshedHiveAuthToken(claimed.refreshedAuthToken)
+  }
+  const payload = parseSharePayload(decryptSharePayload(key, claimed.encryptedPayload))
 
   if (payload.provider === 'anthropic') {
     if (!payload.claude?.blobJson) throw new Error('Share payload is missing Claude credentials')
@@ -267,5 +305,9 @@ export async function importAccountShareFromLink(url: string): Promise<ImportedA
   }
 
   log.info('Imported shared account', { provider: payload.provider, email: payload.email })
-  return { provider: payload.provider, email: payload.email }
+  return {
+    provider: payload.provider,
+    email: payload.email,
+    ...(claimed.refreshedAuthToken ? { refreshedAuthToken: claimed.refreshedAuthToken } : {})
+  }
 }

--- a/src/main/services/account-share-service.ts
+++ b/src/main/services/account-share-service.ts
@@ -213,6 +213,9 @@ function parseSharePayload(json: string): SharePayloadV1 {
   if (payload.v !== 1 || !payload.email) {
     throw new Error('Unsupported share payload')
   }
+  if (payload.provider !== 'anthropic' && payload.provider !== 'openai') {
+    throw new Error(`Unknown share provider: ${String(payload.provider)}`)
+  }
   return payload
 }
 
@@ -255,14 +258,12 @@ export async function importAccountShareFromLink(url: string): Promise<ImportedA
   if (payload.provider === 'anthropic') {
     if (!payload.claude?.blobJson) throw new Error('Share payload is missing Claude credentials')
     await addClaudeAccount(payload.email, payload.claude.uuid ?? '', payload.claude.blobJson)
-  } else if (payload.provider === 'openai') {
+  } else {
     const tokens = payload.codex?.auth?.tokens
     if (!tokens?.access_token || !tokens.refresh_token || typeof tokens.id_token !== 'string') {
       throw new Error('Share payload is missing OpenAI credentials')
     }
     await addCodexAccount(tokens.id_token, tokens.access_token, tokens.refresh_token)
-  } else {
-    throw new Error(`Unknown share provider: ${String(payload.provider)}`)
   }
 
   log.info('Imported shared account', { provider: payload.provider, email: payload.email })

--- a/src/main/services/account-share-service.ts
+++ b/src/main/services/account-share-service.ts
@@ -1,0 +1,214 @@
+/**
+ * Account share links — export a saved Claude/Codex account as a one-time
+ * `hive://share-account` link, and import one on another machine.
+ *
+ * Security model: the account credential blob is encrypted here (AES-256-GCM)
+ * with a random key that only ever travels inside the link itself. The
+ * hive-enterprise server stores just the ciphertext behind an unguessable
+ * one-time token and deletes it on claim — it can never read the credentials.
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
+import { getDatabase } from '../db'
+import {
+  addClaudeAccount,
+  listClaudeAccounts,
+  readClaudeEffectiveBlob
+} from './account-store-claude'
+import {
+  addCodexAccount,
+  listCodexAccounts,
+  readCodexEffectiveAuth,
+  type CodexAuth
+} from './account-store-codex'
+import { createLogger } from './logger'
+import { SHARE_ACCOUNT_LINK_HOST } from '../../shared/account-share-link'
+import type { UsageProvider } from '@shared/types/usage'
+
+const log = createLogger({ component: 'AccountShareService' })
+
+interface SharePayloadV1 {
+  v: 1
+  provider: UsageProvider
+  email: string
+  /** anthropic: the raw Keychain credential blob JSON + identity uuid. */
+  claude?: { uuid: string; blobJson: string }
+  /** openai: the full auth.json snapshot. */
+  codex?: { auth: CodexAuth }
+}
+
+// ── AES-256-GCM link crypto ──────────────────────────────────────────
+// Ciphertext layout: base64( iv(12) || authTag(16) || data ). Key: base64url(32).
+
+export function encryptSharePayload(plaintext: string): { key: string; ciphertext: string } {
+  const key = randomBytes(32)
+  const iv = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', key, iv)
+  const data = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()])
+  const ciphertext = Buffer.concat([iv, cipher.getAuthTag(), data]).toString('base64')
+  return { key: key.toString('base64url'), ciphertext }
+}
+
+export function decryptSharePayload(keyB64url: string, ciphertextB64: string): string {
+  const key = Buffer.from(keyB64url, 'base64url')
+  if (key.length !== 32) throw new Error('Share link has an invalid encryption key')
+  const raw = Buffer.from(ciphertextB64, 'base64')
+  if (raw.length < 12 + 16 + 1) throw new Error('Share payload is malformed')
+  const decipher = createDecipheriv('aes-256-gcm', key, raw.subarray(0, 12))
+  decipher.setAuthTag(raw.subarray(12, 28))
+  return Buffer.concat([decipher.update(raw.subarray(28)), decipher.final()]).toString('utf-8')
+}
+
+// ── Export (source machine) ──────────────────────────────────────────
+
+export interface ExportedAccountShare {
+  provider: UsageProvider
+  email: string
+  /** AES-256-GCM ciphertext of the share payload; safe to hand to the server. */
+  encryptedPayload: string
+  /** base64url key for the link. NEVER send this to the server. */
+  key: string
+}
+
+/**
+ * Read a saved account's effective credentials and seal them for sharing.
+ * The caller uploads `encryptedPayload` to hive-enterprise and builds the
+ * link from the returned token + `key`.
+ */
+export async function exportAccountShare(accountId: string): Promise<ExportedAccountShare> {
+  const row = getDatabase().getSavedUsageAccountById(accountId)
+  if (!row) throw new Error('Account not found')
+
+  let payload: SharePayloadV1
+  if (row.provider === 'anthropic') {
+    const email = row.email.toLowerCase()
+    const account = (await listClaudeAccounts()).find((a) => a.email === email)
+    if (!account) throw new Error('Account is no longer in the Claude account store')
+    const blob = await readClaudeEffectiveBlob(account.num, account.email)
+    if (!blob) throw new Error('No stored credentials for this Claude account')
+    payload = { v: 1, provider: 'anthropic', email, claude: { uuid: account.uuid, blobJson: blob.raw } }
+  } else {
+    const email = row.email.toLowerCase()
+    const account = (await listCodexAccounts()).find((a) => a.email === email)
+    if (!account) throw new Error('Account is no longer in the Codex account store')
+    const auth = await readCodexEffectiveAuth(account.accountKey)
+    if (!auth?.tokens?.id_token || !auth.tokens.access_token || !auth.tokens.refresh_token) {
+      throw new Error('No complete credentials for this OpenAI account')
+    }
+    payload = { v: 1, provider: 'openai', email, codex: { auth } }
+  }
+
+  const { key, ciphertext } = encryptSharePayload(JSON.stringify(payload))
+  return { provider: payload.provider, email: payload.email, encryptedPayload: ciphertext, key }
+}
+
+// ── Import (target machine) ──────────────────────────────────────────
+
+export interface ImportedAccountShare {
+  provider: UsageProvider
+  email: string
+}
+
+export function isShareAccountLink(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'hive:' && parsed.host === SHARE_ACCOUNT_LINK_HOST
+  } catch {
+    return false
+  }
+}
+
+const CLAIM_ACCOUNT_SHARE_MUTATION = /* GraphQL */ `
+  mutation ClaimAccountShare($token: String!) {
+    claimAccountShare(token: $token) {
+      provider
+      encryptedPayload
+    }
+  }
+`
+
+async function claimFromServer(serverUrl: string, token: string): Promise<string> {
+  const endpoint = `${serverUrl.replace(/\/+$/, '')}/api/graphql`
+  let response: Response
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: CLAIM_ACCOUNT_SHARE_MUTATION, variables: { token } })
+    })
+  } catch (error) {
+    throw new Error(
+      `Could not reach ${serverUrl}: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+  if (!response.ok) {
+    throw new Error(`Share server responded with HTTP ${response.status}`)
+  }
+  const body = (await response.json()) as {
+    data?: { claimAccountShare?: { provider: string; encryptedPayload: string } | null }
+    errors?: Array<{ message?: string }>
+  }
+  if (body.errors?.length) {
+    throw new Error(body.errors[0]?.message ?? 'Share claim failed')
+  }
+  const claimed = body.data?.claimAccountShare
+  if (!claimed) {
+    throw new Error('This share link was already used or has expired')
+  }
+  return claimed.encryptedPayload
+}
+
+function parseSharePayload(json: string): SharePayloadV1 {
+  let payload: SharePayloadV1
+  try {
+    payload = JSON.parse(json) as SharePayloadV1
+  } catch {
+    throw new Error('Decrypted share payload is not valid JSON')
+  }
+  if (payload.v !== 1 || !payload.email) {
+    throw new Error('Unsupported share payload')
+  }
+  return payload
+}
+
+/**
+ * Claim a share link end-to-end: fetch the one-time ciphertext from the
+ * server in the link, decrypt it with the key from the link, and register
+ * the account in the local Claude/Codex store. The server row is deleted by
+ * the claim itself, so a second use of the same link fails.
+ */
+export async function importAccountShareFromLink(url: string): Promise<ImportedAccountShare> {
+  let parsed: URL
+  try {
+    parsed = new URL(url.trim())
+  } catch {
+    throw new Error('Not a valid share link')
+  }
+  if (parsed.protocol !== 'hive:' || parsed.host !== SHARE_ACCOUNT_LINK_HOST) {
+    throw new Error('Not a Hive account share link')
+  }
+  const serverUrl = parsed.searchParams.get('server')
+  const token = parsed.searchParams.get('token')
+  const key = parsed.searchParams.get('key')
+  if (!serverUrl || !token || !key) {
+    throw new Error('Share link is missing required parameters')
+  }
+
+  const encryptedPayload = await claimFromServer(serverUrl, token)
+  const payload = parseSharePayload(decryptSharePayload(key, encryptedPayload))
+
+  if (payload.provider === 'anthropic') {
+    if (!payload.claude?.blobJson) throw new Error('Share payload is missing Claude credentials')
+    await addClaudeAccount(payload.email, payload.claude.uuid ?? '', payload.claude.blobJson)
+  } else if (payload.provider === 'openai') {
+    const tokens = payload.codex?.auth?.tokens
+    if (!tokens?.access_token || !tokens.refresh_token || typeof tokens.id_token !== 'string') {
+      throw new Error('Share payload is missing OpenAI credentials')
+    }
+    await addCodexAccount(tokens.id_token, tokens.access_token, tokens.refresh_token)
+  } else {
+    throw new Error(`Unknown share provider: ${String(payload.provider)}`)
+  }
+
+  log.info('Imported shared account', { provider: payload.provider, email: payload.email })
+  return { provider: payload.provider, email: payload.email }
+}

--- a/src/main/services/account-share-service.ts
+++ b/src/main/services/account-share-service.ts
@@ -6,6 +6,13 @@
  * with a random key that only ever travels inside the link itself. The
  * hive-enterprise server stores just the ciphertext behind an unguessable
  * one-time token and deletes it on claim — it can never read the credentials.
+ *
+ * The whole flow requires a connected Hive Enterprise account on BOTH sides:
+ * creating a share needs the renderer's authenticated GraphQL client, and
+ * claiming (below) requires this machine to be logged in to the SAME server
+ * the link points at — the claim mutation itself is authenticated, and the
+ * server-match check ensures our JWT is never sent to a foreign host named
+ * by a crafted link.
  */
 import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
 import { getDatabase } from '../db'
@@ -22,6 +29,7 @@ import {
 } from './account-store-codex'
 import { createLogger } from './logger'
 import { SHARE_ACCOUNT_LINK_HOST } from '../../shared/account-share-link'
+import { APP_SETTINGS_DB_KEY } from '../../shared/types/settings'
 import type { UsageProvider } from '@shared/types/usage'
 
 const log = createLogger({ component: 'AccountShareService' })
@@ -117,6 +125,37 @@ export function isShareAccountLink(url: string): boolean {
   }
 }
 
+function normalizeServerUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '').toLowerCase()
+}
+
+/**
+ * This machine's Hive Enterprise connection, read from the persisted app
+ * settings (the renderer's settings store writes them to the same DB).
+ * Throws when the machine is not logged in — importing a shared account is
+ * only available with a connected enterprise account.
+ */
+function readHiveEnterpriseConnection(): { serverUrl: string; authToken: string } {
+  let settings: { hiveEnterpriseServerUrl?: unknown; hiveAuthToken?: unknown } = {}
+  try {
+    const raw = getDatabase().getSetting(APP_SETTINGS_DB_KEY)
+    if (raw) settings = JSON.parse(raw) as typeof settings
+  } catch (error) {
+    log.warn('Failed to read app settings for share import', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+  const serverUrl =
+    typeof settings.hiveEnterpriseServerUrl === 'string' ? settings.hiveEnterpriseServerUrl : ''
+  const authToken = typeof settings.hiveAuthToken === 'string' ? settings.hiveAuthToken : ''
+  if (!serverUrl || !authToken) {
+    throw new Error(
+      'This computer is not connected to Hive Enterprise. Sign in under Settings → Hive Enterprise, then try the share link again.'
+    )
+  }
+  return { serverUrl, authToken }
+}
+
 const CLAIM_ACCOUNT_SHARE_MUTATION = /* GraphQL */ `
   mutation ClaimAccountShare($token: String!) {
     claimAccountShare(token: $token) {
@@ -126,13 +165,20 @@ const CLAIM_ACCOUNT_SHARE_MUTATION = /* GraphQL */ `
   }
 `
 
-async function claimFromServer(serverUrl: string, token: string): Promise<string> {
+async function claimFromServer(
+  serverUrl: string,
+  token: string,
+  authToken: string
+): Promise<string> {
   const endpoint = `${serverUrl.replace(/\/+$/, '')}/api/graphql`
   let response: Response
   try {
     response = await fetch(endpoint, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${authToken}`
+      },
       body: JSON.stringify({ query: CLAIM_ACCOUNT_SHARE_MUTATION, variables: { token } })
     })
   } catch (error) {
@@ -193,7 +239,17 @@ export async function importAccountShareFromLink(url: string): Promise<ImportedA
     throw new Error('Share link is missing required parameters')
   }
 
-  const encryptedPayload = await claimFromServer(serverUrl, token)
+  // Only claim against the enterprise server this machine is logged in to.
+  // Besides enforcing "share links need enterprise set up", this guarantees
+  // the auth token below is never sent to a host a crafted link chose.
+  const connection = readHiveEnterpriseConnection()
+  if (normalizeServerUrl(serverUrl) !== normalizeServerUrl(connection.serverUrl)) {
+    throw new Error(
+      `This share link is for ${serverUrl}, but this computer is connected to ${connection.serverUrl}.`
+    )
+  }
+
+  const encryptedPayload = await claimFromServer(connection.serverUrl, token, connection.authToken)
   const payload = parseSharePayload(decryptSharePayload(key, encryptedPayload))
 
   if (payload.provider === 'anthropic') {

--- a/src/main/services/account-share-service.ts
+++ b/src/main/services/account-share-service.ts
@@ -57,9 +57,14 @@ export function encryptSharePayload(plaintext: string): { key: string; ciphertex
   return { key: key.toString('base64url'), ciphertext }
 }
 
-export function decryptSharePayload(keyB64url: string, ciphertextB64: string): string {
+function decodeShareKey(keyB64url: string): Buffer {
   const key = Buffer.from(keyB64url, 'base64url')
   if (key.length !== 32) throw new Error('Share link has an invalid encryption key')
+  return key
+}
+
+export function decryptSharePayload(keyB64url: string, ciphertextB64: string): string {
+  const key = decodeShareKey(keyB64url)
   const raw = Buffer.from(ciphertextB64, 'base64')
   if (raw.length < 12 + 16 + 1) throw new Error('Share payload is malformed')
   const decipher = createDecipheriv('aes-256-gcm', key, raw.subarray(0, 12))
@@ -276,6 +281,9 @@ export async function importAccountShareFromLink(url: string): Promise<ImportedA
   if (!serverUrl || !token || !key) {
     throw new Error('Share link is missing required parameters')
   }
+  // Claiming burns the one-time token, so reject a damaged/truncated key
+  // BEFORE the claim — otherwise a bad paste destroys the share for nothing.
+  decodeShareKey(key)
 
   // Only claim against the enterprise server this machine is logged in to.
   // Besides enforcing "share links need enterprise set up", this guarantees

--- a/src/main/services/deep-link-service.ts
+++ b/src/main/services/deep-link-service.ts
@@ -1,0 +1,86 @@
+/**
+ * hive:// deep link handling. Currently the only route is
+ * `hive://share-account?...` (see account-share-service.ts).
+ *
+ * `open-url` can fire before the app (and the local backend) is ready, so
+ * links are queued until index.ts calls `markDeepLinksReady()`.
+ */
+import { app, Notification } from 'electron'
+import { resolve } from 'path'
+import {
+  importAccountShareFromLink,
+  isShareAccountLink
+} from './account-share-service'
+import { publishDesktopBackendEvent } from '../desktop/backend-event-publisher'
+import { SHARED_ACCOUNT_IMPORTED_CHANNEL } from '../../shared/app-events'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'DeepLinkService' })
+
+let ready = false
+const pendingUrls: string[] = []
+
+/** Must run before app 'ready' so a cold-start open-url is not missed. */
+export function registerDeepLinkHandling(): void {
+  // In dev (`electron .`) the protocol must be bound to the electron binary
+  // plus the app path, otherwise macOS routes hive:// to nothing.
+  if (process.defaultApp) {
+    if (process.argv.length >= 2) {
+      app.setAsDefaultProtocolClient('hive', process.execPath, [resolve(process.argv[1])])
+    }
+  } else {
+    app.setAsDefaultProtocolClient('hive')
+  }
+
+  app.on('open-url', (event, url) => {
+    event.preventDefault()
+    if (!ready) {
+      pendingUrls.push(url)
+      return
+    }
+    void handleDeepLink(url)
+  })
+}
+
+/** Flush links that arrived before the backend was up. */
+export function markDeepLinksReady(): void {
+  ready = true
+  const queued = pendingUrls.splice(0, pendingUrls.length)
+  for (const url of queued) {
+    void handleDeepLink(url)
+  }
+}
+
+function notify(title: string, body: string): void {
+  try {
+    if (Notification.isSupported()) {
+      new Notification({ title, body }).show()
+    }
+  } catch (error) {
+    log.warn('Failed to show deep-link notification', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+async function handleDeepLink(url: string): Promise<void> {
+  if (!isShareAccountLink(url)) {
+    log.warn('Ignoring unrecognized deep link', { url: url.slice(0, 64) })
+    return
+  }
+
+  log.info('Handling account share deep link')
+  try {
+    const result = await importAccountShareFromLink(url)
+    const providerLabel = result.provider === 'anthropic' ? 'Claude' : 'OpenAI'
+    notify('Account imported', `${result.email} (${providerLabel}) was added to Hive.`)
+    void publishDesktopBackendEvent(SHARED_ACCOUNT_IMPORTED_CHANNEL, result)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log.error(
+      'Failed to import shared account from deep link',
+      error instanceof Error ? error : new Error(message)
+    )
+    notify('Account import failed', message)
+  }
+}

--- a/src/main/services/deep-link-service.ts
+++ b/src/main/services/deep-link-service.ts
@@ -74,7 +74,11 @@ async function handleDeepLink(url: string): Promise<void> {
     const result = await importAccountShareFromLink(url)
     const providerLabel = result.provider === 'anthropic' ? 'Claude' : 'OpenAI'
     notify('Account imported', `${result.email} (${providerLabel}) was added to Hive.`)
-    void publishDesktopBackendEvent(SHARED_ACCOUNT_IMPORTED_CHANNEL, result)
+    // Only provider/email — the result may also carry a rotated auth token.
+    void publishDesktopBackendEvent(SHARED_ACCOUNT_IMPORTED_CHANNEL, {
+      provider: result.provider,
+      email: result.email
+    })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     log.error(

--- a/src/renderer/src/api/account-api.ts
+++ b/src/renderer/src/api/account-api.ts
@@ -16,6 +16,8 @@ export interface ExportedAccountShare {
 export interface ImportedAccountShare {
   provider: UsageProvider
   email: string
+  /** Rotated Hive Enterprise token from the claim; apply it to the settings store. */
+  refreshedAuthToken?: string
 }
 
 export const accountApi = {

--- a/src/renderer/src/api/account-api.ts
+++ b/src/renderer/src/api/account-api.ts
@@ -3,6 +3,7 @@ import {
   SHARED_ACCOUNT_IMPORTED_CHANNEL,
   type SharedAccountImportedPayload
 } from '@shared/app-events'
+import type { ServerEvent } from '@shared/rpc/protocol'
 import { getRendererRpcClient } from './rpc-client'
 
 export interface ExportedAccountShare {
@@ -47,8 +48,8 @@ export const accountApi = {
   onSharedAccountImported: (
     callback: (payload: SharedAccountImportedPayload) => void
   ): (() => void) =>
-    getRendererRpcClient().subscribe(SHARED_ACCOUNT_IMPORTED_CHANNEL, (payload) => {
-      const data = payload as Partial<SharedAccountImportedPayload> | null
+    getRendererRpcClient().subscribe(SHARED_ACCOUNT_IMPORTED_CHANNEL, (event: ServerEvent) => {
+      const data = event.payload as Partial<SharedAccountImportedPayload> | null
       if (data && (data.provider === 'anthropic' || data.provider === 'openai')) {
         callback({ provider: data.provider, email: data.email ?? '' })
       }

--- a/src/renderer/src/api/account-api.ts
+++ b/src/renderer/src/api/account-api.ts
@@ -1,5 +1,21 @@
 import type { LoginStatusDTO, SavedAccountDTO, UsageProvider } from '@shared/types/usage'
+import {
+  SHARED_ACCOUNT_IMPORTED_CHANNEL,
+  type SharedAccountImportedPayload
+} from '@shared/app-events'
 import { getRendererRpcClient } from './rpc-client'
+
+export interface ExportedAccountShare {
+  provider: UsageProvider
+  email: string
+  encryptedPayload: string
+  key: string
+}
+
+export interface ImportedAccountShare {
+  provider: UsageProvider
+  email: string
+}
 
 export const accountApi = {
   getClaudeEmail: async (): Promise<string | null> =>
@@ -23,5 +39,18 @@ export const accountApi = {
   loginStatus: async (loginId: string): Promise<LoginStatusDTO> =>
     getRendererRpcClient().request<LoginStatusDTO>('accountOps.loginStatus', { loginId }),
   loginCancel: async (loginId: string): Promise<boolean> =>
-    getRendererRpcClient().request<boolean>('accountOps.loginCancel', { loginId })
+    getRendererRpcClient().request<boolean>('accountOps.loginCancel', { loginId }),
+  exportShare: async (accountId: string): Promise<ExportedAccountShare> =>
+    getRendererRpcClient().request<ExportedAccountShare>('accountOps.exportShare', { accountId }),
+  importShare: async (url: string): Promise<ImportedAccountShare> =>
+    getRendererRpcClient().request<ImportedAccountShare>('accountOps.importShare', { url }),
+  onSharedAccountImported: (
+    callback: (payload: SharedAccountImportedPayload) => void
+  ): (() => void) =>
+    getRendererRpcClient().subscribe(SHARED_ACCOUNT_IMPORTED_CHANNEL, (payload) => {
+      const data = payload as Partial<SharedAccountImportedPayload> | null
+      if (data && (data.provider === 'anthropic' || data.provider === 'openai')) {
+        callback({ provider: data.provider, email: data.email ?? '' })
+      }
+    })
 }

--- a/src/renderer/src/api/hive-enterprise/client.ts
+++ b/src/renderer/src/api/hive-enterprise/client.ts
@@ -1,6 +1,7 @@
 import { GraphQLClient } from 'graphql-request'
 import { useSettingsStore, type AppSettings } from '@/stores/useSettingsStore'
 import {
+  CreateAccountShareDocument,
   ListAccountMembersDocument,
   MeDocument,
   RecordPromptIdleDocument,
@@ -167,6 +168,28 @@ export async function fetchHiveAccountMembers(): Promise<
     console.warn('[HiveEnterprise] listAccountMembers failed:', error)
     return null
   }
+}
+
+export interface CreatedAccountShare {
+  token: string
+  expiresAt: string
+}
+
+/**
+ * Store an already-encrypted account payload as a one-time share on the
+ * hive-enterprise server. The encryption key must NOT be passed here — it
+ * belongs only in the generated hive:// link. Throws when the Hive Enterprise
+ * token is not configured (share links require a connected server).
+ */
+export async function createHiveAccountShare(
+  provider: 'anthropic' | 'openai',
+  encryptedPayload: string
+): Promise<CreatedAccountShare> {
+  const data = await requestWithRefresh<
+    { createAccountShare: CreatedAccountShare },
+    { provider: string; encryptedPayload: string }
+  >(CreateAccountShareDocument, { provider, encryptedPayload })
+  return data.createAccountShare
 }
 
 export async function completeHiveEnterpriseLogin(token: string): Promise<void> {

--- a/src/renderer/src/api/hive-enterprise/operations.ts
+++ b/src/renderer/src/api/hive-enterprise/operations.ts
@@ -55,6 +55,15 @@ export const ReportActiveAccountsDocument = /* GraphQL */ `
   }
 `
 
+export const CreateAccountShareDocument = /* GraphQL */ `
+  mutation HiveEnterpriseCreateAccountShare($provider: AccountProvider!, $encryptedPayload: String!) {
+    createAccountShare(provider: $provider, encryptedPayload: $encryptedPayload) {
+      token
+      expiresAt
+    }
+  }
+`
+
 export const ListAccountMembersDocument = /* GraphQL */ `
   query HiveEnterpriseListAccountMembers {
     listAccountMembers {

--- a/src/renderer/src/components/settings/SettingsAccounts.tsx
+++ b/src/renderer/src/components/settings/SettingsAccounts.tsx
@@ -206,7 +206,7 @@ function ProviderAccountsCard({ provider }: { provider: UsageProvider }): React.
                       variant="ghost"
                       size="icon"
                       className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                      onClick={() => handleShare(account)}
+                      onClick={() => void handleShare(account)}
                       disabled={sharingAccountId !== null}
                       aria-label={`Share ${account.email}`}
                       title="Share this account with another computer via a one-time link"

--- a/src/renderer/src/components/settings/SettingsAccounts.tsx
+++ b/src/renderer/src/components/settings/SettingsAccounts.tsx
@@ -364,6 +364,7 @@ function ProviderAccountsCard({ provider }: { provider: UsageProvider }): React.
 export function SettingsAccounts(): React.JSX.Element {
   const loadSavedAccounts = useUsageStore((s) => s.loadSavedAccounts)
   const fetchEmail = useAccountStore((s) => s.fetchEmail)
+  const hiveAuthToken = useSettingsStore((s) => s.hiveAuthToken)
   const [importOpen, setImportOpen] = useState(false)
   const [importUrl, setImportUrl] = useState('')
   const [importing, setImporting] = useState(false)
@@ -412,7 +413,7 @@ export function SettingsAccounts(): React.JSX.Element {
             Manage saved Claude and OpenAI accounts used for usage tracking and quick switching.
           </p>
         </div>
-        {isMac() && (
+        {isMac() && Boolean(hiveAuthToken) && (
           <Button
             variant="outline"
             size="sm"

--- a/src/renderer/src/components/settings/SettingsAccounts.tsx
+++ b/src/renderer/src/components/settings/SettingsAccounts.tsx
@@ -1,10 +1,24 @@
 import { useEffect, useState } from 'react'
-import { Loader2, Plus, RefreshCw, Repeat, Timer, Trash2 } from 'lucide-react'
+import { Link2, Loader2, Plus, RefreshCw, Repeat, Share2, Timer, Trash2 } from 'lucide-react'
 import { useAccountStore, useUsageStore } from '@/stores'
 import { useLoginStore } from '@/stores/useLoginStore'
 import { useAccountScheduleStore } from '@/stores/useAccountScheduleStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { accountApi } from '@/api/account-api'
+import { createHiveAccountShare } from '@/api/hive-enterprise/client'
+import { buildShareAccountLink } from '@shared/account-share-link'
+import { toast, clipboardToast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import {
   ScheduleSwitchForm,
@@ -21,7 +35,7 @@ import {
   AlertDialogTitle
 } from '@/components/ui/alert-dialog'
 import { isMac } from '@/lib/platform'
-import type { UsageProvider } from '@shared/types/usage'
+import type { SavedAccountDTO, UsageProvider } from '@shared/types/usage'
 import claudeIcon from '@/assets/model-icons/claude.svg'
 import openaiIcon from '@/assets/model-icons/openai.svg'
 
@@ -44,6 +58,38 @@ function ProviderAccountsCard({ provider }: { provider: UsageProvider }): React.
   const schedule = useAccountScheduleStore((s) => s.schedules[provider])
   const cancelSchedule = useAccountScheduleStore((s) => s.cancelSchedule)
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null)
+  const hiveAuthToken = useSettingsStore((s) => s.hiveAuthToken)
+  const [sharingAccountId, setSharingAccountId] = useState<string | null>(null)
+  const [shareResult, setShareResult] = useState<{ email: string; link: string } | null>(null)
+
+  // Sharing needs a connected Hive Enterprise server: the encrypted payload is
+  // parked there behind the one-time token. The encryption key stays in the link.
+  const canShare = isMac() && Boolean(hiveAuthToken)
+
+  const handleShare = async (account: SavedAccountDTO): Promise<void> => {
+    setSharingAccountId(account.id)
+    try {
+      const exported = await accountApi.exportShare(account.id)
+      const created = await createHiveAccountShare(exported.provider, exported.encryptedPayload)
+      const serverUrl = useSettingsStore.getState().hiveEnterpriseServerUrl
+      const link = buildShareAccountLink({ serverUrl, token: created.token, key: exported.key })
+      setShareResult({ email: account.email, link })
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to create share link')
+    } finally {
+      setSharingAccountId(null)
+    }
+  }
+
+  const copyShareLink = async (): Promise<void> => {
+    if (!shareResult) return
+    try {
+      await navigator.clipboard.writeText(shareResult.link)
+      clipboardToast.copied('Share link')
+    } catch {
+      clipboardToast.failed()
+    }
+  }
 
   const icon = provider === 'anthropic' ? claudeIcon : openaiIcon
   const label = provider === 'anthropic' ? 'Claude' : 'OpenAI'
@@ -155,6 +201,23 @@ function ProviderAccountsCard({ provider }: { provider: UsageProvider }): React.
                       <RefreshCw className="h-3.5 w-3.5" />
                     )}
                   </Button>
+                  {canShare && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                      onClick={() => handleShare(account)}
+                      disabled={sharingAccountId !== null}
+                      aria-label={`Share ${account.email}`}
+                      title="Share this account with another computer via a one-time link"
+                    >
+                      {sharingAccountId === account.id ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Share2 className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  )}
                   {!isActive && (
                     <Button
                       variant="ghost"
@@ -236,6 +299,36 @@ function ProviderAccountsCard({ provider }: { provider: UsageProvider }): React.
         </div>
       )}
 
+      <Dialog
+        open={shareResult !== null}
+        onOpenChange={(open) => {
+          if (!open) setShareResult(null)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Share account</DialogTitle>
+            <DialogDescription>
+              One-time link for <span className="font-semibold">{shareResult?.email}</span>. Open
+              it in Hive on another computer to add this account there. The link works once and
+              expires in 24 hours — treat it like a password.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex items-center gap-2">
+            <Input
+              readOnly
+              value={shareResult?.link ?? ''}
+              className="font-mono text-xs"
+              onFocus={(event) => event.currentTarget.select()}
+              data-testid="share-account-link"
+            />
+            <Button size="sm" onClick={copyShareLink}>
+              Copy
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
       <AlertDialog
         open={confirmRemoveId !== null}
         onOpenChange={(open) => {
@@ -271,6 +364,9 @@ function ProviderAccountsCard({ provider }: { provider: UsageProvider }): React.
 export function SettingsAccounts(): React.JSX.Element {
   const loadSavedAccounts = useUsageStore((s) => s.loadSavedAccounts)
   const fetchEmail = useAccountStore((s) => s.fetchEmail)
+  const [importOpen, setImportOpen] = useState(false)
+  const [importUrl, setImportUrl] = useState('')
+  const [importing, setImporting] = useState(false)
 
   useEffect(() => {
     loadSavedAccounts().catch(() => {})
@@ -278,13 +374,56 @@ export function SettingsAccounts(): React.JSX.Element {
     fetchEmail('openai')
   }, [loadSavedAccounts, fetchEmail])
 
+  // Refresh when a share link is imported through the hive:// deep link.
+  useEffect(() => {
+    return accountApi.onSharedAccountImported(({ provider, email }) => {
+      toast.success(`Imported ${email} (${provider === 'anthropic' ? 'Claude' : 'OpenAI'})`)
+      loadSavedAccounts().catch(() => {})
+      fetchEmail(provider)
+    })
+  }, [loadSavedAccounts, fetchEmail])
+
+  const handleImport = async (): Promise<void> => {
+    const url = importUrl.trim()
+    if (!url) return
+    setImporting(true)
+    try {
+      const result = await accountApi.importShare(url)
+      toast.success(
+        `Imported ${result.email} (${result.provider === 'anthropic' ? 'Claude' : 'OpenAI'})`
+      )
+      setImportOpen(false)
+      setImportUrl('')
+      await loadSavedAccounts().catch(() => {})
+      fetchEmail(result.provider)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to import share link')
+    } finally {
+      setImporting(false)
+    }
+  }
+
   return (
     <div className="space-y-6">
-      <div>
-        <h3 className="text-base font-medium mb-1">Accounts</h3>
-        <p className="text-sm text-muted-foreground">
-          Manage saved Claude and OpenAI accounts used for usage tracking and quick switching.
-        </p>
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-base font-medium mb-1">Accounts</h3>
+          <p className="text-sm text-muted-foreground">
+            Manage saved Claude and OpenAI accounts used for usage tracking and quick switching.
+          </p>
+        </div>
+        {isMac() && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 shrink-0 text-xs"
+            onClick={() => setImportOpen(true)}
+            data-testid="import-share-link"
+          >
+            <Link2 className="h-3.5 w-3.5" />
+            Import share link
+          </Button>
+        )}
       </div>
 
       <div className="space-y-4">
@@ -292,6 +431,43 @@ export function SettingsAccounts(): React.JSX.Element {
           <ProviderAccountsCard key={provider} provider={provider} />
         ))}
       </div>
+
+      <Dialog
+        open={importOpen}
+        onOpenChange={(open) => {
+          setImportOpen(open)
+          if (!open) setImportUrl('')
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Import account from share link</DialogTitle>
+            <DialogDescription>
+              Paste a <span className="font-mono">hive://share-account</span> link generated on
+              another computer. The account is claimed once and the link stops working.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={importUrl}
+            onChange={(event) => setImportUrl(event.target.value)}
+            placeholder="hive://share-account?server=…&token=…&key=…"
+            className="font-mono text-xs"
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !importing) void handleImport()
+            }}
+          />
+          <DialogFooter>
+            <Button
+              size="sm"
+              onClick={() => void handleImport()}
+              disabled={importing || importUrl.trim().length === 0}
+            >
+              {importing && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              Import
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/src/renderer/src/components/settings/SettingsAccounts.tsx
+++ b/src/renderer/src/components/settings/SettingsAccounts.tsx
@@ -390,6 +390,12 @@ export function SettingsAccounts(): React.JSX.Element {
     setImporting(true)
     try {
       const result = await accountApi.importShare(url)
+      if (result.refreshedAuthToken) {
+        // The claim rotated our enterprise token (import runs outside the
+        // renderer, which normally persists these); adopt it before any other
+        // settings save writes the stale one back.
+        await useSettingsStore.getState().updateSetting('hiveAuthToken', result.refreshedAuthToken)
+      }
       toast.success(
         `Imported ${result.email} (${result.provider === 'anthropic' ? 'Claude' : 'OpenAI'})`
       )

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -875,9 +875,15 @@ if (typeof window !== 'undefined') {
     const typedData = data as {
       commandFilter?: CommandFilterSettings
       customProjectCommands?: unknown
+      hiveAuthToken?: unknown
     }
     if (typedData.commandFilter) {
       useSettingsStore.setState({ commandFilter: typedData.commandFilter })
+    }
+    // Main persists a rotated Hive Enterprise token (e.g. during a share-link
+    // claim); sync it here so a later full-blob save doesn't restore the stale one.
+    if (typeof typedData.hiveAuthToken === 'string' && typedData.hiveAuthToken) {
+      useSettingsStore.setState({ hiveAuthToken: typedData.hiveAuthToken })
     }
     if (Array.isArray(typedData.customProjectCommands)) {
       const validCommands: CustomProjectCommand[] = []

--- a/src/server/rpc/domains/account-ops.ts
+++ b/src/server/rpc/domains/account-ops.ts
@@ -14,6 +14,12 @@ import {
   removeSavedAccount,
   switchAccount
 } from '../../../main/services/saved-usage-orchestrator'
+import {
+  exportAccountShare,
+  importAccountShareFromLink,
+  type ExportedAccountShare,
+  type ImportedAccountShare
+} from '../../../main/services/account-share-service'
 import type { LoginStatusDTO, SavedAccountDTO, UsageProvider } from '../../../shared/types/usage'
 import type { RpcHandler } from '../router'
 
@@ -31,6 +37,8 @@ export interface AccountOpsRpcService {
   ) => Effect.Effect<{ loginId: string }, unknown, never>
   readonly loginStatus: (loginId: string) => Effect.Effect<LoginStatusDTO, unknown, never>
   readonly loginCancel: (loginId: string) => Effect.Effect<boolean, unknown, never>
+  readonly exportShare: (accountId: string) => Effect.Effect<ExportedAccountShare, unknown, never>
+  readonly importShare: (url: string) => Effect.Effect<ImportedAccountShare, unknown, never>
 }
 
 const emptyParamsSchema = z.union([z.object({}).strict(), z.undefined(), z.null()])
@@ -49,6 +57,8 @@ const loginStartParamsSchema = z
   .strict()
 const loginStatusParamsSchema = z.object({ loginId: z.string() }).strict()
 const loginCancelParamsSchema = z.object({ loginId: z.string() }).strict()
+const exportShareParamsSchema = z.object({ accountId: z.string() }).strict()
+const importShareParamsSchema = z.object({ url: z.string() }).strict()
 
 export const makeLiveAccountOpsRpcService = (): AccountOpsRpcService => ({
   getClaudeEmail: () =>
@@ -89,6 +99,16 @@ export const makeLiveAccountOpsRpcService = (): AccountOpsRpcService => ({
   loginCancel: (loginId) =>
     Effect.tryPromise({
       try: () => loginCancel(loginId),
+      catch: (cause) => cause
+    }),
+  exportShare: (accountId) =>
+    Effect.tryPromise({
+      try: () => exportAccountShare(accountId),
+      catch: (cause) => cause
+    }),
+  importShare: (url) =>
+    Effect.tryPromise({
+      try: () => importAccountShareFromLink(url),
       catch: (cause) => cause
     })
 })
@@ -183,6 +203,28 @@ export const makeAccountOpsRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.loginCancel(loginId)
+        })
+    ],
+    [
+      'accountOps.exportShare',
+      (params) =>
+        Effect.gen(function* () {
+          const { accountId } = yield* Effect.try({
+            try: () => exportShareParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.exportShare(accountId)
+        })
+    ],
+    [
+      'accountOps.importShare',
+      (params) =>
+        Effect.gen(function* () {
+          const { url } = yield* Effect.try({
+            try: () => importShareParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* service.importShare(url)
         })
     ]
   ])

--- a/src/shared/account-share-link.ts
+++ b/src/shared/account-share-link.ts
@@ -1,0 +1,16 @@
+/** hive://share-account link building/parsing shared by main and renderer. */
+
+export const SHARE_ACCOUNT_LINK_HOST = 'share-account'
+
+export function buildShareAccountLink(args: {
+  serverUrl: string
+  token: string
+  key: string
+}): string {
+  const params = new URLSearchParams({
+    server: args.serverUrl.replace(/\/+$/, ''),
+    token: args.token,
+    key: args.key
+  })
+  return `hive://${SHARE_ACCOUNT_LINK_HOST}?${params.toString()}`
+}

--- a/src/shared/app-events.ts
+++ b/src/shared/app-events.ts
@@ -1,1 +1,9 @@
 export const WINDOW_FOCUSED_CHANNEL = 'app:windowFocused'
+
+/** Published after a shared account link is imported (deep link or paste). */
+export const SHARED_ACCOUNT_IMPORTED_CHANNEL = 'accounts:sharedAccountImported'
+
+export interface SharedAccountImportedPayload {
+  provider: 'anthropic' | 'openai'
+  email: string
+}


### PR DESCRIPTION
## Summary
- Added `hive://share-account` support to export Claude/OpenAI accounts as one-time encrypted shares and import them on another machine.
- Wired deep-link handling into the Electron main process so cold-start `hive://` links are queued until the backend is ready.
- Added renderer UI in Settings > Accounts to generate, copy, and import share links, plus a listener for imported-account events.
- Extended Hive Enterprise GraphQL client and RPC handlers with `createAccountShare`, `exportShare`, and `importShare` flows.
- Added shared link helpers, app events, and tests for encryption/decryption and link parsing.

## Testing
- Not run
- Added unit coverage for share payload crypto and link validation in `account-share-service.test.ts`
- Verified new RPC and renderer wiring by inspection of the diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Moves live Claude/Codex credentials through encrypt/share/claim/import and authenticated GraphQL; mistakes could leak or corrupt tokens, though server-URL matching and pre-claim key validation reduce exposure.
> 
> **Overview**
> **One-time account sharing** lets users export saved Claude or OpenAI usage accounts as `hive://share-account` links and import them on another Mac. Credentials are **AES-256-GCM encrypted** in the main process; only ciphertext is stored on Hive Enterprise behind a one-time token, while the decryption key stays in the link.
> 
> **Export path:** main RPC `exportShare` seals credentials → renderer uploads ciphertext via new `createAccountShare` GraphQL mutation → UI builds the link with `buildShareAccountLink` and offers copy.
> 
> **Import path:** `importShare` / deep links validate the key *before* claiming (so a bad paste does not burn the token), require Hive Enterprise sign-in on the **same** server as the link, call `claimAccountShare`, decrypt, and register in local Claude/Codex stores. Rotated enterprise JWTs from claim are persisted in main and synced to the renderer settings store.
> 
> **Deep links:** `electron-builder` registers the `hive` scheme; `deep-link-service` registers the protocol client, queues `open-url` until `markDeepLinksReady()`, shows notifications, and publishes `accounts:sharedAccountImported` for UI refresh.
> 
> **Settings → Accounts** gains per-account share (macOS + enterprise), import-by-paste, and subscription to deep-link imports. Unit tests cover crypto and link validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 515e408a532a21c5d83452ff009a7a4e7f043097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->