### PR TITLE
Add Claude CLI background work tracking and badges

### DIFF
--- a/src/main/services/__tests__/claude-cli-background-work-tracker.test.ts
+++ b/src/main/services/__tests__/claude-cli-background-work-tracker.test.ts
@@ -1,0 +1,246 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  clearAllClaudeCliBackgroundWork,
+  clearClaudeCliBackgroundWork,
+  getClaudeCliBackgroundWorkCounts,
+  MONITOR_TIMEOUT_EVENT,
+  parseEndedTaskNotificationIds,
+  processClaudeCliBackgroundWorkHook
+} from '../claude-cli-background-work-tracker'
+import type { ParsedClaudeHook } from '../claude-hook-server'
+
+const SESSION = 'hive-session-1'
+
+// Fixtures mirror real hook payloads captured from claude v2.1.218.
+
+function backgroundBashStart(taskId: string): ParsedClaudeHook {
+  return {
+    hook_event_name: 'PostToolUse',
+    tool_name: 'Bash',
+    tool_input: { run_in_background: true },
+    tool_response: {
+      stdout: '',
+      stderr: '',
+      interrupted: false,
+      isImage: false,
+      noOutputExpected: false,
+      backgroundTaskId: taskId
+    }
+  }
+}
+
+function monitorStart(taskId: string): ParsedClaudeHook {
+  return {
+    hook_event_name: 'PostToolUse',
+    tool_name: 'Monitor',
+    tool_response: { taskId, timeoutMs: 3600000, persistent: false }
+  }
+}
+
+function notificationPrompt(blocks: string[]): ParsedClaudeHook {
+  return { hook_event_name: 'UserPromptSubmit', prompt: blocks.join('\n') }
+}
+
+function terminalBlock(taskId: string, status: string): string {
+  return `<task-notification>\n<task-id>${taskId}</task-id>\n<tool-use-id>toolu_x</tool-use-id>\n<status>${status}</status>\n<summary>Background command "x" ended</summary>\n</task-notification>`
+}
+
+afterEach(() => {
+  clearAllClaudeCliBackgroundWork()
+})
+
+describe('processClaudeCliBackgroundWorkHook', () => {
+  it('counts a background Bash start from PostToolUse', () => {
+    expect(processClaudeCliBackgroundWorkHook(SESSION, backgroundBashStart('bshell1'))).toEqual({
+      runningShells: 1,
+      runningMonitors: 0
+    })
+  })
+
+  it('ignores foreground Bash and failed background launches', () => {
+    const foreground: ParsedClaudeHook = {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: {},
+      tool_response: { stdout: 'ok' }
+    }
+    const noTaskId: ParsedClaudeHook = {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: { run_in_background: true },
+      tool_response: { stdout: '', stderr: 'spawn failed' }
+    }
+
+    expect(processClaudeCliBackgroundWorkHook(SESSION, foreground)).toBeNull()
+    expect(processClaudeCliBackgroundWorkHook(SESSION, noTaskId)).toBeNull()
+  })
+
+  it('counts a Monitor start but not a failed one', () => {
+    const failed: ParsedClaudeHook = {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Monitor',
+      tool_response: 'InputValidationError: Monitor failed'
+    }
+
+    expect(processClaudeCliBackgroundWorkHook(SESSION, monitorStart('bmon1'))).toEqual({
+      runningShells: 0,
+      runningMonitors: 1
+    })
+    expect(processClaudeCliBackgroundWorkHook(SESSION, failed)).toBeNull()
+  })
+
+  it('retires shells and monitors on TaskStop (which never notifies)', () => {
+    processClaudeCliBackgroundWorkHook(SESSION, backgroundBashStart('bshell1'))
+    processClaudeCliBackgroundWorkHook(SESSION, monitorStart('bmon1'))
+
+    const stop: ParsedClaudeHook = {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TaskStop',
+      tool_input: { task_id: 'bshell1' },
+      tool_response: { message: 'Successfully stopped task: bshell1', task_id: 'bshell1' }
+    }
+
+    expect(processClaudeCliBackgroundWorkHook(SESSION, stop)).toEqual({
+      runningShells: 0,
+      runningMonitors: 1
+    })
+  })
+
+  it('retires a task on a terminal notification for every status value', () => {
+    for (const status of ['completed', 'failed', 'killed', 'stopped']) {
+      processClaudeCliBackgroundWorkHook(SESSION, backgroundBashStart('btask'))
+      expect(
+        processClaudeCliBackgroundWorkHook(SESSION, notificationPrompt([terminalBlock('btask', status)]))
+      ).toEqual({ runningShells: 0, runningMonitors: 0 })
+    }
+  })
+
+  it('keeps a monitor alive through routine (statusless) monitor events', () => {
+    processClaudeCliBackgroundWorkHook(SESSION, monitorStart('bmon1'))
+
+    const routineEvent = notificationPrompt([
+      '<task-notification>\n<task-id>bmon1</task-id>\n<summary>Monitor event: "sweep"</summary>\n<event>=== DONE: batch 3 ===</event>\n</task-notification>'
+    ])
+
+    expect(processClaudeCliBackgroundWorkHook(SESSION, routineEvent)).toBeNull()
+    expect(getClaudeCliBackgroundWorkCounts(SESSION)).toEqual({
+      runningShells: 0,
+      runningMonitors: 1
+    })
+  })
+
+  it('retires a monitor on stream-end and on the statusless timeout event', () => {
+    processClaudeCliBackgroundWorkHook(SESSION, monitorStart('bmon1'))
+    processClaudeCliBackgroundWorkHook(SESSION, monitorStart('bmon2'))
+
+    const streamEnded = notificationPrompt([terminalBlock('bmon1', 'completed')])
+    const timedOut = notificationPrompt([
+      `<task-notification>\n<task-id>bmon2</task-id>\n<summary>Monitor event: "sweep"</summary>\n<event>${MONITOR_TIMEOUT_EVENT}</event>\n</task-notification>`
+    ])
+
+    expect(processClaudeCliBackgroundWorkHook(SESSION, streamEnded)).toEqual({
+      runningShells: 0,
+      runningMonitors: 1
+    })
+    expect(processClaudeCliBackgroundWorkHook(SESSION, timedOut)).toEqual({
+      runningShells: 0,
+      runningMonitors: 0
+    })
+  })
+
+  it('reconciles away tasks missing from a Stop background_tasks snapshot', () => {
+    processClaudeCliBackgroundWorkHook(SESSION, backgroundBashStart('bkeep'))
+    processClaudeCliBackgroundWorkHook(SESSION, backgroundBashStart('bgone'))
+    processClaudeCliBackgroundWorkHook(SESSION, monitorStart('bmon1'))
+
+    const stop: ParsedClaudeHook = {
+      hook_event_name: 'Stop',
+      background_tasks: [
+        { id: 'bkeep', type: 'shell', status: 'running' },
+        { id: 'bmon1', type: 'shell', status: 'running' },
+        { id: 'bother-subagent', type: 'subagent', status: 'running' }
+      ]
+    }
+
+    expect(processClaudeCliBackgroundWorkHook(SESSION, stop)).toEqual({
+      runningShells: 1,
+      runningMonitors: 1
+    })
+  })
+
+  it('treats an absent background_tasks key as no snapshot, but an empty array as authoritative', () => {
+    processClaudeCliBackgroundWorkHook(SESSION, backgroundBashStart('bkeep'))
+
+    expect(processClaudeCliBackgroundWorkHook(SESSION, { hook_event_name: 'Stop' })).toBeNull()
+    expect(getClaudeCliBackgroundWorkCounts(SESSION)).toEqual({
+      runningShells: 1,
+      runningMonitors: 0
+    })
+
+    expect(
+      processClaudeCliBackgroundWorkHook(SESSION, { hook_event_name: 'Stop', background_tasks: [] })
+    ).toEqual({ runningShells: 0, runningMonitors: 0 })
+  })
+
+  it('clears everything on session boundaries', () => {
+    for (const event of ['SessionStart', 'SessionEnd']) {
+      processClaudeCliBackgroundWorkHook(SESSION, backgroundBashStart('bshell'))
+      processClaudeCliBackgroundWorkHook(SESSION, monitorStart('bmon'))
+
+      expect(processClaudeCliBackgroundWorkHook(SESSION, { hook_event_name: event })).toEqual({
+        runningShells: 0,
+        runningMonitors: 0
+      })
+    }
+  })
+
+  it('returns null for a session boundary with nothing tracked', () => {
+    expect(processClaudeCliBackgroundWorkHook(SESSION, { hook_event_name: 'SessionStart' })).toBeNull()
+  })
+
+  it('tracks sessions independently', () => {
+    processClaudeCliBackgroundWorkHook('session-a', backgroundBashStart('ba'))
+    processClaudeCliBackgroundWorkHook('session-b', monitorStart('bb'))
+
+    expect(getClaudeCliBackgroundWorkCounts('session-a')).toEqual({
+      runningShells: 1,
+      runningMonitors: 0
+    })
+    expect(getClaudeCliBackgroundWorkCounts('session-b')).toEqual({
+      runningShells: 0,
+      runningMonitors: 1
+    })
+  })
+})
+
+describe('clearClaudeCliBackgroundWork', () => {
+  it('reports whether the session had live counts', () => {
+    expect(clearClaudeCliBackgroundWork(SESSION)).toBe(false)
+
+    processClaudeCliBackgroundWorkHook(SESSION, backgroundBashStart('bshell'))
+    expect(clearClaudeCliBackgroundWork(SESSION)).toBe(true)
+    expect(getClaudeCliBackgroundWorkCounts(SESSION)).toEqual({
+      runningShells: 0,
+      runningMonitors: 0
+    })
+  })
+})
+
+describe('parseEndedTaskNotificationIds', () => {
+  it('extracts only terminal blocks from a batch resume prompt', () => {
+    const prompt = [
+      terminalBlock('bdone', 'completed'),
+      '<task-notification>\n<task-id>bevent</task-id>\n<event>progress line</event>\n</task-notification>',
+      `<task-notification>\n<task-id>btimeout</task-id>\n<event>${MONITOR_TIMEOUT_EVENT}</event>\n</task-notification>`
+    ].join('\n')
+
+    expect(parseEndedTaskNotificationIds(prompt)).toEqual(['bdone', 'btimeout'])
+  })
+
+  it('returns nothing for non-notification prompts', () => {
+    expect(parseEndedTaskNotificationIds('please fix the bug')).toEqual([])
+    expect(parseEndedTaskNotificationIds(undefined)).toEqual([])
+  })
+})

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -1075,3 +1075,130 @@ describe('plan auto-approve', () => {
     expect(isClaudeCliPlanAutoApproveArmed('hive-session-close')).toBe(false)
   })
 })
