### PR TITLE
Add usage refresh countdown to account popover

### DIFF
--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -8,6 +8,15 @@ import { useAccountStore, useUsageStore } from '@/stores'
 import { useAccountScheduleStore } from '@/stores/useAccountScheduleStore'
 import type { AccountMemberInfo } from './MemberAvatarStack'
 import type { OpenAIUsageData, UsageData } from '@shared/types/usage'
+import { nextUsageRefreshAt } from '@/hooks/useAccountScheduleRunner'
+
+// Default to "nothing scheduled" so the countdown stays hidden in the
+// unrelated tests, matching the real function's behavior when no session
+// is running.
+vi.mock('@/hooks/useAccountScheduleRunner', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/useAccountScheduleRunner')>()
+  return { ...actual, nextUsageRefreshAt: vi.fn(() => null) }
+})
 
 afterEach(() => {
   cleanup()
@@ -448,6 +457,96 @@ describe('UsageAccountRow', () => {
 
     expect(screen.queryByTestId('member-avatar')).toBeNull()
     expect(screen.queryByTestId('member-avatar-stack-loading')).toBeNull()
+  })
+})
+
+describe('UsageAccountRow refresh countdown', () => {
+  const initialLastFetchedAt = useUsageStore.getState().anthropicLastFetchedAt
+
+  beforeEach(() => {
+    vi.mocked(nextUsageRefreshAt).mockReturnValue(null)
+    useUsageStore.setState({ anthropicLastFetchedAt: null })
+  })
+
+  afterEach(() => {
+    useUsageStore.setState({ anthropicLastFetchedAt: initialLastFetchedAt })
+  })
+
+  const activeRow = {
+    id: 'acc-1',
+    email: 'active@example.com',
+    usage: sampleUsage,
+    status: 'ok' as const,
+    lastError: null,
+    isActive: true,
+    isRefreshing: false
+  }
+
+  it('shows a seconds countdown on the active row when a refresh is scheduled', () => {
+    vi.mocked(nextUsageRefreshAt).mockImplementation(() => Date.now() + 45_000)
+
+    render(<UsageAccountRow row={activeRow} provider="anthropic" onRefresh={vi.fn()} />)
+
+    expect(screen.getByTestId('usage-refresh-countdown').textContent).toMatch(
+      /^Refreshing in \d+ sec$/
+    )
+  })
+
+  it('shows minutes once the next refresh is over a minute away', () => {
+    vi.mocked(nextUsageRefreshAt).mockImplementation(() => Date.now() + 150_000)
+
+    render(<UsageAccountRow row={activeRow} provider="anthropic" onRefresh={vi.fn()} />)
+
+    expect(screen.getByTestId('usage-refresh-countdown').textContent).toMatch(
+      /^Refreshing in \d+ min$/
+    )
+  })
+
+  it('shows "Refreshing soon" when the scheduled time has already passed', () => {
+    vi.mocked(nextUsageRefreshAt).mockImplementation(() => Date.now() - 5_000)
+
+    render(<UsageAccountRow row={activeRow} provider="anthropic" onRefresh={vi.fn()} />)
+
+    expect(screen.getByTestId('usage-refresh-countdown').textContent).toBe('Refreshing soon')
+  })
+
+  it('shows how long ago usage was refreshed when nothing is scheduled', () => {
+    useUsageStore.setState({ anthropicLastFetchedAt: Date.now() - 5 * 60_000 })
+
+    render(<UsageAccountRow row={activeRow} provider="anthropic" onRefresh={vi.fn()} />)
+
+    expect(screen.getByTestId('usage-refresh-countdown').textContent).toMatch(
+      /^Refreshed \d+ min ago$/
+    )
+  })
+
+  it('shows "Refreshed just now" right after an idle refresh', () => {
+    useUsageStore.setState({ anthropicLastFetchedAt: Date.now() })
+
+    render(<UsageAccountRow row={activeRow} provider="anthropic" onRefresh={vi.fn()} />)
+
+    expect(screen.getByTestId('usage-refresh-countdown').textContent).toBe('Refreshed just now')
+  })
+
+  it('is hidden when nothing is scheduled and usage was never fetched', () => {
+    render(<UsageAccountRow row={activeRow} provider="anthropic" onRefresh={vi.fn()} />)
+
+    expect(screen.queryByTestId('usage-refresh-countdown')).toBeNull()
+  })
+
+  it('is hidden on inactive account rows', () => {
+    vi.mocked(nextUsageRefreshAt).mockImplementation(() => Date.now() + 45_000)
+
+    render(
+      <UsageAccountRow
+        row={{ ...activeRow, isActive: false }}
+        provider="anthropic"
+        onRefresh={vi.fn()}
+        onSwitch={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('usage-refresh-countdown')).toBeNull()
   })
 })
 

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -9,6 +9,8 @@ import {
   normalizeUsage
 } from '@/stores'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useTimerTickStore } from '@/stores/useTimerTickStore'
