### PR TITLE
Reopen completed tickets on explicit follow-up sends

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -2226,6 +2226,14 @@ function PlanReviewModeContent({
     const columnBeforeImplement = ticket.column
     const restoreTerminalColumn = (): void => {
       if (columnBeforeImplement !== 'done' && columnBeforeImplement !== 'merged') return
+      // Only undo our own optimistic reopen. The failure can land seconds
+      // later — if the user or a session event moved the ticket again in the
+      // meantime, that newer transition wins.
+      const current = useKanbanStore
+        .getState()
+        .tickets.get(ticket.project_id)
+        ?.find((t) => t.id === ticket.id)
+      if (current?.column !== 'in_progress') return
       useKanbanStore
         .getState()
         .moveTicket(ticket.id, ticket.project_id, columnBeforeImplement, ticket.sort_order)

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -2227,10 +2227,13 @@ function PlanReviewModeContent({
       useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
       await useSessionStore.getState().setSessionMode(sessionId, 'build')
       lastSendMode.set(sessionId, 'build')
-      useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+      // Send bookkeeping must precede setSessionStatus so the working
+      // transition it causes consumes the explicit-send stamp — a stamp left
+      // unconsumed would mark a later status replay as an explicit send.
       messageSendTimes.set(sessionId, Date.now())
       userExplicitSendTimes.set(sessionId, Date.now())
       snapshotTokenBaseline(sessionId)
+      useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
 
       // Clear plan_ready badge — ticket is back to working
       await useKanbanStore

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -59,12 +59,7 @@ import { MarkdownRenderer } from '../sessions/MarkdownRenderer'
 import { HandoffSplitButton } from '../sessions/HandoffSplitButton'
 import { IndeterminateProgressBar } from '@/components/sessions/IndeterminateProgressBar'
 import { cn } from '@/lib/utils'
-import {
-  clearPendingSessionReopens,
-  parseTicketKey,
-  ticketKey,
-  useKanbanStore
-} from '@/stores/useKanbanStore'
+import { parseTicketKey, ticketKey, useKanbanStore } from '@/stores/useKanbanStore'
 import { BOARD_TAB_ID, useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -2313,7 +2308,6 @@ function PlanReviewModeContent({
           toast.error(`Failed to start implementation: ${reason}`)
           if (implementAttemptSuperseded()) return
           useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
-          clearPendingSessionReopens(sessionId)
           restoreTerminalColumn()
         })
         return
@@ -2337,7 +2331,6 @@ function PlanReviewModeContent({
           toast.error('Failed to approve plan: working path not found')
           if (!implementAttemptSuperseded()) {
             useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
-            clearPendingSessionReopens(sessionId)
             restoreTerminalColumn()
           }
           return
@@ -2355,7 +2348,6 @@ function PlanReviewModeContent({
       toast.error(`Failed to start implementation: ${reason}`)
       if (!implementAttemptSuperseded()) {
         useWorktreeStatusStore.getState().clearSessionStatus(ticket.current_session_id)
-        clearPendingSessionReopens(ticket.current_session_id)
         restoreTerminalColumn()
       }
     } finally {

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -2234,17 +2234,18 @@ function PlanReviewModeContent({
     const columnBeforeImplement = ticket.column
     // Generation of this attempt. Every send path bumps messageSendTimes, and
     // every send, hook event, or auto-resume rewrites the session-status
-    // entry — so if either differs at failure time, something newer owns the
-    // session and the late failure must not clear its status or roll the
-    // ticket back under it.
+    // entry with a fresh object — so if either differs at failure time,
+    // something newer owns the session and the late failure must not clear
+    // its status or roll the ticket back under it. The entry is compared by
+    // identity (not timestamp) so even a same-millisecond newer transition is
+    // detected.
     let sendStampAtImplement: number | undefined
-    let statusStampAtImplement: number | undefined
+    let statusEntryAtImplement: unknown
     const implementAttemptSuperseded = (): boolean => {
       const sessionId = ticket.current_session_id
       if (sessionId == null) return false
       if (messageSendTimes.get(sessionId) !== sendStampAtImplement) return true
-      const entry = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-      return entry?.timestamp !== statusStampAtImplement
+      return useWorktreeStatusStore.getState().sessionStatuses[sessionId] !== statusEntryAtImplement
     }
     const restoreTerminalColumn = (): void => {
       if (columnBeforeImplement !== 'done' && columnBeforeImplement !== 'merged') return
@@ -2280,8 +2281,7 @@ function PlanReviewModeContent({
       snapshotTokenBaseline(sessionId)
       sendStampAtImplement = messageSendTimes.get(sessionId)
       useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
-      statusStampAtImplement =
-        useWorktreeStatusStore.getState().sessionStatuses[sessionId]?.timestamp
+      statusEntryAtImplement = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
 
       // Clear plan_ready badge — ticket is back to working
       await useKanbanStore

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -2258,7 +2258,9 @@ function PlanReviewModeContent({
       if (current?.column !== 'in_progress') return
       useKanbanStore
         .getState()
-        .moveTicket(ticket.id, ticket.project_id, columnBeforeImplement, ticket.sort_order)
+        .moveTicket(ticket.id, ticket.project_id, columnBeforeImplement, ticket.sort_order, {
+          skipCompletionEffects: true
+        })
         .catch(() => {})
     }
 

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -59,7 +59,12 @@ import { MarkdownRenderer } from '../sessions/MarkdownRenderer'
 import { HandoffSplitButton } from '../sessions/HandoffSplitButton'
 import { IndeterminateProgressBar } from '@/components/sessions/IndeterminateProgressBar'
 import { cn } from '@/lib/utils'
-import { parseTicketKey, ticketKey, useKanbanStore } from '@/stores/useKanbanStore'
+import {
+  clearPendingSessionReopens,
+  parseTicketKey,
+  ticketKey,
+  useKanbanStore
+} from '@/stores/useKanbanStore'
 import { BOARD_TAB_ID, useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -2308,6 +2313,7 @@ function PlanReviewModeContent({
           toast.error(`Failed to start implementation: ${reason}`)
           if (implementAttemptSuperseded()) return
           useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+          clearPendingSessionReopens(sessionId)
           restoreTerminalColumn()
         })
         return
@@ -2331,6 +2337,7 @@ function PlanReviewModeContent({
           toast.error('Failed to approve plan: working path not found')
           if (!implementAttemptSuperseded()) {
             useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+            clearPendingSessionReopens(sessionId)
             restoreTerminalColumn()
           }
           return
@@ -2348,6 +2355,7 @@ function PlanReviewModeContent({
       toast.error(`Failed to start implementation: ${reason}`)
       if (!implementAttemptSuperseded()) {
         useWorktreeStatusStore.getState().clearSessionStatus(ticket.current_session_id)
+        clearPendingSessionReopens(ticket.current_session_id)
         restoreTerminalColumn()
       }
     } finally {

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -2232,14 +2232,20 @@ function PlanReviewModeContent({
     // implementation fails, put the ticket back in its terminal column — an
     // in_progress ticket with no running session is a lie on the board.
     const columnBeforeImplement = ticket.column
-    // Send generation at the time of this attempt. Every send path bumps
-    // messageSendTimes, so a mismatch at failure time means a newer send owns
-    // the session — the late failure must not clear its status or roll the
+    // Generation of this attempt. Every send path bumps messageSendTimes, and
+    // every send, hook event, or auto-resume rewrites the session-status
+    // entry — so if either differs at failure time, something newer owns the
+    // session and the late failure must not clear its status or roll the
     // ticket back under it.
     let sendStampAtImplement: number | undefined
-    const implementAttemptSuperseded = (): boolean =>
-      ticket.current_session_id != null &&
-      messageSendTimes.get(ticket.current_session_id) !== sendStampAtImplement
+    let statusStampAtImplement: number | undefined
+    const implementAttemptSuperseded = (): boolean => {
+      const sessionId = ticket.current_session_id
+      if (sessionId == null) return false
+      if (messageSendTimes.get(sessionId) !== sendStampAtImplement) return true
+      const entry = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
+      return entry?.timestamp !== statusStampAtImplement
+    }
     const restoreTerminalColumn = (): void => {
       if (columnBeforeImplement !== 'done' && columnBeforeImplement !== 'merged') return
       // Only undo our own optimistic reopen. The failure can land seconds
@@ -2272,6 +2278,8 @@ function PlanReviewModeContent({
       snapshotTokenBaseline(sessionId)
       sendStampAtImplement = messageSendTimes.get(sessionId)
       useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+      statusStampAtImplement =
+        useWorktreeStatusStore.getState().sessionStatuses[sessionId]?.timestamp
 
       // Clear plan_ready badge — ticket is back to working
       await useKanbanStore

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -402,6 +402,12 @@ async function sendFollowupToSession(opts: {
   followUpMode: FollowUpMode
   ticketId: string
   attachments?: Attachment[]
+  /**
+   * Caller already wrote the send stamps + working status for this attempt
+   * (and may use its messageSendTimes stamp as a generation token to detect
+   * newer sends) — don't overwrite them here.
+   */
+  skipSendBookkeeping?: boolean
 }): Promise<void> {
   const result = await findSessionById(opts.sessionId)
   if (!result) {
@@ -440,13 +446,15 @@ async function sendFollowupToSession(opts: {
     useSessionStore.getState().setSessionMode(opts.sessionId, 'plan')
   }
 
-  messageSendTimes.set(opts.sessionId, Date.now())
-  userExplicitSendTimes.set(opts.sessionId, Date.now())
-  snapshotTokenBaseline(opts.sessionId)
-  lastSendMode.set(opts.sessionId, completionSendMode(opts.followUpMode))
-  useWorktreeStatusStore
-    .getState()
-    .setSessionStatus(opts.sessionId, isPlanLike(opts.followUpMode) ? 'planning' : 'working')
+  if (!opts.skipSendBookkeeping) {
+    messageSendTimes.set(opts.sessionId, Date.now())
+    userExplicitSendTimes.set(opts.sessionId, Date.now())
+    snapshotTokenBaseline(opts.sessionId)
+    lastSendMode.set(opts.sessionId, completionSendMode(opts.followUpMode))
+    useWorktreeStatusStore
+      .getState()
+      .setSessionStatus(opts.sessionId, isPlanLike(opts.followUpMode) ? 'planning' : 'working')
+  }
   bumpWorktreeLastMessage({
     worktreeId: session.worktree_id,
     connectionId: session.connection_id ?? connectionId
@@ -2224,6 +2232,14 @@ function PlanReviewModeContent({
     // implementation fails, put the ticket back in its terminal column — an
     // in_progress ticket with no running session is a lie on the board.
     const columnBeforeImplement = ticket.column
+    // Send generation at the time of this attempt. Every send path bumps
+    // messageSendTimes, so a mismatch at failure time means a newer send owns
+    // the session — the late failure must not clear its status or roll the
+    // ticket back under it.
+    let sendStampAtImplement: number | undefined
+    const implementAttemptSuperseded = (): boolean =>
+      ticket.current_session_id != null &&
+      messageSendTimes.get(ticket.current_session_id) !== sendStampAtImplement
     const restoreTerminalColumn = (): void => {
       if (columnBeforeImplement !== 'done' && columnBeforeImplement !== 'merged') return
       // Only undo our own optimistic reopen. The failure can land seconds
@@ -2254,6 +2270,7 @@ function PlanReviewModeContent({
       messageSendTimes.set(sessionId, Date.now())
       userExplicitSendTimes.set(sessionId, Date.now())
       snapshotTokenBaseline(sessionId)
+      sendStampAtImplement = messageSendTimes.get(sessionId)
       useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
 
       // Clear plan_ready badge — ticket is back to working
@@ -2273,11 +2290,13 @@ function PlanReviewModeContent({
             pendingBeforeAction.planContent
           ),
           followUpMode: 'build',
-          ticketId: ticket.id
+          ticketId: ticket.id,
+          skipSendBookkeeping: true
         }).catch((err) => {
           const reason = err instanceof Error ? err.message : String(err)
           console.error('[KanbanTicketModal] background implement send failed:', err)
           toast.error(`Failed to start implementation: ${reason}`)
+          if (implementAttemptSuperseded()) return
           useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
           restoreTerminalColumn()
         })
@@ -2300,8 +2319,10 @@ function PlanReviewModeContent({
             `[KanbanTicketModal] handleImplement: working path not found — worktree_id=${sessionRecord.worktree_id}, connection_id=${sessionRecord.connection_id}`
           )
           toast.error('Failed to approve plan: working path not found')
-          useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
-          restoreTerminalColumn()
+          if (!implementAttemptSuperseded()) {
+            useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+            restoreTerminalColumn()
+          }
           return
         }
         unwrapEnvelope(
@@ -2315,8 +2336,10 @@ function PlanReviewModeContent({
       const reason = err instanceof Error ? err.message : String(err)
       console.error('[KanbanTicketModal] handleImplement failed:', err)
       toast.error(`Failed to start implementation: ${reason}`)
-      useWorktreeStatusStore.getState().clearSessionStatus(ticket.current_session_id)
-      restoreTerminalColumn()
+      if (!implementAttemptSuperseded()) {
+        useWorktreeStatusStore.getState().clearSessionStatus(ticket.current_session_id)
+        restoreTerminalColumn()
+      }
     } finally {
       setIsActioning(false)
     }

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -2219,6 +2219,19 @@ function PlanReviewModeContent({
     if (!ticket.current_session_id || isActioning) return
     setIsActioning(true)
 
+    // The working status + implement event below reopen a done/merged ticket
+    // before the approval/dispatch actually succeeds. If starting the
+    // implementation fails, put the ticket back in its terminal column — an
+    // in_progress ticket with no running session is a lie on the board.
+    const columnBeforeImplement = ticket.column
+    const restoreTerminalColumn = (): void => {
+      if (columnBeforeImplement !== 'done' && columnBeforeImplement !== 'merged') return
+      useKanbanStore
+        .getState()
+        .moveTicket(ticket.id, ticket.project_id, columnBeforeImplement, ticket.sort_order)
+        .catch(() => {})
+    }
+
     try {
       const sessionId = ticket.current_session_id
       const pendingBeforeAction = pendingPlan
@@ -2258,6 +2271,7 @@ function PlanReviewModeContent({
           console.error('[KanbanTicketModal] background implement send failed:', err)
           toast.error(`Failed to start implementation: ${reason}`)
           useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+          restoreTerminalColumn()
         })
         return
       }
@@ -2278,6 +2292,8 @@ function PlanReviewModeContent({
             `[KanbanTicketModal] handleImplement: working path not found — worktree_id=${sessionRecord.worktree_id}, connection_id=${sessionRecord.connection_id}`
           )
           toast.error('Failed to approve plan: working path not found')
+          useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+          restoreTerminalColumn()
           return
         }
         unwrapEnvelope(
@@ -2292,6 +2308,7 @@ function PlanReviewModeContent({
       console.error('[KanbanTicketModal] handleImplement failed:', err)
       toast.error(`Failed to start implementation: ${reason}`)
       useWorktreeStatusStore.getState().clearSessionStatus(ticket.current_session_id)
+      restoreTerminalColumn()
     } finally {
       setIsActioning(false)
     }
@@ -2299,6 +2316,8 @@ function PlanReviewModeContent({
     ticket.current_session_id,
     ticket.id,
     ticket.project_id,
+    ticket.column,
+    ticket.sort_order,
     isActioning,
     pendingPlan,
     sessionRecord,

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -56,7 +56,10 @@ import { useBashRuns } from '@/hooks/useBashRuns'
 import type { FlatFile } from '@/lib/file-search-utils'
 import { useSessionStore } from '@/stores/useSessionStore'
 import type { CodexThreadGoal } from '@/stores/useSessionStore'
-import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import {
+  markNextWorkingStatusExplicit,
+  useWorktreeStatusStore
+} from '@/stores/useWorktreeStatusStore'
 import { useContextStore } from '@/stores/useContextStore'
 import { maybeExtractJsonTitle } from '@shared/title-utils'
 import {
@@ -2996,6 +2999,10 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
                 mode: 'build'
               })
               lastSendMode.set(sessionId, 'build')
+              // Queued follow-ups are user-authored; the one-shot marker lets
+              // this working transition reopen a done/merged ticket without
+              // restarting the elapsed timer (userExplicitSendTimes stays).
+              markNextWorkingStatusExplicit(sessionId)
               useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
               lastSentPromptRef.current = message
             },

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -4948,11 +4948,14 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
 
         // The SDK resumes within the same prompt cycle after plan approval —
         // it won't emit a new session.status:busy event. Set status explicitly.
+        // The send stamp must precede setSessionStatus so its working
+        // transition consumes it (an unconsumed stamp would mark a later
+        // status replay as an explicit send).
+        userExplicitSendTimes.set(sessionId, Date.now())
+        snapshotTokenBaseline(sessionId)
         useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
         setIsStreaming(true)
         setIsSending(true)
-        userExplicitSendTimes.set(sessionId, Date.now())
-        snapshotTokenBaseline(sessionId)
 
         // Transition the ExitPlanMode tool card to "accepted" state
         updateStreamingPartsRef((parts) =>

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -3,7 +3,10 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import type { CodexThreadGoal } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useGitStore } from '@/stores/useGitStore'
-import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import {
+  markNextWorkingStatusExplicit,
+  useWorktreeStatusStore
+} from '@/stores/useWorktreeStatusStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useQuestionStore } from '@/stores/useQuestionStore'
 import { usePermissionStore } from '@/stores/usePermissionStore'
@@ -695,6 +698,10 @@ export function useOpenCodeGlobalListener(): void {
             source: 'other'
           })
           lastSendMode.set(sessionId, isPlanLike(mode) ? 'plan' : 'build')
+          // Queued follow-ups are user-authored; the one-shot marker lets
+          // this working transition reopen a done/merged ticket without
+          // restarting the elapsed timer (userExplicitSendTimes stays).
+          markNextWorkingStatusExplicit(sessionId)
           useWorktreeStatusStore
             .getState()
             .setSessionStatus(sessionId, isPlanLike(mode) ? 'planning' : 'working')

--- a/src/renderer/src/stores/store-coordination.ts
+++ b/src/renderer/src/stores/store-coordination.ts
@@ -37,7 +37,7 @@ export function clearConnectionSelection(): void {
 // importing useKanbanStore.
 
 export interface KanbanSessionEvent {
-  type: 'session_completed' | 'session_error' | 'plan_ready' | 'plan_followup' | 'supercharge' | 'mode_change' | 'implement' | 'session_working'
+  type: 'session_completed' | 'session_error' | 'plan_ready' | 'plan_followup' | 'supercharge' | 'mode_change' | 'implement' | 'session_working' | 'status_cleared'
   /** The mode the session was running in (build / plan) — relevant for completed events */
   sessionMode?: 'build' | 'plan'
   /** For supercharge: the newly-created session that replaces the old one */

--- a/src/renderer/src/stores/store-coordination.ts
+++ b/src/renderer/src/stores/store-coordination.ts
@@ -42,6 +42,14 @@ export interface KanbanSessionEvent {
   sessionMode?: 'build' | 'plan'
   /** For supercharge: the newly-created session that replaces the old one */
   newSessionId?: string
+  /**
+   * For session_working: the status change was caused by a user-initiated
+   * message send (composer/modal send, or a non-task-notification
+   * UserPromptSubmit hook) rather than a status replay or streaming activity.
+   * Only explicit sends may pull a ticket out of the terminal done/merged
+   * columns.
+   */
+  explicitSend?: boolean
   /** Tokens consumed during the session — accumulated to the ticket's persistent total */
   tokenDelta?: number
 }

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -19,7 +19,7 @@ vi.mock('./useSettingsStore', () => ({
   useSettingsStore: { getState: () => ({ followUpTriggerColumn: 'done' }) }
 }))
 
-import { clearPendingSessionReopens, useKanbanStore } from './useKanbanStore'
+import { useKanbanStore } from './useKanbanStore'
 import { markNextWorkingStatusExplicit, useWorktreeStatusStore } from './useWorktreeStatusStore'
 import { kanbanApi } from '@/api/kanban-api'
 import { userExplicitSendTimes } from '@/lib/message-send-times'
@@ -601,8 +601,9 @@ describe('reconcileFinishedSessions — recovers explicit reopens missed while u
     useKanbanStore.getState().syncTicketWithSession(sessionId, { type: 'implement' })
     await flush()
 
-    // The dispatch failed and the failure path rolled the attempt back.
-    clearPendingSessionReopens(sessionId)
+    // The dispatch failed: the failure path clears the session status, which
+    // notifies status_cleared and drops the pending recoveries.
+    useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
 
     seed(makeTicket({ column: 'done', mode: 'plan', current_session_id: sessionId }))
     setSessionStatus(sessionId, 'working')

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -22,6 +22,7 @@ vi.mock('./useSettingsStore', () => ({
 import { useKanbanStore } from './useKanbanStore'
 import { useWorktreeStatusStore } from './useWorktreeStatusStore'
 import { kanbanApi } from '@/api/kanban-api'
+import { userExplicitSendTimes } from '@/lib/message-send-times'
 import type { SessionStatusType } from '@shared/types/session-status'
 
 const SESSION_ID = 'sess-1'
@@ -287,5 +288,116 @@ describe('syncTicketWithSession — implement consumes auto-approve', () => {
       mode: 'build',
       auto_approve_plan: false
     })
+  })
+})
+
+describe('syncTicketWithSession — explicit follow-up reopens done/merged tickets', () => {
+  it('moves a done ticket to in_progress on session_working with explicitSend', async () => {
+    seed(makeTicket({ column: 'done' }))
+
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(SESSION_ID, { type: 'session_working', explicitSend: true })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
+    expect(kanbanApi.ticket.move).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', 'in_progress', 0)
+  })
+
+  it('moves a merged ticket to in_progress on session_working with explicitSend', async () => {
+    seed(makeTicket({ column: 'merged' }))
+
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(SESSION_ID, { type: 'session_working', explicitSend: true })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
+  })
+
+  it('does not move a done ticket on session_working without explicitSend', async () => {
+    seed(makeTicket({ column: 'done' }))
+
+    useKanbanStore.getState().syncTicketWithSession(SESSION_ID, { type: 'session_working' })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('done')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+
+  it('does not move a merged ticket on session_working with explicitSend false', async () => {
+    seed(makeTicket({ column: 'merged' }))
+
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(SESSION_ID, { type: 'session_working', explicitSend: false })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('merged')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+})
+
+describe('setSessionStatus → session_working explicitSend derivation', () => {
+  beforeEach(() => {
+    userExplicitSendTimes.clear()
+  })
+
+  afterEach(() => {
+    userExplicitSendTimes.clear()
+  })
+
+  it('reopens a done ticket when working follows a recent explicit send', async () => {
+    seed(makeTicket({ column: 'done' }))
+    userExplicitSendTimes.set(SESSION_ID, Date.now())
+
+    useWorktreeStatusStore.getState().setSessionStatus(SESSION_ID, 'working')
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
+  })
+
+  it('reopens a merged ticket on a UserPromptSubmit hook (terminal-typed prompt)', async () => {
+    seed(makeTicket({ column: 'merged' }))
+
+    useWorktreeStatusStore
+      .getState()
+      .setSessionStatus(SESSION_ID, 'working', { hookEventName: 'UserPromptSubmit' })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
+  })
+
+  it('ignores a UserPromptSubmit stamped as a background task-notification', async () => {
+    seed(makeTicket({ column: 'done' }))
+
+    useWorktreeStatusStore.getState().setSessionStatus(SESSION_ID, 'working', {
+      hookEventName: 'UserPromptSubmit',
+      taskNotification: true
+    })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('done')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+
+  it('ignores a bare working re-emit when the last explicit send is stale', async () => {
+    seed(makeTicket({ column: 'merged' }))
+    userExplicitSendTimes.set(SESSION_ID, Date.now() - 60_000)
+
+    useWorktreeStatusStore.getState().setSessionStatus(SESSION_ID, 'working')
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('merged')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+
+  it('still moves a review ticket on a working re-emit without an explicit send', async () => {
+    seed(makeTicket({ column: 'review' }))
+
+    useWorktreeStatusStore.getState().setSessionStatus(SESSION_ID, 'working')
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
   })
 })

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -400,4 +400,71 @@ describe('setSessionStatus → session_working explicitSend derivation', () => {
 
     expect(columnOf('ticket-1')).toBe('in_progress')
   })
+
+  it('consumes the send stamp: a working re-emit cannot reopen a re-done ticket', async () => {
+    const sessionId = 'sess-one-shot'
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+    userExplicitSendTimes.set(sessionId, Date.now())
+
+    useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+    await flush()
+    expect(columnOf('ticket-1')).toBe('in_progress')
+
+    // User drags the ticket back to done while the session is still busy…
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+    // …then a streaming re-emit arrives inside the 15s freshness window.
+    useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('done')
+  })
+
+  it('a task-notification neither reopens nor consumes a pending send stamp', async () => {
+    const sessionId = 'sess-task-notif'
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+    userExplicitSendTimes.set(sessionId, Date.now())
+
+    useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working', {
+      hookEventName: 'UserPromptSubmit',
+      taskNotification: true
+    })
+    await flush()
+    expect(columnOf('ticket-1')).toBe('done')
+
+    // The genuine transition for the send still gets the marker afterwards.
+    useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+    await flush()
+    expect(columnOf('ticket-1')).toBe('in_progress')
+  })
+})
+
+describe('syncTicketWithSession — implement reopens done/merged tickets', () => {
+  it('moves a done plan-ready ticket to in_progress on implement', async () => {
+    seed(makeTicket({ column: 'done', mode: 'plan', plan_ready: true }))
+
+    useKanbanStore.getState().syncTicketWithSession(SESSION_ID, { type: 'implement' })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
+    expect(kanbanApi.ticket.move).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', 'in_progress', 0)
+  })
+
+  it('moves a merged plan-ready ticket to in_progress on implement', async () => {
+    seed(makeTicket({ column: 'merged', mode: 'plan', plan_ready: true }))
+
+    useKanbanStore.getState().syncTicketWithSession(SESSION_ID, { type: 'implement' })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
+  })
+
+  it('does not move a review ticket on implement (session_working handles it)', async () => {
+    seed(makeTicket({ column: 'review', mode: 'plan', plan_ready: true }))
+
+    useKanbanStore.getState().syncTicketWithSession(SESSION_ID, { type: 'implement' })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('review')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -20,7 +20,7 @@ vi.mock('./useSettingsStore', () => ({
 }))
 
 import { useKanbanStore } from './useKanbanStore'
-import { useWorktreeStatusStore } from './useWorktreeStatusStore'
+import { markNextWorkingStatusExplicit, useWorktreeStatusStore } from './useWorktreeStatusStore'
 import { kanbanApi } from '@/api/kanban-api'
 import { userExplicitSendTimes } from '@/lib/message-send-times'
 import type { SessionStatusType } from '@shared/types/session-status'
@@ -417,6 +417,40 @@ describe('setSessionStatus → session_working explicitSend derivation', () => {
     await flush()
 
     expect(columnOf('ticket-1')).toBe('done')
+  })
+
+  it('one-shot marker reopens a done ticket for a queued follow-up drain', async () => {
+    const sessionId = 'sess-queued-drain'
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+
+    // Drain path: no userExplicitSendTimes stamp, only the one-shot marker.
+    markNextWorkingStatusExplicit(sessionId)
+    useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+    await flush()
+    expect(columnOf('ticket-1')).toBe('in_progress')
+
+    // The marker is consumed — a replay cannot reopen a re-done ticket.
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+    useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+    await flush()
+    expect(columnOf('ticket-1')).toBe('done')
+  })
+
+  it('a task-notification does not consume the one-shot marker', async () => {
+    const sessionId = 'sess-marker-notif'
+    seed(makeTicket({ column: 'merged', current_session_id: sessionId }))
+
+    markNextWorkingStatusExplicit(sessionId)
+    useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working', {
+      hookEventName: 'UserPromptSubmit',
+      taskNotification: true
+    })
+    await flush()
+    expect(columnOf('ticket-1')).toBe('merged')
+
+    useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+    await flush()
+    expect(columnOf('ticket-1')).toBe('in_progress')
   })
 
   it('a task-notification neither reopens nor consumes a pending send stamp', async () => {

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -561,6 +561,56 @@ describe('reconcileFinishedSessions — recovers explicit reopens missed while u
     expect(columnOf('ticket-1')).toBe('done')
   })
 
+  it('recovers a terminal-approved implement for a project loaded later', async () => {
+    const sessionId = 'sess-implement-unloaded'
+    // Manual ExitPlanMode approval in the CLI terminal, board not loaded.
+    useKanbanStore.getState().syncTicketWithSession(sessionId, { type: 'implement' })
+    await flush()
+
+    seed(makeTicket({ column: 'done', mode: 'plan', current_session_id: sessionId }))
+    setSessionStatus(sessionId, 'working')
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
+  })
+
+  it('implement recovery keeps an armed auto_approve_plan ticket terminal', async () => {
+    const sessionId = 'sess-implement-armed'
+    useKanbanStore.getState().syncTicketWithSession(sessionId, { type: 'implement' })
+    await flush()
+
+    seed(
+      makeTicket({
+        column: 'merged',
+        mode: 'plan',
+        auto_approve_plan: true,
+        current_session_id: sessionId
+      })
+    )
+    setSessionStatus(sessionId, 'working')
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('merged')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+
+  it('a finished run clears a pending implement recovery too', async () => {
+    const sessionId = 'sess-implement-ended'
+    useKanbanStore.getState().syncTicketWithSession(sessionId, { type: 'implement' })
+    useKanbanStore.getState().syncTicketWithSession(sessionId, { type: 'session_completed' })
+    await flush()
+
+    seed(makeTicket({ column: 'done', mode: 'plan', current_session_id: sessionId }))
+    setSessionStatus(sessionId, 'working')
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('done')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+
   it('reopens when the recovered run is blocked awaiting user input', async () => {
     const sessionId = 'sess-blocked-recovery'
     useKanbanStore

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -553,6 +553,57 @@ describe('reconcileFinishedSessions — recovers explicit reopens missed while u
     expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
   })
 
+  it('a finished run clears the pending reopen before a later auto-resume', async () => {
+    const sessionId = 'sess-run-ended'
+    // Explicit send with the board unloaded, then the run finishes before
+    // any reconcile happened.
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(sessionId, { type: 'session_working', explicitSend: true })
+    useKanbanStore.getState().syncTicketWithSession(sessionId, { type: 'session_completed' })
+    await flush()
+
+    // A later unrelated run (background auto-resume) is working at load time —
+    // the stale marker must not reopen the terminal ticket.
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+    setSessionStatus(sessionId, 'working')
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('done')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+
+  it('recovers the reopen for a second linked project loaded after the send', async () => {
+    const sessionId = 'sess-multi-project'
+    const otherProject = 'proj-2'
+    // Project 1 is loaded and handles the send live; project 2 is not loaded.
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(sessionId, { type: 'session_working', explicitSend: true })
+    await flush()
+    expect(columnOf('ticket-1')).toBe('in_progress')
+
+    // Project 2's tickets load later while the session still runs.
+    useKanbanStore.setState((state) => {
+      const next = new Map(state.tickets)
+      next.set(otherProject, [
+        makeTicket({ id: 'ticket-2', project_id: otherProject, column: 'merged', current_session_id: sessionId })
+      ])
+      return { tickets: next }
+    })
+    setSessionStatus(sessionId, 'working')
+    useKanbanStore.getState().reconcileFinishedSessions(otherProject)
+    await flush()
+
+    const ticket2 = useKanbanStore
+      .getState()
+      .tickets.get(otherProject)
+      ?.find((t) => t.id === 'ticket-2')
+    expect(ticket2?.column).toBe('in_progress')
+  })
+
   it('clears the pending reopen once a loaded ticket handles the explicit send', async () => {
     const sessionId = 'sess-live-handled'
     useKanbanStore

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -325,6 +325,18 @@ describe('syncTicketWithSession — explicit follow-up reopens done/merged ticke
     expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
   })
 
+  it('does not reopen an archived done ticket on an explicit send', async () => {
+    seed(makeTicket({ column: 'done', archived_at: '2026-01-02T00:00:00.000Z' }))
+
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(SESSION_ID, { type: 'session_working', explicitSend: true })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('done')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+
   it('does not move a merged ticket on session_working with explicitSend false', async () => {
     seed(makeTicket({ column: 'merged' }))
 
@@ -535,6 +547,28 @@ describe('reconcileFinishedSessions — recovers explicit reopens missed while u
     useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
     await flush()
     expect(columnOf('ticket-1')).toBe('done')
+  })
+
+  it('does not reopen an archived ticket during reconcile recovery', async () => {
+    const sessionId = 'sess-archived-reconcile'
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(sessionId, { type: 'session_working', explicitSend: true })
+    await flush()
+
+    seed(
+      makeTicket({
+        column: 'merged',
+        current_session_id: sessionId,
+        archived_at: '2026-01-02T00:00:00.000Z'
+      })
+    )
+    setSessionStatus(sessionId, 'working')
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('merged')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
   })
 
   it('does not reopen when the session already finished by load time', async () => {

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -19,7 +19,7 @@ vi.mock('./useSettingsStore', () => ({
   useSettingsStore: { getState: () => ({ followUpTriggerColumn: 'done' }) }
 }))
 
-import { useKanbanStore } from './useKanbanStore'
+import { clearPendingSessionReopens, useKanbanStore } from './useKanbanStore'
 import { markNextWorkingStatusExplicit, useWorktreeStatusStore } from './useWorktreeStatusStore'
 import { kanbanApi } from '@/api/kanban-api'
 import { userExplicitSendTimes } from '@/lib/message-send-times'
@@ -593,6 +593,23 @@ describe('reconcileFinishedSessions — recovers explicit reopens missed while u
     await flush()
 
     expect(columnOf('ticket-1')).toBe('merged')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+
+  it('a failed implement rollback clears pending recoveries', async () => {
+    const sessionId = 'sess-implement-rolled-back'
+    useKanbanStore.getState().syncTicketWithSession(sessionId, { type: 'implement' })
+    await flush()
+
+    // The dispatch failed and the failure path rolled the attempt back.
+    clearPendingSessionReopens(sessionId)
+
+    seed(makeTicket({ column: 'done', mode: 'plan', current_session_id: sessionId }))
+    setSessionStatus(sessionId, 'working')
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('done')
     expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -431,6 +431,18 @@ describe('setSessionStatus → session_working explicitSend derivation', () => {
     expect(columnOf('ticket-1')).toBe('done')
   })
 
+  it('reopens a done ticket on transcript-detected CLI plan feedback', async () => {
+    const sessionId = 'sess-plan-watcher'
+    seed(makeTicket({ column: 'done', current_session_id: sessionId, mode: 'plan' }))
+
+    useWorktreeStatusStore
+      .getState()
+      .setSessionStatus(sessionId, 'planning', { reason: 'claude_cli_plan_followup' })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
+  })
+
   it('one-shot marker reopens a done ticket for a queued follow-up drain', async () => {
     const sessionId = 'sess-queued-drain'
     seed(makeTicket({ column: 'done', current_session_id: sessionId }))
@@ -547,6 +559,21 @@ describe('reconcileFinishedSessions — recovers explicit reopens missed while u
     useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
     await flush()
     expect(columnOf('ticket-1')).toBe('done')
+  })
+
+  it('reopens when the recovered run is blocked awaiting user input', async () => {
+    const sessionId = 'sess-blocked-recovery'
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(sessionId, { type: 'session_working', explicitSend: true })
+    await flush()
+
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+    setSessionStatus(sessionId, 'permission')
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
   })
 
   it('does not reopen an archived ticket during reconcile recovery', async () => {

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -501,4 +501,78 @@ describe('syncTicketWithSession — implement reopens done/merged tickets', () =
     expect(columnOf('ticket-1')).toBe('review')
     expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
   })
+
+  it('does not reopen a done ticket on implement when auto_approve_plan is armed', async () => {
+    seed(makeTicket({ column: 'done', mode: 'plan', plan_ready: true, auto_approve_plan: true }))
+
+    useKanbanStore.getState().syncTicketWithSession(SESSION_ID, { type: 'implement' })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('done')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+})
+
+describe('reconcileFinishedSessions — recovers explicit reopens missed while unloaded', () => {
+  it('reopens a done ticket whose explicit send fired before tickets loaded', async () => {
+    const sessionId = 'sess-unloaded-reopen'
+    // Board not loaded: the explicit session_working matches nothing.
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(sessionId, { type: 'session_working', explicitSend: true })
+    await flush()
+
+    // Tickets load afterwards; the session is still running.
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+    setSessionStatus(sessionId, 'working')
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('in_progress')
+
+    // The recovery is one-shot: re-done ticket stays put on the next reconcile.
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+    expect(columnOf('ticket-1')).toBe('done')
+  })
+
+  it('does not reopen when the session already finished by load time', async () => {
+    const sessionId = 'sess-unloaded-finished'
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(sessionId, { type: 'session_working', explicitSend: true })
+    await flush()
+
+    seed(makeTicket({ column: 'merged', current_session_id: sessionId }))
+    setSessionStatus(sessionId, 'completed')
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('merged')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+
+  it('clears the pending reopen once a loaded ticket handles the explicit send', async () => {
+    const sessionId = 'sess-live-handled'
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(sessionId, { type: 'session_working', explicitSend: true })
+    await flush()
+
+    // A later explicit send arrives with the ticket loaded — handled live.
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+    useKanbanStore
+      .getState()
+      .syncTicketWithSession(sessionId, { type: 'session_working', explicitSend: true })
+    await flush()
+    expect(columnOf('ticket-1')).toBe('in_progress')
+
+    // The stale pending entry must not resurrect a re-done ticket on load.
+    seed(makeTicket({ column: 'done', current_session_id: sessionId }))
+    setSessionStatus(sessionId, 'working')
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+    expect(columnOf('ticket-1')).toBe('done')
+  })
 })

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -996,9 +996,10 @@ export const useKanbanStore = create<KanbanState>()(
             // matters on app relaunch/focus, when a still-active session
             // re-emits its status (e.g. an `idle` replay → session_completed)
             // for a done/merged ticket. Each column-moving branch below guards
-            // on those columns. Sole exception: a session_working caused by an
-            // explicit user follow-up (event.explicitSend) returns the ticket
-            // to in_progress — resuming work on a done/merged ticket reopens it.
+            // on those columns. Exceptions: a session_working caused by an
+            // explicit user follow-up (event.explicitSend) and a plan approval
+            // (implement) return the ticket to in_progress — resuming work on
+            // a done/merged ticket reopens it.
             switch (event.type) {
               case 'session_completed': {
                 // Plan tickets: surface the finished plan for the review UI.
@@ -1123,6 +1124,16 @@ export const useKanbanStore = create<KanbanState>()(
                       mode: 'build',
                       auto_approve_plan: false
                     })
+                    .catch(() => {})
+                }
+                // Approving a plan on a done/merged ticket resumes real work,
+                // but its working status carries no send stamp (opencode) or a
+                // PostToolUse hook (CLI), so session_working won't reopen it.
+                // implement only fires on genuine user approvals — reopen here.
+                // Other columns keep moving via session_working as before.
+                if (ticket.column === 'done' || ticket.column === 'merged') {
+                  get()
+                    .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
                     .catch(() => {})
                 }
                 break

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -996,7 +996,9 @@ export const useKanbanStore = create<KanbanState>()(
             // matters on app relaunch/focus, when a still-active session
             // re-emits its status (e.g. an `idle` replay → session_completed)
             // for a done/merged ticket. Each column-moving branch below guards
-            // on those columns.
+            // on those columns. Sole exception: a session_working caused by an
+            // explicit user follow-up (event.explicitSend) returns the ticket
+            // to in_progress — resuming work on a done/merged ticket reopens it.
             switch (event.type) {
               case 'session_completed': {
                 // Plan tickets: surface the finished plan for the review UI.
@@ -1138,13 +1140,22 @@ export const useKanbanStore = create<KanbanState>()(
 
               case 'session_working': {
                 // Session became active — move ticket to in_progress if it's in
-                // todo (pre-assigned, first activity) or review (returning to work).
+                // todo (pre-assigned, first activity) or review (returning to
+                // work). done/merged move only for explicit user follow-ups
+                // (never for streaming re-emits or status replays).
                 if (ticket.plan_ready) {
                   get()
                     .updateTicket(ticket.id, projectId, { plan_ready: false })
                     .catch(() => {})
                 }
-                if (ticket.column === 'todo' || ticket.column === 'review') {
+                const reopenedByFollowup =
+                  event.explicitSend === true &&
+                  (ticket.column === 'done' || ticket.column === 'merged')
+                if (
+                  ticket.column === 'todo' ||
+                  ticket.column === 'review' ||
+                  reopenedByFollowup
+                ) {
                   get()
                     .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
                     .catch(() => {})

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -346,6 +346,13 @@ interface KanbanState {
 // status (e.g. a background auto-resume) to the old send.
 const pendingExplicitReopens = new Map<string, Set<string>>()
 
+// Same recovery for implement (plan approval) events: a manual ExitPlanMode
+// approval in a CLI terminal emits implement + a PostToolUse working status —
+// neither is an explicit send, so an unloaded project would otherwise lose
+// the reopen. The auto_approve_plan exclusion is applied at reconcile time,
+// when the ticket is available to check. Same lifecycle as above.
+const pendingImplementReopens = new Map<string, Set<string>>()
+
 // ── Store ──────────────────────────────────────────────────────────────
 export const useKanbanStore = create<KanbanState>()(
   persist(
@@ -462,20 +469,27 @@ export const useKanbanStore = create<KanbanState>()(
       reconcileFinishedSessions: (projectId: string) => {
         const tickets = get().tickets.get(projectId) ?? []
         const statuses = useWorktreeStatusStore.getState().sessionStatuses
-        // Sessions whose pending explicit send is being attributed to this
-        // project in this pass — lets several linked tickets all recover,
-        // while the handled-mark stops later reloads from re-attributing.
-        const recoveredThisPass = new Set<string>()
+        // Sessions whose pending explicit send / implement is being
+        // attributed to this project in this pass — lets several linked
+        // tickets all recover, while the handled-mark stops later reloads
+        // from re-attributing.
+        const recoveredExplicit = new Set<string>()
+        const recoveredImplement = new Set<string>()
         for (const ticket of tickets) {
           if (!ticket.current_session_id) continue
           const status = statuses[ticket.current_session_id]?.status ?? null
-          // Attribute a pending explicit send to this project on any linked
-          // ticket visit (whatever its column) — a re-done ticket must not be
-          // reopened by the same send on a future reload.
-          const pendingHandled = pendingExplicitReopens.get(ticket.current_session_id)
-          if (pendingHandled && !pendingHandled.has(projectId)) {
-            pendingHandled.add(projectId)
-            recoveredThisPass.add(ticket.current_session_id)
+          // Attribute pending events to this project on any linked ticket
+          // visit (whatever its column) — a re-done ticket must not be
+          // reopened by the same event on a future reload.
+          const explicitHandled = pendingExplicitReopens.get(ticket.current_session_id)
+          if (explicitHandled && !explicitHandled.has(projectId)) {
+            explicitHandled.add(projectId)
+            recoveredExplicit.add(ticket.current_session_id)
+          }
+          const implementHandled = pendingImplementReopens.get(ticket.current_session_id)
+          if (implementHandled && !implementHandled.has(projectId)) {
+            implementHandled.add(projectId)
+            recoveredImplement.add(ticket.current_session_id)
           }
           if (ticket.column === 'in_progress') {
             // Only act on positive "finished" evidence — never on progressing/
@@ -487,14 +501,18 @@ export const useKanbanStore = create<KanbanState>()(
             }
             get().moveTicket(ticket.id, projectId, 'review', ticket.sort_order).catch(() => {})
           } else if (ticket.column === 'done' || ticket.column === 'merged') {
-            // Recover an explicit follow-up reopen this project missed while
-            // unloaded. Only while the session's run is still active — running
-            // or blocked awaiting user input. A session that already finished
-            // (or never started) gives no license to leave the terminal
-            // column. Archived tickets never reopen (see the session_working
-            // guard).
+            // Recover an explicit follow-up or plan-approval reopen this
+            // project missed while unloaded. Only while the session's run is
+            // still active — running or blocked awaiting user input. A
+            // session that already finished (or never started) gives no
+            // license to leave the terminal column. Archived tickets never
+            // reopen, and auto-approved plans don't reopen armed tickets
+            // (see the session_working / implement guards).
             if (ticket.archived_at) continue
-            if (!recoveredThisPass.has(ticket.current_session_id)) continue
+            const viaExplicit = recoveredExplicit.has(ticket.current_session_id)
+            const viaImplement =
+              recoveredImplement.has(ticket.current_session_id) && !ticket.auto_approve_plan
+            if (!viaExplicit && !viaImplement) continue
             if (
               status !== 'working' &&
               status !== 'planning' &&
@@ -1244,20 +1262,25 @@ export const useKanbanStore = create<KanbanState>()(
             }
           }
         }
-        // Remember explicit sends so projects whose tickets weren't loaded
-        // yet can recover the reopen on load (reconcileFinishedSessions).
-        // The currently-loaded projects have already handled the send live.
+        // Remember explicit sends and plan approvals so projects whose
+        // tickets weren't loaded yet can recover the reopen on load
+        // (reconcileFinishedSessions). The currently-loaded projects have
+        // already handled the event live.
         if (event.type === 'session_working' && event.explicitSend === true) {
           pendingExplicitReopens.set(sessionId, new Set(allTickets.keys()))
         }
-        // The send's run ended — any not-yet-recovered reopen is moot, and a
-        // stale marker must not reopen a ticket on a future unrelated run.
+        if (event.type === 'implement') {
+          pendingImplementReopens.set(sessionId, new Set(allTickets.keys()))
+        }
+        // The run ended — any not-yet-recovered reopen is moot, and a stale
+        // marker must not reopen a ticket on a future unrelated run.
         if (
           event.type === 'session_completed' ||
           event.type === 'plan_ready' ||
           event.type === 'session_error'
         ) {
           pendingExplicitReopens.delete(sessionId)
+          pendingImplementReopens.delete(sessionId)
         }
       },
 

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -248,7 +248,15 @@ interface KanbanState {
     ticketId: string,
     projectId: string,
     column: KanbanTicketColumn,
-    sortOrder: number
+    sortOrder: number,
+    opts?: {
+      /**
+       * Restoring a prior column, not completing work — don't fire
+       * terminal-move side effects (dependent auto-launch / follow-up
+       * trigger).
+       */
+      skipCompletionEffects?: boolean
+    }
   ) => Promise<void>
   reorderTicket: (ticketId: string, projectId: string, newSortOrder: number) => Promise<void>
   toggleBoardView: () => void
@@ -912,7 +920,8 @@ export const useKanbanStore = create<KanbanState>()(
         ticketId: string,
         projectId: string,
         column: KanbanTicketColumn,
-        sortOrder: number
+        sortOrder: number,
+        opts?: { skipCompletionEffects?: boolean }
       ) => {
         const prev = get().tickets.get(projectId) ?? []
         const snapshot = prev.map((t) => ({ ...t }))
@@ -943,9 +952,10 @@ export const useKanbanStore = create<KanbanState>()(
           const { isBlockerSatisfied } = await import('../lib/blocker-utils')
           const triggerColumn = useSettingsStore.getState().followUpTriggerColumn
           if (
-            column === 'done' ||
-            column === 'merged' ||
-            (triggerColumn === 'review' && column === 'review' && movedTicket?.mode === 'build')
+            !opts?.skipCompletionEffects &&
+            (column === 'done' ||
+              column === 'merged' ||
+              (triggerColumn === 'review' && column === 'review' && movedTicket?.mode === 'build'))
           ) {
             const { dependencyMap, tickets: allTickets } = get()
             const movedKey = ticketKey(projectId, ticketId)

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -482,7 +482,9 @@ export const useKanbanStore = create<KanbanState>()(
             // Recover an explicit follow-up reopen this project missed while
             // unloaded. Only while the session is still actively running — a
             // session that already finished (or never started) gives no
-            // license to leave the terminal column.
+            // license to leave the terminal column. Archived tickets never
+            // reopen (see the session_working guard).
+            if (ticket.archived_at) continue
             if (!recoveredThisPass.has(ticket.current_session_id)) continue
             if (status !== 'working' && status !== 'planning') continue
             get()
@@ -1173,7 +1175,8 @@ export const useKanbanStore = create<KanbanState>()(
                 // session_working as before.
                 if (
                   (ticket.column === 'done' || ticket.column === 'merged') &&
-                  !ticket.auto_approve_plan
+                  !ticket.auto_approve_plan &&
+                  !ticket.archived_at
                 ) {
                   get()
                     .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
@@ -1202,9 +1205,13 @@ export const useKanbanStore = create<KanbanState>()(
                     .updateTicket(ticket.id, projectId, { plan_ready: false })
                     .catch(() => {})
                 }
+                // Archived tickets never reopen: clearing the column while
+                // archived_at persists would strand them (the archive UI only
+                // renders archived done/merged, so Unarchive would be lost).
                 const reopenedByFollowup =
                   event.explicitSend === true &&
-                  (ticket.column === 'done' || ticket.column === 'merged')
+                  (ticket.column === 'done' || ticket.column === 'merged') &&
+                  !ticket.archived_at
                 if (
                   ticket.column === 'todo' ||
                   ticket.column === 'review' ||

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -327,12 +327,16 @@ interface KanbanState {
   setHoveredBlockedTicketRef: (ref: TicketRef | null) => void
 }
 
-// Explicit follow-up sends whose session_working matched no loaded ticket —
-// the board hadn't been opened, so the one-shot explicit marker was consumed
-// against an empty map. reconcileFinishedSessions attributes these once the
-// project's tickets load, so the reopen isn't silently lost. In-memory per
-// app run, cleared as soon as a matching ticket handles the send.
-const pendingExplicitReopens = new Set<string>()
+// Explicit follow-up sends that some project's tickets may not have seen —
+// the board (or one of several linked projects) hadn't been loaded, so the
+// one-shot explicit marker was consumed against an incomplete map.
+// sessionId → project IDs whose tickets were loaded when the send fired
+// (those already handled it live). reconcileFinishedSessions recovers the
+// reopen for projects loaded later. In-memory per app run; entries drop as
+// soon as the originating run stops being active (completed / plan_ready /
+// error), so a stale marker can never attribute a future unrelated working
+// status (e.g. a background auto-resume) to the old send.
+const pendingExplicitReopens = new Map<string, Set<string>>()
 
 // ── Store ──────────────────────────────────────────────────────────────
 export const useKanbanStore = create<KanbanState>()(
@@ -450,9 +454,21 @@ export const useKanbanStore = create<KanbanState>()(
       reconcileFinishedSessions: (projectId: string) => {
         const tickets = get().tickets.get(projectId) ?? []
         const statuses = useWorktreeStatusStore.getState().sessionStatuses
+        // Sessions whose pending explicit send is being attributed to this
+        // project in this pass — lets several linked tickets all recover,
+        // while the handled-mark stops later reloads from re-attributing.
+        const recoveredThisPass = new Set<string>()
         for (const ticket of tickets) {
           if (!ticket.current_session_id) continue
           const status = statuses[ticket.current_session_id]?.status ?? null
+          // Attribute a pending explicit send to this project on any linked
+          // ticket visit (whatever its column) — a re-done ticket must not be
+          // reopened by the same send on a future reload.
+          const pendingHandled = pendingExplicitReopens.get(ticket.current_session_id)
+          if (pendingHandled && !pendingHandled.has(projectId)) {
+            pendingHandled.add(projectId)
+            recoveredThisPass.add(ticket.current_session_id)
+          }
           if (ticket.column === 'in_progress') {
             // Only act on positive "finished" evidence — never on progressing/
             // asking/no-status, so we don't yank not-yet-started or actively-
@@ -463,13 +479,12 @@ export const useKanbanStore = create<KanbanState>()(
             }
             get().moveTicket(ticket.id, projectId, 'review', ticket.sort_order).catch(() => {})
           } else if (ticket.column === 'done' || ticket.column === 'merged') {
-            // Recover an explicit follow-up reopen that fired before these
-            // tickets were loaded. Only while the session is still actively
-            // running — a session that already finished (or never started)
-            // gives no license to leave the terminal column.
-            if (!pendingExplicitReopens.has(ticket.current_session_id)) continue
+            // Recover an explicit follow-up reopen this project missed while
+            // unloaded. Only while the session is still actively running — a
+            // session that already finished (or never started) gives no
+            // license to leave the terminal column.
+            if (!recoveredThisPass.has(ticket.current_session_id)) continue
             if (status !== 'working' && status !== 'planning') continue
-            pendingExplicitReopens.delete(ticket.current_session_id)
             get()
               .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
               .catch(() => {})
@@ -1008,11 +1023,9 @@ export const useKanbanStore = create<KanbanState>()(
       syncTicketWithSession: (sessionId: string, event: KanbanSessionEvent) => {
         // Find all tickets across all projects referencing this session
         const allTickets = get().tickets
-        let matchedTicket = false
         for (const [projectId, tickets] of allTickets.entries()) {
           for (const ticket of tickets) {
             if (ticket.current_session_id !== sessionId) continue
-            matchedTicket = true
 
             // 'done' and 'merged' are terminal columns: once a user moves a
             // ticket there, no session event may auto-move it back. This
@@ -1206,11 +1219,20 @@ export const useKanbanStore = create<KanbanState>()(
             }
           }
         }
-        // Remember explicit sends that found no loaded ticket so the reopen
-        // can be recovered when the project's tickets load (reconcile below).
+        // Remember explicit sends so projects whose tickets weren't loaded
+        // yet can recover the reopen on load (reconcileFinishedSessions).
+        // The currently-loaded projects have already handled the send live.
         if (event.type === 'session_working' && event.explicitSend === true) {
-          if (matchedTicket) pendingExplicitReopens.delete(sessionId)
-          else pendingExplicitReopens.add(sessionId)
+          pendingExplicitReopens.set(sessionId, new Set(allTickets.keys()))
+        }
+        // The send's run ended — any not-yet-recovered reopen is moot, and a
+        // stale marker must not reopen a ticket on a future unrelated run.
+        if (
+          event.type === 'session_completed' ||
+          event.type === 'plan_ready' ||
+          event.type === 'session_error'
+        ) {
+          pendingExplicitReopens.delete(sessionId)
         }
       },
 

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -327,6 +327,13 @@ interface KanbanState {
   setHoveredBlockedTicketRef: (ref: TicketRef | null) => void
 }
 
+// Explicit follow-up sends whose session_working matched no loaded ticket —
+// the board hadn't been opened, so the one-shot explicit marker was consumed
+// against an empty map. reconcileFinishedSessions attributes these once the
+// project's tickets load, so the reopen isn't silently lost. In-memory per
+// app run, cleared as soon as a matching ticket handles the send.
+const pendingExplicitReopens = new Set<string>()
+
 // ── Store ──────────────────────────────────────────────────────────────
 export const useKanbanStore = create<KanbanState>()(
   persist(
@@ -434,25 +441,39 @@ export const useKanbanStore = create<KanbanState>()(
       },
 
       // ── reconcileFinishedSessions ────────────────────────────────
-      // Safety net for session_completed/plan_ready events that were dropped
-      // because this project's tickets weren't loaded when the event fired (e.g.
-      // on app relaunch the idle→completed replay can beat the board load). Run
-      // after tickets load: any in_progress ticket whose linked session is in a
-      // concrete "finished" status is advanced to review.
+      // Safety net for session events that were dropped because this project's
+      // tickets weren't loaded when the event fired (e.g. on app relaunch the
+      // idle→completed replay can beat the board load). Run after tickets load:
+      // any in_progress ticket whose linked session is in a concrete "finished"
+      // status is advanced to review, and a done/merged ticket whose session
+      // got an explicit follow-up while unloaded is reopened to in_progress.
       reconcileFinishedSessions: (projectId: string) => {
         const tickets = get().tickets.get(projectId) ?? []
         const statuses = useWorktreeStatusStore.getState().sessionStatuses
         for (const ticket of tickets) {
-          if (ticket.column !== 'in_progress' || !ticket.current_session_id) continue
+          if (!ticket.current_session_id) continue
           const status = statuses[ticket.current_session_id]?.status ?? null
-          // Only act on positive "finished" evidence — never on progressing/asking/
-          // no-status, so we don't yank not-yet-started or actively-running sessions
-          // out of in_progress.
-          if (status !== 'completed' && status !== 'plan_ready') continue
-          if (isPlanLike(ticket.mode) && !ticket.plan_ready) {
-            get().updateTicket(ticket.id, projectId, { plan_ready: true }).catch(() => {})
+          if (ticket.column === 'in_progress') {
+            // Only act on positive "finished" evidence — never on progressing/
+            // asking/no-status, so we don't yank not-yet-started or actively-
+            // running sessions out of in_progress.
+            if (status !== 'completed' && status !== 'plan_ready') continue
+            if (isPlanLike(ticket.mode) && !ticket.plan_ready) {
+              get().updateTicket(ticket.id, projectId, { plan_ready: true }).catch(() => {})
+            }
+            get().moveTicket(ticket.id, projectId, 'review', ticket.sort_order).catch(() => {})
+          } else if (ticket.column === 'done' || ticket.column === 'merged') {
+            // Recover an explicit follow-up reopen that fired before these
+            // tickets were loaded. Only while the session is still actively
+            // running — a session that already finished (or never started)
+            // gives no license to leave the terminal column.
+            if (!pendingExplicitReopens.has(ticket.current_session_id)) continue
+            if (status !== 'working' && status !== 'planning') continue
+            pendingExplicitReopens.delete(ticket.current_session_id)
+            get()
+              .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
+              .catch(() => {})
           }
-          get().moveTicket(ticket.id, projectId, 'review', ticket.sort_order).catch(() => {})
         }
       },
 
@@ -987,9 +1008,11 @@ export const useKanbanStore = create<KanbanState>()(
       syncTicketWithSession: (sessionId: string, event: KanbanSessionEvent) => {
         // Find all tickets across all projects referencing this session
         const allTickets = get().tickets
+        let matchedTicket = false
         for (const [projectId, tickets] of allTickets.entries()) {
           for (const ticket of tickets) {
             if (ticket.current_session_id !== sessionId) continue
+            matchedTicket = true
 
             // 'done' and 'merged' are terminal columns: once a user moves a
             // ticket there, no session event may auto-move it back. This
@@ -1128,10 +1151,17 @@ export const useKanbanStore = create<KanbanState>()(
                 }
                 // Approving a plan on a done/merged ticket resumes real work,
                 // but its working status carries no send stamp (opencode) or a
-                // PostToolUse hook (CLI), so session_working won't reopen it.
-                // implement only fires on genuine user approvals — reopen here.
-                // Other columns keep moving via session_working as before.
-                if (ticket.column === 'done' || ticket.column === 'merged') {
+                // PostToolUse hook (CLI), so session_working won't reopen it —
+                // reopen here instead. Except when auto_approve_plan is armed:
+                // the hook server answers ExitPlanMode with no fresh user
+                // action, and the manual move to done/merged is the newer
+                // intent. Manual modal / plan-card approvals still reopen via
+                // their explicit send stamps. Other columns keep moving via
+                // session_working as before.
+                if (
+                  (ticket.column === 'done' || ticket.column === 'merged') &&
+                  !ticket.auto_approve_plan
+                ) {
                   get()
                     .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
                     .catch(() => {})
@@ -1175,6 +1205,12 @@ export const useKanbanStore = create<KanbanState>()(
               }
             }
           }
+        }
+        // Remember explicit sends that found no loaded ticket so the reopen
+        // can be recovered when the project's tickets load (reconcile below).
+        if (event.type === 'session_working' && event.explicitSend === true) {
+          if (matchedTicket) pendingExplicitReopens.delete(sessionId)
+          else pendingExplicitReopens.add(sessionId)
         }
       },
 

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -353,18 +353,6 @@ const pendingExplicitReopens = new Map<string, Set<string>>()
 // when the ticket is available to check. Same lifecycle as above.
 const pendingImplementReopens = new Map<string, Set<string>>()
 
-/**
- * Drop any pending unloaded-project reopen recovery for this session. Called
- * by failure paths that roll back an optimistic reopen (failed implement
- * dispatch): the originating attempt never started a run, so no run-end
- * event would ever clear the stale entries, and a later unrelated activation
- * must not consume them.
- */
-export function clearPendingSessionReopens(sessionId: string): void {
-  pendingExplicitReopens.delete(sessionId)
-  pendingImplementReopens.delete(sessionId)
-}
-
 // ── Store ──────────────────────────────────────────────────────────────
 export const useKanbanStore = create<KanbanState>()(
   persist(
@@ -1284,12 +1272,14 @@ export const useKanbanStore = create<KanbanState>()(
         if (event.type === 'implement') {
           pendingImplementReopens.set(sessionId, new Set(allTickets.keys()))
         }
-        // The run ended — any not-yet-recovered reopen is moot, and a stale
-        // marker must not reopen a ticket on a future unrelated run.
+        // The run ended or its status was cleared (canceled dispatch,
+        // interrupt, teardown) — any not-yet-recovered reopen is moot, and a
+        // stale marker must not reopen a ticket on a future unrelated run.
         if (
           event.type === 'session_completed' ||
           event.type === 'plan_ready' ||
-          event.type === 'session_error'
+          event.type === 'session_error' ||
+          event.type === 'status_cleared'
         ) {
           pendingExplicitReopens.delete(sessionId)
           pendingImplementReopens.delete(sessionId)

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -353,6 +353,18 @@ const pendingExplicitReopens = new Map<string, Set<string>>()
 // when the ticket is available to check. Same lifecycle as above.
 const pendingImplementReopens = new Map<string, Set<string>>()
 
+/**
+ * Drop any pending unloaded-project reopen recovery for this session. Called
+ * by failure paths that roll back an optimistic reopen (failed implement
+ * dispatch): the originating attempt never started a run, so no run-end
+ * event would ever clear the stale entries, and a later unrelated activation
+ * must not consume them.
+ */
+export function clearPendingSessionReopens(sessionId: string): void {
+  pendingExplicitReopens.delete(sessionId)
+  pendingImplementReopens.delete(sessionId)
+}
+
 // ── Store ──────────────────────────────────────────────────────────────
 export const useKanbanStore = create<KanbanState>()(
   persist(

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -480,13 +480,21 @@ export const useKanbanStore = create<KanbanState>()(
             get().moveTicket(ticket.id, projectId, 'review', ticket.sort_order).catch(() => {})
           } else if (ticket.column === 'done' || ticket.column === 'merged') {
             // Recover an explicit follow-up reopen this project missed while
-            // unloaded. Only while the session is still actively running — a
-            // session that already finished (or never started) gives no
-            // license to leave the terminal column. Archived tickets never
-            // reopen (see the session_working guard).
+            // unloaded. Only while the session's run is still active — running
+            // or blocked awaiting user input. A session that already finished
+            // (or never started) gives no license to leave the terminal
+            // column. Archived tickets never reopen (see the session_working
+            // guard).
             if (ticket.archived_at) continue
             if (!recoveredThisPass.has(ticket.current_session_id)) continue
-            if (status !== 'working' && status !== 'planning') continue
+            if (
+              status !== 'working' &&
+              status !== 'planning' &&
+              status !== 'answering' &&
+              status !== 'permission' &&
+              status !== 'command_approval'
+            )
+              continue
             get()
               .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
               .catch(() => {})

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -9,6 +9,13 @@ import { higherPriority, type SessionStatusType } from '@shared/types/session-st
 // Re-exported from the shared definition so existing importers keep working.
 export type { SessionStatusType }
 
+// Last userExplicitSendTimes value already attributed to a session_working
+// notification, per session. Each send stamp may mark at most one working
+// transition as explicit (the elapsed timer still owns the stamp itself, so
+// it is never deleted) — later streaming re-emits and status replays within
+// the freshness window must not reopen a done/merged ticket.
+const consumedExplicitSendTimes = new Map<string, number>()
+
 export interface SessionStatusEntry {
   status: SessionStatusType
   timestamp: number
@@ -153,14 +160,23 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
       // A working status counts as an explicit user follow-up when it either
       // immediately follows a user-initiated send (every send path writes
       // userExplicitSendTimes right before flipping the status) or carries a
-      // UserPromptSubmit hook event that isn't a background task-notification
-      // auto-resume (prompts typed straight into a CLI terminal). Streaming
-      // re-emits and status replays match neither, so they can never pull a
-      // ticket out of done/merged.
-      const explicitSendAt = userExplicitSendTimes.get(sessionId)
-      const explicitSend =
-        (explicitSendAt !== undefined && Date.now() - explicitSendAt < 15_000) ||
-        (metadata?.hookEventName === 'UserPromptSubmit' && metadata.taskNotification !== true)
+      // UserPromptSubmit hook event (prompts typed straight into a CLI
+      // terminal). Background task-notification auto-resumes are never
+      // explicit, and each send stamp is consumed by the first working
+      // transition it explains, so streaming re-emits and status replays can
+      // never pull a ticket out of done/merged.
+      let explicitSend = false
+      if (metadata?.taskNotification !== true) {
+        const explicitSendAt = userExplicitSendTimes.get(sessionId)
+        const hasUnconsumedSend =
+          explicitSendAt !== undefined &&
+          Date.now() - explicitSendAt < 15_000 &&
+          consumedExplicitSendTimes.get(sessionId) !== explicitSendAt
+        if (hasUnconsumedSend) {
+          consumedExplicitSendTimes.set(sessionId, explicitSendAt)
+        }
+        explicitSend = hasUnconsumedSend || metadata?.hookEventName === 'UserPromptSubmit'
+      }
       notifyKanbanSessionSync(sessionId, { type: 'session_working', explicitSend })
     }
   },

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { useSessionStore } from './useSessionStore'
 import { useConnectionStore } from './useConnectionStore'
-import { lastSendMode } from '@/lib/message-send-times'
+import { lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { notifyKanbanSessionSync } from './store-coordination'
 import { dbApi } from '@/api/db-api'
 import { higherPriority, type SessionStatusType } from '@shared/types/session-status'
@@ -64,6 +64,7 @@ interface WorktreeStatusState {
       hookPath?: string
       toolName?: string
       plan?: string
+      taskNotification?: boolean
     }
   ) => void
   setSessionBackgroundWork: (sessionId: string, work: SessionBackgroundWork) => void
@@ -106,6 +107,7 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
       hookPath?: string
       toolName?: string
       plan?: string
+      taskNotification?: boolean
     }
   ) => {
     set((state) => {
@@ -148,7 +150,18 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
     } else if (status === 'plan_ready') {
       notifyKanbanSessionSync(sessionId, { type: 'plan_ready' })
     } else if (status === 'working' || status === 'planning') {
-      notifyKanbanSessionSync(sessionId, { type: 'session_working' })
+      // A working status counts as an explicit user follow-up when it either
+      // immediately follows a user-initiated send (every send path writes
+      // userExplicitSendTimes right before flipping the status) or carries a
+      // UserPromptSubmit hook event that isn't a background task-notification
+      // auto-resume (prompts typed straight into a CLI terminal). Streaming
+      // re-emits and status replays match neither, so they can never pull a
+      // ticket out of done/merged.
+      const explicitSendAt = userExplicitSendTimes.get(sessionId)
+      const explicitSend =
+        (explicitSendAt !== undefined && Date.now() - explicitSendAt < 15_000) ||
+        (metadata?.hookEventName === 'UserPromptSubmit' && metadata.taskNotification !== true)
+      notifyKanbanSessionSync(sessionId, { type: 'session_working', explicitSend })
     }
   },
 

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -193,8 +193,15 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
         if (hasUnconsumedSend) {
           consumedExplicitSendTimes.set(sessionId, explicitSendAt)
         }
+        // reason === 'claude_cli_plan_followup': plan feedback typed into the
+        // CLI terminal, detected by the transcript watcher when the
+        // UserPromptSubmit hook is delayed or unavailable — a genuine user
+        // send with neither stamp nor hook event.
         explicitSend =
-          oneShotMarker || hasUnconsumedSend || metadata?.hookEventName === 'UserPromptSubmit'
+          oneShotMarker ||
+          hasUnconsumedSend ||
+          metadata?.hookEventName === 'UserPromptSubmit' ||
+          metadata?.reason === 'claude_cli_plan_followup'
       }
       notifyKanbanSessionSync(sessionId, { type: 'session_working', explicitSend })
     }

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -204,6 +204,10 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
           metadata?.reason === 'claude_cli_plan_followup'
       }
       notifyKanbanSessionSync(sessionId, { type: 'session_working', explicitSend })
+    } else if (status === null) {
+      // A cleared status means the run is gone (canceled dispatch, teardown,
+      // interrupt) — pending unloaded-project reopen recoveries die with it.
+      notifyKanbanSessionSync(sessionId, { type: 'status_cleared' })
     }
   },
 
@@ -230,6 +234,9 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
         [sessionId]: null
       }
     }))
+    // Mirror setSessionStatus(sessionId, null): the run is gone, so pending
+    // unloaded-project reopen recoveries must not outlive it.
+    notifyKanbanSessionSync(sessionId, { type: 'status_cleared' })
   },
 
   clearWorktreeUnread: (worktreeId: string) => {

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -16,6 +16,23 @@ export type { SessionStatusType }
 // the freshness window must not reopen a done/merged ticket.
 const consumedExplicitSendTimes = new Map<string, number>()
 
+// One-shot explicit markers for working transitions whose send bookkeeping
+// cannot use userExplicitSendTimes: a queued user follow-up drains long after
+// the user typed it, and stamping the shared map at dispatch would restart
+// the elapsed timer that map exists to drive. The next working/planning
+// status emitted for the session consumes the marker.
+const pendingExplicitWorking = new Set<string>()
+
+/**
+ * Mark the next working/planning status for this session as caused by an
+ * explicit user send. Call right before setSessionStatus when dispatching a
+ * user-authored message that has no fresh userExplicitSendTimes stamp (e.g.
+ * draining the follow-up queue).
+ */
+export function markNextWorkingStatusExplicit(sessionId: string): void {
+  pendingExplicitWorking.add(sessionId)
+}
+
 export interface SessionStatusEntry {
   status: SessionStatusType
   timestamp: number
@@ -167,6 +184,7 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
       // never pull a ticket out of done/merged.
       let explicitSend = false
       if (metadata?.taskNotification !== true) {
+        const oneShotMarker = pendingExplicitWorking.delete(sessionId)
         const explicitSendAt = userExplicitSendTimes.get(sessionId)
         const hasUnconsumedSend =
           explicitSendAt !== undefined &&
@@ -175,7 +193,8 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
         if (hasUnconsumedSend) {
           consumedExplicitSendTimes.set(sessionId, explicitSendAt)
         }
-        explicitSend = hasUnconsumedSend || metadata?.hookEventName === 'UserPromptSubmit'
+        explicitSend =
+          oneShotMarker || hasUnconsumedSend || metadata?.hookEventName === 'UserPromptSubmit'
       }
       notifyKanbanSessionSync(sessionId, { type: 'session_working', explicitSend })
     }


### PR DESCRIPTION
## Summary
- Reopen `done` and `merged` tickets to `in_progress` after explicit follow-up messages.
- Distinguish user sends from status replays, streaming updates, and background task notifications.
- Add session-sync coverage for reopening and non-reopening scenarios.

## Testing
- Added unit tests covering explicit sends, stale sends, terminal prompts, task notifications, and review tickets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core kanban column rules and session-status→board coordination with many edge cases (stamps, replays, multi-project load order); broad unit test coverage reduces regression risk but behavior is easy to get wrong in production.
> 
> **Overview**
> **Done** and **merged** kanban tickets can move back to **in_progress** when the user genuinely resumes work (follow-up message, plan implement, queued drain, CLI prompt)—not when the session merely replays `working` or auto-resumes from task notifications.
> 
> `useWorktreeStatusStore` now classifies `working`/`planning` transitions: unconsumed `userExplicitSendTimes` (one-shot per send), `markNextWorkingStatusExplicit` for queue drains, `UserPromptSubmit` hooks, and CLI plan follow-ups count as explicit; `taskNotification` and stale stamps do not. Kanban sync only reopens terminal columns on `session_working` with `explicitSend: true`, or on `implement` (with `auto_approve_plan` / archived guards).
> 
> **Unload recovery:** pending explicit/implement reopen markers are stored per session and applied in `reconcileFinishedSessions` when a project’s tickets load late; `status_cleared` and finished runs drop stale markers. **Implement rollback:** failed plan approval/dispatch rolls terminal tickets back via `moveTicket(..., { skipCompletionEffects: true })` unless a newer send superseded the attempt. `sendFollowupToSession` gains `skipSendBookkeeping` so implement paths don’t double-stamp status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0abbe87cd9e168d1d7b8f3857090c028d2453f9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->