### PR TITLE
Highlight ultracode and codex ultra model badges

### DIFF
--- a/src/renderer/src/components/kanban/TicketModelBadge.test.tsx
+++ b/src/renderer/src/components/kanban/TicketModelBadge.test.tsx
@@ -104,6 +104,38 @@ describe('TicketModelBadge', () => {
     expect(screen.getByTitle('Claude Opus 4.5')).toBeInTheDocument()
   })
 
+  it('gives the chip a violet border for an ultracode launch', () => {
+    render(
+      <TicketModelBadge
+        ticket={{ model_provider_id: 'claude-code', model_id: 'opus', model_variant: 'ultracode' }}
+      />
+    )
+
+    expect(screen.getByText('opus').closest('span')).toHaveClass('border-violet-500/60')
+  })
+
+  it('gives the chip a violet border for a codex ultra launch', () => {
+    render(
+      <TicketModelBadge
+        ticket={{ model_provider_id: 'codex', model_id: 'gpt-5.6-sol', model_variant: 'ultra' }}
+      />
+    )
+
+    expect(screen.getByText('gpt-5.6-sol').closest('span')).toHaveClass('border-violet-500/60')
+  })
+
+  it('keeps the border transparent for non-ultra variants', () => {
+    render(
+      <TicketModelBadge
+        ticket={{ model_provider_id: 'claude-code', model_id: 'opus', model_variant: 'xhigh' }}
+      />
+    )
+
+    const badge = screen.getByText('opus').closest('span')
+    expect(badge).not.toHaveClass('border-violet-500/60')
+    expect(badge).toHaveClass('border-transparent')
+  })
+
   it('applies the passed className to the chip', () => {
     render(
       <TicketModelBadge

--- a/src/renderer/src/components/kanban/TicketModelBadge.tsx
+++ b/src/renderer/src/components/kanban/TicketModelBadge.tsx
@@ -1,6 +1,6 @@
 import { resolveModelIconAsset } from '@/components/worktrees/ModelIcon'
 import { getAvailableHandoffAgentSdks, getCachedModelCatalog } from '@/lib/handoffSelection'
-import { findModelInfo, getModelDisplayName } from '@/lib/parseProviders'
+import { findModelInfo, getModelDisplayName, isUltraVariant } from '@/lib/parseProviders'
 import { cn } from '@/lib/utils'
 import type { KanbanTicket } from '../../../../main/db/types'
 
@@ -38,7 +38,8 @@ export function TicketModelBadge({
     <span
       title={title}
       className={cn(
-        'inline-flex items-center gap-1 rounded-full bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground',
+        'inline-flex items-center gap-1 rounded-full border border-transparent bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground',
+        isUltraVariant(variant) && 'border-violet-500/60',
         className
       )}
     >

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -11,6 +11,7 @@ import {
   getModelDisplayName,
   getModelVariantKeys,
   getVariantKeysForSdk,
+  isUltraVariant,
   parseProviders,
   ULTRACODE_VARIANT,
   type ModelInfo,
@@ -62,9 +63,7 @@ const ULTRACODE_TOOLTIP = 'xhigh effort + dynamic-workflow orchestration'
 
 /** ultracode and codex's `ultra` effort share the violet accent so both read as
  * special top-tier modes rather than just another effort level. */
-function isAccentVariant(variant: string): boolean {
-  return variant === ULTRACODE_VARIANT || variant === 'ultra'
-}
+const isAccentVariant = isUltraVariant
 
 /** Styling for a variant chip. Accent variants (ultracode, ultra) get a
  * distinct look so they read as the special modes they are. */

--- a/src/renderer/src/lib/__tests__/parseProviders.test.ts
+++ b/src/renderer/src/lib/__tests__/parseProviders.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getVariantKeysForSdk, ULTRACODE_VARIANT } from '../parseProviders'
+import { getVariantKeysForSdk, isUltraVariant, ULTRACODE_VARIANT } from '../parseProviders'
 
 // Opus/Fable-tier models expose xhigh/max; Sonnet/Haiku cap at high.
 const opusLike = { variants: { low: {}, medium: {}, high: {}, xhigh: {}, max: {} } }
@@ -28,5 +28,19 @@ describe('getVariantKeysForSdk', () => {
 
   it('returns base variant keys unchanged when the model has no variants', () => {
     expect(getVariantKeysForSdk({}, 'claude-code-cli')).toEqual([])
+  })
+})
+
+describe('isUltraVariant', () => {
+  it('is true for the claude ultracode and codex ultra variants', () => {
+    expect(isUltraVariant(ULTRACODE_VARIANT)).toBe(true)
+    expect(isUltraVariant('ultra')).toBe(true)
+  })
+
+  it('is false for ordinary efforts and missing variants', () => {
+    expect(isUltraVariant('xhigh')).toBe(false)
+    expect(isUltraVariant('max')).toBe(false)
+    expect(isUltraVariant(null)).toBe(false)
+    expect(isUltraVariant(undefined)).toBe(false)
   })
 })

--- a/src/renderer/src/lib/parseProviders.ts
+++ b/src/renderer/src/lib/parseProviders.ts
@@ -93,6 +93,12 @@ export function getModelVariantKeys(model: Pick<ModelInfo, 'variants'>): string[
 /** CLI-only effort: enabled via the claude `--settings` JSON, not `--effort`. */
 export const ULTRACODE_VARIANT = 'ultracode'
 
+/** claude's `ultracode` and codex's `ultra` are the special top-tier launch
+ * modes; UI surfaces give them a shared violet accent. */
+export function isUltraVariant(variant: string | null | undefined): boolean {
+  return variant === ULTRACODE_VARIANT || variant === 'ultra'
+}
+
 /**
  * Variant keys to offer for a model under a given agent SDK. `claude-code-cli`
  * additionally offers `ultracode` — a CLI-only `--settings` mode — but only for


### PR DESCRIPTION
## Summary
- Add a shared `isUltraVariant` helper for the `ultracode` and `ultra` launch modes.
- Apply a violet border accent to model badges and selector chips when those variants are active.
- Add coverage for the new helper and the badge styling behavior.

## Testing
- `vitest src/renderer/src/lib/__tests__/parseProviders.test.ts`
- `vitest src/renderer/src/components/kanban/TicketModelBadge.test.tsx`
- Not run: full repository test suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic UI and a small shared utility only; no auth, data, or launch logic changes.
> 
> **Overview**
> Introduces a shared **`isUltraVariant`** helper in `parseProviders` so **`ultracode`** (Claude) and **`ultra`** (Codex) are treated as the same top-tier launch modes across the UI.
> 
> **Kanban `TicketModelBadge`** now applies a **violet border** when the ticket uses one of those variants; other variants keep a transparent border. **`ModelSelector`** drops its inline accent check and wires **`isAccentVariant`** to the same helper (selector chip styling is unchanged).
> 
> Unit tests cover the helper and badge border classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51f09eef9b8b8f5b36b2631ae276a2d2307f55a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->