### PR TITLE
Add Cmd+] / Cmd+[ shortcuts to cycle between session tabs

### DIFF
--- a/src/renderer/src/components/layout/LeftSidebar.tsx
+++ b/src/renderer/src/components/layout/LeftSidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useLayoutStore } from '@/stores/useLayoutStore'
 import { useProjectStore, useConnectionStore, useFilterStore, useSpaceStore } from '@/stores'
 import { useSettingsStore } from '@/stores/useSettingsStore'
@@ -27,9 +27,10 @@ export function LeftSidebar(): React.JSX.Element {
   const shouldShowUsageIndicator =
     usageIndicatorMode === 'current-agent' ||
     (usageIndicatorMode === 'specific-providers' && usageIndicatorProviders.length > 0)
-  const [filterQuery, setFilterQuery] = useState('')
-
-  // Filter store for language filters
+  // Filter store for language filters and the text filter query
+  // (in the store so keyboard navigation can respect the visible list)
+  const filterQuery = useFilterStore((s) => s.filterQuery)
+  const setFilterQuery = useFilterStore((s) => s.setFilterQuery)
   const activeLanguages = useFilterStore((s) => s.activeLanguages)
   const removeLanguage = useFilterStore((s) => s.removeLanguage)
   const clearAllFilters = useFilterStore((s) => s.clearAll)
@@ -46,10 +47,9 @@ export function LeftSidebar(): React.JSX.Element {
 
   const canFinalize = connectionModeSelectedIds.size >= 2
 
-  // Clear language filters on space switch
+  // Clear language filters and the text filter on space switch
   useEffect(() => {
     clearAllFilters()
-    setFilterQuery('')
   }, [activeSpaceId, clearAllFilters])
 
   // Escape key exits connection mode

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -51,7 +51,6 @@ import { cn } from '@/lib/utils'
 const SECTIONS = [
   { id: 'appearance', label: 'Appearance', icon: Palette },
   { id: 'general', label: 'General', icon: Monitor },
-  { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
   { id: 'accounts', label: 'Accounts', icon: Users },
   { id: 'custom-commands', label: 'Custom Commands', icon: Zap },
   { id: 'custom-providers', label: 'Custom Providers', icon: Bot },
@@ -68,6 +67,7 @@ const SECTIONS = [
   { id: 'privacy', label: 'Privacy', icon: Eye },
   { id: 'storage', label: 'Storage', icon: Database },
   { id: 'backup', label: 'Backup', icon: DatabaseBackup },
+  { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
   { id: 'advanced', label: 'Advanced', icon: Wrench },
   { id: 'updates', label: 'Updates', icon: Download }
 ] as const

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -98,30 +98,32 @@ export function SettingsModal(): React.JSX.Element {
       >
         <div className="flex h-full min-h-0">
           {/* Left navigation */}
-          <nav className="w-48 border-r bg-muted/30 p-3 flex flex-col gap-1 shrink-0">
-            <div className="flex items-center gap-2 px-2 py-1.5 mb-2">
+          <nav className="w-48 border-r bg-muted/30 p-3 flex flex-col shrink-0 min-h-0">
+            <div className="flex items-center gap-2 px-2 py-1.5 mb-2 shrink-0">
               <Settings className="h-4 w-4 text-muted-foreground" />
               <DialogTitle className="text-sm font-semibold">Settings</DialogTitle>
             </div>
-            {SECTIONS.map((section) => {
-              const Icon = section.icon
-              return (
-                <button
-                  key={section.id}
-                  onClick={() => setActiveSection(section.id)}
-                  className={cn(
-                    'flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors text-left',
-                    activeSection === section.id
-                      ? 'bg-accent text-accent-foreground'
-                      : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
-                  )}
-                  data-testid={`settings-nav-${section.id}`}
-                >
-                  <Icon className="h-4 w-4" />
-                  {section.label}
-                </button>
-              )
-            })}
+            <div className="flex flex-col gap-1 overflow-y-auto min-h-0">
+              {SECTIONS.map((section) => {
+                const Icon = section.icon
+                return (
+                  <button
+                    key={section.id}
+                    onClick={() => setActiveSection(section.id)}
+                    className={cn(
+                      'flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors text-left shrink-0',
+                      activeSection === section.id
+                        ? 'bg-accent text-accent-foreground'
+                        : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                    )}
+                    data-testid={`settings-nav-${section.id}`}
+                  >
+                    <Icon className="h-4 w-4" />
+                    {section.label}
+                  </button>
+                )
+              })}
+            </div>
           </nav>
 
           {/* Content area */}

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -51,6 +51,7 @@ import { cn } from '@/lib/utils'
 const SECTIONS = [
   { id: 'appearance', label: 'Appearance', icon: Palette },
   { id: 'general', label: 'General', icon: Monitor },
+  { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
   { id: 'accounts', label: 'Accounts', icon: Users },
   { id: 'custom-commands', label: 'Custom Commands', icon: Zap },
   { id: 'custom-providers', label: 'Custom Providers', icon: Bot },
@@ -67,7 +68,6 @@ const SECTIONS = [
   { id: 'privacy', label: 'Privacy', icon: Eye },
   { id: 'storage', label: 'Storage', icon: Database },
   { id: 'backup', label: 'Backup', icon: DatabaseBackup },
-  { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
   { id: 'advanced', label: 'Advanced', icon: Wrench },
   { id: 'updates', label: 'Updates', icon: Download }
 ] as const

--- a/src/renderer/src/components/settings/SettingsShortcuts.tsx
+++ b/src/renderer/src/components/settings/SettingsShortcuts.tsx
@@ -5,6 +5,7 @@ import {
   shortcutCategoryLabels,
   shortcutCategoryOrder,
   formatBinding,
+  normalizeEventKey,
   type KeyBinding,
   type ModifierKey,
   type ShortcutCategory,
@@ -55,7 +56,9 @@ export function SettingsShortcuts(): React.JSX.Element {
       }
 
       const binding: KeyBinding = {
-        key: e.key.length === 1 ? e.key.toLowerCase() : e.key,
+        // Normalize shifted punctuation (Shift+] → "]") so stored bindings and
+        // conflict detection always use canonical keys
+        key: normalizeEventKey(e),
         modifiers
       }
 

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -133,45 +133,77 @@ function createNewSession(): void {
  */
 function cycleSession(direction: 1 | -1): void {
   const state = useSessionStore.getState()
-  const { activeSessionId, activeWorktreeId, activeConnectionId } = state
+  const { activeSessionId, activeWorktreeId, activeConnectionId, inlineConnectionSessionId } =
+    state
 
   // Determine scope: connection mode when a connection is active and no worktree is
   const isConnectionMode = !!activeConnectionId && !activeWorktreeId
   const scopeId = isConnectionMode ? activeConnectionId : activeWorktreeId
   if (!scopeId) return
 
-  const tabOrder = isConnectionMode
-    ? state.tabOrderByConnection.get(scopeId) || []
-    : state.tabOrderByWorktree.get(scopeId) || []
+  // Build the visible tab list in display order. In worktree mode, sticky
+  // connection tabs (connections containing this worktree) render before the
+  // worktree's own session tabs — mirror SessionTabs.
+  type Tab = { sessionId: string; inlineConnection: boolean }
+  const tabs: Tab[] = []
+  if (isConnectionMode) {
+    for (const id of state.tabOrderByConnection.get(scopeId) || []) {
+      tabs.push({ sessionId: id, inlineConnection: false })
+    }
+  } else {
+    const connections = useConnectionStore
+      .getState()
+      .connections.filter((c) => c.members.some((m) => m.worktree_id === scopeId))
+    for (const connection of connections) {
+      for (const id of state.tabOrderByConnection.get(connection.id) || []) {
+        tabs.push({ sessionId: id, inlineConnection: true })
+      }
+    }
+    for (const id of state.tabOrderByWorktree.get(scopeId) || []) {
+      tabs.push({ sessionId: id, inlineConnection: false })
+    }
+  }
 
   // Always leave any file/diff view so the session becomes visible,
   // even when there is only one session tab to "cycle" to.
   useFileViewerStore.getState().setActiveFile(null)
-  state.clearInlineConnectionSession()
 
-  if (tabOrder.length === 0) return
+  if (tabs.length === 0) return
 
-  const currentIndex = activeSessionId ? tabOrder.indexOf(activeSessionId) : -1
+  // Current position: an inline connection tab wins over the underlying
+  // worktree session it overlays.
+  const currentIndex =
+    !isConnectionMode && inlineConnectionSessionId
+      ? tabs.findIndex((t) => t.inlineConnection && t.sessionId === inlineConnectionSessionId)
+      : activeSessionId
+        ? tabs.findIndex((t) => !t.inlineConnection && t.sessionId === activeSessionId)
+        : -1
   // With a single tab, still select it when it isn't the active session
   // (e.g. cycling away from the Board tab); otherwise nothing to cycle to.
-  if (tabOrder.length === 1 && currentIndex === 0) return
+  if (tabs.length === 1 && currentIndex === 0) return
 
   const nextIndex =
     currentIndex === -1
       ? direction === 1
         ? 0
-        : tabOrder.length - 1
-      : (currentIndex + direction + tabOrder.length) % tabOrder.length
-  const nextSessionId = tabOrder[nextIndex]
-  if (!nextSessionId) return
+        : tabs.length - 1
+      : (currentIndex + direction + tabs.length) % tabs.length
+  const next = tabs[nextIndex]
+  if (!next) return
 
-  if (isConnectionMode) {
-    state.setActiveConnectionSession(nextSessionId)
+  if (next.inlineConnection) {
+    // Sticky connection tab viewed inline in worktree mode
+    state.setInlineConnectionSession(next.sessionId)
   } else {
-    state.setActiveSession(nextSessionId)
+    state.clearInlineConnectionSession()
+    if (isConnectionMode) {
+      state.setActiveConnectionSession(next.sessionId)
+    } else {
+      state.setActiveSession(next.sessionId)
+    }
   }
   // Match tab-click behavior: viewing the session clears its unread badge
-  useWorktreeStatusStore.getState().clearSessionStatus(nextSessionId)
+  useWorktreeStatusStore.getState().clearSessionStatus(next.sessionId)
 }
 
 /**
@@ -183,9 +215,11 @@ function cycleWorktree(direction: 1 | -1): void {
   const wtState = useWorktreeStore.getState()
   const { selectedWorktreeId, worktreesByProject, worktreeOrderByProject } = wtState
 
-  // Resolve project: from the selected worktree, or fall back to selected project
-  let projectId: string | null = null
-  if (selectedWorktreeId) {
+  // Resolve project: prefer the explicitly selected (highlighted) project so
+  // cycling follows the sidebar selection even when a worktree from another
+  // project is still active; fall back to the selected worktree's project.
+  let projectId: string | null = useProjectStore.getState().selectedProjectId
+  if (!projectId && selectedWorktreeId) {
     for (const [pid, worktrees] of worktreesByProject) {
       if (worktrees.some((w) => w.id === selectedWorktreeId)) {
         projectId = pid
@@ -193,7 +227,6 @@ function cycleWorktree(direction: 1 | -1): void {
       }
     }
   }
-  if (!projectId) projectId = useProjectStore.getState().selectedProjectId
   if (!projectId) return
 
   const ordered = getOrderedProjectWorktrees(worktreesByProject, worktreeOrderByProject, projectId)

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -672,6 +672,19 @@ function getShortcutHandlers(
     },
 
     {
+      id: 'nav:toggle-project-expand',
+      binding: getEffectiveBinding('nav:toggle-project-expand'),
+      allowInInput: true,
+      handler: () => {
+        const { selectedProjectId, toggleProjectExpanded } = useProjectStore.getState()
+        if (!selectedProjectId) return
+        // Ensure the sidebar is visible so the toggle has a visible effect
+        const { leftSidebarCollapsed, setLeftSidebarCollapsed } = useLayoutStore.getState()
+        if (leftSidebarCollapsed) setLeftSidebarCollapsed(false)
+        toggleProjectExpanded(selectedProjectId)
+      }
+    },
+    {
       id: 'nav:next-worktree',
       binding: getEffectiveBinding('nav:next-worktree'),
       allowInInput: true,

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -192,7 +192,9 @@ function cycleSession(direction: 1 | -1): void {
   if (!next) return
 
   if (next.inlineConnection) {
-    // Sticky connection tab viewed inline in worktree mode
+    // Sticky connection tab viewed inline in worktree mode. Also clear any
+    // Board Assistant focus, which otherwise renders above inline sessions.
+    state.clearBoardAssistantFocus()
     state.setInlineConnectionSession(next.sessionId)
   } else {
     state.clearInlineConnectionSession()
@@ -202,8 +204,12 @@ function cycleSession(direction: 1 | -1): void {
       state.setActiveSession(next.sessionId)
     }
   }
-  // Match tab-click behavior: viewing the session clears its unread badge
-  useWorktreeStatusStore.getState().clearSessionStatus(next.sessionId)
+  // Match tab-click behavior: clear only the unread badge, preserving live
+  // statuses (working/planning/answering/permission) that still need action
+  const statusStore = useWorktreeStatusStore.getState()
+  if (statusStore.sessionStatuses[next.sessionId]?.status === 'unread') {
+    statusStore.clearSessionStatus(next.sessionId)
+  }
 }
 
 /**

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -9,13 +9,15 @@ import {
   useSettingsStore,
   useKanbanStore,
   useVimModeStore,
-  useConnectionStore
+  useConnectionStore,
+  useSpaceStore
 } from '@/stores'
 import { useGitStore } from '@/stores/useGitStore'
 import { useShortcutStore } from '@/stores/useShortcutStore'
 import { useWorktreeStore, getOrderedProjectWorktrees } from '@/stores/useWorktreeStore'
 import { useScriptStore, fireRunScript, killRunScript } from '@/stores/useScriptStore'
 import { useFileViewerStore } from '@/stores/useFileViewerStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useTerminalTabStore } from '@/stores/useTerminalTabStore'
 import { useTerminalStore } from '@/stores/useTerminalStore'
 import { eventMatchesBinding, type KeyBinding } from '@/lib/keyboard-shortcuts'
@@ -147,9 +149,13 @@ function cycleSession(direction: 1 | -1): void {
   useFileViewerStore.getState().setActiveFile(null)
   state.clearInlineConnectionSession()
 
-  if (tabOrder.length < 2) return
+  if (tabOrder.length === 0) return
 
   const currentIndex = activeSessionId ? tabOrder.indexOf(activeSessionId) : -1
+  // With a single tab, still select it when it isn't the active session
+  // (e.g. cycling away from the Board tab); otherwise nothing to cycle to.
+  if (tabOrder.length === 1 && currentIndex === 0) return
+
   const nextIndex =
     currentIndex === -1
       ? direction === 1
@@ -164,6 +170,8 @@ function cycleSession(direction: 1 | -1): void {
   } else {
     state.setActiveSession(nextSessionId)
   }
+  // Match tab-click behavior: viewing the session clears its unread badge
+  useWorktreeStatusStore.getState().clearSessionStatus(nextSessionId)
 }
 
 /**
@@ -205,6 +213,8 @@ function cycleWorktree(direction: 1 | -1): void {
 
   useProjectStore.getState().selectProject(projectId)
   wtState.selectWorktree(next.id)
+  // Match mouse navigation: viewing the worktree clears its unread badge
+  useWorktreeStatusStore.getState().clearWorktreeUnread(next.id)
 }
 
 /**
@@ -219,11 +229,19 @@ function cycleProject(direction: 1 | -1): void {
   const { projects, selectedProjectId } = projectState
   const { connections, selectedConnectionId } = connectionState
 
+  // Respect the active Space filter so cycling stays within the visible
+  // sidebar list (mirrors ProjectList's space filtering)
+  const { activeSpaceId, projectSpaceMap } = useSpaceStore.getState()
+  const visibleProjects =
+    activeSpaceId === null
+      ? projects
+      : projects.filter((p) => projectSpaceMap[p.id]?.includes(activeSpaceId))
+
   // Unified sidebar order: connections section first, then projects
   type SidebarItem = { kind: 'connection' | 'project'; id: string }
   const items: SidebarItem[] = [
     ...connections.map((c): SidebarItem => ({ kind: 'connection', id: c.id })),
-    ...projects.map((p): SidebarItem => ({ kind: 'project', id: p.id }))
+    ...visibleProjects.map((p): SidebarItem => ({ kind: 'project', id: p.id }))
   ]
   if (items.length === 0) return
 
@@ -268,7 +286,10 @@ function cycleProject(direction: 1 | -1): void {
       state.worktreeOrderByProject,
       next.id
     )
-    if (ordered[0]) state.selectWorktree(ordered[0].id)
+    if (ordered[0]) {
+      state.selectWorktree(ordered[0].id)
+      useWorktreeStatusStore.getState().clearWorktreeUnread(ordered[0].id)
+    }
   })
 }
 
@@ -354,10 +375,16 @@ export function useKeyboardShortcuts(): void {
       // but allow Ctrl+Tab through for terminal tab cycling.
       const isXtermFocused = target.closest?.('.xterm') !== null
 
-      // Ctrl+[ is the Escape equivalent in terminals (and Vim). Never intercept
-      // it while the terminal is focused, even though meta-modifier bindings
-      // also match Ctrl on Windows/Linux.
-      if (isXtermFocused && event.ctrlKey && !event.metaKey && event.key === '[') {
+      // Ctrl+[ is the Escape equivalent in terminals (and Vim), and Ctrl+] is
+      // Vim's "jump to tag/definition". Never intercept them while the
+      // terminal is focused, even though meta-modifier bindings also match
+      // Ctrl on Windows/Linux.
+      if (
+        isXtermFocused &&
+        event.ctrlKey &&
+        !event.metaKey &&
+        (event.key === '[' || event.key === ']')
+      ) {
         return
       }
 

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -10,8 +10,10 @@ import {
   useKanbanStore,
   useVimModeStore,
   useConnectionStore,
-  useSpaceStore
+  useSpaceStore,
+  useFilterStore
 } from '@/stores'
+import { subsequenceMatch } from '@/lib/subsequence-match'
 import { useGitStore } from '@/stores/useGitStore'
 import { useShortcutStore } from '@/stores/useShortcutStore'
 import { useWorktreeStore, getOrderedProjectWorktrees } from '@/stores/useWorktreeStore'
@@ -268,13 +270,34 @@ function cycleProject(direction: 1 | -1): void {
   const { projects, selectedProjectId } = projectState
   const { connections, selectedConnectionId } = connectionState
 
-  // Respect the active Space filter so cycling stays within the visible
-  // sidebar list (mirrors ProjectList's space filtering)
+  // Respect the active Space, language, and text filters so cycling stays
+  // within the visible sidebar list (mirrors ProjectList's filtering)
   const { activeSpaceId, projectSpaceMap } = useSpaceStore.getState()
-  const visibleProjects =
+  const { activeLanguages, filterQuery } = useFilterStore.getState()
+  let visibleProjects =
     activeSpaceId === null
       ? projects
       : projects.filter((p) => projectSpaceMap[p.id]?.includes(activeSpaceId))
+  if (activeLanguages.length > 0) {
+    const langSet = new Set(activeLanguages)
+    visibleProjects = visibleProjects.filter((p) => p.language && langSet.has(p.language))
+  }
+  if (filterQuery.trim()) {
+    // Filter and sort by match score, mirroring ProjectList's display order
+    visibleProjects = visibleProjects
+      .map((p) => ({
+        project: p,
+        nameMatch: subsequenceMatch(filterQuery, p.name),
+        pathMatch: subsequenceMatch(filterQuery, p.path)
+      }))
+      .filter(({ nameMatch, pathMatch }) => nameMatch.matched || pathMatch.matched)
+      .sort((a, b) => {
+        const aScore = a.nameMatch.matched ? a.nameMatch.score : a.pathMatch.score + 1000
+        const bScore = b.nameMatch.matched ? b.nameMatch.score : b.pathMatch.score + 1000
+        return aScore - bScore
+      })
+      .map(({ project }) => project)
+  }
 
   // Unified sidebar order: connections section first, then projects
   type SidebarItem = { kind: 'connection' | 'project'; id: string }

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -8,7 +8,8 @@ import {
   useFileSearchStore,
   useSettingsStore,
   useKanbanStore,
-  useVimModeStore
+  useVimModeStore,
+  useConnectionStore
 } from '@/stores'
 import { useGitStore } from '@/stores/useGitStore'
 import { useShortcutStore } from '@/stores/useShortcutStore'
@@ -207,26 +208,48 @@ function cycleWorktree(direction: 1 | -1): void {
 }
 
 /**
- * Cycles to the next/previous project in the sidebar order and selects its
- * top worktree so the jump lands somewhere useful. Wraps around at the ends.
+ * Cycles to the next/previous item in the sidebar — connections first (as
+ * displayed above projects), then projects — as one unified list, wrapping
+ * around at the ends. Landing on a connection selects it; landing on a
+ * project selects it and its top worktree so the jump lands somewhere useful.
  */
 function cycleProject(direction: 1 | -1): void {
   const projectState = useProjectStore.getState()
+  const connectionState = useConnectionStore.getState()
   const { projects, selectedProjectId } = projectState
-  if (projects.length === 0) return
+  const { connections, selectedConnectionId } = connectionState
 
-  const currentIndex = selectedProjectId
-    ? projects.findIndex((p) => p.id === selectedProjectId)
-    : -1
+  // Unified sidebar order: connections section first, then projects
+  type SidebarItem = { kind: 'connection' | 'project'; id: string }
+  const items: SidebarItem[] = [
+    ...connections.map((c): SidebarItem => ({ kind: 'connection', id: c.id })),
+    ...projects.map((p): SidebarItem => ({ kind: 'project', id: p.id }))
+  ]
+  if (items.length === 0) return
+
+  // Current position: an explicitly selected connection wins (it clears
+  // worktree/project selection); otherwise the selected project.
+  const currentIndex = selectedConnectionId
+    ? items.findIndex((i) => i.kind === 'connection' && i.id === selectedConnectionId)
+    : selectedProjectId
+      ? items.findIndex((i) => i.kind === 'project' && i.id === selectedProjectId)
+      : -1
   const nextIndex =
     currentIndex === -1
       ? direction === 1
         ? 0
-        : projects.length - 1
-      : (currentIndex + direction + projects.length) % projects.length
-  const next = projects[nextIndex]
-  if (!next || next.id === selectedProjectId) return
+        : items.length - 1
+      : (currentIndex + direction + items.length) % items.length
+  const next = items[nextIndex]
+  if (!next || nextIndex === currentIndex) return
 
+  if (next.kind === 'connection') {
+    connectionState.selectConnection(next.id)
+    return
+  }
+
+  // Landing on a project: clear any connection selection and select the project
+  if (selectedConnectionId) connectionState.selectConnection(null)
   projectState.selectProject(next.id)
 
   // Select the project's top worktree (sidebar order) so the jump is useful
@@ -239,6 +262,7 @@ function cycleProject(direction: 1 | -1): void {
     const state = useWorktreeStore.getState()
     // Bail if the user has moved on to another project meanwhile
     if (useProjectStore.getState().selectedProjectId !== next.id) return
+    if (useConnectionStore.getState().selectedConnectionId) return
     const ordered = getOrderedProjectWorktrees(
       state.worktreesByProject,
       state.worktreeOrderByProject,

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -125,6 +125,44 @@ function createNewSession(): void {
 }
 
 /**
+ * Cycles to the next/previous session tab in the current worktree or connection.
+ * Wraps around at the ends. Shared between session:next and session:previous shortcuts.
+ */
+function cycleSession(direction: 1 | -1): void {
+  const state = useSessionStore.getState()
+  const { activeSessionId, activeWorktreeId, activeConnectionId } = state
+
+  // Determine scope: connection mode when a connection is active and no worktree is
+  const isConnectionMode = !!activeConnectionId && !activeWorktreeId
+  const scopeId = isConnectionMode ? activeConnectionId : activeWorktreeId
+  if (!scopeId) return
+
+  const tabOrder = isConnectionMode
+    ? state.tabOrderByConnection.get(scopeId) || []
+    : state.tabOrderByWorktree.get(scopeId) || []
+  if (tabOrder.length < 2) return
+
+  const currentIndex = activeSessionId ? tabOrder.indexOf(activeSessionId) : -1
+  const nextIndex =
+    currentIndex === -1
+      ? direction === 1
+        ? 0
+        : tabOrder.length - 1
+      : (currentIndex + direction + tabOrder.length) % tabOrder.length
+  const nextSessionId = tabOrder[nextIndex]
+  if (!nextSessionId) return
+
+  // Leave any file/diff view so the session becomes visible
+  useFileViewerStore.getState().setActiveFile(null)
+  state.clearInlineConnectionSession()
+  if (isConnectionMode) {
+    state.setActiveConnectionSession(nextSessionId)
+  } else {
+    state.setActiveSession(nextSessionId)
+  }
+}
+
+/**
  * Checks whether any modal/dialog is currently open and closes it.
  * Returns `true` if a modal was closed, `false` otherwise.
  *
@@ -431,6 +469,22 @@ function getShortcutHandlers(
               toast.error(result.error || 'Failed to close session')
             }
           })
+      }
+    },
+    {
+      id: 'session:next',
+      binding: getEffectiveBinding('session:next'),
+      allowInInput: true,
+      handler: () => {
+        cycleSession(1)
+      }
+    },
+    {
+      id: 'session:previous',
+      binding: getEffectiveBinding('session:previous'),
+      allowInInput: true,
+      handler: () => {
+        cycleSession(-1)
       }
     },
     {

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -140,6 +140,12 @@ function cycleSession(direction: 1 | -1): void {
   const tabOrder = isConnectionMode
     ? state.tabOrderByConnection.get(scopeId) || []
     : state.tabOrderByWorktree.get(scopeId) || []
+
+  // Always leave any file/diff view so the session becomes visible,
+  // even when there is only one session tab to "cycle" to.
+  useFileViewerStore.getState().setActiveFile(null)
+  state.clearInlineConnectionSession()
+
   if (tabOrder.length < 2) return
 
   const currentIndex = activeSessionId ? tabOrder.indexOf(activeSessionId) : -1
@@ -152,9 +158,6 @@ function cycleSession(direction: 1 | -1): void {
   const nextSessionId = tabOrder[nextIndex]
   if (!nextSessionId) return
 
-  // Leave any file/diff view so the session becomes visible
-  useFileViewerStore.getState().setActiveFile(null)
-  state.clearInlineConnectionSession()
   if (isConnectionMode) {
     state.setActiveConnectionSession(nextSessionId)
   } else {
@@ -326,6 +329,13 @@ export function useKeyboardShortcuts(): void {
       // Also skip bare Tab (no ctrl) since the terminal uses it for completion,
       // but allow Ctrl+Tab through for terminal tab cycling.
       const isXtermFocused = target.closest?.('.xterm') !== null
+
+      // Ctrl+[ is the Escape equivalent in terminals (and Vim). Never intercept
+      // it while the terminal is focused, even though meta-modifier bindings
+      // also match Ctrl on Windows/Linux.
+      if (isXtermFocused && event.ctrlKey && !event.metaKey && event.key === '[') {
+        return
+      }
 
       for (const { binding, handler, allowInInput } of shortcuts) {
         if (!binding) continue

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -12,7 +12,7 @@ import {
 } from '@/stores'
 import { useGitStore } from '@/stores/useGitStore'
 import { useShortcutStore } from '@/stores/useShortcutStore'
-import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useWorktreeStore, getOrderedProjectWorktrees } from '@/stores/useWorktreeStore'
 import { useScriptStore, fireRunScript, killRunScript } from '@/stores/useScriptStore'
 import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import { useTerminalTabStore } from '@/stores/useTerminalTabStore'
@@ -160,6 +160,89 @@ function cycleSession(direction: 1 | -1): void {
   } else {
     state.setActiveSession(nextSessionId)
   }
+}
+
+/**
+ * Cycles to the next/previous worktree within the currently selected project.
+ * Uses the sidebar display order (custom order, default worktree last) and
+ * wraps around at the ends.
+ */
+function cycleWorktree(direction: 1 | -1): void {
+  const wtState = useWorktreeStore.getState()
+  const { selectedWorktreeId, worktreesByProject, worktreeOrderByProject } = wtState
+
+  // Resolve project: from the selected worktree, or fall back to selected project
+  let projectId: string | null = null
+  if (selectedWorktreeId) {
+    for (const [pid, worktrees] of worktreesByProject) {
+      if (worktrees.some((w) => w.id === selectedWorktreeId)) {
+        projectId = pid
+        break
+      }
+    }
+  }
+  if (!projectId) projectId = useProjectStore.getState().selectedProjectId
+  if (!projectId) return
+
+  const ordered = getOrderedProjectWorktrees(worktreesByProject, worktreeOrderByProject, projectId)
+  if (ordered.length === 0) return
+
+  const currentIndex = selectedWorktreeId
+    ? ordered.findIndex((w) => w.id === selectedWorktreeId)
+    : -1
+  const nextIndex =
+    currentIndex === -1
+      ? direction === 1
+        ? 0
+        : ordered.length - 1
+      : (currentIndex + direction + ordered.length) % ordered.length
+  const next = ordered[nextIndex]
+  if (!next || next.id === selectedWorktreeId) return
+
+  useProjectStore.getState().selectProject(projectId)
+  wtState.selectWorktree(next.id)
+}
+
+/**
+ * Cycles to the next/previous project in the sidebar order and selects its
+ * top worktree so the jump lands somewhere useful. Wraps around at the ends.
+ */
+function cycleProject(direction: 1 | -1): void {
+  const projectState = useProjectStore.getState()
+  const { projects, selectedProjectId } = projectState
+  if (projects.length === 0) return
+
+  const currentIndex = selectedProjectId
+    ? projects.findIndex((p) => p.id === selectedProjectId)
+    : -1
+  const nextIndex =
+    currentIndex === -1
+      ? direction === 1
+        ? 0
+        : projects.length - 1
+      : (currentIndex + direction + projects.length) % projects.length
+  const next = projects[nextIndex]
+  if (!next || next.id === selectedProjectId) return
+
+  projectState.selectProject(next.id)
+
+  // Select the project's top worktree (sidebar order) so the jump is useful
+  const wtState = useWorktreeStore.getState()
+  const load =
+    wtState.worktreesByProject.has(next.id)
+      ? Promise.resolve()
+      : wtState.loadWorktrees(next.id) ?? Promise.resolve()
+  void Promise.resolve(load).then(() => {
+    const state = useWorktreeStore.getState()
+    // Bail if the user has moved on to another project meanwhile
+    if (useProjectStore.getState().selectedProjectId !== next.id) return
+    const ordered = getOrderedProjectWorktrees(
+      state.worktreesByProject,
+      state.worktreeOrderByProject,
+      next.id
+    )
+    if (ordered[0]) state.selectWorktree(ordered[0].id)
+  })
 }
 
 /**
@@ -575,6 +658,39 @@ function getShortcutHandlers(
           },
           leftSidebarCollapsed ? 100 : 0
         )
+      }
+    },
+
+    {
+      id: 'nav:next-worktree',
+      binding: getEffectiveBinding('nav:next-worktree'),
+      allowInInput: true,
+      handler: () => {
+        cycleWorktree(1)
+      }
+    },
+    {
+      id: 'nav:previous-worktree',
+      binding: getEffectiveBinding('nav:previous-worktree'),
+      allowInInput: true,
+      handler: () => {
+        cycleWorktree(-1)
+      }
+    },
+    {
+      id: 'nav:next-project',
+      binding: getEffectiveBinding('nav:next-project'),
+      allowInInput: true,
+      handler: () => {
+        cycleProject(1)
+      }
+    },
+    {
+      id: 'nav:previous-project',
+      binding: getEffectiveBinding('nav:previous-project'),
+      allowInInput: true,
+      handler: () => {
+        cycleProject(-1)
       }
     },
 

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -56,6 +56,20 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     defaultBinding: { key: 'Tab', modifiers: ['shift'] }
   },
   {
+    id: 'session:next',
+    label: 'Next Session',
+    description: 'Switch to the next session tab',
+    category: 'session',
+    defaultBinding: { key: ']', modifiers: ['meta'] }
+  },
+  {
+    id: 'session:previous',
+    label: 'Previous Session',
+    description: 'Switch to the previous session tab',
+    category: 'session',
+    defaultBinding: { key: '[', modifiers: ['meta'] }
+  },
+  {
     id: 'project:run',
     label: 'Run Project',
     description: 'Start or stop the project run script',

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -101,15 +101,15 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   },
   {
     id: 'nav:next-project',
-    label: 'Next Project',
-    description: 'Switch to the next project in the sidebar',
+    label: 'Next Project/Connection',
+    description: 'Switch to the next connection or project in the sidebar',
     category: 'navigation',
     defaultBinding: { key: ']', modifiers: ['meta', 'alt'] }
   },
   {
     id: 'nav:previous-project',
-    label: 'Previous Project',
-    description: 'Switch to the previous project in the sidebar',
+    label: 'Previous Project/Connection',
+    description: 'Switch to the previous connection or project in the sidebar',
     category: 'navigation',
     defaultBinding: { key: '[', modifiers: ['meta', 'alt'] }
   },

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -114,6 +114,13 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     defaultBinding: { key: '[', modifiers: ['meta', 'alt'] }
   },
   {
+    id: 'nav:toggle-project-expand',
+    label: 'Expand/Collapse Project',
+    description: 'Expand or collapse the selected project in the sidebar',
+    category: 'navigation',
+    defaultBinding: { key: 'e', modifiers: ['meta', 'shift'] }
+  },
+  {
     id: 'nav:file-search',
     label: 'Search Files',
     description: 'Open the file search dialog',

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -289,6 +289,19 @@ const PUNCTUATION_CODE_MAP: Record<string, string> = {
 }
 
 /**
+ * Normalize a keyboard event into the canonical binding key.
+ * For shifted punctuation (e.g. Shift+] produces "}"), returns the unshifted
+ * character from the physical key code so bindings and conflict detection
+ * always compare canonical keys.
+ */
+export function normalizeEventKey(event: Pick<KeyboardEvent, 'key' | 'code' | 'shiftKey'>): string {
+  if (event.shiftKey && event.code && PUNCTUATION_CODE_MAP[event.code]) {
+    return PUNCTUATION_CODE_MAP[event.code]
+  }
+  return event.key.length === 1 ? event.key.toLowerCase() : event.key
+}
+
+/**
  * Derive the logical key from a physical key code, e.g. "KeyT" → "t",
  * "Digit1" → "1", "BracketRight" → "]".
  */

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -86,6 +86,34 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
 
   // Navigation shortcuts
   {
+    id: 'nav:next-worktree',
+    label: 'Next Worktree',
+    description: 'Switch to the next worktree in the current project',
+    category: 'navigation',
+    defaultBinding: { key: ']', modifiers: ['meta', 'shift'] }
+  },
+  {
+    id: 'nav:previous-worktree',
+    label: 'Previous Worktree',
+    description: 'Switch to the previous worktree in the current project',
+    category: 'navigation',
+    defaultBinding: { key: '[', modifiers: ['meta', 'shift'] }
+  },
+  {
+    id: 'nav:next-project',
+    label: 'Next Project',
+    description: 'Switch to the next project in the sidebar',
+    category: 'navigation',
+    defaultBinding: { key: ']', modifiers: ['meta', 'alt'] }
+  },
+  {
+    id: 'nav:previous-project',
+    label: 'Previous Project',
+    description: 'Switch to the previous project in the sidebar',
+    category: 'navigation',
+    defaultBinding: { key: '[', modifiers: ['meta', 'alt'] }
+  },
+  {
     id: 'nav:file-search',
     label: 'Search Files',
     description: 'Open the file search dialog',
@@ -244,23 +272,52 @@ export function deserializeBinding(serialized: string): KeyBinding {
   return { key, modifiers }
 }
 
+// Map physical-key codes for punctuation to their unshifted characters so
+// bindings like meta+shift+] or alt+[ can match via event.code.
+const PUNCTUATION_CODE_MAP: Record<string, string> = {
+  BracketLeft: '[',
+  BracketRight: ']',
+  Backquote: '`',
+  Backslash: '\\',
+  Semicolon: ';',
+  Quote: "'",
+  Comma: ',',
+  Period: '.',
+  Slash: '/',
+  Minus: '-',
+  Equal: '='
+}
+
+/**
+ * Derive the logical key from a physical key code, e.g. "KeyT" → "t",
+ * "Digit1" → "1", "BracketRight" → "]".
+ */
+function keyFromCode(code: string): string {
+  return (
+    PUNCTUATION_CODE_MAP[code] ??
+    code
+      .replace(/^Key/, '')
+      .replace(/^Digit/, '')
+      .toLowerCase()
+  )
+}
+
 /**
  * Check if a keyboard event matches a binding.
  * For cross-platform, treats both ctrl and meta as "command" when modifier is 'meta'.
  */
 export function eventMatchesBinding(event: KeyboardEvent, binding: KeyBinding): boolean {
-  // On macOS, Alt+key produces dead characters (e.g., Alt+T → †) so event.key
-  // won't match. Fall back to event.code (physical key) when alt is involved.
+  // On macOS, Alt+key produces dead characters (e.g., Alt+T → †) and
+  // Shift+punctuation produces the shifted character (e.g., Shift+] → }),
+  // so event.key won't match. Fall back to event.code (physical key).
   const altRequired = binding.modifiers.includes('alt')
   let keyMatches: boolean
   if (altRequired && event.altKey && event.code) {
-    const codeKey = event.code
-      .replace(/^Key/, '')
-      .replace(/^Digit/, '')
-      .toLowerCase()
-    keyMatches = codeKey === binding.key.toLowerCase()
+    keyMatches = keyFromCode(event.code) === binding.key.toLowerCase()
   } else {
-    keyMatches = event.key.toLowerCase() === binding.key.toLowerCase()
+    keyMatches =
+      event.key.toLowerCase() === binding.key.toLowerCase() ||
+      (!!event.code && event.shiftKey && keyFromCode(event.code) === binding.key.toLowerCase())
   }
   if (!keyMatches) return false
 

--- a/src/renderer/src/stores/useFilterStore.ts
+++ b/src/renderer/src/stores/useFilterStore.ts
@@ -24,13 +24,16 @@ export const COLON_COMMANDS: ColonCommand[] = [
 
 interface FilterState {
   activeLanguages: string[]
+  filterQuery: string
   addLanguage: (lang: string) => void
   removeLanguage: (lang: string) => void
+  setFilterQuery: (query: string) => void
   clearAll: () => void
 }
 
 export const useFilterStore = create<FilterState>()((set) => ({
   activeLanguages: [],
+  filterQuery: '',
   addLanguage: (lang) =>
     set((state) => ({
       activeLanguages: state.activeLanguages.includes(lang)
@@ -41,5 +44,6 @@ export const useFilterStore = create<FilterState>()((set) => ({
     set((state) => ({
       activeLanguages: state.activeLanguages.filter((l) => l !== lang)
     })),
-  clearAll: () => set({ activeLanguages: [] })
+  setFilterQuery: (query) => set({ filterQuery: query }),
+  clearAll: () => set({ activeLanguages: [], filterQuery: '' })
 }))

--- a/src/renderer/src/stores/useWorktreeStore.ts
+++ b/src/renderer/src/stores/useWorktreeStore.ts
@@ -191,7 +191,7 @@ function loadPersistedOrder(): Map<string, string[]> {
   return new Map()
 }
 
-function getOrderedProjectWorktrees(
+export function getOrderedProjectWorktrees(
   worktreesByProject: Map<string, Worktree[]>,
   worktreeOrderByProject: Map<string, string[]>,
   projectId: string


### PR DESCRIPTION
## Summary
- Adds **Next Session** (`⌘]`) and **Previous Session** (`⌘[`) keyboard shortcuts to cycle through session tabs
- Works in both worktree mode and connection mode, using the respective tab order
- Wraps around at the ends (last tab → next → first tab)
- Clears any active file/diff view and inline connection session so the target session becomes visible
- Both shortcuts are rebindable in **Settings → Keyboard Shortcuts → Sessions** (rendered automatically from `DEFAULT_SHORTCUTS`) and work while typing in inputs (`allowInInput: true`)

## Changes
- `src/renderer/src/lib/keyboard-shortcuts.ts`: new `session:next` / `session:previous` shortcut definitions
- `src/renderer/src/hooks/useKeyboardShortcuts.ts`: new `cycleSession(direction)` helper and handlers

## Test plan
- [ ] Open multiple session tabs in a worktree, press `⌘]` / `⌘[` — active tab cycles with wraparound
- [ ] Verify it works while the chat input is focused
- [ ] With a file/diff tab active, press `⌘]` — returns to a session view
- [ ] Rebind the shortcuts in Settings → Keyboard Shortcuts and verify the new binding works
- [ ] Verify cycling in connection mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)