### PR TITLE
Prompt on already-merged tickets before moving to done

### DIFF
--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -588,7 +588,14 @@ export function KanbanColumn({
                       return
                     }
 
-                    if (hasUncommitted || commitsAhead > 0) {
+                    // Review/Merged → Done drops with an already-merged branch
+                    // skip the merge steps but still get the archive/keep prompt
+                    const archivePromptOnly =
+                      column === 'done' &&
+                      (sourceColumn === 'review' || sourceColumn === 'merged') &&
+                      worktree.status === 'active'
+
+                    if (hasUncommitted || commitsAhead > 0 || archivePromptOnly) {
                       const sortOrder = store.computeSortOrder(
                         projectTicketsForColumn(ticketProjectId),
                         projectLocalDropIndex(ticketProjectId, targetIndex)

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.test.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.test.tsx
@@ -1,0 +1,191 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MergeOnDoneDialog } from './MergeOnDoneDialog'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket } from '../../../../main/db/types'
+
+const dbApiMocks = vi.hoisted(() => ({
+  worktree: {
+    get: vi.fn(),
+    getActiveByProject: vi.fn()
+  },
+  project: {
+    get: vi.fn()
+  }
+}))
+
+vi.mock('@/api/db-api', () => ({
+  dbApi: dbApiMocks
+}))
+
+const gitApiMocks = vi.hoisted(() => ({
+  hasUncommittedChanges: vi.fn(),
+  branchDiffShortStat: vi.fn(),
+  getDiffStat: vi.fn(),
+  stageAll: vi.fn(),
+  commit: vi.fn(),
+  merge: vi.fn(),
+  pull: vi.fn(),
+  getRemoteUrl: vi.fn()
+}))
+
+vi.mock('@/api/git-api', () => ({
+  gitApi: gitApiMocks
+}))
+
+const now = '2026-01-01T00:00:00.000Z'
+
+const featureWorktree = {
+  id: 'worktree-1',
+  project_id: 'project-1',
+  branch_name: 'feature',
+  path: '/repo/feature',
+  status: 'active' as const,
+  is_default: false,
+  base_branch: null
+}
+
+const baseWorktree = {
+  id: 'worktree-main',
+  project_id: 'project-1',
+  branch_name: 'main',
+  path: '/repo/main',
+  status: 'active' as const,
+  is_default: true,
+  base_branch: null
+}
+
+const ticket: KanbanTicket = {
+  id: 'ticket-1',
+  project_id: 'project-1',
+  title: 'My feature',
+  description: null,
+  attachments: [],
+  column: 'review',
+  sort_order: 1,
+  current_session_id: null,
+  worktree_id: 'worktree-1',
+  mode: null,
+  plan_ready: false,
+  created_at: now,
+  updated_at: now,
+  archived_at: null,
+  external_provider: null,
+  external_id: null,
+  external_url: null,
+  github_pr_number: null,
+  github_pr_url: null,
+  mark: null,
+  total_tokens: 0,
+  pending_launch_config: null,
+  goal_mode: false,
+  goal_success_criteria: null,
+  note: null,
+  created_from_session: false,
+  auto_approve_plan: false,
+  model_provider_id: null,
+  model_id: null,
+  model_variant: null,
+  variant_group_id: null
+}
+
+const moveTicketMock = vi.fn().mockResolvedValue(undefined)
+const archiveWorktreeMock = vi.fn().mockResolvedValue({ success: true })
+
+function setupStores(): void {
+  useKanbanStore.setState({
+    tickets: new Map([['project-1', [ticket]]]),
+    pendingDoneMove: {
+      ticketId: 'ticket-1',
+      projectId: 'project-1',
+      sortOrder: 5,
+      targetColumn: 'done'
+    },
+    moveTicket: moveTicketMock
+  })
+  useWorktreeStore.setState({ archiveWorktree: archiveWorktreeMock })
+}
+
+function mockAlreadyMergedBranch(): void {
+  dbApiMocks.worktree.get.mockResolvedValue(featureWorktree)
+  dbApiMocks.worktree.getActiveByProject.mockResolvedValue([featureWorktree, baseWorktree])
+  dbApiMocks.project.get.mockResolvedValue({ path: '/repo/main' })
+  gitApiMocks.hasUncommittedChanges.mockResolvedValue(false)
+  gitApiMocks.branchDiffShortStat.mockResolvedValue({
+    success: true,
+    filesChanged: 0,
+    insertions: 0,
+    deletions: 0,
+    commitsAhead: 0
+  })
+}
+
+describe('MergeOnDoneDialog — already-merged branch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    moveTicketMock.mockResolvedValue(undefined)
+    archiveWorktreeMock.mockResolvedValue({ success: true })
+    mockAlreadyMergedBranch()
+    setupStores()
+  })
+
+  afterEach(() => {
+    cleanup()
+    useKanbanStore.setState({ pendingDoneMove: null })
+  })
+
+  it('shows the archive/keep step instead of silently moving to done', async () => {
+    render(<MergeOnDoneDialog />)
+
+    expect(await screen.findByText(/Branch already merged/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Archive' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Keep' })).toBeTruthy()
+    expect(moveTicketMock).not.toHaveBeenCalled()
+  })
+
+  it('Keep moves the ticket to done without archiving the worktree', async () => {
+    render(<MergeOnDoneDialog />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Keep' }))
+
+    await waitFor(() =>
+      expect(moveTicketMock).toHaveBeenCalledWith('ticket-1', 'project-1', 'done', 5)
+    )
+    expect(archiveWorktreeMock).not.toHaveBeenCalled()
+  })
+
+  it('Archive moves the ticket to done and archives the worktree', async () => {
+    render(<MergeOnDoneDialog />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Archive' }))
+
+    await waitFor(() =>
+      expect(moveTicketMock).toHaveBeenCalledWith('ticket-1', 'project-1', 'done', 5)
+    )
+    await waitFor(() =>
+      expect(archiveWorktreeMock).toHaveBeenCalledWith(
+        'worktree-1',
+        '/repo/feature',
+        'feature',
+        '/repo/main'
+      )
+    )
+  })
+
+  it('still runs the merge flow when the branch has commits ahead', async () => {
+    gitApiMocks.branchDiffShortStat.mockResolvedValue({
+      success: true,
+      filesChanged: 2,
+      insertions: 10,
+      deletions: 3,
+      commitsAhead: 1
+    })
+
+    render(<MergeOnDoneDialog />)
+
+    expect(await screen.findByText('Merge branch')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Merge' })).toBeTruthy()
+    expect(moveTicketMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -47,6 +47,7 @@ interface ResolvedState {
   baseUncommittedStats: { filesChanged: number; insertions: number; deletions: number }
   baseDirty: boolean
   branchStats: BranchStats
+  alreadyMerged: boolean
 }
 
 export function MergeOnDoneDialog() {
@@ -168,11 +169,9 @@ export function MergeOnDoneDialog() {
           commitsAhead: branchStatResult.commitsAhead
         }
 
-        // If no diffs at all, just move to done
-        if (!hasUncommitted && branchStats.commitsAhead === 0) {
-          await completeDoneMove()
-          return
-        }
+        // No diffs at all means the branch already landed on base — skip the
+        // commit/merge steps but still offer the archive/keep choice
+        const alreadyMerged = !hasUncommitted && branchStats.commitsAhead === 0
 
         // Get project path for archive step
         const project = await dbApi.project.get<MergeProject>(featureWorktree.project_id)
@@ -190,11 +189,14 @@ export function MergeOnDoneDialog() {
           uncommittedStats,
           baseUncommittedStats,
           baseDirty,
-          branchStats
+          branchStats,
+          alreadyMerged
         })
         setCommitMessage(ticket.title)
         setBaseCommitMessage('')
-        setStep(baseDirty ? 'commit_base' : hasUncommitted ? 'commit' : 'merge')
+        setStep(
+          alreadyMerged ? 'archive' : baseDirty ? 'commit_base' : hasUncommitted ? 'commit' : 'merge'
+        )
       } catch (err) {
         if (!cancelled) {
           toast.error(`Failed to check branch: ${err instanceof Error ? err.message : String(err)}`)
@@ -591,7 +593,7 @@ export function MergeOnDoneDialog() {
         {step === 'archive' && resolved && (
           <div className="flex flex-col gap-3 py-2">
             <p className="text-xs text-muted-foreground">
-              Merge successful! Archive the{' '}
+              {resolved.alreadyMerged ? 'Branch already merged.' : 'Merge successful!'} Archive the{' '}
               <code className="bg-muted px-1 rounded">{resolved.featureBranch}</code> worktree?
             </p>
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- Treats review/merged tickets dropped into `Done` as an archive-only flow when the branch is already merged and active.
- Updates the merge-on-done dialog to skip merge steps for already-merged branches while still offering the archive/keep choice.
- Adds tests covering archive, keep, and non-empty branch merge behavior.

## Testing
- Added `MergeOnDoneDialog` tests for the already-merged branch path.
- Added coverage for `Keep` moving the ticket without archiving the worktree.
- Added coverage for `Archive` moving the ticket and archiving the worktree.
- Added coverage that branches with commits ahead still follow the merge flow.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Kanban drag-and-done UX only; git merge behavior is unchanged when there is work to merge.
> 
> **Overview**
> Dragging a ticket from **Review** or **Merged** into **Done** when its feature branch is already on base (no uncommitted changes, zero commits ahead) no longer completes the move immediately. **KanbanColumn** now routes those drops through `pendingDoneMove` via an `archivePromptOnly` path when the worktree is still active.
> 
> **MergeOnDoneDialog** treats that case as `alreadyMerged`: it skips commit/merge and opens the archive step with “Branch already merged.” **Keep** still moves to Done without archiving; **Archive** moves and archives the worktree. Branches with commits ahead still show the normal merge flow.
> 
> Adds **MergeOnDoneDialog** tests for the already-merged path (archive, keep, and commits-ahead regression).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1aa167d1c3c18b392b966facc68bd7c71ff4c1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->