### PR TITLE
Filter sidebar connections with project search

### DIFF
--- a/src/renderer/src/components/connections/ConnectionList.tsx
+++ b/src/renderer/src/components/connections/ConnectionList.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { Link } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useConnectionStore } from '@/stores'
+import { useConnectionStore, useFilterStore, useProjectStore, useSpaceStore } from '@/stores'
+import { filterProjects } from '@/lib/project-filter'
 import {
   SECTION_HEADER_ICON,
   SECTION_HEADER_WRAPPER_STICKY,
@@ -33,7 +34,38 @@ export function ConnectionList(): React.JSX.Element | null {
 
   const connectionModeActive = useConnectionStore((s) => s.connectionModeActive)
 
-  if (connections.length === 0 || connectionModeActive) {
+  // Sidebar filter: a connection matches iff at least one of its projects matches
+  const filterQuery = useFilterStore((s) => s.filterQuery)
+  const activeLanguages = useFilterStore((s) => s.activeLanguages)
+  const projects = useProjectStore((s) => s.projects)
+  const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
+  const projectSpaceMap = useSpaceStore((s) => s.projectSpaceMap)
+  const filterActive = !!filterQuery.trim() || activeLanguages.length > 0
+
+  const visibleConnections = useMemo(() => {
+    if (!filterActive) return connections
+    const matchingProjectIds = new Set(
+      filterProjects(projects, {
+        filterQuery,
+        activeLanguages,
+        activeSpaceId,
+        projectSpaceMap
+      }).map((fp) => fp.project.id)
+    )
+    return connections.filter((connection) =>
+      connection.members?.some((m) => matchingProjectIds.has(m.project_id))
+    )
+  }, [
+    filterActive,
+    connections,
+    projects,
+    filterQuery,
+    activeLanguages,
+    activeSpaceId,
+    projectSpaceMap
+  ])
+
+  if (visibleConnections.length === 0 || connectionModeActive) {
     return null
   }
 
@@ -50,7 +82,7 @@ export function ConnectionList(): React.JSX.Element | null {
         <SidebarSectionHeader
           icon={<Link className={SECTION_HEADER_ICON} />}
           label="Connections"
-          count={connections.length}
+          count={visibleConnections.length}
           expanded={!isCollapsed}
           onToggle={() => setIsCollapsed((collapsed) => !collapsed)}
         />
@@ -59,7 +91,7 @@ export function ConnectionList(): React.JSX.Element | null {
       {/* Connection items */}
       {!isCollapsed && (
         <div className="flex flex-col gap-1.5" data-testid="connections-list-items">
-          {connections.map((connection) => (
+          {visibleConnections.map((connection) => (
             <ConnectionItem
               key={connection.id}
               connection={connection}

--- a/src/renderer/src/components/connections/ConnectionList.tsx
+++ b/src/renderer/src/components/connections/ConnectionList.tsx
@@ -40,8 +40,7 @@ export function ConnectionList(): React.JSX.Element | null {
   const projects = useProjectStore((s) => s.projects)
   const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
   const projectSpaceMap = useSpaceStore((s) => s.projectSpaceMap)
-  const filterActive =
-    !!filterQuery.trim() || activeLanguages.length > 0 || activeSpaceId !== null
+  const filterActive = !!filterQuery.trim() || activeLanguages.length > 0 || activeSpaceId !== null
 
   const visibleConnections = useMemo(() => {
     if (!filterActive) return connections

--- a/src/renderer/src/components/connections/ConnectionList.tsx
+++ b/src/renderer/src/components/connections/ConnectionList.tsx
@@ -40,7 +40,8 @@ export function ConnectionList(): React.JSX.Element | null {
   const projects = useProjectStore((s) => s.projects)
   const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
   const projectSpaceMap = useSpaceStore((s) => s.projectSpaceMap)
-  const filterActive = !!filterQuery.trim() || activeLanguages.length > 0
+  const filterActive =
+    !!filterQuery.trim() || activeLanguages.length > 0 || activeSpaceId !== null
 
   const visibleConnections = useMemo(() => {
     if (!filterActive) return connections

--- a/src/renderer/src/components/projects/ProjectList.tsx
+++ b/src/renderer/src/components/projects/ProjectList.tsx
@@ -11,7 +11,7 @@ import {
   useConnectionStore
 } from '@/stores'
 import { ProjectItem } from './ProjectItem'
-import { subsequenceMatch } from '@/lib/subsequence-match'
+import { filterProjects } from '@/lib/project-filter'
 import {
   assignHints,
   buildNormalModeTargets,
@@ -99,41 +99,11 @@ export function ProjectList({
   const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
   const projectSpaceMap = useSpaceStore((s) => s.projectSpaceMap)
 
-  const filteredProjects = useMemo(() => {
-    // First filter by active space
-    let spaceFiltered = projects
-    if (activeSpaceId !== null) {
-      const allowedIds = new Set(
-        Object.entries(projectSpaceMap)
-          .filter(([, spaceIds]) => spaceIds.includes(activeSpaceId))
-          .map(([projectId]) => projectId)
-      )
-      spaceFiltered = projects.filter((p) => allowedIds.has(p.id))
-    }
-
-    // Then filter by active languages
-    let langFiltered = spaceFiltered
-    if (activeLanguages.length > 0) {
-      const langSet = new Set(activeLanguages)
-      langFiltered = spaceFiltered.filter((p) => p.language && langSet.has(p.language))
-    }
-
-    if (!filterQuery.trim())
-      return langFiltered.map((p) => ({ project: p, nameMatch: null, pathMatch: null }))
-
-    return langFiltered
-      .map((project) => ({
-        project,
-        nameMatch: subsequenceMatch(filterQuery, project.name),
-        pathMatch: subsequenceMatch(filterQuery, project.path)
-      }))
-      .filter(({ nameMatch, pathMatch }) => nameMatch.matched || pathMatch.matched)
-      .sort((a, b) => {
-        const aScore = a.nameMatch.matched ? a.nameMatch.score : a.pathMatch.score + 1000
-        const bScore = b.nameMatch.matched ? b.nameMatch.score : b.pathMatch.score + 1000
-        return aScore - bScore
-      })
-  }, [projects, filterQuery, activeSpaceId, projectSpaceMap, activeLanguages])
+  const filteredProjects = useMemo(
+    () =>
+      filterProjects(projects, { filterQuery, activeLanguages, activeSpaceId, projectSpaceMap }),
+    [projects, filterQuery, activeSpaceId, projectSpaceMap, activeLanguages]
+  )
 
   // Build hint assignments when filter is active
   const { hintMap: computedHintMap, hintTargetMap: computedHintTargetMap } = useMemo(() => {

--- a/src/renderer/src/lib/__tests__/project-filter.test.ts
+++ b/src/renderer/src/lib/__tests__/project-filter.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { filterProjects } from '../project-filter'
+
+const projects = [
+  { id: 'a', name: 'alpha', path: '/code/alpha', language: 'typescript' },
+  { id: 'b', name: 'beta', path: '/code/beta', language: 'python' },
+  { id: 'c', name: 'gamma', path: '/work/gamma', language: null }
+]
+
+const base = { filterQuery: '', activeLanguages: [], activeSpaceId: null, projectSpaceMap: {} }
+
+describe('filterProjects', () => {
+  it('returns every project unmatched when there is no filter', () => {
+    const result = filterProjects(projects, base)
+    expect(result.map((r) => r.project.id)).toEqual(['a', 'b', 'c'])
+    expect(result[0].nameMatch).toBeNull()
+  })
+
+  it('matches by name or path subsequence and sorts name matches first', () => {
+    const result = filterProjects(projects, { ...base, filterQuery: 'wrk' })
+    expect(result.map((r) => r.project.id)).toEqual(['c'])
+    expect(result[0].pathMatch?.matched).toBe(true)
+
+    const byName = filterProjects(projects, { ...base, filterQuery: 'a' })
+    expect(byName[0].project.id).not.toBe('c')
+    expect(byName.map((r) => r.project.id).sort()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('applies language and space filters before the query', () => {
+    expect(
+      filterProjects(projects, { ...base, activeLanguages: ['python'] }).map((r) => r.project.id)
+    ).toEqual(['b'])
+    expect(
+      filterProjects(projects, {
+        ...base,
+        activeSpaceId: 's1',
+        projectSpaceMap: { a: ['s1'], c: ['s2'] },
+        filterQuery: 'a'
+      }).map((r) => r.project.id)
+    ).toEqual(['a'])
+  })
+})

--- a/src/renderer/src/lib/project-filter.ts
+++ b/src/renderer/src/lib/project-filter.ts
@@ -1,0 +1,63 @@
+import { subsequenceMatch, type SubsequenceMatch } from './subsequence-match'
+
+export interface FilterableProject {
+  id: string
+  name: string
+  path: string
+  language: string | null
+}
+
+export interface ProjectFilterCriteria {
+  filterQuery: string
+  activeLanguages: string[]
+  activeSpaceId: string | null
+  projectSpaceMap: Record<string, string[]>
+}
+
+export interface FilteredProject<P extends FilterableProject> {
+  project: P
+  nameMatch: SubsequenceMatch | null
+  pathMatch: SubsequenceMatch | null
+}
+
+/**
+ * Applies the sidebar filter (space → language → subsequence query) to a project
+ * list. When a query is present the result is sorted by match quality and each
+ * entry carries the name/path match details for highlighting.
+ */
+export function filterProjects<P extends FilterableProject>(
+  projects: P[],
+  { filterQuery, activeLanguages, activeSpaceId, projectSpaceMap }: ProjectFilterCriteria
+): FilteredProject<P>[] {
+  let spaceFiltered = projects
+  if (activeSpaceId !== null) {
+    const allowedIds = new Set(
+      Object.entries(projectSpaceMap)
+        .filter(([, spaceIds]) => spaceIds.includes(activeSpaceId))
+        .map(([projectId]) => projectId)
+    )
+    spaceFiltered = projects.filter((p) => allowedIds.has(p.id))
+  }
+
+  let langFiltered = spaceFiltered
+  if (activeLanguages.length > 0) {
+    const langSet = new Set(activeLanguages)
+    langFiltered = spaceFiltered.filter((p) => p.language && langSet.has(p.language))
+  }
+
+  if (!filterQuery.trim())
+    return langFiltered.map((p) => ({ project: p, nameMatch: null, pathMatch: null }))
+
+  return langFiltered
+    .map((project) => ({
+      project,
+      nameMatch: subsequenceMatch(filterQuery, project.name),
+      pathMatch: subsequenceMatch(filterQuery, project.path)
+    }))
+    .filter(({ nameMatch, pathMatch }) => nameMatch.matched || pathMatch.matched)
+    .sort((a, b) => {
+      const aScore = a.nameMatch.matched ? a.nameMatch.score : a.pathMatch.score + 1000
+      const bScore = b.nameMatch.matched ? b.nameMatch.score : b.pathMatch.score + 1000
+      return aScore - bScore
+    })
+}


### PR DESCRIPTION
## Summary

- Apply the shared project filter to sidebar connections.
- Show connections when at least one member project matches the active query, language, or space filters.
- Extract project filtering into a reusable utility with unit test coverage.

## Testing

- Added Vitest coverage for query, language, and space filtering.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar-only UI filtering and a small refactor with tests; no auth, data, or API changes.
> 
> **Overview**
> Sidebar **Connections** now respect the same search, language, and space filters as the project list: a connection stays visible if **any** member project passes `filterProjects`, and the section count reflects filtered rows.
> 
> Project filtering logic is **extracted** from `ProjectList` into `filterProjects` in `project-filter.ts` (space → language → subsequence query, with match metadata for highlighting). `ProjectList` delegates to that helper so behavior stays aligned.
> 
> **Vitest** coverage was added for empty filters, query/path matching and sort order, and language + space constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c9f42d9f87ba5c7a731787446f9f44d9dca4d4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->