### PR TITLE
Preload model catalogs so ticket badges show pretty names

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { AppLayout } from '@/components/layout'
 import { ErrorBoundary } from '@/components/error'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { reportActiveAccountsSnapshot } from '@/lib/hive-account-report'
+import { preloadHandoffModelCatalogs } from '@/lib/handoffSelection'
 import { initPlatform } from '@/lib/platform'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useTipStore } from '@/stores/useTipStore'
@@ -20,6 +21,9 @@ function App(): React.JSX.Element {
     initPlatform().then(() => {
       // Load seen tips from DB so the tip system knows which tips to skip
       useTipStore.getState().loadSeenTips()
+      // Warm the model catalogs so ticket badges show pretty model names
+      // immediately instead of raw slugs until a model picker is opened
+      void preloadHandoffModelCatalogs()
       setReady(true)
     })
   }, [])

--- a/src/renderer/src/components/kanban/TicketModelBadge.test.tsx
+++ b/src/renderer/src/components/kanban/TicketModelBadge.test.tsx
@@ -1,11 +1,11 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { TicketModelBadge } from './TicketModelBadge'
 import { cacheHandoffModelCatalog, clearHandoffModelCatalogCache } from '@/lib/handoffSelection'
 
 describe('TicketModelBadge', () => {
   afterEach(() => {
-    clearHandoffModelCatalogCache()
+    act(() => clearHandoffModelCatalogCache())
     vi.restoreAllMocks()
   })
 
@@ -102,6 +102,33 @@ describe('TicketModelBadge', () => {
 
     expect(screen.getByText('Claude Opus 4.5')).toBeInTheDocument()
     expect(screen.getByTitle('Claude Opus 4.5')).toBeInTheDocument()
+  })
+
+  it('upgrades an already-rendered raw slug once a catalog lands in the cache', () => {
+    render(
+      <TicketModelBadge
+        ticket={{ model_provider_id: 'anthropic', model_id: 'opus', model_variant: null }}
+      />
+    )
+
+    expect(screen.getByText('opus')).toBeInTheDocument()
+
+    act(() => {
+      cacheHandoffModelCatalog('claude-code', {
+        providers: [
+          {
+            id: 'anthropic',
+            name: 'Anthropic',
+            models: {
+              opus: { id: 'opus', name: 'Claude Opus 4.5' }
+            }
+          }
+        ]
+      })
+    })
+
+    expect(screen.queryByText('opus')).toBeNull()
+    expect(screen.getByText('Claude Opus 4.5')).toBeInTheDocument()
   })
 
   it('gives the chip a violet border for an ultracode launch', () => {

--- a/src/renderer/src/components/kanban/TicketModelBadge.tsx
+++ b/src/renderer/src/components/kanban/TicketModelBadge.tsx
@@ -1,5 +1,11 @@
+import { useSyncExternalStore } from 'react'
 import { resolveModelIconAsset } from '@/components/worktrees/ModelIcon'
-import { getAvailableHandoffAgentSdks, getCachedModelCatalog } from '@/lib/handoffSelection'
+import {
+  getAvailableHandoffAgentSdks,
+  getCachedModelCatalog,
+  getModelCatalogCacheVersion,
+  subscribeModelCatalogCache
+} from '@/lib/handoffSelection'
 import { findModelInfo, getModelDisplayName, isUltraVariant } from '@/lib/parseProviders'
 import { cn } from '@/lib/utils'
 import type { KanbanTicket } from '../../../../main/db/types'
@@ -27,6 +33,10 @@ export function TicketModelBadge({
   ticket,
   className
 }: TicketModelBadgeProps): React.JSX.Element | null {
+  // Re-render when a model catalog lands so badges mounted before the launch
+  // preload finishes swap their raw slug for the pretty name.
+  useSyncExternalStore(subscribeModelCatalogCache, getModelCatalogCacheVersion)
+
   const { model_provider_id: providerId, model_id: modelId, model_variant: variant } = ticket
   if (!modelId) return null
 

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -74,6 +74,29 @@ const FALLBACK_MODELS: Record<HandoffAgentSdk, SelectedModel> = {
 const modelCatalogCache = new Map<HandoffAgentSdk, ProviderModels[]>()
 const inflightModelCatalogRequests = new Map<HandoffAgentSdk, Promise<ProviderModels[]>>()
 
+// The cache is a plain module Map, invisible to React. Components that resolve
+// display names during render (e.g. ticket model badges mounted before the
+// catalogs arrive) subscribe to this version so they re-render once a catalog
+// lands instead of waiting for an unrelated re-render.
+let modelCatalogCacheVersion = 0
+const modelCatalogCacheListeners = new Set<() => void>()
+
+function notifyModelCatalogCacheChanged(): void {
+  modelCatalogCacheVersion++
+  for (const listener of modelCatalogCacheListeners) listener()
+}
+
+export function subscribeModelCatalogCache(listener: () => void): () => void {
+  modelCatalogCacheListeners.add(listener)
+  return () => {
+    modelCatalogCacheListeners.delete(listener)
+  }
+}
+
+export function getModelCatalogCacheVersion(): number {
+  return modelCatalogCacheVersion
+}
+
 function normalizeHandoffSdk(
   sdk: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal' | null | undefined
 ): HandoffAgentSdk {
@@ -237,6 +260,7 @@ export function cacheHandoffModelCatalog(
 ): ProviderModels[] {
   const parsed = parseProviders(providerData)
   modelCatalogCache.set(agentSdk, parsed)
+  notifyModelCatalogCacheChanged()
   return parsed
 }
 
@@ -247,6 +271,7 @@ export function getCachedModelCatalog(agentSdk: HandoffAgentSdk): ProviderModels
 export function clearHandoffModelCatalogCache(): void {
   modelCatalogCache.clear()
   inflightModelCatalogRequests.clear()
+  notifyModelCatalogCacheChanged()
 }
 
 export async function loadHandoffModelCatalog(
@@ -275,6 +300,24 @@ export async function loadHandoffModelCatalog(
 
   inflightModelCatalogRequests.set(agentSdk, request)
   return request
+}
+
+/**
+ * Warm the model-catalog cache for every available SDK so model names resolve
+ * to their display form (e.g. "Fable 5" instead of "fable") without the user
+ * first opening a model picker. Deduped by catalog SDK — claude-code and
+ * claude-code-cli share one catalog, so only one fetch goes out for the pair.
+ */
+export async function preloadHandoffModelCatalogs(): Promise<void> {
+  const availableAgentSdks = useSettingsStore.getState().availableAgentSdks
+  const seenCatalogSdks = new Set<AgentSdk>()
+  const sdksToLoad = getAvailableHandoffAgentSdks(availableAgentSdks).filter((sdk) => {
+    const catalogSdk = toModelCatalogSdk(sdk)
+    if (seenCatalogSdks.has(catalogSdk)) return false
+    seenCatalogSdks.add(catalogSdk)
+    return true
+  })
+  await Promise.all(sdksToLoad.map((sdk) => loadHandoffModelCatalog(sdk)))
 }
 
 export function resolveModelForSdkDefault(agentSdk: HandoffAgentSdk): SelectedModel {


### PR DESCRIPTION
## Summary
- Preloads handoff model catalogs at app launch so kanban ticket badges can resolve friendly model names immediately.
- Makes the model catalog cache observable to React so already-mounted badges re-render when catalog data arrives.
- Adds coverage for upgrading a rendered raw slug to a pretty name after the cache is populated.

## Testing
- Added/updated unit test for badge re-render behavior in [`TicketModelBadge.test.tsx`](/Users/mor/.hive-worktrees/hive-electron/hive-electron--model-names/src/renderer/src/components/kanban/TicketModelBadge.test.tsx).
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display-name resolution and a non-blocking startup preload; no auth, data, or session logic changes.
> 
> **Overview**
> Kanban ticket model badges no longer stay on raw slugs like `opus` until someone opens a model picker. **App startup** now warms handoff model catalogs for every available SDK (deduped when `claude-code` and `claude-code-cli` share a catalog).
> 
> The handoff model catalog cache is now **observable to React**: cache updates bump a version and notify subscribers. **`TicketModelBadge`** uses `useSyncExternalStore` so badges that mounted before preload finishes re-render and swap to display names when data lands.
> 
> Tests cover cache-driven re-render (including `act` around cache clears) and the slug-to-pretty-name upgrade path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45e623e7b79d40b25662c5c8ce5d33324f47089a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->