### PR TITLE
Show live Claude subagent progress on Kanban tickets

### DIFF
--- a/src/main/services/__tests__/claude-cli-background-work-tracker.test.ts
+++ b/src/main/services/__tests__/claude-cli-background-work-tracker.test.ts
@@ -13,7 +13,9 @@ import type { ParsedClaudeHook } from '../claude-hook-server'
 
 const SESSION = 'hive-session-1'
 
-// Fixtures mirror real hook payloads captured from claude v2.1.218.
+// Fixtures mirror real hook payloads captured from claude v2.1.218 (shells/
+// monitors) and v2.1.226 (subagents/workflows, via the claude-playground
+// prototype).
 
 function backgroundBashStart(taskId: string): ParsedClaudeHook {
   return {
@@ -39,6 +41,26 @@ function monitorStart(taskId: string): ParsedClaudeHook {
   }
 }
 
+function subagentStart(agentId: string): ParsedClaudeHook {
+  return {
+    hook_event_name: 'SubagentStart',
+    agent_id: agentId,
+    agent_type: 'general-purpose'
+  }
+}
+
+function subagentStop(
+  agentId: string,
+  backgroundTasks: ParsedClaudeHook['background_tasks'] = []
+): ParsedClaudeHook {
+  return {
+    hook_event_name: 'SubagentStop',
+    agent_id: agentId,
+    agent_type: 'general-purpose',
+    background_tasks: backgroundTasks
+  }
+}
+
 function notificationPrompt(blocks: string[]): ParsedClaudeHook {
   return { hook_event_name: 'UserPromptSubmit', prompt: blocks.join('\n') }
 }
@@ -55,7 +77,8 @@ describe('processClaudeCliBackgroundWorkHook', () => {
   it('counts a background Bash start from PostToolUse', () => {
     expect(processClaudeCliBackgroundWorkHook(SESSION, backgroundBashStart('bshell1'))).toEqual({
       runningShells: 1,
-      runningMonitors: 0
+      runningMonitors: 0,
+      runningSubagents: 0
     })
   })
 
@@ -86,7 +109,8 @@ describe('processClaudeCliBackgroundWorkHook', () => {
 
     expect(processClaudeCliBackgroundWorkHook(SESSION, monitorStart('bmon1'))).toEqual({
       runningShells: 0,
-      runningMonitors: 1
+      runningMonitors: 1,
+      runningSubagents: 0
     })
     expect(processClaudeCliBackgroundWorkHook(SESSION, failed)).toBeNull()
   })
@@ -104,7 +128,8 @@ describe('processClaudeCliBackgroundWorkHook', () => {
 
     expect(processClaudeCliBackgroundWorkHook(SESSION, stop)).toEqual({
       runningShells: 0,
-      runningMonitors: 1
+      runningMonitors: 1,
+      runningSubagents: 0
     })
   })
 
@@ -113,7 +138,7 @@ describe('processClaudeCliBackgroundWorkHook', () => {
       processClaudeCliBackgroundWorkHook(SESSION, backgroundBashStart('btask'))
       expect(
         processClaudeCliBackgroundWorkHook(SESSION, notificationPrompt([terminalBlock('btask', status)]))
-      ).toEqual({ runningShells: 0, runningMonitors: 0 })
+      ).toEqual({ runningShells: 0, runningMonitors: 0, runningSubagents: 0 })
     }
   })
 
@@ -127,7 +152,8 @@ describe('processClaudeCliBackgroundWorkHook', () => {
     expect(processClaudeCliBackgroundWorkHook(SESSION, routineEvent)).toBeNull()
     expect(getClaudeCliBackgroundWorkCounts(SESSION)).toEqual({
       runningShells: 0,
-      runningMonitors: 1
+      runningMonitors: 1,
+      runningSubagents: 0
     })
   })
 
@@ -142,11 +168,13 @@ describe('processClaudeCliBackgroundWorkHook', () => {
 
     expect(processClaudeCliBackgroundWorkHook(SESSION, streamEnded)).toEqual({
       runningShells: 0,
-      runningMonitors: 1
+      runningMonitors: 1,
+      runningSubagents: 0
     })
     expect(processClaudeCliBackgroundWorkHook(SESSION, timedOut)).toEqual({
       runningShells: 0,
-      runningMonitors: 0
+      runningMonitors: 0,
+      runningSubagents: 0
     })
   })
 
@@ -164,9 +192,11 @@ describe('processClaudeCliBackgroundWorkHook', () => {
       ]
     }
 
+    // The running subagent in the snapshot is adopted, not ignored.
     expect(processClaudeCliBackgroundWorkHook(SESSION, stop)).toEqual({
       runningShells: 1,
-      runningMonitors: 1
+      runningMonitors: 1,
+      runningSubagents: 1
     })
   })
 
