### PR TITLE
Prevent stranded Claude processes and terminal leaks

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -1770,6 +1770,14 @@ export class DatabaseService {
     return rows.map((row) => this.mapSessionRow(row))
   }
 
+  getSessionByClaudeSessionId(claudeSessionId: string): Session | null {
+    const db = this.getDb()
+    const row = db
+      .prepare('SELECT * FROM sessions WHERE claude_session_id = ? LIMIT 1')
+      .get(claudeSessionId) as Record<string, unknown> | undefined
+    return row ? this.mapSessionRow(row) : null
+  }
+
   getActiveBoardAssistantByProject(projectId: string): Session | null {
     const db = this.getDb()
     const row = db

--- a/src/main/services/__tests__/claude-session-watcher.test.ts
+++ b/src/main/services/__tests__/claude-session-watcher.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { encodePath } from '../claude-transcript-reader'
+import { watchForClaudeSessionId, type ClaudeSessionWatchHandle } from '../claude-session-watcher'
+
+vi.mock('../logger', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }))
+}))
+
+const WORKTREE_PATH = '/repo/watched-worktree'
+
+describe('watchForClaudeSessionId rejection', () => {
+  let configRoot: string
+  let transcriptDir: string
+  let savedConfigDir: string | undefined
+  let handle: ClaudeSessionWatchHandle | null = null
+
+  beforeEach(() => {
+    vi.useFakeTimers({ now: Date.now() })
+    configRoot = mkdtempSync(join(tmpdir(), 'claude-watcher-test-'))
+    transcriptDir = join(configRoot, 'projects', encodePath(WORKTREE_PATH))
+    savedConfigDir = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = configRoot
+  })
+
+  afterEach(() => {
+    handle?.close()
+    handle = null
+    vi.useRealTimers()
+    if (savedConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR
+    else process.env.CLAUDE_CONFIG_DIR = savedConfigDir
+    rmSync(configRoot, { recursive: true, force: true })
+  })
+
+  it('keeps watching after a rejected id and reports the next transcript', () => {
+    const seen: string[] = []
+    // First discovery is rejected (claimed by a concurrent session), later
+    // ones are accepted.
+    const onSessionId = vi.fn((sessionId: string): boolean | void => {
+      seen.push(sessionId)
+      if (sessionId === 'stolen') return false
+    })
+
+    // The transcript dir does not exist yet, so the watcher uses its 1s
+    // polling fallback — deterministic under fake timers.
+    handle = watchForClaudeSessionId(WORKTREE_PATH, onSessionId)
+    expect(onSessionId).not.toHaveBeenCalled()
+
+    mkdirSync(transcriptDir, { recursive: true })
+    writeFileSync(join(transcriptDir, 'stolen.jsonl'), '{}\n')
+    vi.advanceTimersByTime(1000)
+
+    expect(seen).toEqual(['stolen'])
+
+    // The rejected transcript stays excluded on subsequent scans.
+    vi.advanceTimersByTime(2000)
+    expect(seen).toEqual(['stolen'])
+
+    writeFileSync(join(transcriptDir, 'mine.jsonl'), '{}\n')
+    vi.advanceTimersByTime(1000)
+    expect(seen).toEqual(['stolen', 'mine'])
+
+    // Accepted discovery closes the watcher — no further scans fire.
+    writeFileSync(join(transcriptDir, 'later.jsonl'), '{}\n')
+    vi.advanceTimersByTime(3000)
+    expect(seen).toEqual(['stolen', 'mine'])
+  })
+
+  it('recovers an already-present sibling transcript in the same scan after a rejection', () => {
+    const seen: string[] = []
+    const onSessionId = vi.fn((sessionId: string): boolean | void => {
+      seen.push(sessionId)
+      if (sessionId === 'stolen') return false
+    })
+
+    handle = watchForClaudeSessionId(WORKTREE_PATH, onSessionId)
+    mkdirSync(transcriptDir, { recursive: true })
+    writeFileSync(join(transcriptDir, 'mine.jsonl'), '{}\n')
+    writeFileSync(join(transcriptDir, 'stolen.jsonl'), '{}\n')
+    // Force distinct mtimes so 'stolen' is strictly newest.
+    const base = Date.now()
+    utimesSync(join(transcriptDir, 'mine.jsonl'), new Date(base), new Date(base))
+    utimesSync(join(transcriptDir, 'stolen.jsonl'), new Date(base + 100), new Date(base + 100))
+
+    // One poll tick: reject 'stolen', and the immediate re-scan must pick up
+    // 'mine' without waiting for another fs event or poll.
+    vi.advanceTimersByTime(1000)
+
+    expect(seen).toEqual(['stolen', 'mine'])
+  })
+
+  it('closes after an accepted discovery without rejections', () => {
+    const onSessionId = vi.fn()
+
+    handle = watchForClaudeSessionId(WORKTREE_PATH, onSessionId)
+    mkdirSync(transcriptDir, { recursive: true })
+    writeFileSync(join(transcriptDir, 'first.jsonl'), '{}\n')
+    vi.advanceTimersByTime(1000)
+
+    expect(onSessionId).toHaveBeenCalledTimes(1)
+    expect(onSessionId).toHaveBeenCalledWith('first')
+
+    writeFileSync(join(transcriptDir, 'second.jsonl'), '{}\n')
+    vi.advanceTimersByTime(3000)
+    expect(onSessionId).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/services/__tests__/pty-service.test.ts
+++ b/src/main/services/__tests__/pty-service.test.ts
@@ -176,6 +176,39 @@ describe('ptyService.destroy kill escalation', () => {
     expect(killSpy).toHaveBeenCalledWith(PID, 'SIGKILL')
   })
 
+  it('never signals the numeric pid after the pty reported exit (pid-reuse hazard)', () => {
+    // Distinct pid: the exited-pid ledger is module-level and must not leak
+    // into the other escalation tests.
+    const REUSED_PID = 5353
+    nodePtyMocks.spawn.mockImplementation(() => makeFakePty(REUSED_PID))
+    // Simulate the worst case: the pid probe would "succeed" because an
+    // unrelated process inherited the number; the group is empty.
+    killSpy.mockImplementation(((pid: number, signal?: string | number) => {
+      if (signal === 0 && pid < 0) throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' })
+      return true
+    }) as KillFn)
+
+    const id = `pty-escalation-test-${nextId++}`
+    ptyService.create(id, { cwd: '/tmp' })
+    const fakePty = nodePtyMocks.spawn.mock.results.at(-1)?.value as {
+      onExit: ReturnType<typeof vi.fn>
+    }
+    ptyService.destroy(id)
+    // The child exits (and is reaped) during the grace period
+    const exitHandler = fakePty.onExit.mock.calls[0][0] as (e: {
+      exitCode: number
+      signal: number
+    }) => void
+    exitHandler({ exitCode: 0, signal: 1 })
+
+    vi.advanceTimersByTime(1500)
+
+    expect(killSpy).not.toHaveBeenCalledWith(REUSED_PID, 0)
+    expect(killSpy).toHaveBeenCalledWith(-REUSED_PID, 0)
+    expect(killSpy).not.toHaveBeenCalledWith(REUSED_PID, 'SIGKILL')
+    expect(killSpy).not.toHaveBeenCalledWith(-REUSED_PID, 'SIGKILL')
+  })
+
   it('destroyAllAndReap sweeps survivors after the bounded grace (quit path)', async () => {
     killSpy.mockImplementation((() => true) as KillFn)
 

--- a/src/main/services/__tests__/pty-service.test.ts
+++ b/src/main/services/__tests__/pty-service.test.ts
@@ -116,6 +116,11 @@ describe('ptyService.destroy kill escalation', () => {
 
   beforeEach(() => {
     vi.useFakeTimers()
+    // Drain ptys left registered by other describes — their (shared fake)
+    // pids would trip the registered-pty guard in reapSurvivors. Fake timers
+    // keep the escalations this schedules permanently inert.
+    ptyService.destroyAll()
+    vi.clearAllTimers()
     nodePtyMocks.spawn.mockImplementation(() => makeFakePty(PID))
     killSpy = vi.spyOn(process, 'kill') as unknown as MockInstance<KillFn>
     // Never run the real pgrep in unit tests
@@ -322,6 +327,29 @@ describe('ptyService.destroy kill escalation', () => {
 
     expect(killSpy).toHaveBeenCalledWith(-PID, 'SIGKILL')
     expect(killSpy).toHaveBeenCalledWith(PID, 'SIGKILL')
+  })
+
+  it('a stale escalation timer never touches a pid recycled into a registered pty', async () => {
+    const STALE = 8686
+    nodePtyMocks.spawn.mockImplementation(() => makeFakePty(STALE))
+    killSpy.mockImplementation((() => true) as KillFn)
+
+    // Destroy arms the escalation timer for pid STALE
+    const firstId = `pty-escalation-test-${nextId++}`
+    ptyService.create(firstId, { cwd: '/tmp' })
+    ptyService.destroy(firstId)
+
+    // Before the grace elapses, a NEW pty spawns and the OS recycles the pid
+    const secondId = `pty-escalation-test-${nextId++}`
+    ptyService.create(secondId, { cwd: '/tmp' })
+
+    await advancePastGrace()
+
+    // The stale timer must not probe or signal the new session's process
+    expect(killSpy).not.toHaveBeenCalledWith(-STALE, 'SIGKILL')
+    expect(killSpy).not.toHaveBeenCalledWith(STALE, 'SIGKILL')
+
+    ptyService.destroy(secondId)
   })
 
   it('destroyAllAndReap sweeps survivors after the bounded grace (quit path)', async () => {

--- a/src/main/services/__tests__/pty-service.test.ts
+++ b/src/main/services/__tests__/pty-service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
 import { ptyService } from '../pty-service'
 
 const nodePtyMocks = vi.hoisted(() => ({
@@ -18,8 +18,9 @@ vi.mock('../logger', () => ({
   }))
 }))
 
-function makeFakePty(): Record<string, unknown> {
+function makeFakePty(pid = 4242): Record<string, unknown> {
   return {
+    pid,
     cols: 80,
     rows: 24,
     onData: vi.fn(),
@@ -84,5 +85,113 @@ describe('ptyService.create spawn environment', () => {
 
     expect(spawnedEnv().COLUMNS).toBe('120')
     expect(spawnedEnv().HIVE_TEST_VAR).toBe('yes')
+  })
+})
+
+type KillFn = (pid: number, signal?: string | number) => true
+
+describe('ptyService.destroy kill escalation', () => {
+  const PID = 4242
+  let killSpy: MockInstance<KillFn>
+  let nextId = 0
+
+  function createAndGetPty(): { kill: ReturnType<typeof vi.fn> } {
+    const id = `pty-escalation-test-${nextId++}`
+    ptyService.create(id, { cwd: '/tmp' })
+    const fakePty = nodePtyMocks.spawn.mock.results.at(-1)?.value as {
+      kill: ReturnType<typeof vi.fn>
+    }
+    ptyService.destroy(id)
+    return fakePty
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    nodePtyMocks.spawn.mockImplementation(() => makeFakePty(PID))
+    killSpy = vi.spyOn(process, 'kill') as unknown as MockInstance<KillFn>
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    killSpy.mockRestore()
+    vi.clearAllMocks()
+  })
+
+  it('escalates to a process-group SIGKILL when the process survives SIGHUP', () => {
+    killSpy.mockImplementation((() => true) as KillFn)
+
+    const fakePty = createAndGetPty()
+
+    expect(fakePty.kill).toHaveBeenCalledTimes(1)
+    expect(killSpy).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1500)
+
+    expect(killSpy).toHaveBeenCalledWith(PID, 0)
+    expect(killSpy).toHaveBeenCalledWith(-PID, 'SIGKILL')
+  })
+
+  it('does not escalate when the process and its group are both dead at probe time', () => {
+    killSpy.mockImplementation(((_pid: number, signal?: string | number) => {
+      if (signal === 0) throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' })
+      return true
+    }) as KillFn)
+
+    createAndGetPty()
+    vi.advanceTimersByTime(1500)
+
+    expect(killSpy).toHaveBeenCalledWith(PID, 0)
+    expect(killSpy).toHaveBeenCalledWith(-PID, 0)
+    expect(killSpy).not.toHaveBeenCalledWith(-PID, 'SIGKILL')
+    expect(killSpy).not.toHaveBeenCalledWith(PID, 'SIGKILL')
+  })
+
+  it('escalates when the wrapper shell died but a group member survives', () => {
+    // Custom-provider topology: the direct child ($SHELL wrapper) is reaped,
+    // but a HUP-ignoring agent in the same process group lives on.
+    killSpy.mockImplementation(((pid: number, signal?: string | number) => {
+      if (signal === 0 && pid > 0) throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' })
+      return true
+    }) as KillFn)
+
+    createAndGetPty()
+    vi.advanceTimersByTime(1500)
+
+    expect(killSpy).toHaveBeenCalledWith(-PID, 0)
+    expect(killSpy).toHaveBeenCalledWith(-PID, 'SIGKILL')
+  })
+
+  it('falls back to a direct SIGKILL when the group kill fails', () => {
+    killSpy.mockImplementation(((pid: number, signal?: string | number) => {
+      if (signal === 0) return true
+      if (pid < 0) throw Object.assign(new Error('EPERM'), { code: 'EPERM' })
+      return true
+    }) as KillFn)
+
+    createAndGetPty()
+    vi.advanceTimersByTime(1500)
+
+    expect(killSpy).toHaveBeenCalledWith(-PID, 'SIGKILL')
+    expect(killSpy).toHaveBeenCalledWith(PID, 'SIGKILL')
+  })
+
+  it('destroyAllAndReap sweeps survivors after the bounded grace (quit path)', async () => {
+    killSpy.mockImplementation((() => true) as KillFn)
+
+    const id = `pty-escalation-test-${nextId++}`
+    ptyService.create(id, { cwd: '/tmp' })
+    const fakePty = nodePtyMocks.spawn.mock.results.at(-1)?.value as {
+      kill: ReturnType<typeof vi.fn>
+    }
+
+    const reap = ptyService.destroyAllAndReap(300)
+    expect(fakePty.kill).toHaveBeenCalledTimes(1)
+    expect(killSpy).not.toHaveBeenCalledWith(-PID, 'SIGKILL')
+
+    await vi.advanceTimersByTimeAsync(300)
+    await reap
+
+    expect(killSpy).toHaveBeenCalledWith(-PID, 'SIGKILL')
   })
 })

--- a/src/main/services/__tests__/pty-service.test.ts
+++ b/src/main/services/__tests__/pty-service.test.ts
@@ -204,6 +204,79 @@ describe('ptyService.destroy kill escalation', () => {
     expect(killSpy).not.toHaveBeenCalledWith(PID, 'SIGKILL')
   })
 
+  it('kills the surviving group even when the snapshot is empty (pgrep failure fails open)', async () => {
+    // Default groupMembersSpy resolves an empty set — a tooling failure must
+    // not disable the escalation, or the HUP-surviving leak returns.
+    killSpy.mockImplementation(((pid: number, signal?: string | number) => {
+      if (signal === 0 && pid > 0) throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' })
+      return true
+    }) as KillFn)
+
+    createAndGetPty()
+    await advancePastGrace()
+
+    expect(killSpy).toHaveBeenCalledWith(-PID, 'SIGKILL')
+  })
+
+  it('does not kill blind when the leader exited and there is no membership evidence', async () => {
+    // Exited leader + empty snapshot: an alive group with zero traced
+    // members is treated as a recycled pgid, not an untracked survivor.
+    const EXITED = 7575
+    nodePtyMocks.spawn.mockImplementation(() => makeFakePty(EXITED))
+    killSpy.mockImplementation(((pid: number, signal?: string | number) => {
+      if (signal === 0 && pid > 0) throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' })
+      return true
+    }) as KillFn)
+
+    const id = `pty-escalation-test-${nextId++}`
+    ptyService.create(id, { cwd: '/tmp' })
+    const fakePty = nodePtyMocks.spawn.mock.results.at(-1)?.value as {
+      onExit: ReturnType<typeof vi.fn>
+    }
+    ptyService.destroy(id)
+    const exitHandler = fakePty.onExit.mock.calls[0][0] as (e: {
+      exitCode: number
+      signal: number
+    }) => void
+    exitHandler({ exitCode: 0, signal: 1 })
+
+    await advancePastGrace()
+
+    expect(killSpy).not.toHaveBeenCalledWith(-EXITED, 'SIGKILL')
+    expect(killSpy).not.toHaveBeenCalledWith(EXITED, 'SIGKILL')
+  })
+
+  it('a new PTY reusing an exited pid is probed normally (ledger cleared on spawn)', async () => {
+    const RECYCLED = 6464
+    nodePtyMocks.spawn.mockImplementation(() => makeFakePty(RECYCLED))
+    killSpy.mockImplementation((() => true) as KillFn)
+
+    // First pty exits — its pid lands in the exited ledger
+    const firstId = `pty-escalation-test-${nextId++}`
+    ptyService.create(firstId, { cwd: '/tmp' })
+    const firstPty = nodePtyMocks.spawn.mock.results.at(-1)?.value as {
+      onExit: ReturnType<typeof vi.fn>
+    }
+    const exitHandler = firstPty.onExit.mock.calls[0][0] as (e: {
+      exitCode: number
+      signal: number
+    }) => void
+    ptyService.destroy(firstId)
+    exitHandler({ exitCode: 0, signal: 1 })
+    await advancePastGrace()
+    killSpy.mockClear()
+
+    // A new pty spawns with the same (recycled) pid — create() must clear
+    // the stale ledger entry so its own destroy escalation still probes it
+    const secondId = `pty-escalation-test-${nextId++}`
+    ptyService.create(secondId, { cwd: '/tmp' })
+    ptyService.destroy(secondId)
+    await advancePastGrace()
+
+    expect(killSpy).toHaveBeenCalledWith(RECYCLED, 0)
+    expect(killSpy).toHaveBeenCalledWith(-RECYCLED, 'SIGKILL')
+  })
+
   it('never signals the numeric pid after the pty reported exit (pid-reuse hazard)', async () => {
     // Distinct pid: the exited-pid ledger is module-level and must not leak
     // into the other escalation tests.

--- a/src/main/services/__tests__/pty-service.test.ts
+++ b/src/main/services/__tests__/pty-service.test.ts
@@ -93,6 +93,7 @@ type KillFn = (pid: number, signal?: string | number) => true
 describe('ptyService.destroy kill escalation', () => {
   const PID = 4242
   let killSpy: MockInstance<KillFn>
+  let groupMembersSpy: MockInstance<(pgid: number) => Promise<Set<number>>>
   let nextId = 0
 
   function createAndGetPty(): { kill: ReturnType<typeof vi.fn> } {
@@ -105,20 +106,38 @@ describe('ptyService.destroy kill escalation', () => {
     return fakePty
   }
 
+  async function advancePastGrace(): Promise<void> {
+    await vi.advanceTimersByTimeAsync(1500)
+    // Flush the snapshot/ownership promise chains the timer kicked off
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  }
+
   beforeEach(() => {
     vi.useFakeTimers()
     nodePtyMocks.spawn.mockImplementation(() => makeFakePty(PID))
     killSpy = vi.spyOn(process, 'kill') as unknown as MockInstance<KillFn>
+    // Never run the real pgrep in unit tests
+    groupMembersSpy = vi
+      .spyOn(
+        ptyService as unknown as { listGroupMembers(pgid: number): Promise<Set<number>> },
+        'listGroupMembers'
+      )
+      .mockResolvedValue(new Set<number>()) as unknown as MockInstance<
+      (pgid: number) => Promise<Set<number>>
+    >
   })
 
   afterEach(() => {
     vi.clearAllTimers()
     vi.useRealTimers()
     killSpy.mockRestore()
+    groupMembersSpy.mockRestore()
     vi.clearAllMocks()
   })
 
-  it('escalates to a process-group SIGKILL when the process survives SIGHUP', () => {
+  it('escalates to a process-group SIGKILL when the process survives SIGHUP', async () => {
     killSpy.mockImplementation((() => true) as KillFn)
 
     const fakePty = createAndGetPty()
@@ -126,20 +145,20 @@ describe('ptyService.destroy kill escalation', () => {
     expect(fakePty.kill).toHaveBeenCalledTimes(1)
     expect(killSpy).not.toHaveBeenCalled()
 
-    vi.advanceTimersByTime(1500)
+    await advancePastGrace()
 
     expect(killSpy).toHaveBeenCalledWith(PID, 0)
     expect(killSpy).toHaveBeenCalledWith(-PID, 'SIGKILL')
   })
 
-  it('does not escalate when the process and its group are both dead at probe time', () => {
+  it('does not escalate when the process and its group are both dead at probe time', async () => {
     killSpy.mockImplementation(((_pid: number, signal?: string | number) => {
       if (signal === 0) throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' })
       return true
     }) as KillFn)
 
     createAndGetPty()
-    vi.advanceTimersByTime(1500)
+    await advancePastGrace()
 
     expect(killSpy).toHaveBeenCalledWith(PID, 0)
     expect(killSpy).toHaveBeenCalledWith(-PID, 0)
@@ -147,36 +166,45 @@ describe('ptyService.destroy kill escalation', () => {
     expect(killSpy).not.toHaveBeenCalledWith(PID, 'SIGKILL')
   })
 
-  it('escalates when the wrapper shell died but a group member survives', () => {
+  it('escalates when the wrapper shell died but a snapshot member survives in the group', async () => {
     // Custom-provider topology: the direct child ($SHELL wrapper) is reaped,
-    // but a HUP-ignoring agent in the same process group lives on.
+    // but a HUP-ignoring agent in the same process group lives on. The agent
+    // (999) appears in both the destroy-time snapshot and the current group,
+    // proving ownership continuity.
+    groupMembersSpy.mockResolvedValue(new Set([PID, 999]))
     killSpy.mockImplementation(((pid: number, signal?: string | number) => {
       if (signal === 0 && pid > 0) throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' })
       return true
     }) as KillFn)
 
     createAndGetPty()
-    vi.advanceTimersByTime(1500)
+    await advancePastGrace()
 
     expect(killSpy).toHaveBeenCalledWith(-PID, 0)
     expect(killSpy).toHaveBeenCalledWith(-PID, 'SIGKILL')
   })
 
-  it('falls back to a direct SIGKILL when the group kill fails', () => {
+  it('does not kill a group that no longer traces to the destroyed PTY (reused pgid)', async () => {
+    // At destroy time the group held only the leader; at escalation time the
+    // probe finds a live group, but none of its members were ours — the
+    // numeric pgid was recycled by an unrelated process. No SIGKILL.
+    groupMembersSpy
+      .mockResolvedValueOnce(new Set([PID])) // destroy-time snapshot
+      .mockResolvedValueOnce(new Set([777])) // escalation-time membership
     killSpy.mockImplementation(((pid: number, signal?: string | number) => {
-      if (signal === 0) return true
-      if (pid < 0) throw Object.assign(new Error('EPERM'), { code: 'EPERM' })
+      if (signal === 0 && pid > 0) throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' })
       return true
     }) as KillFn)
 
     createAndGetPty()
-    vi.advanceTimersByTime(1500)
+    await advancePastGrace()
 
-    expect(killSpy).toHaveBeenCalledWith(-PID, 'SIGKILL')
-    expect(killSpy).toHaveBeenCalledWith(PID, 'SIGKILL')
+    expect(killSpy).toHaveBeenCalledWith(-PID, 0)
+    expect(killSpy).not.toHaveBeenCalledWith(-PID, 'SIGKILL')
+    expect(killSpy).not.toHaveBeenCalledWith(PID, 'SIGKILL')
   })
 
-  it('never signals the numeric pid after the pty reported exit (pid-reuse hazard)', () => {
+  it('never signals the numeric pid after the pty reported exit (pid-reuse hazard)', async () => {
     // Distinct pid: the exited-pid ledger is module-level and must not leak
     // into the other escalation tests.
     const REUSED_PID = 5353
@@ -201,12 +229,26 @@ describe('ptyService.destroy kill escalation', () => {
     }) => void
     exitHandler({ exitCode: 0, signal: 1 })
 
-    vi.advanceTimersByTime(1500)
+    await advancePastGrace()
 
     expect(killSpy).not.toHaveBeenCalledWith(REUSED_PID, 0)
     expect(killSpy).toHaveBeenCalledWith(-REUSED_PID, 0)
     expect(killSpy).not.toHaveBeenCalledWith(REUSED_PID, 'SIGKILL')
     expect(killSpy).not.toHaveBeenCalledWith(-REUSED_PID, 'SIGKILL')
+  })
+
+  it('falls back to a direct SIGKILL when the group kill fails', async () => {
+    killSpy.mockImplementation(((pid: number, signal?: string | number) => {
+      if (signal === 0) return true
+      if (pid < 0) throw Object.assign(new Error('EPERM'), { code: 'EPERM' })
+      return true
+    }) as KillFn)
+
+    createAndGetPty()
+    await advancePastGrace()
+
+    expect(killSpy).toHaveBeenCalledWith(-PID, 'SIGKILL')
+    expect(killSpy).toHaveBeenCalledWith(PID, 'SIGKILL')
   })
 
   it('destroyAllAndReap sweeps survivors after the bounded grace (quit path)', async () => {

--- a/src/main/services/claude-session-watcher.ts
+++ b/src/main/services/claude-session-watcher.ts
@@ -13,7 +13,11 @@ function listJsonlFiles(dir: string): Set<string> {
   }
 }
 
-function newestJsonlCreatedAfter(dir: string, existing: Set<string>, startedAtMs: number): string | null {
+function newestJsonlCreatedAfter(
+  dir: string,
+  existing: Set<string>,
+  startedAtMs: number
+): { name: string; sessionId: string } | null {
   let newest: { name: string; mtimeMs: number } | null = null
   for (const name of listJsonlFiles(dir)) {
     if (existing.has(name)) continue
@@ -27,7 +31,7 @@ function newestJsonlCreatedAfter(dir: string, existing: Set<string>, startedAtMs
       // File can disappear between readdir and stat; ignore this scan tick.
     }
   }
-  return newest ? basename(newest.name, '.jsonl') : null
+  return newest ? { name: newest.name, sessionId: basename(newest.name, '.jsonl') } : null
 }
 
 export interface ClaudeSessionWatchHandle {
@@ -36,7 +40,10 @@ export interface ClaudeSessionWatchHandle {
 
 export function watchForClaudeSessionId(
   worktreePath: string,
-  onSessionId: (sessionId: string) => void
+  // Return false to reject a discovered id (e.g. the transcript belongs to a
+  // concurrent session in the same worktree) — the watcher then excludes that
+  // file and keeps watching instead of closing.
+  onSessionId: (sessionId: string) => boolean | void
 ): ClaudeSessionWatchHandle {
   const dir = join(resolveProjectsDir(), encodePath(worktreePath))
   const existing = listJsonlFiles(dir)
@@ -53,18 +60,36 @@ export function watchForClaudeSessionId(
     scanScheduled = null
   }
 
-  const complete = (sessionId: string): void => {
+  const complete = (name: string, sessionId: string): void => {
     if (closed) return
+    log.info('Detected Claude CLI session id', { worktreePath, sessionId })
+    let verdict: boolean | void = undefined
+    try {
+      verdict = onSessionId(sessionId)
+    } catch (error) {
+      log.warn('Claude session id consumer threw, closing watcher', {
+        worktreePath,
+        sessionId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+    if (verdict === false) {
+      // Rejected — this transcript belongs to someone else. Exclude it and
+      // keep watching. Re-scan immediately: our own transcript may already
+      // exist (it was merely older than the rejected one), and with fs.watch
+      // active no further event may arrive to trigger the next scan.
+      existing.add(name)
+      scan()
+      return
+    }
     closed = true
     stopTimers()
     watcher?.close()
-    log.info('Detected Claude CLI session id', { worktreePath, sessionId })
-    onSessionId(sessionId)
   }
 
   const scan = (): void => {
-    const sessionId = newestJsonlCreatedAfter(dir, existing, startedAtMs)
-    if (sessionId) complete(sessionId)
+    const found = newestJsonlCreatedAfter(dir, existing, startedAtMs)
+    if (found) complete(found.name, found.sessionId)
   }
 
   // Coalesce bursts of fs events (the CLI appends many lines while a transcript

--- a/src/main/services/pty-service.ts
+++ b/src/main/services/pty-service.ts
@@ -1,4 +1,5 @@
 import * as pty from 'node-pty'
+import { execFile } from 'node:child_process'
 import { createLogger } from './logger'
 
 const log = createLogger({ component: 'PtyService' })
@@ -231,13 +232,33 @@ class PtyService {
     }
     log.info('Destroying PTY', { id })
     const pid = instance.pty.pid
+    // Snapshot the process group BEFORE signaling: the escalation uses it to
+    // prove the group still belongs to this PTY (see reapSurvivors).
+    const groupSnapshot =
+      pid && process.platform !== 'win32'
+        ? this.listGroupMembers(pid)
+        : Promise.resolve(new Set<number>())
     try {
       instance.pty.kill()
     } catch (err) {
       log.error('Error killing PTY', err instanceof Error ? err : new Error(String(err)), { id })
     }
     this.ptys.delete(id)
-    this.scheduleKillEscalation(id, pid)
+    this.scheduleKillEscalation(id, pid, groupSnapshot)
+  }
+
+  /** Pids currently in the given process group (empty when none or on error). */
+  private listGroupMembers(pgid: number): Promise<Set<number>> {
+    return new Promise((resolve) => {
+      execFile('pgrep', ['-g', String(pgid)], { timeout: 2000 }, (err, stdout) => {
+        if (err) return resolve(new Set())
+        const pids = stdout
+          .split('\n')
+          .map((line) => Number(line.trim()))
+          .filter((n) => Number.isInteger(n) && n > 0)
+        resolve(new Set(pids))
+      })
+    })
   }
 
   /**
@@ -250,9 +271,15 @@ class PtyService {
    * and fire-and-forget so destroyAll() under the quit-cleanup deadline
    * never blocks on it.
    */
-  private scheduleKillEscalation(id: string, pid: number | undefined): void {
+  private scheduleKillEscalation(
+    id: string,
+    pid: number | undefined,
+    groupSnapshot: Promise<Set<number>>
+  ): void {
     if (!pid || process.platform === 'win32') return
-    const timer = setTimeout(() => this.reapSurvivors(id, pid), KILL_ESCALATION_GRACE_MS)
+    const timer = setTimeout(() => {
+      void groupSnapshot.then((members) => this.reapSurvivors(id, pid, members))
+    }, KILL_ESCALATION_GRACE_MS)
     timer.unref?.()
   }
 
@@ -264,34 +291,49 @@ class PtyService {
    * interactive job control forked the agent into its OWN pgid is invisible
    * to both probes; covering that would require a descendant walk.
    */
-  private reapSurvivors(id: string, pid: number): void {
+  private async reapSurvivors(id: string, pid: number, groupSnapshot: Set<number>): Promise<void> {
     // Once the pty reported exit, the numeric pid may already belong to an
     // unrelated process — never probe or signal it directly; only the group
     // remains a valid target (surviving wrapper-shell grandchildren).
     const directPidValid = !exitedPtyPids.has(pid)
-    let anyAlive = false
+    let leaderAlive = false
     if (directPidValid) {
       try {
         process.kill(pid, 0)
-        anyAlive = true
+        leaderAlive = true
       } catch {
         // direct child dead and reaped
       }
     }
-    if (!anyAlive) {
-      try {
-        process.kill(-pid, 0)
-        anyAlive = true
-      } catch {
-        // process group empty
+    let groupAlive = false
+    try {
+      process.kill(-pid, 0)
+      groupAlive = true
+    } catch {
+      // process group empty
+    }
+    if (!leaderAlive && !groupAlive) return
+    if (!leaderAlive && groupAlive) {
+      // The leader is gone, so the numeric pgid could in principle have been
+      // recycled by an unrelated new group leader. Establish continuity of
+      // ownership before killing: the kernel keeps a pgid reserved while any
+      // original member lives, so the group is provably still ours exactly
+      // when a destroy-time member (other than the leader) is still in it.
+      const current = await this.listGroupMembers(pid)
+      const stillOurs = [...current].some((member) => member !== pid && groupSnapshot.has(member))
+      if (!stillOurs) {
+        log.warn('Skipping group SIGKILL — group no longer traceable to the destroyed PTY', {
+          id,
+          pid
+        })
+        return
       }
     }
-    if (!anyAlive) return
     log.warn('PTY process (or group member) survived SIGHUP, escalating to SIGKILL', { id, pid })
     try {
       process.kill(-pid, 'SIGKILL')
     } catch {
-      if (directPidValid) {
+      if (leaderAlive) {
         try {
           process.kill(pid, 'SIGKILL')
         } catch {
@@ -316,16 +358,18 @@ class PtyService {
    * sweep HUP-surviving agents would leak on every app quit.
    */
   async destroyAllAndReap(graceMs = 300): Promise<void> {
-    const targets: Array<{ id: string; pid: number }> = []
-    for (const [id, instance] of this.ptys) {
-      const pid = instance.pty.pid
-      if (pid) targets.push({ id, pid })
+    const targets: Array<{ id: string; pid: number; snapshot: Promise<Set<number>> }> = []
+    if (process.platform !== 'win32') {
+      for (const [id, instance] of this.ptys) {
+        const pid = instance.pty.pid
+        if (pid) targets.push({ id, pid, snapshot: this.listGroupMembers(pid) })
+      }
     }
     this.destroyAll()
-    if (process.platform === 'win32' || targets.length === 0) return
+    if (targets.length === 0) return
     await new Promise((resolve) => setTimeout(resolve, graceMs))
-    for (const { id, pid } of targets) {
-      this.reapSurvivors(id, pid)
+    for (const { id, pid, snapshot } of targets) {
+      await this.reapSurvivors(id, pid, await snapshot)
     }
   }
 

--- a/src/main/services/pty-service.ts
+++ b/src/main/services/pty-service.ts
@@ -297,7 +297,19 @@ class PtyService {
    * interactive job control forked the agent into its OWN pgid is invisible
    * to both probes; covering that would require a descendant walk.
    */
+  /** True when the pid belongs to a pty currently registered with this service. */
+  private isCurrentPtyPid(pid: number): boolean {
+    for (const instance of this.ptys.values()) {
+      if (instance.pty.pid === pid) return true
+    }
+    return false
+  }
+
   private async reapSurvivors(id: string, pid: number, groupSnapshot: Set<number>): Promise<void> {
+    // The pid may have been recycled into a CURRENTLY REGISTERED pty (a new
+    // spawn between the destroy and this escalation firing) — that process
+    // is alive on purpose; a stale timer must never touch it.
+    if (this.isCurrentPtyPid(pid)) return
     // Once the pty reported exit, the numeric pid may already belong to an
     // unrelated process — never probe or signal it directly; only the group
     // remains a valid target (surviving wrapper-shell grandchildren).

--- a/src/main/services/pty-service.ts
+++ b/src/main/services/pty-service.ts
@@ -67,6 +67,23 @@ function buildEnvSnapshot(env: Record<string, string>): Record<string, string | 
 /** Grace period between the polite SIGHUP and the SIGKILL escalation probe. */
 const KILL_ESCALATION_GRACE_MS = 1500
 
+// Pids whose pty reported exit (child reaped — the numeric pid is reusable by
+// the OS from that moment). The escalation probe must not signal such a pid
+// directly: a probe hit would be a *different* process that inherited the
+// number. Group probes stay valid — pgid reuse additionally requires the new
+// owner to become a session/group leader. Entries are pruned after 60s.
+const EXITED_PID_RETENTION_MS = 60_000
+const exitedPtyPids = new Map<number, number>()
+
+function recordPtyExit(pid: number | undefined): void {
+  if (!pid) return
+  const now = Date.now()
+  exitedPtyPids.set(pid, now)
+  for (const [oldPid, at] of exitedPtyPids) {
+    if (now - at > EXITED_PID_RETENTION_MS) exitedPtyPids.delete(oldPid)
+  }
+}
+
 class PtyService {
   private ptys: Map<string, PtyInstance> = new Map()
 
@@ -160,6 +177,7 @@ class PtyService {
       const code = exitCode ?? -1
       const sig = signal ?? 0
       log.info('PTY exited', { id, exitCode: code, signal: sig })
+      recordPtyExit(ptyProcess.pid)
       for (const listener of instance.exitListeners) {
         try {
           listener(code, sig)
@@ -247,12 +265,18 @@ class PtyService {
    * to both probes; covering that would require a descendant walk.
    */
   private reapSurvivors(id: string, pid: number): void {
+    // Once the pty reported exit, the numeric pid may already belong to an
+    // unrelated process — never probe or signal it directly; only the group
+    // remains a valid target (surviving wrapper-shell grandchildren).
+    const directPidValid = !exitedPtyPids.has(pid)
     let anyAlive = false
-    try {
-      process.kill(pid, 0)
-      anyAlive = true
-    } catch {
-      // direct child dead and reaped
+    if (directPidValid) {
+      try {
+        process.kill(pid, 0)
+        anyAlive = true
+      } catch {
+        // direct child dead and reaped
+      }
     }
     if (!anyAlive) {
       try {
@@ -267,10 +291,12 @@ class PtyService {
     try {
       process.kill(-pid, 'SIGKILL')
     } catch {
-      try {
-        process.kill(pid, 'SIGKILL')
-      } catch {
-        // Died between the probe and the kill — nothing left to do
+      if (directPidValid) {
+        try {
+          process.kill(pid, 'SIGKILL')
+        } catch {
+          // Died between the probe and the kill — nothing left to do
+        }
       }
     }
   }

--- a/src/main/services/pty-service.ts
+++ b/src/main/services/pty-service.ts
@@ -150,6 +150,10 @@ class PtyService {
       env
     })
 
+    // A fresh child may have received a previously-exited pid — the ledger
+    // entry belongs to the old process, not this one.
+    if (ptyProcess.pid) exitedPtyPids.delete(ptyProcess.pid)
+
     const instance: PtyInstance = {
       pty: ptyProcess,
       cwd: opts.cwd,
@@ -232,8 +236,10 @@ class PtyService {
     }
     log.info('Destroying PTY', { id })
     const pid = instance.pty.pid
-    // Snapshot the process group BEFORE signaling: the escalation uses it to
-    // prove the group still belongs to this PTY (see reapSurvivors).
+    // Snapshot the process group around HUP time (pgrep runs concurrently
+    // with the signal, so it observes the members that survive it) — the
+    // escalation uses it to prove the group still belongs to this PTY
+    // (see reapSurvivors).
     const groupSnapshot =
       pid && process.platform !== 'win32'
         ? this.listGroupMembers(pid)
@@ -295,6 +301,12 @@ class PtyService {
     // Once the pty reported exit, the numeric pid may already belong to an
     // unrelated process — never probe or signal it directly; only the group
     // remains a valid target (surviving wrapper-shell grandchildren).
+    // Entries expire at read time too: pruning on insert alone could leave a
+    // stale record vetoing a later PTY that legitimately reused the pid.
+    const exitedAt = exitedPtyPids.get(pid)
+    if (exitedAt !== undefined && Date.now() - exitedAt > EXITED_PID_RETENTION_MS) {
+      exitedPtyPids.delete(pid)
+    }
     const directPidValid = !exitedPtyPids.has(pid)
     let leaderAlive = false
     if (directPidValid) {
@@ -315,17 +327,31 @@ class PtyService {
     if (!leaderAlive && !groupAlive) return
     if (!leaderAlive && groupAlive) {
       // The leader is gone, so the numeric pgid could in principle have been
-      // recycled by an unrelated new group leader. Establish continuity of
-      // ownership before killing: the kernel keeps a pgid reserved while any
-      // original member lives, so the group is provably still ours exactly
-      // when a destroy-time member (other than the leader) is still in it.
-      const current = await this.listGroupMembers(pid)
-      const stillOurs = [...current].some((member) => member !== pid && groupSnapshot.has(member))
-      if (!stillOurs) {
-        log.warn('Skipping group SIGKILL — group no longer traceable to the destroyed PTY', {
-          id,
-          pid
-        })
+      // recycled by an unrelated new group leader. The destroy-time snapshot
+      // (taken concurrently with the HUP, so it observes the HUP survivors)
+      // lets us check continuity: the kernel keeps a pgid reserved while any
+      // original member lives, so overlap with a current member proves the
+      // group is still ours. With an EMPTY snapshot (pgrep produced no
+      // evidence) the default depends on what we know about the leader:
+      // - leader provably exited: an alive group with zero traced members is
+      //   more likely a recycled pgid than an untracked survivor — skip.
+      // - leader never reported exit: our processes are likely still there
+      //   and pgrep merely failed — fail open toward killing, because
+      //   disabling the escalation is the leak this change exists to fix.
+      if (groupSnapshot.size > 0) {
+        const current = await this.listGroupMembers(pid)
+        const stillOurs = [...current].some(
+          (member) => member !== pid && groupSnapshot.has(member)
+        )
+        if (!stillOurs) {
+          log.warn('Skipping group SIGKILL — group no longer traceable to the destroyed PTY', {
+            id,
+            pid
+          })
+          return
+        }
+      } else if (!directPidValid) {
+        log.warn('Skipping group SIGKILL — exited leader and no membership evidence', { id, pid })
         return
       }
     }

--- a/src/main/services/pty-service.ts
+++ b/src/main/services/pty-service.ts
@@ -64,6 +64,9 @@ function buildEnvSnapshot(env: Record<string, string>): Record<string, string | 
   return snapshot
 }
 
+/** Grace period between the polite SIGHUP and the SIGKILL escalation probe. */
+const KILL_ESCALATION_GRACE_MS = 1500
+
 class PtyService {
   private ptys: Map<string, PtyInstance> = new Map()
 
@@ -209,18 +212,94 @@ class PtyService {
       return
     }
     log.info('Destroying PTY', { id })
+    const pid = instance.pty.pid
     try {
       instance.pty.kill()
     } catch (err) {
       log.error('Error killing PTY', err instanceof Error ? err : new Error(String(err)), { id })
     }
     this.ptys.delete(id)
+    this.scheduleKillEscalation(id, pid)
+  }
+
+  /**
+   * node-pty's kill() sends a single SIGHUP to the direct child and never
+   * checks the outcome. HUP-ignoring processes — and custom-provider spawns,
+   * where the agent is a grandchild of a `$SHELL -ilc` wrapper — survive it
+   * and leak. After a grace period, probe liveness and escalate to a
+   * process-group SIGKILL (the pty child is a session leader, so pgid ===
+   * pid, which also reaps same-group grandchildren). The timer is unref'd
+   * and fire-and-forget so destroyAll() under the quit-cleanup deadline
+   * never blocks on it.
+   */
+  private scheduleKillEscalation(id: string, pid: number | undefined): void {
+    if (!pid || process.platform === 'win32') return
+    const timer = setTimeout(() => this.reapSurvivors(id, pid), KILL_ESCALATION_GRACE_MS)
+    timer.unref?.()
+  }
+
+  /**
+   * Probe the direct child AND its process group before deciding everything
+   * is dead: a wrapper shell can die on SIGHUP while a HUP-ignoring agent in
+   * the same group survives — probing only the (reaped) wrapper pid would
+   * skip the group SIGKILL that reaps the survivor. Known gap: a shell whose
+   * interactive job control forked the agent into its OWN pgid is invisible
+   * to both probes; covering that would require a descendant walk.
+   */
+  private reapSurvivors(id: string, pid: number): void {
+    let anyAlive = false
+    try {
+      process.kill(pid, 0)
+      anyAlive = true
+    } catch {
+      // direct child dead and reaped
+    }
+    if (!anyAlive) {
+      try {
+        process.kill(-pid, 0)
+        anyAlive = true
+      } catch {
+        // process group empty
+      }
+    }
+    if (!anyAlive) return
+    log.warn('PTY process (or group member) survived SIGHUP, escalating to SIGKILL', { id, pid })
+    try {
+      process.kill(-pid, 'SIGKILL')
+    } catch {
+      try {
+        process.kill(pid, 'SIGKILL')
+      } catch {
+        // Died between the probe and the kill — nothing left to do
+      }
+    }
   }
 
   destroyAll(): void {
     log.info('Destroying all PTYs', { count: this.ptys.size })
     for (const [id] of this.ptys) {
       this.destroy(id)
+    }
+  }
+
+  /**
+   * Quit-path variant of destroyAll: HUP everything, wait a short bounded
+   * grace (well inside the quit-cleanup deadline), then synchronously
+   * group-SIGKILL anything still alive. The per-destroy escalation timers
+   * never get to fire on quit — the process exits first — so without this
+   * sweep HUP-surviving agents would leak on every app quit.
+   */
+  async destroyAllAndReap(graceMs = 300): Promise<void> {
+    const targets: Array<{ id: string; pid: number }> = []
+    for (const [id, instance] of this.ptys) {
+      const pid = instance.pty.pid
+      if (pid) targets.push({ id, pid })
+    }
+    this.destroyAll()
+    if (process.platform === 'win32' || targets.length === 0) return
+    await new Promise((resolve) => setTimeout(resolve, graceMs))
+    for (const { id, pid } of targets) {
+      this.reapSurvivors(id, pid)
     }
   }
 

--- a/src/main/services/terminal-pty-bridge.claude-cli.test.ts
+++ b/src/main/services/terminal-pty-bridge.claude-cli.test.ts
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => {
   const handlers = new Map<string, (...args: any[]) => any>()
   const exitCallbacks = new Map<string, (code: number | null) => void>()
   const dataCallbacks = new Map<string, (data: string) => void>()
-  const claudeSessionWatchCallbacks = new Map<string, (claudeSessionId: string) => void>()
+  const claudeSessionWatchCallbacks = new Map<string, (claudeSessionId: string) => boolean | void>()
 
   return {
     handlers,
@@ -40,7 +40,8 @@ const mocks = vi.hoisted(() => {
       write: vi.fn(),
       resize: vi.fn(),
       destroy: vi.fn(),
-      destroyAll: vi.fn()
+      destroyAll: vi.fn(),
+      destroyAllAndReap: vi.fn(async () => {})
     }
   }
 })
@@ -108,7 +109,7 @@ vi.mock('./claude-cli-pty-prompt', async (importOriginal) => ({
 
 vi.mock('./claude-session-watcher', () => ({
   watchForClaudeSessionId: vi.fn(
-    (worktreePath: string, callback: (claudeSessionId: string) => void) => {
+    (worktreePath: string, callback: (claudeSessionId: string) => boolean | void) => {
       mocks.claudeSessionWatchCallbacks.set(worktreePath, callback)
       return { close: vi.fn(() => mocks.claudeSessionWatchCallbacks.delete(worktreePath)) }
     }
@@ -183,6 +184,7 @@ function setupDb(session: Session = makeSession()): void {
     getWorktree: vi.fn(() => ({ path: '/repo/worktree' })),
     getConnection: vi.fn(() => ({ path: '/repo/connection' })),
     getSetting: vi.fn(() => null),
+    getSessionByClaudeSessionId: vi.fn(() => null),
     updateSession: vi.fn()
   })
 }
@@ -464,6 +466,63 @@ describe('Claude CLI terminal hook status wiring', () => {
         'terminal:claude-session-id:hive-session-1',
         'claude-session-new'
       )
+    })
+  })
+
+  it('stamps a discovered claude session id when no other session claims it', async () => {
+    setupDb(makeSession({ claude_session_id: null }))
+    const db = mocks.getDatabase() as { updateSession: ReturnType<typeof vi.fn> }
+
+    await createClaudeCliTerminal('hive-session-1', {})
+
+    const verdict = mocks.claudeSessionWatchCallbacks.get('/repo/worktree')?.('claude-session-new')
+
+    expect(verdict).not.toBe(false)
+    expect(db.updateSession).toHaveBeenCalledWith('hive-session-1', {
+      claude_session_id: 'claude-session-new'
+    })
+  })
+
+  it('rejects a discovered claude session id already claimed by a concurrent session', async () => {
+    setupDb(makeSession({ claude_session_id: null }))
+    const db = mocks.getDatabase() as {
+      updateSession: ReturnType<typeof vi.fn>
+      getSessionByClaudeSessionId: ReturnType<typeof vi.fn>
+    }
+    db.getSessionByClaudeSessionId.mockReturnValue(makeSession({ id: 'hive-session-other' }))
+
+    await createClaudeCliTerminal('hive-session-1', {})
+
+    const verdict = mocks.claudeSessionWatchCallbacks.get('/repo/worktree')?.('claude-session-stolen')
+
+    expect(verdict).toBe(false)
+    expect(db.updateSession).not.toHaveBeenCalled()
+    // Flush the async publish chain (dynamic import + .then) before the
+    // negative assertion — asserting synchronously would pass even if the
+    // rejected branch fell through to the publish.
+    await waitImmediate()
+    await waitImmediate()
+    expect(mocks.publishDesktopBackendEvent).not.toHaveBeenCalledWith(
+      'terminal:claude-session-id:hive-session-1',
+      'claude-session-stolen'
+    )
+  })
+
+  it('stamps a discovered claude session id already claimed by the same session', async () => {
+    setupDb(makeSession({ claude_session_id: null }))
+    const db = mocks.getDatabase() as {
+      updateSession: ReturnType<typeof vi.fn>
+      getSessionByClaudeSessionId: ReturnType<typeof vi.fn>
+    }
+    db.getSessionByClaudeSessionId.mockReturnValue(makeSession({ id: 'hive-session-1' }))
+
+    await createClaudeCliTerminal('hive-session-1', {})
+
+    const verdict = mocks.claudeSessionWatchCallbacks.get('/repo/worktree')?.('claude-session-mine')
+
+    expect(verdict).not.toBe(false)
+    expect(db.updateSession).toHaveBeenCalledWith('hive-session-1', {
+      claude_session_id: 'claude-session-mine'
     })
   })
 

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -353,6 +353,27 @@ export async function createClaudeCliTerminal(
       claudeWatchers.set(
         sessionId,
         watchForClaudeSessionId(worktreePath, (claudeSessionId) => {
+          // The newest-jsonl heuristic can match a transcript created by a
+          // concurrent spawn in the same worktree. A claude session id belongs
+          // to exactly one Hive session — reject an already-claimed id (the
+          // watcher keeps looking) instead of cross-stamping both sessions
+          // into resuming the same transcript.
+          try {
+            const claimedBy = db.getSessionByClaudeSessionId(claudeSessionId)
+            if (claimedBy && claimedBy.id !== sessionId) {
+              log.warn('Discovered Claude session id already claimed by another session', {
+                sessionId,
+                claudeSessionId,
+                claimedBySessionId: claimedBy.id
+              })
+              return false
+            }
+          } catch (error) {
+            log.warn('Failed to check Claude session id claim', {
+              sessionId,
+              error: error instanceof Error ? error.message : String(error)
+            })
+          }
           try {
             db.updateSession(sessionId, { claude_session_id: claudeSessionId })
           } catch (error) {
@@ -371,6 +392,7 @@ export async function createClaudeCliTerminal(
             armClaudePlanFollowupWatcher(sessionId)
           }
           claudeWatchers.delete(sessionId)
+          return true
         })
       )
     }
@@ -442,7 +464,7 @@ export async function createClaudeCliTerminal(
   }
 }
 
-export function cleanupTerminals(): void {
+export function cleanupTerminals(): Promise<void> {
   log.info('Cleaning up all terminals')
   for (const [, cleanup] of listenerCleanups) {
     cleanup.removeData()
@@ -469,6 +491,9 @@ export function cleanupTerminals(): void {
   unsubscribeClaudeCliStatus?.()
   unsubscribeClaudeCliStatus = null
   resetAllClaudeCliTitleState()
-  ptyService.destroyAll()
+  // HUP + bounded-grace SIGKILL sweep: awaited by the quit chain so
+  // HUP-surviving agents are reaped before the process exits.
+  const reaped = ptyService.destroyAllAndReap()
   ghosttyService.shutdown()
+  return reaped
 }

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -3938,7 +3938,7 @@ function JumpToSessionButton({
   label?: string
   testId?: string
 }) {
-  const handleJump = useCallback(() => {
+  const handleJump = useCallback(async () => {
     const sessionId = ticket.current_session_id
     if (!sessionId) return
 
@@ -3956,13 +3956,23 @@ function JumpToSessionButton({
 
     // Jumping to a done-closed session reopens it: restore its tab and flip
     // it back to active so the modal-release cleanup doesn't kill the very
-    // terminal being navigated to.
+    // terminal being navigated to. closeSession drops the session from the
+    // store maps, so the in-memory lookup can miss — fall back to the DB row.
     const sessionStore = useSessionStore.getState()
-    if (ticket.worktree_id && sessionStore.getSessionById(sessionId)?.status === 'completed') {
-      void sessionStore.reopenSession(sessionId, ticket.worktree_id).catch(() => {})
+    if (ticket.worktree_id) {
+      try {
+        const record =
+          sessionStore.getSessionById(sessionId) ??
+          (await dbApi.session.get<Session>(sessionId))
+        if (record?.status === 'completed') {
+          await sessionStore.reopenSession(sessionId, ticket.worktree_id)
+        }
+      } catch {
+        // Best-effort — worst case the jump lands on a tab-less session
+      }
     }
 
-    // Focus the session tab (synchronously, so the modal-close cleanup sees
+    // Focus the session tab (before the modal-close cleanup runs, so it sees
     // this session as active and skips its PTY destroy)
     sessionStore.setActiveSession(sessionId)
 

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -468,6 +468,13 @@ async function sendFollowupToSession(opts: {
   const model = resolveSessionModel(opts.sessionId, result.session)
 
   if (session.agent_sdk === 'claude-code-cli') {
+    // The follow-up may target a session closed when its ticket entered Done.
+    // Reactivate BEFORE delivering: this serializes behind any in-flight
+    // close via the lifecycle lock (delivering first could hand the prompt to
+    // a PTY the close is about to destroy), flips the row back to active, and
+    // restores the tab so the working process has a restore entry and is not
+    // culled by the modal-release cleanup.
+    await useSessionStore.getState().reactivateSession(opts.sessionId)
     const delivery = unwrapEnvelope(
       await terminalApi.sendClaudeCliPrompt(opts.sessionId, fullPrompt)
     )
@@ -479,13 +486,6 @@ async function sendFollowupToSession(opts: {
         throw new Error(createResult.error ?? 'Failed to start Claude CLI session')
       }
     }
-    // The follow-up may target a session closed when its ticket entered Done
-    // (delivered into a modal-resumed PTY or freshly respawned above either
-    // way). Flip it back to active and restore its tab so the working process
-    // has a restore entry and is not culled by the modal-release cleanup — a
-    // completed session with a live PTY would be a stranded process with no
-    // UI affordance to close it.
-    await useSessionStore.getState().reactivateSession(opts.sessionId)
     recordSuccessfulFollowupSideEffects(
       session,
       opts.sessionId,
@@ -518,6 +518,9 @@ async function sendFollowupToSession(opts: {
     ? buildMessageParts(opts.attachments, fullPrompt)
     : [{ type: 'text' as const, text: fullPrompt }]
 
+  // Same as the claude-code-cli branch: reactivate before prompting so the
+  // revival serializes behind any in-flight close of this session.
+  await useSessionStore.getState().reactivateSession(opts.sessionId)
   const promptResult = unwrapEnvelope(
     await opencodeApi.prompt(workingPath, session.opencode_session_id, messageParts, model)
   )
@@ -528,9 +531,6 @@ async function sendFollowupToSession(opts: {
     )
     throw new Error(promptResult.error || 'Failed to send prompt to session')
   }
-  // Same as the claude-code-cli branch: a follow-up to a done-closed session
-  // resumes real work — restore its active status and tab.
-  await useSessionStore.getState().reactivateSession(opts.sessionId)
   recordSuccessfulFollowupSideEffects(session, opts.sessionId, fullPrompt, opts.followUpMode, model)
 }
 

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -228,6 +228,10 @@ function ClaudeCliPortalSlot({ sessionId }: { sessionId: string }): React.JSX.El
     return () => {
       registerTarget(sessionId, null)
       releaseSessionMount(sessionId)
+      // Modal-resumed sessions of Done tickets are completed and tab-less —
+      // kill their PTY when the last mount request goes away (no-op for
+      // active sessions).
+      void useSessionStore.getState().destroyCompletedSessionTerminal(sessionId)
     }
   }, [registerTarget, releaseSessionMount, requestSessionMount, sessionId])
 
@@ -475,6 +479,13 @@ async function sendFollowupToSession(opts: {
         throw new Error(createResult.error ?? 'Failed to start Claude CLI session')
       }
     }
+    // The follow-up may target a session closed when its ticket entered Done
+    // (delivered into a modal-resumed PTY or freshly respawned above either
+    // way). Flip it back to active and restore its tab so the working process
+    // has a restore entry and is not culled by the modal-release cleanup — a
+    // completed session with a live PTY would be a stranded process with no
+    // UI affordance to close it.
+    await useSessionStore.getState().reactivateSession(opts.sessionId)
     recordSuccessfulFollowupSideEffects(
       session,
       opts.sessionId,
@@ -517,6 +528,9 @@ async function sendFollowupToSession(opts: {
     )
     throw new Error(promptResult.error || 'Failed to send prompt to session')
   }
+  // Same as the claude-code-cli branch: a follow-up to a done-closed session
+  // resumes real work — restore its active status and tab.
+  await useSessionStore.getState().reactivateSession(opts.sessionId)
   recordSuccessfulFollowupSideEffects(session, opts.sessionId, fullPrompt, opts.followUpMode, model)
 }
 
@@ -3925,7 +3939,8 @@ function JumpToSessionButton({
   testId?: string
 }) {
   const handleJump = useCallback(() => {
-    if (!ticket.current_session_id) return
+    const sessionId = ticket.current_session_id
+    if (!sessionId) return
 
     // Switch off board view
     const kanbanStore = useKanbanStore.getState()
@@ -3939,8 +3954,17 @@ function JumpToSessionButton({
       useSessionStore.getState().setActiveWorktree(ticket.worktree_id)
     }
 
-    // Focus the session tab
-    useSessionStore.getState().setActiveSession(ticket.current_session_id)
+    // Jumping to a done-closed session reopens it: restore its tab and flip
+    // it back to active so the modal-release cleanup doesn't kill the very
+    // terminal being navigated to.
+    const sessionStore = useSessionStore.getState()
+    if (ticket.worktree_id && sessionStore.getSessionById(sessionId)?.status === 'completed') {
+      void sessionStore.reopenSession(sessionId, ticket.worktree_id).catch(() => {})
+    }
+
+    // Focus the session tab (synchronously, so the modal-close cleanup sees
+    // this session as active and skips its PTY destroy)
+    sessionStore.setActiveSession(sessionId)
 
     onClose()
   }, [ticket.current_session_id, ticket.worktree_id, onClose])

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -503,6 +503,13 @@ async function sendFollowupToSession(opts: {
     throw new Error(`No opencode session ID for session: ${opts.sessionId}`)
   }
 
+  // Same as the claude-code-cli branch: reactivate BEFORE reconnecting so the
+  // revival serializes behind any in-flight close via the lifecycle lock —
+  // otherwise a close could disconnect the implementer state while the
+  // reconnect below is in flight and the prompt would fail "session not
+  // found" on a session that was just restored as active.
+  await useSessionStore.getState().reactivateSession(opts.sessionId)
+
   // Ensure the session is loaded in the agent SDK implementer's in-memory map.
   // SessionView does this on mount via initializeSession(), but the kanban
   // followup path bypasses SessionView entirely.  Without this, the Claude Code
@@ -518,9 +525,6 @@ async function sendFollowupToSession(opts: {
     ? buildMessageParts(opts.attachments, fullPrompt)
     : [{ type: 'text' as const, text: fullPrompt }]
 
-  // Same as the claude-code-cli branch: reactivate before prompting so the
-  // revival serializes behind any in-flight close of this session.
-  await useSessionStore.getState().reactivateSession(opts.sessionId)
   const promptResult = unwrapEnvelope(
     await opencodeApi.prompt(workingPath, session.opencode_session_id, messageParts, model)
   )

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -3973,6 +3973,9 @@ function JumpToSessionButton({
         if (ticket.worktree_id) {
           await sessionStore.reopenSession(sessionId, ticket.worktree_id)
         } else if (record.connection_id) {
+          // MainPane only scopes connection sessions under the selected
+          // connection — select it or the reopened tab has nowhere to mount
+          useConnectionStore.getState().selectConnection(record.connection_id)
           await sessionStore.reopenConnectionSession(sessionId, record.connection_id)
         }
       }

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -3954,11 +3954,16 @@ function JumpToSessionButton({
       useSessionStore.getState().setActiveWorktree(ticket.worktree_id)
     }
 
+    // Claim the session synchronously BEFORE any await: if the modal unmounts
+    // while the reopen below is in flight (user dismisses it), the release
+    // cleanup must already see this session as active and skip its PTY destroy.
+    const sessionStore = useSessionStore.getState()
+    sessionStore.setActiveSession(sessionId)
+
     // Jumping to a done-closed session reopens it: restore its tab and flip
     // it back to active so the modal-release cleanup doesn't kill the very
     // terminal being navigated to. closeSession drops the session from the
     // store maps, so the in-memory lookup can miss — fall back to the DB row.
-    const sessionStore = useSessionStore.getState()
     if (ticket.worktree_id) {
       try {
         const record =
@@ -3971,10 +3976,6 @@ function JumpToSessionButton({
         // Best-effort — worst case the jump lands on a tab-less session
       }
     }
-
-    // Focus the session tab (before the modal-close cleanup runs, so it sees
-    // this session as active and skips its PTY destroy)
-    sessionStore.setActiveSession(sessionId)
 
     onClose()
   }, [ticket.current_session_id, ticket.worktree_id, onClose])

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -3964,17 +3964,20 @@ function JumpToSessionButton({
     // it back to active so the modal-release cleanup doesn't kill the very
     // terminal being navigated to. closeSession drops the session from the
     // store maps, so the in-memory lookup can miss — fall back to the DB row.
-    if (ticket.worktree_id) {
-      try {
-        const record =
-          sessionStore.getSessionById(sessionId) ??
-          (await dbApi.session.get<Session>(sessionId))
-        if (record?.status === 'completed') {
+    // Connection-backed sessions (ticket.worktree_id null) reopen via their
+    // connection, or the jump would target an id MainPane cannot resolve.
+    try {
+      const record =
+        sessionStore.getSessionById(sessionId) ?? (await dbApi.session.get<Session>(sessionId))
+      if (record?.status === 'completed') {
+        if (ticket.worktree_id) {
           await sessionStore.reopenSession(sessionId, ticket.worktree_id)
+        } else if (record.connection_id) {
+          await sessionStore.reopenConnectionSession(sessionId, record.connection_id)
         }
-      } catch {
-        // Best-effort — worst case the jump lands on a tab-less session
       }
+    } catch {
+      // Best-effort — worst case the jump lands on a tab-less session
     }
 
     onClose()

--- a/src/renderer/src/components/layout/MainPane.test.tsx
+++ b/src/renderer/src/components/layout/MainPane.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MainPane } from './MainPane'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -251,5 +251,109 @@ describe('MainPane terminal visibility', () => {
     const terminal = screen.getByTestId('terminal-view-terminal-1')
     expect(terminal.getAttribute('data-visible')).toBe('false')
     expect(terminal.parentElement?.classList.contains('hidden')).toBe(true)
+  })
+})
+
+// Mounting a stateful terminal view spawns its agent process, so sessions that
+// merely have a tab must NOT mount until an activation signal selects them.
+describe('MainPane terminal activation gating', () => {
+  const second = makeSession({ id: 'session-2', name: 'Claude CLI 2' })
+
+  function setupTwoSessions(): void {
+    setupMainPaneState()
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([['worktree-1', [makeSession(), second]]])
+    })
+  }
+
+  it('does not mount an in-scope terminal session that is not activated', () => {
+    setupTwoSessions()
+
+    renderMainPane()
+
+    expect(screen.getByTestId('session-view-session-1')).toBeTruthy()
+    expect(screen.queryByTestId('session-view-session-2')).toBeNull()
+  })
+
+  it('mounts a session once it becomes the active tab and keeps it mounted after switching away', () => {
+    setupTwoSessions()
+
+    renderMainPane()
+    expect(screen.queryByTestId('session-view-session-2')).toBeNull()
+
+    act(() => {
+      useSessionStore.setState({ activeSessionId: 'session-2' })
+    })
+    expect(screen.getByTestId('session-view-session-2').getAttribute('data-visible')).toBe('true')
+
+    // Switching back must keep session-2 mounted (latched) but hidden
+    act(() => {
+      useSessionStore.setState({ activeSessionId: 'session-1' })
+    })
+    const latched = screen.getByTestId('session-view-session-2')
+    expect(latched.getAttribute('data-visible')).toBe('false')
+    expect(latched.closest('.hidden')).not.toBeNull()
+  })
+
+  it('mounts a non-active session with a pending mount request (ticket modal)', () => {
+    setupTwoSessions()
+    useSessionStore.setState({ sessionMountRequests: new Map([['session-2', 1]]) })
+
+    renderMainPane()
+
+    expect(screen.getByTestId('session-view-session-2')).toBeTruthy()
+  })
+
+  it('mounts a non-active session with a queued pending message', () => {
+    setupTwoSessions()
+    useSessionStore.setState({ pendingMessages: new Map([['session-2', 'do the thing']]) })
+
+    renderMainPane()
+
+    expect(screen.getByTestId('session-view-session-2')).toBeTruthy()
+  })
+
+  it('mounts a non-active pinned session', () => {
+    setupTwoSessions()
+    useSessionStore.setState({ activePinnedSessionId: 'session-2' })
+
+    renderMainPane()
+
+    expect(screen.getByTestId('session-view-session-2')).toBeTruthy()
+  })
+
+  it('mounts an inline connection session even when its connection is not selected', () => {
+    setupMainPaneState()
+    const connSession = makeSession({
+      id: 'conn-session-1',
+      worktree_id: null,
+      connection_id: 'connection-1'
+    })
+    useSessionStore.setState({
+      sessionsByConnection: new Map([['connection-1', [connSession]]]),
+      inlineConnectionSessionId: 'conn-session-1'
+    })
+
+    renderMainPane()
+
+    expect(screen.getByTestId('session-view-conn-session-1')).toBeTruthy()
+  })
+
+  it('unmounts a latched session when its tab is closed', () => {
+    setupTwoSessions()
+
+    renderMainPane()
+    act(() => {
+      useSessionStore.setState({ activeSessionId: 'session-2' })
+    })
+    expect(screen.getByTestId('session-view-session-2')).toBeTruthy()
+
+    act(() => {
+      useSessionStore.setState({
+        activeSessionId: 'session-1',
+        closedTerminalSessionIds: new Set(['session-2'])
+      })
+    })
+    expect(screen.queryByTestId('session-view-session-2')).toBeNull()
   })
 })

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -121,6 +121,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const sessionsByWorktree = useSessionStore((state) => state.sessionsByWorktree)
   const sessionsByConnection = useSessionStore((state) => state.sessionsByConnection)
   const sessionMountRequests = useSessionStore((state) => state.sessionMountRequests)
+  const pendingMessages = useSessionStore((state) => state.pendingMessages)
 
   // Look up the agent_sdk for a given session ID
   const getAgentSdk = useCallback((sid: string | null): string | null => {
@@ -128,22 +129,43 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     return useSessionStore.getState().getSessionById(sid)?.agent_sdk ?? null
   }, [])
 
-  // Collect all terminal-type sessions in the current scope.
+  // Collect the terminal-type sessions in the current scope that are activated.
+  // Mounting a stateful terminal view spawns its agent process, so merely
+  // having a tab must NOT admit a session here — selecting the tab, opening
+  // its ticket modal, pinning it, or queueing a prompt for it does. Once
+  // admitted, mountedTerminalSessionIds below keeps it alive across tab
+  // switches until the tab is explicitly closed.
   const terminalSessions = useMemo(() => {
     const terminals = new Set<string>()
+
+    const isActivated = (sessionId: string): boolean =>
+      sessionId === activeSessionId ||
+      sessionId === inlineConnectionSessionId ||
+      sessionId === activePinnedSessionId ||
+      (sessionMountRequests.get(sessionId) ?? 0) > 0 ||
+      pendingMessages.has(sessionId)
 
     if (selectedWorktreeId) {
       const sessions = sessionsByWorktree.get(selectedWorktreeId) || []
       for (const s of sessions) {
-        if (isStatefulTerminalSession(s.agent_sdk)) terminals.add(s.id)
+        if (isStatefulTerminalSession(s.agent_sdk) && isActivated(s.id)) terminals.add(s.id)
       }
     }
 
     if (selectedConnectionId) {
       const sessions = sessionsByConnection.get(selectedConnectionId) || []
       for (const s of sessions) {
-        if (isStatefulTerminalSession(s.agent_sdk)) terminals.add(s.id)
+        if (isStatefulTerminalSession(s.agent_sdk) && isActivated(s.id)) terminals.add(s.id)
       }
+    }
+
+    // Inline sticky-tab sessions belong to a connection that may not be
+    // selected, so admit them independently of the scope scans above.
+    if (
+      inlineConnectionSessionId &&
+      isStatefulTerminalSession(getAgentSdk(inlineConnectionSessionId))
+    ) {
+      terminals.add(inlineConnectionSessionId)
     }
 
     for (const [sessionId, count] of sessionMountRequests.entries()) {
@@ -156,9 +178,13 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   }, [
     selectedWorktreeId,
     selectedConnectionId,
+    activeSessionId,
+    inlineConnectionSessionId,
+    activePinnedSessionId,
     sessionsByWorktree,
     sessionsByConnection,
     sessionMountRequests,
+    pendingMessages,
     getAgentSdk
   ])
 

--- a/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
@@ -117,20 +117,43 @@ describe('destroyCompletedSessionTerminal', () => {
     expect(terminalDestroy).not.toHaveBeenCalled()
   })
 
-  it('skips while a reactivation is in flight (revival race)', async () => {
+  it('serializes behind an in-flight revival and then leaves the active session alone', async () => {
+    // Stateful DB row: the revival's active-write must be visible to the
+    // destroy that runs after it.
+    const dbRow = { current: makeDbSession() }
+    sessionGet.mockImplementation(async () => dbRow.current)
+    sessionUpdate.mockImplementation(async (_id: string, data: Partial<Session>) => {
+      dbRow.current = { ...dbRow.current, ...data } as Session
+      return dbRow.current
+    })
     let releaseReactivateRead: (value: Session) => void = () => {}
     sessionGet.mockImplementationOnce(
       () => new Promise<Session>((resolve) => (releaseReactivateRead = resolve))
     )
 
-    // Reactivation starts first and is parked on its DB read
+    // Reactivation starts first and is parked on its DB read (holding the
+    // lifecycle lock)
     const reactivation = useSessionStore.getState().reactivateSession(SESSION_ID)
 
-    await useSessionStore.getState().destroyCompletedSessionTerminal(SESSION_ID)
+    let destroyed = false
+    const destroying = useSessionStore
+      .getState()
+      .destroyCompletedSessionTerminal(SESSION_ID)
+      .then(() => {
+        destroyed = true
+      })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // The destroy is queued behind the revival, not interleaved with it
+    expect(destroyed).toBe(false)
     expect(terminalDestroy).not.toHaveBeenCalled()
 
-    releaseReactivateRead(makeDbSession())
+    releaseReactivateRead(dbRow.current)
     await reactivation
+    await destroying
+
+    // Running after the revival, the destroy sees the active row and no-ops
+    expect(terminalDestroy).not.toHaveBeenCalled()
   })
 
   it('skips when a new mount request lands during the DB read (re-mount race)', async () => {
@@ -172,27 +195,46 @@ describe('closeSession DB fallback', () => {
     expect(terminalDestroy).not.toHaveBeenCalled()
   })
 
-  it('skips the PTY destroy when a revival starts mid-close', async () => {
+  it('serializes a close behind an in-flight revival (no mid-flight interleave)', async () => {
+    const dbRow = { current: makeDbSession() }
+    sessionGet.mockImplementation(async () => dbRow.current)
+    sessionUpdate.mockImplementation(async (_id: string, data: Partial<Session>) => {
+      dbRow.current = { ...dbRow.current, ...data } as Session
+      return dbRow.current
+    })
     let releaseReactivateRead: (value: Session) => void = () => {}
     sessionGet.mockImplementationOnce(
       () => new Promise<Session>((resolve) => (releaseReactivateRead = resolve))
     )
 
-    // A revival is in flight (parked on its DB read) while closeSession runs
+    // A revival holds the lifecycle lock (parked on its DB read)
     const reactivation = useSessionStore.getState().reactivateSession(SESSION_ID)
 
-    await useSessionStore.getState().closeSession(SESSION_ID)
+    let closed = false
+    const closing = useSessionStore
+      .getState()
+      .closeSession(SESSION_ID)
+      .then(() => {
+        closed = true
+      })
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
-    // The row is still marked completed (last-write ordering), but the live
-    // process is left for the revival to reclaim
-    expect(sessionUpdate).toHaveBeenCalledWith(SESSION_ID, {
-      status: 'completed',
-      completed_at: expect.any(String)
-    })
+    // The close must not interleave with the revival: no completed-write and
+    // no teardown until the revival finishes
+    expect(closed).toBe(false)
+    expect(sessionUpdate).not.toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ status: 'completed' })
+    )
     expect(terminalDestroy).not.toHaveBeenCalled()
 
-    releaseReactivateRead(makeDbSession())
+    releaseReactivateRead(dbRow.current)
     await reactivation
+    await closing
+
+    // The close then runs on the revival's final state as the newest intent
+    expect(closed).toBe(true)
+    expect(terminalDestroy).toHaveBeenCalledWith(SESSION_ID)
   })
 
   it('does not hit the DB when the session is present in the store', async () => {

--- a/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Session } from '../../../../main/db/types'
+
+const { sessionGet, sessionUpdate, terminalDestroy } = vi.hoisted(() => ({
+  sessionGet: vi.fn(),
+  sessionUpdate: vi.fn(),
+  terminalDestroy: vi.fn()
+}))
+
+vi.mock('@/api/db-api', () => ({
+  dbApi: {
+    session: {
+      get: sessionGet,
+      update: sessionUpdate
+    }
+  }
+}))
+
+vi.mock('@/api/terminal-api', () => ({
+  terminalApi: {
+    destroy: terminalDestroy
+  }
+}))
+
+import { useSessionStore } from '../useSessionStore'
+import { useWorktreeStatusStore } from '../useWorktreeStatusStore'
+
+const initialSessionState = useSessionStore.getState()
+const initialStatusState = useWorktreeStatusStore.getState()
+
+const SESSION_ID = 'sess-completed-1'
+
+function makeDbSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: SESSION_ID,
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Session',
+    status: 'completed',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'claude-code-cli',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    remote_launch: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: '2026-01-02T00:00:00.000Z',
+    pinned_to_board: false,
+    ...overrides
+  } as Session
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sessionGet.mockResolvedValue(makeDbSession())
+  terminalDestroy.mockResolvedValue({ success: true, value: undefined })
+  sessionUpdate.mockResolvedValue(makeDbSession({ status: 'active', completed_at: null }))
+})
+
+afterEach(() => {
+  useSessionStore.setState(initialSessionState, true)
+  useWorktreeStatusStore.setState(initialStatusState, true)
+})
+
+describe('destroyCompletedSessionTerminal', () => {
+  it('destroys the PTY of a completed terminal-backed session and marks it closed', async () => {
+    await useSessionStore.getState().destroyCompletedSessionTerminal(SESSION_ID)
+
+    expect(terminalDestroy).toHaveBeenCalledWith(SESSION_ID)
+    expect(useSessionStore.getState().closedTerminalSessionIds.has(SESSION_ID)).toBe(true)
+  })
+
+  it('skips while a mount request is still held', async () => {
+    useSessionStore.getState().requestSessionMount(SESSION_ID)
+
+    await useSessionStore.getState().destroyCompletedSessionTerminal(SESSION_ID)
+
+    expect(terminalDestroy).not.toHaveBeenCalled()
+  })
+
+  it('skips when the session is the active session (Go to session jump)', async () => {
+    useSessionStore.setState({ activeSessionId: SESSION_ID })
+
+    await useSessionStore.getState().destroyCompletedSessionTerminal(SESSION_ID)
+
+    expect(terminalDestroy).not.toHaveBeenCalled()
+  })
+
+  it('skips when the session status reports live work (background follow-up)', async () => {
+    useWorktreeStatusStore.setState({
+      sessionStatuses: { [SESSION_ID]: { status: 'working', timestamp: Date.now() } }
+    })
+
+    await useSessionStore.getState().destroyCompletedSessionTerminal(SESSION_ID)
+
+    expect(terminalDestroy).not.toHaveBeenCalled()
+  })
+
+  it('skips when the session is not completed in the DB', async () => {
+    sessionGet.mockResolvedValue(makeDbSession({ status: 'active', completed_at: null }))
+
+    await useSessionStore.getState().destroyCompletedSessionTerminal(SESSION_ID)
+
+    expect(terminalDestroy).not.toHaveBeenCalled()
+  })
+
+  it('skips non-terminal-backed sessions', async () => {
+    sessionGet.mockResolvedValue(makeDbSession({ agent_sdk: 'claude-code' }))
+
+    await useSessionStore.getState().destroyCompletedSessionTerminal(SESSION_ID)
+
+    expect(terminalDestroy).not.toHaveBeenCalled()
+  })
+
+  it('skips when a new mount request lands during the DB read (re-mount race)', async () => {
+    sessionGet.mockImplementation(async () => {
+      // Simulate a modal re-opening while the status read is in flight
+      useSessionStore.getState().requestSessionMount(SESSION_ID)
+      return makeDbSession()
+    })
+
+    await useSessionStore.getState().destroyCompletedSessionTerminal(SESSION_ID)
+
+    expect(terminalDestroy).not.toHaveBeenCalled()
+  })
+})
+
+describe('closeSession DB fallback', () => {
+  it('destroys the PTY of a terminal-backed session missing from the store maps', async () => {
+    // Session not present in sessionsByWorktree/sessionsByConnection — the
+    // kanban board can close sessions of worktrees never loaded here.
+    await useSessionStore.getState().closeSession(SESSION_ID)
+
+    expect(sessionGet).toHaveBeenCalledWith(SESSION_ID)
+    expect(sessionUpdate).toHaveBeenCalledWith(SESSION_ID, {
+      status: 'completed',
+      completed_at: expect.any(String)
+    })
+    expect(terminalDestroy).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('still completes the session when the DB row cannot be found', async () => {
+    sessionGet.mockResolvedValue(null)
+
+    await useSessionStore.getState().closeSession(SESSION_ID)
+
+    expect(sessionUpdate).toHaveBeenCalledWith(SESSION_ID, {
+      status: 'completed',
+      completed_at: expect.any(String)
+    })
+    expect(terminalDestroy).not.toHaveBeenCalled()
+  })
+
+  it('does not hit the DB when the session is present in the store', async () => {
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([['worktree-1', [makeDbSession({ status: 'active' })]]])
+    })
+
+    await useSessionStore.getState().closeSession(SESSION_ID)
+
+    expect(sessionGet).not.toHaveBeenCalled()
+    expect(terminalDestroy).toHaveBeenCalledWith(SESSION_ID)
+  })
+})

--- a/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Session } from '../../../../main/db/types'
 
-const { sessionGet, sessionUpdate, terminalDestroy } = vi.hoisted(() => ({
+const { sessionGet, sessionUpdate, terminalDestroy, remoteStop } = vi.hoisted(() => ({
   sessionGet: vi.fn(),
   sessionUpdate: vi.fn(),
-  terminalDestroy: vi.fn()
+  terminalDestroy: vi.fn(),
+  remoteStop: vi.fn()
 }))
 
 vi.mock('@/api/db-api', () => ({
@@ -20,6 +21,10 @@ vi.mock('@/api/terminal-api', () => ({
   terminalApi: {
     destroy: terminalDestroy
   }
+}))
+
+vi.mock('@/api/remote-launch-api', () => ({
+  remoteLaunchApi: { stop: remoteStop }
 }))
 
 import { useSessionStore } from '../useSessionStore'
@@ -60,7 +65,22 @@ beforeEach(() => {
   sessionGet.mockResolvedValue(makeDbSession())
   terminalDestroy.mockResolvedValue({ success: true, value: undefined })
   sessionUpdate.mockResolvedValue(makeDbSession({ status: 'active', completed_at: null }))
+  remoteStop.mockResolvedValue({ ok: true })
 })
+
+const REMOTE_LAUNCH_CLIENT = JSON.stringify({
+  role: 'client',
+  host: 'devbox',
+  tmuxSession: 't1'
+})
+
+function seedWorktreeSession(overrides: Partial<Session> = {}): void {
+  useSessionStore.setState({
+    sessionsByWorktree: new Map([
+      ['worktree-1', [makeDbSession({ status: 'active', completed_at: null, ...overrides })]]
+    ])
+  })
+}
 
 afterEach(() => {
   useSessionStore.setState(initialSessionState, true)
@@ -275,5 +295,66 @@ describe('closeSession DB fallback', () => {
 
     expect(sessionGet).not.toHaveBeenCalled()
     expect(terminalDestroy).toHaveBeenCalledWith(SESSION_ID)
+  })
+})
+
+describe('closeSession stopRemote', () => {
+  it('stops a remote-launched client session inside the close', async () => {
+    seedWorktreeSession({ remote_launch: REMOTE_LAUNCH_CLIENT })
+
+    const result = await useSessionStore
+      .getState()
+      .closeSession(SESSION_ID, { stopRemote: true })
+
+    expect(remoteStop).toHaveBeenCalledWith({ sessionId: SESSION_ID })
+    expect(result.success).toBe(true)
+    expect(sessionUpdate).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ status: 'completed' })
+    )
+  })
+
+  it('keeps the session open when the remote stop fails', async () => {
+    seedWorktreeSession({ remote_launch: REMOTE_LAUNCH_CLIENT })
+    remoteStop.mockRejectedValueOnce(new Error('host unreachable'))
+
+    const result = await useSessionStore
+      .getState()
+      .closeSession(SESSION_ID, { stopRemote: true })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/remote stop failed/)
+    expect(sessionUpdate).not.toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ status: 'completed' })
+    )
+    expect(terminalDestroy).not.toHaveBeenCalled()
+  })
+
+  it('does not stop remotes that were already stopped', async () => {
+    seedWorktreeSession({
+      remote_launch: JSON.stringify({
+        role: 'client',
+        host: 'devbox',
+        tmuxSession: 't1',
+        stoppedAt: '2026-01-02T00:00:00.000Z'
+      })
+    })
+
+    const result = await useSessionStore
+      .getState()
+      .closeSession(SESSION_ID, { stopRemote: true })
+
+    expect(remoteStop).not.toHaveBeenCalled()
+    expect(result.success).toBe(true)
+  })
+
+  it('leaves remote agents alone without the stopRemote opt (tab close)', async () => {
+    seedWorktreeSession({ remote_launch: REMOTE_LAUNCH_CLIENT })
+
+    const result = await useSessionStore.getState().closeSession(SESSION_ID)
+
+    expect(remoteStop).not.toHaveBeenCalled()
+    expect(result.success).toBe(true)
   })
 })

--- a/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
@@ -301,6 +301,9 @@ describe('closeSession DB fallback', () => {
 describe('closeSession stopRemote', () => {
   it('stops a remote-launched client session inside the close', async () => {
     seedWorktreeSession({ remote_launch: REMOTE_LAUNCH_CLIENT })
+    sessionGet.mockResolvedValue(
+      makeDbSession({ status: 'active', completed_at: null, remote_launch: REMOTE_LAUNCH_CLIENT })
+    )
 
     const result = await useSessionStore
       .getState()
@@ -314,8 +317,27 @@ describe('closeSession stopRemote', () => {
     )
   })
 
+  it('reads the authoritative remote_launch from the DB when the store copy is stale', async () => {
+    // Teleport-style flows write remote_launch to the DB row only — the
+    // in-store copy still says local. The stop must still fire.
+    seedWorktreeSession({ remote_launch: null })
+    sessionGet.mockResolvedValue(
+      makeDbSession({ status: 'active', completed_at: null, remote_launch: REMOTE_LAUNCH_CLIENT })
+    )
+
+    const result = await useSessionStore
+      .getState()
+      .closeSession(SESSION_ID, { stopRemote: true })
+
+    expect(remoteStop).toHaveBeenCalledWith({ sessionId: SESSION_ID })
+    expect(result.success).toBe(true)
+  })
+
   it('keeps the session open when the remote stop fails', async () => {
     seedWorktreeSession({ remote_launch: REMOTE_LAUNCH_CLIENT })
+    sessionGet.mockResolvedValue(
+      makeDbSession({ status: 'active', completed_at: null, remote_launch: REMOTE_LAUNCH_CLIENT })
+    )
     remoteStop.mockRejectedValueOnce(new Error('host unreachable'))
 
     const result = await useSessionStore
@@ -332,14 +354,16 @@ describe('closeSession stopRemote', () => {
   })
 
   it('does not stop remotes that were already stopped', async () => {
-    seedWorktreeSession({
-      remote_launch: JSON.stringify({
-        role: 'client',
-        host: 'devbox',
-        tmuxSession: 't1',
-        stoppedAt: '2026-01-02T00:00:00.000Z'
-      })
+    const stopped = JSON.stringify({
+      role: 'client',
+      host: 'devbox',
+      tmuxSession: 't1',
+      stoppedAt: '2026-01-02T00:00:00.000Z'
     })
+    seedWorktreeSession({ remote_launch: stopped })
+    sessionGet.mockResolvedValue(
+      makeDbSession({ status: 'active', completed_at: null, remote_launch: stopped })
+    )
 
     const result = await useSessionStore
       .getState()

--- a/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
@@ -195,6 +195,35 @@ describe('closeSession DB fallback', () => {
     expect(terminalDestroy).not.toHaveBeenCalled()
   })
 
+  it('aborts an abortIfRevived close when a revival marked itself before the close ran', async () => {
+    const dbRow = { current: makeDbSession({ status: 'active', completed_at: null }) }
+    sessionGet.mockImplementation(async () => dbRow.current)
+    sessionUpdate.mockImplementation(async (_id: string, data: Partial<Session>) => {
+      dbRow.current = { ...dbRow.current, ...data } as Session
+      return dbRow.current
+    })
+
+    // The close is dispatched first, then a revival starts in the same tick
+    // (markReactivating is synchronous) — the close's in-lock guard must see
+    // it and abort instead of completing the session under the revival.
+    const closing = useSessionStore.getState().closeSession(SESSION_ID, { abortIfRevived: true })
+    const reactivation = useSessionStore.getState().reactivateSession(SESSION_ID)
+
+    const result = await closing
+    await reactivation
+
+    expect(result).toEqual({
+      success: false,
+      aborted: true,
+      error: 'Session was revived concurrently'
+    })
+    expect(sessionUpdate).not.toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ status: 'completed' })
+    )
+    expect(terminalDestroy).not.toHaveBeenCalled()
+  })
+
   it('serializes a close behind an in-flight revival (no mid-flight interleave)', async () => {
     const dbRow = { current: makeDbSession() }
     sessionGet.mockImplementation(async () => dbRow.current)

--- a/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
@@ -117,6 +117,22 @@ describe('destroyCompletedSessionTerminal', () => {
     expect(terminalDestroy).not.toHaveBeenCalled()
   })
 
+  it('skips while a reactivation is in flight (revival race)', async () => {
+    let releaseReactivateRead: (value: Session) => void = () => {}
+    sessionGet.mockImplementationOnce(
+      () => new Promise<Session>((resolve) => (releaseReactivateRead = resolve))
+    )
+
+    // Reactivation starts first and is parked on its DB read
+    const reactivation = useSessionStore.getState().reactivateSession(SESSION_ID)
+
+    await useSessionStore.getState().destroyCompletedSessionTerminal(SESSION_ID)
+    expect(terminalDestroy).not.toHaveBeenCalled()
+
+    releaseReactivateRead(makeDbSession())
+    await reactivation
+  })
+
   it('skips when a new mount request lands during the DB read (re-mount race)', async () => {
     sessionGet.mockImplementation(async () => {
       // Simulate a modal re-opening while the status read is in flight

--- a/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.completed-terminal.test.ts
@@ -172,6 +172,29 @@ describe('closeSession DB fallback', () => {
     expect(terminalDestroy).not.toHaveBeenCalled()
   })
 
+  it('skips the PTY destroy when a revival starts mid-close', async () => {
+    let releaseReactivateRead: (value: Session) => void = () => {}
+    sessionGet.mockImplementationOnce(
+      () => new Promise<Session>((resolve) => (releaseReactivateRead = resolve))
+    )
+
+    // A revival is in flight (parked on its DB read) while closeSession runs
+    const reactivation = useSessionStore.getState().reactivateSession(SESSION_ID)
+
+    await useSessionStore.getState().closeSession(SESSION_ID)
+
+    // The row is still marked completed (last-write ordering), but the live
+    // process is left for the revival to reclaim
+    expect(sessionUpdate).toHaveBeenCalledWith(SESSION_ID, {
+      status: 'completed',
+      completed_at: expect.any(String)
+    })
+    expect(terminalDestroy).not.toHaveBeenCalled()
+
+    releaseReactivateRead(makeDbSession())
+    await reactivation
+  })
+
   it('does not hit the DB when the session is present in the store', async () => {
     useSessionStore.setState({
       sessionsByWorktree: new Map([['worktree-1', [makeDbSession({ status: 'active' })]]])

--- a/src/renderer/src/stores/useKanbanStore.done-close.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.done-close.test.ts
@@ -30,6 +30,7 @@ vi.mock('./useSessionStore', () => ({
 }))
 
 import { useKanbanStore } from './useKanbanStore'
+import { useWorktreeStatusStore } from './useWorktreeStatusStore'
 import { kanbanApi } from '@/api/kanban-api'
 
 const SESSION_ID = 'sess-1'
@@ -90,10 +91,12 @@ beforeEach(() => {
   vi.clearAllMocks()
   closeSession.mockResolvedValue(undefined)
   useKanbanStore.setState({ tickets: new Map(), dependencyMap: new Map() })
+  useWorktreeStatusStore.setState({ sessionStatuses: {} })
 })
 
 afterEach(() => {
   useKanbanStore.setState({ tickets: new Map(), dependencyMap: new Map() })
+  useWorktreeStatusStore.setState({ sessionStatuses: {} })
 })
 
 describe('moveTicket — close attached session on the done column', () => {
@@ -207,6 +210,52 @@ describe('moveTicket — close attached session on the done column', () => {
     expect(closeSession).not.toHaveBeenCalled()
     expect(columnOf('ticket-1')).toBe('done')
     consoleError.mockRestore()
+  })
+
+  it('does not close when the ticket left done again during the async window', async () => {
+    seed(makeTicket())
+    vi.mocked(kanbanApi.ticket.getBySession).mockImplementationOnce(async () => {
+      // User drags the ticket back to in_progress while the link check is in
+      // flight — the optimistic store already reflects the newer intent.
+      useKanbanStore.setState({
+        tickets: new Map([[PROJECT_ID, [makeTicket({ column: 'in_progress' })]]])
+      })
+      return [makeTicket()]
+    })
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('does not close when the session was revived during the move', async () => {
+    seed(makeTicket())
+    vi.mocked(kanbanApi.ticket.getBySession).mockImplementationOnce(async () => {
+      // A background revival (follow-up / plan approval) stamps a fresh
+      // working status while the close flow is in flight.
+      useWorktreeStatusStore.setState({
+        sessionStatuses: { [SESSION_ID]: { status: 'working', timestamp: Date.now() + 1000 } }
+      })
+      return [makeTicket()]
+    })
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('still closes when the session status predates the move (was simply working)', async () => {
+    seed(makeTicket())
+    useWorktreeStatusStore.setState({
+      sessionStatuses: { [SESSION_ID]: { status: 'working', timestamp: Date.now() - 60_000 } }
+    })
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+
+    expect(closeSession).toHaveBeenCalledWith(SESSION_ID)
   })
 
   it('does not fail the move when the session close rejects', async () => {

--- a/src/renderer/src/stores/useKanbanStore.done-close.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.done-close.test.ts
@@ -1,15 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { KanbanTicket, KanbanTicketColumn } from '../../../main/db/types'
 
-const { closeSession, isSessionReactivating, sessionGet, remoteStop, toastError } = vi.hoisted(
-  () => ({
-    closeSession: vi.fn().mockResolvedValue({ success: true }),
-    isSessionReactivating: vi.fn(() => false),
-    sessionGet: vi.fn().mockResolvedValue(null),
-    remoteStop: vi.fn().mockResolvedValue({ ok: true }),
-    toastError: vi.fn()
-  })
-)
+const { closeSession, isSessionReactivating, toastError } = vi.hoisted(() => ({
+  closeSession: vi.fn().mockResolvedValue({ success: true }),
+  isSessionReactivating: vi.fn(() => false),
+  toastError: vi.fn()
+}))
 
 // Mock the kanban RPC API so moveTicket doesn't hit a real client.
 vi.mock('@/api/kanban-api', () => ({
@@ -34,14 +30,6 @@ vi.mock('./useSettingsStore', () => ({
 vi.mock('./useSessionStore', () => ({
   useSessionStore: { getState: () => ({ closeSession }) },
   isSessionReactivating
-}))
-
-vi.mock('@/api/db-api', () => ({
-  dbApi: { session: { get: sessionGet } }
-}))
-
-vi.mock('@/api/remote-launch-api', () => ({
-  remoteLaunchApi: { stop: remoteStop }
 }))
 
 vi.mock('@/lib/toast', () => ({
@@ -117,8 +105,6 @@ beforeEach(() => {
   vi.clearAllMocks()
   closeSession.mockResolvedValue({ success: true })
   isSessionReactivating.mockReturnValue(false)
-  sessionGet.mockResolvedValue(null)
-  remoteStop.mockResolvedValue({ ok: true })
   useKanbanStore.setState({ tickets: new Map(), dependencyMap: new Map() })
   useWorktreeStatusStore.setState({ sessionStatuses: {} })
 })
@@ -136,7 +122,7 @@ describe('moveTicket — close attached session on the done column', () => {
     await flush()
 
     expect(closeSession).toHaveBeenCalledTimes(1)
-    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
+    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true, stopRemote: true })
   })
 
   it('does not close the session when a ticket moves to merged', async () => {
@@ -223,7 +209,7 @@ describe('moveTicket — close attached session on the done column', () => {
     await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
     await flush()
 
-    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
+    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true, stopRemote: true })
   })
 
   it('skips the close (but not the move) when the link check fails', async () => {
@@ -295,99 +281,13 @@ describe('moveTicket — close attached session on the done column', () => {
     await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
     await flush()
 
-    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
+    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true, stopRemote: true })
   })
 
-  it('stops a remote-launched session before closing it locally', async () => {
-    seed(makeTicket())
-    sessionGet.mockResolvedValue({
-      id: SESSION_ID,
-      remote_launch: JSON.stringify({ role: 'client', host: 'devbox', tmuxSession: 't1' })
-    })
 
-    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
-    await flush()
-    await flush()
 
-    expect(remoteStop).toHaveBeenCalledWith({ sessionId: SESSION_ID })
-    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
-  })
 
-  it('keeps the session linked when the remote stop fails', async () => {
-    seed(makeTicket())
-    sessionGet.mockResolvedValue({
-      id: SESSION_ID,
-      remote_launch: JSON.stringify({ role: 'client', host: 'devbox', tmuxSession: 't1' })
-    })
-    remoteStop.mockRejectedValueOnce(new Error('host unreachable'))
 
-    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
-    await flush()
-    await flush()
-
-    expect(closeSession).not.toHaveBeenCalled()
-    expect(toastError).toHaveBeenCalled()
-  })
-
-  it('does not stop remote sessions that were already stopped', async () => {
-    seed(makeTicket())
-    sessionGet.mockResolvedValue({
-      id: SESSION_ID,
-      remote_launch: JSON.stringify({
-        role: 'client',
-        host: 'devbox',
-        tmuxSession: 't1',
-        stoppedAt: '2026-01-02T00:00:00.000Z'
-      })
-    })
-
-    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
-    await flush()
-    await flush()
-
-    expect(remoteStop).not.toHaveBeenCalled()
-    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
-  })
-
-  it('bails before the remote stop when the ticket left done during the DB read', async () => {
-    seed(makeTicket())
-    sessionGet.mockImplementationOnce(async () => {
-      // Backward drag lands while the detached task reads the session row
-      useKanbanStore.setState({
-        tickets: new Map([[PROJECT_ID, [makeTicket({ column: 'in_progress' })]]])
-      })
-      return {
-        id: SESSION_ID,
-        remote_launch: JSON.stringify({ role: 'client', host: 'devbox', tmuxSession: 't1' })
-      }
-    })
-
-    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
-    await flush()
-    await flush()
-
-    expect(remoteStop).not.toHaveBeenCalled()
-    expect(closeSession).not.toHaveBeenCalled()
-  })
-
-  it('bails before the close when a revival marks itself during the remote stop', async () => {
-    seed(makeTicket())
-    sessionGet.mockResolvedValue({
-      id: SESSION_ID,
-      remote_launch: JSON.stringify({ role: 'client', host: 'devbox', tmuxSession: 't1' })
-    })
-    remoteStop.mockImplementationOnce(async () => {
-      isSessionReactivating.mockReturnValue(true)
-      return { ok: true }
-    })
-
-    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
-    await flush()
-    await flush()
-
-    expect(remoteStop).toHaveBeenCalled()
-    expect(closeSession).not.toHaveBeenCalled()
-  })
 
   it('surfaces a non-aborted close failure via toast', async () => {
     seed(makeTicket())
@@ -398,7 +298,9 @@ describe('moveTicket — close attached session on the done column', () => {
     await flush()
     await flush()
 
-    expect(toastError).toHaveBeenCalledWith('Ticket is done, but its session could not be closed')
+    expect(toastError).toHaveBeenCalledWith(
+      'Ticket is done, but its session could not be closed: db locked'
+    )
     consoleError.mockRestore()
   })
 

--- a/src/renderer/src/stores/useKanbanStore.done-close.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.done-close.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { KanbanTicket, KanbanTicketColumn } from '../../../main/db/types'
 
-const { closeSession, isSessionReactivating, toastError } = vi.hoisted(() => ({
+const { closeSession, reactivateSession, isSessionReactivating, toastError } = vi.hoisted(() => ({
   closeSession: vi.fn().mockResolvedValue({ success: true }),
+  reactivateSession: vi.fn().mockResolvedValue(undefined),
   isSessionReactivating: vi.fn(() => false),
   toastError: vi.fn()
 }))
@@ -28,7 +29,7 @@ vi.mock('./useSettingsStore', () => ({
 // moveTicket dynamically imports useSessionStore to close the attached
 // session when a ticket enters the done column.
 vi.mock('./useSessionStore', () => ({
-  useSessionStore: { getState: () => ({ closeSession }) },
+  useSessionStore: { getState: () => ({ closeSession, reactivateSession }) },
   isSessionReactivating
 }))
 
@@ -288,6 +289,50 @@ describe('moveTicket — close attached session on the done column', () => {
 
 
 
+
+  it('reactivates the session when the ticket was dragged back out of done mid-close', async () => {
+    seed(makeTicket())
+    closeSession.mockImplementationOnce(async () => {
+      // Backward drag lands while closeSession's own awaits are in flight
+      useKanbanStore.setState({
+        tickets: new Map([[PROJECT_ID, [makeTicket({ column: 'in_progress' })]]])
+      })
+      return { success: true }
+    })
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+
+    expect(reactivateSession).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('does not undo a backward-drag flow that unlinked the session on purpose', async () => {
+    seed(makeTicket())
+    closeSession.mockImplementationOnce(async () => {
+      // Drag-to-todo completes AND unlinks the session itself
+      useKanbanStore.setState({
+        tickets: new Map([
+          [PROJECT_ID, [makeTicket({ column: 'todo', current_session_id: null })]]
+        ])
+      })
+      return { success: true }
+    })
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+
+    expect(reactivateSession).not.toHaveBeenCalled()
+  })
+
+  it('leaves settled done tickets alone after a successful close', async () => {
+    seed(makeTicket())
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+
+    expect(closeSession).toHaveBeenCalledTimes(1)
+    expect(reactivateSession).not.toHaveBeenCalled()
+  })
 
   it('surfaces a non-aborted close failure via toast', async () => {
     seed(makeTicket())

--- a/src/renderer/src/stores/useKanbanStore.done-close.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.done-close.test.ts
@@ -104,7 +104,14 @@ function columnOf(ticketId: string): KanbanTicketColumn | undefined {
     ?.find((t) => t.id === ticketId)?.column
 }
 
-const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+// Drain the detached close task fully — it spans several awaits (DB read,
+// remote stop, lifecycle-locked close); a partial drain would leak a pending
+// block into the next test where it consumes that test's mocks.
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 6; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+}
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -340,6 +347,46 @@ describe('moveTicket — close attached session on the done column', () => {
 
     expect(remoteStop).not.toHaveBeenCalled()
     expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
+  })
+
+  it('bails before the remote stop when the ticket left done during the DB read', async () => {
+    seed(makeTicket())
+    sessionGet.mockImplementationOnce(async () => {
+      // Backward drag lands while the detached task reads the session row
+      useKanbanStore.setState({
+        tickets: new Map([[PROJECT_ID, [makeTicket({ column: 'in_progress' })]]])
+      })
+      return {
+        id: SESSION_ID,
+        remote_launch: JSON.stringify({ role: 'client', host: 'devbox', tmuxSession: 't1' })
+      }
+    })
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+    await flush()
+
+    expect(remoteStop).not.toHaveBeenCalled()
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('bails before the close when a revival marks itself during the remote stop', async () => {
+    seed(makeTicket())
+    sessionGet.mockResolvedValue({
+      id: SESSION_ID,
+      remote_launch: JSON.stringify({ role: 'client', host: 'devbox', tmuxSession: 't1' })
+    })
+    remoteStop.mockImplementationOnce(async () => {
+      isSessionReactivating.mockReturnValue(true)
+      return { ok: true }
+    })
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+    await flush()
+
+    expect(remoteStop).toHaveBeenCalled()
+    expect(closeSession).not.toHaveBeenCalled()
   })
 
   it('surfaces a non-aborted close failure via toast', async () => {

--- a/src/renderer/src/stores/useKanbanStore.done-close.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.done-close.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KanbanTicket, KanbanTicketColumn } from '../../../main/db/types'
+
+const { closeSession } = vi.hoisted(() => ({
+  closeSession: vi.fn().mockResolvedValue(undefined)
+}))
+
+// Mock the kanban RPC API so moveTicket doesn't hit a real client.
+vi.mock('@/api/kanban-api', () => ({
+  kanbanApi: {
+    ticket: {
+      move: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(null),
+      reorder: vi.fn().mockResolvedValue(undefined),
+      addTokens: vi.fn().mockResolvedValue(null),
+      getBySession: vi.fn().mockResolvedValue([])
+    }
+  }
+}))
+
+// moveTicket dynamically imports useSettingsStore for the follow-up trigger.
+vi.mock('./useSettingsStore', () => ({
+  useSettingsStore: { getState: () => ({ followUpTriggerColumn: 'done' }) }
+}))
+
+// moveTicket dynamically imports useSessionStore to close the attached
+// session when a ticket enters the done column.
+vi.mock('./useSessionStore', () => ({
+  useSessionStore: { getState: () => ({ closeSession }) }
+}))
+
+import { useKanbanStore } from './useKanbanStore'
+import { kanbanApi } from '@/api/kanban-api'
+
+const SESSION_ID = 'sess-1'
+const PROJECT_ID = 'proj-1'
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: PROJECT_ID,
+    title: 'A ticket',
+    description: null,
+    attachments: [],
+    column: 'in_progress',
+    sort_order: 0,
+    current_session_id: SESSION_ID,
+    worktree_id: null,
+    mode: 'build',
+    plan_ready: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    column_changed_at: null,
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
+    created_from_session: true,
+    auto_approve_plan: false,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
+    ...overrides
+  }
+}
+
+function seed(ticket: KanbanTicket): void {
+  useKanbanStore.setState({ tickets: new Map([[PROJECT_ID, [ticket]]]) })
+}
+
+function columnOf(ticketId: string): KanbanTicketColumn | undefined {
+  return useKanbanStore
+    .getState()
+    .tickets.get(PROJECT_ID)
+    ?.find((t) => t.id === ticketId)?.column
+}
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  closeSession.mockResolvedValue(undefined)
+  useKanbanStore.setState({ tickets: new Map(), dependencyMap: new Map() })
+})
+
+afterEach(() => {
+  useKanbanStore.setState({ tickets: new Map(), dependencyMap: new Map() })
+})
+
+describe('moveTicket — close attached session on the done column', () => {
+  it('closes the attached session when a ticket moves to done', async () => {
+    seed(makeTicket())
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+
+    expect(closeSession).toHaveBeenCalledTimes(1)
+    expect(closeSession).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('does not close the session when a ticket moves to merged', async () => {
+    seed(makeTicket())
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'merged', 0)
+    await flush()
+
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('does not close the session for non-terminal columns', async () => {
+    seed(makeTicket({ column: 'todo' }))
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'review', 0)
+    await flush()
+
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('does not close anything for tickets without a session', async () => {
+    seed(makeTicket({ current_session_id: null }))
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('skips the close when completion effects are suppressed (handoff rollback)', async () => {
+    seed(makeTicket())
+
+    await useKanbanStore
+      .getState()
+      .moveTicket('ticket-1', PROJECT_ID, 'done', 0, { skipCompletionEffects: true })
+    await flush()
+
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('does not re-close on a move within the done column', async () => {
+    seed(makeTicket({ column: 'done' }))
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 3)
+    await flush()
+
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('does not close the session when the move RPC fails (optimistic revert)', async () => {
+    seed(makeTicket())
+    vi.mocked(kanbanApi.ticket.move).mockRejectedValueOnce(new Error('boom'))
+
+    await expect(
+      useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    ).rejects.toThrow('boom')
+    await flush()
+
+    expect(closeSession).not.toHaveBeenCalled()
+    expect(columnOf('ticket-1')).toBe('in_progress')
+  })
+
+  it('does not close a session still shared with another live ticket', async () => {
+    seed(makeTicket())
+    vi.mocked(kanbanApi.ticket.getBySession).mockResolvedValueOnce([
+      makeTicket(),
+      makeTicket({ id: 'ticket-2', column: 'in_progress' })
+    ])
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('closes the session when the other linked tickets are all terminal or archived', async () => {
+    seed(makeTicket())
+    vi.mocked(kanbanApi.ticket.getBySession).mockResolvedValueOnce([
+      makeTicket(),
+      makeTicket({ id: 'ticket-2', column: 'merged' }),
+      makeTicket({ id: 'ticket-3', column: 'todo', archived_at: '2026-01-02T00:00:00.000Z' })
+    ])
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+
+    expect(closeSession).toHaveBeenCalledWith(SESSION_ID)
+  })
+
+  it('skips the close (but not the move) when the link check fails', async () => {
+    seed(makeTicket())
+    vi.mocked(kanbanApi.ticket.getBySession).mockRejectedValueOnce(new Error('rpc down'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(
+      useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    ).resolves.toBeUndefined()
+    await flush()
+
+    expect(closeSession).not.toHaveBeenCalled()
+    expect(columnOf('ticket-1')).toBe('done')
+    consoleError.mockRestore()
+  })
+
+  it('does not fail the move when the session close rejects', async () => {
+    seed(makeTicket())
+    closeSession.mockRejectedValueOnce(new Error('pty gone'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(
+      useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    ).resolves.toBeUndefined()
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('done')
+    consoleError.mockRestore()
+  })
+})

--- a/src/renderer/src/stores/useKanbanStore.done-close.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.done-close.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { KanbanTicket, KanbanTicketColumn } from '../../../main/db/types'
 
-const { closeSession, isSessionReactivating } = vi.hoisted(() => ({
-  closeSession: vi.fn().mockResolvedValue(undefined),
-  isSessionReactivating: vi.fn(() => false)
-}))
+const { closeSession, isSessionReactivating, sessionGet, remoteStop, toastError } = vi.hoisted(
+  () => ({
+    closeSession: vi.fn().mockResolvedValue({ success: true }),
+    isSessionReactivating: vi.fn(() => false),
+    sessionGet: vi.fn().mockResolvedValue(null),
+    remoteStop: vi.fn().mockResolvedValue({ ok: true }),
+    toastError: vi.fn()
+  })
+)
 
 // Mock the kanban RPC API so moveTicket doesn't hit a real client.
 vi.mock('@/api/kanban-api', () => ({
@@ -29,6 +34,18 @@ vi.mock('./useSettingsStore', () => ({
 vi.mock('./useSessionStore', () => ({
   useSessionStore: { getState: () => ({ closeSession }) },
   isSessionReactivating
+}))
+
+vi.mock('@/api/db-api', () => ({
+  dbApi: { session: { get: sessionGet } }
+}))
+
+vi.mock('@/api/remote-launch-api', () => ({
+  remoteLaunchApi: { stop: remoteStop }
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { error: toastError, success: vi.fn(), info: vi.fn() }
 }))
 
 import { useKanbanStore } from './useKanbanStore'
@@ -91,8 +108,10 @@ const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 
 
 beforeEach(() => {
   vi.clearAllMocks()
-  closeSession.mockResolvedValue(undefined)
+  closeSession.mockResolvedValue({ success: true })
   isSessionReactivating.mockReturnValue(false)
+  sessionGet.mockResolvedValue(null)
+  remoteStop.mockResolvedValue({ ok: true })
   useKanbanStore.setState({ tickets: new Map(), dependencyMap: new Map() })
   useWorktreeStatusStore.setState({ sessionStatuses: {} })
 })
@@ -270,6 +289,81 @@ describe('moveTicket — close attached session on the done column', () => {
     await flush()
 
     expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
+  })
+
+  it('stops a remote-launched session before closing it locally', async () => {
+    seed(makeTicket())
+    sessionGet.mockResolvedValue({
+      id: SESSION_ID,
+      remote_launch: JSON.stringify({ role: 'client', host: 'devbox', tmuxSession: 't1' })
+    })
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+    await flush()
+
+    expect(remoteStop).toHaveBeenCalledWith({ sessionId: SESSION_ID })
+    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
+  })
+
+  it('keeps the session linked when the remote stop fails', async () => {
+    seed(makeTicket())
+    sessionGet.mockResolvedValue({
+      id: SESSION_ID,
+      remote_launch: JSON.stringify({ role: 'client', host: 'devbox', tmuxSession: 't1' })
+    })
+    remoteStop.mockRejectedValueOnce(new Error('host unreachable'))
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+    await flush()
+
+    expect(closeSession).not.toHaveBeenCalled()
+    expect(toastError).toHaveBeenCalled()
+  })
+
+  it('does not stop remote sessions that were already stopped', async () => {
+    seed(makeTicket())
+    sessionGet.mockResolvedValue({
+      id: SESSION_ID,
+      remote_launch: JSON.stringify({
+        role: 'client',
+        host: 'devbox',
+        tmuxSession: 't1',
+        stoppedAt: '2026-01-02T00:00:00.000Z'
+      })
+    })
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+    await flush()
+
+    expect(remoteStop).not.toHaveBeenCalled()
+    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
+  })
+
+  it('surfaces a non-aborted close failure via toast', async () => {
+    seed(makeTicket())
+    closeSession.mockResolvedValue({ success: false, error: 'db locked' })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+    await flush()
+
+    expect(toastError).toHaveBeenCalledWith('Ticket is done, but its session could not be closed')
+    consoleError.mockRestore()
+  })
+
+  it('stays quiet when the close was aborted by a concurrent revival', async () => {
+    seed(makeTicket())
+    closeSession.mockResolvedValue({ success: false, aborted: true, error: 'revived' })
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+    await flush()
+
+    expect(toastError).not.toHaveBeenCalled()
   })
 
   it('does not fail the move when the session close rejects', async () => {

--- a/src/renderer/src/stores/useKanbanStore.done-close.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.done-close.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { KanbanTicket, KanbanTicketColumn } from '../../../main/db/types'
 
-const { closeSession } = vi.hoisted(() => ({
-  closeSession: vi.fn().mockResolvedValue(undefined)
+const { closeSession, isSessionReactivating } = vi.hoisted(() => ({
+  closeSession: vi.fn().mockResolvedValue(undefined),
+  isSessionReactivating: vi.fn(() => false)
 }))
 
 // Mock the kanban RPC API so moveTicket doesn't hit a real client.
@@ -26,7 +27,8 @@ vi.mock('./useSettingsStore', () => ({
 // moveTicket dynamically imports useSessionStore to close the attached
 // session when a ticket enters the done column.
 vi.mock('./useSessionStore', () => ({
-  useSessionStore: { getState: () => ({ closeSession }) }
+  useSessionStore: { getState: () => ({ closeSession }) },
+  isSessionReactivating
 }))
 
 import { useKanbanStore } from './useKanbanStore'
@@ -90,6 +92,7 @@ const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 
 beforeEach(() => {
   vi.clearAllMocks()
   closeSession.mockResolvedValue(undefined)
+  isSessionReactivating.mockReturnValue(false)
   useKanbanStore.setState({ tickets: new Map(), dependencyMap: new Map() })
   useWorktreeStatusStore.setState({ sessionStatuses: {} })
 })
@@ -243,6 +246,17 @@ describe('moveTicket — close attached session on the done column', () => {
     await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
     await flush()
 
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('does not close while a reactivation is in flight for the session', async () => {
+    seed(makeTicket())
+    isSessionReactivating.mockReturnValue(true)
+
+    await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
+    await flush()
+
+    expect(isSessionReactivating).toHaveBeenCalledWith(SESSION_ID)
     expect(closeSession).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/stores/useKanbanStore.done-close.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.done-close.test.ts
@@ -110,7 +110,7 @@ describe('moveTicket — close attached session on the done column', () => {
     await flush()
 
     expect(closeSession).toHaveBeenCalledTimes(1)
-    expect(closeSession).toHaveBeenCalledWith(SESSION_ID)
+    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
   })
 
   it('does not close the session when a ticket moves to merged', async () => {
@@ -197,7 +197,7 @@ describe('moveTicket — close attached session on the done column', () => {
     await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
     await flush()
 
-    expect(closeSession).toHaveBeenCalledWith(SESSION_ID)
+    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
   })
 
   it('skips the close (but not the move) when the link check fails', async () => {
@@ -269,7 +269,7 @@ describe('moveTicket — close attached session on the done column', () => {
     await useKanbanStore.getState().moveTicket('ticket-1', PROJECT_ID, 'done', 0)
     await flush()
 
-    expect(closeSession).toHaveBeenCalledWith(SESSION_ID)
+    expect(closeSession).toHaveBeenCalledWith(SESSION_ID, { abortIfRevived: true })
   })
 
   it('does not fail the move when the session close rejects', async () => {

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -1059,7 +1059,9 @@ export const useKanbanStore = create<KanbanState>()(
               ) {
                 useSessionStore
                   .getState()
-                  .closeSession(sessionIdToClose)
+                  // abortIfRevived re-checks inside the lifecycle lock, making
+                  // the revival guard and the close transition atomic
+                  .closeSession(sessionIdToClose, { abortIfRevived: true })
                   .catch((err) => {
                     console.error(
                       'Failed to close session for completed ticket:',

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -971,7 +971,8 @@ export const useKanbanStore = create<KanbanState>()(
 
         // Optimistic local update (updated_at/column_changed_at mirror the backend
         // bumps so transition-sorted columns place the ticket correctly right away)
-        const movedAt = new Date().toISOString()
+        const moveStartedAtMs = Date.now()
+        const movedAt = new Date(moveStartedAtMs).toISOString()
         set((state) => {
           const next = new Map(state.tickets)
           const tickets = (next.get(projectId) ?? []).map((t) =>
@@ -1027,7 +1028,27 @@ export const useKanbanStore = create<KanbanState>()(
                   t.column !== 'done' &&
                   t.column !== 'merged'
               )
-              if (!sharedWithLiveTicket) {
+              // The awaits above race two newer intents: the user dragging the
+              // ticket back out of done, and a background revival (follow-up
+              // send, plan approval) putting the session back to work. Re-check
+              // both from current state right before closing — the newer intent
+              // wins. Only status transitions stamped AFTER this move count as
+              // revivals: a session that was merely still working when the user
+              // dragged to done must still be closed (that is the feature).
+              const ticketNow = get()
+                .tickets.get(projectId)
+                ?.find((t) => t.id === ticketId)
+              const statusEntry =
+                useWorktreeStatusStore.getState().sessionStatuses[sessionIdToClose]
+              const revivedDuringMove =
+                statusEntry != null &&
+                statusEntry.timestamp > moveStartedAtMs &&
+                (statusEntry.status === 'working' ||
+                  statusEntry.status === 'planning' ||
+                  statusEntry.status === 'answering' ||
+                  statusEntry.status === 'permission' ||
+                  statusEntry.status === 'command_approval')
+              if (!sharedWithLiveTicket && ticketNow?.column === 'done' && !revivedDuringMove) {
                 const { useSessionStore } = await import('./useSessionStore')
                 useSessionStore
                   .getState()

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -998,6 +998,53 @@ export const useKanbanStore = create<KanbanState>()(
         try {
           await kanban.ticket.move(projectId, ticketId, column, sortOrder)
 
+          // Entering the done column ends the ticket's work: close the attached
+          // session so its agent process dies now and the tab is not restored on
+          // the next worktree selection or app launch. Done only — a merged
+          // move must NOT close the session (user decision). Lives in the
+          // renderer because it is the only production caller of this RPC and
+          // the server child cannot reach main-process PTYs — a future
+          // non-renderer mover (bots, automations) needs its own server-side
+          // hook.
+          if (
+            !opts?.skipCompletionEffects &&
+            column === 'done' &&
+            movedTicket?.current_session_id &&
+            movedTicket.column !== column
+          ) {
+            const sessionIdToClose = movedTicket.current_session_id
+            try {
+              // One session can serve several tickets (pre-assign attaches the
+              // worktree's session to every ticket; handoffs relink in bulk).
+              // Closing it while another live ticket still rides it would kill
+              // that ticket's in-flight work — skip, and skip too when the
+              // link set cannot be verified.
+              const linked = await kanban.ticket.getBySession<KanbanTicket>(sessionIdToClose)
+              const sharedWithLiveTicket = linked.some(
+                (t) =>
+                  t.id !== ticketId &&
+                  !t.archived_at &&
+                  t.column !== 'done' &&
+                  t.column !== 'merged'
+              )
+              if (!sharedWithLiveTicket) {
+                const { useSessionStore } = await import('./useSessionStore')
+                useSessionStore
+                  .getState()
+                  .closeSession(sessionIdToClose)
+                  .catch((err) => {
+                    console.error(
+                      'Failed to close session for completed ticket:',
+                      sessionIdToClose,
+                      err
+                    )
+                  })
+              }
+            } catch (err) {
+              console.error('Skipping session close — link check failed:', sessionIdToClose, err)
+            }
+          }
+
           // When a ticket moves to done (or review, if that's the trigger), check if any dependents can be auto-launched
           const { useSettingsStore } = await import('./useSettingsStore')
           const { isBlockerSatisfied } = await import('../lib/blocker-utils')
@@ -1260,6 +1307,14 @@ export const useKanbanStore = create<KanbanState>()(
                   get()
                     .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
                     .catch(() => {})
+                  // The done-move closed this session; the approved plan puts it
+                  // back to work — restore its active status and tab (no focus
+                  // change) so the process is not culled as a completed leftover.
+                  import('./useSessionStore')
+                    .then(({ useSessionStore }) =>
+                      useSessionStore.getState().reactivateSession(sessionId)
+                    )
+                    .catch(() => {})
                 }
                 break
               }
@@ -1299,6 +1354,15 @@ export const useKanbanStore = create<KanbanState>()(
                   get()
                     .moveTicket(ticket.id, projectId, 'in_progress', ticket.sort_order)
                     .catch(() => {})
+                  if (reopenedByFollowup) {
+                    // An explicit follow-up revived a done-closed session —
+                    // restore its active status and tab (no focus change).
+                    import('./useSessionStore')
+                      .then(({ useSessionStore }) =>
+                        useSessionStore.getState().reactivateSession(sessionId)
+                      )
+                      .catch(() => {})
+                  }
                 }
                 break
               }

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -1078,6 +1078,24 @@ export const useKanbanStore = create<KanbanState>()(
                       `Ticket is done, but its session could not be closed: ${result.error ?? 'unknown error'}`
                     )
                   }
+                  if (result.success) {
+                    // A drag back out of Done during the close (which does not
+                    // mark the session reactivating) means the newer intent is
+                    // to keep working — undo: restore active status and tab.
+                    // Only when the ticket still references this session; the
+                    // backward-drag-to-todo flow completes and unlinks it on
+                    // purpose and must not be undone.
+                    const ticketAfter = get()
+                      .tickets.get(projectId)
+                      ?.find((t) => t.id === ticketId)
+                    if (
+                      ticketAfter &&
+                      ticketAfter.column !== 'done' &&
+                      ticketAfter.current_session_id === sessionIdToClose
+                    ) {
+                      await useSessionStore.getState().reactivateSession(sessionIdToClose)
+                    }
+                  }
                 })().catch((err) => {
                   console.error(
                     'Failed to close session for completed ticket:',

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -21,6 +21,11 @@ import { useConnectionStore } from './useConnectionStore'
 import { usePinnedStore } from './usePinnedStore'
 import { useWorktreeStatusStore } from './useWorktreeStatusStore'
 import { kanbanApi as kanban } from '@/api/kanban-api'
+import { dbApi } from '@/api/db-api'
+import { remoteLaunchApi } from '@/api/remote-launch-api'
+import { parseRemoteLaunch } from '@shared/types/remote-launch'
+import { toast } from '@/lib/toast'
+import type { Session } from '../../../main/db/types'
 
 export interface BoardTelegramTarget {
   ticketId: string
@@ -1057,18 +1062,47 @@ export const useKanbanStore = create<KanbanState>()(
                 // close while a reactivation/reopen is in flight.
                 !isSessionReactivating(sessionIdToClose)
               ) {
-                useSessionStore
-                  .getState()
+                void (async () => {
+                  // Remote-launched agents run in a tmux on the remote host —
+                  // a local close would leave that agent running forever.
+                  // Stop it first (mirroring the backward-drag flow) and keep
+                  // the session linked when the remote cannot be reached.
+                  const dbSession = await dbApi.session.get<Session>(sessionIdToClose)
+                  const remoteInfo = parseRemoteLaunch(dbSession?.remote_launch)
+                  if (remoteInfo?.role === 'client' && !remoteInfo.stoppedAt) {
+                    try {
+                      await remoteLaunchApi.stop({ sessionId: sessionIdToClose })
+                      const { useRemoteLaunchStore } = await import('./useRemoteLaunchStore')
+                      useRemoteLaunchStore.getState().markStopped(sessionIdToClose)
+                    } catch (err) {
+                      toast.error(
+                        `Ticket is done, but its remote session could not be stopped: ${err instanceof Error ? err.message : String(err)}`
+                      )
+                      return
+                    }
+                  }
                   // abortIfRevived re-checks inside the lifecycle lock, making
-                  // the revival guard and the close transition atomic
-                  .closeSession(sessionIdToClose, { abortIfRevived: true })
-                  .catch((err) => {
+                  // the revival guard and the close transition atomic.
+                  // closeSession reports failures via its result, not by
+                  // throwing — surface non-aborted failures.
+                  const result = await useSessionStore
+                    .getState()
+                    .closeSession(sessionIdToClose, { abortIfRevived: true })
+                  if (!result.success && !result.aborted) {
                     console.error(
                       'Failed to close session for completed ticket:',
                       sessionIdToClose,
-                      err
+                      result.error
                     )
-                  })
+                    toast.error('Ticket is done, but its session could not be closed')
+                  }
+                })().catch((err) => {
+                  console.error(
+                    'Failed to close session for completed ticket:',
+                    sessionIdToClose,
+                    err
+                  )
+                })
               }
             } catch (err) {
               console.error('Skipping session close — link check failed:', sessionIdToClose, err)

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -1063,12 +1063,26 @@ export const useKanbanStore = create<KanbanState>()(
                 !isSessionReactivating(sessionIdToClose)
               ) {
                 void (async () => {
+                  // Every await in this detached task races newer intents —
+                  // a backward drag out of Done (which never marks the
+                  // session as reactivating) or a revival. Re-validate on
+                  // fresh state immediately before each irreversible step.
+                  const stillEligible = (): boolean => {
+                    const ticketFresh = get()
+                      .tickets.get(projectId)
+                      ?.find((t) => t.id === ticketId)
+                    return (
+                      ticketFresh?.column === 'done' &&
+                      !isSessionReactivating(sessionIdToClose)
+                    )
+                  }
                   // Remote-launched agents run in a tmux on the remote host —
                   // a local close would leave that agent running forever.
                   // Stop it first (mirroring the backward-drag flow) and keep
                   // the session linked when the remote cannot be reached.
                   const dbSession = await dbApi.session.get<Session>(sessionIdToClose)
                   const remoteInfo = parseRemoteLaunch(dbSession?.remote_launch)
+                  if (!stillEligible()) return
                   if (remoteInfo?.role === 'client' && !remoteInfo.stoppedAt) {
                     try {
                       await remoteLaunchApi.stop({ sessionId: sessionIdToClose })
@@ -1081,6 +1095,7 @@ export const useKanbanStore = create<KanbanState>()(
                       return
                     }
                   }
+                  if (!stillEligible()) return
                   // abortIfRevived re-checks inside the lifecycle lock, making
                   // the revival guard and the close transition atomic.
                   // closeSession reports failures via its result, not by

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -1048,8 +1048,15 @@ export const useKanbanStore = create<KanbanState>()(
                   statusEntry.status === 'answering' ||
                   statusEntry.status === 'permission' ||
                   statusEntry.status === 'command_approval')
-              if (!sharedWithLiveTicket && ticketNow?.column === 'done' && !revivedDuringMove) {
-                const { useSessionStore } = await import('./useSessionStore')
+              const { useSessionStore, isSessionReactivating } = await import('./useSessionStore')
+              if (
+                !sharedWithLiveTicket &&
+                ticketNow?.column === 'done' &&
+                !revivedDuringMove &&
+                // A revival can start before its status stamp lands — never
+                // close while a reactivation/reopen is in flight.
+                !isSessionReactivating(sessionIdToClose)
+              ) {
                 useSessionStore
                   .getState()
                   .closeSession(sessionIdToClose)

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -21,11 +21,7 @@ import { useConnectionStore } from './useConnectionStore'
 import { usePinnedStore } from './usePinnedStore'
 import { useWorktreeStatusStore } from './useWorktreeStatusStore'
 import { kanbanApi as kanban } from '@/api/kanban-api'
-import { dbApi } from '@/api/db-api'
-import { remoteLaunchApi } from '@/api/remote-launch-api'
-import { parseRemoteLaunch } from '@shared/types/remote-launch'
 import { toast } from '@/lib/toast'
-import type { Session } from '../../../main/db/types'
 
 export interface BoardTelegramTarget {
   ticketId: string
@@ -1062,54 +1058,25 @@ export const useKanbanStore = create<KanbanState>()(
                 // close while a reactivation/reopen is in flight.
                 !isSessionReactivating(sessionIdToClose)
               ) {
+                // No awaits sit between the guards above and this call, and
+                // closeSession performs the remote stop and the close INSIDE
+                // its per-session lifecycle lock (after re-checking
+                // abortIfRevived there), so guard and transitions are atomic.
+                // closeSession reports failures via its result, not by
+                // throwing — surface non-aborted failures.
                 void (async () => {
-                  // Every await in this detached task races newer intents —
-                  // a backward drag out of Done (which never marks the
-                  // session as reactivating) or a revival. Re-validate on
-                  // fresh state immediately before each irreversible step.
-                  const stillEligible = (): boolean => {
-                    const ticketFresh = get()
-                      .tickets.get(projectId)
-                      ?.find((t) => t.id === ticketId)
-                    return (
-                      ticketFresh?.column === 'done' &&
-                      !isSessionReactivating(sessionIdToClose)
-                    )
-                  }
-                  // Remote-launched agents run in a tmux on the remote host —
-                  // a local close would leave that agent running forever.
-                  // Stop it first (mirroring the backward-drag flow) and keep
-                  // the session linked when the remote cannot be reached.
-                  const dbSession = await dbApi.session.get<Session>(sessionIdToClose)
-                  const remoteInfo = parseRemoteLaunch(dbSession?.remote_launch)
-                  if (!stillEligible()) return
-                  if (remoteInfo?.role === 'client' && !remoteInfo.stoppedAt) {
-                    try {
-                      await remoteLaunchApi.stop({ sessionId: sessionIdToClose })
-                      const { useRemoteLaunchStore } = await import('./useRemoteLaunchStore')
-                      useRemoteLaunchStore.getState().markStopped(sessionIdToClose)
-                    } catch (err) {
-                      toast.error(
-                        `Ticket is done, but its remote session could not be stopped: ${err instanceof Error ? err.message : String(err)}`
-                      )
-                      return
-                    }
-                  }
-                  if (!stillEligible()) return
-                  // abortIfRevived re-checks inside the lifecycle lock, making
-                  // the revival guard and the close transition atomic.
-                  // closeSession reports failures via its result, not by
-                  // throwing — surface non-aborted failures.
                   const result = await useSessionStore
                     .getState()
-                    .closeSession(sessionIdToClose, { abortIfRevived: true })
+                    .closeSession(sessionIdToClose, { abortIfRevived: true, stopRemote: true })
                   if (!result.success && !result.aborted) {
                     console.error(
                       'Failed to close session for completed ticket:',
                       sessionIdToClose,
                       result.error
                     )
-                    toast.error('Ticket is done, but its session could not be closed')
+                    toast.error(
+                      `Ticket is done, but its session could not be closed: ${result.error ?? 'unknown error'}`
+                    )
                   }
                 })().catch((err) => {
                   console.error(

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -813,6 +813,17 @@ export const useSessionStore = create<SessionState>()(
           // lose its remote process to a stale stop. On failure the session
           // stays linked (and alive) — the caller surfaces the error.
           if (opts?.stopRemote) {
+            // The store copy can predate a later remote launch (teleport
+            // writes remote_launch to the DB row only) — the DB is the
+            // authority on whether a remote agent exists.
+            if (foundInStore) {
+              try {
+                const freshRow = await dbApi.session.get<Session>(sessionId)
+                if (freshRow) remoteLaunchRaw = freshRow.remote_launch ?? null
+              } catch {
+                // Fall back to the store copy
+              }
+            }
             const remoteInfo = parseRemoteLaunch(remoteLaunchRaw)
             if (remoteInfo?.role === 'client' && !remoteInfo.stoppedAt) {
               try {

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -817,6 +817,20 @@ export const useSessionStore = create<SessionState>()(
             }
           }
 
+          // A closed session has no live status. The destroy path above
+          // removes exit listeners before killing, so no pty_exit status
+          // overwrites a pre-close 'working' — left in place, that stale
+          // entry would later veto the modal-release cleanup of a
+          // modal-resumed PTY (isReEngaged) and strand the process.
+          if (!revivedMidClose) {
+            try {
+              const { useWorktreeStatusStore } = await import('./useWorktreeStatusStore')
+              useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+            } catch {
+              // Best-effort — a stale badge is preferable to a failed close
+            }
+          }
+
           // Disconnect agent SDK session to free main-process resources
           // (session state, abort controllers, cached data).
           // Best-effort — session may already be disconnected.

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -32,6 +32,12 @@ const pushQueuedState = (sessionId: string, hasQueued: boolean): void => {
   systemApi.setSessionQueuedState(sessionId, hasQueued).catch(() => {})
 }
 
+// Sessions currently being flipped back to active by reactivateSession.
+// Consulted (synchronously) by destroyCompletedSessionTerminal so a cleanup
+// racing the async DB flip cannot read the stale 'completed' row and kill a
+// just-revived process.
+const reactivatingSessionIds = new Set<string>()
+
 export const BOARD_TAB_ID = '__board__'
 export const BOARD_ASSISTANT_SESSION_NAME_PREFIX = '[Board Assistant]'
 
@@ -399,6 +405,7 @@ export const useSessionStore = create<SessionState>()(
       // the DB row back to active yet).
       destroyCompletedSessionTerminal: async (sessionId: string) => {
         const isReEngaged = async (): Promise<boolean> => {
+          if (reactivatingSessionIds.has(sessionId)) return true
           if (get().sessionMountRequests.has(sessionId)) return true
           if (get().activeSessionId === sessionId) return true
           const { useWorktreeStatusStore } = await import('./useWorktreeStatusStore')
@@ -1087,28 +1094,36 @@ export const useSessionStore = create<SessionState>()(
       // work: the session must regain a tab and a restore entry, or its
       // respawned process would outlive every UI affordance to close it.
       reactivateSession: async (sessionId: string) => {
-        let dbSession: Session | null = null
+        // Marked synchronously so a concurrently-running
+        // destroyCompletedSessionTerminal cannot read the stale 'completed'
+        // DB row and kill the process this revival is claiming.
+        reactivatingSessionIds.add(sessionId)
         try {
-          dbSession = await dbApi.session.get<Session>(sessionId)
-        } catch {
-          return
-        }
-        if (!dbSession || dbSession.status !== 'completed') return
-        if (dbSession.worktree_id) {
-          await get().reopenSession(sessionId, dbSession.worktree_id, { activate: false })
-        } else if (dbSession.connection_id) {
-          await get().reopenConnectionSession(sessionId, dbSession.connection_id, {
-            activate: false
-          })
-        } else {
+          let dbSession: Session | null = null
           try {
-            await dbApi.session.update<Session>(sessionId, {
-              status: 'active',
-              completed_at: null
-            })
+            dbSession = await dbApi.session.get<Session>(sessionId)
           } catch {
-            // Best-effort — the session stays completed
+            return
           }
+          if (!dbSession || dbSession.status !== 'completed') return
+          if (dbSession.worktree_id) {
+            await get().reopenSession(sessionId, dbSession.worktree_id, { activate: false })
+          } else if (dbSession.connection_id) {
+            await get().reopenConnectionSession(sessionId, dbSession.connection_id, {
+              activate: false
+            })
+          } else {
+            try {
+              await dbApi.session.update<Session>(sessionId, {
+                status: 'active',
+                completed_at: null
+              })
+            } catch {
+              // Best-effort — the session stays completed
+            }
+          }
+        } finally {
+          reactivatingSessionIds.delete(sessionId)
         }
       },
 

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -152,6 +152,7 @@ interface SessionState {
   acknowledgeClosedTerminals: (ids: Set<string>) => void
   requestSessionMount: (sessionId: string) => void
   releaseSessionMount: (sessionId: string) => void
+  destroyCompletedSessionTerminal: (sessionId: string) => Promise<void>
   openOrphanedSession: (session: Session) => void
   closeOrphanedSessions: () => void
   loadSessions: (worktreeId: string, projectId: string) => Promise<void>
@@ -170,12 +171,15 @@ interface SessionState {
   closeSession: (sessionId: string) => Promise<{ success: boolean; error?: string }>
   reopenSession: (
     sessionId: string,
-    worktreeId: string
+    worktreeId: string,
+    opts?: { activate?: boolean }
   ) => Promise<{ success: boolean; error?: string }>
   reopenConnectionSession: (
     sessionId: string,
-    connectionId: string
+    connectionId: string,
+    opts?: { activate?: boolean }
   ) => Promise<{ success: boolean; error?: string }>
+  reactivateSession: (sessionId: string) => Promise<void>
   setActiveSession: (sessionId: string | null) => void
   setActiveWorktree: (worktreeId: string | null) => void
   updateSessionName: (sessionId: string, name: string) => Promise<boolean>
@@ -383,6 +387,50 @@ export const useSessionStore = create<SessionState>()(
           }
           return { sessionMountRequests: requests }
         })
+      },
+
+      // Kill the PTY of a completed (tab-less) session once the last mount
+      // request releases it. Ticket modals resume completed sessions of Done
+      // tickets on open; without this the respawned process would outlive the
+      // modal with no tab left to close it from. Guards: never kill a session
+      // that was re-engaged in the meantime — re-mounted by another modal,
+      // navigated to (active session), or actively working/awaiting input per
+      // its hook-driven status (a background follow-up may not have flipped
+      // the DB row back to active yet).
+      destroyCompletedSessionTerminal: async (sessionId: string) => {
+        const isReEngaged = async (): Promise<boolean> => {
+          if (get().sessionMountRequests.has(sessionId)) return true
+          if (get().activeSessionId === sessionId) return true
+          const { useWorktreeStatusStore } = await import('./useWorktreeStatusStore')
+          const status = useWorktreeStatusStore.getState().sessionStatuses[sessionId]?.status
+          return (
+            status === 'working' ||
+            status === 'planning' ||
+            status === 'answering' ||
+            status === 'permission' ||
+            status === 'command_approval'
+          )
+        }
+
+        if (await isReEngaged()) return
+        let dbSession: Session | null = null
+        try {
+          dbSession = await dbApi.session.get<Session>(sessionId)
+        } catch {
+          return
+        }
+        if (dbSession?.status !== 'completed' || !isTerminalBacked(dbSession.agent_sdk)) return
+        // Re-check after the async gap — the session may have been re-engaged
+        // while the DB read was in flight.
+        if (await isReEngaged()) return
+        try {
+          unwrapEnvelope(await terminalApi.destroy(sessionId))
+        } catch {
+          // Best-effort — PTY may already be gone
+        }
+        set((state) => ({
+          closedTerminalSessionIds: new Set([...state.closedTerminalSessionIds, sessionId])
+        }))
       },
 
       // Load sessions for a worktree from database (only active sessions for tabs)
@@ -647,6 +695,7 @@ export const useSessionStore = create<SessionState>()(
           let isTerminalSession = false
           let opencodeSessionId: string | null = null
           let sessionWorktreeId: string | null = null
+          let foundInStore = false
 
           for (const [worktreeId, sessions] of get().sessionsByWorktree.entries()) {
             const found = sessions.find((s) => s.id === sessionId)
@@ -654,6 +703,7 @@ export const useSessionStore = create<SessionState>()(
               isTerminalSession = isTerminalBacked(found.agent_sdk)
               opencodeSessionId = found.opencode_session_id
               sessionWorktreeId = worktreeId
+              foundInStore = true
               break
             }
           }
@@ -663,8 +713,24 @@ export const useSessionStore = create<SessionState>()(
               if (found) {
                 isTerminalSession = isTerminalBacked(found.agent_sdk)
                 opencodeSessionId = found.opencode_session_id
+                foundInStore = true
                 break
               }
+            }
+          }
+          // Board-driven closes (ticket moved to done) can target sessions of
+          // worktrees never loaded into this store — fall back to the DB row so
+          // terminal-backed sessions still get their PTY destroyed.
+          if (!foundInStore) {
+            try {
+              const dbSession = await dbApi.session.get<Session>(sessionId)
+              if (dbSession) {
+                isTerminalSession = isTerminalBacked(dbSession.agent_sdk)
+                opencodeSessionId = dbSession.opencode_session_id
+                sessionWorktreeId = dbSession.worktree_id
+              }
+            } catch {
+              // Best-effort — proceed with the store-derived (empty) info
             }
           }
 
@@ -845,8 +911,12 @@ export const useSessionStore = create<SessionState>()(
         }
       },
 
-      // Reopen a closed session (from history) - marks as active and adds to tabs
-      reopenSession: async (sessionId: string, worktreeId: string) => {
+      // Reopen a closed session (from history) - marks as active and adds to tabs.
+      // opts.activate=false restores the tab without stealing focus — used by
+      // background flows (follow-up sends, plan approvals) where the user
+      // should stay where they are.
+      reopenSession: async (sessionId: string, worktreeId: string, opts?: { activate?: boolean }) => {
+        const activate = opts?.activate !== false
         try {
           // 1. Update database status first - this ensures persistence
           const updatedSession = await dbApi.session.update<Session>(sessionId, {
@@ -875,11 +945,13 @@ export const useSessionStore = create<SessionState>()(
           useQuestionStore.getState().clearSession(sessionId)
           usePermissionStore.getState().clearSession(sessionId)
           useCommandApprovalStore.getState().clearSession(sessionId)
-          // Clear file viewer so session takes focus
-          useFileViewerStore.getState().setActiveFile(null)
-          useFileViewerStore.getState().clearActiveDiff()
+          if (activate) {
+            // Clear file viewer so session takes focus
+            useFileViewerStore.getState().setActiveFile(null)
+            useFileViewerStore.getState().clearActiveDiff()
+          }
 
-          // 3. Update state to add the session to tabs and make it active
+          // 3. Update state to add the session to tabs (and make it active)
           set((state) => {
             const newSessionsMap = new Map(state.sessionsByWorktree)
             const existingSessions = newSessionsMap.get(worktreeId) || []
@@ -908,8 +980,7 @@ export const useSessionStore = create<SessionState>()(
             return {
               sessionsByWorktree: newSessionsMap,
               tabOrderByWorktree: newTabOrderMap,
-              activeSessionId: sessionId,
-              activeWorktreeId: worktreeId
+              ...(activate ? { activeSessionId: sessionId, activeWorktreeId: worktreeId } : {})
             }
           })
 
@@ -922,8 +993,14 @@ export const useSessionStore = create<SessionState>()(
         }
       },
 
-      // Reopen a closed connection session (from history)
-      reopenConnectionSession: async (sessionId: string, connectionId: string) => {
+      // Reopen a closed connection session (from history).
+      // opts.activate=false restores the tab without stealing focus.
+      reopenConnectionSession: async (
+        sessionId: string,
+        connectionId: string,
+        opts?: { activate?: boolean }
+      ) => {
+        const activate = opts?.activate !== false
         try {
           // 1. Update database status first - this ensures persistence
           const updatedSession = await dbApi.session.update<Session>(sessionId, {
@@ -951,10 +1028,12 @@ export const useSessionStore = create<SessionState>()(
           useQuestionStore.getState().clearSession(sessionId)
           usePermissionStore.getState().clearSession(sessionId)
           useCommandApprovalStore.getState().clearSession(sessionId)
-          useFileViewerStore.getState().setActiveFile(null)
-          useFileViewerStore.getState().clearActiveDiff()
+          if (activate) {
+            useFileViewerStore.getState().setActiveFile(null)
+            useFileViewerStore.getState().clearActiveDiff()
+          }
 
-          // 3. Update state to add the session to tabs and make it active
+          // 3. Update state to add the session to tabs (and make it active)
           set((state) => {
             const newSessionsMap = new Map(state.sessionsByConnection)
             const existingSessions = newSessionsMap.get(connectionId) || []
@@ -983,9 +1062,13 @@ export const useSessionStore = create<SessionState>()(
             return {
               sessionsByConnection: newSessionsMap,
               tabOrderByConnection: newTabOrderMap,
-              activeSessionId: sessionId,
-              activeConnectionId: connectionId,
-              activeWorktreeId: null
+              ...(activate
+                ? {
+                    activeSessionId: sessionId,
+                    activeConnectionId: connectionId,
+                    activeWorktreeId: null
+                  }
+                : {})
             }
           })
 
@@ -994,6 +1077,37 @@ export const useSessionStore = create<SessionState>()(
           return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to reopen connection session'
+          }
+        }
+      },
+
+      // Flip a completed session back to active and restore its tab WITHOUT
+      // changing the current selection. Used when background activity (a
+      // follow-up send, a plan approval) puts a done-closed session back to
+      // work: the session must regain a tab and a restore entry, or its
+      // respawned process would outlive every UI affordance to close it.
+      reactivateSession: async (sessionId: string) => {
+        let dbSession: Session | null = null
+        try {
+          dbSession = await dbApi.session.get<Session>(sessionId)
+        } catch {
+          return
+        }
+        if (!dbSession || dbSession.status !== 'completed') return
+        if (dbSession.worktree_id) {
+          await get().reopenSession(sessionId, dbSession.worktree_id, { activate: false })
+        } else if (dbSession.connection_id) {
+          await get().reopenConnectionSession(sessionId, dbSession.connection_id, {
+            activate: false
+          })
+        } else {
+          try {
+            await dbApi.session.update<Session>(sessionId, {
+              status: 'active',
+              completed_at: null
+            })
+          } catch {
+            // Best-effort — the session stays completed
           }
         }
       },

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -215,7 +215,10 @@ interface SessionState {
       customProviderId?: string | null
     }
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
-  closeSession: (sessionId: string) => Promise<{ success: boolean; error?: string }>
+  closeSession: (
+    sessionId: string,
+    opts?: { abortIfRevived?: boolean }
+  ) => Promise<{ success: boolean; error?: string; aborted?: boolean }>
   reopenSession: (
     sessionId: string,
     worktreeId: string,
@@ -738,8 +741,16 @@ export const useSessionStore = create<SessionState>()(
 
       // Close a session tab (removes from tab view, keeps in database for history)
       // Scope-agnostic: works for both worktree and connection sessions
-      closeSession: async (sessionId: string) =>
+      closeSession: async (sessionId: string, opts?: { abortIfRevived?: boolean }) =>
         withSessionLifecycleLock(sessionId, async () => {
+        // Atomic guard for background closes (ticket entered Done): a revival
+        // that queued behind this lock marked itself synchronously before
+        // waiting, so checking here — inside the lock, before the
+        // completed-write — makes guard and transition atomic. Explicit user
+        // closes (tab X, archive) do not pass the flag and always proceed.
+        if (opts?.abortIfRevived && isSessionReactivating(sessionId)) {
+          return { success: false, aborted: true, error: 'Session was revived concurrently' }
+        }
         try {
           // Find the session to determine type and gather disconnect info
           let isTerminalSession = false

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -32,11 +32,26 @@ const pushQueuedState = (sessionId: string, hasQueued: boolean): void => {
   systemApi.setSessionQueuedState(sessionId, hasQueued).catch(() => {})
 }
 
-// Sessions currently being flipped back to active by reactivateSession.
-// Consulted (synchronously) by destroyCompletedSessionTerminal so a cleanup
-// racing the async DB flip cannot read the stale 'completed' row and kill a
-// just-revived process.
-const reactivatingSessionIds = new Set<string>()
+// Refcount of in-flight revivals per session (reactivateSession /
+// reopenSession / reopenConnectionSession, which nest). Consulted
+// (synchronously) by destroyCompletedSessionTerminal and the kanban
+// done-close so a cleanup racing the async DB flip cannot read the stale
+// 'completed' row and kill a just-revived process.
+const reactivatingSessionIds = new Map<string, number>()
+
+export function isSessionReactivating(sessionId: string): boolean {
+  return (reactivatingSessionIds.get(sessionId) ?? 0) > 0
+}
+
+function markReactivating(sessionId: string): void {
+  reactivatingSessionIds.set(sessionId, (reactivatingSessionIds.get(sessionId) ?? 0) + 1)
+}
+
+function unmarkReactivating(sessionId: string): void {
+  const next = (reactivatingSessionIds.get(sessionId) ?? 0) - 1
+  if (next > 0) reactivatingSessionIds.set(sessionId, next)
+  else reactivatingSessionIds.delete(sessionId)
+}
 
 export const BOARD_TAB_ID = '__board__'
 export const BOARD_ASSISTANT_SESSION_NAME_PREFIX = '[Board Assistant]'
@@ -405,7 +420,7 @@ export const useSessionStore = create<SessionState>()(
       // the DB row back to active yet).
       destroyCompletedSessionTerminal: async (sessionId: string) => {
         const isReEngaged = async (): Promise<boolean> => {
-          if (reactivatingSessionIds.has(sessionId)) return true
+          if (isSessionReactivating(sessionId)) return true
           if (get().sessionMountRequests.has(sessionId)) return true
           if (get().activeSessionId === sessionId) return true
           const { useWorktreeStatusStore } = await import('./useWorktreeStatusStore')
@@ -924,6 +939,9 @@ export const useSessionStore = create<SessionState>()(
       // should stay where they are.
       reopenSession: async (sessionId: string, worktreeId: string, opts?: { activate?: boolean }) => {
         const activate = opts?.activate !== false
+        // Guard the revival window: a concurrent completed-session cleanup
+        // must not kill the PTY while the DB flip is in flight.
+        markReactivating(sessionId)
         try {
           // 1. Update database status first - this ensures persistence
           const updatedSession = await dbApi.session.update<Session>(sessionId, {
@@ -997,6 +1015,8 @@ export const useSessionStore = create<SessionState>()(
             success: false,
             error: error instanceof Error ? error.message : 'Failed to reopen session'
           }
+        } finally {
+          unmarkReactivating(sessionId)
         }
       },
 
@@ -1008,6 +1028,7 @@ export const useSessionStore = create<SessionState>()(
         opts?: { activate?: boolean }
       ) => {
         const activate = opts?.activate !== false
+        markReactivating(sessionId)
         try {
           // 1. Update database status first - this ensures persistence
           const updatedSession = await dbApi.session.update<Session>(sessionId, {
@@ -1085,6 +1106,8 @@ export const useSessionStore = create<SessionState>()(
             success: false,
             error: error instanceof Error ? error.message : 'Failed to reopen connection session'
           }
+        } finally {
+          unmarkReactivating(sessionId)
         }
       },
 
@@ -1097,7 +1120,7 @@ export const useSessionStore = create<SessionState>()(
         // Marked synchronously so a concurrently-running
         // destroyCompletedSessionTerminal cannot read the stale 'completed'
         // DB row and kill the process this revival is claiming.
-        reactivatingSessionIds.add(sessionId)
+        markReactivating(sessionId)
         try {
           let dbSession: Session | null = null
           try {
@@ -1123,7 +1146,7 @@ export const useSessionStore = create<SessionState>()(
             }
           }
         } finally {
-          reactivatingSessionIds.delete(sessionId)
+          unmarkReactivating(sessionId)
         }
       },
 

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -893,6 +893,14 @@ export const useSessionStore = create<SessionState>()(
                   break
                 }
               }
+              if (!worktreePath) {
+                // Board-driven closes can target sessions of projects never
+                // loaded into the store — resolve from the DB so the SDK
+                // session still gets disconnected instead of leaking
+                // main-process implementer state.
+                worktreePath =
+                  (await dbApi.worktree.get<{ path: string }>(sessionWorktreeId))?.path ?? null
+              }
               if (worktreePath) {
                 unwrapEnvelope(await opencodeApi.disconnect(worktreePath, opencodeSessionId))
               }

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -763,8 +763,14 @@ export const useSessionStore = create<SessionState>()(
             completed_at: new Date().toISOString()
           })
 
+          // A revival may have started while the completed-write above was in
+          // flight — re-check before tearing down the process. The revival
+          // flips the row back to active and keeps (or respawns into) the
+          // live PTY, so skipping the destroy here is the consistent outcome.
+          const revivedMidClose = isSessionReactivating(sessionId)
+
           // Destroy PTY for terminal sessions
-          if (isTerminalSession) {
+          if (isTerminalSession && !revivedMidClose) {
             try {
               unwrapEnvelope(await terminalApi.destroy(sessionId))
             } catch {
@@ -775,7 +781,7 @@ export const useSessionStore = create<SessionState>()(
           // Disconnect agent SDK session to free main-process resources
           // (session state, abort controllers, cached data).
           // Best-effort — session may already be disconnected.
-          if (!isTerminalSession && opencodeSessionId && sessionWorktreeId) {
+          if (!isTerminalSession && !revivedMidClose && opencodeSessionId && sessionWorktreeId) {
             try {
               // Resolve worktree filesystem path from worktree ID
               let worktreePath: string | null = null

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -16,6 +16,8 @@ import { systemApi } from '@/api/system-api'
 import { dbApi } from '@/api/db-api'
 import { connectionApi } from '@/api/connection-api'
 import { terminalApi } from '@/api/terminal-api'
+import { remoteLaunchApi } from '@/api/remote-launch-api'
+import { parseRemoteLaunch } from '@shared/types/remote-launch'
 import { opencodeApi } from '@/api/opencode-api'
 import { type AgentSdk, isTerminalBacked } from '@shared/types/agent-sdk'
 import { CUSTOM_MODEL_PROVIDER_ID } from '@shared/types/custom-provider'
@@ -130,6 +132,8 @@ interface Session {
   claude_session_id: string | null
   agent_sdk: AgentSdk
   custom_provider_id?: string | null
+  /** JSON RemoteLaunchInfo when this session was launched on a remote host. */
+  remote_launch?: string | null
   mode: SessionMode
   session_type: 'default' | 'board-assistant'
   model_provider_id: string | null
@@ -217,7 +221,7 @@ interface SessionState {
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
   closeSession: (
     sessionId: string,
-    opts?: { abortIfRevived?: boolean }
+    opts?: { abortIfRevived?: boolean; stopRemote?: boolean }
   ) => Promise<{ success: boolean; error?: string; aborted?: boolean }>
   reopenSession: (
     sessionId: string,
@@ -741,7 +745,10 @@ export const useSessionStore = create<SessionState>()(
 
       // Close a session tab (removes from tab view, keeps in database for history)
       // Scope-agnostic: works for both worktree and connection sessions
-      closeSession: async (sessionId: string, opts?: { abortIfRevived?: boolean }) =>
+      closeSession: async (
+        sessionId: string,
+        opts?: { abortIfRevived?: boolean; stopRemote?: boolean }
+      ) =>
         withSessionLifecycleLock(sessionId, async () => {
         // Atomic guard for background closes (ticket entered Done): a revival
         // that queued behind this lock marked itself synchronously before
@@ -756,6 +763,7 @@ export const useSessionStore = create<SessionState>()(
           let isTerminalSession = false
           let opencodeSessionId: string | null = null
           let sessionWorktreeId: string | null = null
+          let remoteLaunchRaw: string | null = null
           let foundInStore = false
 
           for (const [worktreeId, sessions] of get().sessionsByWorktree.entries()) {
@@ -764,6 +772,7 @@ export const useSessionStore = create<SessionState>()(
               isTerminalSession = isTerminalBacked(found.agent_sdk)
               opencodeSessionId = found.opencode_session_id
               sessionWorktreeId = worktreeId
+              remoteLaunchRaw = found.remote_launch ?? null
               foundInStore = true
               break
             }
@@ -774,6 +783,7 @@ export const useSessionStore = create<SessionState>()(
               if (found) {
                 isTerminalSession = isTerminalBacked(found.agent_sdk)
                 opencodeSessionId = found.opencode_session_id
+                remoteLaunchRaw = found.remote_launch ?? null
                 foundInStore = true
                 break
               }
@@ -789,9 +799,36 @@ export const useSessionStore = create<SessionState>()(
                 isTerminalSession = isTerminalBacked(dbSession.agent_sdk)
                 opencodeSessionId = dbSession.opencode_session_id
                 sessionWorktreeId = dbSession.worktree_id
+                remoteLaunchRaw = dbSession.remote_launch ?? null
               }
             } catch {
               // Best-effort — proceed with the store-derived (empty) info
+            }
+          }
+
+          // Ticket-done closes stop remote-launched agents (a tmux on a
+          // remote host) before completing: a local-only close would leave
+          // that agent running forever. This runs INSIDE the lifecycle lock,
+          // after the abortIfRevived check, so a queued revival can never
+          // lose its remote process to a stale stop. On failure the session
+          // stays linked (and alive) — the caller surfaces the error.
+          if (opts?.stopRemote) {
+            const remoteInfo = parseRemoteLaunch(remoteLaunchRaw)
+            if (remoteInfo?.role === 'client' && !remoteInfo.stoppedAt) {
+              try {
+                await remoteLaunchApi.stop({ sessionId })
+              } catch (error) {
+                return {
+                  success: false,
+                  error: `remote stop failed: ${error instanceof Error ? error.message : String(error)}`
+                }
+              }
+              try {
+                const { useRemoteLaunchStore } = await import('./useRemoteLaunchStore')
+                useRemoteLaunchStore.getState().markStopped(sessionId)
+              } catch {
+                // Bookkeeping only — the remote agent is already stopped
+              }
             }
           }
 

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -32,11 +32,37 @@ const pushQueuedState = (sessionId: string, hasQueued: boolean): void => {
   systemApi.setSessionQueuedState(sessionId, hasQueued).catch(() => {})
 }
 
+// Per-session promise chain serializing lifecycle transitions (close,
+// reopen, reactivate, completed-terminal destroy). These flows all
+// read-then-write the session row and the process state; interleaving them
+// produces lost updates — e.g. a revival reading the still-active row while
+// a close's completed-write is in flight would no-op and then lose its
+// process to the close. The lock makes each transition see the previous
+// one's final state.
+const sessionLifecycleLocks = new Map<string, Promise<void>>()
+
+async function withSessionLifecycleLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+  const prev = sessionLifecycleLocks.get(sessionId) ?? Promise.resolve()
+  const run = prev.then(fn)
+  const tail = run.then(
+    () => undefined,
+    () => undefined
+  )
+  sessionLifecycleLocks.set(sessionId, tail)
+  try {
+    return await run
+  } finally {
+    if (sessionLifecycleLocks.get(sessionId) === tail) {
+      sessionLifecycleLocks.delete(sessionId)
+    }
+  }
+}
+
 // Refcount of in-flight revivals per session (reactivateSession /
 // reopenSession / reopenConnectionSession, which nest). Consulted
 // (synchronously) by destroyCompletedSessionTerminal and the kanban
-// done-close so a cleanup racing the async DB flip cannot read the stale
-// 'completed' row and kill a just-revived process.
+// done-close as a fast pre-check; the lifecycle lock above provides the
+// actual serialization.
 const reactivatingSessionIds = new Map<string, number>()
 
 export function isSessionReactivating(sessionId: string): boolean {
@@ -193,12 +219,12 @@ interface SessionState {
   reopenSession: (
     sessionId: string,
     worktreeId: string,
-    opts?: { activate?: boolean }
+    opts?: { activate?: boolean; skipLifecycleLock?: boolean }
   ) => Promise<{ success: boolean; error?: string }>
   reopenConnectionSession: (
     sessionId: string,
     connectionId: string,
-    opts?: { activate?: boolean }
+    opts?: { activate?: boolean; skipLifecycleLock?: boolean }
   ) => Promise<{ success: boolean; error?: string }>
   reactivateSession: (sessionId: string) => Promise<void>
   setActiveSession: (sessionId: string | null) => void
@@ -418,7 +444,8 @@ export const useSessionStore = create<SessionState>()(
       // navigated to (active session), or actively working/awaiting input per
       // its hook-driven status (a background follow-up may not have flipped
       // the DB row back to active yet).
-      destroyCompletedSessionTerminal: async (sessionId: string) => {
+      destroyCompletedSessionTerminal: async (sessionId: string) =>
+        withSessionLifecycleLock(sessionId, async () => {
         const isReEngaged = async (): Promise<boolean> => {
           if (isSessionReactivating(sessionId)) return true
           if (get().sessionMountRequests.has(sessionId)) return true
@@ -453,7 +480,7 @@ export const useSessionStore = create<SessionState>()(
         set((state) => ({
           closedTerminalSessionIds: new Set([...state.closedTerminalSessionIds, sessionId])
         }))
-      },
+        }),
 
       // Load sessions for a worktree from database (only active sessions for tabs)
       loadSessions: async (worktreeId: string, _projectId: string) => {
@@ -711,7 +738,8 @@ export const useSessionStore = create<SessionState>()(
 
       // Close a session tab (removes from tab view, keeps in database for history)
       // Scope-agnostic: works for both worktree and connection sessions
-      closeSession: async (sessionId: string) => {
+      closeSession: async (sessionId: string) =>
+        withSessionLifecycleLock(sessionId, async () => {
         try {
           // Find the session to determine type and gather disconnect info
           let isTerminalSession = false
@@ -937,13 +965,18 @@ export const useSessionStore = create<SessionState>()(
             error: error instanceof Error ? error.message : 'Failed to close session'
           }
         }
-      },
+        }),
 
       // Reopen a closed session (from history) - marks as active and adds to tabs.
       // opts.activate=false restores the tab without stealing focus — used by
       // background flows (follow-up sends, plan approvals) where the user
       // should stay where they are.
-      reopenSession: async (sessionId: string, worktreeId: string, opts?: { activate?: boolean }) => {
+      reopenSession: async (
+        sessionId: string,
+        worktreeId: string,
+        opts?: { activate?: boolean; skipLifecycleLock?: boolean }
+      ) => {
+        const run = async (): Promise<{ success: boolean; error?: string }> => {
         const activate = opts?.activate !== false
         // Guard the revival window: a concurrent completed-session cleanup
         // must not kill the PTY while the DB flip is in flight.
@@ -1024,6 +1057,10 @@ export const useSessionStore = create<SessionState>()(
         } finally {
           unmarkReactivating(sessionId)
         }
+        }
+        // reactivateSession already holds the lifecycle lock — a nested
+        // acquisition would deadlock, so it opts out here.
+        return opts?.skipLifecycleLock ? run() : withSessionLifecycleLock(sessionId, run)
       },
 
       // Reopen a closed connection session (from history).
@@ -1031,8 +1068,9 @@ export const useSessionStore = create<SessionState>()(
       reopenConnectionSession: async (
         sessionId: string,
         connectionId: string,
-        opts?: { activate?: boolean }
+        opts?: { activate?: boolean; skipLifecycleLock?: boolean }
       ) => {
+        const run = async (): Promise<{ success: boolean; error?: string }> => {
         const activate = opts?.activate !== false
         markReactivating(sessionId)
         try {
@@ -1115,6 +1153,8 @@ export const useSessionStore = create<SessionState>()(
         } finally {
           unmarkReactivating(sessionId)
         }
+        }
+        return opts?.skipLifecycleLock ? run() : withSessionLifecycleLock(sessionId, run)
       },
 
       // Flip a completed session back to active and restore its tab WITHOUT
@@ -1123,11 +1163,12 @@ export const useSessionStore = create<SessionState>()(
       // work: the session must regain a tab and a restore entry, or its
       // respawned process would outlive every UI affordance to close it.
       reactivateSession: async (sessionId: string) => {
-        // Marked synchronously so a concurrently-running
-        // destroyCompletedSessionTerminal cannot read the stale 'completed'
-        // DB row and kill the process this revival is claiming.
+        // Marked synchronously (before any await) so concurrent flows get a
+        // fast signal that a revival is queued/running even while it waits
+        // for the lifecycle lock.
         markReactivating(sessionId)
         try {
+          await withSessionLifecycleLock(sessionId, async () => {
           let dbSession: Session | null = null
           try {
             dbSession = await dbApi.session.get<Session>(sessionId)
@@ -1136,10 +1177,14 @@ export const useSessionStore = create<SessionState>()(
           }
           if (!dbSession || dbSession.status !== 'completed') return
           if (dbSession.worktree_id) {
-            await get().reopenSession(sessionId, dbSession.worktree_id, { activate: false })
+            await get().reopenSession(sessionId, dbSession.worktree_id, {
+              activate: false,
+              skipLifecycleLock: true
+            })
           } else if (dbSession.connection_id) {
             await get().reopenConnectionSession(sessionId, dbSession.connection_id, {
-              activate: false
+              activate: false,
+              skipLifecycleLock: true
             })
           } else {
             try {
@@ -1151,6 +1196,7 @@ export const useSessionStore = create<SessionState>()(
               // Best-effort — the session stays completed
             }
           }
+          })
         } finally {
           unmarkReactivating(sessionId)
         }

--- a/src/renderer/src/stores/useWorktreeStore.ts
+++ b/src/renderer/src/stores/useWorktreeStore.ts
@@ -608,13 +608,25 @@ export const useWorktreeStore = create<WorktreeState>((set, get) => ({
     try {
       // Close all sessions so terminal PTYs and agent child processes are
       // released before delete (parity with archiveWorktree — otherwise their
-      // processes keep running against a deleted cwd)
+      // processes keep running against a deleted cwd). closeSession reports
+      // failures via its result rather than throwing — abort the unbranch on
+      // failure instead of deleting the worktree out from under a live agent.
       const sessions = useSessionStore.getState().sessionsByWorktree.get(worktreeId) || []
       for (const session of sessions) {
+        let closeResult: { success: boolean; error?: string }
         try {
-          await useSessionStore.getState().closeSession(session.id)
-        } catch {
-          // Non-critical — session cleanup may already have happened
+          closeResult = await useSessionStore.getState().closeSession(session.id)
+        } catch (error) {
+          closeResult = {
+            success: false,
+            error: error instanceof Error ? error.message : String(error)
+          }
+        }
+        if (!closeResult.success) {
+          return {
+            success: false,
+            error: `Failed to close session before unbranch: ${closeResult.error ?? 'unknown error'}`
+          }
         }
       }
 

--- a/src/renderer/src/stores/useWorktreeStore.ts
+++ b/src/renderer/src/stores/useWorktreeStore.ts
@@ -606,6 +606,18 @@ export const useWorktreeStore = create<WorktreeState>((set, get) => ({
     }))
 
     try {
+      // Close all sessions so terminal PTYs and agent child processes are
+      // released before delete (parity with archiveWorktree — otherwise their
+      // processes keep running against a deleted cwd)
+      const sessions = useSessionStore.getState().sessionsByWorktree.get(worktreeId) || []
+      for (const session of sessions) {
+        try {
+          await useSessionStore.getState().closeSession(session.id)
+        } catch {
+          // Non-critical — session cleanup may already have happened
+        }
+      }
+
       const result = await worktreeApi.delete({
         worktreeId,
         worktreePath,

--- a/test/phase-12/renderer-api-cleanup.test.ts
+++ b/test/phase-12/renderer-api-cleanup.test.ts
@@ -15733,10 +15733,7 @@ describe('renderer API cleanup', () => {
       'utf-8'
     )
     const closeSessionStart = source.indexOf('closeSession: async (sessionId: string)')
-    const reopenSessionStart = source.indexOf(
-      'reopenSession: async (sessionId: string',
-      closeSessionStart
-    )
+    const reopenSessionStart = source.indexOf('reopenSession: async (', closeSessionStart)
     const closeSessionSource = source.slice(closeSessionStart, reopenSessionStart)
 
     expect(closeSessionStart).toBeGreaterThan(-1)
@@ -15996,9 +15993,7 @@ describe('renderer API cleanup', () => {
       path.resolve(__dirname, '../../src/renderer/src/stores/useSessionStore.ts'),
       'utf-8'
     )
-    const reopenSessionStart = source.indexOf(
-      'reopenSession: async (sessionId: string, worktreeId: string'
-    )
+    const reopenSessionStart = source.indexOf('reopenSession: async (')
     const reopenConnectionSessionStart = source.indexOf(
       'reopenConnectionSession: async (',
       reopenSessionStart

--- a/test/phase-12/renderer-api-cleanup.test.ts
+++ b/test/phase-12/renderer-api-cleanup.test.ts
@@ -15997,10 +15997,10 @@ describe('renderer API cleanup', () => {
       'utf-8'
     )
     const reopenSessionStart = source.indexOf(
-      'reopenSession: async (sessionId: string, worktreeId: string)'
+      'reopenSession: async (sessionId: string, worktreeId: string'
     )
     const reopenConnectionSessionStart = source.indexOf(
-      'reopenConnectionSession: async (sessionId: string',
+      'reopenConnectionSession: async (',
       reopenSessionStart
     )
     const reopenSessionSource = source.slice(reopenSessionStart, reopenConnectionSessionStart)
@@ -16023,7 +16023,7 @@ describe('renderer API cleanup', () => {
       'utf-8'
     )
     const reopenConnectionSessionStart = source.indexOf(
-      'reopenConnectionSession: async (sessionId: string, connectionId: string)'
+      'reopenConnectionSession: async ('
     )
     const setActiveSessionStart = source.indexOf(
       'setActiveSession: (sessionId: string | null)',

--- a/test/phase-12/renderer-api-cleanup.test.ts
+++ b/test/phase-12/renderer-api-cleanup.test.ts
@@ -15324,10 +15324,7 @@ describe('renderer API cleanup', () => {
       'utf-8'
     )
     const createSessionStart = source.indexOf('createSession: async (')
-    const closeSessionStart = source.indexOf(
-      'closeSession: async (sessionId: string)',
-      createSessionStart
-    )
+    const closeSessionStart = source.indexOf('closeSession: async (', createSessionStart)
     const createSessionSource = source.slice(createSessionStart, closeSessionStart)
 
     expect(createSessionStart).toBeGreaterThan(-1)
@@ -15732,7 +15729,7 @@ describe('renderer API cleanup', () => {
       path.resolve(__dirname, '../../src/renderer/src/stores/useSessionStore.ts'),
       'utf-8'
     )
-    const closeSessionStart = source.indexOf('closeSession: async (sessionId: string)')
+    const closeSessionStart = source.indexOf('closeSession: async (')
     const reopenSessionStart = source.indexOf('reopenSession: async (', closeSessionStart)
     const closeSessionSource = source.slice(closeSessionStart, reopenSessionStart)
 

--- a/test/terminal/main-pane-terminal-persistence.test.tsx
+++ b/test/terminal/main-pane-terminal-persistence.test.tsx
@@ -128,11 +128,13 @@ describe('MainPane terminal persistence', () => {
 
     const firstTerminalNode = screen.getByTestId('session-terminal-term-1')
     expect(terminalMounts.get('term-1')).toBe(1)
-    expect(terminalMounts.get('term-2')).toBe(1)
+    // Unselected tabs do not mount (mount == process spawn) until activated
+    expect(terminalMounts.get('term-2')).toBeUndefined()
 
     act(() => {
       useSessionStore.setState({ activeSessionId: 'term-2' })
     })
+    expect(terminalMounts.get('term-2')).toBe(1)
 
     // Simulate a transient sessions refresh where the scope map briefly empties,
     // then repopulates with the same terminal sessions.
@@ -195,11 +197,12 @@ describe('MainPane terminal persistence', () => {
   test('removes terminal from mounted list when session is closed via store signal', () => {
     render(<MainPane />)
 
-    // Both terminals are mounted
+    // The active terminal is mounted; the unselected one is not (lazy spawn)
     expect(screen.getByTestId('session-terminal-term-1')).toBeInTheDocument()
-    expect(screen.getByTestId('session-terminal-term-2')).toBeInTheDocument()
+    expect(screen.queryByTestId('session-terminal-term-2')).not.toBeInTheDocument()
 
-    // Simulate closeSession: remove from sessions map AND signal via closedTerminalSessionIds
+    // Simulate closeSession of term-1 while switching to term-2: remove from
+    // sessions map AND signal via closedTerminalSessionIds
     act(() => {
       useSessionStore.setState({
         activeSessionId: 'term-2',
@@ -208,7 +211,7 @@ describe('MainPane terminal persistence', () => {
       })
     })
 
-    // term-1 should be unmounted, term-2 should remain
+    // term-1 should be unmounted, term-2 (now active) should be mounted
     expect(screen.queryByTestId('session-terminal-term-1')).not.toBeInTheDocument()
     expect(screen.getByTestId('session-terminal-term-2')).toBeInTheDocument()
   })
@@ -216,9 +219,8 @@ describe('MainPane terminal persistence', () => {
   test('preserves terminal state across worktree switches', () => {
     render(<MainPane />)
 
-    // Both terminals mounted in wt-1
+    // Only the active terminal mounts in wt-1
     expect(screen.getByTestId('session-terminal-term-1')).toBeInTheDocument()
-    expect(screen.getByTestId('session-terminal-term-2')).toBeInTheDocument()
     expect(terminalMounts.get('term-1')).toBe(1)
 
     // Switch to a different worktree with its own terminal
@@ -234,10 +236,11 @@ describe('MainPane terminal persistence', () => {
       })
     })
 
-    // term-3 is now mounted, term-1 and term-2 are still mounted (hidden)
+    // term-3 is now mounted; term-1 stays mounted (hidden, latched); term-2
+    // was never activated so it still has no instance (and no process)
     expect(screen.getByTestId('session-terminal-term-3')).toBeInTheDocument()
     expect(screen.getByTestId('session-terminal-term-1')).toBeInTheDocument()
-    expect(screen.getByTestId('session-terminal-term-2')).toBeInTheDocument()
+    expect(screen.queryByTestId('session-terminal-term-2')).not.toBeInTheDocument()
 
     // Switch back — term-1 should NOT have remounted
     act(() => {

--- a/test/terminal/pty-service.test.ts
+++ b/test/terminal/pty-service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { EventEmitter } from 'events'
 
 // Mock node-pty
@@ -75,11 +75,20 @@ describe('PtyService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // destroy() schedules a kill-escalation timer that probes real pids;
+    // MockPty's fake pid must never be probed on the test machine. Fake
+    // timers keep those timers permanently un-fired (this suite is fully
+    // synchronous otherwise).
+    vi.useFakeTimers()
     // Clean up any existing PTYs from previous tests
     ptyService.destroyAll()
 
     mockPty = new MockPty(80, 24)
     spawnMock.mockReturnValue(mockPty)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   describe('create', () => {


### PR DESCRIPTION
## Summary
- Escalate surviving PTY process groups to SIGKILL during terminal cleanup.
- Add bounded quit-time reaping for leaked agent processes.
- Reject Claude transcript sessions already claimed by another Hive session.
- Gate terminal mounting to activated sessions and clean up completed terminals.
- Restore completed sessions when reopened or followed up.
- Add comprehensive watcher, PTY, store, and renderer regression tests.

## Testing
- Added and updated Vitest coverage for Claude session watching, PTY kill escalation, terminal bridging, session cleanup, and terminal activation behavior.
- Full test suite not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes process-group SIGKILL escalation, quit cleanup timing, and concurrent close/reactivate/kanban-done logic—mistakes could kill wrong processes or strand/leak agents; extensive new tests mitigate but production PTY behavior is hard to fully simulate.
> 
> **Overview**
> **PTY teardown** now escalates past a single SIGHUP: after a grace period it probes liveness, snapshots process-group membership with `pgrep`, and SIGKILLs survivors while avoiding pid-reuse and recycled pgid false positives. Quit uses **`destroyAllAndReap`** via async **`cleanupTerminals`** so agents that ignore HUP are swept before exit.
> 
> **Claude CLI transcript binding** lets the session watcher reject ids (`return false`) already claimed by another Hive session (`getSessionByClaudeSessionId`), exclude that file, and rescan immediately for the correct transcript.
> 
> **Done-ticket session lifecycle** closes the attached session (with shared-ticket, revival, and drag-back guards), optional **remote stop**, and **`abortIfRevived`** closes. **`reactivateSession`**, modal release **`destroyCompletedSessionTerminal`**, and jump/follow-up reopen paths restore tabs without racing closes via per-session lifecycle locks.
> 
> **MainPane** only mounts stateful terminals when activated (active tab, modal mount, pending message, pin, etc.) but keeps them latched until the tab closes—reducing stray agent spawns from idle tabs.
> 
> **Unbranch** closes worktree sessions before delete, matching archive behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 651ab99deee044ef547ec3417a6150ba865928d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->