+import { nextUsageRefreshAt } from '@/hooks/useAccountScheduleRunner'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { reportActiveAccountsSnapshot } from '@/lib/hive-account-report'
 import { fetchHiveAccountMembers, isHiveTelemetryEnabled } from '@/api/hive-enterprise/client'
@@ -212,6 +214,52 @@ function usageFromSavedAccount(
   return normalizeUsage(provider, null, account.last_usage as OpenAIUsageData)
 }
 
+function formatRefreshCountdown(nextAt: number, nowMs: number): string {
+  const seconds = Math.ceil((nextAt - nowMs) / 1000)
+  if (seconds <= 0) return 'Refreshing soon'
+  if (seconds < 60) return `Refreshing in ${seconds} sec`
+  return `Refreshing in ${Math.ceil(seconds / 60)} min`
+}
+
+function formatRefreshedAgo(lastFetchedAt: number, nowMs: number): string {
+  const seconds = Math.max(0, Math.floor((nowMs - lastFetchedAt) / 1000))
+  if (seconds < 60) return 'Refreshed just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `Refreshed ${minutes} min ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `Refreshed ${hours} hr ago`
+  return `Refreshed ${Math.floor(hours / 24)}d ago`
+}
+
+/**
+ * Live "Refreshing in xx" label for the active account — shows when the
+ * schedule runner will next fetch this provider's usage. When nothing is
+ * scheduled (no running session for the provider), falls back to how long
+ * ago usage was last refreshed; hidden only when it never was.
+ */
+function RefreshCountdown({ provider }: { provider: UsageProvider }): React.JSX.Element | null {
+  const tickMs = useTimerTickStore((s) => s.tickMs)
+  const lastFetchedAt = useUsageStore((s) =>
+    provider === 'anthropic' ? s.anthropicLastFetchedAt : s.openaiLastFetchedAt
+  )
+  const nextAt = nextUsageRefreshAt(provider)
+  const label =
+    nextAt !== null
+      ? formatRefreshCountdown(nextAt, tickMs)
+      : lastFetchedAt !== null
+        ? formatRefreshedAgo(lastFetchedAt, tickMs)
+        : null
+  if (label === null) return null
+  return (
+    <span
+      className="ml-auto shrink-0 text-[9px] text-muted-foreground/70"
+      data-testid="usage-refresh-countdown"
+    >
+      {label}
+    </span>
+  )
+}
+
 export interface UsageAccountRowProps {
   row: AccountRowData
   provider?: UsageProvider
@@ -356,6 +404,7 @@ export function UsageAccountRow({
               Sign in again
             </button>
           )}
+          {row.isActive && provider && <RefreshCountdown provider={provider} />}
         </div>
       )}
 

--- a/src/renderer/src/hooks/useAccountScheduleRunner.ts
+++ b/src/renderer/src/hooks/useAccountScheduleRunner.ts
@@ -1,7 +1,11 @@
 import { useEffect } from 'react'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
-import { useUsageStore, resolveUsageProvider } from '@/stores/useUsageStore'
+import {
+  useUsageStore,
+  resolveUsageProvider,
+  USAGE_FETCH_DEBOUNCE_MS
+} from '@/stores/useUsageStore'
 import { useAccountScheduleStore, getActiveUsagePercent } from '@/stores/useAccountScheduleStore'
 import type { UsageProvider } from '@shared/types/usage'
 