@@ -176,12 +206,13 @@ describe('processClaudeCliBackgroundWorkHook', () => {
     expect(processClaudeCliBackgroundWorkHook(SESSION, { hook_event_name: 'Stop' })).toBeNull()
     expect(getClaudeCliBackgroundWorkCounts(SESSION)).toEqual({
       runningShells: 1,
-      runningMonitors: 0
+      runningMonitors: 0,
+      runningSubagents: 0
     })
 
     expect(
       processClaudeCliBackgroundWorkHook(SESSION, { hook_event_name: 'Stop', background_tasks: [] })
-    ).toEqual({ runningShells: 0, runningMonitors: 0 })
+    ).toEqual({ runningShells: 0, runningMonitors: 0, runningSubagents: 0 })
   })
 
   it('clears everything on session boundaries', () => {
@@ -191,7 +222,8 @@ describe('processClaudeCliBackgroundWorkHook', () => {
 
       expect(processClaudeCliBackgroundWorkHook(SESSION, { hook_event_name: event })).toEqual({
         runningShells: 0,
-        runningMonitors: 0
+        runningMonitors: 0,
+        runningSubagents: 0
       })
     }
   })
@@ -206,11 +238,128 @@ describe('processClaudeCliBackgroundWorkHook', () => {
 
     expect(getClaudeCliBackgroundWorkCounts('session-a')).toEqual({
       runningShells: 1,
-      runningMonitors: 0
+      runningMonitors: 0,
+      runningSubagents: 0
     })
     expect(getClaudeCliBackgroundWorkCounts('session-b')).toEqual({
       runningShells: 0,
-      runningMonitors: 1
+      runningMonitors: 1,
+      runningSubagents: 0
+    })
+  })
+})
+
+describe('subagent counting', () => {
+  it('counts SubagentStart and retires on SubagentStop', () => {
+    expect(processClaudeCliBackgroundWorkHook(SESSION, subagentStart('a1'))).toEqual({
+      runningShells: 0,
+      runningMonitors: 0,
+      runningSubagents: 1
+    })
+    expect(processClaudeCliBackgroundWorkHook(SESSION, subagentStart('a2'))).toEqual({
+      runningShells: 0,
+      runningMonitors: 0,
+      runningSubagents: 2
+    })
+    expect(processClaudeCliBackgroundWorkHook(SESSION, subagentStop('a1'))).toEqual({
+      runningShells: 0,
+      runningMonitors: 0,
+      runningSubagents: 1
+    })
+    expect(processClaudeCliBackgroundWorkHook(SESSION, subagentStop('a2'))).toEqual({
+      runningShells: 0,
+      runningMonitors: 0,
+      runningSubagents: 0
+    })
+  })
+
+  it('ignores a SubagentStart without an agent id', () => {
+    expect(
+      processClaudeCliBackgroundWorkHook(SESSION, { hook_event_name: 'SubagentStart' })
+    ).toBeNull()
+  })
+
+  it("never prunes siblings on a SubagentStop's empty snapshot (foreground agents are invisible there)", () => {
+    // Two foreground subagents; the first one's SubagentStop carries
+    // background_tasks: [] (captured from claude v2.1.226) — the second must
+    // survive it.
+    processClaudeCliBackgroundWorkHook(SESSION, subagentStart('a1'))
+    processClaudeCliBackgroundWorkHook(SESSION, subagentStart('a2'))
+
+    expect(processClaudeCliBackgroundWorkHook(SESSION, subagentStop('a1', []))).toEqual({
+      runningShells: 0,
+      runningMonitors: 0,
+      runningSubagents: 1
+    })
+  })
+
+  it("retires a background subagent on its own SubagentStop even though it self-lists as running", () => {
+    // A background subagent's SubagentStop still lists it as 'running' in the
+    // snapshot (its result has not been consumed yet) — the stop edge wins.
+    processClaudeCliBackgroundWorkHook(SESSION, subagentStart('a1'))
+
+    expect(
+      processClaudeCliBackgroundWorkHook(
+        SESSION,
+        subagentStop('a1', [{ id: 'a1', type: 'subagent', status: 'running' }])
+      )
+    ).toEqual({ runningShells: 0, runningMonitors: 0, runningSubagents: 0 })
+  })
+
+  it('adopts running background subagents from a snapshot when their start was missed', () => {
+    expect(
+      processClaudeCliBackgroundWorkHook(SESSION, {
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'a9', type: 'subagent', status: 'running' }]
+      })
+    ).toEqual({ runningShells: 0, runningMonitors: 0, runningSubagents: 1 })
+  })
+
+  it('keeps workflow-spawned agents through a main Stop whose snapshot only lists the workflow', () => {
+    // Workflow inner agents never appear in background_tasks — only the parent
+    // {type:'workflow'} task does (captured from claude v2.1.226).
+    processClaudeCliBackgroundWorkHook(SESSION, subagentStart('wf-agent-1'))
+
+    expect(
+      processClaudeCliBackgroundWorkHook(SESSION, {
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'w1', type: 'workflow', status: 'running' }]
+      })
+    ).toBeNull()
+    expect(getClaudeCliBackgroundWorkCounts(SESSION)).toEqual({
+      runningShells: 0,
+      runningMonitors: 0,
+      runningSubagents: 1
+    })
+  })
+
+  it('prunes stale subagent ids at a main Stop with no workflow running', () => {
+    processClaudeCliBackgroundWorkHook(SESSION, subagentStart('leaked'))
+
+    expect(
+      processClaudeCliBackgroundWorkHook(SESSION, { hook_event_name: 'Stop', background_tasks: [] })
+    ).toEqual({ runningShells: 0, runningMonitors: 0, runningSubagents: 0 })
+  })
+
+  it('retires a subagent via a terminal task notification when its SubagentStop was missed', () => {
+    processClaudeCliBackgroundWorkHook(SESSION, subagentStart('a1'))
+
+    expect(
+      processClaudeCliBackgroundWorkHook(SESSION, notificationPrompt([terminalBlock('a1', 'completed')]))
+    ).toEqual({ runningShells: 0, runningMonitors: 0, runningSubagents: 0 })
+  })
+
+  it('does not count a running workflow task itself as a subagent', () => {
+    expect(
+      processClaudeCliBackgroundWorkHook(SESSION, {
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'w1', type: 'workflow', status: 'running' }]
+      })
+    ).toBeNull()
+    expect(getClaudeCliBackgroundWorkCounts(SESSION)).toEqual({
+      runningShells: 0,
+      runningMonitors: 0,
+      runningSubagents: 0
     })
   })
 })
