### PR TITLE
fix: make stopping a chat turn reliable and quiet

### DIFF
--- a/src/main/services/__tests__/claude-abort.test.ts
+++ b/src/main/services/__tests__/claude-abort.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { isPermissionAbortArtifact, runBoundedAbortStep } from '../claude-abort'
+
+describe('isPermissionAbortArtifact', () => {
+  it('matches the failure a stopped turn leaves behind', () => {
+    expect(
+      isPermissionAbortArtifact('Tool permission request failed: AbortError: Stream closed')
+    ).toBe(true)
+    expect(isPermissionAbortArtifact('  tool permission request failed: aborterror')).toBe(true)
+  })
+
+  it('leaves real tool failures alone', () => {
+    expect(isPermissionAbortArtifact('Error: ENOENT: no such file or directory')).toBe(false)
+    expect(isPermissionAbortArtifact('')).toBe(false)
+    expect(isPermissionAbortArtifact(undefined)).toBe(false)
+  })
+
+  it('does not match tool output that merely mentions an abort', () => {
+    // Test output from the user's own code must keep its error styling.
+    expect(
+      isPermissionAbortArtifact('FAIL src/a.test.ts: expected AbortError, got Stream closed')
+    ).toBe(false)
+  })
+})
+
+describe('runBoundedAbortStep', () => {
+  it('reports success when the step settles in time', async () => {
+    await expect(runBoundedAbortStep(() => Promise.resolve('ok'), 50)).resolves.toBe(true)
+  })
+
+  it('gives up instead of hanging on a wedged step', async () => {
+    vi.useFakeTimers()
+    try {
+      const pending = runBoundedAbortStep(() => new Promise(() => {}), 2000)
+      await vi.advanceTimersByTimeAsync(2000)
+      await expect(pending).resolves.toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('swallows a rejecting step', async () => {
+    await expect(runBoundedAbortStep(() => Promise.reject(new Error('gone')), 50)).resolves.toBe(
+      false
+    )
+  })
+
+  it('swallows a step that throws synchronously', async () => {
+    await expect(
+      runBoundedAbortStep(() => {
+        throw new Error('sync boom')
+      }, 50)
+    ).resolves.toBe(false)
+  })
+})

--- a/src/main/services/claude-abort.ts
+++ b/src/main/services/claude-abort.ts
@@ -1,0 +1,65 @@
+/**
+ * Helpers for stopping a Claude Agent SDK turn cleanly.
+ *
+ * Two separate problems are handled here.
+ *
+ * 1. Teardown has to be bounded. `query.interrupt()` and the stream fiber
+ *    interrupt both talk to a child process that may already be gone, so an
+ *    unbounded await there leaves the stop button spinning with no way out.
+ *
+ * 2. Aborting a turn while a tool permission request is still in flight makes
+ *    the bundled `claude` binary report `Tool permission request failed:
+ *    AbortError: Stream closed` as a normal failed tool result. That text is
+ *    produced inside the binary, so it can only be recognised by its shape.
+ */
+
+/** Upper bound for a single teardown step. */
+export const ABORT_STEP_TIMEOUT_MS = 2000
+
+/**
+ * Grace period after denying in-flight permission requests, so the SDK can
+ * write those replies before we interrupt the same control stream.
+ */
+export const ABORT_REPLY_FLUSH_MS = 25
+
+/** Replacement output for a tool call that only failed because we stopped. */
+export const STOPPED_TOOL_OUTPUT = 'Stopped by user.'
+
+/**
+ * Deliberately narrow: it must match the CLI's own permission-plumbing failure
+ * and nothing else. Tool output produced by the user's code may well contain
+ * the word "AbortError", and that output must keep its error styling.
+ */
+const PERMISSION_ABORT_ARTIFACT = /^\s*tool permission request failed:.*(aborterror|stream closed)/i
+
+/**
+ * True for the "Tool permission request failed: AbortError: Stream closed"
+ * tool result that a stopped turn leaves behind.
+ */
+export function isPermissionAbortArtifact(text: string | null | undefined): boolean {
+  if (!text) return false
+  return PERMISSION_ABORT_ARTIFACT.test(text)
+}
+
+/**
+ * Run one teardown step. Never rejects, and never waits longer than
+ * `timeoutMs`, so a wedged transport cannot block the stop request.
+ * Returns false when the step threw or ran out of time.
+ */
+export async function runBoundedAbortStep(
+  step: () => Promise<unknown>,
+  timeoutMs: number = ABORT_STEP_TIMEOUT_MS
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    const settled = step().then(() => true as const)
+    const timeout = new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs)
+    })
+    return await Promise.race([settled, timeout])
+  } catch {
+    return false
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -977,9 +977,23 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       })
       session.subscription = subscription
 
+      // abort() tears down on a timeout, so this finisher can still be awaiting the
+      // old stream while a later prompt owns the session. Every side effect below
+      // is gated on still being the current turn: otherwise it would emit idle for
+      // the new turn and null out its query handle, leaving the next stop with
+      // nothing to interrupt.
+      const ownsSession = (): boolean => session.abortController === turnController
+
       const finishPromptInBackground = async () => {
         try {
           const subscriptionExit = await subscription.awaitDone()
+          if (!ownsSession()) {
+            log.info('Prompt: finisher superseded by a newer turn, skipping cleanup', {
+              worktreePath,
+              agentSessionId
+            })
+            return
+          }
           session.subscription = null
           if (
             Exit.isFailure(subscriptionExit) &&
@@ -1014,6 +1028,13 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
 
           this.emitStatus(session.hiveSessionId, 'idle')
         } catch (error) {
+          if (!ownsSession()) {
+            log.info('Prompt: superseded finisher failed, not surfacing', {
+              worktreePath,
+              agentSessionId
+            })
+            return
+          }
           const errorMessage = error instanceof Error ? error.message : String(error)
           const stderrOutput = session.stderrBuffer.join('').trim() || undefined
 
@@ -1060,8 +1081,10 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
           }
           this.emitStatus(session.hiveSessionId, 'idle')
         } finally {
-          session.lastQuery = session.query
-          session.query = null
+          if (ownsSession()) {
+            session.lastQuery = session.query
+            session.query = null
+          }
         }
       }
 

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -375,6 +375,11 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     // Reset stderr buffer so it only captures output from this prompt
     session.stderrBuffer = []
 
+    // Mirrors this turn's AbortController for the outer catch, which sits outside
+    // the try that creates it. Stays null if we fail before the turn even starts,
+    // which is how that catch tells a user stop from a real setup failure.
+    let startedTurnController: AbortController | null = null
+
     this.emitStatus(session.hiveSessionId, 'busy')
     log.info('Prompt: starting', {
       worktreePath,
@@ -485,8 +490,14 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         parts: syntheticParts
       })
 
-      // Fresh AbortController for this prompt turn
-      session.abortController = new AbortController()
+      // Fresh AbortController for this prompt turn. Captured in a local so the
+      // callbacks below can fence themselves to THIS turn: abort() is bounded, so
+      // a timed-out teardown can leave this stream running while a later prompt
+      // installs a new controller. Reading session.abortController would then see
+      // the new turn's un-aborted controller and let stale output merge into it.
+      const turnController = new AbortController()
+      startedTurnController = turnController
+      session.abortController = turnController
 
       // Determine permission mode from DB session mode
       // 'plan' mode uses SDK-native plan mode (ExitPlanMode blocking tool)
@@ -513,15 +524,15 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       // It should never reach here (the picker only offers it for claude-code-cli),
       // but if a stale default leaks it in, fall back to its xhigh equivalent so
       // the SDK never receives an invalid effort value.
