### PR TITLE
Open usage popover at top and stabilize account switching

### DIFF
--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -563,7 +563,7 @@ describe('ProviderUsageBlock provider toggle', () => {
     expect(screen.queryByRole('button', { name: /show .* usage/i })).toBeNull()
   })
 
-  it('does not scroll back to the bottom when accounts load after the user scrolls up', async () => {
+  it('does not move the scroll position when accounts load after opening', async () => {
     const user = userEvent.setup()
     render(
       <ProviderUsageBlock
@@ -576,16 +576,13 @@ describe('ProviderUsageBlock provider toggle', () => {
     await user.hover(screen.getByTestId('usage-trigger-openai'))
     await screen.findByText('OpenAI API Usage')
 
-    const popover = screen.getByText('OpenAI API Usage').closest(
-      '[data-slot="hover-card-content"]'
-    ) as HTMLDivElement
-    Object.defineProperties(popover, {
+    const scroller = screen.getByTestId('usage-popover-scroll') as HTMLDivElement
+    Object.defineProperties(scroller, {
       scrollHeight: { configurable: true, value: 600 },
       clientHeight: { configurable: true, value: 200 }
     })
 
-    popover.scrollTop = 100
-    fireEvent.scroll(popover)
+    expect(scroller.scrollTop).toBe(0)
 
     act(() => {
       useUsageStore.setState((state) => ({
@@ -608,6 +605,120 @@ describe('ProviderUsageBlock provider toggle', () => {
       }))
     })
 
-    expect(popover.scrollTop).toBe(100)
+    expect(scroller.scrollTop).toBe(0)
+  })
+
+  it('preserves a user scroll position when accounts load', async () => {
+    const user = userEvent.setup()
+    render(
+      <ProviderUsageBlock
+        provider="openai"
+        isExplicitlySelected
+        toggleProviders={['openai']}
+      />
+    )
+
+    await user.hover(screen.getByTestId('usage-trigger-openai'))
+    await screen.findByText('OpenAI API Usage')
+
+    const scroller = screen.getByTestId('usage-popover-scroll') as HTMLDivElement
+    Object.defineProperties(scroller, {
+      scrollHeight: { configurable: true, value: 600 },
+      clientHeight: { configurable: true, value: 200 }
+    })
+
+    scroller.scrollTop = 100
+    fireEvent.scroll(scroller)
+
+    act(() => {
+      useUsageStore.setState((state) => ({
+        savedAccounts: {
+          ...state.savedAccounts,
+          openai: [
+            {
+              id: 'openai-loaded-account',
+              provider: 'openai',
+              email: 'loaded@example.com',
+              last_usage: sampleOpenAIUsage,
+              last_fetched_at: null,
+              status: 'ok',
+              last_error: null,
+              created_at: new Date().toISOString(),
+              plan: 'plus'
+            }
+          ]
+        }
+      }))
+    })
+
+    expect(scroller.scrollTop).toBe(100)
+  })
+
+  it('renders the active account first among multiple accounts', async () => {
+    const user = userEvent.setup()
+    useUsageStore.setState((state) => ({
+      savedAccounts: {
+        ...state.savedAccounts,
+        openai: [
+          {
+            id: 'openai-inactive',
+            provider: 'openai',
+            email: 'inactive@example.com',
+            last_usage: sampleOpenAIUsage,
+            last_fetched_at: null,
+            status: 'ok',
+            last_error: null,
+            created_at: new Date().toISOString(),
+            plan: 'plus'
+          },
+          {
+            id: 'openai-active',
+            provider: 'openai',
+            email: 'openai@example.com',
+            last_usage: sampleOpenAIUsage,
+            last_fetched_at: null,
+            status: 'ok',
+            last_error: null,
+            created_at: new Date().toISOString(),
+            plan: 'plus'
+          }
+        ]
+      }
+    }))
+
+    render(
+      <ProviderUsageBlock
+        provider="openai"
+        isExplicitlySelected
+        toggleProviders={['openai']}
+      />
+    )
+
+    await user.hover(screen.getByTestId('usage-trigger-openai'))
+    await screen.findByText('OpenAI API Usage')
+
+    const active = screen.getByText('openai@example.com')
+    const inactive = screen.getByText('inactive@example.com')
+    expect(
+      active.compareDocumentPosition(inactive) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it('keeps the provider toggle outside the scroll container', async () => {
+    const user = userEvent.setup()
+    render(
+      <ProviderUsageBlock
+        provider="openai"
+        isExplicitlySelected
+        toggleProviders={['anthropic', 'openai']}
+      />
+    )
+
+    await user.hover(screen.getByTestId('usage-trigger-openai'))
+    await screen.findByText('OpenAI API Usage')
+
+    const scroller = screen.getByTestId('usage-popover-scroll')
+    const toggle = screen.getByTestId('usage-provider-toggle')
+    expect(scroller.contains(toggle)).toBe(false)
   })
 })

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -490,7 +490,7 @@ function ProviderToggle({
 }): React.JSX.Element {
   return (
     <div
-      className="mt-2 flex justify-center border-t border-border/50 pt-2"
+      className="flex shrink-0 justify-center border-t border-border/50 px-4 py-2"
       data-testid="usage-provider-toggle"
     >
       <div className="inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-background/40 p-0.5">
@@ -577,9 +577,9 @@ function ProviderUsagePopoverBody({ provider }: { provider: UsageProvider }): Re
           }
         ]
 
-  // With multiple accounts, the active one goes last and gets a purple border
-  // so it reads as "currently active" at a glance.
-  const orderedRows = [...accountRows].sort((a, b) => Number(a.isActive) - Number(b.isActive))
+  // With multiple accounts, the active one goes first (and gets a purple
+  // border) so it's visible at the popover's natural top scroll position.
+  const orderedRows = [...accountRows].sort((a, b) => Number(b.isActive) - Number(a.isActive))
   const highlightActive = accountRows.length > 1
 
   const membersFor = (rowEmail: string | null): AccountMemberInfo[] | undefined => {
@@ -686,7 +686,6 @@ export function ProviderUsageBlock({
   // Which provider the popover shows. The bottom toggle can point it at a
   // different provider than the hovered trigger; each open snaps it back.
   const [viewedProvider, setViewedProvider] = useState<UsageProvider>(provider)
-  const viewedSavedAccountsCount = useUsageStore((s) => s.savedAccounts[viewedProvider].length)
 
   const usage = normalizeUsage(provider, anthropicUsage, openaiUsage)
 
@@ -708,40 +707,8 @@ export function ProviderUsageBlock({
   }
 
   const handleOpenChange = (open: boolean): void => {
-    if (open) {
-      shouldPinPopoverToBottomRef.current = true
-      setViewedProvider(provider)
-    }
+    if (open) setViewedProvider(provider)
   }
-
-  // The active account sorts last, so open the popover scrolled to the bottom
-  // to keep it in view when many accounts overflow the max height.
-  const popoverRef = useRef<HTMLDivElement | null>(null)
-  const shouldPinPopoverToBottomRef = useRef(true)
-  const scrollPopoverToBottom = useCallback((node: HTMLDivElement | null): void => {
-    popoverRef.current = node
-    if (node && shouldPinPopoverToBottomRef.current) node.scrollTop = node.scrollHeight
-  }, [])
-
-  const handlePopoverScroll = (event: React.UIEvent<HTMLDivElement>): void => {
-    const node = event.currentTarget
-    const distanceFromBottom = node.scrollHeight - node.clientHeight - node.scrollTop
-    shouldPinPopoverToBottomRef.current = distanceFromBottom <= 1
-  }
-
-  const handleProviderSelect = (nextProvider: UsageProvider): void => {
-    shouldPinPopoverToBottomRef.current = true
-    setViewedProvider(nextProvider)
-  }
-
-  // Saved accounts load async on open and can land after the popover mounts,
-  // growing the content past the initial scroll position. Keep following the
-  // bottom only until the user scrolls away; otherwise the update can move a
-  // Switch button between pointer-down and pointer-up and cancel the click.
-  useEffect(() => {
-    const node = popoverRef.current
-    if (node && shouldPinPopoverToBottomRef.current) node.scrollTop = node.scrollHeight
-  }, [viewedProvider, viewedSavedAccountsCount])
 
   useEffect(() => {
     loadSavedAccounts(provider).catch(() => {})
@@ -812,19 +779,19 @@ export function ProviderUsageBlock({
         </div>
       </HoverCardTrigger>
       <HoverCardContent
-        ref={scrollPopoverToBottom}
         side="top"
         sideOffset={8}
         collisionPadding={8}
-        className="w-72 max-w-[min(18rem,calc(100vw-2rem))] max-h-(--radix-hover-card-content-available-height) overflow-y-auto"
-        onScroll={handlePopoverScroll}
+        className="flex w-72 max-w-[min(18rem,calc(100vw-2rem))] max-h-(--radix-hover-card-content-available-height) flex-col p-0"
       >
-        <ProviderUsagePopoverBody provider={viewedProvider} />
+        <div className="flex-1 overflow-y-auto p-4" data-testid="usage-popover-scroll">
+          <ProviderUsagePopoverBody provider={viewedProvider} />
+        </div>
         {toggleProviders.length > 1 && (
           <ProviderToggle
             providers={toggleProviders}
             viewedProvider={viewedProvider}
-            onSelect={handleProviderSelect}
+            onSelect={setViewedProvider}
           />
         )}
       </HoverCardContent>


### PR DESCRIPTION
## Summary
- Reworked the usage popover so the scrollable account list starts at the top instead of auto-pinning to the bottom.
- Ordered multiple accounts with the active account first, making it visible at the natural initial scroll position.
- Moved the provider toggle outside the scroll container to prevent scroll-related click flakiness.
- Updated tests to cover scroll preservation, active-account ordering, and toggle placement.

## Testing
- Not run
- Added/updated unit coverage for popover scroll behavior when accounts load asynchronously.
- Added/updated unit coverage for active account ordering in the usage list.
- Added/updated unit coverage to verify the provider toggle is outside the scrollable region.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to the usage indicator popover with added unit tests; no auth, data, or API impact.
> 
> **Overview**
> The usage hover popover no longer **auto-scrolls to the bottom** on open or when saved accounts load. Bottom-pinning refs, scroll handlers, and the effect that followed async account updates are removed so the list stays at the top and user scroll position is not jumped when data arrives.
> 
> **Multi-account ordering** now puts the **active account first** (still highlighted with the purple border when there are multiple rows), so the active row is visible without scrolling.
> 
> The popover layout is a **flex column**: only the account body scrolls (`usage-popover-scroll`); the **Anthropic/OpenAI provider toggle** sits in a fixed footer outside the scroller to avoid scroll-related click issues on Switch. Tests were updated and extended for default scroll at top, preserved scroll on load, active-first ordering, and toggle placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f2b1e980f59e496159519a09a02a6a26fd256f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->