### PR TITLE
Optimize auto-switch account refresh by skipping non-viable accounts

### DIFF
--- a/src/main/services/saved-usage-orchestrator.ts
+++ b/src/main/services/saved-usage-orchestrator.ts
@@ -533,9 +533,12 @@ export async function fetchForSavedAccount(
 }
 
 export async function refreshAllForProvider(
-  provider: UsageProvider
+  provider: UsageProvider,
+  excludeAccountIds?: string[]
 ): Promise<RefreshAllResultItem[]> {
-  const accounts = await listSavedAccounts(provider)
+  const allAccounts = await listSavedAccounts(provider)
+  const excluded = new Set(excludeAccountIds ?? [])
+  const accounts = allAccounts.filter((account) => !excluded.has(account.id))
   const batchId = randomUUID()
   const startedAt = Date.now()
   const results: RefreshAllResultItem[] = []
@@ -544,7 +547,10 @@ export async function refreshAllForProvider(
     provider,
     batchId,
     accountCount: accounts.length,
-    accountIds: accounts.map((account) => account.id)
+    accountIds: accounts.map((account) => account.id),
+    skippedAccountIds: allAccounts
+      .filter((account) => excluded.has(account.id))
+      .map((account) => account.id)
   })
 
   for (const account of accounts) {

--- a/src/main/services/usage-ops.ts
+++ b/src/main/services/usage-ops.ts
@@ -162,7 +162,8 @@ export async function fetchForAccountOp(
 }
 
 export async function refreshAllForProviderOp(
-  provider: UsageProvider
+  provider: UsageProvider,
+  excludeAccountIds?: string[]
 ): Promise<RefreshAllResultItem[]> {
-  return refreshAllForProvider(provider)
+  return refreshAllForProvider(provider, excludeAccountIds)
 }

--- a/src/renderer/src/api/usage-api.ts
+++ b/src/renderer/src/api/usage-api.ts
@@ -12,9 +12,13 @@ export const usageApi = {
     getRendererRpcClient().request<UsageResult>('usageOps.fetch', {}),
   fetchOpenai: async (): Promise<OpenAIUsageResult> =>
     getRendererRpcClient().request<OpenAIUsageResult>('usageOps.fetchOpenai', {}),
-  refreshAllForProvider: async (provider: UsageProvider): Promise<RefreshAllResultItem[]> =>
+  refreshAllForProvider: async (
+    provider: UsageProvider,
+    excludeAccountIds?: string[]
+  ): Promise<RefreshAllResultItem[]> =>
     getRendererRpcClient().request<RefreshAllResultItem[]>('usageOps.refreshAllForProvider', {
-      provider
+      provider,
+      ...(excludeAccountIds ? { excludeAccountIds } : {})
     }),
   fetchForAccount: async (
     accountId: string,

--- a/src/renderer/src/lib/__tests__/auto-switch-score.test.ts
+++ b/src/renderer/src/lib/__tests__/auto-switch-score.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { getMaxUsagePercent, scoreAccountHeadroom } from '../auto-switch-score'
+import {
+  getMaxUsagePercent,
+  isProvablyAtOrAbove,
+  scoreAccountHeadroom
+} from '../auto-switch-score'
 import type { UsageData } from '@shared/types/usage'
 
 const NOW = new Date('2026-07-16T10:00:00.000Z').getTime()
@@ -109,5 +113,44 @@ describe('getMaxUsagePercent', () => {
       seven_day: { utilization: 60, resets_at: PAST }
     }
     expect(getMaxUsagePercent(data, NOW)).toBeNull()
+  })
+})
+
+describe('isProvablyAtOrAbove', () => {
+  it('is true when a window is at/over the threshold with a known future reset', () => {
+    expect(isProvablyAtOrAbove(usage(95, 20), 90, NOW)).toBe(true)
+    expect(isProvablyAtOrAbove(usage(10, 20, [{ label: 'Fable', used_percent: 100 }]), 90, NOW)).toBe(
+      true
+    )
+  })
+
+  it('is false when every window sits below the threshold', () => {
+    expect(isProvablyAtOrAbove(usage(10, 20, [{ label: 'Fable', used_percent: 50 }]), 90, NOW)).toBe(
+      false
+    )
+  })
+
+  it('is false when the over-threshold window already reset', () => {
+    const data: UsageData = {
+      five_hour: { utilization: 100, resets_at: PAST },
+      seven_day: { utilization: 10, resets_at: FUTURE }
+    }
+    expect(isProvablyAtOrAbove(data, 90, NOW)).toBe(false)
+  })
+
+  it('is false when the over-threshold window has no known reset horizon', () => {
+    // Without a reset time there is no guarantee the number still holds — a
+    // cached over-threshold reading must not exclude the account forever.
+    const noHorizon: UsageData = {
+      five_hour: { utilization: 95, resets_at: null },
+      seven_day: { utilization: 10, resets_at: FUTURE }
+    }
+    expect(isProvablyAtOrAbove(noHorizon, 90, NOW)).toBe(false)
+
+    const invalidHorizon: UsageData = {
+      five_hour: { utilization: 95, resets_at: 'not-a-date' },
+      seven_day: { utilization: 10, resets_at: FUTURE }
+    }
+    expect(isProvablyAtOrAbove(invalidHorizon, 90, NOW)).toBe(false)
   })
 })

