### PR TITLE
Add configurable model and effort for PR content generation

### DIFF
--- a/src/main/services/pr-content-generator.ts
+++ b/src/main/services/pr-content-generator.ts
@@ -34,6 +34,10 @@ export interface GeneratePRContentOptions {
   diffSummary: string
   diffPatch: string
   provider: AgentSdkId
+  /** Provider-specific model slug; falls back to the router's per-provider default. */
+  model?: string
+  /** Reasoning-effort level; falls back to the router's default ('low'). */
+  effort?: string
   cwd: string
 }
 
@@ -52,7 +56,8 @@ export interface PRContent {
  * Returns null if generation fails or the response cannot be parsed.
  */
 export async function generatePRContent(options: GeneratePRContentOptions): Promise<PRContent> {
-  const { baseBranch, headBranch, commitSummary, diffSummary, diffPatch, provider, cwd } = options
+  const { baseBranch, headBranch, commitSummary, diffSummary, diffPatch, provider, model, effort, cwd } =
+    options
 
   const truncatedCommitSummary = truncate(commitSummary, MAX_COMMIT_SUMMARY_LENGTH)
   const truncatedDiffSummary = truncate(diffSummary, MAX_DIFF_SUMMARY_LENGTH)
@@ -70,7 +75,7 @@ ${truncatedDiffSummary}
 Diff patch:
 ${truncatedDiffPatch}`
 
-  log.info('Generating PR content', { baseBranch, headBranch, provider, cwd })
+  log.info('Generating PR content', { baseBranch, headBranch, provider, model, effort, cwd })
 
   const response = await generateText(
     prompt,
@@ -78,7 +83,9 @@ ${truncatedDiffPatch}`
     provider,
     {
       cwd,
-      outputSchema: PR_CONTENT_JSON_SCHEMA
+      outputSchema: PR_CONTENT_JSON_SCHEMA,
+      ...(model ? { modelOverride: model } : {}),
+      ...(effort ? { effort } : {})
     }
   )
   if (!response) {

--- a/src/main/services/text-generation-router.ts
+++ b/src/main/services/text-generation-router.ts
@@ -6,6 +6,8 @@ import { Effect } from 'effect'
 
 import { loadClaudeSDK } from './claude-sdk-loader'
 import { resolveCodexBinaryPath } from './codex-binary-resolver'
+import { CODEX_REASONING_EFFORTS } from './codex-models'
+import type { CodexReasoningEffort } from './codex-models'
 import { getCodexCliEnv } from './codex-cli-env'
 import { detectAgentSdks } from './system-info'
 import type { AgentSdkDetection } from './system-info'
@@ -30,8 +32,25 @@ const MAX_OUTPUT_SIZE = 1024 * 1024 // 1 MB
 
 export interface GenerateTextOptions {
   modelOverride?: string
+  /** Reasoning-effort level (e.g. 'low' | 'medium' | 'high'); defaults to 'low'. */
+  effort?: string
   outputSchema?: string
   cwd?: string
+}
+
+const CLAUDE_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const
+type ClaudeEffortLevel = (typeof CLAUDE_EFFORT_LEVELS)[number]
+
+function toClaudeEffort(effort?: string): ClaudeEffortLevel {
+  return CLAUDE_EFFORT_LEVELS.includes(effort as ClaudeEffortLevel)
+    ? (effort as ClaudeEffortLevel)
+    : 'low'
+}
+
+function toCodexEffort(effort?: string): CodexReasoningEffort {
+  return CODEX_REASONING_EFFORTS.includes(effort as CodexReasoningEffort)
+    ? (effort as CodexReasoningEffort)
+    : 'low'
 }
 
 let cachedSdks: AgentSdkDetection | null = null
@@ -81,7 +100,7 @@ export async function generateText(
   provider: AgentSdkId,
   options: GenerateTextOptions = {}
 ): Promise<string | null> {
-  const { modelOverride, outputSchema, cwd } = options
+  const { modelOverride, effort, outputSchema, cwd } = options
   const resolvedProvider = resolveProvider(provider)
   if (!resolvedProvider) {
     throw new Error(
@@ -101,6 +120,7 @@ export async function generateText(
         prompt,
         systemPrompt,
         modelOverride,
+        effort,
         outputSchema,
         cwd
       )
@@ -147,17 +167,23 @@ export async function generateText(
  */
 function resolveProvider(provider: AgentSdkId): AgentSdkId | null {
   if (provider === 'terminal') return null
+  // claude-code-cli shares Claude's text-generation path
+  const requested = provider === 'claude-code-cli' ? 'claude-code' : provider
 
   const sdks = getCachedSdkDetection()
-  const providerAvailable: Record<Exclude<AgentSdkId, 'terminal'>, boolean> = {
+  const providerAvailable: Record<Exclude<AgentSdkId, 'terminal' | 'claude-code-cli'>, boolean> = {
     'claude-code': sdks.claude,
     codex: sdks.codex,
     opencode: sdks.opencode
   }
 
-  if (providerAvailable[provider]) return provider
+  if (providerAvailable[requested]) return requested
 
-  const fallbackOrder: Exclude<AgentSdkId, 'terminal'>[] = ['claude-code', 'codex', 'opencode']
+  const fallbackOrder: Exclude<AgentSdkId, 'terminal' | 'claude-code-cli'>[] = [
+    'claude-code',
+    'codex',
+    'opencode'
+  ]
   for (const fallback of fallbackOrder) {
     if (providerAvailable[fallback]) return fallback
   }
@@ -173,14 +199,16 @@ function generateWithProvider(
   prompt: string,
   systemPrompt: string,
   modelOverride?: string,
+  effort?: string,
   outputSchema?: string,
   cwd?: string
 ): Promise<string | null> {
   switch (provider) {
     case 'claude-code':
-      return generateWithClaude(prompt, systemPrompt, modelOverride, cwd)
+    case 'claude-code-cli':
+      return generateWithClaude(prompt, systemPrompt, modelOverride, effort, cwd)
     case 'codex':
-      return generateWithCodex(prompt, systemPrompt, modelOverride, outputSchema, cwd)
+      return generateWithCodex(prompt, systemPrompt, modelOverride, effort, outputSchema, cwd)
     case 'opencode':
       return generateWithOpenCode(prompt, systemPrompt, modelOverride, cwd)
     case 'terminal':
@@ -195,6 +223,7 @@ async function generateWithClaude(
   prompt: string,
   systemPrompt: string,
   modelOverride?: string,
+  effort?: string,
   cwd?: string
 ): Promise<string | null> {
   const sdk = await loadClaudeSDK()
@@ -212,7 +241,7 @@ async function generateWithClaude(
         maxTurns: 2,
         abortController,
         systemPrompt,
-        effort: 'low',
+        effort: toClaudeEffort(effort),
         thinking: { type: 'disabled' },
         tools: [],
         persistSession: false,
@@ -284,6 +313,7 @@ async function generateWithCodex(
   prompt: string,
   systemPrompt: string,
   modelOverride?: string,
+  effort?: string,
   outputSchema?: string,
   cwd?: string
 ): Promise<string | null> {
@@ -307,7 +337,7 @@ async function generateWithCodex(
       '--model',
       model,
       '--config',
-      'model_reasoning_effort="low"'
+      `model_reasoning_effort="${toCodexEffort(effort)}"`
     ]
     if (schemaFile && outputSchema) {
       await writeFile(schemaFile, outputSchema)

--- a/src/renderer/src/api/__tests__/git-api.test.ts
+++ b/src/renderer/src/api/__tests__/git-api.test.ts
@@ -366,6 +366,22 @@ describe('gitApi', () => {
     })
   })
 
+  it('includes model and effort in the generatePRContent payload when provided', async () => {
+    const request = vi.fn().mockResolvedValue({ success: true })
+    const subscribe = vi.fn()
+
+    setRendererRpcClient({ request, subscribe })
+
+    await gitApi.generatePRContent('/tmp/hive', 'origin/main', 'codex', 'gpt-5.5', 'medium')
+    expect(request).toHaveBeenCalledWith('gitOps.generatePRContent', {
+      worktreePath: '/tmp/hive',
+      baseBranch: 'origin/main',
+      provider: 'codex',
+      model: 'gpt-5.5',
+      effort: 'medium'
+    })
+  })
+
   it('routes getDiff through the renderer RPC client', async () => {
     const result = {
       success: true,

--- a/src/renderer/src/api/git-api.ts
+++ b/src/renderer/src/api/git-api.ts
@@ -328,12 +328,16 @@ export const gitApi = {
   generatePRContent: async (
     worktreePath: string,
     baseBranch: string,
-    provider: GitPRContentProvider
+    provider: GitPRContentProvider,
+    model?: string,
+    effort?: string
   ): Promise<GitGeneratePRContentResult> =>
     getRendererRpcClient().request<GitGeneratePRContentResult>('gitOps.generatePRContent', {
       worktreePath,
       baseBranch,
-      provider
+      provider,
+      ...(model ? { model } : {}),
+      ...(effort ? { effort } : {})
     }),
   getDiff: async (
     worktreePath: string,

--- a/src/renderer/src/components/pr/ConnectionPRModal.tsx
+++ b/src/renderer/src/components/pr/ConnectionPRModal.tsx
@@ -24,7 +24,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { toast } from '@/lib/toast'
-import { resolvePRContentProvider } from '@/lib/pr-content-provider'
+import { resolvePRContentGeneration } from '@/lib/pr-content-provider'
 import {
   assessConnectionMembers,
   commitConnectionMembers,
@@ -62,6 +62,7 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
   const stageAll = useGitStore((s) => s.stageAll)
   const defaultAgentSdk = useSettingsStore((s) => s.defaultAgentSdk) ?? 'claude-code'
   const availableAgentSdks = useSettingsStore((s) => s.availableAgentSdks)
+  const prContentModel = useSettingsStore((s) => s.prContentModel)
 
   // ── Phase & assessment state ────────────────────────────────────
   const [phase, setPhase] = useState<ModalPhase>('loading')
@@ -298,7 +299,7 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
   )
 
   const handleCreate = useCallback(() => {
-    const provider = resolvePRContentProvider(defaultAgentSdk, availableAgentSdks)
+    const generation = resolvePRContentGeneration(prContentModel, defaultAgentSdk, availableAgentSdks)
     const gitStore = useGitStore.getState()
 
     const plans = eligible.map((assessment) => ({
@@ -326,7 +327,9 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
       ineligible,
       title: title.trim(),
       body: body.trim(),
-      provider
+      provider: generation?.provider ?? null,
+      model: generation?.model,
+      effort: generation?.effort
     })
   }, [
     eligible,
@@ -337,6 +340,7 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
     body,
     defaultAgentSdk,
     availableAgentSdks,
+    prContentModel,
     setOpen
   ])
 

--- a/src/renderer/src/components/pr/CreatePRModal.tsx
+++ b/src/renderer/src/components/pr/CreatePRModal.tsx
@@ -23,7 +23,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { toast } from '@/lib/toast'
-import { resolvePRContentProvider } from '@/lib/pr-content-provider'
+import { resolvePRContentGeneration } from '@/lib/pr-content-provider'
 import { runCreatePRPipeline } from '@/lib/pr-pipeline'
 import { useGitStore, type GitFileStatus } from '@/stores/useGitStore'
 import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
@@ -63,6 +63,7 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
   const gitCommit = useGitStore((s) => s.commit)
   const defaultAgentSdk = useSettingsStore((s) => s.defaultAgentSdk) ?? 'claude-code'
   const availableAgentSdks = useSettingsStore((s) => s.availableAgentSdks)
+  const prContentModel = useSettingsStore((s) => s.prContentModel)
   const defaultBranchName = useWorktreeStore((s) => {
     for (const [, worktrees] of s.worktreesByProject) {
       if (worktrees.some((w) => w.id === worktreeId)) {
@@ -264,7 +265,7 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
     const prTitle = title.trim()
     const prBody = body.trim()
     const branchName = branchInfo?.name ?? 'Pull Request'
-    const provider = resolvePRContentProvider(defaultAgentSdk, availableAgentSdks)
+    const generation = resolvePRContentGeneration(prContentModel, defaultAgentSdk, availableAgentSdks)
 
     // Persist the selected target branch so the Header dropdowns keep showing it
     // after the push changes branchInfo.tracking
@@ -302,7 +303,9 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
       title: prTitle,
       body: prBody,
       fallbackTitle: branchName,
-      provider,
+      provider: generation?.provider ?? null,
+      model: generation?.model,
+      effort: generation?.effort,
       notifId
     })
   }, [
@@ -313,6 +316,7 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
     body,
     defaultAgentSdk,
     availableAgentSdks,
+    prContentModel,
     branchInfo,
     setOpen
   ])

--- a/src/renderer/src/components/settings/SettingsModels.tsx
+++ b/src/renderer/src/components/settings/SettingsModels.tsx
@@ -10,6 +10,8 @@ export function SettingsModels(): React.JSX.Element {
     resolveModelForSdk(defaultAgentSdk === 'terminal' ? 'opencode' : defaultAgentSdk, s)
   )
   const defaultModels = useSettingsStore((state) => state.defaultModels)
+  const prContentModel = useSettingsStore((state) => state.prContentModel)
+  const updateSetting = useSettingsStore((state) => state.updateSetting)
   const setSelectedModel = useSettingsStore((state) => state.setSelectedModel)
   const setSelectedModelForSdk = useSettingsStore((state) => state.setSelectedModelForSdk)
   const setModeDefaultModel = useSettingsStore((state) => state.setModeDefaultModel)
@@ -170,6 +172,31 @@ export function SettingsModels(): React.JSX.Element {
           </div>
         </>
       )}
+
+      <div className="border-t pt-4" />
+
+      {/* PR content generation */}
+      <div className="space-y-2">
+        <label className="text-sm font-medium">PR Content Generation</label>
+        <p className="text-xs text-muted-foreground">
+          Model and effort used to generate pull request titles and descriptions
+        </p>
+        <div className="flex items-center gap-2">
+          <ModelSelector
+            value={prContentModel || null}
+            onChange={(model) => updateSetting('prContentModel', model)}
+            allowAgentSdkSelection
+          />
+          {prContentModel && (
+            <button
+              onClick={() => updateSetting('prContentModel', null)}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Use default
+            </button>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/lib/__tests__/pr-pipeline.test.ts
+++ b/src/renderer/src/lib/__tests__/pr-pipeline.test.ts
@@ -113,6 +113,25 @@ describe('runCreatePRPipeline', () => {
     expect(useGitStore.getState().creatingPRByWorktreeId.has('wt-1')).toBe(false)
   })
 
+  it('forwards the configured model and effort to generatePRContent', async () => {
+    mockResponses()
+
+    await runCreatePRPipeline({
+      ...baseOptions,
+      model: 'sonnet',
+      effort: 'high',
+      notifId
+    })
+
+    expect(request).toHaveBeenCalledWith('gitOps.generatePRContent', {
+      worktreePath: '/repo/wt-1',
+      baseBranch: 'main',
+      provider: 'claude-code',
+      model: 'sonnet',
+      effort: 'high'
+    })
+  })
+
   it('skips push and generation when nothing to push and content is provided', async () => {
     mockResponses({ 'gitOps.needsPush': false })
 

--- a/src/renderer/src/lib/connection-pr.ts
+++ b/src/renderer/src/lib/connection-pr.ts
@@ -52,6 +52,10 @@ export interface CreateConnectionPRsOptions {
   title: string
   body: string
   provider: PRContentProvider | null
+  /** Model override for PR content generation (provider-specific slug) */
+  model?: string | null
+  /** Effort/reasoning level override for PR content generation */
+  effort?: string | null
 }
 
 // ---------------------------------------------------------------------------
@@ -231,7 +235,7 @@ async function pushAttachedPRUpdates(assessment: MemberAssessment, prefix: strin
  * once the whole batch settles.
  */
 export async function createConnectionPRs(options: CreateConnectionPRsOptions): Promise<void> {
-  const { plans, ineligible, title, body, provider } = options
+  const { plans, ineligible, title, body, provider, model, effort } = options
   const { show } = usePRNotificationStore.getState()
 
   await Promise.allSettled(
@@ -282,6 +286,8 @@ export async function createConnectionPRs(options: CreateConnectionPRsOptions): 
         body,
         fallbackTitle: assessment.branchName,
         provider,
+        model,
+        effort,
         notifId,
         labelPrefix: prefix
       })

--- a/src/renderer/src/lib/pr-content-provider.ts
+++ b/src/renderer/src/lib/pr-content-provider.ts
@@ -1,5 +1,5 @@
 export type PRContentProvider = 'opencode' | 'claude-code' | 'codex'
-export type AgentSdkPreference = PRContentProvider | 'terminal'
+export type AgentSdkPreference = PRContentProvider | 'terminal' | 'claude-code-cli'
 
 export interface AvailableAgentSdks {
   opencode: boolean
@@ -10,9 +10,12 @@ export interface AvailableAgentSdks {
 const PROVIDER_ORDER: PRContentProvider[] = ['claude-code', 'codex', 'opencode']
 
 export function resolvePRContentProvider(
-  preferredSdk: AgentSdkPreference,
+  rawPreferredSdk: AgentSdkPreference,
   availableSdks?: AvailableAgentSdks | null
 ): PRContentProvider | null {
+  // claude-code-cli shares Claude's text-generation provider
+  const preferredSdk: PRContentProvider | 'terminal' =
+    rawPreferredSdk === 'claude-code-cli' ? 'claude-code' : rawPreferredSdk
   if (preferredSdk !== 'terminal') {
     if (!availableSdks || isProviderAvailable(preferredSdk, availableSdks)) {
       return preferredSdk
@@ -30,6 +33,70 @@ export function resolvePRContentProvider(
   }
 
   return null
+}
+
+/** Shape of the persisted `prContentModel` setting (agentSdk-stamped SelectedModel). */
+export interface PRContentModelSetting {
+  agentSdk?: string
+  providerID: string
+  modelID: string
+  variant?: string
+}
+
+export interface PRContentGeneration {
+  provider: PRContentProvider
+  model?: string
+  effort?: string
+}
+
+/**
+ * Resolve the provider + model + effort to use for PR content generation.
+ *
+ * When the user configured a PR content model in Settings → Models, its SDK
+ * picks the provider and its modelID/variant become the model/effort overrides.
+ * Otherwise (or when the configured provider's CLI is unavailable) falls back
+ * to the provider chain derived from the default agent SDK, with no overrides.
+ */
+export function resolvePRContentGeneration(
+  contentModel: PRContentModelSetting | null | undefined,
+  preferredSdk: AgentSdkPreference,
+  availableSdks?: AvailableAgentSdks | null
+): PRContentGeneration | null {
+  if (contentModel) {
+    // A model picked without an explicit SDK is portable across every available
+    // catalog, so the default provider chain decides which CLI runs it.
+    const provider = contentModel.agentSdk
+      ? toPRContentProvider(contentModel.agentSdk)
+      : resolvePRContentProvider(preferredSdk, availableSdks)
+    if (provider && (!availableSdks || isProviderAvailable(provider, availableSdks))) {
+      // opencode expects the fully-qualified "provider/model" form; claude and
+      // codex CLIs take the bare model slug.
+      const model =
+        provider === 'opencode'
+          ? `${contentModel.providerID}/${contentModel.modelID}`
+          : contentModel.modelID
+      // ultracode is a claude-code-cli-only pseudo-effort; xhigh is its SDK equivalent.
+      const effort = contentModel.variant === 'ultracode' ? 'xhigh' : contentModel.variant
+      return { provider, model, ...(effort ? { effort } : {}) }
+    }
+  }
+
+  const fallback = resolvePRContentProvider(preferredSdk, availableSdks)
+  return fallback ? { provider: fallback } : null
+}
+
+function toPRContentProvider(agentSdk: string): PRContentProvider | null {
+  switch (agentSdk) {
+    case 'claude-code':
+    case 'claude-code-cli':
+      return 'claude-code'
+    case 'codex':
+      return 'codex'
+    case 'opencode':
+      return 'opencode'
+    default:
+      return null
+  }
 }
 
 function isProviderAvailable(provider: PRContentProvider, availableSdks: AvailableAgentSdks): boolean {

--- a/src/renderer/src/lib/pr-pipeline.ts
+++ b/src/renderer/src/lib/pr-pipeline.ts
@@ -17,6 +17,10 @@ export interface CreatePRPipelineOptions {
   /** Used as the PR title when generation fails or is unavailable */
   fallbackTitle: string
   provider: PRContentProvider | null
+  /** Model override for PR content generation (provider-specific slug) */
+  model?: string | null
+  /** Effort/reasoning level override for PR content generation */
+  effort?: string | null
   /** Pre-created notification card driven through the pipeline's states */
   notifId: string
   /** Prepended to every notification message, e.g. 'my-project: ' */
@@ -46,6 +50,8 @@ export async function runCreatePRPipeline(
     baseBranch,
     fallbackTitle,
     provider,
+    model,
+    effort,
     notifId,
     labelPrefix = ''
   } = options
@@ -86,7 +92,13 @@ export async function runCreatePRPipeline(
           'No AI provider available for PR content generation. Using default title and description.'
       } else {
         try {
-          const genResult = await gitApi.generatePRContent(worktreePath, baseBranch, provider)
+          const genResult = await gitApi.generatePRContent(
+            worktreePath,
+            baseBranch,
+            provider,
+            model ?? undefined,
+            effort ?? undefined
+          )
           if (genResult.success) {
             if (!finalTitle && genResult.title) finalTitle = genResult.title
             if (!finalBody && genResult.body) finalBody = genResult.body

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -105,6 +105,8 @@ export interface AppSettings {
   selectedModel: SelectedModel | null
   selectedModelByProvider: Record<string, SelectedModel>
   defaultModels: ModeDefaultModels | null
+  /** Model + effort used for PR title/description generation (null = follow defaultAgentSdk). */
+  prContentModel: SelectedModel | null
   lastHandoffOverride: {
     agentSdk: HandoffAgentSdk
     customProviderId?: string | null
@@ -226,6 +228,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   selectedModel: null,
   selectedModelByProvider: {},
   defaultModels: null,
+  prContentModel: null,
   lastHandoffOverride: null,
   lastOpenAction: null,
   lastProjectDirectory: null,
@@ -453,6 +456,7 @@ function extractSettings(state: SettingsState): AppSettings {
     selectedModel: state.selectedModel,
     selectedModelByProvider: state.selectedModelByProvider,
     defaultModels: state.defaultModels,
+    prContentModel: state.prContentModel,
     lastHandoffOverride: state.lastHandoffOverride,
     lastOpenAction: state.lastOpenAction,
     lastProjectDirectory: state.lastProjectDirectory,
@@ -821,6 +825,7 @@ export const useSettingsStore = create<SettingsState>()(
         selectedModel: state.selectedModel,
         selectedModelByProvider: state.selectedModelByProvider,
         defaultModels: state.defaultModels,
+        prContentModel: state.prContentModel,
         lastHandoffOverride: state.lastHandoffOverride,
         lastOpenAction: state.lastOpenAction,
         lastProjectDirectory: state.lastProjectDirectory,

--- a/src/server/__tests__/git-ops-rpc.test.ts
+++ b/src/server/__tests__/git-ops-rpc.test.ts
@@ -1089,6 +1089,32 @@ describe('git ops RPC domain', () => {
     )
   })
 
+  it('forwards model and effort overrides to the PR content generator', async () => {
+    const dir = makeTempDir()
+    git(dir, ['init'])
+    git(dir, ['config', 'user.email', 'hive@example.test'])
+    git(dir, ['config', 'user.name', 'Hive Test'])
+    writeFileSync(join(dir, 'tracked.txt'), 'original\n')
+    git(dir, ['add', 'tracked.txt'])
+    git(dir, ['commit', '-m', 'initial'])
+    git(dir, ['branch', '-M', 'main'])
+    git(dir, ['checkout', '-b', 'feature/pr-content'])
+
+    const runCommand = vi.fn(async () => ({ stdout: '', stderr: '' }))
+    const generatePRContent = vi.fn(async () => ({ title: 'Add RPC', body: 'Body' }))
+    const service = makeLiveGitOpsRpcService({ runCommand, generatePRContent })
+
+    await Effect.runPromise(service.generatePRContent(dir, 'main', 'claude-code', 'sonnet', 'high'))
+
+    expect(generatePRContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'claude-code',
+        model: 'sonnet',
+        effort: 'high'
+      })
+    )
+  })
+
   it('rejects providers that cannot generate pull request content', async () => {
     const generatePRContent = vi.fn(async () => ({ title: 'unused', body: 'unused' }))
     const service = makeLiveGitOpsRpcService({ generatePRContent })

--- a/src/server/rpc/domains/git-ops.ts
+++ b/src/server/rpc/domains/git-ops.ts
@@ -377,7 +377,9 @@ export interface GitOpsRpcService {
   readonly generatePRContent: (
     worktreePath: string,
     baseBranch: string,
-    provider: string
+    provider: string,
+    model?: string,
+    effort?: string
   ) => Effect.Effect<GitGeneratePullRequestContentResult, unknown, never>
   readonly prMerge: (
     worktreePath: string,
@@ -477,7 +479,9 @@ const generatePullRequestContentParamsSchema = z
   .object({
     worktreePath: z.string().min(1),
     baseBranch: z.string().min(1),
-    provider: z.string().min(1)
+    provider: z.string().min(1),
+    model: z.string().min(1).optional(),
+    effort: z.string().min(1).optional()
   })
   .strict()
 const branchNameParamsSchema = z
@@ -578,6 +582,8 @@ export interface GitOpsRpcServiceDependencies {
     readonly diffSummary: string
     readonly diffPatch: string
     readonly provider: string
+    readonly model?: string
+    readonly effort?: string
     readonly cwd: string
   }) => Promise<{ readonly title: string; readonly body: string }>
 }
@@ -1530,7 +1536,7 @@ export const makeLiveGitOpsRpcService = (
           error: cause instanceof Error ? cause.message : String(cause)
         })
       }),
-    generatePRContent: (worktreePath, baseBranch, provider) =>
+    generatePRContent: (worktreePath, baseBranch, provider, model, effort) =>
       Effect.tryPromise({
         try: async (): Promise<GitGeneratePullRequestContentResult> => {
           try {
@@ -1600,6 +1606,8 @@ export const makeLiveGitOpsRpcService = (
               diffSummary,
               diffPatch,
               provider,
+              model,
+              effort,
               cwd: worktreePath
             })
 
@@ -2313,11 +2321,11 @@ export const makeGitOpsRpcHandlers = (
       'gitOps.generatePRContent',
       (params) =>
         Effect.gen(function* () {
-          const { worktreePath, baseBranch, provider } = yield* Effect.try({
+          const { worktreePath, baseBranch, provider, model, effort } = yield* Effect.try({
             try: () => generatePullRequestContentParamsSchema.parse(params),
             catch: (cause) => cause
           })
-          return yield* service.generatePRContent(worktreePath, baseBranch, provider)
+          return yield* service.generatePRContent(worktreePath, baseBranch, provider, model, effort)
         })
     ],
     [

--- a/test/main/pr-content-generator.test.ts
+++ b/test/main/pr-content-generator.test.ts
@@ -47,4 +47,34 @@ describe('pr-content-generator', () => {
       }
     )
   })
+
+  it('passes model and effort overrides through to generateText', async () => {
+    const { generatePRContent, PR_CONTENT_JSON_SCHEMA } = await import(
+      '../../src/main/services/pr-content-generator'
+    )
+
+    await generatePRContent({
+      baseBranch: 'main',
+      headBranch: 'feature/pr-content',
+      commitSummary: 'abc123 Add cwd propagation',
+      diffSummary: ' 1 file changed, 3 insertions(+)',
+      diffPatch: 'diff --git a/file b/file',
+      provider: 'claude-code',
+      model: 'sonnet',
+      effort: 'high',
+      cwd: '/tmp/worktree'
+    })
+
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      'claude-code',
+      {
+        cwd: '/tmp/worktree',
+        outputSchema: PR_CONTENT_JSON_SCHEMA,
+        modelOverride: 'sonnet',
+        effort: 'high'
+      }
+    )
+  })
 })

--- a/test/main/text-generation-router-pr-content.test.ts
+++ b/test/main/text-generation-router-pr-content.test.ts
@@ -109,6 +109,33 @@ describe('text-generation-router codex structured output', () => {
     expect(mockUnlink).toHaveBeenCalledTimes(2)
   })
 
+  it('applies model and effort overrides to the codex invocation', async () => {
+    const { generateText } = await import('../../src/main/services/text-generation-router')
+
+    await generateText('Prompt', 'System', 'codex', {
+      cwd: '/tmp/worktree',
+      modelOverride: 'gpt-5.5',
+      effort: 'high'
+    })
+
+    const options = mockRunOnceOptions.mock.calls[0][0]
+    expect(options.args).toContain('--model')
+    expect(options.args).toContain('gpt-5.5')
+    expect(options.args).toContain('model_reasoning_effort="high"')
+  })
+
+  it('falls back to low effort when the effort value is not a codex effort', async () => {
+    const { generateText } = await import('../../src/main/services/text-generation-router')
+
+    await generateText('Prompt', 'System', 'codex', {
+      cwd: '/tmp/worktree',
+      effort: 'bogus"injection'
+    })
+
+    const options = mockRunOnceOptions.mock.calls[0][0]
+    expect(options.args).toContain('model_reasoning_effort="low"')
+  })
+
   it('uses injected codex binary path when provided', async () => {
     const { generateText, setCodexBinaryPath } = await import('../../src/main/services/text-generation-router')
     setCodexBinaryPath('/resolved/codex')

--- a/test/phase-20/session-11/pr-content-provider-resolution.test.ts
+++ b/test/phase-20/session-11/pr-content-provider-resolution.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolvePRContentProvider } from '../../../src/renderer/src/lib/pr-content-provider'
+import {
+  resolvePRContentGeneration,
+  resolvePRContentProvider
+} from '../../../src/renderer/src/lib/pr-content-provider'
 
 describe('resolvePRContentProvider', () => {
   it('keeps a generating preferred provider when available state is unknown', () => {
@@ -34,6 +37,85 @@ describe('resolvePRContentProvider', () => {
         claude: false,
         codex: false
       })
+    ).toBeNull()
+  })
+
+  it('normalizes claude-code-cli to the claude-code text provider', () => {
+    expect(
+      resolvePRContentProvider('claude-code-cli', {
+        opencode: true,
+        claude: true,
+        codex: true
+      })
+    ).toBe('claude-code')
+  })
+})
+
+describe('resolvePRContentGeneration', () => {
+  const allAvailable = { opencode: true, claude: true, codex: true }
+
+  it('uses the configured PR content model, mapping variant to effort', () => {
+    expect(
+      resolvePRContentGeneration(
+        { agentSdk: 'claude-code', providerID: 'anthropic', modelID: 'sonnet', variant: 'high' },
+        'codex',
+        allAvailable
+      )
+    ).toEqual({ provider: 'claude-code', model: 'sonnet', effort: 'high' })
+  })
+
+  it('maps claude-code-cli models to the claude-code provider and ultracode to xhigh', () => {
+    expect(
+      resolvePRContentGeneration(
+        {
+          agentSdk: 'claude-code-cli',
+          providerID: 'anthropic',
+          modelID: 'opus',
+          variant: 'ultracode'
+        },
+        'codex',
+        allAvailable
+      )
+    ).toEqual({ provider: 'claude-code', model: 'opus', effort: 'xhigh' })
+  })
+
+  it('formats opencode models as provider/model', () => {
+    expect(
+      resolvePRContentGeneration(
+        { agentSdk: 'opencode', providerID: 'anthropic', modelID: 'claude-sonnet-4-5' },
+        'claude-code',
+        allAvailable
+      )
+    ).toEqual({ provider: 'opencode', model: 'anthropic/claude-sonnet-4-5' })
+  })
+
+  it('resolves SDK-less (portable) models through the default provider chain', () => {
+    expect(
+      resolvePRContentGeneration(
+        { providerID: 'anthropic', modelID: 'sonnet', variant: 'low' },
+        'codex',
+        allAvailable
+      )
+    ).toEqual({ provider: 'codex', model: 'sonnet', effort: 'low' })
+  })
+
+  it('ignores the configured model when its provider is unavailable', () => {
+    expect(
+      resolvePRContentGeneration(
+        { agentSdk: 'codex', providerID: 'codex', modelID: 'gpt-5.5', variant: 'high' },
+        'claude-code',
+        { opencode: true, claude: true, codex: false }
+      )
+    ).toEqual({ provider: 'claude-code' })
+  })
+
+  it('falls back to plain provider resolution when no model is configured', () => {
+    expect(resolvePRContentGeneration(null, 'codex', allAvailable)).toEqual({ provider: 'codex' })
+  })
+
+  it('returns null when nothing is available', () => {
+    expect(
+      resolvePRContentGeneration(null, 'terminal', { opencode: false, claude: false, codex: false })
     ).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- Add a dedicated PR content generation model setting in Settings > Models.
- Thread PR content model and reasoning effort through the PR creation flow and connection PR flow.
- Update server and main-process generation paths to pass model overrides and effort levels to Claude, Codex, and OpenCode.
- Expand provider resolution to handle `claude-code-cli` and portable model settings.
- Add coverage for settings resolution, pipeline propagation, RPC plumbing, and text generation behavior.

## Testing
- Added/updated unit tests for PR content provider resolution, PR pipeline forwarding, RPC payload handling, and generation router effort mapping.
- Added main-process tests to verify model and effort overrides are passed to `generateText`.
- Added server RPC tests to confirm overrides reach the PR content generator.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive settings and optional RPC fields with allowlisted effort values; PR creation still falls back when generation fails.
> 
> **Overview**
> Adds a **PR Content Generation** model picker in Settings → Models (`prContentModel`), separate from session defaults. When auto-generating PR titles/descriptions, the app now resolves provider, model slug, and reasoning effort from that setting (including variant → effort and OpenCode `provider/model` formatting), with fallback to the existing default-agent SDK provider chain when unset or unavailable.
> 
> **`model` and `effort`** are threaded end-to-end: PR modals and `runCreatePRPipeline` / connection PR batching → `gitApi.generatePRContent` → `gitOps.generatePRContent` RPC → `generatePRContent` → `generateText`. The text router applies overrides to Claude (`effort` with allowlisting) and Codex (`model_reasoning_effort`, with invalid values defaulting to `low`), and treats **`claude-code-cli`** like **`claude-code`** for provider resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb5818b0ae785b0d34298b1cfb13c29abcd5c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->