### PR TITLE
Move tickets to done when worktrees or connections are unavailable

### DIFF
--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -607,7 +607,9 @@ export function KanbanColumn({
           if (draggedTicket?.worktree_id) {
             try {
               const worktree = await dbApi.worktree.get<Worktree>(draggedTicket.worktree_id)
-              if (worktree) {
+              // Archived/deleted worktrees have nothing to merge — fall
+              // through to the normal move instead of failing the transition
+              if (worktree && worktree.status === 'active') {
                 // Resolve the effective base branch
                 const defaultWorktrees =
                   await dbApi.worktree.getActiveByProject<Worktree>(ticketProjectId)

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -3385,7 +3385,8 @@ function ReviewModeContent({
     if (ticket.worktree_id) {
       try {
         const worktree = await dbApi.worktree.get<Worktree>(ticket.worktree_id)
-        if (worktree) {
+        // Archived/deleted worktrees skip the merge flow — plain move below
+        if (worktree && worktree.status === 'active') {
           const defaultWorktrees = await dbApi.worktree.getActiveByProject<Worktree>(
             ticket.project_id
           )

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.test.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.test.tsx
@@ -174,6 +174,27 @@ describe('MergeOnDoneDialog — already-merged branch', () => {
     )
   })
 
+  it('completes the move when the feature worktree was archived', async () => {
+    dbApiMocks.worktree.get.mockResolvedValue({ ...featureWorktree, status: 'archived' })
+
+    render(<MergeOnDoneDialog />)
+
+    await waitFor(() =>
+      expect(moveTicketMock).toHaveBeenCalledWith('ticket-1', 'project-1', 'done', 5)
+    )
+    expect(useKanbanStore.getState().pendingDoneMove).toBeNull()
+  })
+
+  it('completes the move when the feature worktree row is gone', async () => {
+    dbApiMocks.worktree.get.mockResolvedValue(null)
+
+    render(<MergeOnDoneDialog />)
+
+    await waitFor(() =>
+      expect(moveTicketMock).toHaveBeenCalledWith('ticket-1', 'project-1', 'done', 5)
+    )
+  })
+
   it('still runs the merge flow when the branch has commits ahead', async () => {
     gitApiMocks.branchDiffShortStat.mockResolvedValue({
       success: true,

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -111,8 +111,13 @@ export function MergeOnDoneDialog() {
         // Fetch feature worktree
         const featureWorktree = await dbApi.worktree.get<MergeWorktree>(mergeWorktreeId)
         if (!featureWorktree || featureWorktree.status !== 'active') {
-          toast.warning('Cannot merge — feature worktree is not active')
-          clearPendingDoneMove()
+          // Worktree archived/deleted since the drop — nothing to merge, so
+          // complete the move instead of failing the transition
+          await completeDoneMove({
+            ticketId: pending.ticketId,
+            projectId: pending.projectId,
+            worktreeId: pending.worktreeId
+          })
           return
         }
 
@@ -124,8 +129,12 @@ export function MergeOnDoneDialog() {
         const resolvedBaseBranch = featureWorktree.base_branch ?? defaultWt?.branch_name
 
         if (!resolvedBaseBranch) {
-          toast.warning('Cannot merge — no base branch resolved')
-          clearPendingDoneMove()
+          toast.warning('Skipping merge — no base branch resolved')
+          await completeDoneMove({
+            ticketId: pending.ticketId,
+            projectId: pending.projectId,
+            worktreeId: pending.worktreeId
+          })
           return
         }
 
@@ -135,8 +144,14 @@ export function MergeOnDoneDialog() {
         )
 
         if (!baseWorktree) {
-          toast.warning(`Cannot merge — no worktree for ${resolvedBaseBranch}`)
-          clearPendingDoneMove()
+          // Base worktree archived/deleted — merge impossible, but the move
+          // should still land in the target column
+          toast.warning(`Skipping merge — no worktree for ${resolvedBaseBranch}`)
+          await completeDoneMove({
+            ticketId: pending.ticketId,
+            projectId: pending.projectId,
+            worktreeId: pending.worktreeId
+          })
           return
         }
 

--- a/src/renderer/src/lib/connection-merge.test.ts
+++ b/src/renderer/src/lib/connection-merge.test.ts
@@ -204,4 +204,22 @@ describe('buildConnectionMergeQueue', () => {
     connectionApiMocks.get.mockResolvedValue({ success: false, error: 'nope' })
     await expect(buildConnectionMergeQueue('conn-1')).rejects.toThrow('nope')
   })
+
+  it('returns an empty queue for a deleted connection so the move proceeds', async () => {
+    connectionApiMocks.get.mockResolvedValue({ success: false, error: 'Connection not found' })
+    expect(await buildConnectionMergeQueue('conn-1')).toEqual([])
+  })
+
+  it('returns an empty queue for an archived connection so the move proceeds', async () => {
+    connectionApiMocks.get.mockResolvedValue({
+      success: true,
+      connection: {
+        id: 'conn-1',
+        status: 'archived',
+        members: [{ worktree_id: 'wt-feature', project_id: 'proj-1' }]
+      }
+    })
+    expect(await buildConnectionMergeQueue('conn-1')).toEqual([])
+    expect(dbApiMocks.worktree.get).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/lib/connection-merge.ts
+++ b/src/renderer/src/lib/connection-merge.ts
@@ -30,17 +30,23 @@ export async function resolveTicketConnectionId(
  * Assess every member worktree of a connection and return the ones with work
  * to merge (uncommitted changes or commits ahead of their base branch), using
  * the same pre-checks as the single-project merge-on-done drop path.
- * Members that are on their base branch or inactive are skipped; an
- * unverifiable member (DB/git failure) rejects so callers can abort the move
- * instead of treating unchecked work as clean.
+ * Members that are on their base branch or inactive are skipped, and a
+ * deleted or archived connection yields an empty queue (nothing to merge);
+ * an unverifiable member (DB/git failure) rejects so callers can abort the
+ * move instead of treating unchecked work as clean.
  */
 export async function buildConnectionMergeQueue(
   connectionId: string
 ): Promise<ConnectionMergeTarget[]> {
   const result = await connectionApi.get(connectionId)
   if (!result.success || !result.connection) {
+    // A deleted connection has nothing to merge — return an empty queue so
+    // the ticket move proceeds instead of failing the transition
+    if (result.error === 'Connection not found') return []
     throw new Error(result.error ?? 'Could not retrieve connection members')
   }
+  // Same for archived connections — their members are no longer mergeable
+  if (result.connection.status === 'archived') return []
   const members = result.connection.members
   const seenWorktrees = new Set<string>()
 


### PR DESCRIPTION
## Summary

- Allow tickets to move to Done when their worktree is archived or deleted.
- Skip merge flows when required base worktrees are unavailable.
- Treat deleted or archived connections as having no mergeable work.
- Add regression coverage for unavailable worktrees and connections.

## Testing

- Added unit tests for archived/deleted worktrees and connections.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches merge-on-done transition logic across drop, modal, and connection merge paths. Behavior for active worktrees is unchanged, but unavailable-resource fallbacks now complete moves that previously aborted.
> 
> **Overview**
> **Merge-on-done no longer blocks Done/Merged moves** when the linked worktree or connection is gone.
> 
> Drop and modal paths now only enter the merge flow for **active** worktrees. Archived or deleted feature worktrees fall through to a normal column move.
> 
> In `MergeOnDoneDialog`, unavailable feature/base worktrees (or unresolved base branches) **complete the pending move** with a skip warning instead of aborting the transition.
> 
> `buildConnectionMergeQueue` treats deleted (`Connection not found`) and **archived** connections as empty queues so connection ticket moves still proceed. Regression tests cover archived/missing worktrees and unavailable connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13d7d27dd24d2cbfa507f9ba8cf672886d1a77f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->