--- a/src/renderer/src/lib/auto-switch-score.ts
+++ b/src/renderer/src/lib/auto-switch-score.ts
@@ -43,6 +43,32 @@ export function getMaxUsagePercent(usage: UsageData, nowMs: number): number | nu
 }
 
 /**
+ * True when the account provably sits at/over `thresholdPercent` right now:
+ * some window's cached utilization is at/over it AND that window's reset time
+ * is known to still be in the future — utilization only accrues until a
+ * window resets, so a refresh cannot reveal a viable account. A window whose
+ * reset time is null, invalid, or already passed offers no such guarantee and
+ * never qualifies. Used to skip pointless refreshes in the auto-switch sweep.
+ */
+export function isProvablyAtOrAbove(
+  usage: UsageData,
+  thresholdPercent: number,
+  nowMs: number
+): boolean {
+  const windows: WindowLike[] = [
+    usage.five_hour,
+    usage.seven_day,
+    ...(usage.scoped ?? []).map((s) => ({ utilization: s.used_percent, resets_at: s.resets_at }))
+  ]
+  return windows.some((w) => {
+    if (!w || w.utilization < thresholdPercent) return false
+    if (!w.resets_at) return false
+    const resetTime = new Date(w.resets_at).getTime()
+    return !isNaN(resetTime) && resetTime > nowMs
+  })
+}
+
+/**
  * 0-100 "how long will this account last" score used to pick the auto-switch
  * target: a weighted geometric mean of each window's remaining headroom.
  * Geometric (not arithmetic) so a single nearly-exhausted window drags the

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
@@ -213,11 +213,16 @@ describe('useAccountScheduleStore auto-switch', () => {
     await useAccountScheduleStore.getState().checkSchedules()
     expect(refreshAllCalls()).toHaveLength(1)
 
-    // After the delay it re-evaluates, but the refreshed numbers now prove
-    // no account can be viable — it backs off again without sweeping.
+    // After the delay it re-evaluates: the refreshed numbers now prove no
+    // known account can be viable, so the second sweep excludes them all —
+    // it refreshes nothing, but still runs to discover unseen accounts.
     vi.setSystemTime(Date.now() + 5 * 60_000 + 1_000)
     await useAccountScheduleStore.getState().checkSchedules()
-    expect(refreshAllCalls()).toHaveLength(1)
+    expect(refreshAllCalls()).toHaveLength(2)
+    expect(refreshAllCalls()[1][1]).toEqual({
+      provider: 'anthropic',
+      excludeAccountIds: ['acc-1', 'acc-2', 'acc-3']
+    })
     expect(toast.error).toHaveBeenCalledTimes(2)
     expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.notBefore).toBe(
       Date.now() + 5 * 60_000
@@ -282,24 +287,37 @@ describe('useAccountScheduleStore auto-switch', () => {
     expect(switchCalls()[0][1]).toEqual({ accountId: 'acc-2' })
   })
 
-  it('skips the sweep entirely when no account could possibly be viable', async () => {
-    // The only alternative sits at 95% with its window resetting well in the
-    // future — refreshing it cannot make it viable, so no sweep at all.
+  it('still runs the refresh-free sweep when every cached account is excluded, discovering new accounts', async () => {
+    // Every account this renderer knows about is hopeless — but the sweep
+    // still runs (excluding all of them, so it refreshes nothing it knows)
+    // because the main process lists accounts from the DB: an account added
+    // by another window/process gets refreshed and becomes the switch target.
+    useUsageStore.setState({
+      savedAccounts: {
+        anthropic: [
+          makeAccount('acc-1', 'current@x.com', makeUsage(0, 0)),
+          makeAccount('acc-2', 'best@x.com', makeUsage(95, 20))
+        ],
+        openai: []
+      }
+    })
     refreshedAccounts = [
       makeAccount('acc-1', 'current@x.com', makeUsage(0, 0)),
-      makeAccount('acc-2', 'best@x.com', makeUsage(95, 20))
+      makeAccount('acc-2', 'best@x.com', makeUsage(95, 20)),
+      makeAccount('acc-9', 'new@x.com', makeUsage(5, 5))
     ]
-    useUsageStore.setState({ savedAccounts: { anthropic: refreshedAccounts, openai: [] } })
+    refreshResults = [{ accountId: 'acc-9', success: true }]
     useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
 
     await useAccountScheduleStore.getState().checkSchedules()
 
-    expect(refreshAllCalls()).toHaveLength(0)
-    expect(switchCalls()).toHaveLength(0)
-    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Auto-switch'))
-    expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.notBefore).toBe(
-      Date.now() + 5 * 60_000
-    )
+    expect(refreshAllCalls()).toHaveLength(1)
+    expect(refreshAllCalls()[0][1]).toEqual({
+      provider: 'anthropic',
+      excludeAccountIds: ['acc-1', 'acc-2']
+    })
+    expect(switchCalls()).toHaveLength(1)
+    expect(switchCalls()[0][1]).toEqual({ accountId: 'acc-9' })
   })
 
   it('sweeps everything when the saved-account list has not loaded yet', async () => {

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
@@ -252,6 +252,15 @@ describe('useAccountScheduleStore auto-switch', () => {
           five_hour: { utilization: 100, resets_at: pastReset },
           seven_day: { utilization: 10, resets_at: futureReset }
         }
+      },
+      // Over the threshold but with no known reset horizon: there is no
+      // guarantee the number still holds, so it must still be refreshed.
+      {
+        ...makeAccount('acc-6', 'nohorizon@x.com', null),
+        last_usage: {
+          five_hour: { utilization: 95, resets_at: null },
+          seven_day: { utilization: 10, resets_at: futureReset }
+        }
       }
     ]
     useUsageStore.setState({ savedAccounts: { anthropic: refreshedAccounts, openai: [] } })

--- a/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
+++ b/src/renderer/src/stores/__tests__/useAccountScheduleStore.auto-switch.test.ts
@@ -177,14 +177,25 @@ describe('useAccountScheduleStore auto-switch', () => {
     expect(switchCalls()[0][1]).toEqual({ accountId: 'acc-2' })
   })
 
-  it('backs off with a toast when no account is below the threshold', async () => {
+  it('backs off with a toast when the sweep finds no account below the threshold', async () => {
+    // Cached numbers still look viable, but the sweep reveals both
+    // alternatives are over the threshold.
+    useUsageStore.setState({
+      savedAccounts: {
+        anthropic: [
+          makeAccount('acc-1', 'current@x.com', makeUsage(0, 0)),
+          makeAccount('acc-2', 'best@x.com', makeUsage(10, 20)),
+          makeAccount('acc-3', 'meh@x.com', makeUsage(20, 30))
+        ],
+        openai: []
+      }
+    })
     refreshedAccounts = [
       makeAccount('acc-1', 'current@x.com', makeUsage(0, 0)),
       makeAccount('acc-2', 'best@x.com', makeUsage(95, 20)),
       makeAccount('acc-3', 'meh@x.com', makeUsage(20, 91))
     ]
     refreshResults = [
-      { accountId: 'acc-1', success: true },
       { accountId: 'acc-2', success: true },
       { accountId: 'acc-3', success: true }
     ]
@@ -202,10 +213,101 @@ describe('useAccountScheduleStore auto-switch', () => {
     await useAccountScheduleStore.getState().checkSchedules()
     expect(refreshAllCalls()).toHaveLength(1)
 
-    // After the delay it tries again.
+    // After the delay it re-evaluates, but the refreshed numbers now prove
+    // no account can be viable — it backs off again without sweeping.
     vi.setSystemTime(Date.now() + 5 * 60_000 + 1_000)
     await useAccountScheduleStore.getState().checkSchedules()
-    expect(refreshAllCalls()).toHaveLength(2)
+    expect(refreshAllCalls()).toHaveLength(1)
+    expect(toast.error).toHaveBeenCalledTimes(2)
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.notBefore).toBe(
+      Date.now() + 5 * 60_000
+    )
+  })
+
+  it('sweeps only accounts with the potential to be viable', async () => {
+    const futureReset = new Date(Date.now() + 3 * 86_400_000).toISOString()
+    const pastReset = new Date(Date.now() - 3_600_000).toISOString()
+    refreshedAccounts = [
+      // The active account is never a candidate — no point refreshing it.
+      makeAccount('acc-1', 'current@x.com', makeUsage(0, 0)),
+      // Cached usage below the threshold: viable, refresh.
+      makeAccount('acc-2', 'best@x.com', makeUsage(0, 0)),
+      // A scoped (Fable) window at 100% that only resets in 3 days: its
+      // utilization cannot drop before then, so the account provably stays
+      // over the threshold — skip it.
+      {
+        ...makeAccount('acc-3', 'maxed@x.com', null),
+        last_usage: {
+          ...makeUsage(10, 20),
+          scoped: [{ label: 'Fable', used_percent: 100, resets_at: futureReset }]
+        }
+      },
+      // No cached usage at all: could be viable, refresh.
+      makeAccount('acc-4', 'unknown@x.com', null),
+      // Over the threshold, but that window has since reset — its live
+      // usage is unknown, so it could be viable again: refresh.
+      {
+        ...makeAccount('acc-5', 'reset@x.com', null),
+        last_usage: {
+          five_hour: { utilization: 100, resets_at: pastReset },
+          seven_day: { utilization: 10, resets_at: futureReset }
+        }
+      }
+    ]
+    useUsageStore.setState({ savedAccounts: { anthropic: refreshedAccounts, openai: [] } })
+    refreshResults = [
+      { accountId: 'acc-2', success: true },
+      { accountId: 'acc-4', success: true },
+      { accountId: 'acc-5', success: true }
+    ]
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(refreshAllCalls()).toHaveLength(1)
+    expect(refreshAllCalls()[0][1]).toEqual({
+      provider: 'anthropic',
+      excludeAccountIds: ['acc-1', 'acc-3']
+    })
+    expect(switchCalls()).toHaveLength(1)
+    expect(switchCalls()[0][1]).toEqual({ accountId: 'acc-2' })
+  })
+
+  it('skips the sweep entirely when no account could possibly be viable', async () => {
+    // The only alternative sits at 95% with its window resetting well in the
+    // future — refreshing it cannot make it viable, so no sweep at all.
+    refreshedAccounts = [
+      makeAccount('acc-1', 'current@x.com', makeUsage(0, 0)),
+      makeAccount('acc-2', 'best@x.com', makeUsage(95, 20))
+    ]
+    useUsageStore.setState({ savedAccounts: { anthropic: refreshedAccounts, openai: [] } })
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(refreshAllCalls()).toHaveLength(0)
+    expect(switchCalls()).toHaveLength(0)
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Auto-switch'))
+    expect(useAccountScheduleStore.getState().autoSwitch.anthropic?.notBefore).toBe(
+      Date.now() + 5 * 60_000
+    )
+  })
+
+  it('sweeps everything when the saved-account list has not loaded yet', async () => {
+    // Without a loaded list there is nothing to prove non-viability from —
+    // fall back to the full sweep rather than guessing.
+    useUsageStore.setState({
+      savedAccounts: { anthropic: [], openai: [] },
+      savedAccountsLoaded: { anthropic: false, openai: false }
+    })
+    useAccountScheduleStore.getState().setAutoSwitch('anthropic', 90)
+
+    await useAccountScheduleStore.getState().checkSchedules()
+
+    expect(refreshAllCalls()).toHaveLength(1)
+    expect(refreshAllCalls()[0][1]).toEqual({ provider: 'anthropic' })
+    expect(switchCalls()).toHaveLength(1)
+    expect(switchCalls()[0][1]).toEqual({ accountId: 'acc-2' })
   })
 
   it('keeps auto-switch enabled and backs off when the switch attempt fails', async () => {

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -8,7 +8,11 @@ import type {
   UsageProvider
 } from '@shared/types/usage'
 import { toast } from '@/lib/toast'
-import { getMaxUsagePercent, scoreAccountHeadroom } from '@/lib/auto-switch-score'
+import {
+  getMaxUsagePercent,
+  isProvablyAtOrAbove,
+  scoreAccountHeadroom
+} from '@/lib/auto-switch-score'
 import { useUsageStore, normalizeUsage } from './useUsageStore'
 import { useAccountStore } from './useAccountStore'
 
@@ -249,13 +253,14 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
 
               // Refresh saved accounts so the pick is based on live numbers —
               // but only the ones with a chance of being viable. A usage
-              // window that hasn't reset yet only ever accrues, so an account
-              // whose cached utilization is already at/over the threshold
-              // provably stays there: refreshing it is a wasted request.
-              // Unknown or reset-expired usage stays in (it could be viable),
-              // and the active account is skipped (it is never a candidate).
-              // Before the first successful account-list load there is nothing
-              // to prove non-viability from — fall back to the full sweep.
+              // window only accrues until its (known, future) reset time, so
+              // an account whose cached utilization is already at/over the
+              // threshold provably stays there: refreshing it is a wasted
+              // request. Anything short of that proof — unknown usage, a
+              // passed or missing reset time — stays in the sweep, and the
+              // active account is skipped (it is never a candidate). Before
+              // the first successful account-list load there is nothing to
+              // prove non-viability from — fall back to the full sweep.
               const usageState = useUsageStore.getState()
               let excludeAccountIds: string[] | undefined
               if (usageState.savedAccountsLoaded[provider]) {
@@ -266,8 +271,7 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
                     if (a.email === activeEmail) return true
                     const usage = savedAccountUsage(provider, a)
                     if (!usage) return false
-                    const maxPercent = getMaxUsagePercent(usage, nowMs)
-                    return maxPercent !== null && maxPercent >= auto.thresholdPercent
+                    return isProvablyAtOrAbove(usage, auto.thresholdPercent, nowMs)
                   })
                   .map((a) => a.id)
 

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -30,9 +30,10 @@ export interface ScheduledSwitch {
 
 /**
  * Provider-global "keep me on whichever account has the most headroom" mode:
- * when the ACTIVE account crosses thresholdPercent, refresh every saved
- * account and hop to the best-scoring one — then stay armed for the next
- * crossing. Mutually exclusive with a per-account ScheduledSwitch.
+ * when the ACTIVE account crosses thresholdPercent, refresh the saved
+ * accounts that could plausibly be viable and hop to the best-scoring one —
+ * then stay armed for the next crossing. Mutually exclusive with a
+ * per-account ScheduledSwitch.
  */
 export interface AutoSwitchConfig {
   provider: UsageProvider
@@ -246,12 +247,47 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
                 continue
               }
 
