### PR TITLE
Add provider-wide auto-switch account mode

### DIFF
--- a/src/renderer/src/components/accounts/ScheduleSwitchControls.test.tsx
+++ b/src/renderer/src/components/accounts/ScheduleSwitchControls.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { AutoSwitchControls, ScheduleSwitchForm } from './ScheduleSwitchControls'
+import { useAccountScheduleStore } from '@/stores/useAccountScheduleStore'
+import { useUsageStore } from '@/stores/useUsageStore'
+import type { UsageData } from '@shared/types/usage'
+
+function makeUsage(fiveHour: number, sevenDay: number): UsageData {
+  const futureReset = new Date(Date.now() + 3_600_000).toISOString()
+  return {
+    five_hour: { utilization: fiveHour, resets_at: futureReset },
+    seven_day: { utilization: sevenDay, resets_at: futureReset }
+  }
+}
+
+describe('AutoSwitchControls', () => {
+  beforeEach(() => {
+    useAccountScheduleStore.setState({ schedules: {}, autoSwitch: {} })
+    useUsageStore.setState({ anthropicUsage: makeUsage(73, 10), openaiUsage: null })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('arms auto-switch at the default 90% threshold when toggled on', async () => {
+    const user = userEvent.setup()
+    render(<AutoSwitchControls provider="anthropic" />)
+
+    await user.click(screen.getByRole('switch'))
+
+    const auto = useAccountScheduleStore.getState().autoSwitch.anthropic
+    expect(auto).toBeDefined()
+    expect(auto?.thresholdPercent).toBe(90)
+  })
+
+  it('disarms when toggled off', async () => {
+    const user = userEvent.setup()
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+    render(<AutoSwitchControls provider="anthropic" />)
+
+    await user.click(screen.getByRole('switch'))
+
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic).toBeUndefined()
+  })
+
+  it('warns that arming replaces a pending schedule, and does replace it', async () => {
+    const user = userEvent.setup()
+    useAccountScheduleStore.getState().scheduleByUsage('anthropic', 'acc-2', 'x@y.com', 95)
+    render(<AutoSwitchControls provider="anthropic" />)
+
+    expect(screen.getByText(/replaces the pending/i)).toBeTruthy()
+
+    await user.click(screen.getByRole('switch'))
+
+    const state = useAccountScheduleStore.getState()
+    expect(state.schedules.anthropic).toBeUndefined()
+    expect(state.autoSwitch.anthropic).toBeDefined()
+  })
+
+  it('updates the threshold via presets and marks the active one', async () => {
+    const user = userEvent.setup()
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+    render(<AutoSwitchControls provider="anthropic" />)
+
+    await user.click(screen.getByRole('button', { name: /auto-switch at 95% usage/i }))
+
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.thresholdPercent).toBe(95)
+    expect(
+      screen.getByRole('button', { name: /auto-switch at 95% usage/i }).getAttribute('aria-pressed')
+    ).toBe('true')
+    expect(
+      screen.getByRole('button', { name: /auto-switch at 90% usage/i }).getAttribute('aria-pressed')
+    ).toBe('false')
+  })
+
+  it('sets a custom threshold', async () => {
+    const user = userEvent.setup()
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+    render(<AutoSwitchControls provider="anthropic" />)
+
+    await user.type(screen.getByLabelText(/custom auto-switch percent/i), '85')
+    await user.click(screen.getByRole('button', { name: 'Set' }))
+
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.thresholdPercent).toBe(85)
+  })
+
+  it('shows the live threshold and current usage while armed', () => {
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+    render(<AutoSwitchControls provider="anthropic" />)
+
+    expect(screen.getByText(/at 90% usage/i)).toBeTruthy()
+    expect(screen.getByText(/now 73%/i)).toBeTruthy()
+  })
+})
+
+describe('ScheduleSwitchForm with auto-switch armed', () => {
+  beforeEach(() => {
+    useAccountScheduleStore.setState({ schedules: {}, autoSwitch: {} })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('warns that scheduling replaces auto-switch', () => {
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+    render(<ScheduleSwitchForm provider="anthropic" accountId="acc-2" email="x@y.com" />)
+
+    expect(screen.getByText(/replaces .*auto-switch/i)).toBeTruthy()
+  })
+
+  it('scheduling by usage disarms auto-switch', async () => {
+    const user = userEvent.setup()
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+    render(<ScheduleSwitchForm provider="anthropic" accountId="acc-2" email="x@y.com" />)
+
+    await user.click(screen.getByRole('button', { name: /by usage/i }))
+    await user.click(screen.getByRole('button', { name: /switch at 90% usage/i }))
+
+    const state = useAccountScheduleStore.getState()
+    expect(state.autoSwitch.anthropic).toBeUndefined()
+    expect(state.schedules.anthropic?.accountId).toBe('acc-2')
+  })
+})

--- a/src/renderer/src/components/accounts/ScheduleSwitchControls.tsx
+++ b/src/renderer/src/components/accounts/ScheduleSwitchControls.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
-import { Clock, Gauge, X } from 'lucide-react'
+import { Clock, Gauge, Shuffle, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Switch } from '@/components/ui/switch'
 import { useTimerTickStore } from '@/stores/useTimerTickStore'
+import { useUsageStore } from '@/stores/useUsageStore'
 import {
   useAccountScheduleStore,
   describeSchedule,
@@ -19,6 +21,7 @@ const TIME_PRESETS = [
 ]
 
 const USAGE_PRESETS = [90, 95, 98]
+const DEFAULT_AUTO_SWITCH_THRESHOLD = 90
 
 const presetButtonClass =
   'rounded-sm border border-border/60 px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground'
@@ -46,6 +49,7 @@ export function ScheduleSwitchForm({
   const scheduleByTime = useAccountScheduleStore((s) => s.scheduleByTime)
   const scheduleByUsage = useAccountScheduleStore((s) => s.scheduleByUsage)
   const existing = useAccountScheduleStore((s) => s.schedules[provider])
+  const autoSwitchArmed = useAccountScheduleStore((s) => s.autoSwitch[provider] !== undefined)
   const [mode, setMode] = useState<ScheduleMode>('time')
   const [customValue, setCustomValue] = useState('')
 
@@ -160,7 +164,152 @@ export function ScheduleSwitchForm({
             Replaces the pending {existing?.email ?? 'account'} schedule.
           </span>
         )}
+        {autoSwitchArmed && (
+          <span className="text-amber-500"> Replaces best-account auto-switch.</span>
+        )}
       </div>
+    </div>
+  )
+}
+
+interface AutoSwitchControlsProps {
+  provider: UsageProvider
+  className?: string
+}
+
+/**
+ * Provider-global "auto-switch accounts" control: when armed, crossing the
+ * threshold refreshes every saved account and hops to the one with the most
+ * headroom — and stays armed for the next crossing. Mutually exclusive with
+ * the per-account schedule (arming one replaces the other).
+ */
+export function AutoSwitchControls({
+  provider,
+  className
+}: AutoSwitchControlsProps): React.JSX.Element {
+  const auto = useAccountScheduleStore((s) => s.autoSwitch[provider])
+  const schedule = useAccountScheduleStore((s) => s.schedules[provider])
+  const setAutoSwitch = useAccountScheduleStore((s) => s.setAutoSwitch)
+  const disableAutoSwitch = useAccountScheduleStore((s) => s.disableAutoSwitch)
+  // Subscribed only so the "(now X%)" readout re-renders when fresh usage lands.
+  useUsageStore((s) => (provider === 'anthropic' ? s.anthropicUsage : s.openaiUsage))
+  const [customValue, setCustomValue] = useState('')
+
+  const enabled = auto !== undefined
+  const currentPercent = enabled ? getActiveUsagePercent(provider) : null
+
+  const submitCustom = (): void => {
+    const value = Number(customValue)
+    if (!Number.isFinite(value) || value <= 0 || value > 100) return
+    setAutoSwitch(provider, value)
+    setCustomValue('')
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border px-2 py-1.5',
+        enabled ? 'border-amber-500/40 bg-amber-500/10' : 'border-border/50 bg-background/40',
+        className
+      )}
+      data-testid="auto-switch-controls"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Shuffle
+            className={cn(
+              'h-3 w-3 shrink-0',
+              enabled ? 'text-amber-500' : 'text-muted-foreground'
+            )}
+          />
+          <span
+            className={cn(
+              'truncate text-[11px] font-medium',
+              enabled ? 'text-amber-600 dark:text-amber-400' : 'text-foreground'
+            )}
+          >
+            Auto-switch account
+          </span>
+        </div>
+        <Switch
+          size="sm"
+          checked={enabled}
+          onCheckedChange={(on) =>
+            on
+              ? setAutoSwitch(provider, DEFAULT_AUTO_SWITCH_THRESHOLD)
+              : disableAutoSwitch(provider)
+          }
+          aria-label="Toggle usage-based account auto-switch"
+          data-testid="auto-switch-toggle"
+        />
+      </div>
+
+      {enabled && auto ? (
+        <>
+          <div className="mt-1.5 flex flex-wrap items-center gap-1">
+            <span className="text-[9px] text-muted-foreground">at</span>
+            {USAGE_PRESETS.map((percent) => (
+              <button
+                key={percent}
+                type="button"
+                onClick={() => setAutoSwitch(provider, percent)}
+                aria-pressed={auto.thresholdPercent === percent}
+                aria-label={`Auto-switch at ${percent}% usage`}
+                className={cn(
+                  presetButtonClass,
+                  auto.thresholdPercent === percent &&
+                    'border-amber-500/50 bg-amber-500/10 text-amber-600 dark:text-amber-400'
+                )}
+              >
+                {percent}%
+              </button>
+            ))}
+            <div className="flex items-center gap-1">
+              <input
+                type="number"
+                min={1}
+                max={100}
+                value={customValue}
+                onChange={(e) => setCustomValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    submitCustom()
+                  }
+                }}
+                placeholder={
+                  USAGE_PRESETS.includes(auto.thresholdPercent) ? '%' : `${auto.thresholdPercent}%`
+                }
+                aria-label="Custom auto-switch percent"
+                className="h-5 w-11 rounded-sm border border-border/60 bg-transparent px-1 text-[9px] text-foreground outline-none focus:border-border [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+              />
+              <button
+                type="button"
+                onClick={submitCustom}
+                disabled={!customValue}
+                className={cn(presetButtonClass, 'disabled:cursor-not-allowed disabled:opacity-50')}
+              >
+                Set
+              </button>
+            </div>
+          </div>
+          <div className="mt-1 text-[9px] text-amber-600/90 dark:text-amber-400/90">
+            Hops to the account with the most headroom at {auto.thresholdPercent}% usage
+            {currentPercent !== null && (
+              <span className="opacity-70"> (now {Math.round(currentPercent)}%)</span>
+            )}
+            .
+          </div>
+        </>
+      ) : (
+        <div className="mt-1 text-[9px] text-muted-foreground/70">
+          Automatically hop to the account with the most usage left whenever the active one runs
+          hot.
+          {schedule && (
+            <span className="text-amber-500"> Replaces the pending scheduled switch.</span>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { ProviderUsageBlock, UsageAccountRow } from './UsageIndicator'
 import { useAccountStore, useUsageStore } from '@/stores'
+import { useAccountScheduleStore } from '@/stores/useAccountScheduleStore'
 import type { AccountMemberInfo } from './MemberAvatarStack'
 import type { OpenAIUsageData, UsageData } from '@shared/types/usage'
 
@@ -702,6 +703,80 @@ describe('ProviderUsageBlock provider toggle', () => {
     expect(
       active.compareDocumentPosition(inactive) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
+  })
+
+  it('shows the auto-switch shuffle icon in the bar when armed, instead of the timer', () => {
+    useAccountScheduleStore.setState({
+      schedules: {},
+      autoSwitch: {
+        anthropic: { provider: 'anthropic', thresholdPercent: 90, createdAt: Date.now() }
+      }
+    })
+    render(
+      <ProviderUsageBlock
+        provider="anthropic"
+        isExplicitlySelected
+        toggleProviders={['anthropic']}
+      />
+    )
+
+    expect(screen.getByLabelText(/auto-switch armed/i)).toBeTruthy()
+    expect(screen.queryByLabelText(/account switch scheduled/i)).toBeNull()
+    useAccountScheduleStore.setState({ schedules: {}, autoSwitch: {} })
+  })
+
+  it('shows the auto-switch controls in the popover only with multiple saved accounts', async () => {
+    const user = userEvent.setup()
+    useAccountScheduleStore.setState({ schedules: {}, autoSwitch: {} })
+    useUsageStore.setState((state) => ({
+      savedAccounts: {
+        ...state.savedAccounts,
+        openai: [
+          {
+            id: 'openai-1',
+            provider: 'openai',
+            email: 'one@example.com',
+            last_usage: sampleOpenAIUsage,
+            last_fetched_at: null,
+            status: 'ok',
+            last_error: null,
+            created_at: new Date().toISOString(),
+            plan: 'plus'
+          },
+          {
+            id: 'openai-2',
+            provider: 'openai',
+            email: 'openai@example.com',
+            last_usage: sampleOpenAIUsage,
+            last_fetched_at: null,
+            status: 'ok',
+            last_error: null,
+            created_at: new Date().toISOString(),
+            plan: 'plus'
+          }
+        ]
+      }
+    }))
+
+    render(
+      <ProviderUsageBlock provider="openai" isExplicitlySelected toggleProviders={['openai']} />
+    )
+
+    await user.hover(screen.getByTestId('usage-trigger-openai'))
+    await screen.findByText('OpenAI API Usage')
+    expect(screen.getByTestId('auto-switch-controls')).toBeTruthy()
+  })
+
+  it('hides the auto-switch controls when only one account is saved', async () => {
+    const user = userEvent.setup()
+    useAccountScheduleStore.setState({ schedules: {}, autoSwitch: {} })
+    render(
+      <ProviderUsageBlock provider="openai" isExplicitlySelected toggleProviders={['openai']} />
+    )
+
+    await user.hover(screen.getByTestId('usage-trigger-openai'))
+    await screen.findByText('OpenAI API Usage')
+    expect(screen.queryByTestId('auto-switch-controls')).toBeNull()
   })
 
   it('keeps the provider toggle outside the scroll container', async () => {

--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -767,6 +767,27 @@ describe('ProviderUsageBlock provider toggle', () => {
     expect(screen.getByTestId('auto-switch-controls')).toBeTruthy()
   })
 
+  it('keeps the auto-switch controls visible while armed even with fewer than two accounts', async () => {
+    // Armed, then the alternate account disappears (removed or load failure):
+    // the only control that can disarm must not vanish with it.
+    const user = userEvent.setup()
+    useAccountScheduleStore.setState({
+      schedules: {},
+      autoSwitch: {
+        openai: { provider: 'openai', thresholdPercent: 90, createdAt: Date.now() }
+      }
+    })
+
+    render(
+      <ProviderUsageBlock provider="openai" isExplicitlySelected toggleProviders={['openai']} />
+    )
+
+    await user.hover(screen.getByTestId('usage-trigger-openai'))
+    await screen.findByText('OpenAI API Usage')
+    expect(screen.getByTestId('auto-switch-controls')).toBeTruthy()
+    useAccountScheduleStore.setState({ schedules: {}, autoSwitch: {} })
+  })
+
   it('hides the auto-switch controls when only one account is saved', async () => {
     const user = userEvent.setup()
     useAccountScheduleStore.setState({ schedules: {}, autoSwitch: {} })

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -14,9 +14,10 @@ import { reportActiveAccountsSnapshot } from '@/lib/hive-account-report'
 import { fetchHiveAccountMembers, isHiveTelemetryEnabled } from '@/api/hive-enterprise/client'
 import { MemberAvatarStack, type AccountMemberInfo } from './MemberAvatarStack'
 import { cn } from '@/lib/utils'
-import { Loader2, RefreshCw, Timer } from 'lucide-react'
+import { Loader2, RefreshCw, Shuffle, Timer } from 'lucide-react'
 import { useAccountScheduleStore } from '@/stores/useAccountScheduleStore'
 import {
+  AutoSwitchControls,
   ScheduleSwitchForm,
   SchedulePendingSummary
 } from '@/components/accounts/ScheduleSwitchControls'
@@ -600,6 +601,7 @@ function ProviderUsagePopoverBody({ provider }: { provider: UsageProvider }): Re
   return (
     <div className="space-y-2">
       <div className="font-medium">{PROVIDER_META[provider].title}</div>
+      {savedAccounts.length > 1 && <AutoSwitchControls provider={provider} />}
       {savedAccountLoadError && (
         <div className="rounded-md border border-destructive/30 bg-destructive/10 px-2 py-1 text-[10px] text-destructive">
           Saved accounts unavailable: {savedAccountLoadError}
@@ -682,6 +684,9 @@ export function ProviderUsageBlock({
   )
   const fetchEmail = useAccountStore((s) => s.fetchEmail)
   const hasPendingSchedule = useAccountScheduleStore((s) => s.schedules[provider] !== undefined)
+  const autoSwitchThreshold = useAccountScheduleStore(
+    (s) => s.autoSwitch[provider]?.thresholdPercent
+  )
 
   // Which provider the popover shows. The bottom toggle can point it at a
   // different provider than the hovered trigger; each open snaps it back.
@@ -755,12 +760,19 @@ export function ProviderUsageBlock({
                 )}
               />
             </button>
-            {hasPendingSchedule && (
+            {autoSwitchThreshold !== undefined ? (
+              <Shuffle
+                className="h-2.5 w-2.5 shrink-0 text-amber-500"
+                aria-label="Auto-switch armed"
+              >
+                <title>{`Auto-switching accounts at ${autoSwitchThreshold}% usage`}</title>
+              </Shuffle>
+            ) : hasPendingSchedule ? (
               <Timer
                 className="h-2.5 w-2.5 shrink-0 text-amber-500"
                 aria-label="Account switch scheduled"
               />
-            )}
+            ) : null}
             <div className="flex-1 space-y-0.5">
               <UsageRow
                 label="5h"

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -538,6 +538,7 @@ function ProviderUsagePopoverBody({ provider }: { provider: UsageProvider }): Re
   )
   const startLogin = useLoginStore((s) => s.startLogin)
   const isLoginActive = useLoginStore((s) => s.activeLogin !== null)
+  const autoSwitchArmed = useAccountScheduleStore((s) => s.autoSwitch[provider] !== undefined)
   const telemetryEnabled = useSettingsStore((s) => isHiveTelemetryEnabled(s))
   const {
     membersByAccount,
@@ -601,7 +602,9 @@ function ProviderUsagePopoverBody({ provider }: { provider: UsageProvider }): Re
   return (
     <div className="space-y-2">
       <div className="font-medium">{PROVIDER_META[provider].title}</div>
-      {savedAccounts.length > 1 && <AutoSwitchControls provider={provider} />}
+      {/* Armed state must always expose its own off switch — even when the
+          account list has shrunk below what auto-switch needs to operate. */}
+      {(savedAccounts.length > 1 || autoSwitchArmed) && <AutoSwitchControls provider={provider} />}
       {savedAccountLoadError && (
         <div className="rounded-md border border-destructive/30 bg-destructive/10 px-2 py-1 text-[10px] text-destructive">
           Saved accounts unavailable: {savedAccountLoadError}

--- a/src/renderer/src/lib/__tests__/auto-switch-score.test.ts
+++ b/src/renderer/src/lib/__tests__/auto-switch-score.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+
+import { getMaxUsagePercent, scoreAccountHeadroom } from '../auto-switch-score'
+import type { UsageData } from '@shared/types/usage'
+
+const NOW = new Date('2026-07-16T10:00:00.000Z').getTime()
+const FUTURE = new Date(NOW + 3_600_000).toISOString()
+const PAST = new Date(NOW - 3_600_000).toISOString()
+
+function usage(
+  fiveHour: number,
+  sevenDay: number,
+  scoped?: { label: string; used_percent: number; resets_at?: string | null }[]
+): UsageData {
+  return {
+    five_hour: { utilization: fiveHour, resets_at: FUTURE },
+    seven_day: { utilization: sevenDay, resets_at: FUTURE },
+    ...(scoped
+      ? {
+          scoped: scoped.map((s) => ({
+            label: s.label,
+            used_percent: s.used_percent,
+            resets_at: s.resets_at === undefined ? FUTURE : s.resets_at
+          }))
+        }
+      : {})
+  }
+}
+
+describe('scoreAccountHeadroom', () => {
+  it('prefers an empty 5h window over better model headroom (ticket example)', () => {
+    // A: 5h at 0%, Fable at 70% — B: 5h at 50%, Fable at 30%. The 5h window
+    // expires quickly, so A's untouched 5h should outweigh B's fresher Fable.
+    const a = scoreAccountHeadroom(usage(0, 0, [{ label: 'Fable', used_percent: 70 }]), NOW)
+    const b = scoreAccountHeadroom(usage(50, 0, [{ label: 'Fable', used_percent: 30 }]), NOW)
+    expect(a).toBeGreaterThan(b)
+  })
+
+  it('punishes a nearly-exhausted window harder than a plain average would', () => {
+    // 95% Fable usage with everything else empty should lose to a balanced
+    // account, even though its arithmetic average headroom is higher.
+    const nearlyExhausted = scoreAccountHeadroom(
+      usage(0, 0, [{ label: 'Fable', used_percent: 95 }]),
+      NOW
+    )
+    const balanced = scoreAccountHeadroom(usage(50, 40, [{ label: 'Fable', used_percent: 40 }]), NOW)
+    expect(balanced).toBeGreaterThan(nearlyExhausted)
+  })
+
+  it('scores zero when any window is fully exhausted', () => {
+    expect(scoreAccountHeadroom(usage(100, 0), NOW)).toBe(0)
+    expect(scoreAccountHeadroom(usage(0, 0, [{ label: 'Fable', used_percent: 100 }]), NOW)).toBe(0)
+  })
+
+  it('treats a window whose reset time already passed as full headroom', () => {
+    const stale: UsageData = {
+      five_hour: { utilization: 95, resets_at: PAST },
+      seven_day: { utilization: 10, resets_at: FUTURE }
+    }
+    const fresh: UsageData = {
+      five_hour: { utilization: 0, resets_at: FUTURE },
+      seven_day: { utilization: 10, resets_at: FUTURE }
+    }
+    expect(scoreAccountHeadroom(stale, NOW)).toBe(scoreAccountHeadroom(fresh, NOW))
+  })
+
+  it('uses the WORST scoped window when several models are listed', () => {
+    const oneBadModel = scoreAccountHeadroom(
+      usage(10, 10, [
+        { label: 'Opus', used_percent: 0 },
+        { label: 'Fable', used_percent: 90 }
+      ]),
+      NOW
+    )
+    const allGoodModels = scoreAccountHeadroom(
+      usage(10, 10, [
+        { label: 'Opus', used_percent: 0 },
+        { label: 'Fable', used_percent: 20 }
+      ]),
+      NOW
+    )
+    expect(allGoodModels).toBeGreaterThan(oneBadModel)
+  })
+
+  it('ranks identically-used accounts the same with or without scoped data', () => {
+    // No scoped windows: score still lands on the 0-100 scale and an untouched
+    // account beats a half-used one.
+    expect(scoreAccountHeadroom(usage(0, 0), NOW)).toBeCloseTo(100, 9)
+    expect(scoreAccountHeadroom(usage(0, 0), NOW)).toBeGreaterThan(
+      scoreAccountHeadroom(usage(50, 50), NOW)
+    )
+  })
+})
+
+describe('getMaxUsagePercent', () => {
+  it('returns the highest utilization across 5h, 7d and scoped windows', () => {
+    expect(getMaxUsagePercent(usage(10, 40, [{ label: 'Fable', used_percent: 65 }]), NOW)).toBe(65)
+    expect(getMaxUsagePercent(usage(80, 40), NOW)).toBe(80)
+  })
+
+  it('ignores windows whose reset time already passed', () => {
+    const data = usage(10, 20, [{ label: 'Fable', used_percent: 95, resets_at: PAST }])
+    expect(getMaxUsagePercent(data, NOW)).toBe(20)
+  })
+
+  it('returns null when every window is stale', () => {
+    const data: UsageData = {
+      five_hour: { utilization: 50, resets_at: PAST },
+      seven_day: { utilization: 60, resets_at: PAST }
+    }
+    expect(getMaxUsagePercent(data, NOW)).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/auto-switch-score.ts
+++ b/src/renderer/src/lib/auto-switch-score.ts
@@ -1,0 +1,72 @@
+import type { UsageData } from '@shared/types/usage'
+
+// How much each window's remaining headroom counts toward an account's score.
+// The 5h window dominates: it resets within hours, so headroom there is worth
+// the most right now, while weekly and per-model (Fable/Opus) windows recover
+// slowly. Weights are renormalized when an account has no scoped windows.
+const FIVE_HOUR_WEIGHT = 0.5
+const SEVEN_DAY_WEIGHT = 0.25
+const SCOPED_WEIGHT = 0.25
+
+interface WindowLike {
+  utilization: number
+  resets_at: string | null
+}
+
+// A reset time in the past means the cached utilization predates the window's
+// reset: the window is empty again. null is NOT stale — it means "no active
+// window" (same rule as UsageIndicator / useAccountScheduleStore).
+function hasResetSince(resetsAt: string | null | undefined, nowMs: number): boolean {
+  if (!resetsAt) return false
+  const time = new Date(resetsAt).getTime()
+  return !isNaN(time) && time < nowMs
+}
+
+function headroom(window: WindowLike, nowMs: number): number {
+  if (hasResetSince(window.resets_at, nowMs)) return 100
+  return Math.min(100, Math.max(0, 100 - window.utilization))
+}
+
+/**
+ * Highest current utilization across an account's usage windows (5h, 7d and
+ * scoped model windows), skipping windows whose snapshot predates their own
+ * reset. Null when no window has current data.
+ */
+export function getMaxUsagePercent(usage: UsageData, nowMs: number): number | null {
+  const windows: WindowLike[] = [
+    usage.five_hour,
+    usage.seven_day,
+    ...(usage.scoped ?? []).map((s) => ({ utilization: s.used_percent, resets_at: s.resets_at }))
+  ].filter((w) => w && !hasResetSince(w.resets_at, nowMs))
+  if (windows.length === 0) return null
+  return Math.max(...windows.map((w) => w.utilization))
+}
+
+/**
+ * 0-100 "how long will this account last" score used to pick the auto-switch
+ * target: a weighted geometric mean of each window's remaining headroom.
+ * Geometric (not arithmetic) so a single nearly-exhausted window drags the
+ * score toward 0 no matter how empty the others are — an account at 95% Fable
+ * usage must not win on the strength of an untouched 5h window. The scoped
+ * component uses the WORST model window for the same reason.
+ */
+export function scoreAccountHeadroom(usage: UsageData, nowMs: number): number {
+  const components: { headroom: number; weight: number }[] = [
+    { headroom: headroom(usage.five_hour, nowMs), weight: FIVE_HOUR_WEIGHT },
+    { headroom: headroom(usage.seven_day, nowMs), weight: SEVEN_DAY_WEIGHT }
+  ]
+
+  const scoped = usage.scoped ?? []
+  if (scoped.length > 0) {
+    const worst = Math.min(
+      ...scoped.map((s) => headroom({ utilization: s.used_percent, resets_at: s.resets_at }, nowMs))
+    )
+    components.push({ headroom: worst, weight: SCOPED_WEIGHT })
+  }
+
+  const totalWeight = components.reduce((sum, c) => sum + c.weight, 0)
+  return components.reduce(
+    (score, c) => score * Math.pow(c.headroom, c.weight / totalWeight),
+    1
+  )
+}

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import {
+  useAccountScheduleStore,
+  resetExecutingProvidersForTests
+} from '../useAccountScheduleStore'
+import { useUsageStore } from '../useUsageStore'
+import { useAccountStore } from '../useAccountStore'
+import { toast } from '@/lib/toast'
+import type { RefreshAllResultItem, SavedAccountDTO, UsageData } from '@shared/types/usage'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn()
+  }
+}))
+
+function makeUsage(fiveHour: number, sevenDay: number): UsageData {
+  const futureReset = new Date(Date.now() + 3_600_000).toISOString()
+  return {
+    five_hour: { utilization: fiveHour, resets_at: futureReset },
+    seven_day: { utilization: sevenDay, resets_at: futureReset }
+  }
+}
+
+function makeAccount(
+  id: string,
+  email: string,
+  usage: UsageData | null,
+  status: SavedAccountDTO['status'] = 'ok'
+): SavedAccountDTO {
+  return {
+    id,
+    provider: 'anthropic',
+    email,
+    last_usage: usage,
+    last_fetched_at: usage ? new Date().toISOString() : null,
+    status,
+    last_error: null,
+    created_at: new Date().toISOString(),
+    plan: null
+  }
+}
+
+describe('useAccountScheduleStore auto-switch', () => {
+  let request: ReturnType<typeof vi.fn>
+  let refreshedAccounts: SavedAccountDTO[]
+  let refreshResults: RefreshAllResultItem[]
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-16T10:00:00.000Z'))
+    vi.clearAllMocks()
+
+    useAccountScheduleStore.setState({ schedules: {}, autoSwitch: {} })
+    resetExecutingProvidersForTests()
+    useAccountStore.setState({ anthropicEmail: 'current@x.com', openaiEmail: null })
+
+    // Post-refresh world: the active account is nearly exhausted; acc-2 has
+    // the most headroom, acc-3 less; acc-4's refresh fails; acc-5 is expired.
+    refreshedAccounts = [
+      makeAccount('acc-1', 'current@x.com', makeUsage(0, 0)),
+      makeAccount('acc-2', 'best@x.com', makeUsage(10, 20)),
+      makeAccount('acc-3', 'meh@x.com', makeUsage(60, 50)),
+      makeAccount('acc-4', 'failed@x.com', makeUsage(0, 0)),
+      makeAccount('acc-5', 'expired@x.com', makeUsage(0, 0), 'stale')
+    ]
+    refreshResults = [
+      { accountId: 'acc-1', success: true },
+      { accountId: 'acc-2', success: true },
+      { accountId: 'acc-3', success: true },
+      { accountId: 'acc-4', success: false, error: 'network down' },
+      { accountId: 'acc-5', success: true }
+    ]
+
+    useUsageStore.setState({
+      anthropicUsage: makeUsage(92, 40),
+      anthropicLastFetchedAt: Date.now(),
+      anthropicIsLoading: false,
+      anthropicLastError: null,
+      anthropicLastRetryAfter: null,
+      openaiUsage: null,
+      openaiIsLoading: false,
+      savedAccounts: { anthropic: refreshedAccounts, openai: [] },
+      savedAccountsLoaded: { anthropic: true, openai: false },
+      refreshingProviders: { anthropic: false, openai: false },
+      refreshingAccountIds: new Set<string>(),
+      switchingAccountIds: new Set<string>()
+    })
+
+    request = vi.fn(async (method: string) => {
+      if (method === 'usageOps.refreshAllForProvider') return refreshResults
+      if (method === 'accountOps.listSaved') return refreshedAccounts
+      if (method === 'accountOps.switchAccount') return { success: true }
+      if (method === 'accountOps.getClaudeEmail') return 'best@x.com'
+      if (method === 'usageOps.fetch') return { success: true, data: undefined }
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+    vi.useRealTimers()
+  })
+
+  const calls = (method: string): unknown[][] =>
+    request.mock.calls.filter(([m]) => m === method)
+  const switchCalls = (): unknown[][] => calls('accountOps.switchAccount')
+  const refreshAllCalls = (): unknown[][] => calls('usageOps.refreshAllForProvider')
+
+  it('enabling auto-switch replaces a pending schedule, and scheduling replaces auto-switch', () => {
+    const store = useAccountScheduleStore.getState()
+    store.scheduleByUsage('anthropic', 'acc-2', 'best@x.com', 95)
+    store.setAutoSwitch('anthropic', 90)
+
+    let state = useAccountScheduleStore.getState()
+    expect(state.schedules.anthropic).toBeUndefined()
+    expect(state.autoSwitch.anthropic?.thresholdPercent).toBe(90)
+
+    state.scheduleByTime('anthropic', 'acc-2', 'best@x.com', 60_000)
+    state = useAccountScheduleStore.getState()
+    expect(state.autoSwitch.anthropic).toBeUndefined()
+    expect(state.schedules.anthropic).toBeDefined()
+
+    state.setAutoSwitch('anthropic', 95)
+    state.scheduleByUsage('anthropic', 'acc-2', 'best@x.com', 90)
+    state = useAccountScheduleStore.getState()
+    expect(state.autoSwitch.anthropic).toBeUndefined()
+    expect(state.schedules.anthropic).toBeDefined()
+  })
+
+  it('clamps the threshold and supports disabling', () => {
+    const store = useAccountScheduleStore.getState()
+    store.setAutoSwitch('anthropic', 300)
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.thresholdPercent).toBe(100)
+    store.setAutoSwitch('anthropic', -5)
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.thresholdPercent).toBe(1)
+
+    store.disableAutoSwitch('anthropic')
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic).toBeUndefined()
+  })
+
+  it('does nothing while the active account is below the threshold', async () => {
+    useUsageStore.setState({ anthropicUsage: makeUsage(60, 40) })
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(refreshAllCalls()).toHaveLength(0)
+    expect(switchCalls()).toHaveLength(0)
+  })
+
+  it('refreshes all accounts and switches to the best-scoring eligible one at the threshold', async () => {
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    // acc-1 is the active account (best usage but excluded), acc-4's refresh
+    // failed, acc-5 is expired — acc-2 wins over acc-3 on headroom.
+    expect(refreshAllCalls()).toHaveLength(1)
+    expect(switchCalls()).toHaveLength(1)
+    expect(switchCalls()[0][1]).toEqual({ accountId: 'acc-2' })
+    // Stays armed for the next threshold crossing.
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic).toBeDefined()
+  })
+
+  it('ignores an account whose refresh failed even when its cached usage looks best', async () => {
+    // acc-4 (refresh failed) has pristine cached usage; the pick must fall to
+    // the best account that actually answered.
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()[0][1]).toEqual({ accountId: 'acc-2' })
+  })
+
+  it('backs off with a toast when no account is below the threshold', async () => {
+    refreshedAccounts = [
+      makeAccount('acc-1', 'current@x.com', makeUsage(0, 0)),
+      makeAccount('acc-2', 'best@x.com', makeUsage(95, 20)),
+      makeAccount('acc-3', 'meh@x.com', makeUsage(20, 91))
+    ]
+    refreshResults = [
+      { accountId: 'acc-1', success: true },
+      { accountId: 'acc-2', success: true },
+      { accountId: 'acc-3', success: true }
+    ]
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(0)
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Auto-switch'))
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.notBefore).toBe(
+      Date.now() + 5 * 60_000
+    )
+
+    // Backing off — no second refresh sweep on the next tick.
+    await useAccountScheduleStore.getState().checkSchedules()
+    expect(refreshAllCalls()).toHaveLength(1)
+
+    // After the delay it tries again.
+    vi.setSystemTime(Date.now() + 5 * 60_000 + 1_000)
+    await useAccountScheduleStore.getState().checkSchedules()
+    expect(refreshAllCalls()).toHaveLength(2)
+  })
+
+  it('keeps auto-switch enabled and backs off when the switch attempt fails', async () => {
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.refreshAllForProvider') return refreshResults
+      if (method === 'accountOps.listSaved') return refreshedAccounts
+      if (method === 'accountOps.switchAccount') return { success: false, error: 'boom' }
+      return null
+    })
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(1)
+    const auto = useAccountScheduleStore.getState().autoSwitch.anthropic
+    expect(auto).toBeDefined()
+    expect(auto?.notBefore).toBe(Date.now() + 5 * 60_000)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+    expect(switchCalls()).toHaveLength(1)
+  })
+
+  it('does not switch when auto-switch is disabled during the refresh sweep', async () => {
+    const pendingRefresh: { resolve?: (value: RefreshAllResultItem[]) => void } = {}
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.refreshAllForProvider')
+        return new Promise((resolve) => {
+          pendingRefresh.resolve = resolve
+        })
+      if (method === 'accountOps.listSaved') return refreshedAccounts
+      if (method === 'accountOps.switchAccount') return { success: true }
+      return null
+    })
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    const checking = useAccountScheduleStore.getState().checkSchedules()
+    while (!pendingRefresh.resolve) await Promise.resolve()
+
+    useAccountScheduleStore.getState().disableAutoSwitch('anthropic')
+    pendingRefresh.resolve(refreshResults)
+    await checking
+
+    expect(switchCalls()).toHaveLength(0)
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic).toBeUndefined()
+  })
+
+  it('skips the round without backing off when a refresh sweep is already running', async () => {
+    useUsageStore.setState({ refreshingProviders: { anthropic: true, openai: false } })
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(refreshAllCalls()).toHaveLength(0)
+    expect(switchCalls()).toHaveLength(0)
+    // No backoff: the next tick should retry immediately.
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.notBefore).toBeUndefined()
+  })
+})

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
@@ -252,6 +252,89 @@ describe('useAccountScheduleStore auto-switch', () => {
     expect(useAccountScheduleStore.getState().autoSwitch.anthropic).toBeUndefined()
   })
 
+  it('cools down after a successful switch so a lagging active-usage refresh cannot cause churn', async () => {
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+    expect(switchCalls()).toHaveLength(1)
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.notBefore).toBe(
+      Date.now() + 5 * 60_000
+    )
+
+    // The active usage still reads the OLD account's 92% (its refresh failed
+    // or is slow) — the cooldown must prevent an immediate second hop.
+    await useAccountScheduleStore.getState().checkSchedules()
+    expect(switchCalls()).toHaveLength(1)
+  })
+
+  it('does not sweep or switch while the active account cannot be identified', async () => {
+    useAccountStore.setState({ anthropicEmail: null, openaiEmail: null })
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.refreshAllForProvider') return refreshResults
+      if (method === 'accountOps.listSaved') return refreshedAccounts
+      if (method === 'accountOps.switchAccount') return { success: true }
+      if (method === 'accountOps.getClaudeEmail') return null
+      return null
+    })
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    // It tried to resolve the email, then gave up without touching accounts.
+    expect(calls('accountOps.getClaudeEmail').length).toBeGreaterThan(0)
+    expect(refreshAllCalls()).toHaveLength(0)
+    expect(switchCalls()).toHaveLength(0)
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.notBefore).toBe(
+      Date.now() + 5 * 60_000
+    )
+  })
+
+  it('recovers by fetching the email when the account store has none yet', async () => {
+    useAccountStore.setState({ anthropicEmail: null, openaiEmail: null })
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.refreshAllForProvider') return refreshResults
+      if (method === 'accountOps.listSaved') return refreshedAccounts
+      if (method === 'accountOps.switchAccount') return { success: true }
+      if (method === 'accountOps.getClaudeEmail') return 'current@x.com'
+      if (method === 'usageOps.fetch') return { success: true, data: undefined }
+      return null
+    })
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(1)
+    expect(switchCalls()[0][1]).toEqual({ accountId: 'acc-2' })
+  })
+
+  it('never picks an account whose refreshed windows are all already expired', async () => {
+    const pastReset = new Date(Date.now() - 3_600_000).toISOString()
+    // acc-2 would win on score (expired windows read as full headroom), but
+    // its live usage is unknown — the pick must fall to acc-3.
+    refreshedAccounts = [
+      makeAccount('acc-1', 'current@x.com', makeUsage(0, 0)),
+      {
+        ...makeAccount('acc-2', 'best@x.com', null),
+        last_usage: {
+          five_hour: { utilization: 10, resets_at: pastReset },
+          seven_day: { utilization: 10, resets_at: pastReset }
+        }
+      },
+      makeAccount('acc-3', 'meh@x.com', makeUsage(60, 50))
+    ]
+    refreshResults = [
+      { accountId: 'acc-1', success: true },
+      { accountId: 'acc-2', success: true },
+      { accountId: 'acc-3', success: true }
+    ]
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(switchCalls()).toHaveLength(1)
+    expect(switchCalls()[0][1]).toEqual({ accountId: 'acc-3' })
+  })
+
   it('skips the round without backing off when a refresh sweep is already running', async () => {
     useUsageStore.setState({ refreshingProviders: { anthropic: true, openai: false } })
     useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
@@ -267,6 +267,32 @@ describe('useAccountScheduleStore auto-switch', () => {
     expect(switchCalls()).toHaveLength(1)
   })
 
+  it('seeds the active usage from the switched-to account so a dead refresh cannot re-trigger', async () => {
+    // The post-switch active-usage refresh stays broken (rate limited) — the
+    // slot must carry the NEW account's numbers, not the exhausted 92%, or
+    // every cooldown expiry would hop away from a perfectly healthy account.
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.refreshAllForProvider') return refreshResults
+      if (method === 'accountOps.listSaved') return refreshedAccounts
+      if (method === 'accountOps.switchAccount') return { success: true }
+      if (method === 'accountOps.getClaudeEmail') return 'best@x.com'
+      if (method === 'usageOps.fetch') return { success: false, error: 'rate limited' }
+      return null
+    })
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+    expect(switchCalls()).toHaveLength(1)
+    expect(useUsageStore.getState().anthropicUsage).toEqual(
+      refreshedAccounts.find((a) => a.id === 'acc-2')?.last_usage
+    )
+
+    // Past the cooldown with the refresh still dead: no churn.
+    vi.setSystemTime(Date.now() + 5 * 60_000 + 1_000)
+    await useAccountScheduleStore.getState().checkSchedules()
+    expect(switchCalls()).toHaveLength(1)
+  })
+
   it('does not sweep or switch while the active account cannot be identified', async () => {
     useAccountStore.setState({ anthropicEmail: null, openaiEmail: null })
     request.mockImplementation(async (method: string) => {

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -309,13 +309,26 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
               }
 
               // switchAccount toasts success/failure itself, and the mode
-              // stays armed either way. Both outcomes pause re-evaluation:
-              // on failure so a persistent problem doesn't retry (and toast)
-              // every tick, and on success because the active-usage slot
-              // still holds the PREVIOUS account's numbers until the
-              // post-switch refresh lands — without the pause, a failed or
-              // slow refresh would re-trigger next tick and hop again.
-              await useUsageStore.getState().switchAccount(best.account.id)
+              // stays armed either way. Both outcomes pause re-evaluation so
+              // a persistent problem doesn't retry (and toast) every tick.
+              const switched = await useUsageStore.getState().switchAccount(best.account.id)
+              if (switched && best.account.last_usage) {
+                // Seed the active-usage slot from the account we just picked:
+                // until the post-switch refresh lands (it can fail or be rate
+                // limited indefinitely), the slot would otherwise keep the
+                // PREVIOUS account's exhausted numbers and hop away from a
+                // healthy account on every cooldown expiry. A successful
+                // refresh simply overwrites the seed with live data.
+                if (provider === 'anthropic') {
+                  useUsageStore.setState({
+                    anthropicUsage: best.account.last_usage as UsageData
+                  })
+                } else {
+                  useUsageStore.setState({
+                    openaiUsage: best.account.last_usage as OpenAIUsageData
+                  })
+                }
+              }
               backOff()
             } finally {
               executingProviders.delete(provider)

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -1,7 +1,14 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
-import type { UsageProvider } from '@shared/types/usage'
+import type {
+  OpenAIUsageData,
+  RefreshAllResultItem,
+  SavedAccountDTO,
+  UsageData,
+  UsageProvider
+} from '@shared/types/usage'
 import { toast } from '@/lib/toast'
+import { getMaxUsagePercent, scoreAccountHeadroom } from '@/lib/auto-switch-score'
 import { useUsageStore, normalizeUsage } from './useUsageStore'
 import { useAccountStore } from './useAccountStore'
 
@@ -21,8 +28,24 @@ export interface ScheduledSwitch {
   notBefore?: number
 }
 
+/**
+ * Provider-global "keep me on whichever account has the most headroom" mode:
+ * when the ACTIVE account crosses thresholdPercent, refresh every saved
+ * account and hop to the best-scoring one — then stay armed for the next
+ * crossing. Mutually exclusive with a per-account ScheduledSwitch.
+ */
+export interface AutoSwitchConfig {
+  provider: UsageProvider
+  /** Utilization percent (0-100) at or above which the hop is triggered */
+  thresholdPercent: number
+  createdAt: number
+  /** Set after a failed attempt (or an empty candidate pool) — don't retry before this time */
+  notBefore?: number
+}
+
 interface AccountScheduleState {
   schedules: Partial<Record<UsageProvider, ScheduledSwitch>>
+  autoSwitch: Partial<Record<UsageProvider, AutoSwitchConfig>>
 
   scheduleByTime: (
     provider: UsageProvider,
@@ -37,6 +60,9 @@ interface AccountScheduleState {
     thresholdPercent: number
   ) => void
   cancelSchedule: (provider: UsageProvider) => void
+  /** Enable auto-switch (or update its threshold). Replaces any pending schedule. */
+  setAutoSwitch: (provider: UsageProvider, thresholdPercent: number) => void
+  disableAutoSwitch: (provider: UsageProvider) => void
   checkSchedules: () => Promise<void>
 }
 
@@ -75,6 +101,15 @@ function activeEmailFor(provider: UsageProvider): string | null {
   return provider === 'anthropic' ? state.anthropicEmail : state.openaiEmail
 }
 
+/** A saved account's cached usage in the common (anthropic-shaped) form. */
+function savedAccountUsage(provider: UsageProvider, account: SavedAccountDTO): UsageData | null {
+  if (!account.last_usage) return null
+  if (provider === 'anthropic') {
+    return normalizeUsage(provider, account.last_usage as UsageData, null)
+  }
+  return normalizeUsage(provider, null, account.last_usage as OpenAIUsageData)
+}
+
 // A due schedule whose switch attempt failed is retried, but not more often
 // than this — a persistently failing switch shouldn't toast every tick.
 const RETRY_DELAY_MS = 5 * 60_000
@@ -92,39 +127,48 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
   persist(
     (set, get) => ({
       schedules: {},
+      autoSwitch: {},
 
       scheduleByTime: (provider, accountId, email, delayMs) => {
-        set((state) => ({
-          schedules: {
-            ...state.schedules,
-            [provider]: {
-              provider,
-              accountId,
-              email,
-              mode: 'time' as const,
-              executeAt: Date.now() + delayMs,
-              thresholdPercent: null,
-              createdAt: Date.now()
+        set((state) => {
+          const { [provider]: _, ...autoRest } = state.autoSwitch
+          return {
+            autoSwitch: autoRest,
+            schedules: {
+              ...state.schedules,
+              [provider]: {
+                provider,
+                accountId,
+                email,
+                mode: 'time' as const,
+                executeAt: Date.now() + delayMs,
+                thresholdPercent: null,
+                createdAt: Date.now()
+              }
             }
           }
-        }))
+        })
       },
 
       scheduleByUsage: (provider, accountId, email, thresholdPercent) => {
-        set((state) => ({
-          schedules: {
-            ...state.schedules,
-            [provider]: {
-              provider,
-              accountId,
-              email,
-              mode: 'usage' as const,
-              executeAt: null,
-              thresholdPercent: Math.min(100, Math.max(1, Math.round(thresholdPercent))),
-              createdAt: Date.now()
+        set((state) => {
+          const { [provider]: _, ...autoRest } = state.autoSwitch
+          return {
+            autoSwitch: autoRest,
+            schedules: {
+              ...state.schedules,
+              [provider]: {
+                provider,
+                accountId,
+                email,
+                mode: 'usage' as const,
+                executeAt: null,
+                thresholdPercent: Math.min(100, Math.max(1, Math.round(thresholdPercent))),
+                createdAt: Date.now()
+              }
             }
           }
-        }))
+        })
       },
 
       cancelSchedule: (provider) => {
@@ -134,10 +178,131 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
         })
       },
 
+      setAutoSwitch: (provider, thresholdPercent) => {
+        set((state) => {
+          const { [provider]: _, ...scheduleRest } = state.schedules
+          return {
+            schedules: scheduleRest,
+            autoSwitch: {
+              ...state.autoSwitch,
+              [provider]: {
+                provider,
+                thresholdPercent: Math.min(100, Math.max(1, Math.round(thresholdPercent))),
+                createdAt: Date.now()
+              }
+            }
+          }
+        })
+      },
+
+      disableAutoSwitch: (provider) => {
+        set((state) => {
+          const { [provider]: _, ...rest } = state.autoSwitch
+          return { autoSwitch: rest }
+        })
+      },
+
       checkSchedules: async () => {
         for (const provider of PROVIDERS) {
+          if (executingProviders.has(provider)) continue
+
+          // Auto-switch mode is mutually exclusive with a per-account
+          // schedule — when armed, it owns this provider's evaluation.
+          const auto = get().autoSwitch[provider]
+          if (auto) {
+            if (auto.notBefore !== undefined && Date.now() < auto.notBefore) continue
+            const percent = getActiveUsagePercent(provider)
+            if (percent === null || percent < auto.thresholdPercent) continue
+
+            const backOff = (): void => {
+              set((state) => {
+                const current = state.autoSwitch[provider]
+                if (!current || current.createdAt !== auto.createdAt) return state
+                return {
+                  autoSwitch: {
+                    ...state.autoSwitch,
+                    [provider]: { ...current, notBefore: Date.now() + RETRY_DELAY_MS }
+                  }
+                }
+              })
+            }
+
+            executingProviders.add(provider)
+            try {
+              // Refresh every saved account so the pick is based on live
+              // numbers — and so we know which fetches actually succeeded.
+              let results: RefreshAllResultItem[] | null = null
+              let sweepFailed = false
+              try {
+                results = await useUsageStore.getState().refreshAllForProvider(provider)
+              } catch {
+                sweepFailed = true
+              }
+
+              // The sweep awaited an IPC round-trip — the user may have
+              // toggled auto-switch off (or re-armed it) in the meantime.
+              const latest = get().autoSwitch[provider]
+              if (!latest || latest.createdAt !== auto.createdAt) continue
+
+              if (sweepFailed) {
+                backOff()
+                continue
+              }
+              // Another sweep was already in flight: its numbers may be
+              // mid-write, so skip this round and re-evaluate next tick.
+              if (results === null) continue
+
+              const succeededIds = new Set(
+                results.filter((r) => r.success).map((r) => r.accountId)
+              )
+              const activeEmail = activeEmailFor(provider)
+              const now = Date.now()
+              // Eligible: the refresh succeeded, the token is valid, it's not
+              // the account we're leaving, and it isn't itself at/over the
+              // threshold (hopping there would immediately re-trigger).
+              const candidates = useUsageStore
+                .getState()
+                .savedAccounts[provider].filter(
+                  (a) =>
+                    succeededIds.has(a.id) &&
+                    a.status === 'ok' &&
+                    (activeEmail === null || a.email !== activeEmail)
+                )
+                .map((a) => ({ account: a, usage: savedAccountUsage(provider, a) }))
+                .filter((c): c is { account: SavedAccountDTO; usage: UsageData } => c.usage !== null)
+                .filter((c) => (getMaxUsagePercent(c.usage, now) ?? 0) < latest.thresholdPercent)
+
+              if (candidates.length === 0) {
+                toast.error(
+                  `Auto-switch: no other account below ${latest.thresholdPercent}% usage to switch to`
+                )
+                backOff()
+                continue
+              }
+
+              let best = candidates[0]
+              let bestScore = scoreAccountHeadroom(best.usage, now)
+              for (const candidate of candidates.slice(1)) {
+                const score = scoreAccountHeadroom(candidate.usage, now)
+                if (score > bestScore) {
+                  best = candidate
+                  bestScore = score
+                }
+              }
+
+              // switchAccount toasts success/failure itself. Success keeps the
+              // mode armed for the next crossing; failure backs off so a
+              // persistent problem doesn't retry (and toast) on every tick.
+              const switched = await useUsageStore.getState().switchAccount(best.account.id)
+              if (!switched) backOff()
+            } finally {
+              executingProviders.delete(provider)
+            }
+            continue
+          }
+
           const schedule = get().schedules[provider]
-          if (!schedule || executingProviders.has(provider)) continue
+          if (!schedule) continue
           if (schedule.notBefore !== undefined && Date.now() < schedule.notBefore) continue
 
           // Already on the target account (e.g. the user switched manually) —
@@ -244,7 +409,7 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
     {
       name: 'hive-account-switch-schedules',
       storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({ schedules: state.schedules })
+      partialize: (state) => ({ schedules: state.schedules, autoSwitch: state.autoSwitch })
     }
   )
 )

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -229,6 +229,23 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
 
             executingProviders.add(provider)
             try {
+              // Without knowing which account is active we can't exclude it
+              // from the candidate pool (risking a pointless self-switch) —
+              // resolve the email first, fetching it if the store has none.
+              let activeEmail = activeEmailFor(provider)
+              if (activeEmail === null) {
+                await useAccountStore
+                  .getState()
+                  .fetchEmail(provider)
+                  .catch(() => {})
+                activeEmail = activeEmailFor(provider)
+              }
+              if (activeEmail === null) {
+                toast.error('Auto-switch: could not identify the active account')
+                backOff()
+                continue
+              }
+
               // Refresh every saved account so the pick is based on live
               // numbers — and so we know which fetches actually succeeded.
               let results: RefreshAllResultItem[] | null = null
@@ -255,22 +272,23 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
               const succeededIds = new Set(
                 results.filter((r) => r.success).map((r) => r.accountId)
               )
-              const activeEmail = activeEmailFor(provider)
               const now = Date.now()
               // Eligible: the refresh succeeded, the token is valid, it's not
-              // the account we're leaving, and it isn't itself at/over the
+              // the account we're leaving, its windows carry CURRENT data
+              // (all-expired resets right after a refresh means its live usage
+              // is unknown, not zero), and it isn't itself at/over the
               // threshold (hopping there would immediately re-trigger).
               const candidates = useUsageStore
                 .getState()
                 .savedAccounts[provider].filter(
-                  (a) =>
-                    succeededIds.has(a.id) &&
-                    a.status === 'ok' &&
-                    (activeEmail === null || a.email !== activeEmail)
+                  (a) => succeededIds.has(a.id) && a.status === 'ok' && a.email !== activeEmail
                 )
                 .map((a) => ({ account: a, usage: savedAccountUsage(provider, a) }))
                 .filter((c): c is { account: SavedAccountDTO; usage: UsageData } => c.usage !== null)
-                .filter((c) => (getMaxUsagePercent(c.usage, now) ?? 0) < latest.thresholdPercent)
+                .filter((c) => {
+                  const maxPercent = getMaxUsagePercent(c.usage, now)
+                  return maxPercent !== null && maxPercent < latest.thresholdPercent
+                })
 
               if (candidates.length === 0) {
                 toast.error(
@@ -290,11 +308,15 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
                 }
               }
 
-              // switchAccount toasts success/failure itself. Success keeps the
-              // mode armed for the next crossing; failure backs off so a
-              // persistent problem doesn't retry (and toast) on every tick.
-              const switched = await useUsageStore.getState().switchAccount(best.account.id)
-              if (!switched) backOff()
+              // switchAccount toasts success/failure itself, and the mode
+              // stays armed either way. Both outcomes pause re-evaluation:
+              // on failure so a persistent problem doesn't retry (and toast)
+              // every tick, and on success because the active-usage slot
+              // still holds the PREVIOUS account's numbers until the
+              // post-switch refresh lands — without the pause, a failed or
+              // slow refresh would re-trigger next tick and hop again.
+              await useUsageStore.getState().switchAccount(best.account.id)
+              backOff()
             } finally {
               executingProviders.delete(provider)
             }

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -10,7 +10,8 @@ import type {
   AnthropicRateLimitState,
   OpenAIUsageData,
   UsageProvider,
-  SavedAccountDTO
+  SavedAccountDTO,
+  RefreshAllResultItem
 } from '@shared/types/usage'
 import { accountApi } from '@/api/account-api'
 import { usageApi } from '@/api/usage-api'
@@ -47,7 +48,9 @@ interface UsageState {
   switchingAccountIds: Set<string>
 
   loadSavedAccounts: (provider?: UsageProvider) => Promise<void>
-  refreshAllForProvider: (provider: UsageProvider) => Promise<void>
+  /** Resolves with the per-account fetch outcomes, or null when a sweep for
+   * the provider was already running (nothing was refreshed by this call). */
+  refreshAllForProvider: (provider: UsageProvider) => Promise<RefreshAllResultItem[] | null>
   refreshSavedAccount: (id: string, opts?: { userInitiated?: boolean }) => Promise<void>
   removeSavedAccount: (id: string) => Promise<void>
   /** Resolves true when the switch op succeeded (failures also toast). */
@@ -132,7 +135,7 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
 
   refreshAllForProvider: async (provider: UsageProvider) => {
     const state = get()
-    if (state.refreshingProviders[provider]) return
+    if (state.refreshingProviders[provider]) return null
 
     const accountIds = state.savedAccounts[provider].map((account) => account.id)
     set((current) => ({
@@ -141,8 +144,9 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
     }))
 
     try {
-      await usageApi.refreshAllForProvider(provider)
+      const results = await usageApi.refreshAllForProvider(provider)
       await get().loadSavedAccounts(provider)
+      return results
     } finally {
       set((current) => {
         const nextIds = new Set(current.refreshingAccountIds)


### PR DESCRIPTION
## Summary
- Adds a new provider-wide auto-switch mode to the usage popover for hopping to the best saved account when usage crosses a threshold.
- Introduces headroom scoring logic to pick the best target account across 5h, 7d, and scoped usage windows.
- Updates usage UI to show auto-switch state, controls, and clear replacement warnings when it conflicts with per-account schedules.
- Extends schedule store behavior so auto-switch and per-account scheduling remain mutually exclusive and back off after failed attempts.
- Adds coverage for the new scoring logic, popover controls, UI indicators, and store scheduling flow.

## Testing
- Added unit tests for `scoreAccountHeadroom` and `getMaxUsagePercent`.
- Added component tests for arming/disarming auto-switch, threshold presets, custom thresholds, and conflict messaging.
- Added usage indicator tests for the auto-switch icon and popover visibility rules.
- Added store tests for threshold clamping, refresh-and-switch selection, backoff behavior, and mutual exclusion with schedules.
- Not run in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatically switches API credentials and triggers bulk usage refreshes when thresholds fire; logic is heavily tested but affects live account selection and IPC account ops.
> 
> **Overview**
> Adds **provider-wide auto-switch**: when the active account’s usage crosses a threshold, the app refreshes all saved accounts and switches to the one with the most headroom, then stays armed for the next crossing.
> 
> New **`auto-switch-score`** logic ranks targets via a weighted geometric mean across 5h, 7d, and scoped model windows (worst scoped window counts), with stale resets treated as full headroom. **`useAccountScheduleStore`** gains persisted `autoSwitch` state, mutual exclusion with per-account schedules, and a `checkSchedules` path that refreshes all accounts, filters eligible candidates, picks the best score, switches via IPC, seeds active usage after success, and applies 5-minute backoff on failures or empty pools.
> 
> **UI**: `AutoSwitchControls` in the usage popover (toggle, presets, custom threshold, conflict warnings); usage bar shows a shuffle icon when armed instead of the scheduled-switch timer. Controls show with 2+ accounts but remain visible while armed if accounts drop.
> 
> **`refreshAllForProvider`** now returns per-account refresh results (or `null` if a sweep was already in flight) so auto-switch only trusts accounts that actually refreshed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed55b59473d9831da9d18c91e8c6e3b94ee0b367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->