-      const effortLevel = (isUltracodeEffort(requestedEffort)
-        ? 'xhigh'
-        : requestedEffort) as Options['effort']
+      const effortLevel = (
+        isUltracodeEffort(requestedEffort) ? 'xhigh' : requestedEffort
+      ) as Options['effort']
 
       // Build SDK query options
       const options: Options = {
         cwd: session.worktreePath,
         permissionMode: sdkPermissionMode,
-        abortController: session.abortController,
+        abortController: turnController,
         maxThinkingTokens: 31999,
         includePartialMessages: true,
         enableFileCheckpointing: true,
@@ -604,9 +615,9 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         hiveSessionId: session.hiveSessionId,
         queryIterator: queryData as unknown as AsyncIterable<unknown>,
         onMessage: async (sdkMessage) => {
-          // Break if aborted
-          if (session.abortController?.signal.aborted) {
-            log.info('Prompt: aborted, breaking loop')
+          // Break if this turn was aborted, or if it is no longer the current turn
+          if (turnController.signal.aborted || session.abortController !== turnController) {
+            log.info('Prompt: aborted or superseded, breaking loop')
             return
           }
 
@@ -979,7 +990,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
 
           log.info('Prompt: async iteration loop finished', {
             totalMessages: messageIndex,
-            aborted: session.abortController?.signal.aborted ?? false
+            aborted: turnController.signal.aborted
           })
 
           // Safety net: if the SDK exited without throwing but stderr was captured
@@ -988,7 +999,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
           // ends iteration normally instead of throwing.
           const stderrAfterLoop = session.stderrBuffer.join('').trim()
 
-          if (stderrAfterLoop && messageIndex === 0 && !session.abortController?.signal.aborted) {
+          if (stderrAfterLoop && messageIndex === 0 && !turnController.signal.aborted) {
             log.warn('Prompt: SDK exited silently with stderr and no messages', {
               worktreePath,
               agentSessionId,
@@ -1020,7 +1031,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
           // session error paints a red banner over what the user just asked for.
           // The signal alone is proof: each prompt gets its own controller, so an
           // aborted one cannot be attributed to a later turn.
-          const stoppedByUser = session.abortController?.signal.aborted ?? false
+          const stoppedByUser = turnController.signal.aborted
 
           if (stoppedByUser) {
             log.info('Prompt: stream ended because the turn was stopped', {
@@ -1070,7 +1081,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       }
 
       // Same reasoning as in finishPromptInBackground: a stop is not an error.
-      const stoppedByUser = session.abortController?.signal.aborted ?? false
+      const stoppedByUser = startedTurnController?.signal.aborted ?? false
 
       if (stoppedByUser) {
         log.info('Prompt: setup aborted because the turn was stopped', {

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -31,6 +31,12 @@ import {
   type WorktreeBranchRenamedEvent
 } from '../../shared/worktree-events'
 import { emitWorktreeBranchRenamed } from './worktree-events'
+import {
+  ABORT_REPLY_FLUSH_MS,
+  STOPPED_TOOL_OUTPUT,
+  isPermissionAbortArtifact,
+  runBoundedAbortStep
+} from './claude-abort'
 
 const log = createLogger({ component: 'ClaudeCodeImplementer' })
 
@@ -872,14 +878,21 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
                         p.type === 'tool_use' &&
                         (p.toolUse as Record<string, unknown> | undefined)?.id === tr.tool_use_id
                     )
+                    // Keep the stored copy in sync with what the renderer shows:
+                    // a broken permission round-trip is a stop, not a failure.
+                    let isError = !!tr.is_error
+                    if (isError && isPermissionAbortArtifact(output)) {
+                      isError = false
+                      output = STOPPED_TOOL_OUTPUT
+                    }
                     if (toolPart) {
                       const tu = toolPart.toolUse as Record<string, unknown>
                       tu.output = output
-                      tu.error = tr.is_error ? output : undefined
-                      tu.status = tr.is_error ? 'error' : 'success'
+                      tu.error = isError ? output : undefined
+                      tu.status = isError ? 'error' : 'success'
                       log.info('TOOL_LIFECYCLE: merged tool_result into assistant tool_use', {
                         toolId: tr.tool_use_id,
-                        isError: !!tr.is_error,
+                        isError,
                         hasOutput: !!output
                       })
                     }
@@ -1003,23 +1016,37 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
             }
           }
 
-          log.error(
-            'Prompt streaming error',
-            error instanceof Error ? error : new Error(errorMessage),
-            {
+          // A stopped turn tears the stream down on purpose. Reporting that as a
+          // session error paints a red banner over what the user just asked for.
+          // The signal alone is proof: each prompt gets its own controller, so an
+          // aborted one cannot be attributed to a later turn.
+          const stoppedByUser = session.abortController?.signal.aborted ?? false
+
+          if (stoppedByUser) {
+            log.info('Prompt: stream ended because the turn was stopped', {
               worktreePath,
               agentSessionId,
-              error: errorMessage,
-              stderr: stderrOutput,
-              ...(Object.keys(errorExtras).length > 0 ? { errorExtras } : {})
-            }
-          )
+              error: errorMessage
+            })
+          } else {
+            log.error(
+              'Prompt streaming error',
+              error instanceof Error ? error : new Error(errorMessage),
+              {
+                worktreePath,
+                agentSessionId,
+                error: errorMessage,
+                stderr: stderrOutput,
+                ...(Object.keys(errorExtras).length > 0 ? { errorExtras } : {})
+              }
+            )
 
-          this.sendToRenderer('opencode:stream', {
-            type: 'session.error',
-            sessionId: session.hiveSessionId,
-            data: { error: errorMessage, stderr: stderrOutput }
-          })
+            this.sendToRenderer('opencode:stream', {
+              type: 'session.error',
+              sessionId: session.hiveSessionId,
+              data: { error: errorMessage, stderr: stderrOutput }
+            })
+          }
           this.emitStatus(session.hiveSessionId, 'idle')
         } finally {
           session.lastQuery = session.query
@@ -1042,23 +1069,34 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         }
       }
 
-      log.error(
-        'Prompt streaming error',
-        error instanceof Error ? error : new Error(errorMessage),
-        {
+      // Same reasoning as in finishPromptInBackground: a stop is not an error.
+      const stoppedByUser = session.abortController?.signal.aborted ?? false
+
+      if (stoppedByUser) {
+        log.info('Prompt: setup aborted because the turn was stopped', {
           worktreePath,
           agentSessionId,
-          error: errorMessage,
-          stderr: stderrOutput,
-          ...(Object.keys(errorExtras).length > 0 ? { errorExtras } : {})
-        }
-      )
+          error: errorMessage
+        })
+      } else {
+        log.error(
+          'Prompt streaming error',
+          error instanceof Error ? error : new Error(errorMessage),
+          {
+            worktreePath,
+            agentSessionId,
+            error: errorMessage,
+            stderr: stderrOutput,
+            ...(Object.keys(errorExtras).length > 0 ? { errorExtras } : {})
+          }
+        )
 
-      this.sendToRenderer('opencode:stream', {
-        type: 'session.error',
-        sessionId: session.hiveSessionId,
-        data: { error: errorMessage, stderr: stderrOutput }
-      })
+        this.sendToRenderer('opencode:stream', {
+          type: 'session.error',
+          sessionId: session.hiveSessionId,
+          data: { error: errorMessage, stderr: stderrOutput }
+        })
+      }
       this.emitStatus(session.hiveSessionId, 'idle')
       session.lastQuery = session.query
       session.query = null
@@ -1073,26 +1111,103 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       return false
     }
 
+    // Reply to whatever the CLI is blocked on *before* the transport goes away.
+    // Killing the stream with a permission request still in flight is what makes
+    // Claude report "Tool permission request failed: AbortError: Stream closed"
+    // as a failed tool call.
+    const denied = this.denyPendingRequests(session, 'abort')
+    if (denied > 0) {
+      await new Promise((resolve) => setTimeout(resolve, ABORT_REPLY_FLUSH_MS))
+    }
+
+    // Graceful interrupt first, while the stream is still alive. Every step is
+    // bounded: a wedged child process must not keep the stop button spinning.
+    const query = session.query
+    if (query) {
+      const interrupted = await runBoundedAbortStep(() => query.interrupt())
+      if (!interrupted) {
+        log.warn('Abort: query.interrupt() did not settle in time', {
+          worktreePath,
+          agentSessionId
+        })
+      }
+    }
+
     if (session.abortController) {
       session.abortController.abort()
     }
 
-    if (session.subscription) {
-      await session.subscription.abort()
-      session.subscription = null
-    }
-
-    if (session.query) {
-      try {
-        await session.query.interrupt()
-      } catch {
-        log.warn('Abort: query.interrupt() threw, ignoring', { worktreePath, agentSessionId })
+    const subscription = session.subscription
+    if (subscription) {
+      const closed = await runBoundedAbortStep(() => subscription.abort())
+      if (!closed) {
+        log.warn('Abort: stream teardown did not settle in time', {
+          worktreePath,
+          agentSessionId
+        })
       }
+      session.subscription = null
     }
 
     session.query = null
     this.emitStatus(session.hiveSessionId, 'idle')
     return true
+  }
+
+  /**
+   * Resolve every human-in-the-loop request this session is blocked on with a
+   * denial and clear the matching UI state. Mirrors the abort-signal listeners
+   * in `canUseTool`, but runs while the SDK transport is still open so the
+   * replies actually reach the CLI. Returns how many requests were settled.
+   */
+  private denyPendingRequests(session: ClaudeSessionState, reason: string): number {
+    let denied = 0
+
+    if (session.pendingPlanApproval) {
+      const { requestId, resolve } = session.pendingPlanApproval
+      session.pendingPlanApproval = null
+      this.pendingPlanSessions.delete(requestId)
+      this.sendToRenderer('opencode:stream', {
+        type: 'plan.resolved',
+        sessionId: session.hiveSessionId,
+        data: { approved: false, aborted: true }
+      })
+      log.info('Abort: rejecting pending plan approval', { requestId, reason })
+      resolve({ approved: false })
+      denied++
+    }
+
+    if (session.pendingQuestion) {
+      const { requestId, resolve } = session.pendingQuestion
+      session.pendingQuestion = null
+      this.pendingQuestionSessions.delete(requestId)
+      // question.rejected is what removes the prompt from the renderer's question
+      // store. Without it the store keeps a stale question, the idle that follows
+      // the abort counts as blocked, and the turn never finalizes.
+      this.sendToRenderer('opencode:stream', {
+        type: 'question.rejected',
+        sessionId: session.hiveSessionId,
+        data: { requestId, id: requestId }
+      })
+      log.info('Abort: rejecting pending question', { requestId, reason })
+      resolve({ answers: [], rejected: true })
+      denied++
+    }
+
+    for (const [requestId, pending] of [...this.pendingApprovals]) {
+      if (pending.hiveSessionId !== session.hiveSessionId) continue
+      this.pendingApprovals.delete(requestId)
+      this.sendToRenderer('opencode:stream', {
+        type: 'command.approval_replied',
+        sessionId: pending.hiveSessionId,
+        data: { requestId, id: requestId, approved: false }
+      })
+      log.info('Abort: denying pending command approval', { requestId, reason })
+      pending.resolve({ approved: false })
+      denied++
+    }
+
+    return denied
   }
 
   async getMessages(worktreePath: string, agentSessionId: string): Promise<unknown[]> {
@@ -2869,7 +2984,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
             const b = block as Record<string, unknown>
             if (b.type === 'tool_result') {
               const toolId = b.tool_use_id as string
-              const isError = b.is_error as boolean | undefined
+              let isError = b.is_error as boolean | undefined
               log.info('TOOL_LIFECYCLE: tool_result received', {
                 hiveSessionId,
                 toolId,
@@ -2884,6 +2999,12 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
                   .filter((c) => c.type === 'text')
                   .map((c) => c.text as string)
                   .join('\n')
+              }
+              // Stopping a turn can break the CLI's own permission round-trip.
+              // That is the stop, not a tool failure, so don't paint it red.
+              if (isError && isPermissionAbortArtifact(output)) {
+                isError = false
+                output = STOPPED_TOOL_OUTPUT
               }
               log.info('TOOL_LIFECYCLE: emitting tool_result to renderer', {
                 hiveSessionId,

--- a/src/main/services/claude-transcript-reader.stopped-tool.test.ts
+++ b/src/main/services/claude-transcript-reader.stopped-tool.test.ts
@@ -1,0 +1,100 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { STOPPED_TOOL_OUTPUT } from './claude-abort'
+import { encodePath, readClaudeTranscript } from './claude-transcript-reader'
+
+interface ReplayedToolUse {
+  status?: string
+  error?: string
+  output?: string
+}
+
+let tempDirs: string[] = []
+
+function writeTranscript(toolResultText: string): {
+  worktreePath: string
+  claudeSessionId: string
+} {
+  const tempDir = mkdtempSync(join(tmpdir(), 'hive-stopped-tool-'))
+  tempDirs.push(tempDir)
+  const claudeConfigDir = join(tempDir, 'claude')
+  const worktreePath = join(tempDir, 'worktree')
+  const claudeSessionId = 'session-stopped'
+
+  mkdirSync(worktreePath, { recursive: true })
+  vi.stubEnv('CLAUDE_CONFIG_DIR', claudeConfigDir)
+
+  const transcriptDir = join(claudeConfigDir, 'projects', encodePath(worktreePath))
+  mkdirSync(transcriptDir, { recursive: true })
+
+  const entries = [
+    {
+      type: 'assistant',
+      uuid: 'assistant-1',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tool-1', name: 'Bash', input: { command: 'ls' } }]
+      }
+    },
+    {
+      type: 'user',
+      uuid: 'user-1',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tool-1', is_error: true, content: toolResultText }
+        ]
+      }
+    }
+  ]
+
+  writeFileSync(
+    join(transcriptDir, `${claudeSessionId}.jsonl`),
+    entries.map((entry) => JSON.stringify(entry)).join('\n') + '\n'
+  )
+
+  return { worktreePath, claudeSessionId }
+}
+
+async function replayToolUse(toolResultText: string): Promise<ReplayedToolUse> {
+  const { worktreePath, claudeSessionId } = writeTranscript(toolResultText)
+  const messages = (await readClaudeTranscript(worktreePath, claudeSessionId)) as Array<{
+    role?: string
+    parts?: Array<{ type: string; toolUse?: ReplayedToolUse }>
+  }>
+
+  const toolPart = messages
+    .flatMap((message) => message.parts ?? [])
+    .find((part) => part.type === 'tool_use')
+
+  expect(toolPart?.toolUse).toBeDefined()
+  return toolPart!.toolUse!
+}
+
+describe('readClaudeTranscript with a stopped permission round-trip', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true })
+    tempDirs = []
+  })
+
+  it('replays the abort artifact as stopped, not as an error', async () => {
+    const toolUse = await replayToolUse('Tool permission request failed: AbortError: Stream closed')
+
+    expect(toolUse.status).not.toBe('error')
+    expect(toolUse.error).toBeUndefined()
+    expect(toolUse.output).toBe(STOPPED_TOOL_OUTPUT)
+  })
+
+  it('still replays a real tool failure as an error', async () => {
+    const toolUse = await replayToolUse('ENOENT: no such file or directory')
+
+    expect(toolUse.status).toBe('error')
+    expect(toolUse.error).toBe('ENOENT: no such file or directory')
+  })
+})

--- a/src/main/services/claude-transcript-reader.ts
+++ b/src/main/services/claude-transcript-reader.ts
@@ -3,6 +3,7 @@ import { readFile, readdir, realpath } from 'fs/promises'
 import { join } from 'path'
 import { homedir } from 'os'
 import { createLogger } from './logger'
+import { STOPPED_TOOL_OUTPUT, isPermissionAbortArtifact } from './claude-abort'
 
 const log = createLogger({ component: 'ClaudeTranscriptReader' })
 const ENCODED_PATH_MAX_LEN = 200
@@ -352,10 +353,12 @@ export async function readClaudeTranscript(
             .map((c) => c.text ?? '')
             .join('\n')
         }
-        if (tr.is_error) {
+        // A stopped turn leaves the CLI's own permission failure in the
+        // transcript. Without this it comes back as a red card on every reload.
+        if (tr.is_error && !isPermissionAbortArtifact(output)) {
           toolUseBlock._resolvedError = output
         } else {
-          toolUseBlock._resolvedOutput = output
+          toolUseBlock._resolvedOutput = tr.is_error ? STOPPED_TOOL_OUTPUT : output
         }
       }
       break

--- a/src/main/services/opencode-service.ts
+++ b/src/main/services/opencode-service.ts
@@ -20,6 +20,10 @@ import {
   type WorktreeBranchRenamedEvent
 } from '../../shared/worktree-events'
 import { emitWorktreeBranchRenamed } from './worktree-events'
+import {
+  describeOpenCodeSessionError,
+  isOpenCodeAbortedError
+} from '@shared/opencode-session-error'
 
 const log = createLogger({ component: 'OpenCodeService' })
 
@@ -1150,9 +1154,19 @@ class OpenCodeService {
 
     // Log errors, skip logging for routine events
     if (eventType === 'session.error') {
-      log.error('OpenCode session error', toError(event.properties?.error), {
-        sessionId: event.properties?.sessionID
-      })
+      const sessionError = event.properties?.error
+      if (isOpenCodeAbortedError(sessionError)) {
+        log.info('OpenCode turn stopped by user', {
+          sessionId: event.properties?.sessionID
+        })
+      } else {
+        // Describe the payload explicitly: it is a plain { name, data } object,
+        // so toError() would log a useless "Error: [object Object]".
+        log.error('OpenCode session error', new Error(describeOpenCodeSessionError(sessionError)), {
+          sessionId: event.properties?.sessionID,
+          errorName: (sessionError as { name?: string } | undefined)?.name
+        })
+      }
     }
 
     if (!eventType) {
@@ -1349,6 +1363,13 @@ class OpenCodeService {
           log.warn('Failed to persist session title from server', { err })
         }
       }
+    }
+
+    // A stopped turn arrives as session.error with MessageAbortedError. Forwarding
+    // it would paint a red error banner over something the user asked for. The
+    // separate session.idle event still clears the running state.
+    if (eventType === 'session.error' && isOpenCodeAbortedError(event.properties?.error)) {
+      return
     }
 
     // Send event to renderer

--- a/src/renderer/src/components/sessions/QueuedMessageBubble.tsx
+++ b/src/renderer/src/components/sessions/QueuedMessageBubble.tsx
@@ -1,14 +1,15 @@
 import { cn } from '@/lib/utils'
-import { ShipWheel } from 'lucide-react'
+import { ShipWheel, X } from 'lucide-react'
 
 interface QueuedMessageBubbleProps {
   content: string
   canSteer?: boolean
   isLoading?: boolean
   onSteer?: () => void
+  onDelete?: () => void
 }
 
-export function QueuedMessageBubble({ content, canSteer, isLoading, onSteer }: QueuedMessageBubbleProps): React.JSX.Element {
+export function QueuedMessageBubble({ content, canSteer, isLoading, onSteer, onDelete }: QueuedMessageBubbleProps): React.JSX.Element {
   return (
     <div className="flex justify-end px-6 py-4 opacity-70" data-testid="queued-message-bubble">
       <div className={cn('max-w-[80%] rounded-2xl px-4 py-3', 'bg-primary/10 text-foreground')}>
@@ -28,6 +29,22 @@ export function QueuedMessageBubble({ content, canSteer, isLoading, onSteer }: Q
               title="Steer — inject into active turn"
             >
               <ShipWheel className={cn("w-3.5 h-3.5", isLoading && "animate-spin")} />
+            </button>
+          )}
+          {onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              disabled={isLoading}
+              className={cn(
+                "text-muted-foreground hover:text-destructive transition-colors",
+                isLoading && "opacity-50 cursor-not-allowed"
+              )}
+              aria-label="Remove queued message"
+              title="Remove queued message"
+              data-testid="queued-message-delete"
+            >
+              <X className="w-3.5 h-3.5" />
             </button>
           )}
         </div>

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -4251,6 +4251,21 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
   const handleSteerMessage = useCallback(
     async (messageId: string, content: string) => {
       if (!worktreePath || !opencodeSessionId || steeringGuardRef.current) return
+
+      // Claim the queued entry before the request. The turn can go idle while
+      // steer is in flight, and the idle drain would then submit the same text as
+      // a fresh prompt: the message would be both steered and sent.
+      const queueIndex = queuedMessagesRef.current.findIndex((msg) => msg.id === messageId)
+      const restoreClaim = (): void => {
+        if (queueIndex >= 0) {
+          useSessionStore.getState().insertFollowUpMessageAt(sessionId, queueIndex, content)
+        }
+      }
+      if (queueIndex >= 0) {
+        useSessionStore.getState().removeFollowUpMessageAt(sessionId, queueIndex, content)
+      }
+      setQueuedMessages((prev) => prev.filter((msg) => msg.id !== messageId))
+
       steeringGuardRef.current = true
       setSteeringMessageId(messageId)
       try {
@@ -4258,12 +4273,6 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
           await opencodeApi.steer(worktreePath, opencodeSessionId, content)
         )
         if (result?.success) {
-          // Resolve the queue position after the request but before the local
-          // removal below: the drain or the delete button may have shifted the
-          // queue while steer was in flight, and the ref still mirrors the store.
-          // Index-based because two queued messages can hold identical text.
-          const queueIndex = queuedMessagesRef.current.findIndex((msg) => msg.id === messageId)
-          setQueuedMessages((prev) => prev.filter((msg) => msg.id !== messageId))
           const anchorAssistantMessageId = codexStreamingMessageIdRef.current
           const insertedMessageId = result.insertedMessageId
           const steeredMessage = createLocalMessage('user', content, {
@@ -4284,15 +4293,13 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
           if (!insertion.inserted) {
             void refreshMessagesFromOpenCode()
           }
-
-          if (queueIndex >= 0) {
-            useSessionStore.getState().removeFollowUpMessageAt(sessionId, queueIndex, content)
-          }
         } else {
           console.warn('Steer failed', { messageId, error: result?.error })
+          restoreClaim()
         }
       } catch (error) {
         console.warn('Steer error', { messageId, error })
+        restoreClaim()
       } finally {
         steeringGuardRef.current = false
         setSteeringMessageId(null)

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -100,7 +100,10 @@ import { snapshotTokenBaseline, computeTokenDelta } from '@/lib/token-baselines'
 import { notifyKanbanSessionSync, notifyKanbanAutoCreateTicket } from '@/stores/store-coordination'
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
 import { copyTextToClipboard } from '@/lib/clipboard'
-import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
+import {
+  handleSessionIdleFollowUp,
+  type SessionFollowUpDispatchResult
+} from '@/lib/session-follow-up-dispatch'
 import { shouldPreserveBlockingSessionStatus } from '@/lib/session-status-guards'
 import {
   describeOpenCodeSessionError,
@@ -626,6 +629,11 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
     queuedMessagesRef.current = queuedMessages
   }, [queuedMessages])
   const [isStopping, setIsStopping] = useState(false)
+  // Set by the idle handler so steer can re-run the drain it had to skip.
+  const drainFollowUpsRef = useRef<(() => void) | null>(null)
+  // True when an idle arrived but the drain was blocked, so something else has to
+  // run it once the block clears.
+  const blockedIdleRef = useRef(false)
   // Assigned below, once reclaimQueuedMessages exists. The stream effect is
   // declared before it, so it cannot reference the callback directly.
   const reclaimQueuedMessagesRef = useRef<(() => number) | null>(null)
@@ -3001,12 +3009,16 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
           if (useSessionStore.getState().getPendingPlan(sessionId)) return
 
           setIsCompacting(false)
-          const runFollowUpDrain = (): void => {
+          const runFollowUpDrain = (): Promise<SessionFollowUpDispatchResult> => {
             let optimisticMessageId: string | null = null
 
-            void handleSessionIdleFollowUp({
+            return handleSessionIdleFollowUp({
               sessionId,
               isBlocked: () => {
+                // An in-flight steer is about to inject into this turn. Draining now
+                // would submit the next queued message as a separate prompt and
+                // overlap the two. Steer re-runs this drain when it settles.
+                if (steeringGuardRef.current) return true
                 // Same guard as the background listener: a queued message must not
                 // be sent while the session waits on an approval or a question.
                 const currentStatus = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
@@ -3117,7 +3129,14 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
             })
           }
 
-          runFollowUpDrain()
+          // Keep the drain reachable, and remember an idle that got swallowed so
+          // whatever cleared the block can run it.
+          drainFollowUpsRef.current = () => {
+            void runFollowUpDrain()
+          }
+          void runFollowUpDrain().then((result) => {
+            blockedIdleRef.current = result === 'blocked'
+          })
         } else if (status.type === 'retry') {
           setIsStreaming(true)
           setIsSending(true)
@@ -4303,6 +4322,13 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
       } finally {
         steeringGuardRef.current = false
         setSteeringMessageId(null)
+        // If an idle was swallowed while this steer was in flight, run that drain
+        // now. With an empty queue it just finalizes the turn, which is what the
+        // skipped idle would have done.
+        if (blockedIdleRef.current) {
+          blockedIdleRef.current = false
+          drainFollowUpsRef.current?.()
+        }
       }
     },
     [opencodeSessionId, refreshMessagesFromOpenCode, sessionId, worktreePath]

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -626,12 +626,9 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
     queuedMessagesRef.current = queuedMessages
   }, [queuedMessages])
   const [isStopping, setIsStopping] = useState(false)
-  // Set by the stream effect so the idle drain can also be retried from
-  // outside it. See the recovery effect further down.
-  const drainFollowUpsRef = useRef<(() => void) | null>(null)
-  // One recovery attempt per idle period, so a repeatedly failing dispatch
-  // cannot spin.
-  const drainRetryDoneRef = useRef(false)
+  // Assigned below, once reclaimQueuedMessages exists. The stream effect is
+  // declared before it, so it cannot reference the callback directly.
+  const reclaimQueuedMessagesRef = useRef<(() => number) | null>(null)
   const [attachments, setAttachments] = useState<Attachment[]>([])
   const [ticketPickerOpen, setTicketPickerOpen] = useState(false)
   const fileAttachments = useMemo(
@@ -840,46 +837,6 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
 
   // Pending plan approval (ExitPlanMode blocking tool)
   const pendingPlan = useSessionStore((s) => s.pendingPlans.get(sessionId) ?? null)
-
-  // Recovery net for a queue stranded by a failed turn. session.error ends the
-  // turn without draining, so a queued message would sit there for the rest of
-  // the session: the next send goes out directly and never revisits the queue.
-  // Retry at most once per idle period, and only when the session is
-  // demonstrably free to send.
-  //
-  // This deliberately does not cover a drain that returned 'blocked'. That path
-  // leaves isStreaming true, so the guard below exits first, and the block
-  // resolving produces its own idle which drains normally.
-  useEffect(() => {
-    if (isStreaming || isSending) {
-      drainRetryDoneRef.current = false
-      return
-    }
-    if (persistedFollowUpMessages.length === 0) return
-    if (drainRetryDoneRef.current) return
-    if (activePermission || activeQuestion || pendingPlan) return
-
-    const status = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-    if (
-      shouldPreserveBlockingSessionStatus(
-        status?.status,
-        useQuestionStore.getState().getQuestions(sessionId).length > 0
-      )
-    ) {
-      return
-    }
-
-    drainRetryDoneRef.current = true
-    drainFollowUpsRef.current?.()
-  }, [
-    isStreaming,
-    isSending,
-    persistedFollowUpMessages,
-    activePermission,
-    activeQuestion,
-    pendingPlan,
-    sessionId
-  ])
 
   // Completion badge — reactive subscription to this session's status entry
   const completionEntry = useWorktreeStatusStore((state) => {
@@ -2376,6 +2333,17 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
         // partials cannot leak into the next one.
         resetStreamingState()
         setIsSending(false)
+        // Hand any queued follow-ups back, same as stop does. Leaving them queued
+        // strands them: the next send goes out directly and never revisits the
+        // queue, and the stale text would surface after some later turn instead.
+        const reclaimedOnError = reclaimQueuedMessagesRef.current?.() ?? 0
+        if (reclaimedOnError > 0) {
+          toast.info(
+            reclaimedOnError === 1
+              ? 'Queued message moved back to the input.'
+              : `${reclaimedOnError} queued messages moved back to the input.`
+          )
+        }
         // Notify kanban store so errored tickets auto-move to review
         notifyKanbanSessionSync(sessionId, { type: 'session_error' })
         return
@@ -3149,9 +3117,6 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
             })
           }
 
-          // Expose the drain so the recovery effect can retry it if this idle
-          // was blocked and the queue is still waiting once the block clears.
-          drainFollowUpsRef.current = runFollowUpDrain
           runFollowUpDrain()
         } else if (status.type === 'retry') {
           setIsStreaming(true)
@@ -4321,7 +4286,7 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
           }
 
           if (queueIndex >= 0) {
-            useSessionStore.getState().removeFollowUpMessageAt(sessionId, queueIndex)
+            useSessionStore.getState().removeFollowUpMessageAt(sessionId, queueIndex, content)
           }
         } else {
           console.warn('Steer failed', { messageId, error: result?.error })
@@ -4340,8 +4305,9 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
     (messageId: string) => {
       const queueIndex = queuedMessagesRef.current.findIndex((msg) => msg.id === messageId)
       if (queueIndex < 0) return
+      const content = queuedMessagesRef.current[queueIndex].content
       setQueuedMessages((prev) => prev.filter((msg) => msg.id !== messageId))
-      useSessionStore.getState().removeFollowUpMessageAt(sessionId, queueIndex)
+      useSessionStore.getState().removeFollowUpMessageAt(sessionId, queueIndex, content)
     },
     [sessionId]
   )
@@ -4367,6 +4333,10 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
     dbApi.session.updateDraft(sessionId, next)
     return queued.length
   }, [sessionId])
+
+  useEffect(() => {
+    reclaimQueuedMessagesRef.current = reclaimQueuedMessages
+  }, [reclaimQueuedMessages])
 
   const handleForkFromAssistantMessage = useCallback(
     async (message: OpenCodeMessage) => {
@@ -5226,8 +5196,8 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
           return
         }
         const setModePromise = sessionStore.setSessionMode(result.session.id, 'build', {
-        applyModeDefault: false
-      })
+          applyModeDefault: false
+        })
         registerHivePromptHandoff(sessionId, result.session.id)
         sessionStore.setPendingMessage(result.session.id, handoffPrompt)
         await useKanbanStore

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -101,6 +101,11 @@ import { notifyKanbanSessionSync, notifyKanbanAutoCreateTicket } from '@/stores/
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
 import { copyTextToClipboard } from '@/lib/clipboard'
 import { handleSessionIdleFollowUp } from '@/lib/session-follow-up-dispatch'
+import { shouldPreserveBlockingSessionStatus } from '@/lib/session-status-guards'
+import {
+  describeOpenCodeSessionError,
+  type OpenCodeSessionErrorPayload
+} from '@shared/opencode-session-error'
 import {
   recordHivePromptIdleForSession,
   recordHiveQuestionAnswerTelemetry,
@@ -386,6 +391,12 @@ function extractSessionErrorMessage(data: unknown): string {
   const nestedError = asRecord(record.error)
   const nestedData = asRecord(record.data)
 
+  // OpenCode puts the real text in error.data.message and leaves error.message
+  // unset, so without this the banner degrades to a bare "UnknownError".
+  if (nestedError && asString(asRecord(nestedError.data)?.message)) {
+    return describeOpenCodeSessionError(nestedError as OpenCodeSessionErrorPayload)
+  }
+
   return (
     asString(nestedError?.message) ||
     asString(nestedError?.name) ||
@@ -608,6 +619,19 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
       timestamp: number
     }>
   >([])
+  // Mirrored so handlers can map a bubble id to its queue index without
+  // rebuilding on every queue change.
+  const queuedMessagesRef = useRef(queuedMessages)
+  useEffect(() => {
+    queuedMessagesRef.current = queuedMessages
+  }, [queuedMessages])
+  const [isStopping, setIsStopping] = useState(false)
+  // Set by the stream effect so the idle drain can also be retried from
+  // outside it. See the recovery effect further down.
+  const drainFollowUpsRef = useRef<(() => void) | null>(null)
+  // One recovery attempt per idle period, so a repeatedly failing dispatch
+  // cannot spin.
+  const drainRetryDoneRef = useRef(false)
   const [attachments, setAttachments] = useState<Attachment[]>([])
   const [ticketPickerOpen, setTicketPickerOpen] = useState(false)
   const fileAttachments = useMemo(
@@ -816,6 +840,46 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
 
   // Pending plan approval (ExitPlanMode blocking tool)
   const pendingPlan = useSessionStore((s) => s.pendingPlans.get(sessionId) ?? null)
+
+  // Recovery net for a queue stranded by a failed turn. session.error ends the
+  // turn without draining, so a queued message would sit there for the rest of
+  // the session: the next send goes out directly and never revisits the queue.
+  // Retry at most once per idle period, and only when the session is
+  // demonstrably free to send.
+  //
+  // This deliberately does not cover a drain that returned 'blocked'. That path
+  // leaves isStreaming true, so the guard below exits first, and the block
+  // resolving produces its own idle which drains normally.
+  useEffect(() => {
+    if (isStreaming || isSending) {
+      drainRetryDoneRef.current = false
+      return
+    }
+    if (persistedFollowUpMessages.length === 0) return
+    if (drainRetryDoneRef.current) return
+    if (activePermission || activeQuestion || pendingPlan) return
+
+    const status = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
+    if (
+      shouldPreserveBlockingSessionStatus(
+        status?.status,
+        useQuestionStore.getState().getQuestions(sessionId).length > 0
+      )
+    ) {
+      return
+    }
+
+    drainRetryDoneRef.current = true
+    drainFollowUpsRef.current?.()
+  }, [
+    isStreaming,
+    isSending,
+    persistedFollowUpMessages,
+    activePermission,
+    activeQuestion,
+    pendingPlan,
+    sessionId
+  ])
 
   // Completion badge — reactive subscription to this session's status entry
   const completionEntry = useWorktreeStatusStore((state) => {
@@ -2306,6 +2370,12 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
         if (event.childSessionId) return
         setSessionErrorMessage(extractSessionErrorMessage(event.data))
         setSessionErrorStderr(extractSessionErrorStderr(event.data))
+        // The turn is over. Without this, isStreaming stays true and every later
+        // message is queued behind a turn that will never finish. Reset the whole
+        // streaming state rather than just the flags, so the failed turn's
+        // partials cannot leak into the next one.
+        resetStreamingState()
+        setIsSending(false)
         // Notify kanban store so errored tickets auto-move to review
         notifyKanbanSessionSync(sessionId, { type: 'session_error' })
         return
@@ -2963,117 +3033,126 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
           if (useSessionStore.getState().getPendingPlan(sessionId)) return
 
           setIsCompacting(false)
-          let optimisticMessageId: string | null = null
+          const runFollowUpDrain = (): void => {
+            let optimisticMessageId: string | null = null
 
-          void handleSessionIdleFollowUp({
-            sessionId,
-            isBlocked: () => {
-              const currentStatus = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
-              return (
-                currentStatus?.status === 'command_approval' ||
-                currentStatus?.status === 'permission'
-              )
-            },
-            dequeueFollowUp: () => useSessionStore.getState().consumeFollowUpMessage(sessionId),
-            requeueFollowUp: (message) =>
-              useSessionStore.getState().requeueFollowUpMessageFront(sessionId, message),
-            onBeforeDispatch: (message) => {
-              recordHivePromptIdleForSession(sessionId)
-              const optimisticMessage = createLocalMessage('user', message)
-              optimisticMessageId = optimisticMessage.id
-              setQueuedMessages((prev) => prev.slice(1))
-              hasFinalizedCurrentResponseRef.current = false
-              setIsStreaming(true)
-              setIsSending(true)
-              setMessages((prev) => [...prev, optimisticMessage])
-              newPromptPendingRef.current = true
-              messageSendTimes.set(sessionId, Date.now())
-              snapshotTokenBaseline(sessionId)
-              startHivePromptTelemetry({
-                sessionId,
-                prompt: message,
-                worktreeId,
-                modelId: sessionRecord?.model_id,
-                providerId: sessionRecord?.model_provider_id,
-                modelVariant: sessionRecord?.model_variant,
-                mode: 'build'
-              })
-              lastSendMode.set(sessionId, 'build')
-              // Queued follow-ups are user-authored; the one-shot marker lets
-              // this working transition reopen a done/merged ticket without
-              // restarting the elapsed timer (userExplicitSendTimes stays).
-              markNextWorkingStatusExplicit(sessionId)
-              useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
-              lastSentPromptRef.current = message
-            },
-            dispatchFollowUp: async (message) => {
-              const wtPath = transcriptSourceRef.current.worktreePath
-              const opcSid = transcriptSourceRef.current.opencodeSessionId
-              if (!wtPath || !opcSid) {
-                return false
-              }
-
-              const result = unwrapEnvelope(
-                await opencodeApi.prompt(
-                  wtPath,
-                  opcSid,
-                  [{ type: 'text', text: message }],
-                  getModelForRequests()
+            void handleSessionIdleFollowUp({
+              sessionId,
+              isBlocked: () => {
+                // Same guard as the background listener: a queued message must not
+                // be sent while the session waits on an approval or a question.
+                const currentStatus = useWorktreeStatusStore.getState().sessionStatuses[sessionId]
+                return shouldPreserveBlockingSessionStatus(
+                  currentStatus?.status,
+                  useQuestionStore.getState().getQuestions(sessionId).length > 0
                 )
-              )
+              },
+              dequeueFollowUp: () => useSessionStore.getState().consumeFollowUpMessage(sessionId),
+              requeueFollowUp: (message) =>
+                useSessionStore.getState().requeueFollowUpMessageFront(sessionId, message),
+              onBeforeDispatch: (message) => {
+                recordHivePromptIdleForSession(sessionId)
+                const optimisticMessage = createLocalMessage('user', message)
+                optimisticMessageId = optimisticMessage.id
+                setQueuedMessages((prev) => prev.slice(1))
+                hasFinalizedCurrentResponseRef.current = false
+                setIsStreaming(true)
+                setIsSending(true)
+                setMessages((prev) => [...prev, optimisticMessage])
+                newPromptPendingRef.current = true
+                messageSendTimes.set(sessionId, Date.now())
+                snapshotTokenBaseline(sessionId)
+                startHivePromptTelemetry({
+                  sessionId,
+                  prompt: message,
+                  worktreeId,
+                  modelId: sessionRecord?.model_id,
+                  providerId: sessionRecord?.model_provider_id,
+                  modelVariant: sessionRecord?.model_variant,
+                  mode: 'build'
+                })
+                lastSendMode.set(sessionId, 'build')
+                // Queued follow-ups are user-authored; the one-shot marker lets
+                // this working transition reopen a done/merged ticket without
+                // restarting the elapsed timer (userExplicitSendTimes stays).
+                markNextWorkingStatusExplicit(sessionId)
+                useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+                lastSentPromptRef.current = message
+              },
+              dispatchFollowUp: async (message) => {
+                const wtPath = transcriptSourceRef.current.worktreePath
+                const opcSid = transcriptSourceRef.current.opencodeSessionId
+                if (!wtPath || !opcSid) {
+                  return false
+                }
 
-              if (!result.success) {
-                console.error('Failed to send follow-up message:', result.error)
-                return false
+                const result = unwrapEnvelope(
+                  await opencodeApi.prompt(
+                    wtPath,
+                    opcSid,
+                    [{ type: 'text', text: message }],
+                    getModelForRequests()
+                  )
+                )
+
+                if (!result.success) {
+                  console.error('Failed to send follow-up message:', result.error)
+                  return false
+                }
+
+                return true
+              },
+              onDispatchFailure: (message) => {
+                toast.error('Failed to send follow-up prompt')
+                setIsStreaming(false)
+                setIsSending(false)
+                useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+                setQueuedMessages((prev) => [
+                  {
+                    id: `queued-${crypto.randomUUID()}`,
+                    content: message,
+                    timestamp: Date.now()
+                  },
+                  ...prev
+                ])
+                if (optimisticMessageId) {
+                  setMessages((prev) => prev.filter((entry) => entry.id !== optimisticMessageId))
+                }
+              },
+              onComplete: () => {
+                // Session is done — flush and finalize immediately
+                setSessionRetry(null)
+                immediateFlush()
+                setIsSending(false)
+                setQueuedMessages([])
+                // Clear any stale command approvals when session goes idle
+                useCommandApprovalStore.getState().clearSession(sessionId)
+
+                if (!hasFinalizedCurrentResponseRef.current) {
+                  hasFinalizedCurrentResponseRef.current = true
+                  void finalizeResponse()
+                }
+
+                // Set completion badge with duration since user sent the message
+                const sendTime = messageSendTimes.get(sessionId)
+                const durationMs = sendTime ? Date.now() - sendTime : 0
+                const word = COMPLETION_WORDS[Math.floor(Math.random() * COMPLETION_WORDS.length)]
+                const tokenDelta = computeTokenDelta(sessionId)
+                recordHivePromptIdleForSession(sessionId)
+                const statusStore = useWorktreeStatusStore.getState()
+                statusStore.setSessionStatus(sessionId, 'completed', {
+                  word,
+                  durationMs,
+                  tokenDelta
+                })
               }
+            })
+          }
 
-              return true
-            },
-            onDispatchFailure: (message) => {
-              toast.error('Failed to send follow-up prompt')
-              setIsStreaming(false)
-              setIsSending(false)
-              useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
-              setQueuedMessages((prev) => [
-                {
-                  id: `queued-${crypto.randomUUID()}`,
-                  content: message,
-                  timestamp: Date.now()
-                },
-                ...prev
-              ])
-              if (optimisticMessageId) {
-                setMessages((prev) => prev.filter((entry) => entry.id !== optimisticMessageId))
-              }
-            },
-            onComplete: () => {
-              // Session is done — flush and finalize immediately
-              setSessionRetry(null)
-              immediateFlush()
-              setIsSending(false)
-              setQueuedMessages([])
-              // Clear any stale command approvals when session goes idle
-              useCommandApprovalStore.getState().clearSession(sessionId)
-
-              if (!hasFinalizedCurrentResponseRef.current) {
-                hasFinalizedCurrentResponseRef.current = true
-                void finalizeResponse()
-              }
-
-              // Set completion badge with duration since user sent the message
-              const sendTime = messageSendTimes.get(sessionId)
-              const durationMs = sendTime ? Date.now() - sendTime : 0
-              const word = COMPLETION_WORDS[Math.floor(Math.random() * COMPLETION_WORDS.length)]
-              const tokenDelta = computeTokenDelta(sessionId)
-              recordHivePromptIdleForSession(sessionId)
-              const statusStore = useWorktreeStatusStore.getState()
-              statusStore.setSessionStatus(sessionId, 'completed', {
-                word,
-                durationMs,
-                tokenDelta
-              })
-            }
-          })
+          // Expose the drain so the recovery effect can retry it if this idle
+          // was blocked and the queue is still waiting once the block clears.
+          drainFollowUpsRef.current = runFollowUpDrain
+          runFollowUpDrain()
         } else if (status.type === 'retry') {
           setIsStreaming(true)
           setIsSending(true)
@@ -4214,6 +4293,11 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
           await opencodeApi.steer(worktreePath, opencodeSessionId, content)
         )
         if (result?.success) {
+          // Resolve the queue position after the request but before the local
+          // removal below: the drain or the delete button may have shifted the
+          // queue while steer was in flight, and the ref still mirrors the store.
+          // Index-based because two queued messages can hold identical text.
+          const queueIndex = queuedMessagesRef.current.findIndex((msg) => msg.id === messageId)
           setQueuedMessages((prev) => prev.filter((msg) => msg.id !== messageId))
           const anchorAssistantMessageId = codexStreamingMessageIdRef.current
           const insertedMessageId = result.insertedMessageId
@@ -4236,16 +4320,8 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
             void refreshMessagesFromOpenCode()
           }
 
-          // Remove the steered message from the follow-up queue by content
-          const currentFollowUps =
-            useSessionStore.getState().pendingFollowUpMessages.get(sessionId) ?? []
-          const indexToRemove = currentFollowUps.indexOf(content)
-          if (indexToRemove >= 0) {
-            const updatedFollowUps = [
-              ...currentFollowUps.slice(0, indexToRemove),
-              ...currentFollowUps.slice(indexToRemove + 1)
-            ]
-            useSessionStore.getState().setPendingFollowUpMessages(sessionId, updatedFollowUps)
+          if (queueIndex >= 0) {
+            useSessionStore.getState().removeFollowUpMessageAt(sessionId, queueIndex)
           }
         } else {
           console.warn('Steer failed', { messageId, error: result?.error })
@@ -4259,6 +4335,38 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
     },
     [opencodeSessionId, refreshMessagesFromOpenCode, sessionId, worktreePath]
   )
+
+  const handleDeleteQueuedMessage = useCallback(
+    (messageId: string) => {
+      const queueIndex = queuedMessagesRef.current.findIndex((msg) => msg.id === messageId)
+      if (queueIndex < 0) return
+      setQueuedMessages((prev) => prev.filter((msg) => msg.id !== messageId))
+      useSessionStore.getState().removeFollowUpMessageAt(sessionId, queueIndex)
+    },
+    [sessionId]
+  )
+
+  /**
+   * Pull unsent queued messages back into the composer. Used when the user stops
+   * a turn: the abort is followed by an idle event, and without this the idle
+   * handler would send exactly the messages the user just cancelled.
+   */
+  const reclaimQueuedMessages = useCallback((): number => {
+    const queued = useSessionStore.getState().pendingFollowUpMessages.get(sessionId) ?? []
+    if (queued.length === 0) return 0
+
+    useSessionStore.getState().setPendingFollowUpMessages(sessionId, [])
+    setQueuedMessages([])
+
+    const restored = queued.join('\n\n')
+    const draft = inputValueRef.current.trim()
+    const next = draft ? `${inputValueRef.current}\n\n${restored}` : restored
+    setInputValue(next)
+    inputValueRef.current = next
+    if (draftTimerRef.current) clearTimeout(draftTimerRef.current)
+    dbApi.session.updateDraft(sessionId, next)
+    return queued.length
+  }, [sessionId])
 
   const handleForkFromAssistantMessage = useCallback(
     async (message: OpenCodeMessage) => {
@@ -5422,10 +5530,41 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
       return
     }
     if (!worktreePath || !opencodeSessionId) return
+    if (isStopping) return
+
+    setIsStopping(true)
+    // Stop means stop: hand the queue back before the abort, because the idle
+    // event that follows would otherwise auto-send it.
+    const reclaimed = reclaimQueuedMessages()
     // Clear any pending command approvals — the abort will auto-deny them on the main process side
     useCommandApprovalStore.getState().clearSession(sessionId)
-    unwrapEnvelope(await opencodeApi.abort(worktreePath, opencodeSessionId))
-  }, [isBashRunning, abortBash, worktreePath, opencodeSessionId, sessionId])
+
+    try {
+      const result = unwrapEnvelope(await opencodeApi.abort(worktreePath, opencodeSessionId))
+      if (result?.success === false) {
+        toast.error('Could not stop the session')
+      } else if (reclaimed > 0) {
+        toast.info(
+          reclaimed === 1
+            ? 'Stopped. Queued message moved back to the input.'
+            : `Stopped. ${reclaimed} queued messages moved back to the input.`
+        )
+      }
+    } catch (error) {
+      console.error('Abort failed', error)
+      toast.error('Could not stop the session')
+    } finally {
+      setIsStopping(false)
+    }
+  }, [
+    isBashRunning,
+    abortBash,
+    worktreePath,
+    opencodeSessionId,
+    sessionId,
+    isStopping,
+    reclaimQueuedMessages
+  ])
 
   // Handle keyboard shortcuts
   const handleKeyDown = useCallback(
@@ -6194,6 +6333,7 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
               queuedMessages={queuedMessages}
               canSteer={canSteer}
               onSteerMessage={handleSteerMessage}
+              onDeleteQueuedMessage={handleDeleteQueuedMessage}
               steeringMessageId={steeringMessageId}
               completionEntry={completionEntry}
               scrollElement={scrollElement}
@@ -6438,17 +6578,29 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
                     isCompacting={isCompacting}
                   />
                 )}
-                {(isStreaming || isBashRunning) && !inputValue.trim() ? (
+                {/* isStopping keeps the button in place while the abort runs: stopping
+                    can refill the composer with reclaimed queued text, which would
+                    otherwise swap in the send button mid-stop. */}
+                {(isStreaming || isBashRunning) && (!inputValue.trim() || isStopping) ? (
                   <Button
                     onClick={handleAbort}
+                    disabled={isStopping}
                     size="sm"
                     variant="destructive"
                     className="h-7 w-7 p-0"
-                    aria-label={isBashRunning ? 'Stop command' : 'Stop streaming'}
-                    title={isBashRunning ? 'Stop command' : 'Stop streaming'}
+                    aria-label={
+                      isStopping ? 'Stopping' : isBashRunning ? 'Stop command' : 'Stop streaming'
+                    }
+                    title={
+                      isStopping ? 'Stopping…' : isBashRunning ? 'Stop command' : 'Stop streaming'
+                    }
                     data-testid="stop-button"
                   >
-                    <Square className="h-3 w-3" />
+                    {isStopping ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <Square className="h-3 w-3" />
+                    )}
                   </Button>
                 ) : (
                   <Button

--- a/src/renderer/src/components/sessions/VirtualizedMessageList.tsx
+++ b/src/renderer/src/components/sessions/VirtualizedMessageList.tsx
@@ -41,6 +41,7 @@ export interface VirtualizedMessageListProps {
   queuedMessages: { id: string; content: string }[]
   canSteer: boolean
   onSteerMessage: (messageId: string, content: string) => void | Promise<void>
+  onDeleteQueuedMessage: (messageId: string) => void
   steeringMessageId: string | null
   completionEntry: { word?: string; durationMs?: number } | null
   scrollElement: HTMLDivElement | null
@@ -89,6 +90,7 @@ export const VirtualizedMessageList = memo(
   queuedMessages,
   canSteer,
   onSteerMessage,
+  onDeleteQueuedMessage,
   steeringMessageId,
   completionEntry,
   scrollElement,
@@ -331,6 +333,7 @@ export const VirtualizedMessageList = memo(
               canSteer={canSteer}
               isLoading={steeringMessageId === item.queuedMessage.id}
               onSteer={() => onSteerMessage(item.queuedMessage.id, item.queuedMessage.content)}
+              onDelete={() => onDeleteQueuedMessage(item.queuedMessage.id)}
             />
           )
 

--- a/src/renderer/src/stores/__tests__/useSessionStore.follow-up-queue.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.follow-up-queue.test.ts
@@ -85,6 +85,28 @@ describe('removeFollowUpMessageAt', () => {
     expect(queue()).toEqual(['a', 'b'])
   })
 
+  it('round-trips a claimed entry back to its position', () => {
+    // Steering claims the entry up front so the idle drain cannot also submit it,
+    // then restores it at the same index if the request fails.
+    useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['a', 'b', 'c'])
+
+    useSessionStore.getState().removeFollowUpMessageAt(SESSION_ID, 1, 'b')
+    expect(queue()).toEqual(['a', 'c'])
+
+    useSessionStore.getState().insertFollowUpMessageAt(SESSION_ID, 1, 'b')
+    expect(queue()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('clamps an insert index to the current queue', () => {
+    useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['a'])
+
+    useSessionStore.getState().insertFollowUpMessageAt(SESSION_ID, 99, 'tail')
+    useSessionStore.getState().insertFollowUpMessageAt(SESSION_ID, -5, 'head')
+
+    expect(queue()).toEqual(['head', 'a', 'tail'])
+    expect(setSessionQueuedState).toHaveBeenLastCalledWith(SESSION_ID, true)
+  })
+
   it('ignores out-of-range and unknown-session calls', () => {
     useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['a'])
 

--- a/src/renderer/src/stores/__tests__/useSessionStore.follow-up-queue.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.follow-up-queue.test.ts
@@ -58,6 +58,33 @@ describe('removeFollowUpMessageAt', () => {
     expect(setSessionQueuedState).toHaveBeenLastCalledWith(SESSION_ID, true)
   })
 
+  it('does not drop the wrong entry when the index is stale', () => {
+    // The rendered list lags the store by a render, so an index captured before
+    // an await can point somewhere else by the time the removal runs.
+    useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['second', 'third'])
+
+    // index 1 was captured when the queue was ['first', 'second', 'third']
+    useSessionStore.getState().removeFollowUpMessageAt(SESSION_ID, 1, 'second')
+
+    expect(queue()).toEqual(['third'])
+  })
+
+  it('still honours the index when the content matches', () => {
+    useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['same', 'other', 'same'])
+
+    useSessionStore.getState().removeFollowUpMessageAt(SESSION_ID, 2, 'same')
+
+    expect(queue()).toEqual(['same', 'other'])
+  })
+
+  it('leaves the queue alone when the expected content is gone', () => {
+    useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['a', 'b'])
+
+    useSessionStore.getState().removeFollowUpMessageAt(SESSION_ID, 0, 'already-drained')
+
+    expect(queue()).toEqual(['a', 'b'])
+  })
+
   it('ignores out-of-range and unknown-session calls', () => {
     useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['a'])
 

--- a/src/renderer/src/stores/__tests__/useSessionStore.follow-up-queue.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.follow-up-queue.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { setSessionQueuedState } = vi.hoisted(() => ({
+  setSessionQueuedState: vi.fn()
+}))
+
+vi.mock('@/api/system-api', () => ({
+  systemApi: { setSessionQueuedState }
+}))
+
+import { useSessionStore } from '../useSessionStore'
+
+const SESSION_ID = 'sess-queue-1'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  setSessionQueuedState.mockResolvedValue(undefined)
+  useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, [])
+})
+
+function queue(): string[] {
+  return useSessionStore.getState().pendingFollowUpMessages.get(SESSION_ID) ?? []
+}
+
+describe('removeFollowUpMessageAt', () => {
+  it('removes the entry at the given index', () => {
+    useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['a', 'b', 'c'])
+
+    useSessionStore.getState().removeFollowUpMessageAt(SESSION_ID, 1)
+
+    expect(queue()).toEqual(['a', 'c'])
+  })
+
+  it('removes the clicked duplicate, not the first match', () => {
+    // The bug this guards: content-based removal deletes the wrong bubble when
+    // two queued messages read the same.
+    useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['same', 'other', 'same'])
+
+    useSessionStore.getState().removeFollowUpMessageAt(SESSION_ID, 2)
+
+    expect(queue()).toEqual(['same', 'other'])
+  })
+
+  it('drops the session entry once the queue is empty', () => {
+    useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['only'])
+
+    useSessionStore.getState().removeFollowUpMessageAt(SESSION_ID, 0)
+
+    expect(useSessionStore.getState().pendingFollowUpMessages.has(SESSION_ID)).toBe(false)
+    expect(setSessionQueuedState).toHaveBeenLastCalledWith(SESSION_ID, false)
+  })
+
+  it('keeps the backend queued flag set while messages remain', () => {
+    useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['a', 'b'])
+
+    useSessionStore.getState().removeFollowUpMessageAt(SESSION_ID, 0)
+
+    expect(setSessionQueuedState).toHaveBeenLastCalledWith(SESSION_ID, true)
+  })
+
+  it('ignores out-of-range and unknown-session calls', () => {
+    useSessionStore.getState().setPendingFollowUpMessages(SESSION_ID, ['a'])
+
+    useSessionStore.getState().removeFollowUpMessageAt(SESSION_ID, 5)
+    useSessionStore.getState().removeFollowUpMessageAt(SESSION_ID, -1)
+    useSessionStore.getState().removeFollowUpMessageAt('missing-session', 0)
+
+    expect(queue()).toEqual(['a'])
+  })
+})

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -273,7 +273,7 @@ interface SessionState {
   requeueFollowUpMessageFront: (sessionId: string, message: string) => void
   consumeFollowUpMessage: (sessionId: string) => string | null
   enqueueFollowUpMessage: (sessionId: string, message: string) => void
-  removeFollowUpMessageAt: (sessionId: string, index: number) => void
+  removeFollowUpMessageAt: (sessionId: string, index: number, expectedContent?: string) => void
   closeOtherSessions: (worktreeId: string, keepSessionId: string) => Promise<void>
   closeSessionsToRight: (worktreeId: string, fromSessionId: string) => Promise<void>
   // Plan approval
@@ -2049,10 +2049,21 @@ export const useSessionStore = create<SessionState>()(
 
       // Drop one queued follow-up. Index-based on purpose: two queued messages
       // can hold identical text, and removing by content would hit the wrong one.
-      removeFollowUpMessageAt: (sessionId: string, index: number) => {
+      // Pass expectedContent whenever the index came from the rendered list: that
+      // list lags the store by a render, so an index captured before an await can
+      // point at a different entry by the time this runs. The content check makes a
+      // stale index fall back to the first match instead of dropping the wrong one.
+      removeFollowUpMessageAt: (sessionId: string, index: number, expectedContent?: string) => {
         const existing = get().pendingFollowUpMessages.get(sessionId)
-        if (!existing || index < 0 || index >= existing.length) return
-        const rest = existing.filter((_, i) => i !== index)
+        if (!existing || existing.length === 0) return
+
+        let target = index
+        if (expectedContent !== undefined && existing[target] !== expectedContent) {
+          target = existing.indexOf(expectedContent)
+        }
+        if (target < 0 || target >= existing.length) return
+
+        const rest = existing.filter((_, i) => i !== target)
         set((state) => {
           const newMap = new Map(state.pendingFollowUpMessages)
           if (rest.length === 0) {

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -273,6 +273,7 @@ interface SessionState {
   requeueFollowUpMessageFront: (sessionId: string, message: string) => void
   consumeFollowUpMessage: (sessionId: string) => string | null
   enqueueFollowUpMessage: (sessionId: string, message: string) => void
+  removeFollowUpMessageAt: (sessionId: string, index: number) => void
   closeOtherSessions: (worktreeId: string, keepSessionId: string) => Promise<void>
   closeSessionsToRight: (worktreeId: string, fromSessionId: string) => Promise<void>
   // Plan approval
@@ -2044,6 +2045,24 @@ export const useSessionStore = create<SessionState>()(
           return { pendingFollowUpMessages: newMap }
         })
         pushQueuedState(sessionId, true)
+      },
+
+      // Drop one queued follow-up. Index-based on purpose: two queued messages
+      // can hold identical text, and removing by content would hit the wrong one.
+      removeFollowUpMessageAt: (sessionId: string, index: number) => {
+        const existing = get().pendingFollowUpMessages.get(sessionId)
+        if (!existing || index < 0 || index >= existing.length) return
+        const rest = existing.filter((_, i) => i !== index)
+        set((state) => {
+          const newMap = new Map(state.pendingFollowUpMessages)
+          if (rest.length === 0) {
+            newMap.delete(sessionId)
+          } else {
+            newMap.set(sessionId, rest)
+          }
+          return { pendingFollowUpMessages: newMap }
+        })
+        pushQueuedState(sessionId, rest.length > 0)
       },
 
       // Close all sessions except the kept one

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -274,6 +274,7 @@ interface SessionState {
   consumeFollowUpMessage: (sessionId: string) => string | null
   enqueueFollowUpMessage: (sessionId: string, message: string) => void
   removeFollowUpMessageAt: (sessionId: string, index: number, expectedContent?: string) => void
+  insertFollowUpMessageAt: (sessionId: string, index: number, message: string) => void
   closeOtherSessions: (worktreeId: string, keepSessionId: string) => Promise<void>
   closeSessionsToRight: (worktreeId: string, fromSessionId: string) => Promise<void>
   // Plan approval
@@ -2074,6 +2075,20 @@ export const useSessionStore = create<SessionState>()(
           return { pendingFollowUpMessages: newMap }
         })
         pushQueuedState(sessionId, rest.length > 0)
+      },
+
+      // Put a follow-up back at a known position. Used to undo an optimistic
+      // removal, e.g. when steering claimed the entry up front and then failed.
+      insertFollowUpMessageAt: (sessionId: string, index: number, message: string) => {
+        const existing = get().pendingFollowUpMessages.get(sessionId) ?? []
+        const at = Math.max(0, Math.min(index, existing.length))
+        const next = [...existing.slice(0, at), message, ...existing.slice(at)]
+        set((state) => {
+          const newMap = new Map(state.pendingFollowUpMessages)
+          newMap.set(sessionId, next)
+          return { pendingFollowUpMessages: newMap }
+        })
+        pushQueuedState(sessionId, true)
       },
 
       // Close all sessions except the kept one

--- a/src/shared/__tests__/opencode-session-error.test.ts
+++ b/src/shared/__tests__/opencode-session-error.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { describeOpenCodeSessionError, isOpenCodeAbortedError } from '../opencode-session-error'
+
+describe('isOpenCodeAbortedError', () => {
+  it('recognises a turn the user stopped', () => {
+    expect(isOpenCodeAbortedError({ name: 'MessageAbortedError', data: {} })).toBe(true)
+  })
+
+  it('does not treat real failures as a stop', () => {
+    expect(isOpenCodeAbortedError({ name: 'UnknownError', data: { message: 'boom' } })).toBe(false)
+    expect(isOpenCodeAbortedError({ name: 'ProviderAuthError', data: {} })).toBe(false)
+    expect(isOpenCodeAbortedError(undefined)).toBe(false)
+    expect(isOpenCodeAbortedError('MessageAbortedError')).toBe(false)
+  })
+})
+
+describe('describeOpenCodeSessionError', () => {
+  it('surfaces the message that toError() used to swallow', () => {
+    // The real payload behind the "Error: [object Object]" log line.
+    expect(
+      describeOpenCodeSessionError({
+        name: 'UnknownError',
+        data: { message: 'no such provider: claude-code' }
+      })
+    ).toBe('UnknownError: no such provider: claude-code')
+  })
+
+  it('includes the provider for auth errors', () => {
+    expect(
+      describeOpenCodeSessionError({
+        name: 'ProviderAuthError',
+        data: { providerID: 'anthropic', message: 'missing api key' }
+      })
+    ).toBe('ProviderAuthError: missing api key (provider: anthropic)')
+  })
+
+  it('falls back to the name when there is no message', () => {
+    expect(describeOpenCodeSessionError({ name: 'MessageOutputLengthError', data: {} })).toBe(
+      'MessageOutputLengthError'
+    )
+  })
+
+  it('passes a plain string through', () => {
+    expect(describeOpenCodeSessionError('server exploded')).toBe('server exploded')
+  })
+
+  it('has a sane fallback for unusable input', () => {
+    expect(describeOpenCodeSessionError(undefined)).toBe('OpenCode session failed')
+    expect(describeOpenCodeSessionError({})).toBe('OpenCode session failed')
+    expect(describeOpenCodeSessionError('')).toBe('OpenCode session failed')
+  })
+})

--- a/src/shared/opencode-session-error.ts
+++ b/src/shared/opencode-session-error.ts
@@ -1,0 +1,60 @@
+/**
+ * OpenCode reports session failures on the `session.error` event as
+ * `{ name, data: { message } }` (see `EventSessionError` in the SDK types).
+ *
+ * Two things go wrong if that shape is not respected:
+ *
+ * 1. `new Error(String(payload))` yields `Error: [object Object]`, so the log
+ *    says nothing and the real cause is lost.
+ * 2. The renderer falls back to the bare `name`, so the user sees
+ *    "UnknownError" with no hint of what actually failed.
+ */
+
+export interface OpenCodeSessionErrorPayload {
+  name?: string
+  data?: {
+    message?: string
+    providerID?: string
+    statusCode?: number
+  }
+}
+
+/**
+ * OpenCode reports a turn the user interrupted as a session error. It is a
+ * stop, not a failure, so it must not surface as one.
+ */
+export const OPENCODE_ABORTED_ERROR_NAME = 'MessageAbortedError'
+
+function asPayload(error: unknown): OpenCodeSessionErrorPayload | null {
+  if (typeof error !== 'object' || error === null) return null
+  return error as OpenCodeSessionErrorPayload
+}
+
+export function isOpenCodeAbortedError(error: unknown): boolean {
+  return asPayload(error)?.name === OPENCODE_ABORTED_ERROR_NAME
+}
+
+/** Human-readable one-liner for logs and the error banner. */
+export function describeOpenCodeSessionError(error: unknown): string {
+  if (typeof error === 'string' && error.trim().length > 0) return error
+
+  const payload = asPayload(error)
+  if (!payload) return 'OpenCode session failed'
+
+  const name = typeof payload.name === 'string' ? payload.name : undefined
+  const message =
+    typeof payload.data?.message === 'string' && payload.data.message.trim().length > 0
+      ? payload.data.message
+      : undefined
+  const providerID =
+    typeof payload.data?.providerID === 'string' ? payload.data.providerID : undefined
+
+  const detail = [message, providerID ? `provider: ${providerID}` : undefined]
+    .filter(Boolean)
+    .join(' (')
+  const suffix = providerID && message ? `${detail})` : detail
+
+  if (name && suffix) return `${name}: ${suffix}`
+  // Truthiness, not ??: an empty detail string must fall through to the default.
+  return name || suffix || 'OpenCode session failed'
+}

--- a/test/claude-code-abort-ordering.test.ts
+++ b/test/claude-code-abort-ordering.test.ts
@@ -1,0 +1,225 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ClaudeSessionState } from '../src/main/services/claude-code-implementer'
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('../src/main/services/claude-sdk-loader', () => ({
+  loadClaudeSDK: vi.fn()
+}))
+
+vi.mock('../src/main/services/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+vi.mock('../src/main/services/claude-transcript-reader', () => ({
+  readClaudeTranscript: vi.fn().mockResolvedValue([]),
+  translateEntry: vi.fn()
+}))
+
+vi.mock('../src/main/services/git-service', () => ({
+  autoRenameWorktreeBranch: vi.fn()
+}))
+
+const mockAgentPublish = vi.fn()
+vi.mock('../src/main/services/agent-event-bus', () => ({
+  agentEventBus: { publish: (...args: any[]) => mockAgentPublish(...args) }
+}))
+
+vi.mock('../src/main/services/worktree-events', () => ({
+  emitWorktreeBranchRenamed: vi.fn()
+}))
+
+vi.mock('../src/main/desktop/backend-event-publisher', () => ({
+  publishDesktopBackendEvent: vi.fn()
+}))
+
+vi.mock('../src/main/services/notification-service', () => ({
+  notificationService: {
+    notifySessionComplete: vi.fn(),
+    notifyUserFeedbackNeeded: vi.fn(),
+    setSessionQueuedState: vi.fn()
+  }
+}))
+
+vi.mock('../src/main/services/usage/session-usage-service', () => ({
+  scheduleSessionUsageReport: vi.fn()
+}))
+
+import { ClaudeCodeImplementer } from '../src/main/services/claude-code-implementer'
+
+const WORKTREE = '/path/to/worktree'
+const SDK_SESSION = 'sdk-session-123'
+
+function createMockSession(overrides: Partial<ClaudeSessionState> = {}): ClaudeSessionState {
+  return {
+    claudeSessionId: SDK_SESSION,
+    hiveSessionId: 'hive-session-456',
+    worktreePath: WORKTREE,
+    abortController: new AbortController(),
+    subscription: null,
+    checkpointCounter: 0,
+    checkpoints: new Map(),
+    query: null,
+    lastQuery: null,
+    materialized: true,
+    messages: [],
+    toolNames: new Map(),
+    pendingQuestion: null,
+    pendingPlanApproval: null,
+    revertMessageID: null,
+    revertCheckpointUuid: null,
+    revertDiff: null,
+    pendingFork: false,
+    pendingResumeSessionAt: null,
+    titleDeferred: false,
+    stderrBuffer: [],
+    ...overrides
+  } as ClaudeSessionState
+}
+
+function injectSession(impl: ClaudeCodeImplementer, session: ClaudeSessionState): void {
+  const sessions = (impl as any).sessions as Map<string, ClaudeSessionState>
+  sessions.set(`${session.worktreePath}::${session.claudeSessionId}`, session)
+}
+
+describe('ClaudeCodeImplementer.abort', () => {
+  let impl: ClaudeCodeImplementer
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    impl = new ClaudeCodeImplementer()
+    impl.setDatabaseService({
+      updateSession: vi.fn(),
+      getSession: vi.fn(),
+      getWorktreeBySessionId: vi.fn().mockReturnValue(null)
+    } as any)
+  })
+
+  it('replies to a pending command approval before tearing the stream down', async () => {
+    const order: string[] = []
+    const approvalResolve = vi.fn(() => order.push('approval-replied'))
+
+    const session = createMockSession({
+      query: { interrupt: vi.fn(async () => order.push('interrupt')) } as any,
+      subscription: { abort: vi.fn(async () => order.push('subscription-abort')) } as any
+    })
+    session.abortController!.signal.addEventListener('abort', () => order.push('controller-abort'))
+    injectSession(impl, session)
+    ;(impl as any).pendingApprovals.set('approval-1', {
+      resolve: approvalResolve,
+      toolName: 'Bash',
+      input: {},
+      commandStr: 'ls',
+      hiveSessionId: session.hiveSessionId
+    })
+
+    await expect(impl.abort(WORKTREE, SDK_SESSION)).resolves.toBe(true)
+
+    // The deny has to land first, otherwise the CLI reports
+    // "Tool permission request failed: AbortError: Stream closed".
+    expect(order).toEqual([
+      'approval-replied',
+      'interrupt',
+      'controller-abort',
+      'subscription-abort'
+    ])
+    expect(approvalResolve).toHaveBeenCalledWith({ approved: false })
+    expect((impl as any).pendingApprovals.size).toBe(0)
+  })
+
+  it('rejects a pending question and plan approval too', async () => {
+    const questionResolve = vi.fn()
+    const planResolve = vi.fn()
+    const session = createMockSession({
+      pendingQuestion: { requestId: 'q-1', questions: [], resolve: questionResolve },
+      pendingPlanApproval: { requestId: 'p-1', resolve: planResolve }
+    })
+    injectSession(impl, session)
+
+    await impl.abort(WORKTREE, SDK_SESSION)
+
+    expect(questionResolve).toHaveBeenCalledWith({ answers: [], rejected: true })
+    expect(planResolve).toHaveBeenCalledWith({ approved: false })
+    expect(session.pendingQuestion).toBeNull()
+    expect(session.pendingPlanApproval).toBeNull()
+
+    // Both must tell the renderer to drop the prompt. Without question.rejected
+    // the question store keeps a stale entry, the following idle counts as
+    // blocked, and the turn never finalizes.
+    const emitted = mockAgentPublish.mock.calls.map(([event]: any[]) => event)
+    expect(emitted).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'question.rejected',
+          data: expect.objectContaining({ requestId: 'q-1', id: 'q-1' })
+        }),
+        expect.objectContaining({
+          type: 'plan.resolved',
+          data: expect.objectContaining({ approved: false, aborted: true })
+        })
+      ])
+    )
+  })
+
+  it('leaves another session’s pending approval untouched', async () => {
+    const otherResolve = vi.fn()
+    const session = createMockSession()
+    injectSession(impl, session)
+    ;(impl as any).pendingApprovals.set('approval-other', {
+      resolve: otherResolve,
+      toolName: 'Bash',
+      input: {},
+      commandStr: 'ls',
+      hiveSessionId: 'some-other-session'
+    })
+
+    await impl.abort(WORKTREE, SDK_SESSION)
+
+    expect(otherResolve).not.toHaveBeenCalled()
+    expect((impl as any).pendingApprovals.size).toBe(1)
+  })
+
+  it('still finishes when interrupt and teardown never settle', async () => {
+    vi.useFakeTimers()
+    try {
+      const session = createMockSession({
+        query: { interrupt: vi.fn(() => new Promise(() => {})) } as any,
+        subscription: { abort: vi.fn(() => new Promise(() => {})) } as any
+      })
+      injectSession(impl, session)
+
+      const pending = impl.abort(WORKTREE, SDK_SESSION)
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      await expect(pending).resolves.toBe(true)
+      // The hard abort must happen even though the graceful path hung.
+      expect(session.abortController!.signal.aborted).toBe(true)
+      expect(session.query).toBeNull()
+      expect(session.subscription).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reports failure for an unknown session', async () => {
+    await expect(impl.abort(WORKTREE, 'missing-session')).resolves.toBe(false)
+  })
+
+  it('emits an idle status so the UI stops showing the turn as running', async () => {
+    const session = createMockSession()
+    injectSession(impl, session)
+
+    await impl.abort(WORKTREE, SDK_SESSION)
+
+    const statusEvents = mockAgentPublish.mock.calls
+      .map(([event]: any[]) => event)
+      .filter((event: any) => event?.type === 'session.status')
+    expect(statusEvents.at(-1)?.statusPayload).toEqual({ type: 'idle' })
+  })
+})

