### PR TITLE
Add optional merged Kanban column

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -2980,14 +2980,22 @@ export class DatabaseService {
     return this.getKanbanTicket(id)
   }
 
-  archiveAllDoneKanbanTickets(projectId: string): number {
+  archiveAllDoneKanbanTickets(projectId: string, includeMerged = false): number {
     const db = this.getDb()
     const now = new Date().toISOString()
-    const result = db
-      .prepare(
-        'UPDATE kanban_tickets SET archived_at = ?, updated_at = ? WHERE project_id = ? AND "column" = ? AND archived_at IS NULL'
-      )
-      .run(now, now, projectId, 'done')
+    // includeMerged: when the Merged board column is hidden, merged tickets
+    // display inside Done, so "Archive all" must cover them too
+    const result = includeMerged
+      ? db
+          .prepare(
+            'UPDATE kanban_tickets SET archived_at = ?, updated_at = ? WHERE project_id = ? AND "column" IN (?, ?) AND archived_at IS NULL'
+          )
+          .run(now, now, projectId, 'done', 'merged')
+      : db
+          .prepare(
+            'UPDATE kanban_tickets SET archived_at = ?, updated_at = ? WHERE project_id = ? AND "column" = ? AND archived_at IS NULL'
+          )
+          .run(now, now, projectId, 'done')
     return result.changes
   }
 

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -33,6 +33,8 @@ export type KanbanMarkdownConfig =
         todo: string
         in_progress: string
         review: string
+        /** Optional — merged cards fall back to the done folder when unset. */
+        merged?: string
         done: string
       }
     }
@@ -43,6 +45,8 @@ export type KanbanMarkdownConfig =
         todo: string
         in_progress: string
         review: string
+        /** Optional — merged cards fall back to the done folder when unset. */
+        merged?: string
         done: string
       }
     }
@@ -489,7 +493,7 @@ export interface SessionSearchOptions {
 }
 
 // Kanban ticket types
