### PR TITLE
Fix false expired-session detection for Claude accounts

### DIFF
--- a/src/main/services/__tests__/account-maintenance-heal.test.ts
+++ b/src/main/services/__tests__/account-maintenance-heal.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { startAccountMaintenance } from '../account-maintenance'
+import { listClaudeAccounts, readClaudeEffectiveBlob } from '../account-store-claude'
+import { listCodexAccounts } from '../account-store-codex'
+import {
+  fetchForSavedAccount,
+  refreshTokensForStoreAccount
+} from '../saved-usage-orchestrator'
+import { getDatabase } from '../../db'
+
+vi.mock('../../db', () => ({ getDatabase: vi.fn() }))
+vi.mock('../account-store-claude', () => ({
+  listClaudeAccounts: vi.fn(),
+  readClaudeEffectiveBlob: vi.fn()
+}))
+vi.mock('../account-store-codex', () => ({
+  listCodexAccounts: vi.fn(),
+  readCodexEffectiveAuth: vi.fn()
+}))
+vi.mock('../credentials-migration', () => ({
+  migrateSavedCredentialsToStores: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('../saved-usage-orchestrator', () => ({
+  fetchForSavedAccount: vi.fn(),
+  refreshAllForProvider: vi.fn().mockResolvedValue([]),
+  refreshTokensForStoreAccount: vi.fn().mockResolvedValue('needsLogin')
+}))
+
+const TICK_MS = 60_000
+
+function claudeAccount(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    num: '9',
+    email: 'active@example.com',
+    uuid: 'u',
+    expiresAtMs: Date.now() + 60 * 60_000,
+    hasRefresh: true,
+    plan: null,
+    active: true,
+    ...overrides
+  }
+}
+
+function staleRow(id: string, email: string, status = 'stale'): Record<string, unknown> {
+  return {
+    id,
+    provider: 'anthropic',
+    email,
+    credentials_json: '',
+    last_usage_json: null,
+    last_fetched_at: null,
+    status,
+    last_error: 'Token refresh failed: invalid_grant (...)',
+    created_at: '',
+    updated_at: ''
+  }
+}
+
+describe('account-maintenance stale-row self-heal', () => {
+  let stop: (() => void) | null = null
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(listCodexAccounts).mockResolvedValue([])
+    vi.mocked(readClaudeEffectiveBlob).mockResolvedValue({
+      raw: '{}',
+      parsed: { refreshToken: 'current-refresh-token' }
+    })
+    vi.mocked(getDatabase).mockReturnValue({
+      getSavedUsageAccountsByProvider: vi.fn().mockReturnValue([])
+    } as never)
+  })
+
+  afterEach(() => {
+    stop?.()
+    stop = null
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('re-fetches a stale row whose credentials now look healthy, and skips dead ones', async () => {
+    vi.mocked(listClaudeAccounts).mockResolvedValue([
+      claudeAccount() as never,
+      claudeAccount({
+        num: '2',
+        email: 'dead@example.com',
+        expiresAtMs: Date.now() - 60 * 60_000,
+        active: false
+      }) as never
+    ])
+    const rows = [
+      staleRow('row-healthy', 'active@example.com'),
+      staleRow('row-dead', 'dead@example.com'),
+      staleRow('row-fine', 'ok@example.com', 'ok')
+    ]
+    vi.mocked(getDatabase).mockReturnValue({
+      getSavedUsageAccountsByProvider: vi.fn().mockReturnValue(rows)
+    } as never)
+    vi.mocked(fetchForSavedAccount).mockResolvedValue({ success: true, status: 'ok' } as never)
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+
+    // Only the stale row backed by a comfortably-unexpired access token is
+    // retried; the row with genuinely-expired credentials and the ok row are
+    // left alone.
+    expect(fetchForSavedAccount).toHaveBeenCalledTimes(1)
+    expect(fetchForSavedAccount).toHaveBeenCalledWith('row-healthy', {
+      caller: 'usage:fetchForAccount'
+    })
+    // The dead account still went through the ordinary expiry watcher.
+    expect(refreshTokensForStoreAccount).toHaveBeenCalledWith('anthropic', {
+      num: '2',
+      email: 'dead@example.com'
+    })
+  })
+
+  it('parks a needsLogin heal outcome until the refresh token changes', async () => {
+    vi.mocked(listClaudeAccounts).mockResolvedValue([claudeAccount() as never])
+    vi.mocked(getDatabase).mockReturnValue({
+      getSavedUsageAccountsByProvider: vi
+        .fn()
+        .mockReturnValue([staleRow('row-1', 'active@example.com')])
+    } as never)
+    vi.mocked(fetchForSavedAccount).mockResolvedValue({
+      success: false,
+      error: 'Usage API returned 401: Unauthorized',
+      status: 'stale',
+      needsLogin: true
+    } as never)
+
+    stop = startAccountMaintenance()
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(fetchForSavedAccount).toHaveBeenCalledTimes(1)
+
+    // Same refresh token → parked, no retry on the next tick.
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(fetchForSavedAccount).toHaveBeenCalledTimes(1)
+
+    // Another process rotates the token → the park lifts and the heal retries.
+    vi.mocked(readClaudeEffectiveBlob).mockResolvedValue({
+      raw: '{}',
+      parsed: { refreshToken: 'rotated-refresh-token' }
+    })
+    await vi.advanceTimersByTimeAsync(TICK_MS)
+    expect(fetchForSavedAccount).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/services/__tests__/account-store-claude-live-entry.test.ts
+++ b/src/main/services/__tests__/account-store-claude-live-entry.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  clearAccountStoreCacheForTests,
+  readClaudeEffectiveBlob,
+  readClaudeLiveKeychainRaw
+} from '../account-store-claude'
+import { keychainListAccounts, keychainRead } from '../keychain'
+import { readJsonFile } from '../atomic-json'
+
+vi.mock('../keychain', () => ({
+  keychainRead: vi.fn(),
+  keychainWrite: vi.fn(),
+  keychainDelete: vi.fn(),
+  keychainListAccounts: vi.fn()
+}))
+
+vi.mock('../atomic-json', () => ({
+  readJsonFile: vi.fn(),
+  atomicWriteJson: vi.fn()
+}))
+
+const LIVE_SERVICE = 'Claude Code-credentials'
+const BACKUP_SERVICE = 'Claude Code-Account-9-user@example.com'
+
+const blob = (oauth: Record<string, unknown>): string => JSON.stringify({ claudeAiOauth: oauth })
+
+/** Wire keychainRead to a (service[, account]) lookup table; keys without an
+ * account segment answer first-match (no explicit account) reads. */
+function stubKeychain(entries: Record<string, string>): void {
+  vi.mocked(keychainRead).mockImplementation(async (service, account) => {
+    const key = account === undefined ? service : `${service}::${account}`
+    return entries[key] ?? null
+  })
+}
+
+beforeEach(() => {
+  vi.mocked(keychainRead).mockReset()
+  vi.mocked(keychainListAccounts).mockReset()
+  clearAccountStoreCacheForTests()
+  // Live identity matches the account under test.
+  vi.mocked(readJsonFile).mockResolvedValue({
+    oauthAccount: { emailAddress: 'user@example.com', accountUuid: 'uuid-9' }
+  })
+})
+
+describe('duplicate live Keychain entry resolution', () => {
+  it('picks the duplicate whose blob has an access token and the latest expiresAt', async () => {
+    vi.mocked(keychainListAccounts).mockResolvedValue(['stale-copy', 'fresh-copy'])
+    stubKeychain({
+      // First-match read would land on the stale copy — the bug this fixes.
+      [LIVE_SERVICE]: blob({ accessToken: 'old', refreshToken: 'burned', expiresAt: 1 }),
+      [`${LIVE_SERVICE}::stale-copy`]: blob({
+        accessToken: 'old',
+        refreshToken: 'burned',
+        expiresAt: 1
+      }),
+      [`${LIVE_SERVICE}::fresh-copy`]: blob({
+        accessToken: 'fresh',
+        refreshToken: 'current',
+        expiresAt: 2_000_000_000_000
+      })
+    })
+
+    const effective = await readClaudeEffectiveBlob('9', 'user@example.com')
+    expect(effective?.parsed.accessToken).toBe('fresh')
+    expect(effective?.parsed.refreshToken).toBe('current')
+  })
+
+  it('skips duplicates whose blob has no access token', async () => {
+    vi.mocked(keychainListAccounts).mockResolvedValue(['empty-copy', 'real-copy'])
+    stubKeychain({
+      [`${LIVE_SERVICE}::empty-copy`]: '{}',
+      [`${LIVE_SERVICE}::real-copy`]: blob({ accessToken: 'fresh', expiresAt: 5 })
+    })
+
+    const raw = await readClaudeLiveKeychainRaw()
+    expect(raw).toBe(blob({ accessToken: 'fresh', expiresAt: 5 }))
+  })
+
+  it('falls back to a first-match read when enumeration fails', async () => {
+    vi.mocked(keychainListAccounts).mockRejectedValue(new Error('security dump-keychain failed'))
+    stubKeychain({ [LIVE_SERVICE]: blob({ accessToken: 'only', expiresAt: 5 }) })
+
+    const effective = await readClaudeEffectiveBlob('9', 'user@example.com')
+    expect(effective?.parsed.accessToken).toBe('only')
+  })
+})
+
+describe('readClaudeEffectiveBlob live-blob fallback', () => {
+  it('falls back to the backup blob when the live blob parses without an access token', async () => {
+    vi.mocked(keychainListAccounts).mockResolvedValue(['the-only-copy'])
+    stubKeychain({
+      [`${LIVE_SERVICE}::the-only-copy`]: '{"someOtherShape": true}',
+      [BACKUP_SERVICE]: blob({ accessToken: 'backup-token', refreshToken: 'backup-refresh' })
+    })
+
+    const effective = await readClaudeEffectiveBlob('9', 'user@example.com')
+    expect(effective?.parsed.accessToken).toBe('backup-token')
+  })
+
+  it('still prefers a live blob that does carry an access token', async () => {
+    vi.mocked(keychainListAccounts).mockResolvedValue(['the-only-copy'])
+    stubKeychain({
+      [`${LIVE_SERVICE}::the-only-copy`]: blob({ accessToken: 'live-token' }),
+      [BACKUP_SERVICE]: blob({ accessToken: 'backup-token' })
+    })
+
+    const effective = await readClaudeEffectiveBlob('9', 'user@example.com')
+    expect(effective?.parsed.accessToken).toBe('live-token')
+  })
+
+  it('reads the backup blob directly for non-active accounts', async () => {
+    vi.mocked(readJsonFile).mockResolvedValue({
+      oauthAccount: { emailAddress: 'someone-else@example.com' }
+    })
+    stubKeychain({ [BACKUP_SERVICE]: blob({ accessToken: 'backup-token' }) })
+
+    const effective = await readClaudeEffectiveBlob('9', 'user@example.com')
+    expect(effective?.parsed.accessToken).toBe('backup-token')
+    expect(keychainListAccounts).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/services/__tests__/usage-stale-classification.test.ts
+++ b/src/main/services/__tests__/usage-stale-classification.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import { isClaudeStaleError, isOpenAIStaleError } from '../saved-usage-orchestrator'
+import { parseDumpAccounts } from '../keychain'
+
+describe('stale-vs-error classification', () => {
+  it('flags genuine auth rejections as stale', () => {
+    expect(
+      isClaudeStaleError(
+        'Token refresh failed: invalid_grant (Anthropic refresh needs login (400): {"error": "invalid_grant", "error_description": "Refresh token expired"})'
+      )
+    ).toBe(true)
+    expect(isClaudeStaleError('Usage API returned 401: Unauthorized')).toBe(true)
+    expect(isClaudeStaleError('No refresh token available')).toBe(true)
+
+    expect(isOpenAIStaleError('Usage API returned 403: Forbidden')).toBe(true)
+    expect(isOpenAIStaleError('Token refresh failed: invalid_grant (bad token)')).toBe(true)
+    expect(isOpenAIStaleError('No refresh token available')).toBe(true)
+  })
+
+  it('does NOT flag transient refresh failures as stale', () => {
+    // These arrive with the same "Token refresh failed:" prefix as
+    // invalid_grant but mean the network/endpoint hiccuped, not that the
+    // user must sign in again — they must map to `error`, never `stale`.
+    expect(isClaudeStaleError('Token refresh failed: fetch failed')).toBe(false)
+    expect(isClaudeStaleError('Token refresh failed: Anthropic token request timed out')).toBe(false)
+    expect(
+      isClaudeStaleError('Token refresh failed: Anthropic token refresh returned 503: upstream')
+    ).toBe(false)
+    expect(isClaudeStaleError('Usage API request timed out')).toBe(false)
+    expect(isClaudeStaleError('Usage API returned 429: Too Many Requests')).toBe(false)
+
+    expect(isOpenAIStaleError('Token refresh failed: fetch failed')).toBe(false)
+    expect(isOpenAIStaleError('Usage API returned 500: Internal Server Error')).toBe(false)
+  })
+})
+
+describe('parseDumpAccounts', () => {
+  const item = (opts: { keychain?: string; cls?: string; svce: string; acct?: string | null }): string => {
+    const acctLine =
+      opts.acct === null
+        ? '    "acct"<blob>=<NULL>'
+        : `    "acct"<blob>="${opts.acct ?? 'user'}"`
+    return [
+      `keychain: "${opts.keychain ?? '/Users/u/Library/Keychains/login.keychain-db'}"`,
+      'version: 512',
+      `class: "${opts.cls ?? 'genp'}"`,
+      'attributes:',
+      '    0x00000007 <blob>="ignored"',
+      acctLine,
+      '    "cdat"<timedate>=0x32303236 "20260415123456Z\\000"',
+      `    "svce"<blob>="${opts.svce}"`
+    ].join('\n')
+  }
+
+  it('returns the acct of a single matching item', () => {
+    const dump = [
+      item({ svce: 'Other Service', acct: 'someone' }),
+      item({ svce: 'Claude Code-credentials', acct: 'idan_bg' })
+    ].join('\n')
+    expect(parseDumpAccounts(dump, 'Claude Code-credentials')).toEqual(['idan_bg'])
+  })
+
+  it('returns every duplicate item for the same service, in order', () => {
+    const dump = [
+      item({ svce: 'Claude Code-credentials', acct: 'stale-copy' }),
+      item({ svce: 'Claude Code-Account-1-a@b.com', acct: 'user' }),
+      item({ svce: 'Claude Code-credentials', acct: 'fresh-copy' })
+    ].join('\n')
+    expect(parseDumpAccounts(dump, 'Claude Code-credentials')).toEqual([
+      'stale-copy',
+      'fresh-copy'
+    ])
+  })
+
+  it('reports NULL acct attributes as null', () => {
+    const dump = item({ svce: 'Claude Code-credentials', acct: null })
+    expect(parseDumpAccounts(dump, 'Claude Code-credentials')).toEqual([null])
+  })
+
+  it('ignores non-generic-password items and other services', () => {
+    const dump = [
+      item({ svce: 'Claude Code-credentials', acct: 'cert-item', cls: 'inet' }),
+      item({ svce: 'Claude Code-credentials-other', acct: 'near-miss' })
+    ].join('\n')
+    expect(parseDumpAccounts(dump, 'Claude Code-credentials')).toEqual([])
+  })
+
+  it('returns [] for empty dumps', () => {
+    expect(parseDumpAccounts('', 'Claude Code-credentials')).toEqual([])
+  })
+})

--- a/src/main/services/account-maintenance.ts
+++ b/src/main/services/account-maintenance.ts
@@ -6,11 +6,16 @@
  * a refresh that needs a human to log back in is left for the renderer
  * (Phase 6) to notice via the cached account's `stale` status.
  */
-import { listClaudeAccounts, readClaudeEffectiveBlob } from './account-store-claude'
-import { listCodexAccounts, readCodexEffectiveAuth } from './account-store-codex'
+import { getDatabase } from '../db'
+import { listClaudeAccounts, readClaudeEffectiveBlob, type ClaudeStoreAccount } from './account-store-claude'
+import { listCodexAccounts, readCodexEffectiveAuth, type CodexStoreAccount } from './account-store-codex'
 import { migrateSavedCredentialsToStores } from './credentials-migration'
 import { createLogger } from './logger'
-import { refreshAllForProvider, refreshTokensForStoreAccount } from './saved-usage-orchestrator'
+import {
+  fetchForSavedAccount,
+  refreshAllForProvider,
+  refreshTokensForStoreAccount
+} from './saved-usage-orchestrator'
 
 const log = createLogger({ component: 'AccountMaintenance' })
 
@@ -92,6 +97,86 @@ async function readCurrentCodexRefreshToken(accountKey: string): Promise<string 
   return auth?.tokens?.refresh_token
 }
 
+/**
+ * Self-heal pass for one provider: a cache row stuck on `stale` whose store
+ * credentials now carry a comfortably-unexpired access token was refreshed by
+ * another process after the failure that flagged it (typically the `claude`
+ * CLI rotating the live entry mid-session) — re-fetch usage so the flag can
+ * clear itself instead of sticking until relaunch or a manual Refresh.
+ * Genuinely-dead accounts keep an expired access token and are never
+ * retried here. Shares the watcher's backoff map (a failed heal backs off;
+ * a needsLogin outcome parks until the refresh token changes).
+ */
+async function healStaleRows(
+  backoff: Map<string, BackoffState>,
+  provider: 'anthropic' | 'openai',
+  accounts: Array<{ key: string; email: string; expiresAtMs: number | null; refreshToken: () => Promise<string | undefined> }>,
+  now: number
+): Promise<void> {
+  const rows = getDatabase().getSavedUsageAccountsByProvider(provider)
+  for (const row of rows) {
+    if (row.status !== 'stale') continue
+
+    const account = accounts.find((a) => a.email === row.email.toLowerCase())
+    if (!account) continue
+    if (account.expiresAtMs === null || account.expiresAtMs - now < EXPIRY_THRESHOLD_MS) continue
+
+    const key = `heal:${provider}:${account.key}`
+    const currentRefreshToken = await account.refreshToken()
+    if (!shouldAttempt(backoff, key, now, currentRefreshToken)) continue
+
+    log.info('Retrying stale account with fresh-looking credentials', {
+      provider,
+      email: account.email
+    })
+    const result = await fetchForSavedAccount(row.id, { caller: 'usage:fetchForAccount' }).catch(
+      (error): { success: false; error: string; status: 'error'; needsLogin?: boolean } => {
+        log.warn('Stale-account heal fetch threw', { provider, email: account.email, error: message(error) })
+        return { success: false, error: message(error), status: 'error' }
+      }
+    )
+    const outcome = result.success
+      ? ('refreshed' as const)
+      : result.needsLogin === true
+        ? ('needsLogin' as const)
+        : ('error' as const)
+    recordOutcome(backoff, key, outcome, currentRefreshToken)
+    log[outcome === 'refreshed' ? 'info' : 'warn']('Stale-account heal outcome', {
+      provider,
+      email: account.email,
+      outcome
+    })
+  }
+}
+
+function claudeHealCandidates(accounts: ClaudeStoreAccount[]): Array<{
+  key: string
+  email: string
+  expiresAtMs: number | null
+  refreshToken: () => Promise<string | undefined>
+}> {
+  return accounts.map((account) => ({
+    key: account.num,
+    email: account.email,
+    expiresAtMs: account.expiresAtMs,
+    refreshToken: () => readCurrentClaudeRefreshToken(account.num, account.email)
+  }))
+}
+
+function codexHealCandidates(accounts: CodexStoreAccount[]): Array<{
+  key: string
+  email: string
+  expiresAtMs: number | null
+  refreshToken: () => Promise<string | undefined>
+}> {
+  return accounts.map((account) => ({
+    key: account.accountKey,
+    email: account.email,
+    expiresAtMs: account.expiresAtMs,
+    refreshToken: () => readCurrentCodexRefreshToken(account.accountKey)
+  }))
+}
+
 async function tick(backoff: Map<string, BackoffState>): Promise<void> {
   const now = Date.now()
 
@@ -123,6 +208,12 @@ async function tick(backoff: Map<string, BackoffState>): Promise<void> {
     })
   }
 
+  await healStaleRows(backoff, 'anthropic', claudeHealCandidates(claudeAccounts), now).catch(
+    (error) => {
+      log.warn('Stale-account heal pass failed', { provider: 'anthropic', error: message(error) })
+    }
+  )
+
   const codexAccounts = await listCodexAccounts().catch((error) => {
     log.warn('Failed to list Codex accounts for expiry check', { error: message(error) })
     return []
@@ -152,6 +243,10 @@ async function tick(backoff: Map<string, BackoffState>): Promise<void> {
       outcome
     })
   }
+
+  await healStaleRows(backoff, 'openai', codexHealCandidates(codexAccounts), now).catch((error) => {
+    log.warn('Stale-account heal pass failed', { provider: 'openai', error: message(error) })
+  })
 }
 
 async function runLaunchMassRefresh(): Promise<void> {

--- a/src/main/services/account-store-claude.ts
+++ b/src/main/services/account-store-claude.ts
@@ -14,7 +14,7 @@ import { existsSync } from 'fs'
 import { readFile } from 'fs/promises'
 import { homedir } from 'os'
 import { join } from 'path'
-import { keychainDelete, keychainRead, keychainWrite } from './keychain'
+import { keychainDelete, keychainListAccounts, keychainRead, keychainWrite } from './keychain'
 import { atomicWriteJson, readJsonFile } from './atomic-json'
 import { createLogger } from './logger'
 
@@ -72,8 +72,18 @@ export interface ClaudeStoreAccount {
 const LIST_CACHE_TTL_MS = 15_000
 let listCache: { value: ClaudeStoreAccount[]; expiresAt: number } | null = null
 
+/**
+ * Short TTL memo for the live Keychain entry's `acct` attribute (see
+ * `resolveLiveKeychainAccount`). Caches only the RESOLUTION — which item to
+ * read/write — never the secret itself, so token reads always hit the
+ * Keychain fresh. `{ value: null }` (resolved-to-nothing) is a valid cached
+ * state; the whole slot being null means "not resolved yet".
+ */
+let liveAccountCache: { value: string | null; expiresAt: number } | null = null
+
 function invalidateListCache(): void {
   listCache = null
+  liveAccountCache = null
 }
 
 /** Test-only escape hatch: forces the next `listClaudeAccounts()` call to
@@ -158,9 +168,10 @@ function nextNumber(seq: SequenceFile): number {
 
 /** Read+parse a Keychain credential blob, tolerating a missing or corrupt entry (=> null). */
 async function readKeychainBlob(
-  service: string
+  service: string,
+  account?: string
 ): Promise<{ raw: string; parsed: ClaudeOauthBlob } | null> {
-  const raw = await keychainRead(service)
+  const raw = await keychainRead(service, account)
   if (raw === null) return null
   try {
     const full = JSON.parse(raw) as ClaudeCredentialBlob
@@ -174,9 +185,84 @@ async function readKeychainBlob(
   }
 }
 
+function hasAccessToken(blob: { parsed: ClaudeOauthBlob } | null): boolean {
+  return typeof blob?.parsed.accessToken === 'string' && blob.parsed.accessToken.length > 0
+}
+
+/**
+ * The `acct` attribute of the Keychain item that actually holds the live
+ * Claude credentials, or null to fall back to first-match reads/default-acct
+ * writes.
+ *
+ * The live slot can hold DUPLICATE items (same service, different account
+ * attribute) — seen in the field when the `claude` CLI's item and an
+ * `add-generic-password -a $USER` write disagree on the account attribute.
+ * `find-generic-password -s` then always returns the first item, which may be
+ * a long-stale copy: Hive keeps refreshing with a rotated-away refresh token
+ * (invalid_grant) and flags a perfectly healthy active account as expired.
+ * When duplicates exist, pick the item whose blob parses with an access token
+ * and the latest expiresAt — the copy the CLI keeps fresh. Writes reuse the
+ * same attribute so `-U` updates that item in place instead of forking yet
+ * another duplicate.
+ */
+async function resolveLiveKeychainAccount(): Promise<string | null> {
+  if (liveAccountCache !== null && liveAccountCache.expiresAt > Date.now()) {
+    return liveAccountCache.value
+  }
+
+  let account: string | null = null
+  try {
+    const accounts = (await keychainListAccounts(LIVE_CLAUDE_KEYCHAIN_SERVICE)).filter(
+      (acct): acct is string => acct !== null
+    )
+    const unique = [...new Set(accounts)]
+
+    if (unique.length === 1) {
+      account = unique[0]
+    } else if (unique.length > 1) {
+      let best: { account: string; expiresAt: number } | null = null
+      for (const acct of unique) {
+        const blob = await readKeychainBlob(LIVE_CLAUDE_KEYCHAIN_SERVICE, acct)
+        if (!hasAccessToken(blob)) continue
+        const expiresAt = typeof blob?.parsed.expiresAt === 'number' ? blob.parsed.expiresAt : 0
+        if (best === null || expiresAt > best.expiresAt) {
+          best = { account: acct, expiresAt }
+        }
+      }
+      account = best?.account ?? null
+      log.warn('Multiple live Claude Keychain entries found; targeting the freshest', {
+        entryCount: unique.length,
+        resolved: account !== null
+      })
+    }
+  } catch (error) {
+    log.warn('Failed to enumerate live Claude Keychain entries; using first-match reads', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+
+  liveAccountCache = { value: account, expiresAt: Date.now() + LIST_CACHE_TTL_MS }
+  return account
+}
+
 /** The currently-live Keychain credential blob ("Claude Code-credentials"). */
 async function readLiveBlob(): Promise<{ raw: string; parsed: ClaudeOauthBlob } | null> {
-  return readKeychainBlob(LIVE_CLAUDE_KEYCHAIN_SERVICE)
+  const account = await resolveLiveKeychainAccount()
+  return readKeychainBlob(LIVE_CLAUDE_KEYCHAIN_SERVICE, account ?? undefined)
+}
+
+/** The raw live Keychain credential blob, read via duplicate-aware resolution
+ * (see `resolveLiveKeychainAccount`). Keychain-only — no file fallback. */
+export async function readClaudeLiveKeychainRaw(): Promise<string | null> {
+  const account = await resolveLiveKeychainAccount()
+  return keychainRead(LIVE_CLAUDE_KEYCHAIN_SERVICE, account ?? undefined)
+}
+
+/** Write the live Keychain credential blob onto the item the `claude` CLI
+ * actually uses (see `resolveLiveKeychainAccount`). */
+async function writeLiveBlob(raw: string): Promise<void> {
+  const account = await resolveLiveKeychainAccount()
+  await keychainWrite(LIVE_CLAUDE_KEYCHAIN_SERVICE, raw, account ?? undefined)
 }
 
 /** The per-account backup Keychain credential blob. */
@@ -191,6 +277,11 @@ export async function readClaudeAccountBlob(
  * Effective credentials for an account: the live Keychain blob when this
  * account is currently active (its real, freshest tokens live there),
  * otherwise the per-account backup blob.
+ *
+ * A live blob that parses but carries no access token (an empty or foreign
+ * shape — e.g. a stale duplicate Keychain item) is treated as absent rather
+ * than returned: short-circuiting on it would skip the backup blob and
+ * misreport a recoverable account as "Invalid Claude credentials".
  */
 export async function readClaudeEffectiveBlob(
   num: string,
@@ -199,7 +290,7 @@ export async function readClaudeEffectiveBlob(
   const liveEmail = await readClaudeLiveEmail()
   if (liveEmail !== null && liveEmail === email.toLowerCase()) {
     const live = await readLiveBlob()
-    if (live) return live
+    if (live && hasAccessToken(live)) return live
   }
   return readClaudeAccountBlob(num, email)
 }
@@ -291,7 +382,7 @@ export async function updateClaudeTokens(
 
   const liveEmail = await readClaudeLiveEmail()
   if (liveEmail !== null && liveEmail === email.toLowerCase()) {
-    await keychainWrite(LIVE_CLAUDE_KEYCHAIN_SERVICE, raw)
+    await writeLiveBlob(raw)
   }
 }
 
@@ -305,7 +396,7 @@ interface LiveCredentialsSource {
  * would find them: Keychain first, falling back to the legacy credentials
  * file. Returns null when neither source has anything. */
 async function readLiveCredentialsSource(): Promise<LiveCredentialsSource | null> {
-  const keychainRaw = await keychainRead(LIVE_CLAUDE_KEYCHAIN_SERVICE)
+  const keychainRaw = await readClaudeLiveKeychainRaw()
   if (keychainRaw !== null) return { kind: 'keychain', raw: keychainRaw }
 
   const filePath = join(homedir(), '.claude', '.credentials.json')
@@ -376,7 +467,7 @@ export async function persistRotatedLiveClaudeTokens(
   const patchedRaw = JSON.stringify(full)
 
   if (source.kind === 'keychain') {
-    await keychainWrite(LIVE_CLAUDE_KEYCHAIN_SERVICE, patchedRaw)
+    await writeLiveBlob(patchedRaw)
   } else {
     await atomicWriteJson(source.filePath!, full, { mode: 0o600 })
   }
@@ -420,7 +511,7 @@ export async function switchClaudeAccount(num: string, email: string): Promise<v
   if (!target) {
     throw new Error(`No stored Claude credentials for account ${num} (${email})`)
   }
-  await keychainWrite(LIVE_CLAUDE_KEYCHAIN_SERVICE, target.raw)
+  await writeLiveBlob(target.raw)
 
   // 3) Merge oauthAccount identity fields into the identity file, preserving
   //    everything else. Never clobber a file we couldn't parse.

--- a/src/main/services/keychain.ts
+++ b/src/main/services/keychain.ts
@@ -19,7 +19,7 @@ function isItemNotFoundError(error: unknown): boolean {
   return /could not be found/i.test(message)
 }
 
-function runSecurity(args: string[]): Promise<string> {
+function runSecurity(args: string[], timeoutMs = 5000): Promise<string> {
   const subcommand = args[0] ?? 'security'
   return new Promise((resolve, reject) => {
     // `-w <secret>` passes the secret as an argv element, so it is briefly
@@ -33,7 +33,7 @@ function runSecurity(args: string[]): Promise<string> {
     // saved_usage_accounts.last_error column, switchAccount error results, and
     // renderer toasts. Reject instead with only the subcommand name, the exit
     // code, and security's stderr (which never echoes `-w` values).
-    execFile('security', args, { timeout: 5000 }, (error, stdout, stderr) => {
+    execFile('security', args, { timeout: timeoutMs, maxBuffer: 16 * 1024 * 1024 }, (error, stdout, stderr) => {
       if (error) {
         const rawCode = (error as ExecFileException).code
         const trimmedStderr = typeof stderr === 'string' ? stderr.trim() : ''
@@ -57,14 +57,20 @@ function runSecurity(args: string[]): Promise<string> {
 }
 
 /**
- * Read a secret from the macOS Keychain's generic password store.
- * Returns null when not on macOS, the item isn't found, or any other error
- * occurs.
+ * Read a secret from the macOS Keychain's generic password store. When
+ * `account` is given, only an item matching BOTH service and account is
+ * returned — `find-generic-password -s` alone returns the FIRST match, which
+ * is ambiguous when duplicate items share a service name (see
+ * `keychainListAccounts`). Returns null when not on macOS, the item isn't
+ * found, or any other error occurs.
  */
-export async function keychainRead(service: string): Promise<string | null> {
+export async function keychainRead(service: string, account?: string): Promise<string | null> {
   if (platform() !== 'darwin') return null
+  const args = ['find-generic-password', '-s', service]
+  if (account !== undefined) args.push('-a', account)
+  args.push('-w')
   try {
-    const stdout = await runSecurity(['find-generic-password', '-s', service, '-w'])
+    const stdout = await runSecurity(args)
     return stdout || null
   } catch {
     return null
@@ -75,19 +81,87 @@ export async function keychainRead(service: string): Promise<string | null> {
  * Write (or overwrite) a secret in the macOS Keychain's generic password
  * store. Throws on non-macOS platforms and when the underlying `security`
  * CLI call fails.
+ *
+ * `-U` only updates in place when an item matches BOTH service and account —
+ * writing with a different account attribute than an existing item's silently
+ * creates a duplicate item under the same service name. Callers that target a
+ * pre-existing item (e.g. the live Claude entry the `claude` CLI owns) must
+ * pass that item's actual `account` so the update lands on it.
  */
-export async function keychainWrite(service: string, secret: string): Promise<void> {
+export async function keychainWrite(service: string, secret: string, account?: string): Promise<void> {
   if (platform() !== 'darwin') {
     throw new Error('Keychain is only available on macOS')
   }
-  const account = process.env.USER ?? userInfo().username
+  const accountAttr = account ?? process.env.USER ?? userInfo().username
   try {
-    await runSecurity(['add-generic-password', '-U', '-s', service, '-a', account, '-w', secret])
+    await runSecurity(['add-generic-password', '-U', '-s', service, '-a', accountAttr, '-w', secret])
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     log.warn('Keychain write failed', { service, error: message })
     throw error
   }
+}
+
+/**
+ * The `acct` attributes of every generic-password item whose service matches
+ * `service`, in keychain order (null for items with no account attribute).
+ * There is normally exactly one, but duplicates happen — e.g. Claude Code CLI
+ * and an `add-generic-password -a $USER` write disagreeing on the account
+ * attribute — and `find-generic-password` then resolves reads/updates against
+ * whichever item happens to come first. `security` has no "find all" verb, so
+ * this parses the attribute listing of `dump-keychain` (which prints item
+ * attributes only — it never touches secret data, so it cannot trigger
+ * permission prompts).
+ *
+ * Returns [] on non-macOS; throws when `security dump-keychain` itself fails
+ * so callers can distinguish "no items" from "could not enumerate".
+ */
+export async function keychainListAccounts(service: string): Promise<Array<string | null>> {
+  if (platform() !== 'darwin') return []
+  const dump = await runSecurity(['dump-keychain'], 15000)
+  return parseDumpAccounts(dump, service)
+}
+
+/** Exported for tests: parse `security dump-keychain` output into the acct
+ * attributes of generic-password items matching `service`. */
+export function parseDumpAccounts(dump: string, service: string): Array<string | null> {
+  const accounts: Array<string | null> = []
+  let itemClass: string | null = null
+  let itemService: string | null = null
+  let itemAccount: string | null = null
+
+  const flush = (): void => {
+    if (itemClass === 'genp' && itemService === service) {
+      accounts.push(itemAccount)
+    }
+    itemClass = null
+    itemService = null
+    itemAccount = null
+  }
+
+  for (const line of dump.split('\n')) {
+    if (line.startsWith('keychain: ')) {
+      flush()
+      continue
+    }
+    const classMatch = line.match(/^class: "(\w+)"/)
+    if (classMatch) {
+      itemClass = classMatch[1]
+      continue
+    }
+    const svceMatch = line.match(/^\s*"svce"<blob>="(.*)"\s*$/)
+    if (svceMatch) {
+      itemService = svceMatch[1]
+      continue
+    }
+    const acctMatch = line.match(/^\s*"acct"<blob>=(?:"(.*)"|<NULL>)\s*$/)
+    if (acctMatch) {
+      itemAccount = acctMatch[1] ?? null
+    }
+  }
+  flush()
+
+  return accounts
 }
 
 /**

--- a/src/main/services/saved-usage-orchestrator.ts
+++ b/src/main/services/saved-usage-orchestrator.ts
@@ -325,18 +325,25 @@ function isAuthStatusError(message: string): boolean {
   return /\b(401|403)\b/.test(message)
 }
 
-function isOpenAIStaleError(message: string): boolean {
+// `stale` means "the user must sign in again", so only genuine auth
+// rejections qualify: an auth-status response from the usage API, an
+// `invalid_grant` from the token endpoint, or no refresh token to try.
+// Transient refresh failures (network errors, timeouts, token-endpoint 5xx)
+// also arrive prefixed "Token refresh failed:" — matching on that prefix
+// would flag healthy accounts as expired on every VPN blip, so they map to
+// `error` instead.
+export function isOpenAIStaleError(message: string): boolean {
   return (
     isAuthStatusError(message) ||
-    message.includes('Token refresh failed') ||
+    message.includes('invalid_grant') ||
     message.includes('No refresh token available')
   )
 }
 
-function isClaudeStaleError(message: string): boolean {
+export function isClaudeStaleError(message: string): boolean {
   return (
     /\b401\b/.test(message) ||
-    message.includes('Token refresh failed') ||
+    message.includes('invalid_grant') ||
     message.includes('No refresh token available')
   )
 }

--- a/src/main/services/usage-service.ts
+++ b/src/main/services/usage-service.ts
@@ -3,7 +3,7 @@ import { readFile } from 'fs/promises'
 import { join } from 'path'
 import { homedir } from 'os'
 import { createLogger } from './logger'
-import { keychainRead } from './keychain'
+import { readClaudeLiveKeychainRaw } from './account-store-claude'
 import { refreshAnthropicToken } from './oauth-anthropic'
 import type { ClaudeRefreshResult, ScopedUsageWindow, UsageData, UsageResult } from '@shared/types/usage'
 
@@ -105,10 +105,12 @@ function parseClaudeCredentials(raw: string): ClaudeUsageOverride | null {
 /**
  * Read the OAuth access token from macOS Keychain.
  * Claude Code v2.x stores credentials in the keychain under
- * service "Claude Code-credentials".
+ * service "Claude Code-credentials". Read via the account store's
+ * duplicate-aware resolution — a plain first-match read can land on a stale
+ * duplicate item and burn refresh attempts on a rotated-away token.
  */
 async function readFromKeychain(): Promise<ClaudeUsageOverride | null> {
-  const stdout = await keychainRead('Claude Code-credentials')
+  const stdout = await readClaudeLiveKeychainRaw()
   if (!stdout) return null
   return parseClaudeCredentials(stdout)
 }


### PR DESCRIPTION
## Summary

- Resolve duplicate Claude Keychain entries using the freshest valid credentials.
- Prevent transient refresh failures from being classified as stale sessions.
- Add stale-account self-healing with refresh-token-aware backoff.
- Add regression coverage for Keychain resolution, stale classification, and healing.

## Testing

- Added Vitest coverage for Claude live-entry resolution and fallback behavior.
- Added tests for transient versus genuine authentication failures.
- Added tests for stale-row self-healing and refresh-token rotation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live OAuth credential reads/writes and account status classification on macOS Keychain; behavior is well covered by new tests but mistakes could still affect token refresh or UI session state.
> 
> **Overview**
> Fixes **false “expired session”** states for Claude accounts by reading and writing the live Keychain item the CLI actually uses, and by only marking usage cache rows **stale** when auth is truly dead—not on transient failures.
> 
> **Keychain / Claude store:** `keychainRead`/`keychainWrite` accept an optional **account** attribute; **`keychainListAccounts`** enumerates duplicates via `dump-keychain`. Live **`Claude Code-credentials`** resolution picks the duplicate with a valid access token and latest **`expiresAt`**, routes live reads/writes through that item, and treats token-less live blobs as absent so **`readClaudeEffectiveBlob`** can fall back to per-account backups. **`usage-service`** uses **`readClaudeLiveKeychainRaw`** instead of a first-match read.
> 
> **Stale classification:** **`isClaudeStaleError`** / **`isOpenAIStaleError`** no longer treat every **`Token refresh failed:`** message as stale—only **`invalid_grant`**, auth **401/403**, and missing refresh tokens.
> 
> **Self-heal:** Account maintenance **`healStaleRows`** re-runs **`fetchForSavedAccount`** for **`stale`** cache rows whose store tokens look healthy (unexpired access token), with the same refresh-token-aware backoff as the expiry watcher; genuinely dead accounts are skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77d7b85a1a014e8a6bd2225b5c1a7846e7cd47d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->