### PR TITLE
Add Cmd+F board search with ticket highlights

### DIFF
--- a/src/renderer/src/components/kanban/BoardSearchBar.tsx
+++ b/src/renderer/src/components/kanban/BoardSearchBar.tsx
@@ -1,0 +1,94 @@
+import { useEffect } from 'react'
+import { Search, X } from 'lucide-react'
+import { Switch } from '@/components/ui/switch'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+
+interface BoardSearchBarProps {
+  inputRef: React.RefObject<HTMLInputElement | null>
+  matchCount: number
+}
+
+export function BoardSearchBar({ inputRef, matchCount }: BoardSearchBarProps): React.JSX.Element {
+  const query = useKanbanStore((s) => s.boardSearch.query)
+  const searchDescriptions = useKanbanStore((s) => s.boardSearch.searchDescriptions)
+  const setBoardSearchQuery = useKanbanStore((s) => s.setBoardSearchQuery)
+  const setBoardSearchDescriptions = useKanbanStore((s) => s.setBoardSearchDescriptions)
+  const closeBoardSearch = useKanbanStore((s) => s.closeBoardSearch)
+  const hasQuery = query.trim().length > 0
+
+  // Bare Tab is globally bound to session:mode-toggle (allowInInput, document
+  // capture) — swallow it at window capture while inside the search bar so
+  // tabbing to the switch doesn't toggle a hidden session's plan/build mode.
+  // preventDefault is NOT called, preserving normal focus traversal.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key !== 'Tab' || e.ctrlKey || e.metaKey || e.altKey) return
+      const target = e.target as HTMLElement | null
+      if (!target?.closest?.('[data-testid="board-search-bar"]')) return
+      e.stopImmediatePropagation()
+    }
+    window.addEventListener('keydown', handler, true)
+    return () => window.removeEventListener('keydown', handler, true)
+  }, [])
+
+  return (
+    <div
+      data-testid="board-search-bar"
+      className="flex shrink-0 items-center gap-3 px-3 pt-3 pb-0 animate-in fade-in slide-in-from-top-2 duration-150"
+    >
+      <div className="relative w-[320px]">
+        <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <input
+          ref={inputRef}
+          type="text"
+          data-testid="board-search-input"
+          placeholder="Search tickets…"
+          autoFocus
+          value={query}
+          onChange={(e) => setBoardSearchQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.preventDefault()
+              e.stopPropagation()
+              closeBoardSearch()
+            }
+          }}
+          className="w-full rounded-md border border-border bg-muted/50 py-1.5 pl-8 pr-8 text-sm placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+        <button
+          data-testid="board-search-close"
+          title={hasQuery ? 'Clear' : 'Close (Escape)'}
+          onClick={() => {
+            if (hasQuery) {
+              setBoardSearchQuery('')
+              inputRef.current?.focus()
+            } else {
+              closeBoardSearch()
+            }
+          }}
+          className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <label className="flex cursor-pointer select-none items-center gap-1.5 text-xs text-muted-foreground">
+        <Switch
+          data-testid="board-search-descriptions-toggle"
+          size="sm"
+          checked={searchDescriptions}
+          onCheckedChange={setBoardSearchDescriptions}
+        />
+        Search descriptions
+      </label>
+      {hasQuery && (
+        <span
+          data-testid="board-search-count"
+          aria-live="polite"
+          className="text-xs text-muted-foreground"
+        >
+          {matchCount === 0 ? 'No matches' : matchCount === 1 ? '1 match' : `${matchCount} matches`}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/kanban/BoardSearchBar.tsx
+++ b/src/renderer/src/components/kanban/BoardSearchBar.tsx
@@ -1,7 +1,9 @@
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Search, X } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
 import { useKanbanStore } from '@/stores/useKanbanStore'
+
+const SEARCH_DEBOUNCE_MS = 150
 
 interface BoardSearchBarProps {
   inputRef: React.RefObject<HTMLInputElement | null>
@@ -14,6 +16,31 @@ export function BoardSearchBar({ inputRef, matchCount }: BoardSearchBarProps): R
   const setBoardSearchQuery = useKanbanStore((s) => s.setBoardSearchQuery)
   const setBoardSearchDescriptions = useKanbanStore((s) => s.setBoardSearchDescriptions)
   const closeBoardSearch = useKanbanStore((s) => s.closeBoardSearch)
+
+  // The input is locally controlled so typing stays instant; the store query
+  // (which drives filtering, highlights, and the count) updates debounced.
+  const [inputValue, setInputValue] = useState(query)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const cancelPendingQuery = (): void => {
+    if (debounceRef.current !== null) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+  }
+
+  useEffect(() => cancelPendingQuery, [])
+
+  const handleChange = (value: string): void => {
+    setInputValue(value)
+    cancelPendingQuery()
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null
+      setBoardSearchQuery(value)
+    }, SEARCH_DEBOUNCE_MS)
+  }
+
+  const hasText = inputValue.trim().length > 0
   const hasQuery = query.trim().length > 0
 
   // Bare Tab is globally bound to session:mode-toggle (allowInInput, document
@@ -44,22 +71,29 @@ export function BoardSearchBar({ inputRef, matchCount }: BoardSearchBarProps): R
           data-testid="board-search-input"
           placeholder="Search tickets…"
           autoFocus
-          value={query}
-          onChange={(e) => setBoardSearchQuery(e.target.value)}
+          value={inputValue}
+          onChange={(e) => handleChange(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === 'Escape') {
               e.preventDefault()
               e.stopPropagation()
+              cancelPendingQuery()
               closeBoardSearch()
+            } else if (e.key === 'Enter') {
+              // Flush the pending debounce — search now
+              cancelPendingQuery()
+              setBoardSearchQuery(inputValue)
             }
           }}
           className="w-full rounded-md border border-border bg-muted/50 py-1.5 pl-8 pr-8 text-sm placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"
         />
         <button
           data-testid="board-search-close"