-              // Refresh every saved account so the pick is based on live
-              // numbers — and so we know which fetches actually succeeded.
+              // Refresh saved accounts so the pick is based on live numbers —
+              // but only the ones with a chance of being viable. A usage
+              // window that hasn't reset yet only ever accrues, so an account
+              // whose cached utilization is already at/over the threshold
+              // provably stays there: refreshing it is a wasted request.
+              // Unknown or reset-expired usage stays in (it could be viable),
+              // and the active account is skipped (it is never a candidate).
+              // Before the first successful account-list load there is nothing
+              // to prove non-viability from — fall back to the full sweep.
+              const usageState = useUsageStore.getState()
+              let excludeAccountIds: string[] | undefined
+              if (usageState.savedAccountsLoaded[provider]) {
+                const saved = usageState.savedAccounts[provider]
+                const nowMs = Date.now()
+                excludeAccountIds = saved
+                  .filter((a) => {
+                    if (a.email === activeEmail) return true
+                    const usage = savedAccountUsage(provider, a)
+                    if (!usage) return false
+                    const maxPercent = getMaxUsagePercent(usage, nowMs)
+                    return maxPercent !== null && maxPercent >= auto.thresholdPercent
+                  })
+                  .map((a) => a.id)
+
+                if (saved.length > 0 && excludeAccountIds.length === saved.length) {
+                  // Every account is either the active one or provably over
+                  // the threshold — nothing worth refreshing, nothing to hop to.
+                  toast.error(
+                    `Auto-switch: no other account below ${auto.thresholdPercent}% usage to switch to`
+                  )
+                  backOff()
+                  continue
+                }
+              }
+
               let results: RefreshAllResultItem[] | null = null
               let sweepFailed = false
               try {
-                results = await useUsageStore.getState().refreshAllForProvider(provider)
+                results = await useUsageStore
+                  .getState()
+                  .refreshAllForProvider(provider, excludeAccountIds)
               } catch {
                 sweepFailed = true
               }