-export type KanbanTicketColumn = 'todo' | 'in_progress' | 'review' | 'done'
+export type KanbanTicketColumn = 'todo' | 'in_progress' | 'review' | 'merged' | 'done'
 export type TicketMark = 'common' | 'rare' | 'epic' | 'legendary'
 
 export interface KanbanTicket {

--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -68,7 +68,13 @@ const HIVE_FRONTMATTER_FIELDS = new Set([
 ])
 
 const CARD_FILE_SIZE_LIMIT_BYTES = 1024 * 1024
-const VALID_COLUMNS = new Set<KanbanTicketColumn>(['todo', 'in_progress', 'review', 'done'])
+const VALID_COLUMNS = new Set<KanbanTicketColumn>([
+  'todo',
+  'in_progress',
+  'review',
+  'merged',
+  'done'
+])
 const VALID_MODES = new Set(['build', 'plan', 'super-plan'])
 const VALID_MARKS = new Set(['common', 'rare', 'epic', 'legendary'])
 
@@ -2126,7 +2132,7 @@ async function planSingleFolderToStatusFolders(
       const id = asString(parsed.frontmatter.id)
       validateKnownFrontmatter(parsed.frontmatter, id)
       const column = asColumn(parsed.frontmatter.column) ?? 'todo'
-      const targetFolder = nextConfig.statusFolders[column]
+      const targetFolder = nextConfig.statusFolders[column] ?? nextConfig.statusFolders.done
       moves.push({
         source,
         target: join(resolveProjectPath(project.path, targetFolder), entry.name)
@@ -2318,7 +2324,7 @@ function validateKnownFrontmatter(frontmatter: Frontmatter, ticketId: string | n
   if ('id' in frontmatter && !asString(frontmatter.id)) invalid('id', 'a non-empty string')
   if ('title' in frontmatter && !asString(frontmatter.title)) invalid('title', 'a non-empty string')
   if ('column' in frontmatter && !asColumn(frontmatter.column)) {
-    invalid('column', 'todo, in_progress, review, or done')
+    invalid('column', 'todo, in_progress, review, merged, or done')
   }
   if ('mode' in frontmatter && frontmatter.mode !== null && !asMode(frontmatter.mode)) {
     invalid('mode', 'build, plan, super-plan, or null')

--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -201,7 +201,7 @@ export interface KanbanBackend {
   reorder(projectId: string, ticketId: string, sortOrder: number): Promise<void>
   delete(projectId: string, ticketId: string): Promise<boolean>
   archive(projectId: string, ticketId: string): Promise<KanbanTicket | null>
-  archiveAllDone(projectId: string): Promise<number>
+  archiveAllDone(projectId: string, includeMerged?: boolean): Promise<number>
   unarchive(projectId: string, ticketId: string): Promise<KanbanTicket | null>
   getBySession(sessionId: string): Promise<KanbanTicket[]>
   addTokens(projectId: string, ticketId: string, tokens: number): Promise<KanbanTicket | null>
@@ -325,8 +325,8 @@ class InternalKanbanBackend implements KanbanBackend {
     return getDatabase().archiveKanbanTicket(ticketId)
   }
 
-  async archiveAllDone(projectId: string): Promise<number> {
-    return getDatabase().archiveAllDoneKanbanTickets(projectId)
+  async archiveAllDone(projectId: string, includeMerged?: boolean): Promise<number> {
+    return getDatabase().archiveAllDoneKanbanTickets(projectId, includeMerged)
   }
 
   async unarchive(projectId: string, ticketId: string): Promise<KanbanTicket | null> {
@@ -836,11 +836,15 @@ class MarkdownKanbanBackend implements KanbanBackend {
     return this.get(projectId, ticketId)
   }
 
-  async archiveAllDone(projectId: string): Promise<number> {
+  async archiveAllDone(projectId: string, includeMerged?: boolean): Promise<number> {
     const index = await this.reloadIndex(projectId)
     const archivedIds = new Set(
       index.tickets
-        .filter((ticket) => ticket.column === 'done' && !ticket.archived_at)
+        .filter(
+          (ticket) =>
+            (ticket.column === 'done' || (includeMerged && ticket.column === 'merged')) &&
+            !ticket.archived_at
+        )
         .map((ticket) => ticket.id)
     )
     if (archivedIds.size === 0) return 0

--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -1648,12 +1648,12 @@ class MarkdownKanbanBackend implements KanbanBackend {
     const folders =
       config.layout === 'single-folder'
         ? [{ folder: resolveProjectPath(project.path, config.singleFolder), column: null }]
-        : (Object.entries(config.statusFolders) as Array<[KanbanTicketColumn, string]>).map(
-            ([column, folder]) => ({
+        : (Object.entries(config.statusFolders) as Array<[KanbanTicketColumn, string]>)
+            .filter(([, folder]) => folder?.trim())
+            .map(([column, folder]) => ({
               folder: resolveProjectPath(project.path, folder),
               column
-            })
-          )
+            }))
     for (const candidate of folders) {
       const canonicalFolder = await realpath(candidate.folder).catch(() => null)
       if (canonicalFolder === canonicalFileFolder) {
@@ -2132,7 +2132,10 @@ async function planSingleFolderToStatusFolders(
       const id = asString(parsed.frontmatter.id)
       validateKnownFrontmatter(parsed.frontmatter, id)
       const column = asColumn(parsed.frontmatter.column) ?? 'todo'
-      const targetFolder = nextConfig.statusFolders[column] ?? nextConfig.statusFolders.done
+      const configuredFolder = nextConfig.statusFolders[column]
+      const targetFolder = configuredFolder?.trim()
+        ? configuredFolder
+        : nextConfig.statusFolders.done
       moves.push({
         source,
         target: join(resolveProjectPath(project.path, targetFolder), entry.name)

--- a/src/main/services/kanban-markdown-paths.ts
+++ b/src/main/services/kanban-markdown-paths.ts
@@ -96,6 +96,7 @@ export async function configuredFolders(
           config.statusFolders.todo,
           config.statusFolders.in_progress,
           config.statusFolders.review,
+          ...(config.statusFolders.merged ? [config.statusFolders.merged] : []),
           config.statusFolders.done
         ]
   const folders = paths.map((folder) => resolveProjectPath(project.path, folder))
@@ -113,7 +114,8 @@ export async function ensureFolder(
   const folder =
     config.layout === 'single-folder'
       ? config.singleFolder
-      : config.statusFolders[column]
+      : // merged has no dedicated folder unless configured — fall back to done
+        (config.statusFolders[column] ?? config.statusFolders.done)
   const resolved = resolveProjectPath(project.path, folder)
   await mkdir(resolved, { recursive: true })
   return resolved

--- a/src/main/services/kanban-markdown-paths.ts
+++ b/src/main/services/kanban-markdown-paths.ts
@@ -96,7 +96,7 @@ export async function configuredFolders(
           config.statusFolders.todo,
           config.statusFolders.in_progress,
           config.statusFolders.review,
-          ...(config.statusFolders.merged ? [config.statusFolders.merged] : []),
+          ...(config.statusFolders.merged?.trim() ? [config.statusFolders.merged] : []),
           config.statusFolders.done
         ]
   const folders = paths.map((folder) => resolveProjectPath(project.path, folder))
@@ -111,11 +111,15 @@ export async function ensureFolder(
   config: KanbanMarkdownConfig,
   column: KanbanTicketColumn
 ): Promise<string> {
-  const folder =
-    config.layout === 'single-folder'
+  const configured =
+    config.layout === 'single-folder' ? config.singleFolder : config.statusFolders[column]
+  // merged has no dedicated folder unless configured (blank counts as unset) —
+  // fall back to the done folder
+  const folder = configured?.trim()
+    ? configured
+    : config.layout === 'single-folder'
       ? config.singleFolder
-      : // merged has no dedicated folder unless configured — fall back to done
-        (config.statusFolders[column] ?? config.statusFolders.done)
+      : config.statusFolders.done
   const resolved = resolveProjectPath(project.path, folder)
   await mkdir(resolved, { recursive: true })
   return resolved

--- a/src/renderer/src/api/kanban-api.ts
+++ b/src/renderer/src/api/kanban-api.ts
@@ -70,8 +70,11 @@ export const kanbanApi = {
       getRendererRpcClient().request<boolean>('kanban.ticket.delete', { projectId, id }),
     archive: async <TResult>(projectId: string, id: string): Promise<TResult> =>
       getRendererRpcClient().request<TResult>('kanban.ticket.archive', { projectId, id }),
-    archiveAllDone: async (projectId: string): Promise<number> =>
-      getRendererRpcClient().request<number>('kanban.ticket.archiveAllDone', { projectId }),
+    archiveAllDone: async (projectId: string, includeMerged?: boolean): Promise<number> =>
+      getRendererRpcClient().request<number>('kanban.ticket.archiveAllDone', {
+        projectId,
+        ...(includeMerged !== undefined ? { includeMerged } : {})
+      }),
     unarchive: async <TResult>(projectId: string, id: string): Promise<TResult> =>
       getRendererRpcClient().request<TResult>('kanban.ticket.unarchive', { projectId, id }),
     detachWorktree: async (worktreeId: string): Promise<number> =>

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { LayoutGroup, motion } from 'motion/react'
 import { Pin } from 'lucide-react'
 import { parseTicketKey, ticketKey, useKanbanStore } from '@/stores/useKanbanStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
 import { usePinnedStore } from '@/stores/usePinnedStore'
 import { useBoardChatStore } from '@/stores/useBoardChatStore'
 import { useSessionStore } from '@/stores/useSessionStore'
@@ -15,6 +16,10 @@ import { cardOccurrenceKeys } from '@/components/kanban/kanban-card-identity'
 import type { KanbanTicketColumn } from '../../../../main/db/types'
 
 const COLUMNS: KanbanTicketColumn[] = ['todo', 'in_progress', 'review', 'done']
+const COLUMNS_WITH_MERGED: KanbanTicketColumn[] = ['todo', 'in_progress', 'review', 'merged', 'done']
+
+const byUpdatedAtDesc = (a: { updated_at: string }, b: { updated_at: string }): number =>
+  b.updated_at.localeCompare(a.updated_at)
 
 interface KanbanBoardProps {
   projectId?: string
@@ -44,6 +49,7 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
     if (state.activeScopeKey === key) return state.status
     return state.snapshots[key]?.status ?? 'idle'
   })
+  const showMergedColumn = useSettingsStore((state) => state.showMergedColumn)
   const boardAssistantByProject = useSessionStore((state) => state.boardAssistantByProject)
   const createBoardAssistantSession = useSessionStore((s) => s.createBoardAssistantSession)
   const focusBoardAssistantSession = useSessionStore((s) => s.focusBoardAssistantSession)
@@ -346,14 +352,25 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
           >
             {(() => {
               const occurrenceCounts = new Map<string, number>()
-              return COLUMNS.map((column) => {
-                const tickets = isPinnedMode
+              const ticketsFor = (column: KanbanTicketColumn): ReturnType<typeof getTicketsByColumn> =>
+                isPinnedMode
                   ? getTicketsByColumnForPinned(column)
                   : isConnectionMode
                     ? getTicketsByColumnForConnection(connectionId, column)
                     : projectId
                       ? getTicketsByColumn(projectId, column)
                       : []
+              return (showMergedColumn ? COLUMNS_WITH_MERGED : COLUMNS).map((column) => {
+                let tickets = ticketsFor(column)
+
+                // When the Merged column is hidden, fold merged tickets into
+                // Done so they never disappear from the board
+                if (column === 'done' && !showMergedColumn) {
+                  const mergedTickets = ticketsFor('merged')
+                  if (mergedTickets.length > 0) {
+                    tickets = [...tickets, ...mergedTickets].sort(byUpdatedAtDesc)
+                  }
+                }
 
                 const archivedTickets = column === 'done'
                   ? isPinnedMode

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -283,13 +283,20 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
     return () => el.removeEventListener('scroll', handler)
   }, [computePaths])
 
+  // Archived merged tickets surface in Done's archive section too (the Merged
+  // column has no archive UI of its own)
+  const archivedDoneFor = (pid: string): ReturnType<typeof getArchivedTicketsByColumn> =>
+    [...getArchivedTicketsByColumn(pid, 'done'), ...getArchivedTicketsByColumn(pid, 'merged')].sort(
+      (a, b) => (b.archived_at ?? '').localeCompare(a.archived_at ?? '')
+    )
+
   // Aggregate archived tickets across all connection member projects for the done column
   const connectionArchivedDoneTickets = isConnectionMode
-    ? connectionProjectIds.flatMap((pid) => getArchivedTicketsByColumn(pid, 'done'))
+    ? connectionProjectIds.flatMap(archivedDoneFor)
     : undefined
 
   const pinnedArchivedDoneTickets = isPinnedMode
-    ? pinnedProjectIdsArray.flatMap((pid) => getArchivedTicketsByColumn(pid, 'done'))
+    ? pinnedProjectIdsArray.flatMap(archivedDoneFor)
     : undefined
   const invalidPlaceholders = isPinnedMode
     ? getInvalidPlaceholdersForPinned()
@@ -378,7 +385,7 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
                     : isConnectionMode
                       ? connectionArchivedDoneTickets
                       : projectId
-                        ? getArchivedTicketsByColumn(projectId, 'done')
+                        ? archivedDoneFor(projectId)
                         : undefined
                   : undefined
 

--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -67,6 +67,7 @@ const COLUMN_TITLES: Record<ColumnType, string> = {
   todo: 'To Do',
   in_progress: 'In Progress',
   review: 'Review',
+  merged: 'Merged',
   done: 'Done'
 }
 
@@ -203,8 +204,11 @@ export function KanbanColumn({
   const shortTextMeasureRef = useRef<HTMLSpanElement>(null)
 
   const isDoneColumn = column === 'done'
+  const isMergedColumn = column === 'merged'
   const isTodoColumn = column === 'todo'
   const isInProgressColumn = column === 'in_progress'
+  // Done and Merged share date-sorted behavior (no manual reordering)
+  const isDateSortedColumn = isDoneColumn || isMergedColumn
   const isMultiProjectMode = !!connectionId || !!isPinnedMode
 
   // ── Multi-project helpers ─────────────────────────────────────────
@@ -400,10 +404,10 @@ export function KanbanColumn({
 
   const handleDragOver = useCallback(
     (e: React.DragEvent) => {
-      // Done is date-sorted (newest first): reordering within it is disabled,
+      // Done/Merged are date-sorted (newest first): reordering within them is disabled,
       // and cross-column drops always land at the top regardless of cursor position
-      if (isDoneColumn) {
-        if (getKanbanDragData()?.sourceColumn === 'done') return
+      if (isDateSortedColumn) {
+        if (getKanbanDragData()?.sourceColumn === column) return
         e.preventDefault()
         e.dataTransfer.dropEffect = 'move'
         setIsDragOver(true)
@@ -433,7 +437,7 @@ export function KanbanColumn({
       dropIndexRef.current = index
       setDropIndex(index)
     },
-    [tickets.length, isDoneColumn]
+    [tickets.length, isDateSortedColumn, column]
   )
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
@@ -524,8 +528,8 @@ export function KanbanColumn({
           }
         }
 
-        // Merge-on-done: intercept drops to Done for feature-branch worktrees
-        if (column === 'done') {
+        // Merge-on-done: intercept drops to Done/Merged for feature-branch worktrees
+        if (column === 'done' || column === 'merged') {
           const draggedTicket = findTicket(ticketId, ticketProjectId)
           if (draggedTicket?.worktree_id) {
             try {
@@ -566,7 +570,12 @@ export function KanbanColumn({
                         projectTicketsForColumn(ticketProjectId),
                         projectLocalDropIndex(ticketProjectId, targetIndex)
                       )
-                      store.setPendingDoneMove({ ticketId, projectId: ticketProjectId, sortOrder })
+                      store.setPendingDoneMove({
+                        ticketId,
+                        projectId: ticketProjectId,
+                        sortOrder,
+                        targetColumn: column
+                      })
                       return
                     }
                   }
@@ -597,8 +606,8 @@ export function KanbanColumn({
         }
       } else {
         // ── Same-column reorder ───────────────────────────────
-        // Done is always date-sorted — manual reordering is disabled
-        if (isDoneColumn) return
+        // Done/Merged are always date-sorted — manual reordering is disabled
+        if (isDateSortedColumn) return
         const ticketProjectId = findTicketProjectId(ticketId, draggedProjectId)
         const draggedKey = ticketKey(ticketProjectId, ticketId)
         const projectTickets = projectTicketsForColumn(ticketProjectId)
@@ -622,7 +631,7 @@ export function KanbanColumn({
       tickets.length,
       isInProgressColumn,
       isTodoColumn,
-      isDoneColumn,
+      isDateSortedColumn,
       isMultiProjectMode,
       projectId,
       findTicketProjectId,

--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -369,13 +369,16 @@ export function KanbanColumn({
   )
 
   const handleArchiveAll = useCallback(async () => {
+    // When the Merged column is hidden, merged tickets display inside Done, so
+    // "Archive all" must archive them too (WYSIWYG with the confirm count)
+    const includeMerged = !useSettingsStore.getState().showMergedColumn
     try {
       if (isPinnedMode) {
         // In pinned mode, archive done tickets across all pinned-derived projects
         const projectIds = useKanbanStore.getState().getPinnedProjectIdsArray()
         let total = 0
         for (const pid of projectIds) {
-          total += await useKanbanStore.getState().archiveAllDone(pid)
+          total += await useKanbanStore.getState().archiveAllDone(pid, includeMerged)
         }
         toast.success(`Archived ${total} ticket${total !== 1 ? 's' : ''}`)
       } else if (connectionId) {
@@ -383,11 +386,11 @@ export function KanbanColumn({
         const projectIds = useKanbanStore.getState().getConnectionProjectIds(connectionId)
         let total = 0
         for (const pid of projectIds) {
-          total += await useKanbanStore.getState().archiveAllDone(pid)
+          total += await useKanbanStore.getState().archiveAllDone(pid, includeMerged)
         }
         toast.success(`Archived ${total} ticket${total !== 1 ? 's' : ''}`)
       } else {
-        const count = await useKanbanStore.getState().archiveAllDone(projectId)
+        const count = await useKanbanStore.getState().archiveAllDone(projectId, includeMerged)
         toast.success(`Archived ${count} ticket${count !== 1 ? 's' : ''}`)
       }
     } catch {

--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -410,7 +410,18 @@ export function KanbanColumn({
       // Done/Merged are date-sorted (newest first): reordering within them is disabled,
       // and cross-column drops always land at the top regardless of cursor position
       if (isDateSortedColumn) {
-        if (getKanbanDragData()?.sourceColumn === column) return
+        const sourceColumn = getKanbanDragData()?.sourceColumn
+        if (sourceColumn === column) return
+        // Folded merged cards render inside Done when the Merged column is
+        // hidden — dragging them within Done is a same-column no-op, not a
+        // promotion to done
+        if (
+          isDoneColumn &&
+          sourceColumn === 'merged' &&
+          !useSettingsStore.getState().showMergedColumn
+        ) {
+          return
+        }
         e.preventDefault()
         e.dataTransfer.dropEffect = 'move'
         setIsDragOver(true)
@@ -477,6 +488,15 @@ export function KanbanColumn({
 
       if (sourceColumn !== column) {
         // ── Cross-column move ─────────────────────────────────
+        // Folded merged card dropped back on the visual Done list — no-op so
+        // merged-but-unverified work isn't silently marked done
+        if (
+          column === 'done' &&
+          sourceColumn === 'merged' &&
+          !useSettingsStore.getState().showMergedColumn
+        ) {
+          return
+        }
         const ticketProjectId = findTicketProjectId(ticketId, draggedProjectId)
         const simpleModeKey = isMultiProjectMode ? projectId : ticketProjectId
         const isSimpleMode =

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -527,10 +527,11 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     (isBusy || isAsking) && ticket.column === 'in_progress'
   )
 
-  // Accumulated total for done column
-  const doneTokenText = ticket.column === 'done' && ticket.total_tokens > 0
-    ? formatTokenCount(ticket.total_tokens)
-    : null
+  // Accumulated total for done/merged columns
+  const doneTokenText =
+    (ticket.column === 'done' || ticket.column === 'merged') && ticket.total_tokens > 0
+      ? formatTokenCount(ticket.total_tokens)
+      : null
 
   // Per-turn delta for active columns (unchanged)
   const turnTokenText = useSessionTokenDelta(

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -742,7 +742,9 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     useKanbanStore.getState().setHoveredBlockedTicketRef(null)
   }, [])
 
-  const isDone = ticket.column === 'done'
+  // Merged behaves like Done for archive/delete affordances — merged tickets
+  // are archivable and surface in Done's archived section
+  const isDone = ticket.column === 'done' || ticket.column === 'merged'
 
   // ── Context menu handlers ─────────────────────────────────────
   const handleDelete = useCallback(async () => {

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -2990,7 +2990,7 @@ function ReviewModeContent({
   moveTicket: (
     ticketId: string,
     projectId: string,
-    column: 'todo' | 'in_progress' | 'review' | 'done',
+    column: 'todo' | 'in_progress' | 'review' | 'merged' | 'done',
     sortOrder: number
   ) => Promise<void>
   updateTicket: (ticketId: string, projectId: string, data: KanbanTicketUpdate) => Promise<void>
@@ -3317,7 +3317,8 @@ function ReviewModeContent({
             kanbanStore.setPendingDoneMove({
               ticketId: ticket.id,
               projectId: ticket.project_id,
-              sortOrder
+              sortOrder,
+              targetColumn: 'done'
             })
             return
           }

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -389,7 +389,7 @@ export function MergeOnDoneDialog() {
     } catch (err) {
       setArchiving(false)
       toast.error(
-        `Failed to move ticket to done: ${err instanceof Error ? err.message : String(err)}`
+        `Failed to move ticket: ${err instanceof Error ? err.message : String(err)}`
       )
       return
     }
@@ -414,8 +414,11 @@ export function MergeOnDoneDialog() {
       })
   }, [resolved, completeDoneMove])
 
+  // The dialog serves both the Done and the optional Merged column
+  const targetLabel = pendingDoneMove?.targetColumn === 'merged' ? 'Merged' : 'Done'
+
   const stepTitle: Record<Step, string> = {
-    loading: 'Moving to Done...',
+    loading: `Moving to ${targetLabel}...`,
     commit_base: 'Uncommitted changes on base',
     commit: 'Uncommitted changes',
     merge: 'Merge branch',
@@ -479,7 +482,7 @@ export function MergeOnDoneDialog() {
                   onClick={() => completeDoneMove()}
                   disabled={committingBase}
                 >
-                  Move to Done anyway
+                  Move to {targetLabel} anyway
                 </Button>
                 <Button
                   size="sm"
@@ -524,7 +527,7 @@ export function MergeOnDoneDialog() {
                   onClick={() => completeDoneMove()}
                   disabled={committing}
                 >
-                  Move to Done anyway
+                  Move to {targetLabel} anyway
                 </Button>
                 <Button
                   size="sm"
@@ -570,7 +573,7 @@ export function MergeOnDoneDialog() {
                   onClick={() => completeDoneMove()}
                   disabled={merging}
                 >
-                  Move to Done anyway
+                  Move to {targetLabel} anyway
                 </Button>
                 <Button size="sm" onClick={handleMerge} disabled={merging}>
                   {merging ? (

--- a/src/renderer/src/components/kanban/TicketPickerModal.tsx
+++ b/src/renderer/src/components/kanban/TicketPickerModal.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
 import type { KanbanTicket, KanbanTicketColumn } from '../../../../main/db/types'
 
 // ── Stable empty array to avoid infinite re-renders with Zustand ────
@@ -36,6 +37,7 @@ const COLUMNS: { key: KanbanTicketColumn; label: string; color: string; activeCo
   { key: 'todo', label: 'To Do', color: 'border-zinc-600 text-zinc-400', activeColor: 'border-zinc-400 bg-zinc-400/15 text-zinc-200' },
   { key: 'in_progress', label: 'In Progress', color: 'border-blue-600/50 text-blue-400/70', activeColor: 'border-blue-500 bg-blue-500/15 text-blue-300' },
   { key: 'review', label: 'Review', color: 'border-amber-600/50 text-amber-400/70', activeColor: 'border-amber-500 bg-amber-500/15 text-amber-300' },
+  { key: 'merged', label: 'Merged', color: 'border-purple-600/50 text-purple-400/70', activeColor: 'border-purple-500 bg-purple-500/15 text-purple-300' },
   { key: 'done', label: 'Done', color: 'border-emerald-600/50 text-emerald-400/70', activeColor: 'border-emerald-500 bg-emerald-500/15 text-emerald-300' }
 ]
 
@@ -65,6 +67,7 @@ export function TicketPickerModal({
   const [searchQuery, setSearchQuery] = useState('')
   const [activeFilters, setActiveFilters] = useState<Set<KanbanTicketColumn>>(new Set())
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const showMergedColumn = useSettingsStore((s) => s.showMergedColumn)
 
   // ── Store access ────────────────────────────────────────────────
   const tickets = useKanbanStore(
@@ -178,7 +181,7 @@ export function TicketPickerModal({
 
         {/* Column filter chips */}
         <div className="flex gap-1.5 px-5 pb-3">
-          {COLUMNS.map((col) => (
+          {COLUMNS.filter((col) => col.key !== 'merged' || showMergedColumn).map((col) => (
             <button
               key={col.key}
               onClick={() => toggleFilter(col.key)}

--- a/src/renderer/src/components/kanban/TicketPickerModal.tsx
+++ b/src/renderer/src/components/kanban/TicketPickerModal.tsx
@@ -88,9 +88,15 @@ export function TicketPickerModal({
   const filteredTickets = useMemo(() => {
     let result = tickets
 
-    // Column filter (multi-select — show all if none selected)
+    // Column filter (multi-select — show all if none selected). When the
+    // Merged column is hidden, the board folds merged tickets into Done, so
+    // the Done filter must match them too (the Merged chip isn't shown).
     if (activeFilters.size > 0) {
-      result = result.filter((t) => activeFilters.has(t.column))
+      result = result.filter(
+        (t) =>
+          activeFilters.has(t.column) ||
+          (!showMergedColumn && t.column === 'merged' && activeFilters.has('done'))
+      )
     }
 
     // Search filter (case-insensitive by title)
@@ -100,7 +106,7 @@ export function TicketPickerModal({
     }
 
     return result
-  }, [tickets, activeFilters, searchQuery])
+  }, [tickets, activeFilters, searchQuery, showMergedColumn])
 
   // ── Handlers ────────────────────────────────────────────────────
   const toggleFilter = (column: KanbanTicketColumn) => {

--- a/src/renderer/src/components/projects/ProjectSettingsDialog.tsx
+++ b/src/renderer/src/components/projects/ProjectSettingsDialog.tsx
@@ -48,12 +48,12 @@ type MarkdownConfig =
   | {
       layout: 'single-folder'
       singleFolder: string
-      statusFolders?: { todo: string; in_progress: string; review: string; done: string }
+      statusFolders?: { todo: string; in_progress: string; review: string; merged?: string; done: string }
     }
   | {
       layout: 'status-folders'
       singleFolder?: string
-      statusFolders: { todo: string; in_progress: string; review: string; done: string }
+      statusFolders: { todo: string; in_progress: string; review: string; merged?: string; done: string }
     }
 
 const DEFAULT_MARKDOWN_FOLDERS = {
@@ -99,6 +99,8 @@ export function ProjectSettingsDialog({
   const [inProgressFolder, setInProgressFolder] = useState('docs/kanban/in-progress')
   const [reviewFolder, setReviewFolder] = useState('docs/kanban/review')
   const [doneFolder, setDoneFolder] = useState('docs/kanban/done')
+  // Optional Merged-column folder — no UI input yet; preserved across saves
+  const [mergedFolder, setMergedFolder] = useState<string | undefined>(undefined)
   const [kanbanConfigError, setKanbanConfigError] = useState<string | null>(null)
   const [canCreateKanbanFolders, setCanCreateKanbanFolders] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -167,6 +169,7 @@ export function ProjectSettingsDialog({
         )
         setReviewFolder(folderOrDefault(statusFolders.review, DEFAULT_MARKDOWN_FOLDERS.review))
         setDoneFolder(folderOrDefault(statusFolders.done, DEFAULT_MARKDOWN_FOLDERS.done))
+        setMergedFolder(statusFolders.merged?.trim() ? statusFolders.merged : undefined)
       })
       .catch(() => {
         if (cancelled) return
@@ -270,6 +273,7 @@ export function ProjectSettingsDialog({
             todo: folderOrDefault(todoFolder, DEFAULT_MARKDOWN_FOLDERS.todo),
             in_progress: folderOrDefault(inProgressFolder, DEFAULT_MARKDOWN_FOLDERS.inProgress),
             review: folderOrDefault(reviewFolder, DEFAULT_MARKDOWN_FOLDERS.review),
+            ...(mergedFolder ? { merged: mergedFolder } : {}),
             done: folderOrDefault(doneFolder, DEFAULT_MARKDOWN_FOLDERS.done)
           }
         }
@@ -280,6 +284,7 @@ export function ProjectSettingsDialog({
             todo: folderOrDefault(todoFolder, DEFAULT_MARKDOWN_FOLDERS.todo),
             in_progress: folderOrDefault(inProgressFolder, DEFAULT_MARKDOWN_FOLDERS.inProgress),
             review: folderOrDefault(reviewFolder, DEFAULT_MARKDOWN_FOLDERS.review),
+            ...(mergedFolder ? { merged: mergedFolder } : {}),
             done: folderOrDefault(doneFolder, DEFAULT_MARKDOWN_FOLDERS.done)
           }
         }

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -21,6 +21,7 @@ export function SettingsGeneral(): React.JSX.Element {
     followUpTriggerColumn,
     autoPinBaseWorktreeOnBoardPrompt,
     automaticallyCreateTicket,
+    showMergedColumn,
     vimModeEnabled,
     keepAwakeEnabled,
     mergeConflictMode,
@@ -267,6 +268,35 @@ export function SettingsGeneral(): React.JSX.Element {
             className={cn(
               'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
               automaticallyCreateTicket ? 'translate-x-4' : 'translate-x-0'
+            )}
+          />
+        </button>
+      </div>
+
+      {/* Merged column */}
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <label className="text-sm font-medium">Merged column</label>
+          <p className="text-xs text-muted-foreground">
+            Show a Merged column on the board between Review and Done. Dragging a ticket there
+            prompts to merge its branch, so merged-but-unverified work can wait before moving to
+            Done.
+          </p>
+        </div>
+        <button
+          role="switch"
+          aria-checked={showMergedColumn}
+          onClick={() => updateSetting('showMergedColumn', !showMergedColumn)}
+          className={cn(
+            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+            showMergedColumn ? 'bg-primary' : 'bg-muted'
+          )}
+          data-testid="show-merged-column-toggle"
+        >
+          <span
+            className={cn(
+              'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+              showMergedColumn ? 'translate-x-4' : 'translate-x-0'
             )}
           />
         </button>

--- a/src/renderer/src/lib/blocker-utils.ts
+++ b/src/renderer/src/lib/blocker-utils.ts
@@ -6,10 +6,11 @@ export function isBlockerSatisfied(
   blockerMode: 'build' | 'plan' | 'super-plan' | null,
   triggerColumn: FollowUpTriggerColumn
 ): boolean {
+  // A merged blocker's work already landed on the base branch, so it
+  // satisfies dependents just like done.
+  if (blockerColumn === 'done' || blockerColumn === 'merged') return true
   if (triggerColumn === 'review') {
-    if (blockerColumn === 'done') return true
     if (blockerColumn === 'review' && blockerMode === 'build') return true
-    return false
   }
-  return blockerColumn === 'done'
+  return false
 }

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -252,7 +252,7 @@ interface KanbanState {
   toggleBoardView: () => void
   setSimpleMode: (projectId: string, enabled: boolean) => Promise<void>
   archiveTicket: (ticketId: string, projectId: string) => Promise<void>
-  archiveAllDone: (projectId: string) => Promise<number>
+  archiveAllDone: (projectId: string, includeMerged?: boolean) => Promise<number>
   unarchiveTicket: (ticketId: string, projectId: string) => Promise<void>
   detachWorktreeTickets: (worktreeId: string) => Promise<void>
   setShowArchived: (projectId: string, show: boolean) => void
@@ -706,7 +706,9 @@ export const useKanbanStore = create<KanbanState>()(
       },
 
       // ── archiveAllDone (optimistic) ────────────────────────────────
-      archiveAllDone: async (projectId: string): Promise<number> => {
+      // includeMerged: when the Merged column is hidden, merged tickets fold
+      // into Done, so "Archive all" covers them too
+      archiveAllDone: async (projectId: string, includeMerged?: boolean): Promise<number> => {
         const prev = get().tickets.get(projectId) ?? []
         const snapshot = prev.map((t) => ({ ...t }))
 
@@ -716,7 +718,10 @@ export const useKanbanStore = create<KanbanState>()(
         set((state) => {
           const next = new Map(state.tickets)
           const tickets = (next.get(projectId) ?? []).map((t) => {
-            if (t.column === 'done' && !t.archived_at) {
+            if (
+              (t.column === 'done' || (includeMerged && t.column === 'merged')) &&
+              !t.archived_at
+            ) {
               count++
               return { ...t, archived_at: now, updated_at: now }
             }
@@ -727,7 +732,7 @@ export const useKanbanStore = create<KanbanState>()(
         })
 
         try {
-          await kanban.ticket.archiveAllDone(projectId)
+          await kanban.ticket.archiveAllDone(projectId, includeMerged)
           return count
         } catch (err) {
           // Revert on failure

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -122,13 +122,17 @@ const COLUMN_ORDER: Record<KanbanTicketColumn, number> = {
   todo: 0,
   in_progress: 1,
   review: 2,
-  done: 3
+  merged: 3,
+  done: 4
 }
 
-// Done ignores manual sort_order — always newest first (updated_at ≈ when the
-// ticket entered Done, since moving a ticket bumps updated_at)
+// Done and Merged ignore manual sort_order — always newest first (updated_at ≈
+// when the ticket entered the column, since moving a ticket bumps updated_at)
 const byUpdatedAtDesc = (a: KanbanTicket, b: KanbanTicket): number =>
   b.updated_at.localeCompare(a.updated_at)
+
+export const isDateSortedColumn = (column: KanbanTicketColumn): boolean =>
+  column === 'done' || column === 'merged'
 
 function findTicketByRef(
   ticketsByProject: Map<string, KanbanTicket[]>,
@@ -206,11 +210,12 @@ interface KanbanState {
   showArchivedByProject: Record<string, boolean>
   markdownDiagnostics: Map<string, MarkdownCardDiagnostic[]>
   markdownPlaceholders: Map<string, MarkdownCardPlaceholder[]>
-  /** Pending "move to done" data — set when a feature-branch ticket is dropped on Done, triggering the merge dialog */
+  /** Pending "move to done/merged" data — set when a feature-branch ticket is dropped on Done or Merged, triggering the merge dialog */
   pendingDoneMove: {
     ticketId: string
     projectId: string
     sortOrder: number
+    targetColumn: 'merged' | 'done'
   } | null
   /** Ephemeral board focus target used by the header Telegram toggle. */
   boardTelegramTarget: BoardTelegramTarget | null
@@ -251,7 +256,12 @@ interface KanbanState {
   unarchiveTicket: (ticketId: string, projectId: string) => Promise<void>
   detachWorktreeTickets: (worktreeId: string) => Promise<void>
   setShowArchived: (projectId: string, show: boolean) => void
-  setPendingDoneMove: (data: { ticketId: string; projectId: string; sortOrder: number }) => void
+  setPendingDoneMove: (data: {
+    ticketId: string
+    projectId: string
+    sortOrder: number
+    targetColumn: 'merged' | 'done'
+  }) => void
   clearPendingDoneMove: () => void
   completeDoneMove: () => Promise<void>
 
@@ -858,6 +868,7 @@ export const useKanbanStore = create<KanbanState>()(
           const triggerColumn = useSettingsStore.getState().followUpTriggerColumn
           if (
             column === 'done' ||
+            column === 'merged' ||
             (triggerColumn === 'review' && column === 'review' && movedTicket?.mode === 'build')
           ) {
             const { dependencyMap, tickets: allTickets } = get()
@@ -950,11 +961,12 @@ export const useKanbanStore = create<KanbanState>()(
           for (const ticket of tickets) {
             if (ticket.current_session_id !== sessionId) continue
 
-            // 'done' is a terminal column: once a user marks a ticket done, no
-            // session event may auto-move it back. This matters on app
-            // relaunch/focus, when a still-active session re-emits its status
-            // (e.g. an `idle` replay → session_completed) for a done ticket.
-            // Each column-moving branch below guards on `column !== 'done'`.
+            // 'done' and 'merged' are terminal columns: once a user moves a
+            // ticket there, no session event may auto-move it back. This
+            // matters on app relaunch/focus, when a still-active session
+            // re-emits its status (e.g. an `idle` replay → session_completed)
+            // for a done/merged ticket. Each column-moving branch below guards
+            // on those columns.
             switch (event.type) {
               case 'session_completed': {
                 // Plan tickets: surface the finished plan for the review UI.
@@ -966,7 +978,11 @@ export const useKanbanStore = create<KanbanState>()(
                 // The session finished → its progress bar is gone. Any non-terminal
                 // ticket must advance to review regardless of mode/plan state (board
                 // invariant: in_progress ⇔ a running progress bar). Move is idempotent.
-                if (ticket.column !== 'review' && ticket.column !== 'done') {
+                if (
+                  ticket.column !== 'review' &&
+                  ticket.column !== 'done' &&
+                  ticket.column !== 'merged'
+                ) {
                   get()
                     .moveTicket(ticket.id, projectId, 'review', ticket.sort_order)
                     .catch(() => {})
@@ -1002,7 +1018,11 @@ export const useKanbanStore = create<KanbanState>()(
                 // ...and move any non-terminal ticket to review. A build ticket can
                 // land here when its completion is rerouted to plan_ready by a stale
                 // lastSendMode, so the move must not be gated on mode.
-                if (ticket.column !== 'review' && ticket.column !== 'done') {
+                if (
+                  ticket.column !== 'review' &&
+                  ticket.column !== 'done' &&
+                  ticket.column !== 'merged'
+                ) {
                   get()
                     .moveTicket(ticket.id, projectId, 'review', ticket.sort_order)
                     .catch(() => {})
@@ -1019,7 +1039,11 @@ export const useKanbanStore = create<KanbanState>()(
                     .updateTicket(ticket.id, projectId, { plan_ready: false })
                     .catch(() => {})
                 }
-                if (ticket.column !== 'in_progress' && ticket.column !== 'done') {
+                if (
+                  ticket.column !== 'in_progress' &&
+                  ticket.column !== 'done' &&
+                  ticket.column !== 'merged'
+                ) {
                   get()
                     .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
                     .catch(() => {})
@@ -1195,7 +1219,12 @@ export const useKanbanStore = create<KanbanState>()(
         const pending = get().pendingDoneMove
         if (!pending) return
         set({ pendingDoneMove: null })
-        await get().moveTicket(pending.ticketId, pending.projectId, 'done', pending.sortOrder)
+        await get().moveTicket(
+          pending.ticketId,
+          pending.projectId,
+          pending.targetColumn ?? 'done',
+          pending.sortOrder
+        )
       },
 
       // ── getTicketsForProject ─────────────────────────────────────
@@ -1213,7 +1242,7 @@ export const useKanbanStore = create<KanbanState>()(
         const tickets = get().tickets.get(projectId) ?? []
         return tickets
           .filter((t) => t.column === column && !t.archived_at)
-          .sort(column === 'done' ? byUpdatedAtDesc : (a, b) => a.sort_order - b.sort_order)
+          .sort(isDateSortedColumn(column) ? byUpdatedAtDesc : (a, b) => a.sort_order - b.sort_order)
       },
 
       // ── getArchivedTicketsByColumn ─────────────────────────────────
@@ -1317,7 +1346,7 @@ export const useKanbanStore = create<KanbanState>()(
       ): KanbanTicket[] => {
         const projectIds = get().getConnectionProjectIds(connectionId)
         const merged = projectIds.flatMap((pid) => get().getTicketsByColumn(pid, column))
-        merged.sort(column === 'done' ? byUpdatedAtDesc : (a, b) => a.sort_order - b.sort_order)
+        merged.sort(isDateSortedColumn(column) ? byUpdatedAtDesc : (a, b) => a.sort_order - b.sort_order)
         return merged
       },
 
@@ -1399,7 +1428,7 @@ export const useKanbanStore = create<KanbanState>()(
       getTicketsByColumnForPinned: (column: KanbanTicketColumn): KanbanTicket[] => {
         const projectIds = [...usePinnedStore.getState().pinnedProjectIds]
         const merged = projectIds.flatMap((pid) => get().getTicketsByColumn(pid, column))
-        merged.sort(column === 'done' ? byUpdatedAtDesc : (a, b) => a.sort_order - b.sort_order)
+        merged.sort(isDateSortedColumn(column) ? byUpdatedAtDesc : (a, b) => a.sort_order - b.sort_order)
         return merged
       },
 

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -1222,7 +1222,7 @@ export const useKanbanStore = create<KanbanState>()(
         await get().moveTicket(
           pending.ticketId,
           pending.projectId,
-          pending.targetColumn ?? 'done',
+          pending.targetColumn,
           pending.sortOrder
         )
       },

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -86,6 +86,8 @@ export interface AppSettings {
   autoPinBaseWorktreeOnBoardPrompt: boolean
   /** Auto-create a kanban ticket on the first message of a manually-created session. */
   automaticallyCreateTicket: boolean
+  /** Show the optional Merged column on the board between Review and Done. */
+  showMergedColumn: boolean
 
   // Editor
   defaultEditor: EditorOption
@@ -212,6 +214,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   followUpTriggerColumn: 'done',
   autoPinBaseWorktreeOnBoardPrompt: false,
   automaticallyCreateTicket: false,
+  showMergedColumn: false,
   defaultEditor: 'vscode',
   customEditorCommand: '',
   defaultTerminal: 'terminal',
@@ -438,6 +441,7 @@ function extractSettings(state: SettingsState): AppSettings {
     followUpTriggerColumn: state.followUpTriggerColumn,
     autoPinBaseWorktreeOnBoardPrompt: state.autoPinBaseWorktreeOnBoardPrompt,
     automaticallyCreateTicket: state.automaticallyCreateTicket,
+    showMergedColumn: state.showMergedColumn,
     defaultEditor: state.defaultEditor,
     customEditorCommand: state.customEditorCommand,
     defaultTerminal: state.defaultTerminal,
@@ -805,6 +809,7 @@ export const useSettingsStore = create<SettingsState>()(
         followUpTriggerColumn: state.followUpTriggerColumn,
         autoPinBaseWorktreeOnBoardPrompt: state.autoPinBaseWorktreeOnBoardPrompt,
         automaticallyCreateTicket: state.automaticallyCreateTicket,
+        showMergedColumn: state.showMergedColumn,
         defaultEditor: state.defaultEditor,
         customEditorCommand: state.customEditorCommand,
         defaultTerminal: state.defaultTerminal,

--- a/src/server/rpc/domains/backup-ops.ts
+++ b/src/server/rpc/domains/backup-ops.ts
@@ -169,7 +169,7 @@ const backupTicketSchema = z
     key: z.string(),
     title: z.string(),
     description: z.string().nullable(),
-    column: z.enum(['todo', 'in_progress', 'review', 'done']),
+    column: z.enum(['todo', 'in_progress', 'review', 'merged', 'done']),
     sort_order: z.number(),
     mode: z.enum(['build', 'plan', 'super-plan']).nullable(),
     mark: z.string().nullable(),

--- a/src/server/rpc/domains/kanban.ts
+++ b/src/server/rpc/domains/kanban.ts
@@ -201,7 +201,7 @@ export interface KanbanRpcService {
   ) => Effect.Effect<{ success: boolean; error?: string }, unknown, never>
 }
 
-const ticketColumnSchema = z.enum(['todo', 'in_progress', 'review', 'done'])
+const ticketColumnSchema = z.enum(['todo', 'in_progress', 'review', 'merged', 'done'])
 const sessionModeSchema = z.enum(['build', 'plan', 'super-plan'])
 const ticketMarkSchema = z.enum(['common', 'rare', 'epic', 'legendary'])
 

--- a/src/server/rpc/domains/kanban.ts
+++ b/src/server/rpc/domains/kanban.ts
@@ -428,6 +428,7 @@ const kanbanMarkdownStatusFoldersSchema = z
     todo: z.string(),
     in_progress: z.string(),
     review: z.string(),
+    merged: z.string().optional(),
     done: z.string()
   })
   .strict()

--- a/src/server/rpc/domains/kanban.ts
+++ b/src/server/rpc/domains/kanban.ts
@@ -76,7 +76,10 @@ export interface KanbanRpcService {
     projectId: string,
     id: string
   ) => Effect.Effect<KanbanTicket | null, unknown, never>
-  readonly archiveAllDoneTickets: (projectId: string) => Effect.Effect<number, unknown, never>
+  readonly archiveAllDoneTickets: (
+    projectId: string,
+    includeMerged?: boolean
+  ) => Effect.Effect<number, unknown, never>
   readonly unarchiveTicket: (
     projectId: string,
     id: string
@@ -309,6 +312,12 @@ const getTicketsByProjectParamsSchema = z
   })
   .strict()
 const projectIdParamsSchema = z.object({ projectId: z.string() }).strict()
+const archiveAllDoneParamsSchema = z
+  .object({
+    projectId: z.string(),
+    includeMerged: z.boolean().optional()
+  })
+  .strict()
 const markdownFileParamsSchema = z
   .object({
     projectId: z.string(),
@@ -573,11 +582,11 @@ export const makeLiveKanbanRpcService = (): KanbanRpcService => ({
       },
       catch: (cause) => cause
     }),
-  archiveAllDoneTickets: (projectId) =>
+  archiveAllDoneTickets: (projectId, includeMerged) =>
     Effect.tryPromise({
       try: async () => {
         const { getKanbanBackendForProject } = await import('../../../main/services/kanban-backend')
-        return getKanbanBackendForProject(projectId).archiveAllDone(projectId)
+        return getKanbanBackendForProject(projectId).archiveAllDone(projectId, includeMerged)
       },
       catch: (cause) => cause
     }),
@@ -1163,11 +1172,11 @@ export const makeKanbanRpcHandlers = (
       'kanban.ticket.archiveAllDone',
       (params) =>
         Effect.gen(function* () {
-          const { projectId } = yield* Effect.try({
-            try: () => projectIdParamsSchema.parse(params),
+          const { projectId, includeMerged } = yield* Effect.try({
+            try: () => archiveAllDoneParamsSchema.parse(params),
             catch: (cause) => cause
           })
-          return yield* service.archiveAllDoneTickets(projectId)
+          return yield* service.archiveAllDoneTickets(projectId, includeMerged)
         })
     ],
     [

--- a/src/shared/types/backup.ts
+++ b/src/shared/types/backup.ts
@@ -45,7 +45,7 @@ export interface BackupTicket {
   key: string // stable export-time key t1..tN for dependency edges
   title: string
   description: string | null
-  column: 'todo' | 'in_progress' | 'review' | 'done'
+  column: 'todo' | 'in_progress' | 'review' | 'merged' | 'done'
   sort_order: number
   mode: 'build' | 'plan' | 'super-plan' | null
   mark: string | null // 'common'|'rare'|'epic'|'legendary'

--- a/test/kanban/merge-on-done-dialog.test.tsx
+++ b/test/kanban/merge-on-done-dialog.test.tsx
@@ -202,7 +202,8 @@ describe('MergeOnDoneDialog', () => {
       pendingDoneMove: {
         ticketId: 'ticket-1',
         projectId: 'project-1',
-        sortOrder: 100
+        sortOrder: 100,
+        targetColumn: 'done' as const
       }
     })
     useGitStore.setState({ conflictsByWorktree: {} })
@@ -361,7 +362,8 @@ describe('MergeOnDoneDialog', () => {
         pendingDoneMove: {
           ticketId: 'ticket-2',
           projectId: 'project-1',
-          sortOrder: 200
+          sortOrder: 200,
+          targetColumn: 'done' as const
         }
       })
     })

--- a/test/kanban/merged-column.test.ts
+++ b/test/kanban/merged-column.test.ts
@@ -4,7 +4,8 @@ import type { KanbanTicket } from '../../src/main/db/types'
 const apiMocks = vi.hoisted(() => ({
   kanbanApi: {
     ticket: {
-      move: vi.fn()
+      move: vi.fn(),
+      archiveAllDone: vi.fn()
     }
   },
   settingsApi: {
@@ -137,6 +138,34 @@ describe('merged column', () => {
 
     const ordered = useKanbanStore.getState().getTicketsForProject('proj-1')
     expect(ordered.map((t) => t.id)).toEqual(['r', 'm', 'd'])
+  })
+
+  test('archiveAllDone with includeMerged archives folded merged tickets too', async () => {
+    mockKanbanTicketApi.archiveAllDone.mockResolvedValue(2)
+    const done = makeTicket({ id: 'd', column: 'done' })
+    const merged = makeTicket({ id: 'm', column: 'merged' })
+    useKanbanStore.setState({ tickets: new Map([['proj-1', [done, merged]]]) })
+
+    const count = await useKanbanStore.getState().archiveAllDone('proj-1', true)
+
+    expect(count).toBe(2)
+    expect(mockKanbanTicketApi.archiveAllDone).toHaveBeenCalledWith('proj-1', true)
+    const tickets = useKanbanStore.getState().tickets.get('proj-1') ?? []
+    expect(tickets.every((t) => t.archived_at)).toBe(true)
+  })
+
+  test('archiveAllDone without includeMerged leaves merged tickets alone', async () => {
+    mockKanbanTicketApi.archiveAllDone.mockResolvedValue(1)
+    const done = makeTicket({ id: 'd', column: 'done' })
+    const merged = makeTicket({ id: 'm', column: 'merged' })
+    useKanbanStore.setState({ tickets: new Map([['proj-1', [done, merged]]]) })
+
+    const count = await useKanbanStore.getState().archiveAllDone('proj-1')
+
+    expect(count).toBe(1)
+    const tickets = useKanbanStore.getState().tickets.get('proj-1') ?? []
+    expect(tickets.find((t) => t.id === 'm')?.archived_at).toBeNull()
+    expect(tickets.find((t) => t.id === 'd')?.archived_at).toBeTruthy()
   })
 
   test('merged blockers satisfy dependents in both trigger modes', () => {

--- a/test/kanban/merged-column.test.ts
+++ b/test/kanban/merged-column.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { KanbanTicket } from '../../src/main/db/types'
+
+const apiMocks = vi.hoisted(() => ({
+  kanbanApi: {
+    ticket: {
+      move: vi.fn()
+    }
+  },
+  settingsApi: {
+    onSettingsUpdated: vi.fn(() => vi.fn())
+  }
+}))
+
+vi.mock('@/api/kanban-api', () => ({
+  kanbanApi: apiMocks.kanbanApi
+}))
+
+vi.mock('@/api/settings-api', () => ({
+  settingsApi: apiMocks.settingsApi
+}))
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: Object.assign(vi.fn(), {
+    getState: () => ({ followUpTriggerColumn: 'done', showMergedColumn: true })
+  })
+}))
+
+import { kanbanApi } from '@/api/kanban-api'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { isBlockerSatisfied } from '@/lib/blocker-utils'
+
+const mockKanbanTicketApi = vi.mocked(kanbanApi.ticket)
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'proj-1',
+    title: 'Merged column ticket',
+    description: null,
+    attachments: [],
+    column: 'review',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: null,
+    mode: 'build',
+    plan_ready: false,
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: '2026-07-01T00:00:00.000Z',
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
+    ...overrides
+  } as KanbanTicket
+}
+
+describe('merged column', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useKanbanStore.setState({
+      tickets: new Map(),
+      pendingDoneMove: null,
+      dependencyMap: new Map()
+    })
+  })
+
+  test('completeDoneMove moves the ticket to the pending target column', async () => {
+    mockKanbanTicketApi.move.mockResolvedValue(undefined)
+    useKanbanStore.setState({
+      tickets: new Map([['proj-1', [makeTicket()]]]),
+      pendingDoneMove: {
+        ticketId: 'ticket-1',
+        projectId: 'proj-1',
+        sortOrder: 5,
+        targetColumn: 'merged'
+      }
+    })
+
+    await useKanbanStore.getState().completeDoneMove()
+
+    expect(mockKanbanTicketApi.move).toHaveBeenCalledWith('proj-1', 'ticket-1', 'merged', 5)
+    expect(useKanbanStore.getState().pendingDoneMove).toBeNull()
+    const moved = useKanbanStore.getState().tickets.get('proj-1')?.find((t) => t.id === 'ticket-1')
+    expect(moved?.column).toBe('merged')
+  })
+
+  test('completeDoneMove still targets done when the dialog was opened from Done', async () => {
+    mockKanbanTicketApi.move.mockResolvedValue(undefined)
+    useKanbanStore.setState({
+      tickets: new Map([['proj-1', [makeTicket()]]]),
+      pendingDoneMove: {
+        ticketId: 'ticket-1',
+        projectId: 'proj-1',
+        sortOrder: 0,
+        targetColumn: 'done'
+      }
+    })
+
+    await useKanbanStore.getState().completeDoneMove()
+
+    expect(mockKanbanTicketApi.move).toHaveBeenCalledWith('proj-1', 'ticket-1', 'done', 0)
+  })
+
+  test('getTicketsByColumn date-sorts the merged column newest first', () => {
+    const older = makeTicket({
+      id: 'older',
+      column: 'merged',
+      sort_order: 0,
+      updated_at: '2026-07-01T00:00:00.000Z'
+    })
+    const newer = makeTicket({
+      id: 'newer',
+      column: 'merged',
+      sort_order: 99,
+      updated_at: '2026-07-02T00:00:00.000Z'
+    })
+    useKanbanStore.setState({ tickets: new Map([['proj-1', [older, newer]]]) })
+
+    const tickets = useKanbanStore.getState().getTicketsByColumn('proj-1', 'merged')
+    expect(tickets.map((t) => t.id)).toEqual(['newer', 'older'])
+  })
+
+  test('getTicketsForProject orders merged between review and done', () => {
+    const review = makeTicket({ id: 'r', column: 'review' })
+    const merged = makeTicket({ id: 'm', column: 'merged' })
+    const done = makeTicket({ id: 'd', column: 'done' })
+    useKanbanStore.setState({ tickets: new Map([['proj-1', [done, merged, review]]]) })
+
+    const ordered = useKanbanStore.getState().getTicketsForProject('proj-1')
+    expect(ordered.map((t) => t.id)).toEqual(['r', 'm', 'd'])
+  })
+
+  test('merged blockers satisfy dependents in both trigger modes', () => {
+    expect(isBlockerSatisfied('merged', 'build', 'done')).toBe(true)
+    expect(isBlockerSatisfied('merged', 'plan', 'review')).toBe(true)
+    expect(isBlockerSatisfied('done', 'build', 'done')).toBe(true)
+    expect(isBlockerSatisfied('review', 'build', 'done')).toBe(false)
+    expect(isBlockerSatisfied('review', 'build', 'review')).toBe(true)
+  })
+})

--- a/test/settings/show-merged-column.test.tsx
+++ b/test/settings/show-merged-column.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockUpdateSetting = vi.fn()
+let mockSettingsState: Record<string, unknown> = {}
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: Object.assign(
+    (selector?: (s: unknown) => unknown) => {
+      return selector ? selector(mockSettingsState) : mockSettingsState
+    },
+    {
+      getState: () => mockSettingsState
+    }
+  )
+}))
+
+vi.mock('@/stores/useThemeStore', () => ({
+  useThemeStore: () => ({ setTheme: vi.fn() })
+}))
+
+vi.mock('@/stores/useShortcutStore', () => ({
+  useShortcutStore: () => ({ resetToDefaults: vi.fn() })
+}))
+
+vi.mock('@/lib/themes', () => ({
+  DEFAULT_THEME_ID: 'default'
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+describe('SettingsGeneral merged column toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSettingsState = {
+      autoStartSession: true,
+      autoPullBeforeWorktree: true,
+      boardMode: 'sticky-tab',
+      followUpTriggerColumn: 'done',
+      autoPinBaseWorktreeOnBoardPrompt: false,
+      automaticallyCreateTicket: false,
+      showMergedColumn: false,
+      vimModeEnabled: false,
+      keepAwakeEnabled: false,
+      mergeConflictMode: 'always-ask',
+      tipsEnabled: true,
+      warnBeforeQuitting: true,
+      breedType: 'dogs',
+      showModelIcons: false,
+      showModelProvider: false,
+      usageIndicatorMode: 'current-agent',
+      usageIndicatorProviders: [],
+      defaultAgentSdk: 'opencode',
+      availableAgentSdks: null,
+      stripAtMentions: true,
+      updateSetting: mockUpdateSetting,
+      resetToDefaults: vi.fn()
+    }
+  })
+
+  it('renders off by default and enables the merged column on click', async () => {
+    const { SettingsGeneral } = await import('@/components/settings/SettingsGeneral')
+    render(<SettingsGeneral />)
+
+    const toggle = screen.getByTestId('show-merged-column-toggle')
+
+    expect(screen.getByText('Merged column')).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+
+    await userEvent.click(toggle)
+
+    expect(mockUpdateSetting).toHaveBeenCalledWith('showMergedColumn', true)
+  })
+
+  it('renders on and disables the merged column on click', async () => {
+    mockSettingsState.showMergedColumn = true
+    const { SettingsGeneral } = await import('@/components/settings/SettingsGeneral')
+    render(<SettingsGeneral />)
+
+    const toggle = screen.getByTestId('show-merged-column-toggle')
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
+
+    await userEvent.click(toggle)
+
+    expect(mockUpdateSetting).toHaveBeenCalledWith('showMergedColumn', false)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a new optional `Merged` Kanban column between `Review` and `Done`, with a settings toggle to show or hide it.
- Treats `merged` as a valid ticket column across backend validation, RPC schemas, backup types, and kanban state logic.
- Updates board rendering, drag-and-drop behavior, merge-on-done dialog copy, blocker handling, and ticket counts to work with the new column.
- When the `Merged` column is hidden, merged tickets are folded into `Done` so they remain visible on the board.
- Adds coverage for merged-column movement, ordering, blocker satisfaction, and the settings toggle UI.

## Testing
- Added unit tests in `test/kanban/merged-column.test.ts` covering `completeDoneMove`, merged-column ordering, and blocker behavior.
- Added UI tests in `test/settings/show-merged-column.test.tsx` covering the merged-column settings toggle.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches kanban column semantics, git merge-on-drop flows, markdown folder layout, and session auto-move rules across a wide surface; behavior when the column is hidden must stay consistent with archive and DnD.
> 
> **Overview**
> Adds an optional **Merged** Kanban column (between Review and Done), controlled by a new **Merged column** toggle in General settings (`showMergedColumn`, default off).
> 
> **`merged`** is now a first-class ticket column across the stack: types, DB/RPC/backup schemas, markdown kanban validation, and optional `merged` status folder (falls back to **done** when unset). **Archive all** on Done accepts `includeMerged` so bulk archive matches the board when merged cards are folded into Done.
> 
> **Board UX:** When the column is hidden, merged tickets render inside Done (active + archived), date-sorted like Done/Merged elsewhere; drag-and-drop blocks re-dropping folded merged cards onto Done so they are not promoted to done. Merge-on-done flow targets **Done** or **Merged** via `pendingDoneMove.targetColumn` and updated dialog copy. Merged tickets share Done-like behaviors (token totals, archive affordances, terminal column for session sync, dependency follow-up triggers). **Merged** blockers satisfy dependents like **done**.
> 
> Tests cover store/RPC behavior, settings toggle, and merge dialog `targetColumn`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9141e938d4de7c3907edeb45632b56a029ff47f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->