+
+describe('background shell/monitor counts (HTTP round-trip)', () => {
+  const SESSION = 'hive-session-bg'
+
+  function backgroundBashHook(taskId: string): Record<string, unknown> {
+    return {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'sleep 300', run_in_background: true },
+      tool_response: { stdout: '', stderr: '', backgroundTaskId: taskId }
+    }
+  }
+
+  function backgroundWorkCalls(): unknown[][] {
+    return backendManagerMocks.publishDesktopBackendEvent.mock.calls.filter(
+      ([channel]) => channel === 'claude-cli:background-work'
+    )
+  }
+
+  it('publishes count changes for background Bash starts and TaskStop kills', async () => {
+    const { port } = await getClaudeHookServer()
+    backendManagerMocks.publishDesktopBackendEvent.mockResolvedValue(true)
+
+    await postHook(port, SESSION, 'tool', backgroundBashHook('bshell1'))
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:background-work',
+        { sessionId: SESSION, runningShells: 1, runningMonitors: 0 }
+      )
+    })
+
+    await postHook(port, SESSION, 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Monitor',
+      tool_response: { taskId: 'bmon1', timeoutMs: 300000, persistent: false }
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:background-work',
+        { sessionId: SESSION, runningShells: 1, runningMonitors: 1 }
+      )
+    })
+
+    await postHook(port, SESSION, 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TaskStop',
+      tool_input: { task_id: 'bshell1' },
+      tool_response: { message: 'Successfully stopped task: bshell1', task_id: 'bshell1' }
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:background-work',
+        { sessionId: SESSION, runningShells: 0, runningMonitors: 1 }
+      )
+    })
+  })
+
+  it('does not publish for foreground tool use', async () => {
+    const { port } = await getClaudeHookServer()
+    backendManagerMocks.publishDesktopBackendEvent.mockResolvedValue(true)
+
+    await postHook(port, SESSION, 'tool', {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      tool_response: { stdout: 'ok' }
+    })
+    // Flush: the later status publish proves the hook was fully processed.
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:status',
+        expect.objectContaining({ sessionId: SESSION })
+      )
+    })
+
+    expect(backgroundWorkCalls()).toEqual([])
+  })
+
+  it('zeroes counts from a Stop background_tasks snapshot and terminal notifications', async () => {
+    const { port } = await getClaudeHookServer()
+    backendManagerMocks.publishDesktopBackendEvent.mockResolvedValue(true)
+
+    await postHook(port, SESSION, 'tool', backgroundBashHook('bshell1'))
+    await postHook(port, SESSION, 'tool', backgroundBashHook('bshell2'))
+
+    // bshell1 finished mid-turn (no hook fired): the Stop snapshot only lists bshell2.
+    await postHook(port, SESSION, 'stop', {
+      hook_event_name: 'Stop',
+      last_assistant_message: 'done',
+      background_tasks: [{ id: 'bshell2', type: 'shell', status: 'running' }]
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:background-work',
+        { sessionId: SESSION, runningShells: 1, runningMonitors: 0 }
+      )
+    })
+
+    // bshell2 ends via its task-notification resume turn.
+    await postHook(port, SESSION, 'start', {
+      hook_event_name: 'UserPromptSubmit',
+      prompt:
+        '<task-notification>\n<task-id>bshell2</task-id>\n<status>completed</status>\n<summary>Background command "x" completed (exit code 0)</summary>\n</task-notification>'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:background-work',
+        { sessionId: SESSION, runningShells: 0, runningMonitors: 0 }
+      )
+    })
+  })
+
+  it('zeroes counts when the session ends', async () => {
+    const { port } = await getClaudeHookServer()
+    backendManagerMocks.publishDesktopBackendEvent.mockResolvedValue(true)
+
+    await postHook(port, SESSION, 'tool', backgroundBashHook('bshell1'))
+    await postHook(port, SESSION, 'session', { hook_event_name: 'SessionEnd' })
+
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:background-work',
+        { sessionId: SESSION, runningShells: 0, runningMonitors: 0 }
+      )
+    })
+  })
+})