--- a/src/renderer/src/stores/useAccountScheduleStore.ts
+++ b/src/renderer/src/stores/useAccountScheduleStore.ts
@@ -274,17 +274,11 @@ export const useAccountScheduleStore = create<AccountScheduleState>()(
                     return isProvablyAtOrAbove(usage, auto.thresholdPercent, nowMs)
                   })
                   .map((a) => a.id)
-
-                if (saved.length > 0 && excludeAccountIds.length === saved.length) {
-                  // Every account is either the active one or provably over
-                  // the threshold — nothing worth refreshing, nothing to hop to.
-                  toast.error(
-                    `Auto-switch: no other account below ${auto.thresholdPercent}% usage to switch to`
-                  )
-                  backOff()
-                  continue
-                }
               }
+              // Even when every known account is excluded the (then refresh-
+              // free) sweep still runs: the main process lists accounts from
+              // the DB, so it refreshes anything this renderer hasn't seen
+              // yet, and the post-sweep reload revalidates the cached list.
 
               let results: RefreshAllResultItem[] | null = null
               let sweepFailed = false

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -50,7 +50,10 @@ interface UsageState {
   loadSavedAccounts: (provider?: UsageProvider) => Promise<void>
   /** Resolves with the per-account fetch outcomes, or null when a sweep for
    * the provider was already running (nothing was refreshed by this call). */
-  refreshAllForProvider: (provider: UsageProvider) => Promise<RefreshAllResultItem[] | null>
+  refreshAllForProvider: (
+    provider: UsageProvider,
+    excludeAccountIds?: string[]
+  ) => Promise<RefreshAllResultItem[] | null>
   refreshSavedAccount: (id: string, opts?: { userInitiated?: boolean }) => Promise<void>
   removeSavedAccount: (id: string) => Promise<void>
   /** Resolves true when the switch op succeeded (failures also toast). */
@@ -133,18 +136,21 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
     }
   },
 