@@ -223,8 +372,14 @@ describe('clearClaudeCliBackgroundWork', () => {
     expect(clearClaudeCliBackgroundWork(SESSION)).toBe(true)
     expect(getClaudeCliBackgroundWorkCounts(SESSION)).toEqual({
       runningShells: 0,
-      runningMonitors: 0
+      runningMonitors: 0,
+      runningSubagents: 0
     })
+  })
+
+  it('reports live counts for a session tracking only subagents', () => {
+    processClaudeCliBackgroundWorkHook(SESSION, subagentStart('a1'))
+    expect(clearClaudeCliBackgroundWork(SESSION)).toBe(true)
   })
 })
 

--- a/src/main/services/__tests__/claude-cli-subagent-tracker.test.ts
+++ b/src/main/services/__tests__/claude-cli-subagent-tracker.test.ts
@@ -144,6 +144,66 @@ describe('queued-notification gap', () => {
   })
 })
 
+describe('deferring a Stop with a running workflow', () => {
+  it('defers while a workflow task is running even with no subagent entries', () => {
+    // Real trace (claude v2.1.226): a Workflow-tool run appears as a single
+    // {type:'workflow'} background task; its spawned agents are never listed
+    // individually, so without workflow awareness this Stop would pass and
+    // flip the session to completed mid-workflow.
+    expect(
+      process(
+        { event: 'Stop', backgroundTasks: [{ id: 'w1', type: 'workflow', status: 'running' }] },
+        buildMapped(SESSION, 'completed')
+      )
+    ).toEqual({ kind: 'defer_stop' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(true)
+
+    // Workflow completes → its notification resume consumes the deferral →
+    // the resume turn's own clean Stop passes.
+    expect(
+      process(
+        { event: 'UserPromptSubmit', prompt: notificationPrompt('w1') },
+        buildMapped(SESSION, 'working')
+      )
+    ).toEqual({ kind: 'pass' })
+    expect(process({ event: 'Stop', backgroundTasks: [] })).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(false)
+  })
+
+  it('a completed workflow task does not defer', () => {
+    expect(
+      process({
+        event: 'Stop',
+        backgroundTasks: [{ id: 'w1', type: 'workflow', status: 'completed' }]
+      })
+    ).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+  })
+
+  it('running shells alone never defer', () => {
+    expect(
+      process({
+        event: 'Stop',
+        backgroundTasks: [{ id: 'bshell', type: 'shell', status: 'running' }]
+      })
+    ).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+  })
+
+  it("a workflow-spawned agent's SubagentStop (not self-listed) adds no pending notification", () => {
+    expect(
+      process({
+        event: 'SubagentStop',
+        agentId: 'wf-inner-agent',
+        backgroundTasks: [{ id: 'w1', type: 'workflow', status: 'running' }]
+      })
+    ).toEqual({ kind: 'pass' })
+    expect(hasPendingClaudeCliSubagentWork(SESSION)).toBe(false)
+  })
+})
+
 describe('foreground subagents', () => {
   it('a SubagentStop not self-listed in background_tasks leaves nothing pending', () => {
     expect(

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -203,6 +203,16 @@ describe('buildClaudeCliHookSettings', () => {
             ]
           }
         ],
+        SubagentStart: [
+          {
+            hooks: [
+              {
+                type: 'http',
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/subagent'
+              }
+            ]
+          }
+        ],
         SubagentStop: [
           {
             hooks: [
@@ -247,8 +257,6 @@ describe('buildClaudeCliHookSettings', () => {
             ]
           }
         ],
-        // SubagentStart is intentionally not registered: only completion of a
-        // background subagent (SubagentStop) is needed by the tracker.
         PermissionRequest: [
           {
             matcher: '*',
@@ -262,7 +270,6 @@ describe('buildClaudeCliHookSettings', () => {
         ]
       }
     })
-    expect(settings.hooks).not.toHaveProperty('SubagentStart')
   })
 })
 
@@ -1102,7 +1109,7 @@ describe('background shell/monitor counts (HTTP round-trip)', () => {
     await vi.waitFor(() => {
       expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
         'claude-cli:background-work',
-        { sessionId: SESSION, runningShells: 1, runningMonitors: 0 }
+        { sessionId: SESSION, runningShells: 1, runningMonitors: 0, runningSubagents: 0 }
       )
     })
 
@@ -1114,7 +1121,7 @@ describe('background shell/monitor counts (HTTP round-trip)', () => {
     await vi.waitFor(() => {
       expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
         'claude-cli:background-work',
-        { sessionId: SESSION, runningShells: 1, runningMonitors: 1 }
+        { sessionId: SESSION, runningShells: 1, runningMonitors: 1, runningSubagents: 0 }
       )
     })
 
@@ -1127,7 +1134,7 @@ describe('background shell/monitor counts (HTTP round-trip)', () => {
     await vi.waitFor(() => {
       expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
         'claude-cli:background-work',
-        { sessionId: SESSION, runningShells: 0, runningMonitors: 1 }
+        { sessionId: SESSION, runningShells: 0, runningMonitors: 1, runningSubagents: 0 }
       )
     })
   })
@@ -1169,7 +1176,7 @@ describe('background shell/monitor counts (HTTP round-trip)', () => {
     await vi.waitFor(() => {
       expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
         'claude-cli:background-work',
-        { sessionId: SESSION, runningShells: 1, runningMonitors: 0 }
+        { sessionId: SESSION, runningShells: 1, runningMonitors: 0, runningSubagents: 0 }
       )
     })
 
@@ -1182,7 +1189,7 @@ describe('background shell/monitor counts (HTTP round-trip)', () => {
     await vi.waitFor(() => {
       expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
         'claude-cli:background-work',
-        { sessionId: SESSION, runningShells: 0, runningMonitors: 0 }
+        { sessionId: SESSION, runningShells: 0, runningMonitors: 0, runningSubagents: 0 }
       )
     })
   })
@@ -1197,7 +1204,38 @@ describe('background shell/monitor counts (HTTP round-trip)', () => {
     await vi.waitFor(() => {
       expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
         'claude-cli:background-work',
-        { sessionId: SESSION, runningShells: 0, runningMonitors: 0 }
+        { sessionId: SESSION, runningShells: 0, runningMonitors: 0, runningSubagents: 0 }
+      )
+    })
+  })
+
+  it('publishes subagent count changes for SubagentStart/SubagentStop round-trips', async () => {
+    const { port } = await getClaudeHookServer()
+    backendManagerMocks.publishDesktopBackendEvent.mockResolvedValue(true)
+
+    // Payload shapes captured from claude v2.1.226 (workflow-spawned agents).
+    await postHook(port, SESSION, 'subagent', {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'a01d7c67fdfa59db2',
+      agent_type: 'workflow-subagent'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:background-work',
+        { sessionId: SESSION, runningShells: 0, runningMonitors: 0, runningSubagents: 1 }
+      )
+    })
+
+    await postHook(port, SESSION, 'subagent', {
+      hook_event_name: 'SubagentStop',
+      agent_id: 'a01d7c67fdfa59db2',
+      agent_type: 'workflow-subagent',
+      background_tasks: [{ id: 'w7op2i0my', type: 'workflow', status: 'running' }]
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:background-work',
+        { sessionId: SESSION, runningShells: 0, runningMonitors: 0, runningSubagents: 0 }
       )
     })
   })

--- a/src/main/services/claude-cli-background-work-tracker.ts
+++ b/src/main/services/claude-cli-background-work-tracker.ts
@@ -25,6 +25,16 @@ import { isTaskNotificationPrompt } from './claude-cli-subagent-tracker'
  *   authoritative reconciliation that self-heals such gaps at each turn
  *   boundary (both shells and monitors appear there as type 'shell', so it
  *   can prune but never classify — classification only happens at start).
+ * - Subagents (validated against claude v2.1.226): every subagent —
+ *   foreground Task, background Task, and workflow-spawned — fires
+ *   `SubagentStart` with an `agent_id` and `SubagentStop` with the same id,
+ *   so the live count comes from those edges. Snapshot reconciliation differs
+ *   from shells: background Task subagents DO appear as classified
+ *   `{type:'subagent'}` entries (adoptable), but workflow-spawned agents
+ *   never appear — only their parent `{type:'workflow'}` task does — so
+ *   pruning the whole set is only safe when the snapshot shows no running
+ *   subagent-or-workflow work at a main-agent Stop (nothing agent-ish can be
+ *   alive then; foreground subagents cannot outlive their turn).
  * - SessionStart/SessionEnd clear everything; background tasks never survive
  *   the CLI process, and orphans are reported to the *next* session.
  */
@@ -32,11 +42,13 @@ import { isTaskNotificationPrompt } from './claude-cli-subagent-tracker'
 export interface ClaudeCliBackgroundWorkCounts {
   runningShells: number
   runningMonitors: number
+  runningSubagents: number
 }
 
 interface SessionWork {
   shells: Set<string>
   monitors: Set<string>
+  subagents: Set<string>
 }
 
 // sessionId -> live background-task ids. Same accepted race as the subagent
@@ -53,14 +65,14 @@ const NOTIFICATION_BLOCK_PATTERN = /<task-notification>([\s\S]*?)<\/task-notific
 function getOrCreateWork(sessionId: string): SessionWork {
   let work = sessions.get(sessionId)
   if (!work) {
-    work = { shells: new Set(), monitors: new Set() }
+    work = { shells: new Set(), monitors: new Set(), subagents: new Set() }
     sessions.set(sessionId, work)
   }
   return work
 }
 
 function pruneIfEmpty(sessionId: string, work: SessionWork): void {
-  if (work.shells.size === 0 && work.monitors.size === 0) {
+  if (work.shells.size === 0 && work.monitors.size === 0 && work.subagents.size === 0) {
     sessions.delete(sessionId)
   }
 }
@@ -68,7 +80,8 @@ function pruneIfEmpty(sessionId: string, work: SessionWork): void {
 function counts(work: SessionWork | undefined): ClaudeCliBackgroundWorkCounts {
   return {
     runningShells: work?.shells.size ?? 0,
-    runningMonitors: work?.monitors.size ?? 0
+    runningMonitors: work?.monitors.size ?? 0,
+    runningSubagents: work?.subagents.size ?? 0
   }
 }
 
@@ -111,6 +124,17 @@ function responseId(hook: ParsedClaudeHook, field: string): string | null {
 }
 
 function canStartBackgroundWork(hook: ParsedClaudeHook): boolean {
+  if (hook.hook_event_name === 'SubagentStart') return true
+  // Stop/SubagentStop snapshots can adopt background subagents this process
+  // never saw start (e.g. hooks lost mid-flight).
+  if (
+    (hook.hook_event_name === 'Stop' || hook.hook_event_name === 'SubagentStop') &&
+    (hook.background_tasks ?? []).some(
+      (task) => task.type === 'subagent' && task.status === 'running'
+    )
+  ) {
+    return true
+  }
   return (
     hook.hook_event_name === 'PostToolUse' &&
     (hook.tool_name === 'Bash' || hook.tool_name === 'Monitor')
@@ -150,14 +174,37 @@ function reconcileWithSnapshot(work: SessionWork, hook: ParsedClaudeHook): void 
   if (!Array.isArray(tasks)) return
 
   const running = new Set<string>()
+  const runningSubagents = new Set<string>()
+  let runningWorkflow = false
   for (const task of tasks) {
-    if (task.status === 'running' && task.id) running.add(task.id)
+    if (task.status !== 'running') continue
+    if (task.id) running.add(task.id)
+    if (task.type === 'subagent' && task.id) runningSubagents.add(task.id)
+    if (task.type === 'workflow') runningWorkflow = true
   }
   for (const id of work.shells) {
     if (!running.has(id)) work.shells.delete(id)
   }
   for (const id of work.monitors) {
     if (!running.has(id)) work.monitors.delete(id)
+  }
+  // Adoption: unlike shells/monitors, snapshot entries classify subagents, so
+  // a background subagent whose SubagentStart this process missed can still
+  // be counted.
+  for (const id of runningSubagents) {
+    work.subagents.add(id)
+  }
+  // Subagent pruning is only safe at a main-agent Stop with no workflow
+  // running: foreground subagents cannot outlive their turn, so everything
+  // still alive must be in the snapshot then. A running workflow blocks
+  // pruning because its spawned agents never appear in snapshots (only the
+  // parent workflow task does) yet outlive main-agent turns. A SubagentStop's
+  // snapshot proves nothing about sibling foreground agents, so it never
+  // prunes.
+  if (hook.hook_event_name === 'Stop' && !hook.agent_id && !runningWorkflow) {
+    for (const id of work.subagents) {
+      if (!runningSubagents.has(id)) work.subagents.delete(id)
+    }
   }
 }
 
@@ -187,19 +234,34 @@ export function processClaudeCliBackgroundWorkHook(
 
   if (event === 'PostToolUse') {
     observePostToolUse(work, hook)
+  } else if (event === 'SubagentStart') {
+    if (typeof hook.agent_id === 'string' && hook.agent_id.length > 0) {
+      work.subagents.add(hook.agent_id)
+    }
   } else if (event === 'UserPromptSubmit') {
     for (const id of parseEndedTaskNotificationIds(hook.prompt)) {
       work.shells.delete(id)
       work.monitors.delete(id)
+      // A background subagent stays 'running' in snapshots until its result
+      // is consumed by this resume — retire it here in case a snapshot
+      // re-adopted it after its SubagentStop.
+      work.subagents.delete(id)
     }
   } else if (event === 'Stop' || event === 'SubagentStop') {
     reconcileWithSnapshot(work, hook)
+    // Delete after reconciling: a background subagent's own SubagentStop
+    // still self-lists it as 'running' (result not yet consumed), and the
+    // stop edge must win over that snapshot adoption.
+    if (event === 'SubagentStop' && typeof hook.agent_id === 'string') {
+      work.subagents.delete(hook.agent_id)
+    }
   }
 
   const after = counts(work)
   pruneIfEmpty(sessionId, work)
   return after.runningShells !== before.runningShells ||
-    after.runningMonitors !== before.runningMonitors
+    after.runningMonitors !== before.runningMonitors ||
+    after.runningSubagents !== before.runningSubagents
     ? after
     : null
 }
@@ -214,7 +276,7 @@ export function clearClaudeCliBackgroundWork(sessionId: string): boolean {
   const work = sessions.get(sessionId)
   if (!work) return false
   sessions.delete(sessionId)
-  return work.shells.size > 0 || work.monitors.size > 0
+  return work.shells.size > 0 || work.monitors.size > 0 || work.subagents.size > 0
 }
 
 export function clearAllClaudeCliBackgroundWork(): void {

--- a/src/main/services/claude-cli-subagent-tracker.ts
+++ b/src/main/services/claude-cli-subagent-tracker.ts
@@ -163,7 +163,19 @@ function onTimerFire(sessionId: string): void {
 function runningSubagentIds(backgroundTasks: ClaudeCliBackgroundTask[] | undefined): Set<string> {
   const ids = new Set<string>()
   for (const task of backgroundTasks ?? []) {
-    if (task.type === 'subagent' && task.status === 'running' && task.id) ids.add(task.id)
+    // Workflows count as running subagent work: a Workflow-tool run appears in
+    // the snapshot as one {type:'workflow'} task (its spawned agents are never
+    // listed individually), keeps running across main-agent Stops exactly like
+    // a background subagent, and delivers its result via the same
+    // task-notification resume. Without this, a Stop mid-workflow flips the
+    // session to completed while agents are still working.
+    if (
+      (task.type === 'subagent' || task.type === 'workflow') &&
+      task.status === 'running' &&
+      task.id
+    ) {
+      ids.add(task.id)
+    }
   }
   return ids
 }

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -61,7 +61,7 @@ export interface ParsedClaudeHook {
   /** Final assistant message of the turn (Stop hook). Read both spellings: */
   assistant_message?: string
   last_assistant_message?: string
-  /** Present on subagent-scoped hooks (SubagentStop, subagent-scoped Stop). */
+  /** Present on subagent-scoped hooks (SubagentStart/SubagentStop, subagent-scoped Stop). */
   agent_id?: string
   agent_type?: string
   /** Snapshot of in-flight background work at Stop/SubagentStop time. */
@@ -121,6 +121,11 @@ export function buildClaudeCliHookSettings(port: number, hiveSessionId: string):
           hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'stop') }]
         }
       ],
+      SubagentStart: [
+        {
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'subagent') }]
+        }
+      ],
       SubagentStop: [
         {
           hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'subagent') }]