--- a/src/main/services/claude-cli-background-work-tracker.ts
+++ b/src/main/services/claude-cli-background-work-tracker.ts
@@ -1,0 +1,209 @@
+// Type-only import: claude-hook-server imports this module at runtime, so a
+// runtime import back would create a cycle.
+import type { ParsedClaudeHook } from './claude-hook-server'
+import { isTaskNotificationPrompt } from './claude-cli-subagent-tracker'
+
+/**
+ * Counts a Claude CLI session's live background work from hook payloads alone
+ * (validated empirically against claude v2.1.218 with the claude-playground
+ * prototype):
+ *
+ * - A background shell starts at `PostToolUse` for Bash with
+ *   `tool_input.run_in_background` and a `tool_response.backgroundTaskId`
+ *   (PostToolUse fires immediately for backgrounded commands). A monitor
+ *   starts at `PostToolUse` for Monitor with a `tool_response.taskId`; a
+ *   failed launch has no id and must never count.
+ * - `TaskStop` is the one ending that never produces a task notification, so
+ *   its `tool_input.task_id` retires the task directly.
+ * - Completions are delivered as `UserPromptSubmit` resume turns whose prompt
+ *   carries `<task-notification>` blocks. A block is terminal only when it has
+ *   a `<status>` tag (completed/failed/killed/stopped) or the literal
+ *   monitor-timeout `<event>` — routine monitor events have neither and must
+ *   not retire the monitor.
+ * - A task finishing mid-turn fires NO hook at all; the `background_tasks`
+ *   snapshot on every Stop/SubagentStop payload (claude >= 2.1.145) is the
+ *   authoritative reconciliation that self-heals such gaps at each turn
+ *   boundary (both shells and monitors appear there as type 'shell', so it
+ *   can prune but never classify — classification only happens at start).
+ * - SessionStart/SessionEnd clear everything; background tasks never survive
+ *   the CLI process, and orphans are reported to the *next* session.
+ */
+
+export interface ClaudeCliBackgroundWorkCounts {
+  runningShells: number
+  runningMonitors: number
+}
+
+interface SessionWork {
+  shells: Set<string>
+  monitors: Set<string>
+}
+
+// sessionId -> live background-task ids. Same accepted race as the subagent
+// tracker: a late hook can re-create bounded state for a dead session, which
+// self-heals on the next SessionStart/PTY teardown clear.
+const sessions = new Map<string, SessionWork>()
+
+/** The literal `<event>` text of a monitor-timeout notification — the only
+ * terminal monitor notification that carries no `<status>` tag. */
+export const MONITOR_TIMEOUT_EVENT = '[Monitor timed out — re-arm if needed.]'
+
+const NOTIFICATION_BLOCK_PATTERN = /<task-notification>([\s\S]*?)<\/task-notification>/g
+
+function getOrCreateWork(sessionId: string): SessionWork {
+  let work = sessions.get(sessionId)
+  if (!work) {
+    work = { shells: new Set(), monitors: new Set() }
+    sessions.set(sessionId, work)
+  }
+  return work
+}
+
+function pruneIfEmpty(sessionId: string, work: SessionWork): void {
+  if (work.shells.size === 0 && work.monitors.size === 0) {
+    sessions.delete(sessionId)
+  }
+}
+
+function counts(work: SessionWork | undefined): ClaudeCliBackgroundWorkCounts {
+  return {
+    runningShells: work?.shells.size ?? 0,
+    runningMonitors: work?.monitors.size ?? 0
+  }
+}
+
+function tagText(block: string, tag: string): string | null {
+  const open = `<${tag}>`
+  const close = `</${tag}>`
+  const start = block.indexOf(open)
+  if (start === -1) return null
+  const end = block.indexOf(close, start + open.length)
+  if (end === -1) return null
+  return block.slice(start + open.length, end).trim()
+}
+
+/**
+ * Task ids of *terminal* `<task-notification>` blocks in a resume prompt.
+ * Unlike the subagent tracker's parseTaskNotificationIds (every id), this
+ * keeps only blocks that actually end a task: ones carrying a `<status>` tag
+ * or the monitor-timeout event.
+ */
+export function parseEndedTaskNotificationIds(prompt: unknown): string[] {
+  if (!isTaskNotificationPrompt(prompt)) return []
+
+  const ids: string[] = []
+  for (const match of (prompt as string).matchAll(NOTIFICATION_BLOCK_PATTERN)) {
+    const block = match[1]
+    const terminal =
+      tagText(block, 'status') !== null || tagText(block, 'event') === MONITOR_TIMEOUT_EVENT
+    if (!terminal) continue
+    const id = tagText(block, 'task-id')
+    if (id) ids.push(id)
+  }
+  return ids
+}
+
+function responseId(hook: ParsedClaudeHook, field: string): string | null {
+  const response = hook.tool_response
+  if (typeof response !== 'object' || response === null) return null
+  const id = (response as Record<string, unknown>)[field]
+  return typeof id === 'string' && id.length > 0 ? id : null
+}
+
+function observePostToolUse(work: SessionWork, hook: ParsedClaudeHook): void {
+  switch (hook.tool_name) {
+    case 'Bash': {
+      // A denied or failed launch has no backgroundTaskId — never count it.
+      if (hook.tool_input?.run_in_background === true) {
+        const id = responseId(hook, 'backgroundTaskId')
+        if (id) work.shells.add(id)
+      }
+      return
+    }
+    case 'Monitor': {
+      const id = responseId(hook, 'taskId')
+      if (id) work.monitors.add(id)
+      return
+    }
+    case 'TaskStop': {
+      const id = hook.tool_input?.task_id
+      if (typeof id === 'string') {
+        work.shells.delete(id)
+        work.monitors.delete(id)
+      }
+      return
+    }
+  }
+}
+
+function reconcileWithSnapshot(work: SessionWork, hook: ParsedClaudeHook): void {
+  // Older claude versions omit the key entirely — only an actual snapshot may
+  // prune (an empty array is an authoritative "nothing is running").
+  const tasks = hook.background_tasks
+  if (!Array.isArray(tasks)) return
+
+  const running = new Set<string>()
+  for (const task of tasks) {
+    if (task.status === 'running' && task.id) running.add(task.id)
+  }
+  for (const id of work.shells) {
+    if (!running.has(id)) work.shells.delete(id)
+  }
+  for (const id of work.monitors) {
+    if (!running.has(id)) work.monitors.delete(id)
+  }
+}
+
+/**
+ * Feed a Claude CLI hook through the background-work counter. Returns the new
+ * counts when they changed, or null when the hook left them untouched.
+ */
+export function processClaudeCliBackgroundWorkHook(
+  sessionId: string,
+  hook: ParsedClaudeHook
+): ClaudeCliBackgroundWorkCounts | null {
+  const event = hook.hook_event_name ?? ''
+
+  if (event === 'SessionStart' || event === 'SessionEnd') {
+    return clearClaudeCliBackgroundWork(sessionId) ? counts(undefined) : null
+  }
+
+  const existing = sessions.get(sessionId)
+  const before = counts(existing)
+  const work = existing ?? getOrCreateWork(sessionId)
+
+  if (event === 'PostToolUse') {
+    observePostToolUse(work, hook)
+  } else if (event === 'UserPromptSubmit') {
+    for (const id of parseEndedTaskNotificationIds(hook.prompt)) {
+      work.shells.delete(id)
+      work.monitors.delete(id)
+    }
+  } else if (event === 'Stop' || event === 'SubagentStop') {
+    reconcileWithSnapshot(work, hook)
+  }
+
+  const after = counts(work)
+  pruneIfEmpty(sessionId, work)
+  return after.runningShells !== before.runningShells ||
+    after.runningMonitors !== before.runningMonitors
+    ? after
+    : null
+}
+
+export function getClaudeCliBackgroundWorkCounts(sessionId: string): ClaudeCliBackgroundWorkCounts {
+  return counts(sessions.get(sessionId))
+}
+
+/** Drop a session's tracked work. Returns true when it had live counts (the
+ * caller should publish zeros so the renderer badge clears). */
+export function clearClaudeCliBackgroundWork(sessionId: string): boolean {
+  const work = sessions.get(sessionId)
+  if (!work) return false
+  sessions.delete(sessionId)
+  return work.shells.size > 0 || work.monitors.size > 0
+}
+
+export function clearAllClaudeCliBackgroundWork(): void {
+  sessions.clear()
+}

