### PR TITLE
Autofill email for Sign in again login

### DIFF
--- a/src/main/services/__tests__/login-service.test.ts
+++ b/src/main/services/__tests__/login-service.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  loginCancel,
+  loginStart,
+  setLoginBrowserLauncherForTests,
+  type BrowserContextLike,
+  type ElementHandleLike,
+  type PageLike
+} from '../login-service'
+
+vi.mock('fs/promises', () => ({
+  mkdir: vi.fn(async () => undefined)
+}))
+
+vi.mock('../../db', () => ({
+  getDatabase: vi.fn(() => ({
+    getSavedUsageAccountByProviderEmail: vi.fn(() => null)
+  }))
+}))
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+vi.mock('../account-store-claude', () => ({
+  addClaudeAccount: vi.fn(async () => undefined)
+}))
+
+vi.mock('../account-store-codex', () => ({
+  addCodexAccount: vi.fn(async () => ({ email: 'x@y.com' }))
+}))
+
+vi.mock('../saved-usage-orchestrator', () => ({
+  listSavedAccounts: vi.fn(async () => []),
+  fetchForSavedAccount: vi.fn(async () => undefined)
+}))
+
+interface FakeButton extends ElementHandleLike {
+  click: ReturnType<typeof vi.fn>
+}
+
+function makeElement(label: string): FakeButton {
+  return {
+    click: vi.fn(async () => undefined),
+    fill: vi.fn(async () => undefined),
+    press: vi.fn(async () => undefined),
+    innerText: vi.fn(async () => label),
+    getAttribute: vi.fn(async () => null),
+    isVisible: vi.fn(async () => true),
+    isEnabled: vi.fn(async () => true)
+  }
+}
+
+interface FakeDriver {
+  context: BrowserContextLike
+  page: PageLike
+  emailInput: FakeButton
+  buttons: FakeButton[]
+}
+
+function makeFakeDriver(options?: { hasEmailInput?: boolean; buttons?: FakeButton[] }): FakeDriver {
+  const emailInput = makeElement('')
+  const buttons = options?.buttons ?? []
+  const page: PageLike = {
+    goto: vi.fn(async () => undefined),
+    on: vi.fn(),
+    mainFrame: () => ({ url: () => 'about:blank' }),
+    waitForSelector: vi.fn(async (selector: string) => {
+      if (options?.hasEmailInput === false) throw new Error('timeout')
+      return selector === 'input[type="email"]' ? emailInput : null
+    }),
+    $$: vi.fn(async () => buttons)
+  }
+  const context: BrowserContextLike = {
+    pages: () => [page],
+    newPage: async () => page,
+    route: vi.fn(async () => undefined),
+    on: vi.fn(),
+    close: vi.fn(async () => undefined)
+  }
+  return { context, page, emailInput, buttons }
+}
+
+describe.runIf(process.platform === 'darwin')('loginStart email autofill', () => {
+  let activeLoginId: string | null = null
+
+  beforeEach(() => {
+    activeLoginId = null
+  })
+
+  afterEach(async () => {
+    if (activeLoginId) await loginCancel(activeLoginId)
+    setLoginBrowserLauncherForTests(null)
+    vi.clearAllMocks()
+  })
+
+  async function start(driver: FakeDriver, email?: string): Promise<string> {
+    setLoginBrowserLauncherForTests(async () => driver.context)
+    const { loginId } = await loginStart('anthropic', email)
+    activeLoginId = loginId
+    return loginId
+  }
+
+  it('fills the email and clicks the email submit button, skipping social buttons', async () => {
+    const social = makeElement('Continue with Google')
+    const submit = makeElement('Continue with email')
+    const driver = makeFakeDriver({ buttons: [social, submit] })
+
+    await start(driver, 'user@example.com')
+
+    await vi.waitFor(() => expect(submit.click).toHaveBeenCalled())
+    expect(driver.emailInput.fill).toHaveBeenCalledWith('user@example.com')
+    expect(social.click).not.toHaveBeenCalled()
+  })
+
+  it('presses Enter on the input when no submit button is found', async () => {
+    const driver = makeFakeDriver({ buttons: [makeElement('Continue with Google')] })
+
+    await start(driver, 'user@example.com')
+
+    await vi.waitFor(() => expect(driver.emailInput.press).toHaveBeenCalledWith('Enter'))
+    expect(driver.emailInput.fill).toHaveBeenCalledWith('user@example.com')
+  })
+
+  it('does not touch the page when no email hint is given', async () => {
+    const driver = makeFakeDriver()
+
+    await start(driver)
+
+    // Give any (buggy) fire-and-forget autofill a beat to run.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(driver.page.waitForSelector).not.toHaveBeenCalled()
+    expect(driver.emailInput.fill).not.toHaveBeenCalled()
+  })
+
+  it('leaves the login waiting when the email field never appears', async () => {
+    const driver = makeFakeDriver({ hasEmailInput: false })
+
+    const loginId = await start(driver, 'user@example.com')
+
+    await vi.waitFor(() =>
+      expect(vi.mocked(driver.page.waitForSelector)).toHaveBeenCalledTimes(6)
+    )
+    expect(driver.emailInput.fill).not.toHaveBeenCalled()
+
+    const { loginStatus } = await import('../login-service')
+    expect(loginStatus(loginId).state).toBe('waiting')
+  })
+})

--- a/src/main/services/login-service.ts
+++ b/src/main/services/login-service.ts
@@ -3,9 +3,10 @@
  * stealth-patched Playwright) with a persistent per-account profile, navigates
  * to the provider's authorize URL, captures the resulting `code`/`state` from
  * the redirect, exchanges it for tokens, and stores the account. TypeScript