-          title={hasQuery ? 'Clear' : 'Close (Escape)'}
+          title={hasText ? 'Clear' : 'Close (Escape)'}
           onClick={() => {
-            if (hasQuery) {
+            if (hasText) {
+              cancelPendingQuery()
+              setInputValue('')
               setBoardSearchQuery('')
               inputRef.current?.focus()
             } else {

--- a/src/renderer/src/components/kanban/HighlightedText.tsx
+++ b/src/renderer/src/components/kanban/HighlightedText.tsx
@@ -1,0 +1,30 @@
+import { normalizeSearchText } from '@/lib/board-search'
+
+/** Wraps every case-insensitive occurrence of normQuery in a <mark>.
+ *  normQuery must be pre-normalized (normalizeSearchText); '' renders plain text. */
+export function HighlightedText({
+  text,
+  normQuery
+}: {
+  text: string
+  normQuery: string
+}): React.JSX.Element {
+  if (!normQuery) return <>{text}</>
+  const display = text.normalize('NFC')
+  const hay = normalizeSearchText(display)
+  const parts: React.ReactNode[] = []
+  let cursor = 0
+  let idx = hay.indexOf(normQuery)
+  while (idx !== -1) {
+    if (idx > cursor) parts.push(display.slice(cursor, idx))
+    parts.push(
+      <mark key={idx} className="bg-primary/25 text-inherit rounded-[3px] px-px">
+        {display.slice(idx, idx + normQuery.length)}
+      </mark>
+    )
+    cursor = idx + normQuery.length
+    idx = hay.indexOf(normQuery, cursor)
+  }
+  if (cursor < display.length) parts.push(display.slice(cursor))
+  return <>{parts}</>
+}

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { LayoutGroup, motion } from 'motion/react'
 import { Pin } from 'lucide-react'
 import { parseTicketKey, ticketKey, useKanbanStore } from '@/stores/useKanbanStore'
@@ -9,11 +9,13 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { KanbanColumn } from '@/components/kanban/KanbanColumn'
 import { KanbanTicketModal } from '@/components/kanban/KanbanTicketModal'
 import { BoardChatLauncher } from '@/components/kanban/BoardChatLauncher'
+import { BoardSearchBar } from '@/components/kanban/BoardSearchBar'
 import { MergeOnDoneDialog } from './MergeOnDoneDialog'
 import { toast } from '@/lib/toast'
 import { useMarkdownKanbanWatcher } from '@/hooks/useMarkdownKanbanWatcher'
 import { cardOccurrenceKeys } from '@/components/kanban/kanban-card-identity'
-import type { KanbanTicketColumn } from '../../../../main/db/types'
+import { normalizeSearchText, ticketMatchesQuery } from '@/lib/board-search'
+import type { KanbanTicket, KanbanTicketColumn } from '../../../../main/db/types'
 
 const COLUMNS: KanbanTicketColumn[] = ['todo', 'in_progress', 'review', 'done']
 const COLUMNS_WITH_MERGED: KanbanTicketColumn[] = ['todo', 'in_progress', 'review', 'merged', 'done']
@@ -66,6 +68,25 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
   // Subscribe to the multi-project archive toggle ('' key used by pinned/connection boards)
   const showArchivedAll = useKanbanStore(
     useCallback((s) => s.showArchivedByProject[''] ?? false, [])
+  )
+
+  // ── Board search (Cmd+F) ──────────────────────────────────────────
+  const boardSearch = useKanbanStore((state) => state.boardSearch)
+  // Archive visibility for THIS board's Done column ('' key on pinned/connection boards)
+  const showArchivedForBoard = useKanbanStore(
+    useCallback((s) => s.showArchivedByProject[projectId ?? ''] ?? false, [projectId])
+  )
+  const deferredQuery = useDeferredValue(boardSearch.query)
+  const normQuery = useMemo(() => normalizeSearchText(deferredQuery.trim()), [deferredQuery])
+  const searchActive = boardSearch.open && normQuery.length > 0
+  const searchDescriptions = boardSearch.searchDescriptions
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const filterBoardTickets = useCallback(
+    (list: KanbanTicket[]): KanbanTicket[] =>
+      searchActive
+        ? list.filter((t) => ticketMatchesQuery(t, normQuery, searchDescriptions) !== null)
+        : list,
+    [searchActive, normQuery, searchDescriptions]
   )
 
   // Derived: source ticket title for dependency mode overlay
@@ -133,6 +154,53 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [dependencyMode?.active, exitDependencyMode])
+
+  // Cmd+F opens board search — capture phase; KanbanBoard only mounts when the
+  // board is the main-pane content, so no "focused" check needed (RunTab pattern).
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (!((e.metaKey || e.ctrlKey) && e.key === 'f')) return
+      const target = e.target as HTMLElement
+      if (target.closest?.('.xterm')) return // terminal owns its own Cmd+F find
+      if (useKanbanStore.getState().selectedTicketId !== null) return // ticket modal open
+      if (document.querySelector('[role="dialog"], [role="alertdialog"]')) return
+      if (
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) &&
+        target.getAttribute('data-testid') !== 'board-search-input'
+      ) {
+        return
+      }
+      e.preventDefault()
+      e.stopPropagation()
+      useKanbanStore.getState().openBoardSearch()
+      // Re-invoke while open = refocus + select-all (never toggles closed)
+      requestAnimationFrame(() => {
+        searchInputRef.current?.focus()
+        searchInputRef.current?.select()
+      })
+    }
+    document.addEventListener('keydown', handleKeyDown, true)
+    return () => document.removeEventListener('keydown', handleKeyDown, true)
+  }, [])
+
+  // Escape anywhere on the board closes search (input-focused Esc is handled
+  // by the input itself; Radix dialogs and dependency mode take precedence)
+  useEffect(() => {
+    if (!boardSearch.open) return
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return
+      if (document.querySelector('[role="dialog"], [role="alertdialog"]')) return
+      if (useKanbanStore.getState().dependencyMode?.active) return
+      useKanbanStore.getState().closeBoardSearch()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [boardSearch.open])
+
+  // Search is per-board-view: clear when switching boards or unmounting
+  useEffect(() => {
+    return () => useKanbanStore.getState().closeBoardSearch()
+  }, [projectId, connectionId, isPinnedMode])
 
   // Click handler for toggling dependencies during dependency mode
   const handleBoardClick = useCallback((e: React.MouseEvent) => {
@@ -284,10 +352,25 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
   }, [computePaths])
 
   // Archived merged tickets surface in Done's archive section too (the Merged
-  // column has no archive UI of its own)
+  // column has no archive UI of its own). Search-filtered like active tickets;
+  // when the archive toggle is off these lists aren't rendered (or even
+  // fetched), so the search domain always equals the rendered domain.
   const archivedDoneFor = (pid: string): ReturnType<typeof getArchivedTicketsByColumn> =>
-    [...getArchivedTicketsByColumn(pid, 'done'), ...getArchivedTicketsByColumn(pid, 'merged')].sort(
-      (a, b) => (b.archived_at ?? '').localeCompare(a.archived_at ?? '')
+    filterBoardTickets(
+      [...getArchivedTicketsByColumn(pid, 'done'), ...getArchivedTicketsByColumn(pid, 'merged')].sort(
+        (a, b) => (b.archived_at ?? '').localeCompare(a.archived_at ?? '')
+      )
+    )
+
+  const ticketsFor = (column: KanbanTicketColumn): KanbanTicket[] =>
+    filterBoardTickets(
+      isPinnedMode
+        ? getTicketsByColumnForPinned(column)
+        : isConnectionMode
+          ? getTicketsByColumnForConnection(connectionId, column)
+          : projectId
+            ? getTicketsByColumn(projectId, column)
+            : []
     )
 
   // Aggregate archived tickets across all connection member projects for the done column
@@ -298,6 +381,24 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
   const pinnedArchivedDoneTickets = isPinnedMode
     ? pinnedProjectIdsArray.flatMap(archivedDoneFor)
     : undefined
+
+  const archivedDoneTicketsForBoard = isPinnedMode
+    ? pinnedArchivedDoneTickets
+    : isConnectionMode
+      ? connectionArchivedDoneTickets
+      : projectId
+        ? archivedDoneFor(projectId)
+        : undefined
+
+  const matchCount = searchActive
+    ? (showMergedColumn ? COLUMNS_WITH_MERGED : COLUMNS).reduce(
+        (n, c) => n + ticketsFor(c).length,
+        0
+      ) +
+      (showMergedColumn ? 0 : ticketsFor('merged').length) +
+      (showArchivedForBoard ? (archivedDoneTicketsForBoard?.length ?? 0) : 0)
+    : 0
+
   const invalidPlaceholders = isPinnedMode
     ? getInvalidPlaceholdersForPinned()
     : isConnectionMode && connectionId
@@ -341,6 +442,7 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
             </h2>
           </div>
         )}
