### PR TITLE
Implement right-click drag to start worktree

### DIFF
--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -845,11 +845,14 @@ export function KanbanColumn({
   return (
     <div
       data-testid={`kanban-column-${column}`}
+      data-kanban-column={column}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
       className={cn(
         'flex w-[268px] min-w-[268px] flex-col min-h-0 rounded-lg border transition-colors duration-200',
+        isInProgressColumn &&
+          'data-[right-drag-over]:border-dashed data-[right-drag-over]:border-ring data-[right-drag-over]:bg-foreground/[0.02]',
         isDragOver
           ? 'border-dashed border-ring bg-foreground/[0.02]'
           : isDragging

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -86,7 +86,8 @@ import {
   AlertDialogAction,
   AlertDialogCancel
 } from '@/components/ui/alert-dialog'
-import { WorktreePickerModal } from '@/components/kanban/WorktreePickerModal'
+import { WorktreePickerModal, quickLaunchTicket } from '@/components/kanban/WorktreePickerModal'
+import { useRightButtonDrag } from '@/components/kanban/useRightButtonDrag'
 import { Popover, PopoverAnchor } from '@/components/ui/popover'
 import { AttachPRPopover } from '@/components/kanban/AttachPRPopover'
 import { useGitStore } from '@/stores/useGitStore'
@@ -779,9 +780,29 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     [ticket.id, ticket.worktree_id, ticket.project_id, isArchived, isPinnedMode, connectionId, connectionSession, recordBoardTelegramTarget, blockingDiagnostic]
   )
 
+  // ── Right-button drag into In Progress — start immediately with the
+  // picker's defaults (new worktree, build mode, default SDK/model), no modal
+  const handleRightDrop = useCallback(
+    (column: string | null) => {
+      if (column !== 'in_progress' || ticket.column === 'in_progress') return
+      if (isBlocked) {
+        toast.warning('Ticket is blocked — resolve its dependencies first')
+        return
+      }
+      void quickLaunchTicket(ticket)
+    },
+    [ticket, isBlocked]
+  )
+  const { onMouseDown: rightDragMouseDown, onContextMenuCapture: rightDragContextMenuCapture } =
+    useRightButtonDrag({
+      enabled: !isArchived && !blockingDiagnostic && !connectionId,
+      onDrop: handleRightDrop
+    })
+
   // ── Middle-click — select attached worktree (same as sidebar) ─
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
+      rightDragMouseDown(e)
       if (e.button !== 1) return            // only middle-click
       if (!ticket.worktree_id) return        // no-op for unassigned tickets
       if (isArchived) return                 // no-op for archived tickets
@@ -794,7 +815,14 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
       useProjectStore.getState().selectProject(ticket.project_id, selectionOptions)
       useWorktreeStatusStore.getState().clearWorktreeUnread(ticket.worktree_id)
     },
-    [ticket.worktree_id, ticket.project_id, isArchived, isPinnedMode, recordBoardTelegramTarget]
+    [
+      ticket.worktree_id,
+      ticket.project_id,
+      isArchived,
+      isPinnedMode,
+      recordBoardTelegramTarget,
+      rightDragMouseDown
+    ]
   )
 
   const handleMouseEnter = useCallback(() => {
@@ -1095,6 +1123,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                 onDragEnd={handleDragEnd}
                 onClick={handleClick}
                 onMouseDown={handleMouseDown}
+                onContextMenuCapture={rightDragContextMenuCapture}
                 onMouseEnter={handleMouseEnter}
                 onMouseLeave={handleMouseLeave}
                 className={cn(

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -65,6 +65,7 @@ import {
 import { FALLBACK_MODELS } from '@shared/model-resolution'
 import { runMultiModelLaunch, type MultiModelLaunchPlan } from '@/lib/multi-model-launch'
 import {
+  launchTicketWithModel,
   resolveBadgeModel,
   resolveCustomProviderBadge,
   type LaunchModelConfig
@@ -301,6 +302,59 @@ function resolveRowDefaultModel(sdk: PickerAgentSdk, mode: PickerMode): Selected
   if (modeModel && modeModel.agentSdk === sdk) return modeModel
   const resolved = resolveModelForSdk(sdk) ?? FALLBACK_MODELS[sdk]
   return { providerID: resolved.providerID, modelID: resolved.modelID, variant: resolved.variant }
+}
+
+/**
+ * Start a ticket exactly as the picker would with nothing changed: build mode,
+ * a fresh worktree off the remembered/default branch, the prefilled ticket
+ * prompt, and the default SDK + model. Used by right-button drags into In
+ * Progress, which skip the modal entirely.
+ */
+export async function quickLaunchTicket(ticket: KanbanTicket): Promise<boolean> {
+  const projectId = ticket.project_id
+  const settings = useSettingsStore.getState()
+  const rawSdk = settings.defaultAgentSdk ?? 'opencode'
+  const sdk: PickerAgentSdk = rawSdk === 'terminal' ? 'opencode' : rawSdk
+  const model = resolveRowDefaultModel(sdk, 'build')
+
+  const worktrees = useWorktreeStore.getState().worktreesByProject.get(projectId) ?? []
+  const defaultBranch = worktrees.find((w) => w.is_default)?.branch_name ?? 'main'
+  const sourceBranch = _lastSourceBranchByProject[projectId] ?? defaultBranch
+  _lastSourceBranchByProject[projectId] = sourceBranch
+
+  const store = useKanbanStore.getState()
+  const sortOrder = store.computeSortOrder(store.getTicketsByColumn(projectId, 'in_progress'), 0)
+
+  const result = await launchTicketWithModel({
+    ticketId: ticket.id,
+    projectId,
+    ticketTitle: ticket.title,
+    worktree: { type: 'new', sourceBranch },
+    prompt: buildPrompt('build', ticket),
+    mode: 'build',
+    modelConfig: { sdk, model, codexFastMode: settings.codexFastMode, customProviderId: null },
+    goalMode: false,
+    goalSuccessCriteria: null,
+    ticketUpdateExtras: {
+      column: 'in_progress',
+      sort_order: sortOrder,
+      plan_ready: false,
+      pending_launch_config: null
+    }
+  })
+
+  if (!result.success) {
+    toast.error(result.error || 'Failed to start session')
+    return false
+  }
+
+  void autoPinBaseWorktree(projectId)
+  if (useSettingsStore.getState().boardMode === 'sticky-tab') {
+    const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
+    useSessionStore.getState().setActiveSession(BOARD_TAB_ID)
+  }
+  toast.success('Session started')
+  return true
 }
 
 // ── SDK toggle button group (shared by row 1 and each extra row) ────

--- a/src/renderer/src/components/kanban/useRightButtonDrag.test.tsx
+++ b/src/renderer/src/components/kanban/useRightButtonDrag.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { useRightButtonDrag } from './useRightButtonDrag'
+
+function Card({
+  onDrop,
+  enabled = true
+}: {
+  onDrop: (c: string | null) => void
+  enabled?: boolean
+}) {
+  const drag = useRightButtonDrag({ enabled, onDrop })
+  return (
+    <div>
+      <div
+        data-testid="card"
+        onMouseDown={drag.onMouseDown}
+        onContextMenuCapture={drag.onContextMenuCapture}
+        onContextMenu={() => onDrop('__menu__')}
+      >
+        card
+      </div>
+      <div data-testid="target" data-kanban-column="in_progress">
+        target
+      </div>
+    </div>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('useRightButtonDrag', () => {
+  it('reports the column under the pointer after a right-button drag', () => {
+    const onDrop = vi.fn()
+    const { getByTestId } = render(<Card onDrop={onDrop} />)
+    const card = getByTestId('card')
+    const target = getByTestId('target')
+    // jsdom has no layout — stub hit-testing
+    document.elementFromPoint = () => target
+
+    fireEvent.mouseDown(card, { button: 2, clientX: 10, clientY: 10 })
+    fireEvent.contextMenu(card, { clientX: 10, clientY: 10 }) // macOS: fires on press
+    fireEvent.mouseMove(window, { clientX: 80, clientY: 60 })
+    fireEvent.mouseUp(window, { button: 2, clientX: 80, clientY: 60 })
+
+    expect(onDrop).toHaveBeenCalledTimes(1)
+    expect(onDrop).toHaveBeenCalledWith('in_progress')
+    // Post-mouseup contextmenu (Windows/Linux) is suppressed after a drag
+    fireEvent.contextMenu(card, { clientX: 80, clientY: 60 })
+    expect(onDrop).toHaveBeenCalledTimes(1)
+  })
+
+  it('replays the context menu for a plain right click', () => {
+    const onDrop = vi.fn()
+    const { getByTestId } = render(<Card onDrop={onDrop} />)
+    const card = getByTestId('card')
+
+    fireEvent.mouseDown(card, { button: 2, clientX: 10, clientY: 10 })
+    fireEvent.contextMenu(card, { clientX: 10, clientY: 10 })
+    expect(onDrop).not.toHaveBeenCalled() // swallowed while the button is held
+    fireEvent.mouseUp(window, { button: 2, clientX: 10, clientY: 10 })
+
+    expect(onDrop).toHaveBeenCalledTimes(1)
+    expect(onDrop).toHaveBeenCalledWith('__menu__')
+  })
+
+  it('leaves left-button presses alone', () => {
+    const onDrop = vi.fn()
+    const { getByTestId } = render(<Card onDrop={onDrop} />)
+    const card = getByTestId('card')
+    fireEvent.mouseDown(card, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(window, { clientX: 80, clientY: 60 })
+    fireEvent.mouseUp(window, { button: 0, clientX: 80, clientY: 60 })
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/kanban/useRightButtonDrag.ts
+++ b/src/renderer/src/components/kanban/useRightButtonDrag.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type React from 'react'
+
+/** Pixels the pointer must travel before a right-button press becomes a drag. */
+const DRAG_THRESHOLD_PX = 6
+
+const REPLAY_FLAG = '__hiveReplayedContextMenu'
+
+interface RightButtonDragOptions {
+  enabled: boolean
+  /** Called with the `data-kanban-column` under the pointer on release (null = none). */
+  onDrop: (column: string | null) => void
+}
+
+interface RightButtonDragHandlers {
+  onMouseDown: (e: React.MouseEvent) => void
+  onContextMenuCapture: (e: React.MouseEvent) => void
+}
+
+/**
+ * Chromium never starts an HTML5 drag from the right mouse button (it fires
+ * `contextmenu` instead), so this hook runs its own press → move → release
+ * gesture on top of mouse events. While the button is held the context menu is
+ * swallowed; a plain click (no movement) replays it on release so the normal
+ * right-click menu still works, and a real drag suppresses it entirely.
+ */
+export function useRightButtonDrag({
+  enabled,
+  onDrop
+}: RightButtonDragOptions): RightButtonDragHandlers {
+  const onDropRef = useRef(onDrop)
+  onDropRef.current = onDrop
+
+  const pressRef = useRef<{ x: number; y: number; el: HTMLElement } | null>(null)
+  const draggingRef = useRef(false)
+  const swallowedMenuRef = useRef(false)
+  const suppressNextMenuRef = useRef(false)
+  const ghostRef = useRef<HTMLElement | null>(null)
+  const hoveredColumnRef = useRef<HTMLElement | null>(null)
+  const cleanupRef = useRef<(() => void) | null>(null)
+
+  const setHoveredColumn = (el: HTMLElement | null): void => {
+    if (hoveredColumnRef.current === el) return
+    hoveredColumnRef.current?.removeAttribute('data-right-drag-over')
+    hoveredColumnRef.current = el
+    el?.setAttribute('data-right-drag-over', 'true')
+  }
+
+  const endGesture = (): void => {
+    cleanupRef.current?.()
+    cleanupRef.current = null
+    ghostRef.current?.remove()
+    ghostRef.current = null
+    setHoveredColumn(null)
+    document.body.style.removeProperty('cursor')
+    pressRef.current = null
+    draggingRef.current = false
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => endGesture, [])
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (!enabled || e.button !== 2 || pressRef.current) return
+      const el = e.currentTarget as HTMLElement
+      pressRef.current = { x: e.clientX, y: e.clientY, el }
+      draggingRef.current = false
+      swallowedMenuRef.current = false
+
+      const columnAt = (x: number, y: number): HTMLElement | null =>
+        (document.elementFromPoint(x, y)?.closest('[data-kanban-column]') as HTMLElement | null) ??
+        null
+
+      const handleMove = (ev: MouseEvent): void => {
+        const press = pressRef.current
+        if (!press) return
+        if (!draggingRef.current) {
+          if (Math.hypot(ev.clientX - press.x, ev.clientY - press.y) < DRAG_THRESHOLD_PX) return
+          draggingRef.current = true
+          const ghost = press.el.cloneNode(true) as HTMLElement
+          ghost.style.width = `${press.el.offsetWidth}px`
+          ghost.style.position = 'fixed'
+          ghost.style.left = '0'
+          ghost.style.top = '0'
+          ghost.style.pointerEvents = 'none'
+          ghost.style.zIndex = '9999'
+          ghost.style.opacity = '0.85'
+          ghost.style.margin = '0'
+          document.body.appendChild(ghost)
+          ghostRef.current = ghost
+          document.body.style.cursor = 'grabbing'
+        }
+        const ghost = ghostRef.current
+        if (ghost) {
+          ghost.style.transform = `translate(${ev.clientX - ghost.offsetWidth / 2}px, ${ev.clientY - ghost.offsetHeight / 2}px) rotate(3deg)`
+        }
+        setHoveredColumn(columnAt(ev.clientX, ev.clientY))
+      }
+
+      const handleUp = (ev: MouseEvent): void => {
+        if (ev.button !== 2) return
+        const press = pressRef.current
+        const wasDragging = draggingRef.current
+        const swallowed = swallowedMenuRef.current
+        endGesture()
+        if (!press) return
+        if (wasDragging) {
+          // Windows/Linux fire contextmenu after mouseup — eat that one only
+          suppressNextMenuRef.current = true
+          setTimeout(() => {
+            suppressNextMenuRef.current = false
+          }, 100)
+          const column = columnAt(ev.clientX, ev.clientY)
+          onDropRef.current(column?.getAttribute('data-kanban-column') ?? null)
+        } else if (swallowed) {
+          // macOS fires contextmenu on mousedown; we swallowed it while waiting
+          // to see whether this was a drag — replay it as a plain right-click
+          const replay = new MouseEvent('contextmenu', {
+            bubbles: true,
+            cancelable: true,
+            clientX: ev.clientX,
+            clientY: ev.clientY,
+            button: 2
+          })
+          ;(replay as unknown as Record<string, boolean>)[REPLAY_FLAG] = true
+          press.el.dispatchEvent(replay)
+        }
+      }
+
+      const handleKeyDown = (ev: KeyboardEvent): void => {
+        if (ev.key === 'Escape') endGesture()
+      }
+
+      window.addEventListener('mousemove', handleMove, true)
+      window.addEventListener('mouseup', handleUp, true)
+      window.addEventListener('keydown', handleKeyDown, true)
+      cleanupRef.current = () => {
+        window.removeEventListener('mousemove', handleMove, true)
+        window.removeEventListener('mouseup', handleUp, true)
+        window.removeEventListener('keydown', handleKeyDown, true)
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [enabled]
+  )
+
+  const onContextMenuCapture = useCallback((e: React.MouseEvent) => {
+    if ((e.nativeEvent as unknown as Record<string, boolean>)[REPLAY_FLAG]) return
+    if (pressRef.current) {
+      swallowedMenuRef.current = true
+    } else if (!suppressNextMenuRef.current) {
+      return
+    }
+    suppressNextMenuRef.current = false
+    e.preventDefault()
+    e.stopPropagation()
+  }, [])
+
+  return { onMouseDown, onContextMenuCapture }
+}


### PR DESCRIPTION
## Summary

- Add right-button drag support for starting tickets in the In Progress column.
- Launch new worktrees immediately with picker defaults when a ticket is dropped.
- Preserve normal right-click context menus and show drag-over column feedback.
- Add coverage for drag, context-menu replay, and left-button behavior.

## Testing

- Added Vitest tests for `useRightButtonDrag` covering right-drag, plain right-click, and left-click handling.
- Not run: full test suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Quick-launch bypasses the worktree picker and immediately creates worktrees/sessions; mistakes are easier than with the modal, though behavior matches existing default launch paths.
> 
> **Overview**
> **Right-button drag** on kanban tickets now starts work without opening the worktree picker: drag a card onto **In Progress** and the app calls new **`quickLaunchTicket`**, which mirrors the picker’s defaults (new worktree, build mode, default SDK/model, ticket prompt) and moves the ticket into that column.
> 
> A new **`useRightButtonDrag`** hook implements press/move/release because Chromium won’t HTML5-drag on the right button; it shows a ghost card, highlights the target column via **`data-kanban-column`** / **`data-right-drag-over`**, and either fires **`onDrop`** after a real drag or **replays** the context menu on a plain right-click (macOS vs Windows/Linux menu timing). **`KanbanTicketCard`** wires this in (disabled for archived, markdown-blocked, and connection-board tickets) and warns on blocked dependencies.
> 
> Vitest coverage was added for column hit-testing, context-menu replay, and left-click passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4298afa173e6594bc0e7f64e7ff17d17a2aa82fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->