### PR TITLE
Add Open action to file context menus

### DIFF
--- a/src/renderer/src/components/file-tree/ChangesView.tsx
+++ b/src/renderer/src/components/file-tree/ChangesView.tsx
@@ -15,7 +15,8 @@ import {
   FileDiff,
   Link,
   Paperclip,
-  Copy
+  Copy,
+  ExternalLink
 } from 'lucide-react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { toast } from '@/lib/toast'
@@ -727,7 +728,7 @@ export function ChangesView({
                             <FileDiff className="h-3.5 w-3.5 mr-2" />
                             Open Diff
                           </ContextMenuItem>
-                          <CopyPathMenuItems file={item.file} />
+                          <FileActionMenuItems file={item.file} />
                         </ContextMenuContent>
                       }
                     />
@@ -746,7 +747,7 @@ export function ChangesView({
                             <FileDiff className="h-3.5 w-3.5 mr-2" />
                             Open Diff
                           </ContextMenuItem>
-                          <CopyPathMenuItems file={item.file} />
+                          <FileActionMenuItems file={item.file} />
                         </ContextMenuContent>
                       }
                     />
@@ -765,7 +766,7 @@ export function ChangesView({
                             <FileDiff className="h-3.5 w-3.5 mr-2" />
                             Open Diff
                           </ContextMenuItem>
-                          <CopyPathMenuItems file={item.file} />
+                          <FileActionMenuItems file={item.file} />
                           <ContextMenuSeparator />
                           <ContextMenuItem
                             onClick={() => handleDiscardFile(item.file)}
@@ -788,7 +789,7 @@ export function ChangesView({
                             <Plus className="h-3.5 w-3.5 mr-2" />
                             Stage
                           </ContextMenuItem>
-                          <CopyPathMenuItems file={item.file} />
+                          <FileActionMenuItems file={item.file} />
                           <ContextMenuSeparator />
                           <ContextMenuItem
                             onClick={() => handleDiscardFile(item.file)}
@@ -887,10 +888,14 @@ export function ChangesView({
 
 /* ---- Sub-components ---- */
 
-function CopyPathMenuItems({ file }: { file: GitFileStatus }): React.JSX.Element {
+function FileActionMenuItems({ file }: { file: GitFileStatus }): React.JSX.Element {
   return (
     <>
       <ContextMenuSeparator />
+      <ContextMenuItem onClick={() => projectApi.openPath(file.path)}>
+        <ExternalLink className="h-3.5 w-3.5 mr-2" />
+        Open
+      </ContextMenuItem>
       <ContextMenuItem onClick={() => projectApi.copyToClipboard(file.path)}>
         <Copy className="h-3.5 w-3.5 mr-2" />
         Copy Path
@@ -1225,7 +1230,7 @@ const MemberChanges = memo(function MemberChanges({
                             <FileDiff className="h-3.5 w-3.5 mr-2" />
                             Open Diff
                           </ContextMenuItem>
-                          <CopyPathMenuItems file={item.file} />
+                          <FileActionMenuItems file={item.file} />
                         </ContextMenuContent>
                       }
                     />
@@ -1242,7 +1247,7 @@ const MemberChanges = memo(function MemberChanges({
                             <Minus className="h-3.5 w-3.5 mr-2" />
                             Unstage
                           </ContextMenuItem>
-                          <CopyPathMenuItems file={item.file} />
+                          <FileActionMenuItems file={item.file} />
                         </ContextMenuContent>
                       }
                     />
@@ -1259,7 +1264,7 @@ const MemberChanges = memo(function MemberChanges({
                             <Plus className="h-3.5 w-3.5 mr-2" />
                             Stage
                           </ContextMenuItem>
-                          <CopyPathMenuItems file={item.file} />
+                          <FileActionMenuItems file={item.file} />
                           <ContextMenuSeparator />
                           <ContextMenuItem
                             onClick={() => onDiscardChanges(wp, item.file.relativePath)}
@@ -1284,7 +1289,7 @@ const MemberChanges = memo(function MemberChanges({
                             <Plus className="h-3.5 w-3.5 mr-2" />
                             Stage
                           </ContextMenuItem>
-                          <CopyPathMenuItems file={item.file} />
+                          <FileActionMenuItems file={item.file} />
                         </ContextMenuContent>
                       }
                     />

--- a/src/renderer/src/components/file-tree/FileContextMenu.tsx
+++ b/src/renderer/src/components/file-tree/FileContextMenu.tsx
@@ -15,7 +15,8 @@ import {
   Trash2,
   AlertCircle,
   EyeOff,
-  FileDiff
+  FileDiff,
+  ExternalLink
 } from 'lucide-react'
 import { useGitStore, type GitStatusCode } from '@/stores/useGitStore'
 import { DiffModal } from '@/components/diff'
@@ -82,6 +83,12 @@ export function FileContextMenu({
     await addToGitignore(worktreePath, node.relativePath)
     onClose?.()
   }, [addToGitignore, worktreePath, node.relativePath, onClose])
+
+  // Handle open with default application
+  const handleOpen = useCallback(async () => {
+    await projectApi.openPath(node.path)
+    onClose?.()
+  }, [node.path, onClose])
 
   // Handle open in editor
   const handleOpenInEditor = useCallback(async () => {
@@ -168,6 +175,10 @@ export function FileContextMenu({
           )}
 
           {/* File actions */}
+          <ContextMenuItem onClick={handleOpen}>
+            <ExternalLink className="mr-2 h-4 w-4" />
+            Open
+          </ContextMenuItem>
           <ContextMenuItem onClick={handleOpenInEditor}>
             <FileCode className="mr-2 h-4 w-4" />
             Open in Editor


### PR DESCRIPTION
## Summary
- Add an Open action for files using the system default application.
- Expose Open in file tree and changed-file context menus.
- Preserve existing editor, diff, staging, discard, and copy-path actions.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only context menu additions using an existing `openPath` IPC path; no auth, data, or git workflow logic changes.
> 
> **Overview**
> Adds an **Open** context-menu action that launches the selected path with the OS default application via `projectApi.openPath`.
> 
> In **ChangesView**, the shared menu helper is renamed from `CopyPathMenuItems` to `FileActionMenuItems` and now includes **Open** above the existing copy-path actions for conflict, staged, modified, and untracked rows (including connection-mode member lists). In **FileContextMenu**, **Open** is inserted ahead of **Open in Editor** and reveal-in-finder, with the same API call on `node.path`.
> 
> Stage/unstage, diff, discard, gitignore, and copy-path behavior are unchanged aside from the rename and new item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f68f7acc8dc06565e6e8c5914a9c814513b20e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->