@@ -178,6 +183,7 @@ export function mapHookEventToStatus(hook: ParsedClaudeHook): SessionStatusType 
       if (hook.tool_name === 'ExitPlanMode') return 'plan_ready'
       if (hook.tool_name === 'AskUserQuestion') return 'answering'
       return 'permission'
+    case 'SubagentStart':
     case 'SubagentStop':
       return null
     default:
@@ -252,7 +258,12 @@ function publishClaudeCliBackgroundWork(payload: ClaudeCliBackgroundWorkPayload)
  */
 export function resetClaudeCliBackgroundWork(sessionId: string): void {
   if (clearClaudeCliBackgroundWork(sessionId)) {
-    publishClaudeCliBackgroundWork({ sessionId, runningShells: 0, runningMonitors: 0 })
+    publishClaudeCliBackgroundWork({
+      sessionId,
+      runningShells: 0,
+      runningMonitors: 0,
+      runningSubagents: 0
+    })
   }
 }
 

--- a/src/renderer/src/components/kanban/KanbanTicketCard.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.test.tsx
@@ -143,9 +143,11 @@ describe('KanbanTicketCard background work badges', () => {
 
   const linkedTicket: KanbanTicket = { ...baseTicket, current_session_id: 'session-1' }
 
-  it('renders shell and monitor count badges for the linked session', () => {
+  it('renders shell, monitor, and subagent count badges for the linked session', () => {
     useWorktreeStatusStore.setState({
-      backgroundWorkBySession: { 'session-1': { runningShells: 2, runningMonitors: 1 } }
+      backgroundWorkBySession: {
+        'session-1': { runningShells: 2, runningMonitors: 1, runningSubagents: 3 }
+      }
     })
 
     render(
@@ -156,11 +158,14 @@ describe('KanbanTicketCard background work badges', () => {
 
     expect(screen.getByTestId('kanban-ticket-running-shells')).toHaveTextContent('2')
     expect(screen.getByTestId('kanban-ticket-running-monitors')).toHaveTextContent('1')
+    expect(screen.getByTestId('kanban-ticket-running-subagents')).toHaveTextContent('3')
   })
 
   it('renders only the badge whose count is non-zero', () => {
     useWorktreeStatusStore.setState({
-      backgroundWorkBySession: { 'session-1': { runningShells: 1, runningMonitors: 0 } }
+      backgroundWorkBySession: {
+        'session-1': { runningShells: 1, runningMonitors: 0, runningSubagents: 0 }
+      }
     })
 
     render(
@@ -171,11 +176,32 @@ describe('KanbanTicketCard background work badges', () => {
 
     expect(screen.getByTestId('kanban-ticket-running-shells')).toHaveTextContent('1')
     expect(screen.queryByTestId('kanban-ticket-running-monitors')).toBeNull()
+    expect(screen.queryByTestId('kanban-ticket-running-subagents')).toBeNull()
+  })
+
+  it('renders the subagent badge alone while a workflow runs its agents', () => {
+    useWorktreeStatusStore.setState({
+      backgroundWorkBySession: {
+        'session-1': { runningShells: 0, runningMonitors: 0, runningSubagents: 2 }
+      }
+    })
+
+    render(
+      <TooltipProvider>
+        <KanbanTicketCard ticket={linkedTicket} />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByTestId('kanban-ticket-running-subagents')).toHaveTextContent('2')
+    expect(screen.queryByTestId('kanban-ticket-running-shells')).toBeNull()
+    expect(screen.queryByTestId('kanban-ticket-running-monitors')).toBeNull()
   })
 
   it('renders no badges without counts or for other sessions', () => {
     useWorktreeStatusStore.setState({
-      backgroundWorkBySession: { 'other-session': { runningShells: 3, runningMonitors: 3 } }
+      backgroundWorkBySession: {
+        'other-session': { runningShells: 3, runningMonitors: 3, runningSubagents: 3 }
+      }
     })
 
     render(
@@ -186,5 +212,6 @@ describe('KanbanTicketCard background work badges', () => {
 
     expect(screen.queryByTestId('kanban-ticket-running-shells')).toBeNull()
     expect(screen.queryByTestId('kanban-ticket-running-monitors')).toBeNull()
+    expect(screen.queryByTestId('kanban-ticket-running-subagents')).toBeNull()
   })
 })

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -35,7 +35,8 @@ import {
   RadioTower,
   Unplug,
   SquareTerminal,
-  Radar
+  Radar,
+  Bot
 } from 'lucide-react'
 import { CheckeredFlagIcon } from './CheckeredFlagIcon'
 import { HighlightedText } from './HighlightedText'
@@ -1181,6 +1182,25 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                     <GitBranch className="h-3 w-3" />
                     {queuedBranchLabel}
                   </span>
+                )}
+                {/* Running subagents in the linked claude-cli session */}
+                {backgroundWork && backgroundWork.runningSubagents > 0 && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        data-testid="kanban-ticket-running-subagents"
+                        className="inline-flex items-center gap-1 rounded-full bg-violet-500/10 border border-violet-500/30 px-2 py-0.5 text-[11px] font-medium text-violet-500 cursor-help"
+                      >
+                        <Bot className="h-3 w-3" />
+                        {backgroundWork.runningSubagents}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {backgroundWork.runningSubagents === 1
+                        ? '1 subagent running'
+                        : `${backgroundWork.runningSubagents} subagents running`}
+                    </TooltipContent>
+                  </Tooltip>
                 )}
                 {/* Running background shells in the linked claude-cli session */}
                 {backgroundWork && backgroundWork.runningShells > 0 && (

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -775,6 +775,7 @@ describe('useClaudeCliStatusListener — background work counts', () => {
       sessionId: string
       runningShells: number
       runningMonitors: number
+      runningSubagents: number
     }) => void) | null = null
     mocks.onClaudeCliBackgroundWork.mockImplementation((callback) => {
       subscribed = callback
@@ -783,11 +784,17 @@ describe('useClaudeCliStatusListener — background work counts', () => {
 
     renderHook(() => useClaudeCliStatusListener())
 
-    subscribed?.({ sessionId: 'hive-session-1', runningShells: 2, runningMonitors: 1 })
+    subscribed?.({
+      sessionId: 'hive-session-1',
+      runningShells: 2,
+      runningMonitors: 1,
+      runningSubagents: 3
+    })
 
     expect(mocks.setSessionBackgroundWork).toHaveBeenCalledWith('hive-session-1', {
       runningShells: 2,
-      runningMonitors: 1
+      runningMonitors: 1,
+      runningSubagents: 3
     })
   })
 

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -201,13 +201,14 @@ export function useClaudeCliStatusListener(): void {
       worktreeStatus.setSessionStatus(sessionId, status, metadata)
     })
 
-    // Live background shell/monitor counts for the kanban ticket badges —
-    // pure store writes, deliberately outside the status state machine above.
+    // Live background shell/monitor/subagent counts for the kanban ticket
+    // badges — pure store writes, deliberately outside the status state
+    // machine above.
     const unsubscribeBackgroundWork = terminalApi.onClaudeCliBackgroundWork(
-      ({ sessionId, runningShells, runningMonitors }) => {
+      ({ sessionId, runningShells, runningMonitors, runningSubagents }) => {
         useWorktreeStatusStore
           .getState()
-          .setSessionBackgroundWork(sessionId, { runningShells, runningMonitors })
+          .setSessionBackgroundWork(sessionId, { runningShells, runningMonitors, runningSubagents })
       }
     )
 

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -54,6 +54,7 @@ export type MergeConflictFlow =
 export interface SessionBackgroundWork {
   runningShells: number
   runningMonitors: number
+  runningSubagents: number
 }
 
 interface WorktreeStatusState {
@@ -213,7 +214,7 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
 
   setSessionBackgroundWork: (sessionId: string, work: SessionBackgroundWork) => {
     set((state) => {
-      if (work.runningShells === 0 && work.runningMonitors === 0) {
+      if (work.runningShells === 0 && work.runningMonitors === 0 && work.runningSubagents === 0) {
         if (!(sessionId in state.backgroundWorkBySession)) return {}
         const { [sessionId]: _, ...rest } = state.backgroundWorkBySession
         return { backgroundWorkBySession: rest }

--- a/src/shared/types/claude-cli-background-work.ts
+++ b/src/shared/types/claude-cli-background-work.ts
@@ -1,9 +1,9 @@
 /**
  * Live background-work counts for a Claude CLI session: how many background
- * shells (Bash with run_in_background) and monitors (Monitor tool) are running
- * right now. Published by the main-process hook server on the dedicated
- * channel below (the status channel dedups by status string, which would
- * swallow count-only changes).
+ * shells (Bash with run_in_background), monitors (Monitor tool), and subagents
+ * (Task/Agent tool + workflow-spawned agents) are running right now. Published
+ * by the main-process hook server on the dedicated channel below (the status
+ * channel dedups by status string, which would swallow count-only changes).
  */
 export const CLAUDE_CLI_BACKGROUND_WORK_CHANNEL = 'claude-cli:background-work'
 
@@ -11,6 +11,7 @@ export interface ClaudeCliBackgroundWorkPayload {
   sessionId: string
   runningShells: number
   runningMonitors: number
+  runningSubagents: number
 }
 
 export function isClaudeCliBackgroundWorkPayload(
@@ -21,6 +22,7 @@ export function isClaudeCliBackgroundWorkPayload(
   return (
     typeof payload.sessionId === 'string' &&
     typeof payload.runningShells === 'number' &&
-    typeof payload.runningMonitors === 'number'
+    typeof payload.runningMonitors === 'number' &&
+    typeof payload.runningSubagents === 'number'
   )
 }


### PR DESCRIPTION
## Summary
- Track Claude subagents and workflow-spawned agents alongside background shells and monitors.
- Register `SubagentStart` hooks and reconcile subagent/workflow snapshots safely.
- Publish subagent counts through the main/renderer status pipeline.
- Display live subagent count badges on linked Kanban tickets.
- Add comprehensive tracker, hook-server, listener, and UI test coverage.

## Testing
- Added and updated unit tests for subagent lifecycle tracking, workflow deferral, hook round-trips, status listeners, and Kanban badges.
- Not run: full test suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session completion deferral and background-work reconciliation for workflows and subagents; mistakes could show wrong Kanban state or complete sessions too early, but behavior is heavily covered by new tests.
> 
> **Overview**
> Extends Claude CLI **background-work** tracking with **`runningSubagents`**, wired from **`SubagentStart`/`SubagentStop`** (and snapshot adoption/pruning rules that treat **workflows** differently from listed subagents).
> 
> **`SubagentStart`** is now registered on the hook server so counts update on start/stop; the **`claude-cli:background-work`** payload, worktree store, and status listener all carry the third count. Kanban tickets linked to a session show a violet **subagent** badge when the count is non-zero.
> 
> The **subagent completion gate** treats a running **`{type:'workflow'}`** task like in-flight subagent work so a main **`Stop`** is deferred mid-workflow instead of marking the session completed while workflow-spawned agents still run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0108e11aeb707f40d56b93759fc568621fd0a699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->