@@ -63,17 +67,35 @@ function providersWithRunningSessions(): Set<UsageProvider> {
   return providers
 }
 
+// Failed fetches don't advance lastFetchedAt, so gate on our own attempt
+// time too — otherwise a flaky network turns the 5-minute refresh into
+// polling on every tick. Module scope so nextUsageRefreshAt can see it.
+const lastAttemptAt: Partial<Record<UsageProvider, number>> = {}
+
+/**
+ * When the runner will next fetch usage for `provider`, or null when no
+ * refresh is scheduled (no running session for that provider). Mirrors the
+ * tick's gating — interval since last fetch/attempt — floored by the store's
+ * fetch debounce, which would swallow an earlier attempt anyway.
+ */
+export function nextUsageRefreshAt(provider: UsageProvider): number | null {
+  if (!providersWithRunningSessions().has(provider)) return null
+  const usageStore = useUsageStore.getState()
+  const lastFetchedAt =
+    provider === 'anthropic' ? usageStore.anthropicLastFetchedAt : usageStore.openaiLastFetchedAt
+  const lastActivity = Math.max(lastFetchedAt ?? 0, lastAttemptAt[provider] ?? 0)
+  return Math.max(
+    lastActivity + usageRefreshIntervalMs(provider),
+    (lastFetchedAt ?? 0) + USAGE_FETCH_DEBOUNCE_MS
+  )
+}
+
 /**
  * Drives scheduled account switches (see useAccountScheduleStore) and the
  * mid-session usage refresh. Mount once at the app root.
  */
 export function useAccountScheduleRunner(): void {
   useEffect(() => {
-    // Failed fetches don't advance lastFetchedAt, so gate on our own attempt
-    // time too — otherwise a flaky network turns the 5-minute refresh into
-    // polling on every tick.
-    const lastAttemptAt: Partial<Record<UsageProvider, number>> = {}
-
     const tick = (): void => {
       const usageStore = useUsageStore.getState()
       for (const provider of providersWithRunningSessions()) {

--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -65,7 +65,10 @@ interface UsageState {
   fetchUsage: () => Promise<void>
 }
 
-const DEBOUNCE_MS = 180_000 // 3 minutes
+// Exported so the popover's "Refreshing in…" countdown can model the floor
+// this debounce puts under the scheduled refresh cadence.
+export const USAGE_FETCH_DEBOUNCE_MS = 180_000 // 3 minutes
+const DEBOUNCE_MS = USAGE_FETCH_DEBOUNCE_MS
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Summary
- Add a live refresh countdown for the active account’s usage popover row.
- Show seconds/minutes until the next scheduled refresh, or recent refresh age when idle.
- Expose refresh scheduling metadata and debounce timing for countdown calculations.
- Add coverage for countdown states and inactive or never-refreshed accounts.

## Testing
- Added Vitest coverage for scheduled, overdue, idle, and hidden countdown states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only labeling aligned with existing refresh scheduling; no auth or fetch logic changes beyond exposing timing helpers.
> 
> **Overview**
> The usage popover’s **active account row** now shows a small live label (`usage-refresh-countdown`) that updates via `useTimerTickStore`.
> 
> When a session is running for that provider, it counts down to the next scheduled usage fetch (**seconds/minutes**, or **“Refreshing soon”** if overdue), using the same gating as `useAccountScheduleRunner` through new **`nextUsageRefreshAt`**. With no scheduled refresh, it shows **how long ago** usage was last fetched; the label stays hidden if usage was never fetched or the row is inactive.
> 
> **`USAGE_FETCH_DEBOUNCE_MS`** is exported from the usage store so the countdown respects the fetch debounce floor. **`lastAttemptAt`** moves to module scope so failed attempts are reflected in the schedule prediction. Tests mock `nextUsageRefreshAt` by default and add cases for scheduled, idle, hidden, and inactive-row behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb8e3433795e7471d36565a6967ac0509f120cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->