-  refreshAllForProvider: async (provider: UsageProvider) => {
+  refreshAllForProvider: async (provider: UsageProvider, excludeAccountIds?: string[]) => {
     const state = get()
     if (state.refreshingProviders[provider]) return null
 
-    const accountIds = state.savedAccounts[provider].map((account) => account.id)
+    const excluded = new Set(excludeAccountIds ?? [])
+    const accountIds = state.savedAccounts[provider]
+      .filter((account) => !excluded.has(account.id))
+      .map((account) => account.id)
     set((current) => ({
       refreshingProviders: { ...current.refreshingProviders, [provider]: true },
       refreshingAccountIds: new Set([...current.refreshingAccountIds, ...accountIds])
     }))
 
     try {
-      const results = await usageApi.refreshAllForProvider(provider)
+      const results = await usageApi.refreshAllForProvider(provider, excludeAccountIds)
       await get().loadSavedAccounts(provider)
       return results
     } finally {

--- a/src/server/__tests__/usage-rpc.mock-provider.test.ts
+++ b/src/server/__tests__/usage-rpc.mock-provider.test.ts
@@ -276,11 +276,35 @@ describe('usage ops RPC mocked provider', () => {
       })
     )
 
-    expect(refreshAllForProvider).toHaveBeenCalledWith('openai')
+    expect(refreshAllForProvider).toHaveBeenCalledWith('openai', undefined)
     expect(response).toEqual({
       id: 'usage-refresh-all-for-provider-1',
       ok: true,
       value: result
+    })
+  })
+
+  it('passes excludeAccountIds through to the injected provider service', async () => {
+    const refreshAllForProvider = vi.fn(() => Effect.succeed([]))
+    const service = { refreshAllForProvider } as unknown as UsageOpsRpcService
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      usageOps: service
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'usage-refresh-all-for-provider-exclude',
+        method: 'usageOps.refreshAllForProvider',
+        params: { provider: 'anthropic', excludeAccountIds: ['account-1', 'account-2'] }
+      })
+    )
+
+    expect(refreshAllForProvider).toHaveBeenCalledWith('anthropic', ['account-1', 'account-2'])
+    expect(response).toEqual({
+      id: 'usage-refresh-all-for-provider-exclude',
+      ok: true,
+      value: []
     })
   })
 

