### PR TITLE
Move tickets to Merged after PR merge

### DIFF
--- a/src/renderer/src/components/pr/PRNotificationStack.tsx
+++ b/src/renderer/src/components/pr/PRNotificationStack.tsx
@@ -17,6 +17,7 @@ import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { toast } from '@/lib/toast'
 import { gitApi } from '@/api/git-api'
+import { moveWorktreeTicketsToMerged } from '@/lib/pr-merge-ticket-move'
 
 // ---------------------------------------------------------------------------
 // Status icon
@@ -104,6 +105,7 @@ function PRNotificationCard({
       const result = await gitApi.prMerge(worktreePath, prNumber)
       if (result.success) {
         setMergePhase('merged')
+        void moveWorktreeTicketsToMerged(worktreeId, prNumber)
       } else {
         toast.error(`Merge failed: ${result.error}`)
         setMergePhase('idle')

--- a/src/renderer/src/hooks/useLifecycleActions.ts
+++ b/src/renderer/src/hooks/useLifecycleActions.ts
@@ -13,6 +13,7 @@ import { messageSendTimes, userExplicitSendTimes, lastSendMode } from '@/lib/mes
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
+import { moveWorktreeTicketsToMerged } from '@/lib/pr-merge-ticket-move'
 import { systemApi } from '@/api/system-api'
 import { opencodeApi } from '@/api/opencode-api'
 import { dbApi } from '@/api/db-api'
@@ -338,6 +339,7 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
       if (result.success) {
         toast.success('PR merged successfully')
         setPrLiveState((prev) => ({ state: 'MERGED', title: prev?.title }))
+        void moveWorktreeTicketsToMerged(worktreeId, pr.number)
         return true
       } else {
         toast.error(`Merge failed: ${result.error}`)

--- a/src/renderer/src/lib/__tests__/pr-merge-ticket-move.test.ts
+++ b/src/renderer/src/lib/__tests__/pr-merge-ticket-move.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KanbanTicket } from '../../../../main/db/types'
+
+const { moveTicket, rpcMove, rpcGetByProject } = vi.hoisted(() => ({
+  moveTicket: vi.fn().mockResolvedValue(undefined),
+  rpcMove: vi.fn().mockResolvedValue(undefined),
+  rpcGetByProject: vi.fn().mockResolvedValue([])
+}))
+
+vi.mock('@/api/kanban-api', () => ({
+  kanbanApi: {
+    ticket: {
+      move: rpcMove,
+      getByProject: rpcGetByProject
+    }
+  }
+}))
+
+vi.mock('@/stores/useKanbanStore', () => {
+  const state = { tickets: new Map<string, KanbanTicket[]>(), moveTicket }
+  return {
+    useKanbanStore: {
+      getState: () => state,
+      setState: (partial: Partial<typeof state>) => Object.assign(state, partial)
+    }
+  }
+})
+
+vi.mock('@/stores/useSettingsStore', () => {
+  const state = { showMergedColumn: true }
+  return {
+    useSettingsStore: {
+      getState: () => state,
+      setState: (partial: Partial<typeof state>) => Object.assign(state, partial)
+    }
+  }
+})
+
+vi.mock('@/stores/useWorktreeStore', () => {
+  const state = { worktreesByProject: new Map<string, Array<{ id: string }>>() }
+  return {
+    useWorktreeStore: {
+      getState: () => state,
+      setState: (partial: Partial<typeof state>) => Object.assign(state, partial)
+    }
+  }
+})
+
+import { moveWorktreeTicketsToMerged } from '../pr-merge-ticket-move'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+const PROJECT_ID = 'proj-1'
+const WORKTREE_ID = 'wt-1'
+
+// The mocked worktree store only needs `id` on its worktrees; the cast keeps
+// the real module's Worktree[] typing out of the fixture.
+const seedWorktreeProject = (): void => {
+  useWorktreeStore.setState({
+    worktreesByProject: new Map([[PROJECT_ID, [{ id: WORKTREE_ID }]]])
+  } as unknown as Parameters<typeof useWorktreeStore.setState>[0])
+}
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: PROJECT_ID,
+    title: 'A ticket',
+    description: null,
+    attachments: [],
+    column: 'review',
+    sort_order: 5,
+    current_session_id: null,
+    worktree_id: WORKTREE_ID,
+    mode: 'build',
+    plan_ready: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    column_changed_at: null,
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
+    created_from_session: true,
+    auto_approve_plan: false,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
+    ...overrides
+  } as KanbanTicket
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  rpcGetByProject.mockResolvedValue([])
+  useKanbanStore.setState({ tickets: new Map() })
+  useSettingsStore.setState({ showMergedColumn: true })
+  useWorktreeStore.setState({ worktreesByProject: new Map() })
+})
+
+afterEach(() => {
+  useKanbanStore.setState({ tickets: new Map() })
+})
+
+describe('moveWorktreeTicketsToMerged', () => {
+  it('moves the linked loaded ticket to the merged column', async () => {
+    useKanbanStore.setState({ tickets: new Map([[PROJECT_ID, [makeTicket()]]]) })
+
+    await moveWorktreeTicketsToMerged(WORKTREE_ID, 42)
+
+    expect(moveTicket).toHaveBeenCalledWith('ticket-1', PROJECT_ID, 'merged', 5)
+    expect(rpcGetByProject).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the merged column is hidden in settings', async () => {
+    useSettingsStore.setState({ showMergedColumn: false })
+    useKanbanStore.setState({ tickets: new Map([[PROJECT_ID, [makeTicket()]]]) })
+
+    await moveWorktreeTicketsToMerged(WORKTREE_ID, 42)
+
+    expect(moveTicket).not.toHaveBeenCalled()
+    expect(rpcMove).not.toHaveBeenCalled()
+  })
+
+  it('leaves terminal, archived, unrelated, and other-PR tickets in place', async () => {
+    useKanbanStore.setState({
+      tickets: new Map([
+        [
+          PROJECT_ID,
+          [
+            makeTicket({ id: 'done', column: 'done' }),
+            makeTicket({ id: 'merged', column: 'merged' }),
+            makeTicket({ id: 'archived', archived_at: '2026-01-02T00:00:00.000Z' }),
+            makeTicket({ id: 'other-worktree', worktree_id: 'wt-other' }),
+            makeTicket({ id: 'other-pr', github_pr_number: 7 }),
+            makeTicket({ id: 'same-pr', github_pr_number: 42 })
+          ]
+        ]
+      ])
+    })
+
+    await moveWorktreeTicketsToMerged(WORKTREE_ID, 42)
+
+    expect(moveTicket).toHaveBeenCalledTimes(1)
+    expect(moveTicket).toHaveBeenCalledWith('same-pr', PROJECT_ID, 'merged', 5)
+  })
+
+  it('falls back to a DB fetch + RPC move when the project board was never loaded', async () => {
+    seedWorktreeProject()
+    rpcGetByProject.mockResolvedValue([makeTicket({ id: 'db-ticket', sort_order: 3 })])
+
+    await moveWorktreeTicketsToMerged(WORKTREE_ID, 42)
+
+    expect(moveTicket).not.toHaveBeenCalled()
+    expect(rpcGetByProject).toHaveBeenCalledWith(PROJECT_ID, false)
+    expect(rpcMove).toHaveBeenCalledWith(PROJECT_ID, 'db-ticket', 'merged', 3)
+  })
+
+  it('skips the DB fallback when the worktree project is already loaded', async () => {
+    useKanbanStore.setState({ tickets: new Map([[PROJECT_ID, [makeTicket()]]]) })
+    seedWorktreeProject()
+
+    await moveWorktreeTicketsToMerged(WORKTREE_ID, 42)
+
+    expect(moveTicket).toHaveBeenCalledTimes(1)
+    expect(rpcGetByProject).not.toHaveBeenCalled()
+  })
+
+  it('swallows move failures instead of rejecting', async () => {
+    moveTicket.mockRejectedValueOnce(new Error('boom'))
+    useKanbanStore.setState({ tickets: new Map([[PROJECT_ID, [makeTicket()]]]) })
+
+    await expect(moveWorktreeTicketsToMerged(WORKTREE_ID, 42)).resolves.toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/pr-merge-ticket-move.ts
+++ b/src/renderer/src/lib/pr-merge-ticket-move.ts
@@ -1,0 +1,68 @@
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { kanbanApi } from '@/api/kanban-api'
+import type { KanbanTicket } from '../../../main/db/types'
+
+function resolveProjectIdForWorktree(worktreeId: string): string | null {
+  for (const [projectId, worktrees] of useWorktreeStore.getState().worktreesByProject) {
+    if (worktrees.some((w) => w.id === worktreeId)) return projectId
+  }
+  return null
+}
+
+/**
+ * After a PR merge succeeds, advance the worktree's linked tickets to the
+ * Merged column — only when that column exists on the board (the
+ * showMergedColumn setting). Terminal-column tickets stay put: done/merged
+ * are already final, and a ticket carrying a different PR number belongs to
+ * another PR's lifecycle.
+ */
+export async function moveWorktreeTicketsToMerged(
+  worktreeId: string,
+  prNumber?: number
+): Promise<void> {
+  try {
+    if (!useSettingsStore.getState().showMergedColumn) return
+
+    const shouldMove = (t: KanbanTicket): boolean =>
+      t.worktree_id === worktreeId &&
+      !t.archived_at &&
+      t.column !== 'merged' &&
+      t.column !== 'done' &&
+      (prNumber == null || t.github_pr_number == null || t.github_pr_number === prNumber)
+
+    // Tickets already loaded in the store move via moveTicket so any open
+    // board updates optimistically and completion effects (dependent
+    // auto-launch) fire, matching a manual drag onto Merged.
+    const kanban = useKanbanStore.getState()
+    const loadedProjectIds = new Set<string>()
+    const loadedMoves: Array<Promise<void>> = []
+    for (const [projectId, tickets] of kanban.tickets) {
+      loadedProjectIds.add(projectId)
+      for (const ticket of tickets) {
+        if (!shouldMove(ticket)) continue
+        loadedMoves.push(
+          kanban.moveTicket(ticket.id, projectId, 'merged', ticket.sort_order).catch(() => {})
+        )
+      }
+    }
+    await Promise.all(loadedMoves)
+
+    // The worktree's board may never have been opened this session — its
+    // tickets then only exist in the DB, so move them through the RPC
+    // directly (no store state to keep in sync).
+    const projectId = resolveProjectIdForWorktree(worktreeId)
+    if (!projectId || loadedProjectIds.has(projectId)) return
+    const dbTickets = await kanbanApi.ticket.getByProject<KanbanTicket>(projectId, false)
+    await Promise.all(
+      dbTickets
+        .filter(shouldMove)
+        .map((t) =>
+          kanbanApi.ticket.move(projectId, t.id, 'merged', t.sort_order).catch(() => {})
+        )
+    )
+  } catch {
+    // Best-effort: a failed board sync must never surface as a merge failure.
+  }
+}


### PR DESCRIPTION
## Summary

- Automatically moves eligible worktree tickets to the Merged column after a successful PR merge.
- Supports both loaded kanban boards and database fallback updates.
- Preserves terminal, archived, unrelated, and differently linked PR tickets.
- Adds coverage for visibility settings, fallback behavior, and failure handling.

## Testing

- Added Vitest coverage for loaded-board moves, database fallback moves, filtering, hidden Merged columns, and swallowed failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort kanban column updates after merge with guarded filtering and no change to git merge behavior; failures are non-blocking.
> 
> **Overview**
> After a successful PR merge (from the notification stack or lifecycle actions), eligible kanban tickets for that worktree are moved to **Merged** automatically when `showMergedColumn` is enabled.
> 
> A new helper `moveWorktreeTicketsToMerged` applies filtering: same worktree, not archived, not already in `done`/`merged`, and PR-linked tickets only when they match the merged PR (or have no PR number). Loaded boards use `moveTicket` for optimistic UI and side effects; if that project’s board was never opened, it fetches tickets via RPC and moves them in the DB. Failures are swallowed so merge success is never blocked.
> 
> Vitest coverage was added for the main paths, settings gate, filtering, DB fallback, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3155802a310727daa038374a1ea88929047f30e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->