--- a/src/main/services/claude-cli-background-work-tracker.ts
+++ b/src/main/services/claude-cli-background-work-tracker.ts
@@ -110,6 +110,13 @@ function responseId(hook: ParsedClaudeHook, field: string): string | null {
   return typeof id === 'string' && id.length > 0 ? id : null
 }
 
+function canStartBackgroundWork(hook: ParsedClaudeHook): boolean {
+  return (
+    hook.hook_event_name === 'PostToolUse' &&
+    (hook.tool_name === 'Bash' || hook.tool_name === 'Monitor')
+  )
+}
+
 function observePostToolUse(work: SessionWork, hook: ParsedClaudeHook): void {
   switch (hook.tool_name) {
     case 'Bash': {
@@ -169,6 +176,12 @@ export function processClaudeCliBackgroundWorkHook(
   }
 
   const existing = sessions.get(sessionId)
+  // With nothing tracked, only a task START can change counts — every other
+  // event just removes/reconciles. Skip the transient state allocation this
+  // hot path (every tool use of every session) would otherwise churn through.
+  if (!existing && !canStartBackgroundWork(hook)) {
+    return null
+  }
   const before = counts(existing)
   const work = existing ?? getOrCreateWork(sessionId)
 

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -20,6 +20,15 @@ import {
   type ClaudeCliBackgroundTask
 } from './claude-cli-subagent-tracker'
 import {
+  clearAllClaudeCliBackgroundWork,
+  clearClaudeCliBackgroundWork,
+  processClaudeCliBackgroundWorkHook
+} from './claude-cli-background-work-tracker'
+import {
+  CLAUDE_CLI_BACKGROUND_WORK_CHANNEL,
+  type ClaudeCliBackgroundWorkPayload
+} from '@shared/types/claude-cli-background-work'
+import {
   clearAllClaudeCliPlanAutoApprove,
   consumeClaudeCliPlanAutoApprove,
   isClaudeCliPlanAutoApproveArmed,
@@ -42,7 +51,13 @@ export interface ParsedClaudeHook {
   tool_input?: {
     plan?: unknown
     questions?: unknown
+    /** Bash: true when the command was launched as a background shell. */
+    run_in_background?: unknown
+    /** TaskStop: the background task id being stopped. */
+    task_id?: unknown
   }
+  /** PostToolUse tool result (backgroundTaskId / taskId live here). */
+  tool_response?: unknown
   /** Final assistant message of the turn (Stop hook). Read both spellings: */
   assistant_message?: string
   last_assistant_message?: string
@@ -223,6 +238,24 @@ export function publishClaudeCliStatus(payload: ClaudeCliStatusPayload): void {
   )
 }
 
+function publishClaudeCliBackgroundWork(payload: ClaudeCliBackgroundWorkPayload): void {
+  void Promise.resolve(
+    publishDesktopBackendEvent(CLAUDE_CLI_BACKGROUND_WORK_CHANNEL, payload)
+  ).catch(() => undefined)
+}
+
+/**
+ * Drop a session's background-work counts and, if it had any, tell the
+ * renderer they are gone. For teardown paths that fire no SessionEnd hook
+ * (PTY exit, destroy, restart) — the CLI's background tasks die with the
+ * process, so the badge must not linger.
+ */
+export function resetClaudeCliBackgroundWork(sessionId: string): void {
+  if (clearClaudeCliBackgroundWork(sessionId)) {
+    publishClaudeCliBackgroundWork({ sessionId, runningShells: 0, runningMonitors: 0 })
+  }
+}
+
 /**
  * Read the most recently published live status for a Claude CLI session, or
  * undefined if none has been published in this process. Used to gate actions
@@ -312,6 +345,14 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
             metadata: buildStatusMetadata(body, route.hookPath)
           }
         : null
+      // Live background shell/monitor counts for the kanban ticket badge.
+      // Independent of the status pipeline below: counting must see every
+      // hook (including ones the subagent gate swallows), and count changes
+      // ride a dedicated channel so the status dedup can't eat them.
+      const backgroundWork = processClaudeCliBackgroundWorkHook(route.sessionId, body)
+      if (backgroundWork) {
+        publishClaudeCliBackgroundWork({ sessionId: route.sessionId, ...backgroundWork })
+      }
       // Background Task subagents can keep running after the main agent's
       // Stop fires; the tracker decides whether this Stop is truly final
       // ('pass'), must be swallowed because work is still in flight
@@ -508,6 +549,7 @@ export async function closeClaudeHookServer(): Promise<void> {
     statusSubscribers.clear()
     clearAllClaudeCliInteractions()
     clearAllClaudeCliSubagentTracking()
+    clearAllClaudeCliBackgroundWork()
     clearAllClaudeCliPlanAutoApprove()
     setClaudeCliDeferredCompletionHandler(null)
     return
@@ -530,6 +572,7 @@ export async function closeClaudeHookServer(): Promise<void> {
   statusSubscribers.clear()
   clearAllClaudeCliInteractions()
   clearAllClaudeCliSubagentTracking()
+  clearAllClaudeCliBackgroundWork()
   clearAllClaudeCliPlanAutoApprove()
   setClaudeCliDeferredCompletionHandler(null)
 }

--- a/src/main/services/terminal-pty-bridge.claude-cli.test.ts
+++ b/src/main/services/terminal-pty-bridge.claude-cli.test.ts
@@ -133,7 +133,10 @@ vi.mock('./claude-cli-interaction-ledger', () => ({
   clearAllClaudeCliInteractions: mocks.clearAllClaudeCliInteractions
 }))
 
-vi.mock('./claude-cli-subagent-tracker', () => ({
+// Spread the real module so transitive importers (claude-cli-background-work-tracker
+// named-imports isTaskNotificationPrompt from here) keep their exports working.
+vi.mock('./claude-cli-subagent-tracker', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./claude-cli-subagent-tracker')>()),
   clearClaudeCliSubagentTracking: mocks.clearClaudeCliSubagentTracking,
   clearAllClaudeCliSubagentTracking: mocks.clearAllClaudeCliSubagentTracking
 }))

--- a/src/main/services/terminal-pty-bridge.claude-cli.test.ts
+++ b/src/main/services/terminal-pty-bridge.claude-cli.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => {
     buildClaudeCliHookSettings: vi.fn(),
     getLastClaudeCliStatus: vi.fn(),
     publishClaudeCliStatus: vi.fn(),
+    resetClaudeCliBackgroundWork: vi.fn(),
     subscribeClaudeCliStatus: vi.fn(() => vi.fn()),
     clearClaudeCliInteractions: vi.fn(),
     clearAllClaudeCliInteractions: vi.fn(),
@@ -119,6 +120,7 @@ vi.mock('./claude-hook-server', () => ({
   buildClaudeCliHookSettings: mocks.buildClaudeCliHookSettings,
   getLastClaudeCliStatus: mocks.getLastClaudeCliStatus,
   publishClaudeCliStatus: mocks.publishClaudeCliStatus,
+  resetClaudeCliBackgroundWork: mocks.resetClaudeCliBackgroundWork,
   subscribeClaudeCliStatus: mocks.subscribeClaudeCliStatus
 }))
 
@@ -311,6 +313,22 @@ describe('Claude CLI terminal hook status wiring', () => {
       rows: 40
     })
     expect(mocks.ptyService.write).not.toHaveBeenCalled()
+  })
+
+  it('resets background-work counts when spawning a fresh Claude process', async () => {
+    mocks.ptyService.has.mockReturnValue(false)
+
+    await createClaudeCliTerminal('hive-session-1', {})
+
+    expect(mocks.resetClaudeCliBackgroundWork).toHaveBeenCalledWith('hive-session-1')
+  })
+
+  it('keeps background-work counts when reusing an already-running PTY', async () => {
+    mocks.ptyService.has.mockReturnValue(true)
+
+    await createClaudeCliTerminal('hive-session-1', {})
+
+    expect(mocks.resetClaudeCliBackgroundWork).not.toHaveBeenCalled()
   })
 
   it('does not register the old terminal:create IPC handler', () => {

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -407,8 +407,14 @@ export async function createClaudeCliTerminal(
     // ...nor a stale subagent deferral/pending-notification set, which could
     // otherwise swallow the next turn's Stop after a restart.
     clearClaudeCliSubagentTracking(sessionId)
-    // ...nor the previous process's background shell/monitor counts.
-    resetClaudeCliBackgroundWork(sessionId)
+    // ...nor a dead previous process's background shell/monitor counts. Only
+    // on a true (re)spawn: when the live PTY was reused above, its claude
+    // process — and its background tasks — are still running, and the
+    // Stop-snapshot reconciliation only prunes tracked ids (it never adopts),
+    // so a reset here could not self-heal until those tasks ended.
+    if (!alreadyExists) {
+      resetClaudeCliBackgroundWork(sessionId)
+    }
     claudeCliWorktreeBasenames.set(sessionId, path.basename(worktreePath))
     if (!pendingPrompt) {
       publishClaudeCliStatus({

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -5,6 +5,7 @@ import {
   getClaudeHookServer,
   getLastClaudeCliStatus,
   publishClaudeCliStatus,
+  resetClaudeCliBackgroundWork,
   subscribeClaudeCliStatus,
   type ClaudeCliStatusPayload
 } from './claude-hook-server'
@@ -16,6 +17,7 @@ import {
   clearAllClaudeCliSubagentTracking,
   clearClaudeCliSubagentTracking
 } from './claude-cli-subagent-tracker'
+import { clearAllClaudeCliBackgroundWork } from './claude-cli-background-work-tracker'
 import { setClaudeCliPlanAutoApprove } from './claude-cli-plan-auto-approve'
 import { logClaudeBinaryVersion, resolveClaudeBinaryPath } from './claude-binary-resolver'
 import { buildClaudeCliPtySpawn } from './claude-cli-spawner'
@@ -154,6 +156,7 @@ export function destroyNodePtyTerminal(terminalId: string): void {
   closeClaudePlanFollowupWatcher(terminalId)
   clearClaudeCliInteractions(terminalId)
   clearClaudeCliSubagentTracking(terminalId)
+  resetClaudeCliBackgroundWork(terminalId)
   claudeCliSessions.delete(terminalId)
   claudeCliWorktreeBasenames.delete(terminalId)
   claudeCliTranscriptSources.delete(terminalId)
@@ -221,6 +224,9 @@ function attachNodePtyListeners(terminalId: string): void {
     if (claudeCliSessions.has(terminalId)) {
       clearClaudeCliInteractions(terminalId)
       clearClaudeCliSubagentTracking(terminalId)
+      // The CLI process just died, taking its background shells/monitors with
+      // it (survivors are orphans reported only to a future session).
+      resetClaudeCliBackgroundWork(terminalId)
       setClaudeCliPlanAutoApprove(terminalId, false)
       publishClaudeCliStatus({
         sessionId: terminalId,
@@ -401,6 +407,8 @@ export async function createClaudeCliTerminal(
     // ...nor a stale subagent deferral/pending-notification set, which could
     // otherwise swallow the next turn's Stop after a restart.
     clearClaudeCliSubagentTracking(sessionId)
+    // ...nor the previous process's background shell/monitor counts.
+    resetClaudeCliBackgroundWork(sessionId)
     claudeCliWorktreeBasenames.set(sessionId, path.basename(worktreePath))
     if (!pendingPrompt) {
       publishClaudeCliStatus({
@@ -451,6 +459,7 @@ export function cleanupTerminals(): void {
   claudeCliLastStatus.clear()
   clearAllClaudeCliInteractions()
   clearAllClaudeCliSubagentTracking()
+  clearAllClaudeCliBackgroundWork()
   unsubscribeClaudeCliStatus?.()
   unsubscribeClaudeCliStatus = null
   resetAllClaudeCliTitleState()

--- a/src/renderer/src/api/terminal-api.ts
+++ b/src/renderer/src/api/terminal-api.ts
@@ -11,6 +11,13 @@ import type {
 import type { ServerEvent } from '@shared/rpc/protocol'
 import type { Envelope } from '@shared/types/ipc-envelope'
 import type { GhosttyTerminalConfig } from '@shared/types/terminal'
+import {
+  CLAUDE_CLI_BACKGROUND_WORK_CHANNEL,
+  isClaudeCliBackgroundWorkPayload,
+  type ClaudeCliBackgroundWorkPayload
+} from '@shared/types/claude-cli-background-work'
+
+export type { ClaudeCliBackgroundWorkPayload }
 
 export type ClaudeCliSessionStatusType =
   | 'working'
@@ -147,6 +154,16 @@ export const terminalApi = {
     return getRendererRpcClient().subscribe('claude-cli:status', (event: ServerEvent) => {
       if (isClaudeCliStatusPayload(event.payload)) callback(event.payload)
     })
+  },
+  onClaudeCliBackgroundWork: (
+    callback: (payload: ClaudeCliBackgroundWorkPayload) => void
+  ): (() => void) => {
+    return getRendererRpcClient().subscribe(
+      CLAUDE_CLI_BACKGROUND_WORK_CHANNEL,
+      (event: ServerEvent) => {
+        if (isClaudeCliBackgroundWorkPayload(event.payload)) callback(event.payload)
+      }
+    )
   },
   ghosttyPasteText: async (terminalId: string, text: string): Promise<Envelope<void>> => {
     await getRendererRpcClient().request<void>('terminalOps.ghosttyPasteText', { terminalId, text })

--- a/src/renderer/src/components/kanban/KanbanTicketCard.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { KanbanTicketCard } from './KanbanTicketCard'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import type { KanbanTicket } from '../../../../main/db/types'
 
 const now = '2026-01-01T00:00:00.000Z'
@@ -105,5 +107,59 @@ describe('KanbanTicketCard model badge', () => {
 
     expect(screen.queryByRole('img', { name: 'Claude' })).toBeNull()
     expect(screen.queryByRole('img', { name: 'OpenAI' })).toBeNull()
+  })
+})
+
+describe('KanbanTicketCard background work badges', () => {
+  afterEach(() => {
+    cleanup()
+    useWorktreeStatusStore.setState({ backgroundWorkBySession: {} })
+  })
+
+  const linkedTicket: KanbanTicket = { ...baseTicket, current_session_id: 'session-1' }
+
+  it('renders shell and monitor count badges for the linked session', () => {
+    useWorktreeStatusStore.setState({
+      backgroundWorkBySession: { 'session-1': { runningShells: 2, runningMonitors: 1 } }
+    })
+
+    render(
+      <TooltipProvider>
+        <KanbanTicketCard ticket={linkedTicket} />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByTestId('kanban-ticket-running-shells')).toHaveTextContent('2')
+    expect(screen.getByTestId('kanban-ticket-running-monitors')).toHaveTextContent('1')
+  })
+
+  it('renders only the badge whose count is non-zero', () => {
+    useWorktreeStatusStore.setState({
+      backgroundWorkBySession: { 'session-1': { runningShells: 1, runningMonitors: 0 } }
+    })
+
+    render(
+      <TooltipProvider>
+        <KanbanTicketCard ticket={linkedTicket} />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByTestId('kanban-ticket-running-shells')).toHaveTextContent('1')
+    expect(screen.queryByTestId('kanban-ticket-running-monitors')).toBeNull()
+  })
+
+  it('renders no badges without counts or for other sessions', () => {
+    useWorktreeStatusStore.setState({
+      backgroundWorkBySession: { 'other-session': { runningShells: 3, runningMonitors: 3 } }
+    })
+
+    render(
+      <TooltipProvider>
+        <KanbanTicketCard ticket={linkedTicket} />
+      </TooltipProvider>
+    )
+
+    expect(screen.queryByTestId('kanban-ticket-running-shells')).toBeNull()
+    expect(screen.queryByTestId('kanban-ticket-running-monitors')).toBeNull()
   })
 })

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -33,7 +33,9 @@ import {
   FolderInput,
   FastForward,
   RadioTower,
-  Unplug
+  Unplug,
+  SquareTerminal,
+  Radar
 } from 'lucide-react'
 import { CheckeredFlagIcon } from './CheckeredFlagIcon'
 import { TicketModelBadge } from './TicketModelBadge'
@@ -454,6 +456,17 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
         if (!ticket.current_session_id) return false
         const entry = state.sessionStatuses[ticket.current_session_id]
         return entry?.status === 'working' || entry?.status === 'planning'
+      },
+      [ticket.current_session_id]
+    )
+  )
+
+  // ── Live background shells/monitors in the linked claude-cli session ──
+  const backgroundWork = useWorktreeStatusStore(
+    useCallback(
+      (state) => {
+        if (!ticket.current_session_id) return null
+        return state.backgroundWorkBySession[ticket.current_session_id] ?? null
       },
       [ticket.current_session_id]
     )
@@ -1072,7 +1085,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
             </div>
 
             {/* Badges + progress row */}
-            {(hasAttachments || hasNote || worktreeName || queuedBranchLabel || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || blockingDiagnostic || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode || ticket.auto_approve_plan || activeRemoteLaunch || showModelBadge) && (
+            {(hasAttachments || hasNote || worktreeName || queuedBranchLabel || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || blockingDiagnostic || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode || ticket.auto_approve_plan || activeRemoteLaunch || showModelBadge || backgroundWork) && (
               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                 {/* Archived badge */}
                 {isArchived && (
@@ -1121,6 +1134,44 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                     <GitBranch className="h-3 w-3" />
                     {queuedBranchLabel}
                   </span>
+                )}
+                {/* Running background shells in the linked claude-cli session */}
+                {backgroundWork && backgroundWork.runningShells > 0 && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        data-testid="kanban-ticket-running-shells"
+                        className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 border border-emerald-500/30 px-2 py-0.5 text-[11px] font-medium text-emerald-500 cursor-help"
+                      >
+                        <SquareTerminal className="h-3 w-3" />
+                        {backgroundWork.runningShells}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {backgroundWork.runningShells === 1
+                        ? '1 background shell running'
+                        : `${backgroundWork.runningShells} background shells running`}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+                {/* Running monitors in the linked claude-cli session */}
+                {backgroundWork && backgroundWork.runningMonitors > 0 && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        data-testid="kanban-ticket-running-monitors"
+                        className="inline-flex items-center gap-1 rounded-full bg-cyan-500/10 border border-cyan-500/30 px-2 py-0.5 text-[11px] font-medium text-cyan-500 cursor-help"
+                      >
+                        <Radar className="h-3 w-3" />
+                        {backgroundWork.runningMonitors}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {backgroundWork.runningMonitors === 1
+                        ? '1 monitor running'
+                        : `${backgroundWork.runningMonitors} monitors running`}
+                    </TooltipContent>
+                  </Tooltip>
                 )}
                 {/* Attachment badge */}
                 {hasAttachments && (

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   onClaudeCliStatus: vi.fn(),
+  onClaudeCliBackgroundWork: vi.fn().mockReturnValue(() => {}),
+  setSessionBackgroundWork: vi.fn(),
   setClaudeCliPlanAutoApprove: vi.fn().mockResolvedValue({ success: true }),
   setSessionStatus: vi.fn(),
   setPendingPlan: vi.fn(),
@@ -35,7 +37,8 @@ vi.mock('@/stores/useWorktreeStatusStore', () => ({
   useWorktreeStatusStore: {
     getState: () => ({
       sessionStatuses: mocks.sessionStatuses,
-      setSessionStatus: mocks.setSessionStatus
+      setSessionStatus: mocks.setSessionStatus,
+      setSessionBackgroundWork: mocks.setSessionBackgroundWork
     })
   }
 }))
@@ -73,6 +76,7 @@ vi.mock('@/stores/useUsageStore', () => ({
 vi.mock('@/api/terminal-api', () => ({
   terminalApi: {
     onClaudeCliStatus: mocks.onClaudeCliStatus,
+    onClaudeCliBackgroundWork: mocks.onClaudeCliBackgroundWork,
     setClaudeCliPlanAutoApprove: mocks.setClaudeCliPlanAutoApprove
   }
 }))
@@ -758,5 +762,42 @@ describe('useClaudeCliStatusListener — usage refresh on completion', () => {
     })
 
     expect(mocks.fetchUsageForProvider).not.toHaveBeenCalled()
+  })
+})
+
+describe('useClaudeCliStatusListener — background work counts', () => {
+  beforeEach(() => {
+    mocks.onClaudeCliStatus.mockReturnValue(() => {})
+  })
+
+  it('routes background-work payloads into the store', () => {
+    let subscribed: ((payload: {
+      sessionId: string
+      runningShells: number
+      runningMonitors: number
+    }) => void) | null = null
+    mocks.onClaudeCliBackgroundWork.mockImplementation((callback) => {
+      subscribed = callback
+      return () => {}
+    })
+
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribed?.({ sessionId: 'hive-session-1', runningShells: 2, runningMonitors: 1 })
+
+    expect(mocks.setSessionBackgroundWork).toHaveBeenCalledWith('hive-session-1', {
+      runningShells: 2,
+      runningMonitors: 1
+    })
+  })
+
+  it('unsubscribes from background-work events on unmount', () => {
+    const unsubscribeBackgroundWork = vi.fn()
+    mocks.onClaudeCliBackgroundWork.mockReturnValue(unsubscribeBackgroundWork)
+
+    const { unmount } = renderHook(() => useClaudeCliStatusListener())
+    unmount()
+
+    expect(unsubscribeBackgroundWork).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -201,6 +201,19 @@ export function useClaudeCliStatusListener(): void {
       worktreeStatus.setSessionStatus(sessionId, status, metadata)
     })
 
-    return unsubscribe
+    // Live background shell/monitor counts for the kanban ticket badges —
+    // pure store writes, deliberately outside the status state machine above.
+    const unsubscribeBackgroundWork = terminalApi.onClaudeCliBackgroundWork(
+      ({ sessionId, runningShells, runningMonitors }) => {
+        useWorktreeStatusStore
+          .getState()
+          .setSessionBackgroundWork(sessionId, { runningShells, runningMonitors })
+      }
+    )
+
+    return () => {
+      unsubscribe()
+      unsubscribeBackgroundWork()
+    }
   }, [])
 }

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -27,9 +27,17 @@ export type MergeConflictFlow =
   | { phase: 'running'; sessionId: string; seenBusy: boolean }
   | { phase: 'refreshing' }
 
+export interface SessionBackgroundWork {
+  runningShells: number
+  runningMonitors: number
+}
+
 interface WorktreeStatusState {
   // sessionId → status info (null means no status / cleared)
   sessionStatuses: Record<string, SessionStatusEntry | null>
+  // sessionId → live background shell/monitor counts (claude-cli only; entries
+  // are dropped when both counts reach zero)
+  backgroundWorkBySession: Record<string, SessionBackgroundWork>
   // worktreeId → epoch ms of last message activity
   lastMessageTimeByWorktree: Record<string, number>
   // worktreeId → sessionId for active review sessions
@@ -58,6 +66,7 @@ interface WorktreeStatusState {
       plan?: string
     }
   ) => void
+  setSessionBackgroundWork: (sessionId: string, work: SessionBackgroundWork) => void
   clearSessionStatus: (sessionId: string) => void
   clearWorktreeUnread: (worktreeId: string) => void
   getWorktreeStatus: (worktreeId: string) => SessionStatusType | null
@@ -77,6 +86,7 @@ interface WorktreeStatusState {
 
 export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => ({
   sessionStatuses: {},
+  backgroundWorkBySession: {},
   lastMessageTimeByWorktree: {},
   reviewSessionByWorktree: {},
   completedReviewSessionByWorktree: {},
@@ -140,6 +150,22 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
     } else if (status === 'working' || status === 'planning') {
       notifyKanbanSessionSync(sessionId, { type: 'session_working' })
     }
+  },
+
+  setSessionBackgroundWork: (sessionId: string, work: SessionBackgroundWork) => {
+    set((state) => {
+      if (work.runningShells === 0 && work.runningMonitors === 0) {
+        if (!(sessionId in state.backgroundWorkBySession)) return {}
+        const { [sessionId]: _, ...rest } = state.backgroundWorkBySession
+        return { backgroundWorkBySession: rest }
+      }
+      return {
+        backgroundWorkBySession: {
+          ...state.backgroundWorkBySession,
+          [sessionId]: work
+        }
+      }
+    })
   },
 
   clearSessionStatus: (sessionId: string) => {

--- a/src/shared/types/claude-cli-background-work.ts
+++ b/src/shared/types/claude-cli-background-work.ts
@@ -1,0 +1,26 @@
+/**
+ * Live background-work counts for a Claude CLI session: how many background
+ * shells (Bash with run_in_background) and monitors (Monitor tool) are running
+ * right now. Published by the main-process hook server on the dedicated
+ * channel below (the status channel dedups by status string, which would
+ * swallow count-only changes).
+ */
+export const CLAUDE_CLI_BACKGROUND_WORK_CHANNEL = 'claude-cli:background-work'
+
+export interface ClaudeCliBackgroundWorkPayload {
+  sessionId: string
+  runningShells: number
+  runningMonitors: number
+}
+
+export function isClaudeCliBackgroundWorkPayload(
+  value: unknown
+): value is ClaudeCliBackgroundWorkPayload {
+  if (typeof value !== 'object' || value === null) return false
+  const payload = value as Record<string, unknown>
+  return (
+    typeof payload.sessionId === 'string' &&
+    typeof payload.runningShells === 'number' &&
+    typeof payload.runningMonitors === 'number'
+  )
+}


### PR DESCRIPTION
## Summary
- Track live Claude CLI background shells and monitors in the main process from hook events, session resets, and PTY teardown.
- Publish background-work counts on a dedicated channel and wire the renderer store to consume them.
- Show shell and monitor count badges on kanban tickets linked to an active Claude session.
- Add coverage for hook parsing, server publishing, renderer subscription, and badge rendering.

## Testing
- `vitest src/main/services/__tests__/claude-cli-background-work-tracker.test.ts`
- `vitest src/main/services/__tests__/claude-hook-server.test.ts`
- `vitest src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx`
- `vitest src/renderer/src/components/kanban/KanbanTicketCard.test.tsx`
- Not run: full app/e2e verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New hook parsing and reconciliation logic can miscount if Claude CLI payload shapes change; teardown/reset paths are carefully split for PTY reuse vs respawn to avoid stale or wrongly cleared badges.
> 
> **Overview**
> Adds **live tracking of Claude CLI background shells and monitors** so kanban tickets can show when work is still running after the main agent goes idle.
> 
> The main process introduces `claude-cli-background-work-tracker`, which derives per-session `runningShells` / `runningMonitors` from hook payloads (background Bash/Monitor starts, `TaskStop`, terminal `<task-notification>` resumes, `Stop` `background_tasks` reconciliation, session boundaries). Count updates are published on a **dedicated** `claude-cli:background-work` channel so they are not dropped by status deduplication. The hook server processes every hook before the subagent gate; `resetClaudeCliBackgroundWork` clears stale badges on PTY respawn (not PTY reuse), exit, destroy, and global cleanup.
> 
> The renderer subscribes via `useClaudeCliStatusListener`, stores counts in `useWorktreeStatusStore`, and **KanbanTicketCard** shows emerald shell and cyan monitor count badges for the ticket’s `current_session_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb125a128e7859d18ab989352278d9177650dfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->