--- a/src/server/rpc/domains/usage-ops.ts
+++ b/src/server/rpc/domains/usage-ops.ts
@@ -23,7 +23,8 @@ export interface UsageOpsRpcService {
     userInitiated?: boolean
   ) => Effect.Effect<FetchForAccountResult, unknown, never>
   readonly refreshAllForProvider: (
-    provider: UsageProvider
+    provider: UsageProvider,
+    excludeAccountIds?: string[]
   ) => Effect.Effect<RefreshAllResultItem[], unknown, never>
 }
 
@@ -32,7 +33,10 @@ const fetchForAccountParamsSchema = z
   .object({ accountId: z.string(), userInitiated: z.boolean().optional() })
   .strict()
 const refreshAllForProviderParamsSchema = z
-  .object({ provider: z.enum(['anthropic', 'openai']) })
+  .object({
+    provider: z.enum(['anthropic', 'openai']),
+    excludeAccountIds: z.array(z.string()).optional()
+  })
   .strict()
 
 export const makeLiveUsageOpsRpcService = (): UsageOpsRpcService => ({
@@ -51,9 +55,9 @@ export const makeLiveUsageOpsRpcService = (): UsageOpsRpcService => ({
       try: () => fetchForAccountOp(accountId, userInitiated),
       catch: (cause) => cause
     }),
-  refreshAllForProvider: (provider) =>
+  refreshAllForProvider: (provider, excludeAccountIds) =>
     Effect.tryPromise({
-      try: () => refreshAllForProviderOp(provider),
+      try: () => refreshAllForProviderOp(provider, excludeAccountIds),
       catch: (cause) => cause
     })
 })
