### PR TITLE
Track opening-turn Claude model downgrades

### DIFF
--- a/src/main/services/claude-cli-model-watcher.test.ts
+++ b/src/main/services/claude-cli-model-watcher.test.ts
@@ -150,12 +150,13 @@ describe('handleClaudeCliModelChangeHook', () => {
 
     appendFileSync(transcriptPath, assistantLine('claude-opus-4-8'))
     handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
-    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'opus' })
+    // Stored as the distinct fallback id, not the selectable `opus` (Opus 5).
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'opus-4-8' })
     expect(publishDesktopBackendEvent).toHaveBeenCalledWith(
       'opencode:stream',
       expect.objectContaining({
         type: 'session.model_changed',
-        data: expect.objectContaining({ modelId: 'opus', previousModelId: 'fable' })
+        data: expect.objectContaining({ modelId: 'opus-4-8', previousModelId: 'fable' })
       })
     )
   })
@@ -171,7 +172,39 @@ describe('handleClaudeCliModelChangeHook', () => {
 
     appendFileSync(transcriptPath, assistantLine('claude-opus-4-8'))
     handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'opus-4-8' })
+  })
+
+  it('keeps a safety fallback distinct from a selectable Opus 5 line', () => {
+    // A real Opus 5 snapshot collapses to the selectable `opus`; only the
+    // Opus 4.x fallback keeps its own non-selectable id.
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    appendFileSync(transcriptPath, assistantLine('claude-opus-5-20260101'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
     expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'opus' })
+  })
+
+  it('does not clamp effort for an opus 4.x fallback and no-ops once stored', () => {
+    // Opus-tier fallback keeps extended efforts (unlike sonnet/haiku), and a
+    // second opus-4-8 line must not rewrite the already-stored id.
+    const db = makeDb(makeSession({ model_variant: 'max' }))
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    appendFileSync(transcriptPath, assistantLine('claude-opus-4-8'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'opus-4-8' })
+
+    // Row now reflects the fallback; a further opus-4-8 line canonicalizes to
+    // the same id, so there is nothing new to write.
+    db.getSession = vi.fn(() => makeSession({ model_id: 'opus-4-8', model_variant: 'max' }))
+    ;(db.updateSession as ReturnType<typeof vi.fn>).mockClear()
+    appendFileSync(transcriptPath, assistantLine('claude-opus-4-8'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
   })
 
   it('carries the running model across a /clear so a pending UI choice is not reverted', () => {
@@ -348,7 +381,7 @@ describe('handleClaudeCliModelChangeHook', () => {
       { hook_event_name: 'UserPromptSubmit', transcript_path: transcriptPath },
       { db }
     )
-    appendFileSync(transcriptPath, assistantLine('claude-opus-4-8'))
+    appendFileSync(transcriptPath, assistantLine('claude-opus-5-20260101'))
     handleClaudeCliModelChangeHook(
       SESSION_ID,
       { hook_event_name: 'UserPromptSubmit', transcript_path: transcriptPath },
@@ -402,7 +435,7 @@ describe('handleClaudeCliModelChangeHook', () => {
     handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
     expect(db.updateSession).not.toHaveBeenCalled()
 
-    appendFileSync(transcriptPath, assistantLine('claude-opus-4-8'))
+    appendFileSync(transcriptPath, assistantLine('claude-opus-5-20260101'))
     handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
     expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'opus' })
   })

--- a/src/main/services/claude-cli-model-watcher.test.ts
+++ b/src/main/services/claude-cli-model-watcher.test.ts
@@ -133,6 +133,74 @@ describe('handleClaudeCliModelChangeHook', () => {
     )
   })
 
+  it('detects an opening-turn safety fallback (empty transcript baseline, first line differs)', () => {
+    // The ticket case: a session launched on fable whose very first prompt
+    // triggers a safety degrade to opus 4.8. SessionStart baselines the still
+    // model-less transcript, then the first committed assistant line is already
+    // opus — with no prior fable line in the file, this must still register as
+    // a fable→opus switch and update the row.
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, userLine())
+    handleClaudeCliModelChangeHook(
+      SESSION_ID,
+      { hook_event_name: 'SessionStart', transcript_path: transcriptPath },
+      { db }
+    )
+    expect(db.updateSession).not.toHaveBeenCalled()
+
+    appendFileSync(transcriptPath, assistantLine('claude-opus-4-8'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'opus' })
+    expect(publishDesktopBackendEvent).toHaveBeenCalledWith(
+      'opencode:stream',
+      expect.objectContaining({
+        type: 'session.model_changed',
+        data: expect.objectContaining({ modelId: 'opus', previousModelId: 'fable' })
+      })
+    )
+  })
+
+  it('fires on an opening-turn fallback even without a prior SessionStart hook', () => {
+    // Same degrade observed for the first time on the Stop hook, before any
+    // assistant line existed at attach: the launch model (row) seeds the
+    // baseline so the opus line is a transition, not a silent baseline.
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, userLine())
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).not.toHaveBeenCalled()
+
+    appendFileSync(transcriptPath, assistantLine('claude-opus-4-8'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'opus' })
+  })
+
+  it('carries the running model across a /clear so a pending UI choice is not reverted', () => {
+    // The CLI runs fable; the user picks sonnet in Hive (row=sonnet) without
+    // respawning, so the CLI keeps answering fable. A /clear then yields a
+    // fresh empty transcript. The baseline must seed the running fable (carried
+    // from the prior tracker), not the ahead-of-CLI row, so the first fable
+    // line is no transition and the pending sonnet choice survives.
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    db.getSession = vi.fn(() => makeSession({ model_id: 'sonnet' }))
+    const clearedPath = path.join(dir, 'session-cleared.jsonl')
+    writeFileSync(clearedPath, userLine())
+    handleClaudeCliModelChangeHook(
+      SESSION_ID,
+      { hook_event_name: 'SessionStart', transcript_path: clearedPath },
+      { db }
+    )
+    appendFileSync(clearedPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(
+      SESSION_ID,
+      { hook_event_name: 'Stop', transcript_path: clearedPath },
+      { db }
+    )
+    expect(db.updateSession).not.toHaveBeenCalled()
+  })
+
   it('consumes pre-existing backlog silently — historical transitions never fire', () => {
     // The exact respawn scenario: a fable→sonnet degrade already sits in the
     // transcript from a previous run, but the user has since explicitly picked

--- a/src/main/services/claude-cli-model-watcher.ts
+++ b/src/main/services/claude-cli-model-watcher.ts
@@ -1,5 +1,6 @@
 import { closeSync, fstatSync, openSync, readSync } from 'fs'
 import { CUSTOM_MODEL_PROVIDER_ID } from '@shared/types/custom-provider'
+import { resolveClaudeCliFallbackModel } from '@shared/types/claude-cli-fallback-models'
 import { OPENCODE_STREAM_CHANNEL } from '@shared/opencode-events'
 import type { DatabaseService } from '../db/database'
 import type { Session, SessionUpdate } from '../db/types'
@@ -271,20 +272,33 @@ function clampEffortVariant(alias: string, variant: string | null | undefined): 
   return undefined
 }
 
+/**
+ * The model id Hive stores for a raw transcript model (or an already-stored
+ * id). Selectable models collapse to their alias (fable/opus/sonnet/haiku); a
+ * safety/usage fallback keeps a distinct id (e.g. `opus-4-8`) so the ticket
+ * badge shows "Opus 4.8" instead of the selectable "Opus 5". Comparing both
+ * sides through this resolver keeps the no-op guard honest — a stored
+ * `opus-4-8` and a fresh `claude-opus-4-8` line canonicalize to the same id.
+ */
+function canonicalClaudeCliModelId(rawModel: string | null | undefined): string | null {
+  const fallback = resolveClaudeCliFallbackModel(rawModel)
+  if (fallback) return fallback.id
+  return normalizeClaudeCliModel(rawModel)
+}
+
 function applyDetectedClaudeCliModel(
   sessionId: string,
   session: Session,
   rawModel: string,
   db: DatabaseService
 ): void {
-  const alias = normalizeClaudeCliModel(rawModel)
-  if (!alias) return
+  const modelId = canonicalClaudeCliModelId(rawModel)
+  if (!modelId) return
 
-  const currentAlias = normalizeClaudeCliModel(session.model_id)
-  if (alias === currentAlias) return
+  if (modelId === canonicalClaudeCliModelId(session.model_id)) return
 
-  const update: SessionUpdate = { model_id: alias }
-  const clampedVariant = clampEffortVariant(alias, session.model_variant)
+  const update: SessionUpdate = { model_id: modelId }
+  const clampedVariant = clampEffortVariant(modelId, session.model_variant)
   if (clampedVariant !== undefined) {
     update.model_variant = clampedVariant
   }
@@ -292,7 +306,7 @@ function applyDetectedClaudeCliModel(
   log.info('claude-cli switched models mid-session', {
     sessionId,
     from: session.model_id,
-    to: alias,
+    to: modelId,
     rawModel
   })
 
@@ -301,7 +315,7 @@ function applyDetectedClaudeCliModel(
       type: 'session.model_changed',
       sessionId,
       data: {
-        modelId: alias,
+        modelId,
         previousModelId: session.model_id,
         rawModel,
         ...(clampedVariant !== undefined ? { modelVariant: clampedVariant } : {})

--- a/src/main/services/claude-cli-model-watcher.ts
+++ b/src/main/services/claude-cli-model-watcher.ts
@@ -36,6 +36,24 @@ const log = createLogger({ component: 'ClaudeCliModelWatcher' })
  *   appended after baselining fire.
  * Transitions are tracked at alias granularity (fable/opus/sonnet/haiku): a
  * dated snapshot bump within the same alias is not a switch Hive can express.
+ *
+ * A switch is only ever an in-transcript transition, so the baseline must seed
+ * the model the CLI is *currently* running before the first live line lands —
+ * otherwise a session whose very first committed line is already the fallback
+ * model (a safety degrade or usage-limit degrade that fires on the opening
+ * turn) shows no transition and the change is missed. When the backlog has an
+ * assistant model, that model is the seed; when it has none yet (a fresh or
+ * just-cleared transcript), the seed is the alias the tracker was already
+ * following across a transcript-path change, or — on the very first attach —
+ * the session's launch model (the row's model_id is exactly the CLI's --model
+ * flag). Seeding the launch model cannot fabricate a spurious switch: a lawful
+ * pending UI choice only exists alongside an already-running CLI, whose
+ * transcript is never empty, so it takes the carried-forward alias instead and
+ * is never reverted.
+ *
+ * The transcript is read incrementally — a per-session byte cursor consumes
+ * only the bytes appended since the previous hook (plus a one-time bounded tail
+ * at first attach); the whole file is never rescanned.
  */
 
 interface ModelTrackerState {
@@ -46,6 +64,14 @@ interface ModelTrackerState {
   lastRawModel: string | null
   /** normalizeClaudeCliModel(lastRawModel) — transition tracking granularity. */
   lastAlias: string | null
+  /**
+   * The CLI's currently-running model alias, used to seed `lastAlias` when the
+   * baseline finds no assistant model in the backlog (fresh/cleared transcript)
+   * — the carried-forward alias across a path change, or the launch model on
+   * first attach. Anchors the first live line so an opening-turn fallback reads
+   * as a transition rather than a silent baseline.
+   */
+  seedAlias: string | null
   /** True once the pre-existing backlog has been consumed silently. */
   baselined: boolean
 }
@@ -124,10 +150,25 @@ function foldModels(tracker: ModelTrackerState, models: string[]): boolean {
 }
 
 function markForRebaseline(tracker: ModelTrackerState): void {
+  // Preserve the running model across the rewrite so a fresh empty file
+  // re-seeds it (a rewritten transcript does not restart the CLI).
+  tracker.seedAlias = tracker.lastAlias ?? tracker.seedAlias
   tracker.offset = 0
   tracker.lastRawModel = null
   tracker.lastAlias = null
   tracker.baselined = false
+}
+
+/**
+ * After a baseline consumed no assistant model (empty/cleared transcript),
+ * anchor `lastAlias` to the CLI's running model so the first live line is
+ * measured as a transition. A backlog that did carry a model leaves `lastAlias`
+ * set and is untouched.
+ */
+function applyBaselineSeed(tracker: ModelTrackerState): void {
+  if (tracker.lastAlias === null && tracker.seedAlias !== null) {
+    tracker.lastAlias = tracker.seedAlias
+  }
 }
 
 /**
@@ -297,12 +338,17 @@ export function handleClaudeCliModelChangeHook(
     let tracker = trackers.get(sessionId)
     if (!tracker || tracker.transcriptPath !== transcriptPath) {
       // New session transcript (first hook, /clear, resume under a new id):
-      // its existing content becomes a silent baseline.
+      // its existing content becomes a silent baseline. When that content has
+      // no assistant model yet, the baseline seeds the CLI's running model:
+      // the alias we were already following across a path change (the running
+      // CLI, not the possibly-ahead row), or the launch model on first attach.
+      const seedAlias = tracker?.lastAlias ?? normalizeClaudeCliModel(session.model_id)
       tracker = {
         transcriptPath,
         offset: 0,
         lastRawModel: null,
         lastAlias: null,
+        seedAlias,
         baselined: false
       }
       trackers.set(sessionId, tracker)
@@ -311,6 +357,7 @@ export function handleClaudeCliModelChangeHook(
     if (!tracker.baselined) {
       baselineTracker(tracker)
       if (!tracker.baselined) return
+      applyBaselineSeed(tracker)
     }
 
     let chunk = readTranscriptChunk(tracker)
@@ -319,6 +366,7 @@ export function handleClaudeCliModelChangeHook(
       // content silently, then pick up anything appended after it.
       baselineTracker(tracker)
       if (!tracker.baselined) return
+      applyBaselineSeed(tracker)
       chunk = readTranscriptChunk(tracker)
     }
     if (!chunk) return

--- a/src/renderer/src/components/kanban/TicketModelBadge.test.tsx
+++ b/src/renderer/src/components/kanban/TicketModelBadge.test.tsx
@@ -163,6 +163,31 @@ describe('TicketModelBadge', () => {
     expect(badge).toHaveClass('border-transparent')
   })
 
+  it('names a non-selectable safety fallback (opus-4-8 → Opus 4.8) and tags it', () => {
+    // The fallback id is absent from the picker catalog by design, so its name
+    // must resolve without a catalog hit, and a "fallback" tag marks it as an
+    // involuntary degrade rather than a chosen model.
+    render(
+      <TicketModelBadge
+        ticket={{ model_provider_id: 'anthropic', model_id: 'opus-4-8', model_variant: 'high' }}
+      />
+    )
+
+    expect(screen.getByText('Opus 4.8')).toBeInTheDocument()
+    expect(screen.getByTestId('model-fallback-tag')).toBeInTheDocument()
+    expect(screen.getByTitle('Opus 4.8 (high) — safety fallback')).toBeInTheDocument()
+  })
+
+  it('does not tag a normal selectable model', () => {
+    render(
+      <TicketModelBadge
+        ticket={{ model_provider_id: 'anthropic', model_id: 'opus', model_variant: null }}
+      />
+    )
+
+    expect(screen.queryByTestId('model-fallback-tag')).toBeNull()
+  })
+
   it('applies the passed className to the chip', () => {
     render(
       <TicketModelBadge

--- a/src/renderer/src/components/kanban/TicketModelBadge.tsx
+++ b/src/renderer/src/components/kanban/TicketModelBadge.tsx
@@ -7,10 +7,19 @@ import {
   subscribeModelCatalogCache
 } from '@/lib/handoffSelection'
 import { findModelInfo, getModelDisplayName, isUltraVariant } from '@/lib/parseProviders'
+import {
+  claudeCliFallbackModelName,
+  isClaudeCliFallbackModelId
+} from '@shared/types/claude-cli-fallback-models'
 import { cn } from '@/lib/utils'
 import type { KanbanTicket } from '../../../../main/db/types'
 
-/** Looks up the pretty model name from any cached handoff SDK catalog, falling back to the raw modelId. */
+/**
+ * Looks up the pretty model name from any cached handoff SDK catalog, falling
+ * back to a known safety/usage-fallback name (e.g. `opus-4-8` → "Opus 4.8") and
+ * then to the raw modelId. Fallback models are intentionally absent from the
+ * picker catalog, so their name never resolves via findModelInfo.
+ */
 function resolveModelDisplayName(providerId: string | null, modelId: string): string {
   if (providerId) {
     for (const sdk of getAvailableHandoffAgentSdks()) {
@@ -21,7 +30,7 @@ function resolveModelDisplayName(providerId: string | null, modelId: string): st
     }
   }
 
-  return modelId
+  return claudeCliFallbackModelName(modelId) ?? modelId
 }
 
 interface TicketModelBadgeProps {
@@ -42,7 +51,11 @@ export function TicketModelBadge({
 
   const icon = resolveModelIconAsset(providerId, modelId)
   const displayName = resolveModelDisplayName(providerId, modelId)
-  const title = variant ? `${displayName} (${variant})` : displayName
+  // A non-selectable safety/usage fallback (the CLI degraded the session off the
+  // picked model) — flag it so the badge reads as an involuntary state, not a choice.
+  const isFallback = isClaudeCliFallbackModelId(modelId)
+  const baseTitle = variant ? `${displayName} (${variant})` : displayName
+  const title = isFallback ? `${baseTitle} — safety fallback` : baseTitle
 
   return (
     <span
@@ -55,6 +68,14 @@ export function TicketModelBadge({
     >
       {icon && <img src={icon.src} alt={icon.alt} className="h-3 w-3 shrink-0" draggable={false} />}
       {displayName}
+      {isFallback && (
+        <span
+          className="rounded-sm bg-amber-500/15 px-1 text-[9px] font-semibold uppercase leading-tight tracking-wide text-amber-600 dark:text-amber-400"
+          data-testid="model-fallback-tag"
+        >
+          fallback
+        </span>
+      )}
     </span>
   )
 }

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -23,6 +23,7 @@ import {
   type SelectedModel,
   type HandoffAgentSdk
 } from '@/stores/useSettingsStore'
+import { claudeCliFallbackModelName } from '@shared/types/claude-cli-fallback-models'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { toModelCatalogSdk } from '@shared/types/agent-sdk'
 import { toast } from '@/lib/toast'
@@ -440,12 +441,15 @@ export const ModelSelector = memo(function ModelSelector({
     return () => window.removeEventListener('hive:cycle-variant', handleCycleVariant)
   }, [cycleVariant, onChange])
 
-  // Determine display name for the pill
+  // Determine display name for the pill. A safety/usage fallback (e.g.
+  // `opus-4-8`) is absent from the catalog by design, so name it explicitly
+  // rather than showing the raw slug.
   const displayName = currentModel
     ? getModelDisplayName(currentModel)
-    : getModelDisplayName({
+    : (claudeCliFallbackModelName(selectedModel?.modelID) ??
+      getModelDisplayName({
         id: selectedModel?.modelID || 'claude-opus-4-5-20251101'
-      })
+      }))
 
   const sdkFilterOptions = useMemo((): SdkFilterOption[] => {
     const availableSdks = new Set(providers.map((provider) => provider.agentSdk))

--- a/src/shared/types/claude-cli-fallback-models.test.ts
+++ b/src/shared/types/claude-cli-fallback-models.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  claudeCliFallbackModelName,
+  isClaudeCliFallbackModelId,
+  resolveClaudeCliFallbackModel
+} from './claude-cli-fallback-models'
+
+describe('resolveClaudeCliFallbackModel', () => {
+  it('maps an Opus 4.x raw transcript model to its fallback id + name', () => {
+    expect(resolveClaudeCliFallbackModel('claude-opus-4-8')).toEqual({
+      id: 'opus-4-8',
+      name: 'Opus 4.8'
+    })
+    expect(resolveClaudeCliFallbackModel('claude-opus-4-5-20251101')).toEqual({
+      id: 'opus-4-5',
+      name: 'Opus 4.5'
+    })
+  })
+
+  it('also resolves an already-stored fallback id (idempotent canonicalization)', () => {
+    expect(resolveClaudeCliFallbackModel('opus-4-8')).toEqual({ id: 'opus-4-8', name: 'Opus 4.8' })
+  })
+
+  it('returns null for selectable models and empty input', () => {
+    expect(resolveClaudeCliFallbackModel('claude-opus-5-20260101')).toBeNull()
+    expect(resolveClaudeCliFallbackModel('claude-fable-5')).toBeNull()
+    expect(resolveClaudeCliFallbackModel('opus')).toBeNull()
+    expect(resolveClaudeCliFallbackModel(null)).toBeNull()
+    expect(resolveClaudeCliFallbackModel(undefined)).toBeNull()
+  })
+})
+
+describe('isClaudeCliFallbackModelId / claudeCliFallbackModelName', () => {
+  it('recognizes stored fallback ids', () => {
+    expect(isClaudeCliFallbackModelId('opus-4-8')).toBe(true)
+    expect(isClaudeCliFallbackModelId('opus-4-5')).toBe(true)
+    expect(isClaudeCliFallbackModelId('opus')).toBe(false)
+    expect(isClaudeCliFallbackModelId('claude-opus-4-8')).toBe(false)
+    expect(isClaudeCliFallbackModelId(null)).toBe(false)
+  })
+
+  it('gives display names only for fallback ids', () => {
+    expect(claudeCliFallbackModelName('opus-4-8')).toBe('Opus 4.8')
+    expect(claudeCliFallbackModelName('opus')).toBeNull()
+    expect(claudeCliFallbackModelName(undefined)).toBeNull()
+  })
+})

--- a/src/shared/types/claude-cli-fallback-models.ts
+++ b/src/shared/types/claude-cli-fallback-models.ts
@@ -1,0 +1,52 @@
+/**
+ * Claude CLI safety / usage fallbacks land a session on an Opus 4.x snapshot
+ * (e.g. Fable 5's dual-use guard degrades to Opus 4.8). These are real models
+ * the CLI answers on, but they are NOT selectable picker options — the picker
+ * only offers the current top-tier line (Opus 5, Fable 5, …). Collapsing them
+ * to the plain `opus` alias made a degraded session read as the selectable
+ * "Opus 5" on its ticket badge, so they get their own id + display name here.
+ *
+ * This module is the single source of truth shared by the main-process detector
+ * (which stores the id on the session) and the renderer (which resolves the
+ * display name and fallback tag) — neither should hard-code these strings.
+ */
+
+/** Matches an Opus 4.x model in either raw (`claude-opus-4-8`) or id (`opus-4-8`) form. */
+const OPUS_4X_PATTERN = /opus-4-(\d+)/
+
+/** A fallback model id Hive stores on the session (e.g. `opus-4-8`). */
+const FALLBACK_MODEL_ID_PATTERN = /^opus-4-(\d+)$/
+
+export interface ClaudeCliFallbackModel {
+  /** Stable, non-selectable model id stored on the session (e.g. `opus-4-8`). */
+  id: string
+  /** Human display name for badges/selectors (e.g. `Opus 4.8`). */
+  name: string
+}
+
+/**
+ * Resolve a raw CLI model (from the transcript, e.g. `claude-opus-4-8`) or an
+ * already-stored fallback id to its fallback descriptor, or null when it is a
+ * normal selectable model.
+ */
+export function resolveClaudeCliFallbackModel(
+  rawModel: string | null | undefined
+): ClaudeCliFallbackModel | null {
+  if (!rawModel) return null
+  const match = OPUS_4X_PATTERN.exec(rawModel.toLowerCase())
+  if (!match) return null
+  const minor = match[1]
+  return { id: `opus-4-${minor}`, name: `Opus 4.${minor}` }
+}
+
+/** True when a stored model id is a non-selectable safety/usage fallback. */
+export function isClaudeCliFallbackModelId(modelId: string | null | undefined): boolean {
+  return typeof modelId === 'string' && FALLBACK_MODEL_ID_PATTERN.test(modelId)
+}
+
+/** Display name for a stored fallback model id, or null when it is not one. */
+export function claudeCliFallbackModelName(modelId: string | null | undefined): string | null {
+  if (!modelId) return null
+  const match = FALLBACK_MODEL_ID_PATTERN.exec(modelId)
+  return match ? `Opus 4.${match[1]}` : null
+}


### PR DESCRIPTION
## Summary
- Seed model tracking across fresh and cleared transcripts.
- Detect safety or usage-limit fallbacks on the opening turn.
- Preserve the running CLI model across transcript path changes.
- Add regression tests for initial fallbacks and `/clear` behavior.

## Testing
- Added unit tests in `claude-cli-model-watcher.test.ts` covering opening-turn fallbacks, missing `SessionStart`, and `/clear` handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-process session `model_id` updates and baseline logic that must not replay stale transitions or clobber pending user model picks; behavior is well covered by new unit tests.
> 
> **Overview**
> Fixes **missed safety/usage degrades** when the first assistant line in a transcript is already a fallback model (e.g. Fable → Opus 4.8 on the opening turn). The Claude CLI model watcher now **seeds baseline tracking** from the launch model or the model carried across `/clear` and transcript path changes, so the first live line counts as an in-transcript switch instead of a silent baseline. **`/clear` with a pending UI model choice** no longer reverts the row by seeding from the running CLI alias instead of the ahead-of-CLI session row.
> 
> Introduces shared **`claude-cli-fallback-models`** so Opus 4.x fallbacks persist as distinct ids (e.g. `opus-4-8`) rather than the selectable `opus` alias. **Ticket badges** show names like "Opus 4.8" with an amber **fallback** tag; the **model selector** pill uses the same naming when the catalog has no entry.
> 
> Regression tests cover opening-turn fallbacks, missing `SessionStart`, `/clear`, and canonicalization vs Opus 5.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61eb166666d791e117c7140f82c71f3553c0f2cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->