### PR TITLE
Update Claude Opus label to 5

### DIFF
--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -47,7 +47,7 @@ const CLAUDE_MODELS = [
   },
   {
     id: 'opus',
-    name: 'Opus 4.8',
+    name: 'Opus 5',
     limit: { context: 1000000, output: 32000 },
     variants: CLAUDE_OPUS_EFFORT_VARIANTS,
     defaultVariant: 'high'

--- a/src/renderer/src/components/kanban/WorktreePickerModal.ultracode.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.ultracode.test.tsx
@@ -23,7 +23,7 @@ const PROVIDERS = [
     models: {
       opus: {
         id: 'opus',
-        name: 'Opus 4.8',
+        name: 'Opus 5',
         variants: { low: {}, medium: {}, high: {}, xhigh: {}, max: {} }
       },
       sonnet: { id: 'sonnet', name: 'Sonnet 4.6', variants: { low: {}, medium: {}, high: {} } }

--- a/src/renderer/src/components/sessions/ModelSelector.ultracode.test.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.ultracode.test.tsx
@@ -12,7 +12,7 @@ const PROVIDERS = [
     id: 'claude-code',
     name: 'Claude Code',
     models: {
-      opus: { id: 'opus', name: 'Opus 4.8', variants: { low: {}, medium: {}, high: {}, xhigh: {}, max: {} } },
+      opus: { id: 'opus', name: 'Opus 5', variants: { low: {}, medium: {}, high: {}, xhigh: {}, max: {} } },
       sonnet: { id: 'sonnet', name: 'Sonnet 4.6', variants: { low: {}, medium: {}, high: {} } }
     }
   }

--- a/test/phase-21/session-6/claude-model-catalog.test.ts
+++ b/test/phase-21/session-6/claude-model-catalog.test.ts
@@ -65,7 +65,7 @@ describe('ClaudeCodeImplementer model catalog', () => {
     const info = await impl.getModelInfo('any', 'opus')
     expect(info).toEqual({
       id: 'opus',
-      name: 'Opus 4.8',
+      name: 'Opus 5',
       limit: { context: 1000000, output: 32000 }
     })
   })


### PR DESCRIPTION
## Summary
- Rename the Claude Code Opus model display label from `Opus 4.8` to `Opus 5`.
- Update renderer and unit test fixtures so model selection UI expectations match the new label.
- Adjust the model catalog test to assert the new Opus name.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-string-only change with no routing, SDK model id, or behavior changes.
> 
> **Overview**
> Updates the **Claude Code** catalog so the `opus` model’s user-facing name is **Opus 5** instead of **Opus 4.8** in `CLAUDE_MODELS` (what `getAvailableModels` / `getModelInfo` expose to the UI).
> 
> Renderer ultracode tests and the phase-21 model catalog test fixtures are aligned so assertions and mocked `listModels` data match the new label. **Model id**, limits, and variants are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cfab7d1fc9dfd37e41b34650817e691ed91518e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->