--- a/test/claude-code-turn-fence.test.ts
+++ b/test/claude-code-turn-fence.test.ts
@@ -1,0 +1,191 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ClaudeSessionState } from '../src/main/services/claude-code-implementer'
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+const mockQuery = vi.fn()
+vi.mock('../src/main/services/claude-sdk-loader', () => ({
+  loadClaudeSDK: vi.fn(async () => ({ query: (...args: any[]) => mockQuery(...args) }))
+}))
+
+vi.mock('../src/main/services/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('../src/main/services/claude-transcript-reader', () => ({
+  readClaudeTranscript: vi.fn().mockResolvedValue([]),
+  translateEntry: vi.fn()
+}))
+
+vi.mock('../src/main/services/git-service', () => ({ autoRenameWorktreeBranch: vi.fn() }))
+vi.mock('../src/main/services/worktree-events', () => ({ emitWorktreeBranchRenamed: vi.fn() }))
+vi.mock('../src/main/desktop/backend-event-publisher', () => ({
+  publishDesktopBackendEvent: vi.fn()
+}))
+vi.mock('../src/main/services/claude-session-title', () => ({
+  generateSessionTitle: vi.fn().mockResolvedValue(null)
+}))
+vi.mock('../src/main/services/env-vars', () => ({
+  getUserEnvironmentVariables: vi.fn().mockResolvedValue({})
+}))
+vi.mock('../src/main/services/usage/session-usage-service', () => ({
+  scheduleSessionUsageReport: vi.fn()
+}))
+vi.mock('../src/main/services/notification-service', () => ({
+  notificationService: {
+    notifySessionComplete: vi.fn(),
+    notifyUserFeedbackNeeded: vi.fn(),
+    setSessionQueuedState: vi.fn()
+  }
+}))
+
+const mockAgentPublish = vi.fn()
+vi.mock('../src/main/services/agent-event-bus', () => ({
+  agentEventBus: { publish: (...args: any[]) => mockAgentPublish(...args) }
+}))
+
+// Capture the subscription params so the test can drive onMessage and awaitDone.
+type Captured = {
+  onMessage: (m: unknown) => Promise<void>
+  settleDone: (value: unknown) => void
+  abort: ReturnType<typeof vi.fn>
+}
+const captured: Captured[] = []
+
+vi.mock('../src/main/effect/claude/facade', () => ({
+  claudeAgentFacade: {
+    startSessionEvents: (params: any) => {
+      let settleDone: (value: unknown) => void = () => {}
+      const done = new Promise((resolve) => {
+        settleDone = resolve
+      })
+      captured.push({ onMessage: params.onMessage, settleDone, abort: vi.fn(() => done) })
+      return {
+        // never settles on its own; the test decides
+        awaitDone: () => done,
+        abort: captured[captured.length - 1].abort
+      }
+    }
+  }
+}))
+
+import { ClaudeCodeImplementer } from '../src/main/services/claude-code-implementer'
+
+const WORKTREE = '/path/to/worktree'
+const SDK_SESSION = 'sdk-session-123'
+const HIVE_SESSION = 'hive-session-456'
+
+function makeSession(): ClaudeSessionState {
+  return {
+    claudeSessionId: SDK_SESSION,
+    hiveSessionId: HIVE_SESSION,
+    worktreePath: WORKTREE,
+    abortController: null,
+    subscription: null,
+    checkpointCounter: 0,
+    checkpoints: new Map(),
+    query: null,
+    lastQuery: null,
+    materialized: true,
+    messages: [],
+    toolNames: new Map(),
+    pendingQuestion: null,
+    pendingPlanApproval: null,
+    revertMessageID: null,
+    revertCheckpointUuid: null,
+    revertDiff: null,
+    pendingFork: false,
+    pendingResumeSessionAt: null,
+    titleDeferred: false,
+    stderrBuffer: []
+  } as ClaudeSessionState
+}
+
+function statusEvents(): any[] {
+  return mockAgentPublish.mock.calls
+    .map(([event]: any[]) => event)
+    .filter((event: any) => event?.type === 'session.status')
+}
+
+describe('turn fencing after a timed-out abort', () => {
+  let impl: ClaudeCodeImplementer
+  let session: ClaudeSessionState
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    captured.length = 0
+    mockQuery.mockReturnValue({
+      [Symbol.asyncIterator]: () => ({ next: () => new Promise(() => {}) }),
+      interrupt: vi.fn(() => new Promise(() => {})),
+      close: vi.fn()
+    })
+
+    impl = new ClaudeCodeImplementer()
+    impl.setDatabaseService({
+      getSession: vi.fn().mockReturnValue({ id: HIVE_SESSION, mode: 'build' }),
+      updateSession: vi.fn(),
+      getWorktreeBySessionId: vi.fn().mockReturnValue(null),
+      getWorktreeByPath: vi.fn().mockReturnValue(null),
+      getSetting: vi.fn().mockReturnValue(null)
+    } as any)
+
+    session = makeSession()
+    const sessions = (impl as any).sessions as Map<string, ClaudeSessionState>
+    sessions.set(`${WORKTREE}::${SDK_SESSION}`, session)
+  })
+
+  it('ignores stream messages from a turn that was superseded', async () => {
+    await impl.prompt(WORKTREE, SDK_SESSION, 'first')
+    expect(captured).toHaveLength(1)
+    const firstTurn = captured[0]
+
+    // Stop, with a teardown that never settles, then start a new turn.
+    vi.useFakeTimers()
+    try {
+      const stopping = impl.abort(WORKTREE, SDK_SESSION)
+      await vi.advanceTimersByTimeAsync(10_000)
+      await stopping
+    } finally {
+      vi.useRealTimers()
+    }
+    await impl.prompt(WORKTREE, SDK_SESSION, 'second')
+
+    mockAgentPublish.mockClear()
+    await firstTurn.onMessage({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'stale' }] }
+    })
+
+    // Nothing from the dead turn may reach the renderer.
+    expect(mockAgentPublish).not.toHaveBeenCalled()
+  })
+
+  it('does not let a superseded finisher clear the live turn', async () => {
+    await impl.prompt(WORKTREE, SDK_SESSION, 'first')
+    const firstTurn = captured[0]
+
+    vi.useFakeTimers()
+    try {
+      const stopping = impl.abort(WORKTREE, SDK_SESSION)
+      await vi.advanceTimersByTimeAsync(10_000)
+      await stopping
+    } finally {
+      vi.useRealTimers()
+    }
+    await impl.prompt(WORKTREE, SDK_SESSION, 'second')
+
+    const liveQuery = session.query
+    expect(liveQuery).not.toBeNull()
+    mockAgentPublish.mockClear()
+
+    // The abandoned stream finally finishes.
+    firstTurn.settleDone({ _tag: 'Success', value: undefined })
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // The live turn keeps its handle, so the next stop still has something to
+    // interrupt, and the UI is not told the new turn is done.
+    expect(session.query).toBe(liveQuery)
+    expect(statusEvents().map((e) => e.statusPayload?.type)).not.toContain('idle')
+  })
+})