- * port of ccswitch's manual-login path (`login-sidecar/login.mjs` capture
- * mechanics + `src/login.rs` orchestration) — no email autofill, no OTP
- * control channel.
+ * port of ccswitch's manual-login path (`login-sidecar/login.mjs` capture +
+ * email-autofill mechanics + `src/login.rs` orchestration) — no OTP control
+ * channel. When an email hint is provided (e.g. "Sign in again" on a known
+ * account), the provider's email field is auto-filled and submitted.
  *
  * Runs in-process (in the spawned server process) rather than as a sidecar.
  * `patchright` is loaded via dynamic `import()` inside `loginStart` so that
@@ -61,10 +62,25 @@ export interface FrameLike {
   url: () => string
 }
 
+export interface ElementHandleLike {
+  click: (options?: { clickCount?: number }) => Promise<void>
+  fill: (value: string) => Promise<void>
+  press: (key: string) => Promise<void>
+  innerText: () => Promise<string>
+  getAttribute: (name: string) => Promise<string | null>
+  isVisible: () => Promise<boolean>
+  isEnabled: () => Promise<boolean>
+}
+
 export interface PageLike {
   goto: (url: string) => Promise<unknown>
   on: (event: 'framenavigated', handler: (frame: FrameLike) => void) => void
   mainFrame: () => FrameLike
+  waitForSelector: (
+    selector: string,
+    options: { timeout: number; state: 'visible' }
+  ) => Promise<ElementHandleLike | null>
+  $$: (selector: string) => Promise<ElementHandleLike[]>
 }
 
 export interface BrowserContextLike {
@@ -352,6 +368,107 @@ async function runLoginFlow(session: LoginSession, emailHint?: string): Promise<
     await page.goto(authorizeUrl)
   } catch (error) {
     failSession(session, error instanceof Error ? error.message : String(error))
+    return
+  }
+
+  // Best-effort, fire-and-forget: never blocks or fails the login. If the
+  // profile still has a live session, the provider skips the email form and
+  // this quietly finds nothing to fill.
+  if (emailHint) {
+    void autofillEmail(session, page, emailHint)
+  }
+}
+
+// ─── Email autofill (port of login.mjs submitEmail/clickByText) ───────────
+
+const EMAIL_INPUT_SELECTORS = [
+  'input[type="email"]',
+  'input[name="email"]',
+  'input[autocomplete="username"]',
+  'input[name="username"]',
+  'input[id*="email" i]',
+  'input[type="text"]'
+]
+
+const EMAIL_SUBMIT_PATTERNS = [
+  /continue with email/i,
+  /^continue$/i,
+  /^next$/i,
+  /^log ?in$/i,
+  /^sign ?in$/i,
+  /^submit$/i
+]
+
+/** Social-provider buttons ("Continue with Google/Apple/…") sit next to the email form — never click those. */
+const SOCIAL_BUTTON_PATTERN = /google|apple|microsoft|phone|passkey|sso|saml|facebook|github|okta/i
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function clickByText(
+  page: PageLike,
+  patterns: RegExp[],
+  exclude?: RegExp
+): Promise<boolean> {
+  const buttons = await page.$$('button, [role="button"], input[type="submit"], a')
+  for (const button of buttons) {
+    let label = ''
+    try {
+      label =
+        (await button.innerText().catch(() => '')) ||
+        (await button.getAttribute('value').catch(() => null)) ||
+        ''
+    } catch {
+      // ignore — treat as unlabeled
+    }
+    label = label.trim()
+    if (!label) continue
+    if (exclude && exclude.test(label)) continue
+    if (patterns.some((re) => re.test(label))) {
+      const visible = await button.isVisible().catch(() => false)
+      const enabled = await button.isEnabled().catch(() => true)
+      if (visible && enabled) {
+        await button.click().catch(() => {})
+        return true
+      }
+    }
+  }
+  return false
+}
+
+async function autofillEmail(session: LoginSession, page: PageLike, email: string): Promise<void> {
+  try {
+    let input: ElementHandleLike | null = null
+    for (const selector of EMAIL_INPUT_SELECTORS) {
+      // The redirect may already have been captured (profile still signed in),
+      // or the user may have cancelled — stop poking at the page.
+      if (isTerminal(session.state) || session.resolved) return
+      try {
+        input = await page.waitForSelector(selector, { timeout: 8000, state: 'visible' })
+        if (input) break
+      } catch {
+        // selector not found within the timeout — try the next one
+      }
+    }
+    if (!input) {
+      log.info('Email field not found for autofill', { loginId: session.loginId })
+      return
+    }
+    if (isTerminal(session.state) || session.resolved) return
+
+    await input.click({ clickCount: 3 }).catch(() => {})
+    await input.fill(email)
+    await sleep(200)
+
+    const clicked = await clickByText(page, EMAIL_SUBMIT_PATTERNS, SOCIAL_BUTTON_PATTERN)
+    if (!clicked) {
+      await input.press('Enter').catch(() => {})
+    }
+    log.info('Email autofilled and submitted', { loginId: session.loginId })
+  } catch (error) {
+    log.warn('Email autofill failed', {
+      loginId: session.loginId,
+      error: error instanceof Error ? error.message : String(error)
+    })
   }
 }
 


### PR DESCRIPTION
## Summary

- Add best-effort email autofill and submission during login flows with an email hint.
- Skip social sign-in buttons and fall back to pressing Enter when no email submit button is found.
- Add macOS-focused unit tests covering autofill, fallback submission, missing hints, and unavailable fields.

## Testing

- Added Vitest coverage for the login email autofill flow.
- Tests run only on macOS via `describe.runIf(process.platform === 'darwin')`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 743a2db52aeeb1eef74da649d65afac996a38b62. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->