+        {boardSearch.open && <BoardSearchBar inputRef={searchInputRef} matchCount={matchCount} />}
         {/* Columns */}
         {isPinnedMode && pinnedProjectIdsArray.length === 0 ? (
           <div className="flex-1 flex items-center justify-center text-muted-foreground">
@@ -359,14 +461,6 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
           >
             {(() => {
               const occurrenceCounts = new Map<string, number>()
-              const ticketsFor = (column: KanbanTicketColumn): ReturnType<typeof getTicketsByColumn> =>
-                isPinnedMode
-                  ? getTicketsByColumnForPinned(column)
-                  : isConnectionMode
-                    ? getTicketsByColumnForConnection(connectionId, column)
-                    : projectId
-                      ? getTicketsByColumn(projectId, column)
-                      : []
               return (showMergedColumn ? COLUMNS_WITH_MERGED : COLUMNS).map((column) => {
                 let tickets = ticketsFor(column)
 
@@ -379,15 +473,7 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
                   }
                 }
 
-                const archivedTickets = column === 'done'
-                  ? isPinnedMode
-                    ? pinnedArchivedDoneTickets
-                    : isConnectionMode
-                      ? connectionArchivedDoneTickets
-                      : projectId
-                        ? archivedDoneFor(projectId)
-                        : undefined
-                  : undefined
+                const archivedTickets = column === 'done' ? archivedDoneTicketsForBoard : undefined
 
                 const activeCardIdentityKeys = cardOccurrenceKeys(
                   tickets,

--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -293,6 +293,12 @@ export function KanbanColumn({
     useCallback((state) => state.showArchivedByProject[projectId] ?? false, [projectId])
   )
 
+  // Board search (Cmd+F): while a query is active, hide add-ticket affordances
+  // (a new ticket would instantly vanish behind the filter) and relabel empties
+  const searchActive = useKanbanStore(
+    (s) => s.boardSearch.open && s.boardSearch.query.trim().length > 0
+  )
+
   // ── Measure header and pick title fit mode (In Progress column only) ─────
   useLayoutEffect(() => {
     if (!isInProgressColumn) return
@@ -925,7 +931,7 @@ export function KanbanColumn({
             isDragOver ? (
               dropIndicator
             ) : /* Empty state: show the add-ticket card as the only item */
-            isTodoColumn ? (
+            isTodoColumn && !searchActive ? (
               <button
                 data-testid="kanban-add-ticket-card"
                 onClick={() => setIsCreateModalOpen(true)}
@@ -935,7 +941,9 @@ export function KanbanColumn({
                 <span>New ticket</span>
               </button>
             ) : (
-              <p className="px-2 py-4 text-center text-xs text-muted-foreground/60">No tickets</p>
+              <p className="px-2 py-4 text-center text-xs text-muted-foreground/60">
+                {searchActive ? 'No matches' : 'No tickets'}
+              </p>
             )
           ) : (
             <>
@@ -1007,7 +1015,7 @@ export function KanbanColumn({
               )}
 
               {/* Add-ticket card at the end of the To Do column */}
-              {isTodoColumn && (
+              {isTodoColumn && !searchActive && (
                 <button
                   data-testid="kanban-add-ticket-card"
                   onClick={() => setIsCreateModalOpen(true)}

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -38,6 +38,7 @@ import {
   Radar
 } from 'lucide-react'
 import { CheckeredFlagIcon } from './CheckeredFlagIcon'
+import { HighlightedText } from './HighlightedText'
 import { TicketModelBadge } from './TicketModelBadge'
 import { UpdateStatusModal } from './UpdateStatusModal'
 import { RemoteTerminalDialog } from './RemoteTerminalDialog'
@@ -46,6 +47,7 @@ import { Button } from '@/components/ui/button'
 import { NoteEditorModal } from './NoteEditorModal'
 import { MoveToProjectModal } from './MoveToProjectModal'
 import { cn, parseColorQuad } from '@/lib/utils'
+import { extractSnippet, normalizeSearchText, stripMarkdown } from '@/lib/board-search'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { opencodeApi } from '@/api/opencode-api'
 import { remoteLaunchApi } from '@/api/remote-launch-api'
@@ -173,6 +175,18 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     remoteLaunchInfo && !remoteLaunchInfo.stoppedAt ? remoteLaunchInfo : null
   const hasNote = !!ticket.note && ticket.note.trim().length > 0
   const isExternalTicket = !!ticket.external_provider
+
+  // Board search (Cmd+F): highlight title matches; when only the description
+  // matched (toggle on), surface a one-line snippet under the title
+  const searchOpen = useKanbanStore((s) => s.boardSearch.open)
+  const searchQuery = useKanbanStore((s) => s.boardSearch.query)
+  const searchDescriptions = useKanbanStore((s) => s.boardSearch.searchDescriptions)
+  const normQuery = searchOpen ? normalizeSearchText(searchQuery.trim()) : ''
+  const titleMatched = normQuery.length > 0 && normalizeSearchText(ticket.title).includes(normQuery)
+  const descriptionSnippet =
+    normQuery.length > 0 && searchDescriptions && !titleMatched && ticket.description
+      ? extractSnippet(stripMarkdown(ticket.description), normQuery)
+      : null
   const dragCloneRef = useRef<HTMLElement | null>(null)
   const currentTicketKey = ticketKey(ticket.project_id, ticket.id)
   const domTicketKey = cardIdentityKey ?? currentTicketKey
@@ -1048,7 +1062,9 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
               >
             {/* Title + top-right indicators */}
             <div className="flex items-start justify-between gap-2">
-              <p className="text-sm font-medium leading-snug text-foreground min-w-0 flex-1 break-words">{ticket.title}</p>
+              <p className="text-sm font-medium leading-snug text-foreground min-w-0 flex-1 break-words">
+                <HighlightedText text={ticket.title} normQuery={normQuery} />
+              </p>
               <div className="flex items-center gap-1.5 shrink-0">
                 {tokenText && (
                   <span className="text-[11px] tabular-nums text-muted-foreground">
@@ -1083,6 +1099,22 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                 )}
               </div>
             </div>
+
+            {/* Description match snippet (board search) */}
+            {descriptionSnippet && (
+              <p
+                data-testid="board-search-snippet"
+                className="mt-1.5 truncate border-l-2 border-primary/40 pl-2 text-[11px] leading-snug text-muted-foreground"
+              >
+                {descriptionSnippet.prefixEllipsis && '…'}
+                {descriptionSnippet.before}
+                <mark className="bg-primary/25 text-foreground rounded-[3px] px-px">
+                  {descriptionSnippet.match}
+                </mark>
+                {descriptionSnippet.after}
+                {descriptionSnippet.suffixEllipsis && '…'}
+              </p>
+            )}
 
             {/* Badges + progress row */}
             {(hasAttachments || hasNote || worktreeName || queuedBranchLabel || projectTag || connectionName || ticket.plan_ready || isError || rightAlignedSlot || isArchived || isBlocked || blockingDiagnostic || isRunProcessAlive || ticket.github_pr_number || isCreatingPR || isForwardedToTelegram || ticket.goal_mode || ticket.auto_approve_plan || activeRemoteLaunch || showModelBadge || backgroundWork) && (

--- a/src/renderer/src/components/kanban/WorktreePickerModal.shortcuts.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.shortcuts.test.tsx
@@ -1,0 +1,358 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorktreePickerModal, _resetLastSourceBranch } from './WorktreePickerModal'
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { clearHandoffModelCatalogCache } from '@/lib/handoffSelection'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useUsageStore } from '@/stores/useUsageStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import type { KanbanTicket, Session } from '../../../../main/db/types'
+
+// IMPORTANT: do NOT mock ModelSelector — the Cmd+U shortcut resolves the ultra
+// variant through the same cached catalog the real ModelSelector populates.
+
+const PROVIDERS = [
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    models: {
+      opus: {
+        id: 'opus',
+        name: 'Opus 5',
+        variants: { low: {}, medium: {}, high: {}, xhigh: {}, max: {} }
+      },
+      sonnet: { id: 'sonnet', name: 'Sonnet 4.6', variants: { low: {}, medium: {}, high: {} } }
+    }
+  }
+]
+
+vi.mock('@/api/opencode-api', () => ({
+  opencodeApi: {
+    listModels: vi.fn(async () => ({ success: true, providers: PROVIDERS })),
+    connect: vi.fn(async () => ({ success: true })),
+    prompt: vi.fn(async () => ({ success: true }))
+  }
+}))
+
+vi.mock('@/api/hive-enterprise/client', () => ({
+  isHiveTelemetryEnabled: vi.fn(() => false),
+  recordHivePromptStart: vi.fn(),
+  recordHivePromptIdle: vi.fn(),
+  recordHiveQuestionsAnswered: vi.fn()
+}))
+
+vi.mock('@/components/sessions/CodexFastToggle', () => ({
+  CodexFastToggle: () => <div data-testid="codex-fast-toggle" />
+}))
+
+vi.mock('@/lib/toast', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+vi.mock('@/api/settings-api', () => ({
+  settingsApi: {
+    detectEditors: vi.fn(),
+    detectTerminals: vi.fn(),
+    loadCustomCommandsFile: vi.fn().mockResolvedValue({ commands: [] }),
+    onSettingsUpdated: vi.fn(() => vi.fn()),
+    openWithTerminal: vi.fn()
+  }
+}))
+
+vi.mock('@/api/pet-api', () => ({
+  petApi: {
+    updateSettings: vi.fn().mockResolvedValue({
+      success: true,
+      value: { enabled: true, size: 'md', position: { x: 0, y: 0 }, hatched: true }
+    })
+  }
+}))
+
+const initialSettingsState = useSettingsStore.getState()
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+const initialConnectionState = useConnectionStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialUsageState = useUsageStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
+
+const baseTicket: KanbanTicket = {
+  id: 'ticket-1',
+  project_id: 'project-1',
+  title: 'Launch Claude CLI',
+  description: 'desc',
+  column: 'todo',
+  sort_order: 0,
+  worktree_id: null,
+  current_session_id: null,
+  mode: 'build',
+  plan_ready: false,
+  goal_mode: false,
+  goal_success_criteria: null,
+  pending_launch_config: null,
+  created_from_session: false,
+  auto_approve_plan: false,
+  attachments: [],
+  archived_at: null,
+  external_provider: null,
+  external_id: null,
+  external_url: null,
+  github_pr_number: null,
+  github_pr_url: null,
+  mark: null,
+  note: null,
+  total_tokens: 0,
+  model_provider_id: null,
+  model_id: null,
+  model_variant: null,
+  variant_group_id: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z'
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session 1',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    remote_launch: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    pinned_to_board: false,
+    ...overrides
+  }
+}
+
+function setupStores(): void {
+  useSettingsStore.setState({
+    availableAgentSdks: { opencode: true, claude: true, codex: true },
+    defaultAgentSdk: 'codex',
+    selectedModel: null,
+    selectedModelByProvider: {
+      'claude-code-cli': { providerID: 'claude-code', modelID: 'opus', variant: 'xhigh' }
+    },
+    defaultModels: {
+      build: {
+        agentSdk: 'claude-code-cli',
+        providerID: 'claude-code',
+        modelID: 'opus',
+        variant: 'high'
+      },
+      plan: null,
+      ask: null,
+      review: null
+    },
+    codexFastMode: false,
+    codexFastModeAccepted: true,
+    boardMode: 'toggle',
+    showModelProvider: false,
+    favoriteModels: []
+  })
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        worktree_create_script: null,
+        custom_commands: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        last_accessed_at: '2026-01-01T00:00:00.000Z'
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([
+      [
+        'project-1',
+        [
+          {
+            id: 'worktree-1',
+            project_id: 'project-1',
+            name: 'Feature',
+            branch_name: 'feature',
+            path: '/repo/feature',
+            status: 'active',
+            is_default: false,
+            branch_renamed: 0,
+            last_message_at: null,
+            session_titles: '[]',
+            last_model_provider_id: null,
+            last_model_id: null,
+            last_model_variant: null,
+            attachments: '[]',
+            created_at: '2026-01-01T00:00:00.000Z',
+            last_accessed_at: '2026-01-01T00:00:00.000Z',
+            github_pr_number: null,
+            github_pr_url: null
+          }
+        ]
+      ]
+    ]),
+    worktreeOrderByProject: new Map(),
+    syncWorktrees: vi.fn(),
+    createWorktreeFromBranch: vi.fn()
+  })
+  useConnectionStore.setState({ connections: [], loaded: true })
+  useKanbanStore.setState({
+    tickets: new Map([['project-1', [baseTicket]]]),
+    updateTicket: vi.fn(async () => undefined),
+    computeSortOrder: vi.fn(() => 1),
+    getTicketsByColumn: vi.fn(() => []),
+    getTicketsByColumnForConnection: vi.fn(() => [])
+  })
+  useSessionStore.setState({
+    sessionsByWorktree: new Map(),
+    sessionsByConnection: new Map(),
+    modeBySession: new Map(),
+    createSession: vi.fn(async () => ({ success: true, session: makeSession() })),
+    createConnectionSession: vi.fn(),
+    setSessionModel: vi.fn(async () => undefined),
+    setSessionMode: vi.fn(async () => undefined),
+    setOpenCodeSessionId: vi.fn(),
+    setActiveSession: vi.fn()
+  })
+  useWorktreeStatusStore.setState({ setSessionStatus: vi.fn(), setLastMessageTime: vi.fn() })
+  useUsageStore.setState({ fetchUsageForProvider: vi.fn() })
+}
+
+beforeAll(async () => {
+  Element.prototype.hasPointerCapture = vi.fn()
+  Element.prototype.releasePointerCapture = vi.fn()
+  Element.prototype.scrollIntoView = vi.fn()
+  // useSettingsStore schedules a one-shot 200ms timer on module import that
+  // reloads settings against the RPC client and can null availableAgentSdks
+  // mid-test. Let it fire against a mock client before any test renders.
+  const bootRequest: ReturnType<typeof vi.fn> = vi.fn(async () => null)
+  setRendererRpcClient({ request: bootRequest, subscribe: vi.fn(() => () => {}) })
+  await new Promise((resolve) => setTimeout(resolve, 400))
+  resetRendererRpcClientForTests()
+})
+
+beforeEach(() => {
+  _resetLastSourceBranch()
+  vi.clearAllMocks()
+  clearHandoffModelCatalogCache()
+  resetRendererRpcClientForTests()
+  const request: ReturnType<typeof vi.fn> = vi.fn(async () => null)
+  setRendererRpcClient({ request, subscribe: vi.fn(() => () => {}) })
+  setupStores()
+})
+
+afterEach(() => {
+  cleanup()
+  useSettingsStore.setState(initialSettingsState, true)
+  useSessionStore.setState(initialSessionState, true)
+  useWorktreeStore.setState(initialWorktreeState, true)
+  useConnectionStore.setState(initialConnectionState, true)
+  useKanbanStore.setState(initialKanbanState, true)
+  useProjectStore.setState(initialProjectState, true)
+  useUsageStore.setState(initialUsageState, true)
+  useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
+  resetRendererRpcClientForTests()
+})
+
+function renderModal(): void {
+  render(
+    <WorktreePickerModal
+      ticket={baseTicket}
+      projectId="project-1"
+      open
+      onOpenChange={vi.fn()}
+      onSendComplete={vi.fn()}
+    />
+  )
+}
+
+describe('WorktreePickerModal keyboard shortcuts', () => {
+  it('Cmd+G toggles goal mode on, focuses the criteria input, and toggles it back off', async () => {
+    renderModal()
+
+    // Build-mode default SDK is claude-code-cli (goal-capable) — switch present.
+    await screen.findByTestId('goal-mode-toggle')
+    expect(screen.queryByTestId('goal-success-criteria')).toBeNull()
+
+    fireEvent.keyDown(window, { key: 'g', metaKey: true })
+
+    const criteria = await screen.findByTestId('goal-success-criteria')
+    await waitFor(() => expect(criteria).toHaveFocus())
+
+    fireEvent.keyDown(window, { key: 'g', metaKey: true })
+    await waitFor(() => expect(screen.queryByTestId('goal-success-criteria')).toBeNull())
+  })
+
+  it('Cmd+U flips the model to ultracode and a second press restores the prior variant', async () => {
+    renderModal()
+
+    // Wait for the real ModelSelector to load (and cache) the claude catalog.
+    await waitFor(() => expect(screen.getByTestId('variant-indicator')).toHaveTextContent('high'))
+
+    fireEvent.keyDown(window, { key: 'u', metaKey: true })
+    await waitFor(() =>
+      expect(screen.getByTestId('variant-indicator')).toHaveTextContent('ultracode')
+    )
+
+    fireEvent.keyDown(window, { key: 'u', metaKey: true })
+    await waitFor(() =>
+      expect(screen.getByTestId('variant-indicator')).not.toHaveTextContent('ultracode')
+    )
+    expect(screen.getByTestId('variant-indicator')).toHaveTextContent('high')
+  })
+
+  it('Cmd+Enter confirms and sends', async () => {
+    renderModal()
+
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+
+    fireEvent.keyDown(window, { key: 'Enter', metaKey: true })
+
+    await waitFor(() => {
+      const createSession = useSessionStore.getState().createSession as ReturnType<typeof vi.fn>
+      expect(createSession).toHaveBeenCalledTimes(1)
+      expect(createSession.mock.calls[0].slice(0, 2)).toEqual(['worktree-1', 'project-1'])
+    })
+  })
+
+  it('Cmd+Enter does nothing while goal criteria is required but empty', async () => {
+    renderModal()
+
+    await userEvent.click(screen.getByTestId('worktree-item-worktree-1'))
+    await screen.findByTestId('goal-mode-toggle')
+
+    fireEvent.keyDown(window, { key: 'g', metaKey: true })
+    await screen.findByTestId('goal-success-criteria')
+
+    fireEvent.keyDown(window, { key: 'Enter', metaKey: true })
+
+    // Give the (should-be-absent) send flow a beat to run.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(useSessionStore.getState().createSession).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -71,7 +71,12 @@ import {
 } from '@/lib/ticket-launch'
 import type { AvailableAgentSdks } from '@/lib/agent-sdk-availability'
 import { findCustomProvider, type CustomClaudeProvider } from '@shared/types/custom-provider'
-import { resolveCustomProviderSelectedModel } from '@/lib/handoffSelection'
+import {
+  getCachedModelCatalog,
+  loadHandoffModelCatalog,
+  resolveCustomProviderSelectedModel
+} from '@/lib/handoffSelection'
+import { findModelInfo, getVariantKeysForSdk, isUltraVariant } from '@/lib/parseProviders'
 
 // Stable empty array to avoid referential-inequality loops in Zustand selectors
 const EMPTY_ARRAY: readonly never[] = []
@@ -447,6 +452,9 @@ export function WorktreePickerModal({
   // manual uncheck is never overridden.
   const goalPrefillRef = useRef<string | null>(null)
   const promptRef = useRef<HTMLTextAreaElement>(null)
+  const goalCriteriaRef = useRef<HTMLTextAreaElement>(null)
+  // The variant row 1 had before Cmd+U armed ultra, so a second press restores it.
+  const preUltraVariantRef = useRef<string | undefined>(undefined)
   const [sourceBranch, setSourceBranch] = useState<string | null>(null) // null = default
   const [branchPopoverOpen, setBranchPopoverOpen] = useState(false)
   const [branches, setBranches] = useState<BranchInfo[]>([])
@@ -661,6 +669,7 @@ export function WorktreePickerModal({
       setSelectedModel(null)
       setSelectedSdk(null)
       setSelectedCustomProviderId(null)
+      preUltraVariantRef.current = undefined
       setExtraModelRows([])
       setSourceBranch(_lastSourceBranchByProject[projectId] ?? null)
       setBranches([])
@@ -870,6 +879,60 @@ export function WorktreePickerModal({
       return next
     })
   }, [runOnRemote])
+
+  // ── Handle Cmd+G goal-mode shortcut ─────────────────────────────
+  const toggleGoalShortcut = useCallback((): boolean => {
+    if (!goalAvailable) return false
+    const next = !goalMode
+    setGoalMode(next)
+    if (next) {
+      // The criteria textarea mounts on the next render — focus once present.
+      setTimeout(() => goalCriteriaRef.current?.focus(), 0)
+    }
+    return true
+  }, [goalAvailable, goalMode])
+
+  // ── Handle Cmd+U ultra shortcut ─────────────────────────────────
+  // Flips row 1's model to its top-tier variant — claude's `ultracode` or
+  // codex's `ultra`, whichever the current model offers — and back to the
+  // pre-ultra variant on a second press.
+  const toggleUltraShortcut = useCallback((): boolean => {
+    if (preAssignOnly || effectiveCustomProviderId) return false
+    const effectiveModel = selectedModel ?? autoResolvedModel
+    if (!effectiveModel) return false
+    const sdk: PickerAgentSdk = runOnRemote
+      ? 'claude-code-cli'
+      : (effectiveModel.agentSdk ?? agentSdk)
+    const catalog = getCachedModelCatalog(sdk)
+    if (!catalog) {
+      void loadHandoffModelCatalog(sdk) // warm the cache for the next press
+      return false
+    }
+    const modelInfo = findModelInfo(catalog, effectiveModel.providerID, effectiveModel.modelID)
+    if (!modelInfo) return false
+    const variantKeys = getVariantKeysForSdk(modelInfo, sdk)
+    const ultraVariant = variantKeys.find((variant) => isUltraVariant(variant))
+    if (!ultraVariant) return false
+    if (isUltraVariant(effectiveModel.variant)) {
+      const previous = preUltraVariantRef.current
+      const restored =
+        previous && variantKeys.includes(previous) && !isUltraVariant(previous)
+          ? previous
+          : variantKeys.filter((variant) => !isUltraVariant(variant)).pop()
+      setSelectedModel({ ...effectiveModel, variant: restored })
+    } else {
+      preUltraVariantRef.current = effectiveModel.variant
+      setSelectedModel({ ...effectiveModel, variant: ultraVariant })
+    }
+    return true
+  }, [
+    preAssignOnly,
+    effectiveCustomProviderId,
+    selectedModel,
+    autoResolvedModel,
+    runOnRemote,
+    agentSdk
+  ])
 
   // ── Handle Tab / Shift+Tab keys ─────────────────────────────────
   // Must use window-level capture-phase listener to beat SessionView's
@@ -1712,6 +1775,43 @@ export function WorktreePickerModal({
     isMultiModel
   ])
 
+  // ── Handle Cmd+G / Cmd+U / Cmd+Enter shortcuts ──────────────────
+  // Window-level capture listener (same pattern as Tab above) so the
+  // shortcuts win over any global app handlers while the modal is open.
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent): void => {
+      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return
+      let handled = false
+      if (e.key === 'g') {
+        handled = toggleGoalShortcut()
+      } else if (e.key === 'u') {
+        handled = toggleUltraShortcut()
+      } else if (e.key === 'Enter') {
+        const isRemoteRetry = isRemoteLaunchActive && remotePhase === 'failed'
+        if (isRemoteRetry || canSend) {
+          void handleSend()
+          handled = true
+        }
+      }
+      if (!handled) return
+      e.preventDefault()
+      e.stopImmediatePropagation()
+    }
+    window.addEventListener('keydown', handler, true) // capture phase
+    return () => {
+      window.removeEventListener('keydown', handler, true)
+    }
+  }, [
+    open,
+    toggleGoalShortcut,
+    toggleUltraShortcut,
+    canSend,
+    isRemoteLaunchActive,
+    remotePhase,
+    handleSend
+  ])
+
   // ── Mode toggle chip ────────────────────────────────────────────
   const ModeIcon = mode === 'build' ? Hammer : Map
   const modeLabel = mode === 'build' ? 'Build' : 'Plan'
@@ -2124,6 +2224,7 @@ export function WorktreePickerModal({
                       </label>
                       <Textarea
                         id="goal-success-criteria"
+                        ref={goalCriteriaRef}
                         value={goalCriteria}
                         onChange={(e) => setGoalCriteria(e.target.value)}
                         placeholder="What does success look like?"

--- a/src/renderer/src/lib/board-search.test.ts
+++ b/src/renderer/src/lib/board-search.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeSearchText,
+  stripMarkdown,
+  ticketMatchesQuery,
+  extractSnippet
+} from './board-search'
+
+describe('normalizeSearchText', () => {
+  it('lowercases and NFC-normalizes', () => {
+    expect(normalizeSearchText('HeLLo')).toBe('hello')
+    // e + combining acute (NFD) normalizes to precomposed é
+    expect(normalizeSearchText('Café')).toBe('café')
+  })
+})
+
+describe('stripMarkdown', () => {
+  it('strips code fences, inline code, links, images, headings, and emphasis', () => {
+    const md = [
+      '# Heading',
+      'Some **bold** and _italic_ text with `inline code`.',
+      '```ts',
+      'const hidden = true',
+      '```',
+      '[link text](https://example.com) and ![alt text](img.png)',
+      '> quoted'
+    ].join('\n')
+    const out = stripMarkdown(md)
+    expect(out).not.toContain('#')
+    expect(out).not.toContain('```')
+    expect(out).not.toContain('hidden')
+    expect(out).not.toContain('https://example.com')
+    expect(out).toContain('Heading')
+    expect(out).toContain('bold')
+    expect(out).toContain('inline code')
+    expect(out).toContain('link text')
+    expect(out).toContain('alt text')
+    expect(out).toContain('quoted')
+  })
+
+  it('collapses whitespace', () => {
+    expect(stripMarkdown('a\n\n  b\tc')).toBe('a b c')
+  })
+})
+
+describe('ticketMatchesQuery', () => {
+  const ticket = { title: 'Fix Login Bug', description: 'The OAuth flow breaks on refresh' }
+
+  it('matches everything on empty query', () => {
+    expect(ticketMatchesQuery(ticket, '', false)).toBe('title')
+  })
+
+  it('matches title case-insensitively', () => {
+    expect(ticketMatchesQuery(ticket, 'login', false)).toBe('title')
+    expect(ticketMatchesQuery(ticket, 'LOGIN'.toLowerCase(), false)).toBe('title')
+  })
+
+  it('ignores description when toggle is off', () => {
+    expect(ticketMatchesQuery(ticket, 'oauth', false)).toBeNull()
+  })
+
+  it('matches description when toggle is on', () => {
+    expect(ticketMatchesQuery(ticket, 'oauth', true)).toBe('description')
+  })
+
+  it('prefers title over description', () => {
+    const t = { title: 'OAuth revamp', description: 'oauth details' }
+    expect(ticketMatchesQuery(t, 'oauth', true)).toBe('title')
+  })
+
+  it('returns null when nothing matches', () => {
+    expect(ticketMatchesQuery(ticket, 'zzz', true)).toBeNull()
+  })
+
+  it('handles null description', () => {
+    expect(ticketMatchesQuery({ title: 'abc', description: null }, 'zzz', true)).toBeNull()
+  })
+
+  it('matches through markdown syntax in descriptions', () => {
+    const t = { title: 'abc', description: 'uses **OAuth two** under the hood' }
+    expect(ticketMatchesQuery(t, 'oauth two', true)).toBe('description')
+  })
+})
+
+describe('extractSnippet', () => {
+  it('returns null for no match or empty query', () => {
+    expect(extractSnippet('hello world', 'zzz')).toBeNull()
+    expect(extractSnippet('hello world', '')).toBeNull()
+  })
+
+  it('extracts a full short string without ellipsis', () => {
+    const s = extractSnippet('hello world', 'world')
+    expect(s).toEqual({
+      before: 'hello ',
+      match: 'world',
+      after: '',
+      prefixEllipsis: false,
+      suffixEllipsis: false
+    })
+  })
+
+  it('adds ellipsis on both sides for a mid-string match in long text', () => {
+    const long = `${'a'.repeat(100)} needle ${'b'.repeat(100)}`
+    const s = extractSnippet(long, 'needle')
+    expect(s).not.toBeNull()
+    expect(s!.match).toBe('needle')
+    expect(s!.prefixEllipsis).toBe(true)
+    expect(s!.suffixEllipsis).toBe(true)
+    expect(s!.before.length).toBeLessThanOrEqual(30)
+  })
+
+  it('handles match at string start', () => {
+    const s = extractSnippet('needle in a haystack', 'needle')
+    expect(s!.before).toBe('')
+    expect(s!.prefixEllipsis).toBe(false)
+  })
+
+  it('matches case-insensitively and preserves original casing', () => {
+    const s = extractSnippet('The NEEDLE is here', 'needle')
+    expect(s!.match).toBe('NEEDLE')
+  })
+
+  it('snaps the start forward to a word boundary', () => {
+    const long = `wwwwwwwwww xxxxxxxxxx yyyyyyyyyy zzzzzzzzzz needle tail`
+    const s = extractSnippet(long, 'needle')
+    // start lands mid-word without snapping; after snapping, before-context begins post-space
+    expect(s!.before.startsWith(' ')).toBe(false)
+    expect(s!.match).toBe('needle')
+  })
+})

--- a/src/renderer/src/lib/board-search.ts
+++ b/src/renderer/src/lib/board-search.ts
@@ -1,0 +1,73 @@
+import type { KanbanTicket } from '../../../main/db/types'
+
+export function normalizeSearchText(s: string): string {
+  return s.normalize('NFC').toLowerCase()
+}
+
+/** Strip markdown syntax so snippets read as prose and matching is WYSIWYG. */
+export function stripMarkdown(md: string): string {
+  return md
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/[*_~>]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export type TicketMatchKind = 'title' | 'description' | null
+
+/** normQuery must already be normalizeSearchText()-ed. Empty query = match everything (as 'title'). */
+export function ticketMatchesQuery(
+  ticket: Pick<KanbanTicket, 'title' | 'description'>,
+  normQuery: string,
+  searchDescriptions: boolean
+): TicketMatchKind {
+  if (!normQuery) return 'title'
+  if (normalizeSearchText(ticket.title).includes(normQuery)) return 'title'
+  if (
+    searchDescriptions &&
+    ticket.description &&
+    normalizeSearchText(stripMarkdown(ticket.description)).includes(normQuery)
+  ) {
+    return 'description'
+  }
+  return null
+}
+
+export interface Snippet {
+  before: string
+  match: string
+  after: string
+  prefixEllipsis: boolean
+  suffixEllipsis: boolean
+}
+
+/** One-line ~80-char excerpt around the FIRST match; ~30 chars of context before,
+ *  start snapped forward to the nearest word boundary. Returns null if no match. */
+export function extractSnippet(
+  strippedText: string,
+  normQuery: string,
+  contextBefore = 30,
+  total = 80
+): Snippet | null {
+  if (!normQuery) return null
+  const display = strippedText.normalize('NFC')
+  const idx = display.toLowerCase().indexOf(normQuery)
+  if (idx === -1) return null
+  let start = Math.max(0, idx - contextBefore)
+  if (start > 0) {
+    const sp = display.indexOf(' ', start)
+    if (sp !== -1 && sp < idx) start = sp + 1
+  }
+  const end = Math.min(display.length, start + Math.max(total, normQuery.length + 20))
+  return {
+    before: display.slice(start, idx),
+    match: display.slice(idx, idx + normQuery.length),
+    after: display.slice(idx + normQuery.length, end),
+    prefixEllipsis: start > 0,
+    suffixEllipsis: end < display.length
+  }
+}

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -219,6 +219,8 @@ interface KanbanState {
   } | null
   /** Ephemeral board focus target used by the header Telegram toggle. */
   boardTelegramTarget: BoardTelegramTarget | null
+  /** Ephemeral Cmd+F board search — NOT persisted (partialize is inclusion-based). */
+  boardSearch: { open: boolean; query: string; searchDescriptions: boolean }
 
   // ── Actions ────────────────────────────────────────────────────────
   setSelectedTicketId: (id: null) => void
@@ -256,6 +258,10 @@ interface KanbanState {
   unarchiveTicket: (ticketId: string, projectId: string) => Promise<void>
   detachWorktreeTickets: (worktreeId: string) => Promise<void>
   setShowArchived: (projectId: string, show: boolean) => void
+  openBoardSearch: () => void
+  closeBoardSearch: () => void
+  setBoardSearchQuery: (query: string) => void
+  setBoardSearchDescriptions: (on: boolean) => void
   setPendingDoneMove: (data: {
     ticketId: string
     projectId: string
@@ -339,6 +345,7 @@ export const useKanbanStore = create<KanbanState>()(
       markdownPlaceholders: new Map(),
       pendingDoneMove: null,
       boardTelegramTarget: null,
+      boardSearch: { open: false, query: '', searchDescriptions: false },
       dependencyMap: new Map(),
       dependencyMode: null,
       hoveredBlockedTicketKey: null,
@@ -834,6 +841,24 @@ export const useKanbanStore = create<KanbanState>()(
         if (projectId) {
           get().loadTickets(projectId)
         }
+      },
+
+      // ── Board search (Cmd+F) ───────────────────────────────────────
+      openBoardSearch: () => {
+        const s = get().boardSearch
+        if (!s.open) set({ boardSearch: { ...s, open: true } })
+      },
+      // Close = clear query + restore full board; searchDescriptions persists for the app session.
+      closeBoardSearch: () => {
+        const s = get().boardSearch
+        if (!s.open && s.query === '') return
+        set({ boardSearch: { ...s, open: false, query: '' } })
+      },
+      setBoardSearchQuery: (query: string) => {
+        set({ boardSearch: { ...get().boardSearch, query } })
+      },
+      setBoardSearchDescriptions: (on: boolean) => {
+        set({ boardSearch: { ...get().boardSearch, searchDescriptions: on } })
       },
 
       // ── moveTicket (optimistic) ──────────────────────────────────


### PR DESCRIPTION
## Summary
- Added a board-level Cmd+F search UI with debounced filtering, Escape-to-close, and a toggle to include ticket descriptions.
- Filtered kanban columns and archived Done tickets to match the active search query, while hiding add-ticket affordances during search.
- Highlighted title matches and showed description snippets for description-only hits.
- Added board-search helpers plus unit tests for normalization, markdown stripping, matching, and snippet extraction.

## Testing
- Ran/updated unit coverage in `src/renderer/src/lib/board-search.test.ts` for search normalization, markdown stripping, matching, and snippet extraction.
- Verified the search state is ephemeral and clears when the board view unmounts or switches.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only kanban UI and ephemeral search state; no persistence, auth, or data-layer changes. WorktreePicker shortcuts only affect modal launch flow when open.
> 
> **Overview**
> Adds **Cmd/Ctrl+F kanban board search**: ephemeral `boardSearch` state in the kanban store, a debounced search bar with optional description matching, and keyboard handling (open/refocus, Escape, Tab isolation so plan/build mode doesn’t steal focus).
> 
> While a query is active, columns filter tickets (including archived Done when visible), show a live match count, hide “new ticket” affordances, and relabel empty columns as “No matches”. Cards **highlight title hits** and show a **description snippet** when only the body matched. Shared helpers in `board-search` cover normalization, markdown stripping, matching, and snippets, with unit tests.
> 
> **WorktreePickerModal** also gains capture-phase shortcuts: **Cmd+G** toggles goal mode and focuses criteria, **Cmd+U** toggles ultra/ultracode variant (and back), **Cmd+Enter** sends when allowed—covered by new shortcut tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a837e65942fb413fc232eaa3e61cbda8fd7249df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->