--- a/test/phase-22/session-10/session-follow-up-steer-overlap.test.ts
+++ b/test/phase-22/session-10/session-follow-up-steer-overlap.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  handleSessionIdleFollowUp,
+  resetSessionFollowUpDispatchState
+} from '../../../src/renderer/src/lib/session-follow-up-dispatch'
+
+/**
+ * Steering claims one queued message and injects it into the active turn. If that
+ * turn goes idle while the steer request is still in flight, the drain must not
+ * submit the NEXT queued message as a separate prompt: the two would overlap. The
+ * drain reports 'blocked' so the steer can re-run it once it settles.
+ */
+describe('drain versus an in-flight steer', () => {
+  beforeEach(() => {
+    resetSessionFollowUpDispatchState()
+    vi.clearAllMocks()
+  })
+
+  test('does not dispatch while a steer is in flight', async () => {
+    const dispatchFollowUp = vi.fn().mockResolvedValue(true)
+    const dequeueFollowUp = vi.fn().mockReturnValue('second')
+    const onComplete = vi.fn()
+    let steerInFlight = true
+
+    const result = await handleSessionIdleFollowUp({
+      sessionId: 'session-steer',
+      isBlocked: () => steerInFlight,
+      dequeueFollowUp,
+      requeueFollowUp: vi.fn(),
+      dispatchFollowUp,
+      onComplete
+    })
+
+    expect(result).toBe('blocked')
+    // The queued message is still queued, and nothing was sent or finalized.
+    expect(dequeueFollowUp).not.toHaveBeenCalled()
+    expect(dispatchFollowUp).not.toHaveBeenCalled()
+    expect(onComplete).not.toHaveBeenCalled()
+
+    // Steer settles and re-runs the drain, which now goes through.
+    steerInFlight = false
+    const retry = await handleSessionIdleFollowUp({
+      sessionId: 'session-steer',
+      isBlocked: () => steerInFlight,
+      dequeueFollowUp,
+      requeueFollowUp: vi.fn(),
+      dispatchFollowUp,
+      onComplete
+    })
+
+    expect(retry).toBe('dispatched')
+    expect(dispatchFollowUp).toHaveBeenCalledWith('second')
+  })
+
+  test('the re-run finalizes the turn when the queue is empty', async () => {
+    const onComplete = vi.fn()
+
+    const result = await handleSessionIdleFollowUp({
+      sessionId: 'session-steer-empty',
+      isBlocked: () => false,
+      dequeueFollowUp: () => null,
+      requeueFollowUp: vi.fn(),
+      dispatchFollowUp: vi.fn(),
+      onComplete
+    })
+
+    // This is why steer re-runs the drain unconditionally: with nothing queued it
+    // still has to finalize the turn the blocked idle skipped.
+    expect(result).toBe('completed')
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Description

Stopping a chat turn was unreliable and noisy. Four separate causes:

1. **`ClaudeCodeImplementer.abort()` tore the transport down in the wrong order.** It called
   `abortController.abort()` first, but that same signal is what the pending `canUseTool`
   handlers listen to. They resolved with `deny` while the stream was already closing, so the
   reply never reached the CLI. The CLI then reported
   `Tool permission request failed: AbortError: Stream closed` as a failed tool result, which
   Hive painted as a red tool card. It also landed in the session JSONL, so it came back on
   every reload.
2. **Both awaits in `abort()` were unbounded**, so a wedged child process kept the stop request
   hanging.
3. **`session.error` never cleared `isStreaming`**, so after a failed turn every later message
   was queued behind a turn that would never finish.
4. **OpenCode reports an interrupted turn as `session.error` with `MessageAbortedError`**, which
   was never handled, so stopping an OpenCode session also produced a red banner.

Note on the error text: `"Tool permission request failed: AbortError: Stream closed"` is not in
Hive or in `@anthropic-ai/claude-agent-sdk`'s JS. It comes from the Bun-compiled `claude` binary
the SDK ships, so it can only be recognised by shape. The pattern is deliberately narrow and
anchored, so tool output that merely mentions `AbortError` keeps its error styling.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX improvement

## Changes Made

- `abort()` now denies pending approval, question and plan requests first, waits ~25ms so those
  replies flush, then calls `query.interrupt()`, then `abortController.abort()`, then tears the
  subscription down. Each step is bounded at 2s so stop always returns.
- Denying a pending question now emits `question.rejected`. Without it the renderer kept a stale
  question, the following idle counted as blocked, and the turn never finalized.
- Abort-only stream errors no longer emit `session.error`. The per-prompt `AbortController`
  proves the stop, since each prompt gets its own.
- The abort-artifact tool result is rewritten to a plain "Stopped by user." in the live stream,
  the stored message copy, and the transcript reader, so a reload does not resurrect it.
- Stop button shows a spinner, disables while in flight, and toasts on failure.
- Stop hands queued messages back to the composer instead of letting the following idle send
  them.
- `session.error` resets the full streaming state, so a failed turn's partials cannot leak into
  the next one.
- OpenCode's `MessageAbortedError` is treated as a stop, not a failure, and real OpenCode errors
  now log and display `name: data.message` instead of `Error: [object Object]`.
- Queued message bubbles get a delete button, backed by a new index-based
  `removeFollowUpMessageAt`. Steer uses the same path, fixing a case where it removed the wrong
  entry when two queued messages held identical text.

## Testing

### Test Configuration
- **OS**: macOS 15
- **Node Version**: 20.20.2
- **Test Type**: Unit + Manual

### Test Steps
1. Start a long turn in a `claude-code` session, press stop.
2. Queue a second message mid-turn, then press stop.
3. Stop while a permission prompt is open.
4. Delete a queued message with the X on its bubble.

### Test Results
- [x] All existing tests pass
- [x] New tests added (if applicable)
- [x] Manual testing completed

27 new tests across 5 files. Full suite shows no new failures: 41 failing files with this
branch, 41 on the same commit without it, verified by stashing. No new TypeScript errors in
either project, measured the same way. 0 lint errors.

The abort ordering assertion was mutation-tested: reintroducing the old sequence fails it.

## Additional Notes

**One behaviour choice worth a look.** Stop now moves queued messages back into the composer
rather than sending them, which felt closer to what "stop" means, and nothing is lost. Happy to
change it to leaving them queued if you prefer.

Independent of this PR, but relevant if you test in a dev build: #630 fixes main and the desktop
backend opening different databases, which makes every session fall back to OpenCode and hides
the Claude stop path entirely. No code overlap with this branch, so they merge in either order.

One follow-up found while working on this, deliberately left out of scope: queued messages render
above the previous turn's reply, and can duplicate when switching session tabs.
`onBeforeDispatch` appends the optimistic user bubble before the previous reply is committed, and
`finalizeResponse` short-circuits on `newPromptPendingRef`. Fixing it means touching the
message-list reconciliation, which is riskier than anything here.

## Performance Impact

- [x] No performance impact

## Breaking Changes

- [x] No breaking changes