### PR TITLE
connection-dragging-to-merged-co

### DIFF
--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -40,6 +40,7 @@ import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { isBlockerSatisfied } from '@/lib/blocker-utils'
+import { buildConnectionMergeQueue, resolveTicketConnectionId } from '@/lib/connection-merge'
 import type {
   KanbanTicket,
   KanbanTicketColumn as ColumnType,
@@ -661,6 +662,40 @@ export function KanbanColumn({
                   // No base worktree OR nothing to commit/merge — fall through to normal move
                 }
               }
+            } catch (err) {
+              toast.warning(
+                `Could not verify merge status: ${err instanceof Error ? err.message : String(err)}`
+              )
+              return
+            }
+          } else if (draggedTicket?.current_session_id) {
+            // Connection tickets have no worktree_id — queue the merge flow
+            // once per member worktree with work to merge, then move the ticket
+            try {
+              const ticketConnectionId = await resolveTicketConnectionId(
+                draggedTicket.current_session_id
+              )
+              if (ticketConnectionId) {
+                const mergeQueue = await buildConnectionMergeQueue(ticketConnectionId)
+                if (mergeQueue.length > 0) {
+                  const [firstTarget, ...restTargets] = mergeQueue
+                  const sortOrder = store.computeSortOrder(
+                    projectTicketsForColumn(ticketProjectId),
+                    projectLocalDropIndex(ticketProjectId, targetIndex)
+                  )
+                  store.setPendingDoneMove({
+                    ticketId,
+                    projectId: ticketProjectId,
+                    sortOrder,
+                    targetColumn: column,
+                    worktreeId: firstTarget.worktreeId,
+                    worktreeProjectId: firstTarget.projectId,
+                    remainingWorktrees: restTargets
+                  })
+                  return
+                }
+              }
+              // No connection or nothing to merge — fall through to normal move
             } catch (err) {
               toast.warning(
                 `Could not verify merge status: ${err instanceof Error ? err.message : String(err)}`

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -300,10 +300,12 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
 
   const conflictTargetWorktreeId = useWorktreeStatusStore(
     useCallback(
+      // Check the per-ticket map first — connection tickets have no
+      // worktree_id but still record a conflict target on failed merges
       (state) =>
-        ticket.worktree_id
-          ? (state.mergeConflictWorktreeByTicket[ticketKey(ticket.project_id, ticket.id)] ?? ticket.worktree_id)
-          : null,
+        state.mergeConflictWorktreeByTicket[ticketKey(ticket.project_id, ticket.id)] ??
+        ticket.worktree_id ??
+        null,
       [ticket.id, ticket.project_id, ticket.worktree_id]
     )
   )

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -535,21 +535,21 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
 
   const rightAlignedSlot: 'conflicts' | 'busy' | 'reviewing' | 'completed-review' | null =
     useMemo(() => {
-      if (!isArchived && hasConflicts && ticket.worktree_id) return 'conflicts'
+      if (!isArchived && hasConflicts && conflictTargetWorktreeId) return 'conflicts'
       if ((isBusy || isAsking) && ticket.mode && !isBlocked) return 'busy'
       if (isBeingReviewed) return 'reviewing'
       if (completedReviewSessionId) return 'completed-review'
       return null
     }, [
       completedReviewSessionId,
+      conflictTargetWorktreeId,
       hasConflicts,
       isArchived,
       isAsking,
       isBeingReviewed,
       isBlocked,
       isBusy,
-      ticket.mode,
-      ticket.worktree_id
+      ticket.mode
     ])
   const hasRightAlignedStatus = rightAlignedSlot !== null
 

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -645,7 +645,7 @@ function MergeConflictBanner({ ticket }: { ticket: KanbanTicket }) {
   const mergeConflictMode = useSettingsStore((s) => s.mergeConflictMode)
   const { startFixFlow, openAttachedSession } = useConflictFixFlow(conflictTargetWorktreeId)
 
-  if (!ticket.worktree_id || ticket.archived_at || !hasConflicts) return null
+  if (!conflictTargetWorktreeId || ticket.archived_at || !hasConflicts) return null
 
   const isConflictFlowActive =
     conflictFlow?.phase === 'starting' ||

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -605,11 +605,12 @@ export function KanbanTicketModal() {
 function MergeConflictBanner({ ticket }: { ticket: KanbanTicket }) {
   const conflictTargetWorktreeId = useWorktreeStatusStore(
     useCallback(
+      // Check the per-ticket map first — connection tickets have no
+      // worktree_id but still record a conflict target on failed merges
       (state) =>
-        ticket.worktree_id
-          ? (state.mergeConflictWorktreeByTicket[ticketKey(ticket.project_id, ticket.id)] ??
-            ticket.worktree_id)
-          : null,
+        state.mergeConflictWorktreeByTicket[ticketKey(ticket.project_id, ticket.id)] ??
+        ticket.worktree_id ??
+        null,
       [ticket.id, ticket.project_id, ticket.worktree_id]
     )
   )

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.test.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.test.tsx
@@ -190,3 +190,77 @@ describe('MergeOnDoneDialog — already-merged branch', () => {
     expect(moveTicketMock).not.toHaveBeenCalled()
   })
 })
+
+describe('MergeOnDoneDialog — connection member queue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    moveTicketMock.mockResolvedValue(undefined)
+    archiveWorktreeMock.mockResolvedValue({ success: true })
+    mockAlreadyMergedBranch()
+    setupStores()
+    // Connection tickets have no worktree_id — the queue supplies it
+    useKanbanStore.setState({
+      tickets: new Map([['project-1', [{ ...ticket, worktree_id: null }]]]),
+      pendingDoneMove: {
+        ticketId: 'ticket-1',
+        projectId: 'project-1',
+        sortOrder: 5,
+        targetColumn: 'merged',
+        worktreeId: 'worktree-1',
+        worktreeProjectId: 'project-1',
+        remainingWorktrees: [{ worktreeId: 'worktree-next', projectId: 'project-2' }]
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useKanbanStore.setState({ pendingDoneMove: null })
+  })
+
+  it('advances the queue after a successful merge instead of offering archive', async () => {
+    gitApiMocks.branchDiffShortStat.mockResolvedValue({
+      success: true,
+      filesChanged: 2,
+      insertions: 10,
+      deletions: 3,
+      commitsAhead: 1
+    })
+    gitApiMocks.getRemoteUrl.mockResolvedValue({ url: null })
+    gitApiMocks.merge.mockResolvedValue({ success: true })
+
+    render(<MergeOnDoneDialog />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Merge' }))
+
+    await waitFor(() =>
+      expect(useKanbanStore.getState().pendingDoneMove?.worktreeId).toBe('worktree-next')
+    )
+    expect(gitApiMocks.merge).toHaveBeenCalledWith('/repo/main', 'feature')
+    expect(moveTicketMock).not.toHaveBeenCalled()
+    expect(archiveWorktreeMock).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: 'Archive' })).toBeNull()
+  })
+
+  it('skips the archive prompt for an already-merged member and moves after the last one', async () => {
+    useKanbanStore.setState({
+      pendingDoneMove: {
+        ticketId: 'ticket-1',
+        projectId: 'project-1',
+        sortOrder: 5,
+        targetColumn: 'merged',
+        worktreeId: 'worktree-1',
+        worktreeProjectId: 'project-1',
+        remainingWorktrees: []
+      }
+    })
+
+    render(<MergeOnDoneDialog />)
+
+    await waitFor(() =>
+      expect(moveTicketMock).toHaveBeenCalledWith('ticket-1', 'project-1', 'merged', 5)
+    )
+    expect(archiveWorktreeMock).not.toHaveBeenCalled()
+    expect(screen.queryByText(/Branch already merged/)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ticketKey, useKanbanStore } from '@/stores/useKanbanStore'
 import { useGitStore } from '@/stores/useGitStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
@@ -56,6 +56,20 @@ export function MergeOnDoneDialog() {
   const pendingDoneMove = useKanbanStore((s) => s.pendingDoneMove)
   const completeDoneMove = useKanbanStore((s) => s.completeDoneMove)
   const clearPendingDoneMove = useKanbanStore((s) => s.clearPendingDoneMove)
+
+  // Identity passed to completeDoneMove so a stale async completion (e.g. a
+  // merge resolving after dismissal) can't act on a replacement pending move
+  const pendingIdentity = useMemo(
+    () =>
+      pendingDoneMove
+        ? {
+            ticketId: pendingDoneMove.ticketId,
+            projectId: pendingDoneMove.projectId,
+            worktreeId: pendingDoneMove.worktreeId
+          }
+        : undefined,
+    [pendingDoneMove]
+  )
 
   const [step, setStep] = useState<Step>('loading')
   const [resolved, setResolved] = useState<ResolvedState | null>(null)
@@ -181,7 +195,11 @@ export function MergeOnDoneDialog() {
         // Connection members never get the archive prompt — archiving would
         // tear the worktree out of the connection (symlink + membership)
         if (pending.worktreeId && alreadyMerged) {
-          await completeDoneMove()
+          await completeDoneMove({
+            ticketId: pending.ticketId,
+            projectId: pending.projectId,
+            worktreeId: pending.worktreeId
+          })
           return
         }
 
@@ -271,14 +289,14 @@ export function MergeOnDoneDialog() {
         setStep('merge')
       } else {
         // No divergence after commit — base already has everything
-        await completeDoneMove()
+        await completeDoneMove(pendingIdentity)
       }
     } catch (err) {
       toast.error(`Commit failed: ${err instanceof Error ? err.message : String(err)}`)
     } finally {
       setCommitting(false)
     }
-  }, [resolved, commitMessage, completeDoneMove, clearPendingDoneMove])
+  }, [resolved, commitMessage, pendingIdentity, completeDoneMove, clearPendingDoneMove])
 
   const handleCommitBase = useCallback(async () => {
     if (!resolved || !baseCommitMessage.trim()) return
@@ -331,7 +349,7 @@ export function MergeOnDoneDialog() {
           )
           setStep('merge')
         } else {
-          await completeDoneMove()
+          await completeDoneMove(pendingIdentity)
         }
       }
     } catch (err) {
@@ -339,7 +357,7 @@ export function MergeOnDoneDialog() {
     } finally {
       setCommittingBase(false)
     }
-  }, [resolved, baseCommitMessage, completeDoneMove, clearPendingDoneMove])
+  }, [resolved, baseCommitMessage, pendingIdentity, completeDoneMove, clearPendingDoneMove])
 
   const handleMerge = useCallback(async () => {
     if (!resolved || !pendingDoneMove) return
@@ -387,7 +405,7 @@ export function MergeOnDoneDialog() {
       // Connection members advance the queue instead of offering the
       // destructive archive step (see init)
       if (pendingDoneMove.worktreeId) {
-        await completeDoneMove()
+        await completeDoneMove(pendingIdentity)
         return
       }
       setStep('archive')
@@ -397,7 +415,7 @@ export function MergeOnDoneDialog() {
     } finally {
       setMerging(false)
     }
-  }, [resolved, pendingDoneMove, completeDoneMove, clearPendingDoneMove])
+  }, [resolved, pendingDoneMove, pendingIdentity, completeDoneMove, clearPendingDoneMove])
 
   const handleArchive = useCallback(async () => {
     if (!resolved) return
@@ -411,7 +429,7 @@ export function MergeOnDoneDialog() {
 
     try {
       setArchiving(true)
-      await completeDoneMove()
+      await completeDoneMove(pendingIdentity)
     } catch (err) {
       setArchiving(false)
       toast.error(
@@ -438,7 +456,7 @@ export function MergeOnDoneDialog() {
       .catch((err) => {
         toast.error(`Archive failed: ${err instanceof Error ? err.message : String(err)}`)
       })
-  }, [resolved, completeDoneMove])
+  }, [resolved, pendingIdentity, completeDoneMove])
 
   // The dialog serves both the Done and the optional Merged column
   const targetLabel = pendingDoneMove?.targetColumn === 'merged' ? 'Merged' : 'Done'
@@ -517,7 +535,7 @@ export function MergeOnDoneDialog() {
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => completeDoneMove()}
+                  onClick={() => completeDoneMove(pendingIdentity)}
                   disabled={committingBase}
                 >
                   Move to {targetLabel} anyway
@@ -562,7 +580,7 @@ export function MergeOnDoneDialog() {
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => completeDoneMove()}
+                  onClick={() => completeDoneMove(pendingIdentity)}
                   disabled={committing}
                 >
                   Move to {targetLabel} anyway
@@ -608,7 +626,7 @@ export function MergeOnDoneDialog() {
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => completeDoneMove()}
+                  onClick={() => completeDoneMove(pendingIdentity)}
                   disabled={merging}
                 >
                   Move to {targetLabel} anyway
@@ -633,7 +651,7 @@ export function MergeOnDoneDialog() {
               <code className="bg-muted px-1 rounded">{resolved.featureBranch}</code> worktree?
             </p>
             <div className="flex items-center justify-between">
-              <Button variant="outline" size="sm" onClick={() => completeDoneMove()}>
+              <Button variant="outline" size="sm" onClick={() => completeDoneMove(pendingIdentity)}>
                 Keep
               </Button>
               <Button size="sm" onClick={handleArchive} disabled={archiving}>

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -25,6 +25,7 @@ type MergeWorktree = {
 
 type MergeProject = {
   path: string
+  name?: string
 }
 
 interface BranchStats {
@@ -43,6 +44,7 @@ interface ResolvedState {
   baseBranch: string
   ticketTitle: string
   projectPath: string
+  projectName: string | null
   uncommittedStats: { filesChanged: number; insertions: number; deletions: number }
   baseUncommittedStats: { filesChanged: number; insertions: number; deletions: number }
   baseDirty: boolean
@@ -84,22 +86,25 @@ export function MergeOnDoneDialog() {
         const tickets = useKanbanStore.getState().getTicketsForProject(pending.projectId)
         const ticket = tickets.find((t) => t.id === pending.ticketId)
 
-        if (!ticket || !ticket.worktree_id) {
+        // Connection tickets carry no worktree_id — the drop handler queues
+        // each member worktree explicitly via pending.worktreeId
+        const mergeWorktreeId = pending.worktreeId ?? ticket?.worktree_id
+        if (!ticket || !mergeWorktreeId) {
           clearPendingDoneMove()
           return
         }
 
         // Fetch feature worktree
-        const featureWorktree = await dbApi.worktree.get<MergeWorktree>(ticket.worktree_id)
+        const featureWorktree = await dbApi.worktree.get<MergeWorktree>(mergeWorktreeId)
         if (!featureWorktree || featureWorktree.status !== 'active') {
           toast.warning('Cannot merge — feature worktree is not active')
           clearPendingDoneMove()
           return
         }
 
-        // Resolve base branch
+        // Resolve base branch (connection members may live in another project)
         const activeWorktrees = await dbApi.worktree.getActiveByProject<MergeWorktree>(
-          pending.projectId
+          pending.worktreeProjectId ?? pending.projectId
         )
         const defaultWt = activeWorktrees.find((w) => w.is_default)
         const resolvedBaseBranch = featureWorktree.base_branch ?? defaultWt?.branch_name
@@ -186,6 +191,7 @@ export function MergeOnDoneDialog() {
           baseBranch: resolvedBaseBranch,
           ticketTitle: ticket.title,
           projectPath: project?.path ?? baseWorktree.path,
+          projectName: project?.name ?? null,
           uncommittedStats,
           baseUncommittedStats,
           baseDirty,
@@ -419,6 +425,10 @@ export function MergeOnDoneDialog() {
   // The dialog serves both the Done and the optional Merged column
   const targetLabel = pendingDoneMove?.targetColumn === 'merged' ? 'Merged' : 'Done'
 
+  // Connection tickets run this dialog once per member worktree with changes
+  const isConnectionFlow = !!pendingDoneMove?.worktreeId
+  const remainingCount = pendingDoneMove?.remainingWorktrees?.length ?? 0
+
   const stepTitle: Record<Step, string> = {
     loading: `Moving to ${targetLabel}...`,
     commit_base: 'Uncommitted changes on base',
@@ -447,6 +457,14 @@ export function MergeOnDoneDialog() {
           <DialogTitle className="flex items-center gap-2 text-sm">
             {stepIcon[step]}
             {stepTitle[step]}
+            {isConnectionFlow && resolved?.projectName && (
+              <span className="font-normal text-muted-foreground">— {resolved.projectName}</span>
+            )}
+            {isConnectionFlow && remainingCount > 0 && (
+              <span className="text-xs font-normal text-muted-foreground">
+                ({remainingCount} more project{remainingCount !== 1 ? 's' : ''})
+              </span>
+            )}
           </DialogTitle>
         </DialogHeader>
 

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -178,6 +178,13 @@ export function MergeOnDoneDialog() {
         // commit/merge steps but still offer the archive/keep choice
         const alreadyMerged = !hasUncommitted && branchStats.commitsAhead === 0
 
+        // Connection members never get the archive prompt — archiving would
+        // tear the worktree out of the connection (symlink + membership)
+        if (pending.worktreeId && alreadyMerged) {
+          await completeDoneMove()
+          return
+        }
+
         // Get project path for archive step
         const project = await dbApi.project.get<MergeProject>(featureWorktree.project_id)
         if (cancelled) return
@@ -372,6 +379,12 @@ export function MergeOnDoneDialog() {
       }
 
       toast.success('Branch merged successfully')
+      // Connection members advance the queue instead of offering the
+      // destructive archive step (see init)
+      if (pendingDoneMove.worktreeId) {
+        await completeDoneMove()
+        return
+      }
       setStep('archive')
     } catch (err) {
       toast.error(`Merge failed: ${err instanceof Error ? err.message : String(err)}`)
@@ -379,7 +392,7 @@ export function MergeOnDoneDialog() {
     } finally {
       setMerging(false)
     }
-  }, [resolved, pendingDoneMove, clearPendingDoneMove])
+  }, [resolved, pendingDoneMove, completeDoneMove, clearPendingDoneMove])
 
   const handleArchive = useCallback(async () => {
     if (!resolved) return

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -367,6 +367,11 @@ export function MergeOnDoneDialog() {
               ticketKey(pendingDoneMove.projectId, pendingDoneMove.ticketId),
               resolved.baseWorktreeId
             )
+          // Hydrate the owning project's worktrees so the conflict banner can
+          // resolve the worktree path when the member project isn't loaded yet
+          void useWorktreeStore
+            .getState()
+            .loadWorktrees(pendingDoneMove.worktreeProjectId ?? pendingDoneMove.projectId)
           void useGitStore.getState().refreshStatuses(resolved.baseWorktreePath)
           toast.error(
             `Merge conflicts in ${mergeResult.conflicts.length} file${mergeResult.conflicts.length !== 1 ? 's' : ''} — merge manually`

--- a/src/renderer/src/lib/connection-merge.test.ts
+++ b/src/renderer/src/lib/connection-merge.test.ts
@@ -200,8 +200,8 @@ describe('buildConnectionMergeQueue', () => {
     await expect(buildConnectionMergeQueue('conn-1')).rejects.toThrow('git exploded')
   })
 
-  it('returns empty when the connection lookup fails', async () => {
+  it('rejects when the connection lookup fails, so the drop can abort', async () => {
     connectionApiMocks.get.mockResolvedValue({ success: false, error: 'nope' })
-    expect(await buildConnectionMergeQueue('conn-1')).toEqual([])
+    await expect(buildConnectionMergeQueue('conn-1')).rejects.toThrow('nope')
   })
 })

--- a/src/renderer/src/lib/connection-merge.test.ts
+++ b/src/renderer/src/lib/connection-merge.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const connectionApiMocks = vi.hoisted(() => ({
+  get: vi.fn()
+}))
+
+vi.mock('@/api/connection-api', () => ({
+  connectionApi: connectionApiMocks
+}))
+
+const dbApiMocks = vi.hoisted(() => ({
+  session: {
+    get: vi.fn()
+  },
+  worktree: {
+    get: vi.fn(),
+    getActiveByProject: vi.fn()
+  }
+}))
+
+vi.mock('@/api/db-api', () => ({
+  dbApi: dbApiMocks
+}))
+
+const gitApiMocks = vi.hoisted(() => ({
+  hasUncommittedChanges: vi.fn(),
+  branchDiffShortStat: vi.fn()
+}))
+
+vi.mock('@/api/git-api', () => ({
+  gitApi: gitApiMocks
+}))
+
+const sessionStoreState = vi.hoisted(() => ({
+  sessionsByConnection: new Map<string, { id: string }[]>()
+}))
+
+vi.mock('@/stores/useSessionStore', () => ({
+  useSessionStore: { getState: () => sessionStoreState }
+}))
+
+import { buildConnectionMergeQueue, resolveTicketConnectionId } from './connection-merge'
+
+function worktree(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'wt-feature',
+    project_id: 'proj-1',
+    branch_name: 'feature',
+    path: '/repo/feature',
+    status: 'active',
+    is_default: false,
+    base_branch: null,
+    ...overrides
+  }
+}
+
+const mainWorktree = worktree({
+  id: 'wt-main',
+  branch_name: 'main',
+  path: '/repo/main',
+  is_default: true
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sessionStoreState.sessionsByConnection = new Map()
+})
+
+describe('resolveTicketConnectionId', () => {
+  it('returns null without a session id', async () => {
+    expect(await resolveTicketConnectionId(null)).toBeNull()
+    expect(dbApiMocks.session.get).not.toHaveBeenCalled()
+  })
+
+  it('finds the connection in the session store without hitting the DB', async () => {
+    sessionStoreState.sessionsByConnection = new Map([['conn-1', [{ id: 'sess-1' }]]])
+    expect(await resolveTicketConnectionId('sess-1')).toBe('conn-1')
+    expect(dbApiMocks.session.get).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the DB when the store map is cold', async () => {
+    dbApiMocks.session.get.mockResolvedValue({ id: 'sess-1', connection_id: 'conn-2' })
+    expect(await resolveTicketConnectionId('sess-1')).toBe('conn-2')
+  })
+
+  it('returns null for non-connection sessions', async () => {
+    dbApiMocks.session.get.mockResolvedValue({ id: 'sess-1', connection_id: null })
+    expect(await resolveTicketConnectionId('sess-1')).toBeNull()
+  })
+})
+
+describe('buildConnectionMergeQueue', () => {
+  it('returns only member worktrees with work to merge', async () => {
+    connectionApiMocks.get.mockResolvedValue({
+      success: true,
+      connection: {
+        id: 'conn-1',
+        members: [
+          { worktree_id: 'wt-dirty', project_id: 'proj-1' },
+          { worktree_id: 'wt-clean', project_id: 'proj-2' },
+          { worktree_id: 'wt-on-base', project_id: 'proj-3' }
+        ]
+      }
+    })
+    dbApiMocks.worktree.get.mockImplementation(async (id: string) => {
+      if (id === 'wt-dirty') return worktree({ id: 'wt-dirty', project_id: 'proj-1' })
+      if (id === 'wt-clean')
+        return worktree({ id: 'wt-clean', project_id: 'proj-2', path: '/repo/clean' })
+      if (id === 'wt-on-base')
+        return worktree({ id: 'wt-on-base', project_id: 'proj-3', branch_name: 'main' })
+      return null
+    })
+    dbApiMocks.worktree.getActiveByProject.mockResolvedValue([mainWorktree])
+    gitApiMocks.hasUncommittedChanges.mockImplementation(
+      async (path: string) => path === '/repo/feature'
+    )
+    gitApiMocks.branchDiffShortStat.mockResolvedValue({
+      success: true,
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+      commitsAhead: 0
+    })
+
+    const queue = await buildConnectionMergeQueue('conn-1')
+    expect(queue).toEqual([{ worktreeId: 'wt-dirty', projectId: 'proj-1' }])
+  })
+
+  it('includes clean-but-ahead worktrees and skips archived ones', async () => {
+    connectionApiMocks.get.mockResolvedValue({
+      success: true,
+      connection: {
+        id: 'conn-1',
+        members: [
+          { worktree_id: 'wt-ahead', project_id: 'proj-1' },
+          { worktree_id: 'wt-archived', project_id: 'proj-2' }
+        ]
+      }
+    })
+    dbApiMocks.worktree.get.mockImplementation(async (id: string) => {
+      if (id === 'wt-ahead') return worktree({ id: 'wt-ahead' })
+      if (id === 'wt-archived') return worktree({ id: 'wt-archived', status: 'archived' })
+      return null
+    })
+    dbApiMocks.worktree.getActiveByProject.mockResolvedValue([mainWorktree])
+    gitApiMocks.hasUncommittedChanges.mockResolvedValue(false)
+    gitApiMocks.branchDiffShortStat.mockResolvedValue({
+      success: true,
+      filesChanged: 2,
+      insertions: 10,
+      deletions: 1,
+      commitsAhead: 3
+    })
+
+    const queue = await buildConnectionMergeQueue('conn-1')
+    expect(queue).toEqual([{ worktreeId: 'wt-ahead', projectId: 'proj-1' }])
+  })
+
+  it('skips members whose base worktree is missing and survives member errors', async () => {
+    connectionApiMocks.get.mockResolvedValue({
+      success: true,
+      connection: {
+        id: 'conn-1',
+        members: [
+          { worktree_id: 'wt-no-base', project_id: 'proj-1' },
+          { worktree_id: 'wt-error', project_id: 'proj-2' }
+        ]
+      }
+    })
+    dbApiMocks.worktree.get.mockImplementation(async (id: string) => {
+      if (id === 'wt-no-base') return worktree({ id: 'wt-no-base' })
+      throw new Error('db down')
+    })
+    // No default/base worktree in the project
+    dbApiMocks.worktree.getActiveByProject.mockResolvedValue([])
+
+    expect(await buildConnectionMergeQueue('conn-1')).toEqual([])
+  })
+
+  it('returns empty when the connection lookup fails', async () => {
+    connectionApiMocks.get.mockResolvedValue({ success: false, error: 'nope' })
+    expect(await buildConnectionMergeQueue('conn-1')).toEqual([])
+  })
+})

--- a/src/renderer/src/lib/connection-merge.test.ts
+++ b/src/renderer/src/lib/connection-merge.test.ts
@@ -156,25 +156,48 @@ describe('buildConnectionMergeQueue', () => {
     expect(queue).toEqual([{ worktreeId: 'wt-ahead', projectId: 'proj-1' }])
   })
 
-  it('skips members whose base worktree is missing and survives member errors', async () => {
+  it('skips members whose base worktree is missing', async () => {
     connectionApiMocks.get.mockResolvedValue({
       success: true,
       connection: {
         id: 'conn-1',
-        members: [
-          { worktree_id: 'wt-no-base', project_id: 'proj-1' },
-          { worktree_id: 'wt-error', project_id: 'proj-2' }
-        ]
+        members: [{ worktree_id: 'wt-no-base', project_id: 'proj-1' }]
       }
     })
-    dbApiMocks.worktree.get.mockImplementation(async (id: string) => {
-      if (id === 'wt-no-base') return worktree({ id: 'wt-no-base' })
-      throw new Error('db down')
-    })
+    dbApiMocks.worktree.get.mockResolvedValue(worktree({ id: 'wt-no-base' }))
     // No default/base worktree in the project
     dbApiMocks.worktree.getActiveByProject.mockResolvedValue([])
 
     expect(await buildConnectionMergeQueue('conn-1')).toEqual([])
+  })
+
+  it('rejects when a member assessment throws, so the drop can abort', async () => {
+    connectionApiMocks.get.mockResolvedValue({
+      success: true,
+      connection: {
+        id: 'conn-1',
+        members: [{ worktree_id: 'wt-error', project_id: 'proj-1' }]
+      }
+    })
+    dbApiMocks.worktree.get.mockRejectedValue(new Error('db down'))
+
+    await expect(buildConnectionMergeQueue('conn-1')).rejects.toThrow('db down')
+  })
+
+  it('rejects when branch stats cannot be verified', async () => {
+    connectionApiMocks.get.mockResolvedValue({
+      success: true,
+      connection: {
+        id: 'conn-1',
+        members: [{ worktree_id: 'wt-feature', project_id: 'proj-1' }]
+      }
+    })
+    dbApiMocks.worktree.get.mockResolvedValue(worktree())
+    dbApiMocks.worktree.getActiveByProject.mockResolvedValue([mainWorktree])
+    gitApiMocks.hasUncommittedChanges.mockResolvedValue(false)
+    gitApiMocks.branchDiffShortStat.mockResolvedValue({ success: false, error: 'git exploded' })
+
+    await expect(buildConnectionMergeQueue('conn-1')).rejects.toThrow('git exploded')
   })
 
   it('returns empty when the connection lookup fails', async () => {

--- a/src/renderer/src/lib/connection-merge.ts
+++ b/src/renderer/src/lib/connection-merge.ts
@@ -38,7 +38,10 @@ export async function buildConnectionMergeQueue(
   connectionId: string
 ): Promise<ConnectionMergeTarget[]> {
   const result = await connectionApi.get(connectionId)
-  const members = result.connection?.members ?? []
+  if (!result.success || !result.connection) {
+    throw new Error(result.error ?? 'Could not retrieve connection members')
+  }
+  const members = result.connection.members
   const seenWorktrees = new Set<string>()
 
   const assessed = await Promise.all(

--- a/src/renderer/src/lib/connection-merge.ts
+++ b/src/renderer/src/lib/connection-merge.ts
@@ -1,0 +1,79 @@
+import { connectionApi } from '@/api/connection-api'
+import { dbApi } from '@/api/db-api'
+import { gitApi } from '@/api/git-api'
+import { useSessionStore } from '@/stores/useSessionStore'
+import type { Session, Worktree } from '../../../main/db/types'
+
+/** One connection-member worktree that needs the merge-on-done flow */
+export interface ConnectionMergeTarget {
+  worktreeId: string
+  projectId: string
+}
+
+/**
+ * Resolve the connection a ticket's session belongs to, if any.
+ * Checks the session store first (cheap), then falls back to the DB —
+ * the store map may be cold on project boards.
+ */
+export async function resolveTicketConnectionId(
+  sessionId: string | null | undefined
+): Promise<string | null> {
+  if (!sessionId) return null
+  for (const [connectionId, sessions] of useSessionStore.getState().sessionsByConnection.entries()) {
+    if (sessions.some((s) => s.id === sessionId)) return connectionId
+  }
+  const session = await dbApi.session.get<Session>(sessionId)
+  return session?.connection_id ?? null
+}
+
+/**
+ * Assess every member worktree of a connection and return the ones with work
+ * to merge (uncommitted changes or commits ahead of their base branch), using
+ * the same pre-checks as the single-project merge-on-done drop path.
+ * Members that are on their base branch, inactive, or unverifiable are skipped.
+ */
+export async function buildConnectionMergeQueue(
+  connectionId: string
+): Promise<ConnectionMergeTarget[]> {
+  const result = await connectionApi.get(connectionId)
+  const members = result.connection?.members ?? []
+  const seenWorktrees = new Set<string>()
+
+  const assessed = await Promise.all(
+    members.map(async (member): Promise<ConnectionMergeTarget | null> => {
+      if (seenWorktrees.has(member.worktree_id)) return null
+      seenWorktrees.add(member.worktree_id)
+      try {
+        const worktree = await dbApi.worktree.get<Worktree>(member.worktree_id)
+        if (!worktree || worktree.status !== 'active') return null
+
+        const activeWorktrees = await dbApi.worktree.getActiveByProject<Worktree>(
+          member.project_id
+        )
+        const defaultWt = activeWorktrees.find((w) => w.is_default)
+        const baseBranch = worktree.base_branch ?? defaultWt?.branch_name
+        if (!baseBranch || worktree.branch_name === baseBranch) return null
+
+        const baseWorktree = activeWorktrees.find(
+          (w) => w.branch_name === baseBranch && w.status === 'active'
+        )
+        if (!baseWorktree) return null
+
+        const [hasUncommitted, branchStatResult] = await Promise.all([
+          gitApi.hasUncommittedChanges(worktree.path),
+          gitApi.branchDiffShortStat(worktree.path, baseBranch)
+        ])
+        const commitsAhead = branchStatResult.success ? branchStatResult.commitsAhead : 0
+
+        if (hasUncommitted || commitsAhead > 0) {
+          return { worktreeId: worktree.id, projectId: member.project_id }
+        }
+        return null
+      } catch {
+        return null
+      }
+    })
+  )
+
+  return assessed.filter((t): t is ConnectionMergeTarget => t !== null)
+}

--- a/src/renderer/src/lib/connection-merge.ts
+++ b/src/renderer/src/lib/connection-merge.ts
@@ -30,7 +30,9 @@ export async function resolveTicketConnectionId(
  * Assess every member worktree of a connection and return the ones with work
  * to merge (uncommitted changes or commits ahead of their base branch), using
  * the same pre-checks as the single-project merge-on-done drop path.
- * Members that are on their base branch, inactive, or unverifiable are skipped.
+ * Members that are on their base branch or inactive are skipped; an
+ * unverifiable member (DB/git failure) rejects so callers can abort the move
+ * instead of treating unchecked work as clean.
  */
 export async function buildConnectionMergeQueue(
   connectionId: string
@@ -43,35 +45,34 @@ export async function buildConnectionMergeQueue(
     members.map(async (member): Promise<ConnectionMergeTarget | null> => {
       if (seenWorktrees.has(member.worktree_id)) return null
       seenWorktrees.add(member.worktree_id)
-      try {
-        const worktree = await dbApi.worktree.get<Worktree>(member.worktree_id)
-        if (!worktree || worktree.status !== 'active') return null
 
-        const activeWorktrees = await dbApi.worktree.getActiveByProject<Worktree>(
-          member.project_id
+      const worktree = await dbApi.worktree.get<Worktree>(member.worktree_id)
+      if (!worktree || worktree.status !== 'active') return null
+
+      const activeWorktrees = await dbApi.worktree.getActiveByProject<Worktree>(member.project_id)
+      const defaultWt = activeWorktrees.find((w) => w.is_default)
+      const baseBranch = worktree.base_branch ?? defaultWt?.branch_name
+      if (!baseBranch || worktree.branch_name === baseBranch) return null
+
+      const baseWorktree = activeWorktrees.find(
+        (w) => w.branch_name === baseBranch && w.status === 'active'
+      )
+      if (!baseWorktree) return null
+
+      const [hasUncommitted, branchStatResult] = await Promise.all([
+        gitApi.hasUncommittedChanges(worktree.path),
+        gitApi.branchDiffShortStat(worktree.path, baseBranch)
+      ])
+      if (!branchStatResult.success) {
+        throw new Error(
+          `${worktree.branch_name}: ${branchStatResult.error ?? 'could not verify merge status'}`
         )
-        const defaultWt = activeWorktrees.find((w) => w.is_default)
-        const baseBranch = worktree.base_branch ?? defaultWt?.branch_name
-        if (!baseBranch || worktree.branch_name === baseBranch) return null
-
-        const baseWorktree = activeWorktrees.find(
-          (w) => w.branch_name === baseBranch && w.status === 'active'
-        )
-        if (!baseWorktree) return null
-
-        const [hasUncommitted, branchStatResult] = await Promise.all([
-          gitApi.hasUncommittedChanges(worktree.path),
-          gitApi.branchDiffShortStat(worktree.path, baseBranch)
-        ])
-        const commitsAhead = branchStatResult.success ? branchStatResult.commitsAhead : 0
-
-        if (hasUncommitted || commitsAhead > 0) {
-          return { worktreeId: worktree.id, projectId: member.project_id }
-        }
-        return null
-      } catch {
-        return null
       }
+
+      if (hasUncommitted || branchStatResult.commitsAhead > 0) {
+        return { worktreeId: worktree.id, projectId: member.project_id }
+      }
+      return null
     })
   )
 

--- a/src/renderer/src/stores/useKanbanStore.connection-merge-queue.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.connection-merge-queue.test.ts
@@ -54,6 +54,28 @@ describe('completeDoneMove — connection merge queue', () => {
     expect(moveTicketMock).not.toHaveBeenCalled()
   })
 
+  it('ignores stale completions whose identity no longer matches the pending move', async () => {
+    await useKanbanStore.getState().completeDoneMove({
+      ticketId: 'ticket-1',
+      projectId: 'proj-a',
+      worktreeId: 'wt-stale'
+    })
+
+    expect(moveTicketMock).not.toHaveBeenCalled()
+    // Queue untouched — still on wt-a
+    expect(useKanbanStore.getState().pendingDoneMove?.worktreeId).toBe('wt-a')
+  })
+
+  it('completes when the expected identity matches the pending move', async () => {
+    await useKanbanStore.getState().completeDoneMove({
+      ticketId: 'ticket-1',
+      projectId: 'proj-a',
+      worktreeId: 'wt-a'
+    })
+
+    expect(useKanbanStore.getState().pendingDoneMove?.worktreeId).toBe('wt-b')
+  })
+
   it('moves the ticket directly when no queue is present (single-project flow)', async () => {
     useKanbanStore.setState({
       pendingDoneMove: {

--- a/src/renderer/src/stores/useKanbanStore.connection-merge-queue.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.connection-merge-queue.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useKanbanStore } from './useKanbanStore'
+
+const moveTicketMock = vi.fn().mockResolvedValue(undefined)
+
+describe('completeDoneMove — connection merge queue', () => {
+  beforeEach(() => {
+    moveTicketMock.mockClear()
+    useKanbanStore.setState({
+      moveTicket: moveTicketMock,
+      pendingDoneMove: {
+        ticketId: 'ticket-1',
+        projectId: 'proj-a',
+        sortOrder: 5,
+        targetColumn: 'merged',
+        worktreeId: 'wt-a',
+        worktreeProjectId: 'proj-a',
+        remainingWorktrees: [
+          { worktreeId: 'wt-b', projectId: 'proj-b' },
+          { worktreeId: 'wt-c', projectId: 'proj-c' }
+        ]
+      }
+    })
+  })
+
+  it('advances to the next member worktree without moving the ticket', async () => {
+    await useKanbanStore.getState().completeDoneMove()
+
+    expect(moveTicketMock).not.toHaveBeenCalled()
+    expect(useKanbanStore.getState().pendingDoneMove).toEqual({
+      ticketId: 'ticket-1',
+      projectId: 'proj-a',
+      sortOrder: 5,
+      targetColumn: 'merged',
+      worktreeId: 'wt-b',
+      worktreeProjectId: 'proj-b',
+      remainingWorktrees: [{ worktreeId: 'wt-c', projectId: 'proj-c' }]
+    })
+  })
+
+  it('moves the ticket only after the last worktree completes', async () => {
+    await useKanbanStore.getState().completeDoneMove() // wt-a → wt-b
+    await useKanbanStore.getState().completeDoneMove() // wt-b → wt-c
+    expect(moveTicketMock).not.toHaveBeenCalled()
+
+    await useKanbanStore.getState().completeDoneMove() // wt-c done → move
+    expect(moveTicketMock).toHaveBeenCalledExactlyOnceWith('ticket-1', 'proj-a', 'merged', 5)
+    expect(useKanbanStore.getState().pendingDoneMove).toBeNull()
+  })
+
+  it('clearPendingDoneMove cancels the whole queue', () => {
+    useKanbanStore.getState().clearPendingDoneMove()
+    expect(useKanbanStore.getState().pendingDoneMove).toBeNull()
+    expect(moveTicketMock).not.toHaveBeenCalled()
+  })
+
+  it('moves the ticket directly when no queue is present (single-project flow)', async () => {
+    useKanbanStore.setState({
+      pendingDoneMove: {
+        ticketId: 'ticket-2',
+        projectId: 'proj-x',
+        sortOrder: 1,
+        targetColumn: 'done'
+      }
+    })
+
+    await useKanbanStore.getState().completeDoneMove()
+    expect(moveTicketMock).toHaveBeenCalledExactlyOnceWith('ticket-2', 'proj-x', 'done', 1)
+    expect(useKanbanStore.getState().pendingDoneMove).toBeNull()
+  })
+})

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -204,6 +204,20 @@ async function loadProjectTicketsSnapshot(
   return { tickets, diagnostics }
 }
 
+/** Pending "move to done/merged" data — drives the MergeOnDoneDialog */
+export interface PendingDoneMove {
+  ticketId: string
+  projectId: string
+  sortOrder: number
+  targetColumn: 'merged' | 'done'
+  /** Connection flow: merge this worktree instead of ticket.worktree_id (which is null) */
+  worktreeId?: string
+  /** Project owning `worktreeId` — may differ from the ticket's project */
+  worktreeProjectId?: string
+  /** Connection flow: member worktrees still to merge after the current one */
+  remainingWorktrees?: { worktreeId: string; projectId: string }[]
+}
+
 // ── State interface ────────────────────────────────────────────────────
 interface KanbanState {
   /** Tickets keyed by project ID */
@@ -226,12 +240,7 @@ interface KanbanState {
   markdownDiagnostics: Map<string, MarkdownCardDiagnostic[]>
   markdownPlaceholders: Map<string, MarkdownCardPlaceholder[]>
   /** Pending "move to done/merged" data — set when a feature-branch ticket is dropped on Done or Merged, triggering the merge dialog */
-  pendingDoneMove: {
-    ticketId: string
-    projectId: string
-    sortOrder: number
-    targetColumn: 'merged' | 'done'
-  } | null
+  pendingDoneMove: PendingDoneMove | null
   /** Ephemeral board focus target used by the header Telegram toggle. */
   boardTelegramTarget: BoardTelegramTarget | null
   /** Ephemeral Cmd+F board search — NOT persisted (partialize is inclusion-based). */
@@ -286,12 +295,7 @@ interface KanbanState {
   closeBoardSearch: () => void
   setBoardSearchQuery: (query: string) => void
   setBoardSearchDescriptions: (on: boolean) => void
-  setPendingDoneMove: (data: {
-    ticketId: string
-    projectId: string
-    sortOrder: number
-    targetColumn: 'merged' | 'done'
-  }) => void
+  setPendingDoneMove: (data: PendingDoneMove) => void
   clearPendingDoneMove: () => void
   completeDoneMove: () => Promise<void>
 
@@ -1551,6 +1555,23 @@ export const useKanbanStore = create<KanbanState>()(
       completeDoneMove: async () => {
         const pending = get().pendingDoneMove
         if (!pending) return
+        // Connection flow: advance to the next member worktree before moving
+        // the ticket — the move only happens after the last worktree finishes
+        const [nextWorktree, ...restWorktrees] = pending.remainingWorktrees ?? []
+        if (nextWorktree) {
+          set({
+            pendingDoneMove: {
+              ticketId: pending.ticketId,
+              projectId: pending.projectId,
+              sortOrder: pending.sortOrder,
+              targetColumn: pending.targetColumn,
+              worktreeId: nextWorktree.worktreeId,
+              worktreeProjectId: nextWorktree.projectId,
+              remainingWorktrees: restWorktrees
+            }
+          })
+          return
+        }
         set({ pendingDoneMove: null })
         await get().moveTicket(
           pending.ticketId,

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -297,7 +297,11 @@ interface KanbanState {
   setBoardSearchDescriptions: (on: boolean) => void
   setPendingDoneMove: (data: PendingDoneMove) => void
   clearPendingDoneMove: () => void
-  completeDoneMove: () => Promise<void>
+  completeDoneMove: (expected?: {
+    ticketId: string
+    projectId: string
+    worktreeId?: string
+  }) => Promise<void>
 
   // ── Session coordination ────────────────────────────────────────────
   syncTicketWithSession: (sessionId: string, event: KanbanSessionEvent) => void
@@ -1552,9 +1556,20 @@ export const useKanbanStore = create<KanbanState>()(
         set({ pendingDoneMove: null })
       },
 
-      completeDoneMove: async () => {
+      completeDoneMove: async (expected) => {
         const pending = get().pendingDoneMove
         if (!pending) return
+        // Stale async completion (e.g. a merge resolving after the dialog was
+        // dismissed and another ticket set a new pending move) must not
+        // advance or move an unrelated pending state
+        if (
+          expected &&
+          (expected.ticketId !== pending.ticketId ||
+            expected.projectId !== pending.projectId ||
+            expected.worktreeId !== pending.worktreeId)
+        ) {
+          return
+        }
         // Connection flow: advance to the next member worktree before moving
         // the ticket — the move only happens after the last worktree finishes
         const [nextWorktree, ...restWorktrees] = pending.remainingWorktrees ?? []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches multi-project git merge and ticket-move orchestration, so incorrect queue/archive handling could leave worktrees unmerged or tear connection membership. Changes are guarded and covered by focused tests.
> 
> **Overview**
> Dragging a **connection ticket** (no `worktree_id`) to Done/Merged now runs merge-on-done for each member worktree that still has uncommitted changes or commits ahead of base, then moves the ticket only after the queue finishes.
> 
> Adds `buildConnectionMergeQueue` / `resolveTicketConnectionId` and extends `PendingDoneMove` so `completeDoneMove` advances member-by-member (with a stale-completion identity guard). The dialog skips the archive step for connection members, shows the current project name and remaining count, and conflict banners/cards resolve via the per-ticket conflict map even without a ticket worktree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2c1ec2f2b1f6d23403cdb61213cf417f55ba94d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->