### PR TITLE
Detect and propagate Claude CLI mid-session model changes

### DIFF
--- a/src/main/services/claude-cli-model-watcher.test.ts
+++ b/src/main/services/claude-cli-model-watcher.test.ts
@@ -1,0 +1,375 @@
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DatabaseService } from '../db/database'
+import type { Session } from '../db/types'
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('../db', () => ({
+  getDatabase: vi.fn(() => {
+    throw new Error('tests must inject deps.db')
+  })
+}))
+
+const publishDesktopBackendEvent = vi.fn()
+vi.mock('../desktop/backend-event-publisher', () => ({
+  publishDesktopBackendEvent: (...args: unknown[]) => publishDesktopBackendEvent(...args)
+}))
+
+import {
+  handleClaudeCliModelChangeHook,
+  mainChainAssistantModels,
+  resetAllClaudeCliModelWatchers,
+  resetClaudeCliModelWatcher
+} from './claude-cli-model-watcher'
+
+const SESSION_ID = 'hive-session-1'
+
+function assistantLine(model: string, extra: Record<string, unknown> = {}): string {
+  return `${JSON.stringify({
+    type: 'assistant',
+    isSidechain: false,
+    message: { role: 'assistant', model, content: [{ type: 'text', text: 'hi' }] },
+    ...extra
+  })}\n`
+}
+
+function userLine(): string {
+  return `${JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello' } })}\n`
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: SESSION_ID,
+    agent_sdk: 'claude-code-cli',
+    model_provider_id: 'anthropic',
+    model_id: 'fable',
+    model_variant: 'high',
+    custom_provider_id: null,
+    ...overrides
+  } as Session
+}
+
+function makeDb(session: Session | null): DatabaseService & { updateSession: ReturnType<typeof vi.fn> } {
+  return {
+    getSession: vi.fn(() => session),
+    updateSession: vi.fn(() => session)
+  } as unknown as DatabaseService & { updateSession: ReturnType<typeof vi.fn> }
+}
+
+describe('mainChainAssistantModels', () => {
+  it('collects assistant models in order, skipping other line types', () => {
+    const text =
+      userLine() +
+      assistantLine('claude-fable-5') +
+      userLine() +
+      assistantLine('claude-sonnet-5-20250929')
+    expect(mainChainAssistantModels(text)).toEqual(['claude-fable-5', 'claude-sonnet-5-20250929'])
+  })
+
+  it('ignores sidechain, synthetic and malformed lines', () => {
+    const text =
+      assistantLine('claude-fable-5') +
+      assistantLine('claude-haiku-4-5-20251001', { isSidechain: true }) +
+      assistantLine('<synthetic>', { isApiErrorMessage: true }) +
+      'not json\n' +
+      `${JSON.stringify({ type: 'assistant', message: null })}\n`
+    expect(mainChainAssistantModels(text)).toEqual(['claude-fable-5'])
+  })
+})
+
+describe('handleClaudeCliModelChangeHook', () => {
+  let dir: string
+  let transcriptPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'model-watcher-'))
+    transcriptPath = path.join(dir, 'session.jsonl')
+    resetAllClaudeCliModelWatchers()
+    publishDesktopBackendEvent.mockClear()
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const stopHook = (): { hook_event_name: string; transcript_path: string } => ({
+    hook_event_name: 'Stop',
+    transcript_path: transcriptPath
+  })
+
+  it('does nothing while the session stays on one model', () => {
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5') + assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+    expect(publishDesktopBackendEvent).not.toHaveBeenCalled()
+  })
+
+  it('applies a mid-session degrade and publishes the change', () => {
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    appendFileSync(transcriptPath, assistantLine('claude-sonnet-5-20250929'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'sonnet' })
+    expect(publishDesktopBackendEvent).toHaveBeenCalledWith(
+      'opencode:stream',
+      expect.objectContaining({
+        type: 'session.model_changed',
+        sessionId: SESSION_ID,
+        data: expect.objectContaining({
+          modelId: 'sonnet',
+          previousModelId: 'fable',
+          rawModel: 'claude-sonnet-5-20250929'
+        })
+      })
+    )
+  })
+
+  it('consumes pre-existing backlog silently — historical transitions never fire', () => {
+    // The exact respawn scenario: a fable→sonnet degrade already sits in the
+    // transcript from a previous run, but the user has since explicitly picked
+    // opus (+max) in Hive. Attaching must not replay the stale transition and
+    // revert that choice.
+    const db = makeDb(makeSession({ model_id: 'opus', model_variant: 'max' }))
+    writeFileSync(
+      transcriptPath,
+      assistantLine('claude-fable-5') + assistantLine('claude-sonnet-5-20250929')
+    )
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+
+    // The respawned CLI answers on opus: a live sonnet→opus transition whose
+    // alias equals the row — still nothing to write.
+    appendFileSync(transcriptPath, assistantLine('claude-opus-5-20260101'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+  })
+
+  it('does not fire on a row/transcript mismatch without an in-transcript switch', () => {
+    // The user picked sonnet in Hive while the CLI keeps running fable until
+    // respawn — the pending choice must not be reverted.
+    const db = makeDb(makeSession({ model_id: 'sonnet' }))
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    appendFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+  })
+
+  it('stays quiet when a live switch nets out to the session row model', () => {
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    appendFileSync(
+      transcriptPath,
+      assistantLine('claude-sonnet-5-20250929') + assistantLine('claude-fable-5')
+    )
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+  })
+
+  it('ignores raw-id churn within the same alias — not a switch Hive can express', () => {
+    // DB says opus (pending user choice); a dated sonnet snapshot bump must
+    // not count as a transition and revert it.
+    const db = makeDb(makeSession({ model_id: 'opus' }))
+    writeFileSync(transcriptPath, assistantLine('claude-sonnet-5-20250929'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    appendFileSync(transcriptPath, assistantLine('claude-sonnet-5-20260101'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+  })
+
+  it('ignores sidechain and synthetic lines when tracking switches', () => {
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    appendFileSync(
+      transcriptPath,
+      assistantLine('claude-haiku-4-5-20251001', { isSidechain: true }) +
+        assistantLine('<synthetic>', { isApiErrorMessage: true }) +
+        assistantLine('claude-fable-5')
+    )
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+  })
+
+  it('clamps an extended effort variant when degrading to sonnet/haiku', () => {
+    const db = makeDb(makeSession({ model_variant: 'max' }))
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    appendFileSync(transcriptPath, assistantLine('claude-sonnet-5-20250929'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, {
+      model_id: 'sonnet',
+      model_variant: 'high'
+    })
+    expect(publishDesktopBackendEvent).toHaveBeenCalledWith(
+      'opencode:stream',
+      expect.objectContaining({
+        data: expect.objectContaining({ modelVariant: 'high' })
+      })
+    )
+  })
+
+  it('leaves the ultracode variant untouched on degrade', () => {
+    const db = makeDb(makeSession({ model_variant: 'ultracode' }))
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    appendFileSync(transcriptPath, assistantLine('claude-sonnet-5-20250929'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'sonnet' })
+  })
+
+  it('skips custom-provider sessions entirely', () => {
+    const db = makeDb(makeSession({ model_provider_id: 'custom', model_id: 'kimi-sonnet' }))
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    appendFileSync(transcriptPath, assistantLine('claude-sonnet-5-20250929'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+  })
+
+  it('skips non claude-code-cli sessions and unknown sessions', () => {
+    const sdkDb = makeDb(makeSession({ agent_sdk: 'claude-code' }))
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db: sdkDb })
+    appendFileSync(transcriptPath, assistantLine('claude-sonnet-5-20250929'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db: sdkDb })
+    expect(sdkDb.updateSession).not.toHaveBeenCalled()
+
+    const missingDb = makeDb(null)
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db: missingDb })
+    expect(missingDb.updateSession).not.toHaveBeenCalled()
+  })
+
+  it('ignores hooks without a usable event name or transcript path', () => {
+    const db = makeDb(makeSession())
+    writeFileSync(
+      transcriptPath,
+      assistantLine('claude-fable-5') + assistantLine('claude-sonnet-5-20250929')
+    )
+    handleClaudeCliModelChangeHook(
+      SESSION_ID,
+      { hook_event_name: 'PostToolUse', transcript_path: transcriptPath },
+      { db }
+    )
+    handleClaudeCliModelChangeHook(SESSION_ID, { hook_event_name: 'Stop' }, { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+    expect(db.getSession).not.toHaveBeenCalled()
+  })
+
+  it('detects on UserPromptSubmit as well as Stop', () => {
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(
+      SESSION_ID,
+      { hook_event_name: 'UserPromptSubmit', transcript_path: transcriptPath },
+      { db }
+    )
+    appendFileSync(transcriptPath, assistantLine('claude-opus-4-8'))
+    handleClaudeCliModelChangeHook(
+      SESSION_ID,
+      { hook_event_name: 'UserPromptSubmit', transcript_path: transcriptPath },
+      { db }
+    )
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'opus' })
+  })
+
+  it('leaves a partial trailing line for the next read instead of parsing half a line', () => {
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    const switchLine = assistantLine('claude-sonnet-5-20250929')
+    const splitAt = Math.floor(switchLine.length / 2)
+    appendFileSync(transcriptPath, switchLine.slice(0, splitAt))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+
+    appendFileSync(transcriptPath, switchLine.slice(splitAt))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'sonnet' })
+  })
+
+  it('re-baselines when the transcript path changes (new CLI session)', () => {
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    // /clear → new session file, running on sonnet from its first turn: no
+    // in-transcript switch, so nothing to apply.
+    const newPath = path.join(dir, 'session-2.jsonl')
+    writeFileSync(newPath, assistantLine('claude-sonnet-5-20250929'))
+    handleClaudeCliModelChangeHook(
+      SESSION_ID,
+      { hook_event_name: 'Stop', transcript_path: newPath },
+      { db }
+    )
+    expect(db.updateSession).not.toHaveBeenCalled()
+  })
+
+  it('re-baselines when the transcript shrinks (rewritten file)', () => {
+    const db = makeDb(makeSession())
+    writeFileSync(
+      transcriptPath,
+      assistantLine('claude-fable-5') + assistantLine('claude-fable-5')
+    )
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    writeFileSync(transcriptPath, assistantLine('claude-sonnet-5-20250929'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+
+    appendFileSync(transcriptPath, assistantLine('claude-opus-4-8'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'opus' })
+  })
+
+  it('resetClaudeCliModelWatcher drops state; re-attach re-baselines silently', () => {
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    resetClaudeCliModelWatcher(SESSION_ID)
+
+    // The whole file (including this appended switch) is backlog for the
+    // fresh tracker — consumed silently, never replayed.
+    appendFileSync(transcriptPath, assistantLine('claude-sonnet-5-20250929'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+
+    // A live transition after re-attach still fires.
+    appendFileSync(transcriptPath, assistantLine('claude-haiku-4-5-20251001'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'haiku' })
+  })
+
+  it('baselines a large backlog from the file tail only', () => {
+    const db = makeDb(makeSession())
+    // >512KB of non-assistant noise, then the backlog's final model (sonnet).
+    const noise = `${JSON.stringify({ type: 'user', message: { content: 'x'.repeat(4000) } })}\n`
+    writeFileSync(transcriptPath, noise.repeat(140) + assistantLine('claude-sonnet-5-20250929'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+
+    // The tail-read baseline must have seeded sonnet: a live opus line is a
+    // sonnet→opus transition, and opus ≠ the row's fable.
+    appendFileSync(transcriptPath, assistantLine('claude-opus-5-20260101'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'opus' })
+  })
+})

--- a/src/main/services/claude-cli-model-watcher.ts
+++ b/src/main/services/claude-cli-model-watcher.ts
@@ -1,0 +1,344 @@
+import { closeSync, fstatSync, openSync, readSync } from 'fs'
+import { CUSTOM_MODEL_PROVIDER_ID } from '@shared/types/custom-provider'
+import { OPENCODE_STREAM_CHANNEL } from '@shared/opencode-events'
+import type { DatabaseService } from '../db/database'
+import type { Session, SessionUpdate } from '../db/types'
+import { getDatabase } from '../db'
+import { publishDesktopBackendEvent } from '../desktop/backend-event-publisher'
+import { normalizeClaudeCliModel } from './claude-cli-spawner'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'ClaudeCliModelWatcher' })
+
+/**
+ * Detects the claude CLI switching models mid-session — usage-limit
+ * degradation (e.g. Fable→Sonnet), safety fallback, or a user /model — and
+ * propagates the change to the session row so the ticket badge, respawn
+ * --model, telemetry, etc. all follow.
+ *
+ * The only signal that covers PTY (TUI) sessions is the session transcript
+ * JSONL: every main-chain assistant line records the model that actually
+ * produced it in `message.model` (hook payloads carry no model field). The
+ * watcher tails the transcript from the `transcript_path` every hook already
+ * delivers and reacts to *transitions* between consecutive assistant models.
+ *
+ * Two deliberate suppressions keep the watcher from clobbering user intent:
+ * - A mere mismatch between transcript and session row never fires: a user
+ *   picking a new model in Hive updates the row while the running CLI keeps
+ *   answering on the old model until respawn, so the transcript lawfully lags
+ *   the row. Only an observed in-transcript switch proves the CLI itself
+ *   changed models.
+ * - The backlog present when a tracker attaches (respawn --resume, app
+ *   restart, rewritten file) is consumed as a silent baseline — its
+ *   historical transitions were either already applied live in a previous
+ *   run or superseded by an explicit user choice made while no CLI was
+ *   running, so replaying them could revert that choice. Only transitions
+ *   appended after baselining fire.
+ * Transitions are tracked at alias granularity (fable/opus/sonnet/haiku): a
+ * dated snapshot bump within the same alias is not a switch Hive can express.
+ */
+
+interface ModelTrackerState {
+  transcriptPath: string
+  /** Byte offset of the first unconsumed transcript byte (complete lines only). */
+  offset: number
+  /** Raw model of the last main-chain assistant line seen (event payloads). */
+  lastRawModel: string | null
+  /** normalizeClaudeCliModel(lastRawModel) — transition tracking granularity. */
+  lastAlias: string | null
+  /** True once the pre-existing backlog has been consumed silently. */
+  baselined: boolean
+}
+
+const trackers = new Map<string, ModelTrackerState>()
+
+/** Placeholder model on API-error assistant lines (isApiErrorMessage) — not a real model. */
+const SYNTHETIC_MODEL = '<synthetic>'
+
+/**
+ * The baseline only needs the backlog's *final* model, so reading the file
+ * tail suffices — a multi-hundred-MB transcript must not be synchronously
+ * read in full on the hook path.
+ */
+const BASELINE_TAIL_BYTES = 512 * 1024
+
+// A model switch only becomes visible when the next assistant line is written,
+// so per-turn boundaries are the natural (and cheap) polling points.
+const MODEL_HOOK_EVENTS = new Set(['SessionStart', 'UserPromptSubmit', 'Stop', 'SessionEnd'])
+
+// Mirrors the claude-cli catalog in claude-code-implementer.ts: sonnet/haiku
+// effort tops out at 'high'; only fable/opus offer xhigh/max. A degrade must
+// not leave a variant the target model cannot run ('ultracode' is exempt —
+// it is settings-injected, not an --effort value).
+const REDUCED_EFFORT_MODELS = new Set(['sonnet', 'haiku'])
+const EXTENDED_EFFORTS = new Set(['xhigh', 'max'])
+
+export interface ClaudeCliModelChangeHook {
+  hook_event_name?: string
+  transcript_path?: unknown
+}
+
+export interface ClaudeCliModelWatcherDeps {
+  db?: DatabaseService
+}
+
+/**
+ * Extract the models of main-chain assistant lines from a chunk of transcript
+ * JSONL, in order. Sidechain (subagent) lines and synthetic API-error
+ * placeholders are excluded — their models never describe the main session.
+ */
+export function mainChainAssistantModels(text: string): string[] {
+  const models: string[] = []
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue
+    let value: unknown
+    try {
+      value = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) continue
+    const record = value as Record<string, unknown>
+    if (record.type !== 'assistant') continue
+    if (record.isSidechain === true) continue
+    const message = record.message
+    if (typeof message !== 'object' || message === null || Array.isArray(message)) continue
+    const model = (message as Record<string, unknown>).model
+    if (typeof model !== 'string' || !model || model === SYNTHETIC_MODEL) continue
+    models.push(model)
+  }
+  return models
+}
+
+/** Fold a chunk's models into the tracker; true when an alias-level switch was observed. */
+function foldModels(tracker: ModelTrackerState, models: string[]): boolean {
+  let switched = false
+  for (const model of models) {
+    const alias = normalizeClaudeCliModel(model)
+    if (alias === null) continue
+    if (tracker.lastAlias !== null && alias !== tracker.lastAlias) switched = true
+    tracker.lastRawModel = model
+    tracker.lastAlias = alias
+  }
+  return switched
+}
+
+function markForRebaseline(tracker: ModelTrackerState): void {
+  tracker.offset = 0
+  tracker.lastRawModel = null
+  tracker.lastAlias = null
+  tracker.baselined = false
+}
+
+/**
+ * Consume the transcript's existing content as the silent baseline: seed the
+ * tracker's last model from the backlog tail without firing on its historical
+ * transitions. Reads at most BASELINE_TAIL_BYTES from the end (discarding the
+ * partial first line of the window); the final model is all a baseline needs.
+ * On read errors the tracker stays un-baselined and retries on the next hook.
+ */
+function baselineTracker(tracker: ModelTrackerState): void {
+  let fd: number
+  try {
+    fd = openSync(tracker.transcriptPath, 'r')
+  } catch {
+    // No transcript yet — everything written later is live.
+    tracker.baselined = true
+    return
+  }
+
+  try {
+    const size = fstatSync(fd).size
+    let start = size > BASELINE_TAIL_BYTES ? size - BASELINE_TAIL_BYTES : 0
+    const buffer = Buffer.alloc(size - start)
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, start)
+    let data = buffer.subarray(0, Math.max(0, bytesRead))
+
+    if (start > 0) {
+      const firstNewline = data.indexOf(0x0a)
+      if (firstNewline === -1) {
+        // A single torn line fills the window; skip the backlog outright.
+        tracker.offset = size
+        tracker.baselined = true
+        return
+      }
+      data = data.subarray(firstNewline + 1)
+      start += firstNewline + 1
+    }
+
+    const lastNewline = data.lastIndexOf(0x0a)
+    if (lastNewline === -1) {
+      tracker.offset = start
+      tracker.baselined = true
+      return
+    }
+
+    foldModels(tracker, mainChainAssistantModels(data.subarray(0, lastNewline + 1).toString('utf8')))
+    tracker.offset = start + lastNewline + 1
+    tracker.baselined = true
+  } catch {
+    // Leave un-baselined; the next hook retries.
+  } finally {
+    closeSync(fd)
+  }
+}
+
+/**
+ * Read the transcript bytes appended since the last call, consuming complete
+ * lines only (a partial trailing line is re-read next time, so a line split
+ * across writes is never parsed in halves). A shrunken file (rewritten
+ * transcript) flags the tracker for a fresh silent baseline.
+ */
+function readTranscriptChunk(tracker: ModelTrackerState): string | null {
+  let fd: number
+  try {
+    fd = openSync(tracker.transcriptPath, 'r')
+  } catch {
+    return null
+  }
+
+  try {
+    const size = fstatSync(fd).size
+    if (size < tracker.offset) {
+      markForRebaseline(tracker)
+      return null
+    }
+    if (size === tracker.offset) return null
+
+    const buffer = Buffer.alloc(size - tracker.offset)
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, tracker.offset)
+    if (bytesRead <= 0) return null
+
+    const data = buffer.subarray(0, bytesRead)
+    const lastNewline = data.lastIndexOf(0x0a)
+    if (lastNewline === -1) return null
+
+    tracker.offset += lastNewline + 1
+    return data.subarray(0, lastNewline + 1).toString('utf8')
+  } catch {
+    return null
+  } finally {
+    closeSync(fd)
+  }
+}
+
+function clampEffortVariant(alias: string, variant: string | null | undefined): string | undefined {
+  if (!variant) return undefined
+  if (REDUCED_EFFORT_MODELS.has(alias) && EXTENDED_EFFORTS.has(variant.toLowerCase())) {
+    return 'high'
+  }
+  return undefined
+}
+
+function applyDetectedClaudeCliModel(
+  sessionId: string,
+  session: Session,
+  rawModel: string,
+  db: DatabaseService
+): void {
+  const alias = normalizeClaudeCliModel(rawModel)
+  if (!alias) return
+
+  const currentAlias = normalizeClaudeCliModel(session.model_id)
+  if (alias === currentAlias) return
+
+  const update: SessionUpdate = { model_id: alias }
+  const clampedVariant = clampEffortVariant(alias, session.model_variant)
+  if (clampedVariant !== undefined) {
+    update.model_variant = clampedVariant
+  }
+  db.updateSession(sessionId, update)
+  log.info('claude-cli switched models mid-session', {
+    sessionId,
+    from: session.model_id,
+    to: alias,
+    rawModel
+  })
+
+  void Promise.resolve(
+    publishDesktopBackendEvent(OPENCODE_STREAM_CHANNEL, {
+      type: 'session.model_changed',
+      sessionId,
+      data: {
+        modelId: alias,
+        previousModelId: session.model_id,
+        rawModel,
+        ...(clampedVariant !== undefined ? { modelVariant: clampedVariant } : {})
+      }
+    })
+  ).catch(() => undefined)
+}
+
+/**
+ * Per-hook entry point (call sites: main-session hooks that passed the
+ * subagent gate). Synchronous end-to-end so concurrent hooks cannot interleave
+ * tracker reads with the DB compare-and-write.
+ */
+export function handleClaudeCliModelChangeHook(
+  sessionId: string,
+  hook: ClaudeCliModelChangeHook,
+  deps: ClaudeCliModelWatcherDeps = {}
+): void {
+  try {
+    if (!hook.hook_event_name || !MODEL_HOOK_EVENTS.has(hook.hook_event_name)) return
+    const transcriptPath =
+      typeof hook.transcript_path === 'string' && hook.transcript_path
+        ? hook.transcript_path
+        : null
+    if (!transcriptPath) return
+
+    const db = deps.db ?? getDatabase()
+    const session = db.getSession(sessionId)
+    if (!session || session.agent_sdk !== 'claude-code-cli') return
+    // Custom providers own their model slugs (proxies report arbitrary model
+    // ids) — never overwrite them with a stock alias.
+    if (session.model_provider_id === CUSTOM_MODEL_PROVIDER_ID || session.custom_provider_id) return
+
+    let tracker = trackers.get(sessionId)
+    if (!tracker || tracker.transcriptPath !== transcriptPath) {
+      // New session transcript (first hook, /clear, resume under a new id):
+      // its existing content becomes a silent baseline.
+      tracker = {
+        transcriptPath,
+        offset: 0,
+        lastRawModel: null,
+        lastAlias: null,
+        baselined: false
+      }
+      trackers.set(sessionId, tracker)
+    }
+
+    if (!tracker.baselined) {
+      baselineTracker(tracker)
+      if (!tracker.baselined) return
+    }
+
+    let chunk = readTranscriptChunk(tracker)
+    if (!tracker.baselined) {
+      // The file shrank mid-read (rewritten transcript): re-baseline its new
+      // content silently, then pick up anything appended after it.
+      baselineTracker(tracker)
+      if (!tracker.baselined) return
+      chunk = readTranscriptChunk(tracker)
+    }
+    if (!chunk) return
+
+    const switched = foldModels(tracker, mainChainAssistantModels(chunk))
+    if (switched && tracker.lastRawModel !== null) {
+      applyDetectedClaudeCliModel(sessionId, session, tracker.lastRawModel, db)
+    }
+  } catch (error) {
+    log.warn('model-change detection failed', {
+      sessionId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+export function resetClaudeCliModelWatcher(sessionId: string): void {
+  trackers.delete(sessionId)
+}
+
+export function resetAllClaudeCliModelWatchers(): void {
+  trackers.clear()
+}

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -4,6 +4,10 @@ import { OPENCODE_STREAM_CHANNEL } from '@shared/opencode-events'
 import { createLogger } from './logger'
 import { cliHookTransportRouter } from './cli-hook-transport-router'
 import { handleClaudeCliHiveTelemetryHook } from './hive-enterprise-claude-cli-telemetry'
+import {
+  handleClaudeCliModelChangeHook,
+  resetAllClaudeCliModelWatchers
+} from './claude-cli-model-watcher'
 import { scheduleSessionUsageReport } from './usage/session-usage-service'
 import { publishDesktopBackendEvent } from '../desktop/backend-event-publisher'
 import {
@@ -380,6 +384,11 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
           publishClaudeCliStatus(payload)
         }
         void handleClaudeCliHiveTelemetryHook(route.sessionId, body)
+        // Mid-session model change (usage-limit/safety degrade, /model): the
+        // transcript is the only surface that records it for PTY sessions.
+        // Main-session hooks only — a subagent-scoped hook's transcript_path
+        // points at the subagent's own file.
+        handleClaudeCliModelChangeHook(route.sessionId, body)
       }
       // First user prompt of this CLI session → tell the renderer so it can
       // auto-create a kanban ticket (if the setting is on). Fires for prompts
@@ -562,6 +571,7 @@ export async function closeClaudeHookServer(): Promise<void> {
     clearAllClaudeCliSubagentTracking()
     clearAllClaudeCliBackgroundWork()
     clearAllClaudeCliPlanAutoApprove()
+    resetAllClaudeCliModelWatchers()
     setClaudeCliDeferredCompletionHandler(null)
     return
   }
@@ -585,5 +595,6 @@ export async function closeClaudeHookServer(): Promise<void> {
   clearAllClaudeCliSubagentTracking()
   clearAllClaudeCliBackgroundWork()
   clearAllClaudeCliPlanAutoApprove()
+  resetAllClaudeCliModelWatchers()
   setClaudeCliDeferredCompletionHandler(null)
 }

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -18,6 +18,10 @@ import {
   clearClaudeCliSubagentTracking
 } from './claude-cli-subagent-tracker'
 import { clearAllClaudeCliBackgroundWork } from './claude-cli-background-work-tracker'
+import {
+  resetAllClaudeCliModelWatchers,
+  resetClaudeCliModelWatcher
+} from './claude-cli-model-watcher'
 import { setClaudeCliPlanAutoApprove } from './claude-cli-plan-auto-approve'
 import { logClaudeBinaryVersion, resolveClaudeBinaryPath } from './claude-binary-resolver'
 import { buildClaudeCliPtySpawn } from './claude-cli-spawner'
@@ -162,6 +166,7 @@ export function destroyNodePtyTerminal(terminalId: string): void {
   claudeCliTranscriptSources.delete(terminalId)
   claudeCliLastStatus.delete(terminalId)
   resetClaudeCliTitleState(terminalId)
+  resetClaudeCliModelWatcher(terminalId)
   ptyService.destroy(terminalId)
 }
 
@@ -239,6 +244,7 @@ function attachNodePtyListeners(terminalId: string): void {
     claudeCliTranscriptSources.delete(terminalId)
     claudeCliLastStatus.delete(terminalId)
     resetClaudeCliTitleState(terminalId)
+    resetClaudeCliModelWatcher(terminalId)
   })
 
   listenerCleanups.set(terminalId, { removeData, removeExit })
@@ -466,6 +472,7 @@ export function cleanupTerminals(): void {
   clearAllClaudeCliInteractions()
   clearAllClaudeCliSubagentTracking()
   clearAllClaudeCliBackgroundWork()
+  resetAllClaudeCliModelWatchers()
   unsubscribeClaudeCliStatus?.()
   unsubscribeClaudeCliStatus = null
   resetAllClaudeCliTitleState()

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -382,6 +382,21 @@ export function useOpenCodeGlobalListener(): void {
         return
       }
 
+      // Mid-session model change detected from the claude-cli transcript
+      // (e.g. the CLI degraded Fable→Sonnet on usage limits). Main already
+      // persisted the session row; patch the in-memory session and sync the
+      // linked kanban ticket's model badge.
+      if (event.type === 'session.model_changed') {
+        const data = event.data as { modelId?: unknown; modelVariant?: unknown } | undefined
+        if (typeof data?.modelId === 'string' && data.modelId) {
+          useSessionStore.getState().applyDetectedSessionModel(sessionId, {
+            modelId: data.modelId,
+            ...(typeof data.modelVariant === 'string' ? { modelVariant: data.modelVariant } : {})
+          })
+        }
+        return
+      }
+
       // session.updated — sync title for both background and active sessions.
       // ClaudeCliSessionView has no stream listener of its own, so active
       // claude-cli renames need to flow through the global listener.

--- a/src/renderer/src/stores/store-coordination.ts
+++ b/src/renderer/src/stores/store-coordination.ts
@@ -124,3 +124,25 @@ export function registerKanbanRenameSync(fn: KanbanRenameSyncFn): void {
 export function notifyKanbanRenameSync(sessionId: string, name: string): void {
   _kanbanRenameSync?.(sessionId, name)
 }
+
+// ── Kanban ↔ Session: mid-session model change detected in the CLI ─────────
+// Fired after a model change detected from the claude-cli transcript (usage
+// limit / safety degradation, /model) is applied to the session store. The
+// kanban store syncs the model badge of the ticket linked to this session.
+export interface KanbanModelSyncModel {
+  modelId: string
+  /** Present only when main clamped the effort variant for the new model. */
+  modelVariant?: string
+}
+
+type KanbanModelSyncFn = (sessionId: string, model: KanbanModelSyncModel) => void
+
+let _kanbanModelSync: KanbanModelSyncFn | null = null
+
+export function registerKanbanModelSync(fn: KanbanModelSyncFn): void {
+  _kanbanModelSync = fn
+}
+
+export function notifyKanbanModelSync(sessionId: string, model: KanbanModelSyncModel): void {
+  _kanbanModelSync?.(sessionId, model)
+}

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -14,8 +14,10 @@ import {
   registerKanbanNewSession,
   registerKanbanAutoCreateTicket,
   registerKanbanRenameSync,
+  registerKanbanModelSync,
   type KanbanSessionEvent
 } from './store-coordination'
+import { CUSTOM_MODEL_PROVIDER_ID } from '@shared/types/custom-provider'
 import { isPlanLike } from '../lib/constants'
 import { useConnectionStore } from './useConnectionStore'
 import { usePinnedStore } from './usePinnedStore'
@@ -1971,6 +1973,50 @@ registerKanbanRenameSync((sessionId, name) => {
       const target = linked.find((t) => t.created_from_session && !t.archived_at)
       if (target && target.title !== name) {
         store.updateTicket(target.id, target.project_id, { title: name }).catch(() => {})
+      }
+    } catch {
+      // Best-effort.
+    }
+  })()
+})
+
+// ── Register model-sync callback (mid-session model change → ticket badge) ──
+// The CLI can switch models mid-session (usage-limit or safety degradation,
+// /model in the terminal). Main persists the session row and the session store
+// patches its maps; this syncs the linked ticket's badge so the board shows
+// the model actually running. Only tickets that already carry a model are
+// touched — a model-less ticket has no stale badge to fix — and custom-provider
+// slugs are never overwritten with a stock alias.
+registerKanbanModelSync((sessionId, model) => {
+  void (async () => {
+    try {
+      const store = useKanbanStore.getState()
+      const apply = (ticket: KanbanTicket, projectId: string): void => {
+        if (!ticket.model_id || ticket.model_provider_id === CUSTOM_MODEL_PROVIDER_ID) return
+        const patch: KanbanTicketUpdate = {}
+        if (ticket.model_id !== model.modelId) patch.model_id = model.modelId
+        if (model.modelVariant !== undefined && ticket.model_variant !== model.modelVariant) {
+          patch.model_variant = model.modelVariant
+        }
+        if (Object.keys(patch).length === 0) return
+        store.updateTicket(ticket.id, projectId, patch).catch(() => {})
+      }
+
+      let matched = false
+      for (const [projectId, tickets] of store.tickets.entries()) {
+        for (const ticket of tickets) {
+          if (ticket.current_session_id === sessionId && !ticket.archived_at) {
+            matched = true
+            apply(ticket, projectId)
+          }
+        }
+      }
+      if (matched) return
+
+      // Fallback: the ticket's board may not be loaded into the map yet.
+      const linked = await kanban.ticket.getBySession<KanbanTicket>(sessionId)
+      for (const target of linked) {
+        if (!target.archived_at) apply(target, target.project_id)
       }
     } catch {
       // Best-effort.

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -5,7 +5,8 @@ import { useWorktreeStore } from './useWorktreeStore'
 import {
   notifyKanbanSessionSync,
   notifyKanbanNewSession,
-  notifyKanbanRenameSync
+  notifyKanbanRenameSync,
+  notifyKanbanModelSync
 } from './store-coordination'
 import { useSettingsStore } from './useSettingsStore'
 import { getUnavailableAgentSdkMessage } from '@/lib/agent-sdk-availability'
@@ -199,6 +200,10 @@ interface SessionState {
     model: SelectedModel,
     options?: { skipGlobalUpdate?: boolean }
   ) => Promise<void>
+  applyDetectedSessionModel: (
+    sessionId: string,
+    model: { modelId: string; modelVariant?: string }
+  ) => void
   setOpenCodeSessionId: (sessionId: string, opencodeSessionId: string | null) => void
   setClaudeSessionId: (sessionId: string, claudeSessionId: string | null) => void
   setPendingMessage: (sessionId: string, message: string) => void
@@ -1511,6 +1516,56 @@ export const useSessionStore = create<SessionState>()(
             /* non-critical */
           }
         }
+      },
+
+      // Apply a model change detected from the running CLI itself (usage-limit
+      // or safety degradation, /model in the terminal). Main already persisted
+      // the session row, so this only patches in-memory state — unlike
+      // setSessionModel it must not write the DB, push to the agent backend,
+      // or rewrite global/worktree model preferences (a CLI-side degrade is
+      // not a user preference).
+      applyDetectedSessionModel: (sessionId, model) => {
+        set((state) => {
+          const newWorktreeSessionsMap = new Map(state.sessionsByWorktree)
+          for (const [worktreeId, sessions] of newWorktreeSessionsMap.entries()) {
+            const updated = sessions.map((s) =>
+              s.id === sessionId
+                ? {
+                    ...s,
+                    model_id: model.modelId,
+                    model_variant: model.modelVariant !== undefined ? model.modelVariant : s.model_variant
+                  }
+                : s
+            )
+            if (updated.some((s, i) => s !== sessions[i])) {
+              newWorktreeSessionsMap.set(worktreeId, updated)
+            }
+          }
+
+          const newConnectionSessionsMap = new Map(state.sessionsByConnection)
+          for (const [connectionId, sessions] of newConnectionSessionsMap.entries()) {
+            const updated = sessions.map((s) =>
+              s.id === sessionId
+                ? {
+                    ...s,
+                    model_id: model.modelId,
+                    model_variant: model.modelVariant !== undefined ? model.modelVariant : s.model_variant
+                  }
+                : s
+            )
+            if (updated.some((s, i) => s !== sessions[i])) {
+              newConnectionSessionsMap.set(connectionId, updated)
+            }
+          }
+
+          return {
+            sessionsByWorktree: newWorktreeSessionsMap,
+            sessionsByConnection: newConnectionSessionsMap
+          }
+        })
+
+        // Keep the linked kanban ticket's model badge in sync.
+        notifyKanbanModelSync(sessionId, model)
       },
 
       // Apply mode-specific default model when toggling modes


### PR DESCRIPTION
## Summary

- Add transcript-based detection of Claude CLI model switches, including usage-limit and safety degradations.
- Persist detected model and compatible effort-variant changes to the session.
- Publish model-change events and synchronize renderer session and Kanban ticket state.
- Add lifecycle cleanup and comprehensive watcher coverage for baselining, partial files, rewrites, and filtering.

## Testing

- Added Vitest coverage in `claude-cli-model-watcher.test.ts` for model transitions and edge cases.
- Not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session `model_id`/`model_variant` from automated transcript inference; logic is heavily guarded (baselining, custom-provider skip, no row/transcript mismatch writes) but incorrect detection could still skew badges and respawn model selection.
> 
> **Overview**
> Adds **transcript-based detection** when the Claude CLI switches models mid-session (usage-limit degrade, safety fallback, or `/model`), so Hive’s session row, UI badges, and respawn `--model` stay aligned with what the PTY is actually running.
> 
> A new main-process watcher tails the hook `transcript_path`, tracks **alias-level** transitions on main-chain assistant lines (ignoring sidechain/synthetic noise), and on a real switch updates the DB, emits `session.model_changed` on the opencode stream, and **clamps** effort variants when degrading to sonnet/haiku (e.g. `max` → `high`). It deliberately **does not** sync when the DB and transcript merely disagree (user picked a new model in Hive before respawn) and **silently baselines** existing transcript history on attach so stale degrades are not replayed.
> 
> Wiring: invoked from main-session Claude hook paths after the subagent gate; tracker state is reset on PTY teardown and hook-server shutdown. The renderer handles the new event via `applyDetectedSessionModel` (in-memory only—no preference/backend writes) and **kanban model-sync** for linked tickets with a model badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10da503678e26d87b22dca8c25b48f77a715f9cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->