@@ -99,11 +103,11 @@ export const makeUsageOpsRpcHandlers = (
       'usageOps.refreshAllForProvider',
       (params) =>
         Effect.gen(function* () {
-          const { provider } = yield* Effect.try({
+          const { provider, excludeAccountIds } = yield* Effect.try({
             try: () => refreshAllForProviderParamsSchema.parse(params),
             catch: (cause) => cause
           })
-          return yield* service.refreshAllForProvider(provider)
+          return yield* service.refreshAllForProvider(provider, excludeAccountIds)
         })
     ]
   ])

--- a/test/phase-12/renderer-api-cleanup.test.ts
+++ b/test/phase-12/renderer-api-cleanup.test.ts
@@ -9327,7 +9327,7 @@ describe('renderer API cleanup', () => {
       'utf-8'
     )
     const actionStart = source.indexOf(
-      'refreshAllForProvider: async (provider: UsageProvider) => {'
+      'refreshAllForProvider: async (provider: UsageProvider, excludeAccountIds?: string[]) => {'
     )
     const actionEnd = source.indexOf('  refreshSavedAccount:', actionStart)
     const actionSource = source.slice(actionStart, actionEnd)
@@ -9335,7 +9335,9 @@ describe('renderer API cleanup', () => {
     expect(actionStart).toBeGreaterThan(-1)
     expect(actionEnd).toBeGreaterThan(actionStart)
     expect(source).toContain("import { usageApi } from '@/api/usage-api'")
-    expect(actionSource).toContain('await usageApi.refreshAllForProvider(provider)')
+    expect(actionSource).toContain(
+      'await usageApi.refreshAllForProvider(provider, excludeAccountIds)'
+    )
     expect(actionSource).toContain('await get().loadSavedAccounts(provider)')
     expect(actionSource).not.toContain('window.usageOps.refreshAllForProvider')
     expect(actionSource).not.toContain('unwrapEnvelope(await window.usageOps.refreshAllForProvider')


### PR DESCRIPTION
## Summary
- Skip refreshing accounts that cannot fall below the auto-switch threshold before their usage window resets.
- Exclude the active account and pass excluded IDs through the renderer, RPC, and usage services.
- Add coverage for selective sweeps, empty candidate sets, unloaded account lists, and RPC propagation.

## Testing
- Added and updated auto-switch store tests.
- Added RPC mock-provider coverage for `excludeAccountIds` propagation.
- Updated renderer API cleanup assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when per-account OAuth usage fetches run during auto-switch; conservative exclusion rules limit wrong skips, but mistaken viability logic could miss a switch target or leave unnecessary refreshes.
> 
> **Overview**
> **Auto-switch** no longer refreshes every saved account when the active account crosses the usage threshold. It builds an **`excludeAccountIds`** list (active account plus accounts whose cached usage is **provably** at or above the threshold until a known future window reset) and only refreshes the rest.
> 
> Adds **`isProvablyAtOrAbove`** in `auto-switch-score.ts` for that proof; accounts with missing usage, stale resets, or unknown reset horizons are still refreshed. If the saved-account list has not loaded yet, behavior falls back to a full sweep. The sweep still runs when every known account is excluded so the main process can refresh accounts only present in the DB.
> 
> **`excludeAccountIds`** is threaded through the renderer store/API, RPC (`usageOps.refreshAllForProvider`), and **`refreshAllForProvider`** in the saved-usage orchestrator (with logging of skipped IDs). Tests cover selective sweeps, backoff retries, new-account discovery, and RPC propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaa5df99e7b11b5e26c9a185cc8b4ea80946c1ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->