### PR TITLE
Display dates for usage windows beyond 24 hours

### DIFF
--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -100,6 +100,71 @@ describe('UsageAccountRow', () => {
     expect(screen.getByText('66%')).toBeTruthy()
   })
 
+  it('includes the date in the five_hour reset time when it is more than 24h away', () => {
+    const farReset = new Date(Date.now() + 30 * 60 * 60 * 1000)
+    farReset.setMinutes(0, 0, 0)
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-far-window',
+          email: 'far@example.com',
+          usage: {
+            five_hour: { utilization: 20, resets_at: farReset.toISOString() },
+            seven_day: { utilization: 10, resets_at: null }
+          },
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+      />
+    )
+
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec'
+    ]
+    const hour12 = farReset.getHours() % 12 || 12
+    const ampm = farReset.getHours() >= 12 ? 'pm' : 'am'
+    const expected = `${months[farReset.getMonth()]} ${farReset.getDate()}, ${hour12}${ampm}`
+    expect(screen.getByText(expected)).toBeTruthy()
+  })
+
+  it('shows only the time for a five_hour reset within 24h', () => {
+    const nearReset = new Date(Date.now() + 60 * 60 * 1000)
+    nearReset.setMinutes(0, 0, 0)
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-near-window',
+          email: 'near@example.com',
+          usage: {
+            five_hour: { utilization: 20, resets_at: nearReset.toISOString() },
+            seven_day: { utilization: 10, resets_at: null }
+          },
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+      />
+    )
+
+    const hour12 = nearReset.getHours() % 12 || 12
+    const ampm = nearReset.getHours() >= 12 ? 'pm' : 'am'
+    expect(screen.getByText(`${hour12}${ampm}`)).toBeTruthy()
+  })
+
   it('shows N/A and an empty bar for a scoped entry whose reset time is in the past', () => {
     render(
       <UsageAccountRow

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -61,7 +61,9 @@ function formatResetTime(
   const timeStr =
     minutes === 0 ? `${hour12}${ampm}` : `${hour12}:${String(minutes).padStart(2, '0')}${ampm}`
 
-  if (type === 'five_hour') {
+  // 5h resets within 24h show just the time; anything further out (or the
+  // weekly window, always) needs the date to be unambiguous.
+  if (type === 'five_hour' && date.getTime() - Date.now() <= 24 * 60 * 60 * 1000) {
     return timeStr
   }
 


### PR DESCRIPTION
## Summary
- Show only the time for five-hour resets within 24 hours.
- Include the date for five-hour resets farther than 24 hours away.
- Add tests covering near and distant reset times.

## Testing
- Added and updated `UsageAccountRow` tests for reset-time formatting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting change in the usage indicator with matching unit tests; no auth, data, or API behavior affected.
> 
> **Overview**
> **Five-hour usage reset times** now include the date when the reset is more than 24 hours away, instead of always showing only the clock time.
> 
> Resets within 24 hours still show time only (e.g. `3pm`). Farther resets and weekly windows keep the unambiguous `Mon D, time` format. Tests cover both near and distant five-hour cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 818682fabe6547b205e24d475b6d52b6b0605e06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->