### PR TITLE
Add app-wide projects to recent connections sidebar

### DIFF
--- a/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
+++ b/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
@@ -19,7 +19,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
-import { useConnectionStore } from '@/stores'
+import { useConnectionStore, useProjectStore } from '@/stores'
 import { connectionApi } from '@/api/connection-api'
 import { toast } from '@/lib/toast'
 import { formatRelativeTime } from '@/lib/format-utils'
@@ -39,6 +39,7 @@ export function RecentConnectionsDialog({
   onOpenChange
 }: RecentConnectionsDialogProps): React.JSX.Element {
   const quickCreateConnection = useConnectionStore((s) => s.quickCreateConnection)
+  const storeProjects = useProjectStore((s) => s.projects)
 
   const [entries, setEntries] = useState<RecentConnectionEntry[]>([])
   const [isLoading, setIsLoading] = useState(false)
@@ -89,16 +90,21 @@ export function RecentConnectionsDialog({
       })
   }, [open])
 
-  // Every project that appears in at least one recent connection
+  // Every project in the app (current name/path wins), plus any project that only
+  // survives inside a recent connection entry (e.g. since removed from the app) --
+  // so brand-new combinations are creatable, not just previously-used ones.
   const allProjects = useMemo(() => {
     const byId = new Map<string, RecentConnectionProject>()
+    for (const project of storeProjects) {
+      byId.set(project.id, { id: project.id, name: project.name, path: project.path })
+    }
     for (const entry of entries) {
       for (const project of entry.projects) {
         if (!byId.has(project.id)) byId.set(project.id, project)
       }
     }
     return Array.from(byId.values()).sort((a, b) => a.name.localeCompare(b.name))
-  }, [entries])
+  }, [storeProjects, entries])
 
   // Same fuzzy matching + ranking as the sidebar project filter
   const filteredProjects = useMemo(() => {
@@ -443,13 +449,12 @@ export function RecentConnectionsDialog({
                 >
                   <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
                 </div>
-              ) : entries.length === 0 ? (
+              ) : entries.length === 0 && !showSelectionRow ? (
                 <div
                   className="px-4 py-8 text-center text-sm text-muted-foreground"
                   data-testid="recent-connections-empty"
                 >
-                  No recent connections yet. Create one by right-clicking a worktree and choosing
-                  Connect to…
+                  No recent connections yet. Select two or more projects on the left to create one.
                 </div>
               ) : displayEntries.length === 0 && !showSelectionRow ? (
                 <div

--- a/src/renderer/src/components/connections/__tests__/RecentConnectionsDialog.test.tsx
+++ b/src/renderer/src/components/connections/__tests__/RecentConnectionsDialog.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 
 import { RecentConnectionsDialog } from '../RecentConnectionsDialog'
 import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useProjectStore } from '@/stores/useProjectStore'
 import type { RecentConnectionEntry } from '@shared/types/connection'
 
 vi.mock('@/api/connection-api', () => ({
@@ -40,6 +41,10 @@ const entries = [
   entry('e3', [beta, gamma])
 ]
 
+function setStoreProjects(projects: (typeof alpha)[]): void {
+  useProjectStore.setState({ projects } as never)
+}
+
 async function renderDialog(data: RecentConnectionEntry[] = entries): Promise<void> {
   vi.mocked(connectionApi.getRecentConnections).mockResolvedValue({
     success: true,
@@ -54,6 +59,7 @@ async function renderDialog(data: RecentConnectionEntry[] = entries): Promise<vo
 describe('RecentConnectionsDialog project filter panel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    setStoreProjects([])
   })
 
   it('lists the unique projects from all entries in the project panel', async () => {
@@ -155,9 +161,68 @@ describe('RecentConnectionsDialog project filter panel', () => {
   })
 })
 
+describe('RecentConnectionsDialog all-projects panel', () => {
+  const delta = { id: 'proj-d', name: 'delta-cli', path: '/repo/delta-cli' }
+  const epsilon = { id: 'proj-e', name: 'epsilon-lib', path: '/repo/epsilon-lib' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setStoreProjects([])
+  })
+
+  it('lists app projects that appear in no recent connection', async () => {
+    setStoreProjects([alpha, delta])
+    await renderDialog()
+
+    const panel = screen.getByTestId('recent-connections-project-list')
+    expect(within(panel).getByText('delta-cli')).toBeInTheDocument()
+    // Entry-only projects remain listed alongside store projects, deduped
+    expect(within(panel).getAllByText('alpha-service')).toHaveLength(1)
+    expect(within(panel).getByText('beta-web')).toBeInTheDocument()
+  })
+
+  it('prefers the current app name over the recorded entry snapshot', async () => {
+    setStoreProjects([{ ...alpha, name: 'alpha-renamed' }])
+    await renderDialog()
+
+    const panel = screen.getByTestId('recent-connections-project-list')
+    expect(within(panel).getByText('alpha-renamed')).toBeInTheDocument()
+    expect(within(panel).queryByText('alpha-service')).not.toBeInTheDocument()
+  })
+
+  it('creates a connection from app projects never used together before', async () => {
+    const quickCreateConnection = vi.fn().mockResolvedValue('conn-2')
+    useConnectionStore.setState({ quickCreateConnection } as never)
+    setStoreProjects([delta, epsilon])
+    await renderDialog([])
+
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-d'))
+    await userEvent.click(screen.getByTestId('recent-connections-project-option-proj-e'))
+
+    // The zero-entries empty state must not hide the synthetic selection row
+    expect(screen.queryByTestId('recent-connections-empty')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('recent-connection-row-selected-combo'))
+    await userEvent.click(screen.getByTestId('recent-connections-create-button'))
+
+    await waitFor(() => expect(quickCreateConnection).toHaveBeenCalledWith([delta, epsilon]))
+  })
+
+  it('filters store projects with the same fuzzy matching as the sidebar', async () => {
+    setStoreProjects([delta, epsilon])
+    await renderDialog([])
+
+    await userEvent.type(screen.getByTestId('recent-connections-project-filter'), 'dcli')
+
+    const panel = screen.getByTestId('recent-connections-project-list')
+    expect(within(panel).getByText('delta-cli')).toBeInTheDocument()
+    expect(within(panel).queryByText('epsilon-lib')).not.toBeInTheDocument()
+  })
+})
+
 describe('RecentConnectionsDialog pinned selection row', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    setStoreProjects([])
   })
 
   it('does not show the selection row with fewer than 2 projects selected', async () => {


### PR DESCRIPTION
## Summary
- Include all projects from the app in the recent connections project panel, while still preserving any projects seen only in recent connection entries.
- Prefer the current project name/path from the store when a project exists in both sources.
- Update the empty-state copy so users are prompted to select two or more projects from the left panel.
- Add coverage for store-backed projects, renamed projects, fuzzy filtering, and creating a connection from previously unused project combinations.

## Testing
- `Not run`
- Added/updated unit tests in `RecentConnectionsDialog.test.tsx` for merged project lists and selection flow.
- Verified the dialog no longer hides the synthetic selection row when no recent entries exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in the recent connections dialog with expanded test coverage; connection creation still goes through the existing quickCreateConnection path.
> 
> **Overview**
> The **Recent Connections** dialog left panel now lists **every project in the app**, not only projects that appear in saved recent entries. Store-backed projects supply the current **name and path**; entries still contribute projects that were removed from the app so they remain selectable.
> 
> Users can pick **new multi-project combinations** (including when there are **no recent connections**) via the existing synthetic selection row—the empty state no longer blocks that row and now tells users to select two or more projects on the left.
> 
> Tests cover merged lists, renamed projects, fuzzy filter on store projects, and creating a connection with zero history entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa2799ef454dde5128d1fdaa9cfa5be545fff50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->