### PR TITLE
Show source branch in PR notifications

### DIFF
--- a/src/renderer/src/components/pr/CreatePRModal.tsx
+++ b/src/renderer/src/components/pr/CreatePRModal.tsx
@@ -281,6 +281,7 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
     const notifId = usePRNotificationStore.getState().show({
       status: 'loading',
       message: 'Creating pull request...',
+      branchName: branchInfo?.name,
       worktreeId
     })
 

--- a/src/renderer/src/components/pr/PRNotificationStack.tsx
+++ b/src/renderer/src/components/pr/PRNotificationStack.tsx
@@ -7,6 +7,7 @@ import {
   Info,
   X,
   ExternalLink,
+  GitBranch,
   GitMerge,
   Archive
 } from 'lucide-react'
@@ -52,6 +53,7 @@ function PRNotificationCard({
   prTitle,
   prUrl,
   prNumber,
+  branchName,
   worktreeId,
   showArchiveButton
 }: {
@@ -62,6 +64,7 @@ function PRNotificationCard({
   prTitle?: string
   prUrl?: string
   prNumber?: number
+  branchName?: string
   worktreeId?: string
   showArchiveButton?: boolean
 }): React.JSX.Element {
@@ -212,6 +215,15 @@ function PRNotificationCard({
       {/* Content */}
       <div className="flex-1 min-w-0 space-y-1">
         <p className="text-sm font-medium text-foreground leading-snug">{message}</p>
+        {branchName && (
+          <p
+            className="flex items-center gap-1 text-xs text-muted-foreground leading-snug"
+            title={branchName}
+          >
+            <GitBranch className="h-3 w-3 shrink-0" />
+            <span className="truncate font-mono">{branchName}</span>
+          </p>
+        )}
         {prTitle && (
           <p className="text-xs text-muted-foreground leading-snug line-clamp-2" title={prTitle}>
             {prTitle}
@@ -312,6 +324,7 @@ export function PRNotificationStack(): React.JSX.Element | null {
           prTitle={n.prTitle}
           prUrl={n.prUrl}
           prNumber={n.prNumber}
+          branchName={n.branchName}
           worktreeId={n.worktreeId}
           showArchiveButton={n.showArchiveButton}
         />

--- a/src/renderer/src/lib/connection-pr.ts
+++ b/src/renderer/src/lib/connection-pr.ts
@@ -191,6 +191,7 @@ async function pushAttachedPRUpdates(assessment: MemberAssessment, prefix: strin
   const notifId = show({
     status: 'loading',
     message: `${prefix}Pushing updates to PR #${pr.number}...`,
+    branchName: assessment.branchName,
     worktreeId: assessment.worktreeId
   })
   try {
@@ -269,6 +270,7 @@ export async function createConnectionPRs(options: CreateConnectionPRsOptions): 
       const notifId = show({
         status: 'loading',
         message: `${prefix}Creating pull request...`,
+        branchName: assessment.branchName,
         worktreeId: assessment.worktreeId
       })
       await runCreatePRPipeline({

--- a/src/renderer/src/stores/usePRNotificationStore.ts
+++ b/src/renderer/src/stores/usePRNotificationStore.ts
@@ -14,6 +14,8 @@ interface PRNotification {
   prUrl?: string
   prNumber?: number
   prTitle?: string
+  /** Source branch the PR is created from */
+  branchName?: string
   worktreeId?: string
   /** Render an Archive button for worktrees with nothing to PR */
   showArchiveButton?: boolean


### PR DESCRIPTION
## Summary
- Adds the source branch name to PR notification state so it can be carried through creation and update flows.
- Displays the branch name in PR toast/notification cards with a branch icon and monospace styling.
- Threads branch metadata through both standalone PR creation and connection PR update notifications.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional display metadata on PR notifications only; no changes to PR creation, git, or auth logic.
> 
> **Overview**
> PR notification toasts now carry an optional **source branch** so users can tell which worktree/branch a card refers to when several PR flows run at once.
> 
> The notification store gains optional `branchName`, and creation/update entry points pass it from git branch info (`CreatePRModal`) or connection member assessment (`connection-pr`). **PR notification cards** render the branch under the status line with a `GitBranch` icon and truncated monospace text when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d489538782b8589e5a438bb329d2cddba5fdec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->