### PR TITLE
Show active working-session count beside Projects

### DIFF
--- a/src/renderer/src/components/layout/LeftSidebar.tsx
+++ b/src/renderer/src/components/layout/LeftSidebar.tsx
@@ -4,6 +4,7 @@ import { useProjectStore, useConnectionStore, useFilterStore, useSpaceStore } fr
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useFileViewerStore } from '@/stores/useFileViewerStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { ResizeHandle } from './ResizeHandle'
 import { KanbanSquare, Link, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -23,6 +24,7 @@ import { UpdatePill } from './UpdatePill'
 import { PinnedList } from './PinnedList'
 import { RecentList } from './RecentList'
 import {
+  AgentStateDot,
   LIST_CONTAINER,
   LIST_SCROLL,
   NAV_ICON,
@@ -95,6 +97,16 @@ export function LeftSidebar(): React.JSX.Element {
 
   // Connection mode state
   const connectionModeActive = useConnectionStore((s) => s.connectionModeActive)
+  // Number of sessions currently streaming ('working'/'planning'), same
+  // definition useKeepAwake uses. Drives the yellow spinner + counter next to
+  // the "Projects" title.
+  const workingSessionCount = useWorktreeStatusStore((state) => {
+    let count = 0
+    for (const entry of Object.values(state.sessionStatuses)) {
+      if (entry && (entry.status === 'working' || entry.status === 'planning')) count++
+    }
+    return count
+  })
   const connectionModeSelectedIds = useConnectionStore((s) => s.connectionModeSelectedIds)
   const connectionModeSubmitting = useConnectionStore((s) => s.connectionModeSubmitting)
   const exitConnectionMode = useConnectionStore((s) => s.exitConnectionMode)
@@ -242,6 +254,16 @@ export function LeftSidebar(): React.JSX.Element {
           <div className={SIDEBAR_HEADER}>
             <div className={SIDEBAR_HEADER_LEFT}>
               <span className={SIDEBAR_HEADER_LABEL}>Projects</span>
+              {workingSessionCount > 0 && (
+                <span
+                  className="flex shrink-0 items-center gap-1 text-xs font-semibold tabular-nums text-yellow-500"
+                  data-testid="working-session-indicator"
+                  title={`${workingSessionCount} active ${workingSessionCount === 1 ? 'session' : 'sessions'}`}
+                >
+                  <AgentStateDot state="working" size="md" />
+                  <span data-testid="working-session-count">{workingSessionCount}</span>
+                </span>
+              )}
             </div>
             <div className={SIDEBAR_HEADER_ACTIONS}>
               <ConnectionsButton />

--- a/src/renderer/src/components/layout/LeftSidebar.working-indicator.test.tsx
+++ b/src/renderer/src/components/layout/LeftSidebar.working-indicator.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, cleanup } from '@testing-library/react'
+import React from 'react'
+
+vi.mock('@/components/projects', () => ({
+  ProjectList: () => <div data-testid="project-list" />,
+  AddProjectButton: () => null,
+  SortProjectsButton: () => null,
+  RecentToggleButton: () => null,
+  FilterChips: () => null
+}))
+vi.mock('@/components/projects/ProjectFilter', () => ({ ProjectFilter: () => null }))
+vi.mock('@/components/connections', () => ({
+  ConnectionList: () => null,
+  ConnectionsButton: () => null
+}))
+vi.mock('@/components/spaces', () => ({ SpacesTabBar: () => null }))
+vi.mock('./UsageIndicator', () => ({ UsageIndicator: () => null }))
+vi.mock('./UpdatePill', () => ({ UpdatePill: () => null }))
+vi.mock('./PinnedList', () => ({ PinnedList: () => null }))
+vi.mock('./RecentList', () => ({ RecentList: () => null }))
+vi.mock('./ResizeHandle', () => ({ ResizeHandle: () => null }))
+
+import { LeftSidebar } from './LeftSidebar'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useLayoutStore } from '@/stores/useLayoutStore'
+
+describe('LeftSidebar working-session indicator', () => {
+  beforeEach(() => {
+    cleanup()
+    useLayoutStore.setState({ leftSidebarCollapsed: false })
+    useWorktreeStatusStore.setState({ sessionStatuses: {} })
+  })
+
+  it('is hidden when no session is working', () => {
+    render(<LeftSidebar />)
+    expect(screen.getByText('Projects')).toBeInTheDocument()
+    expect(screen.queryByTestId('working-session-indicator')).toBeNull()
+  })
+
+  it('shows a yellow spinner and the count of working/planning sessions', () => {
+    render(<LeftSidebar />)
+    act(() => {
+      useWorktreeStatusStore.setState({
+        sessionStatuses: {
+          a: { status: 'working', timestamp: 1 },
+          b: { status: 'planning', timestamp: 1 },
+          c: { status: 'completed', timestamp: 1 },
+          d: { status: 'permission', timestamp: 1 },
+          e: null
+        }
+      })
+    })
+    const indicator = screen.getByTestId('working-session-indicator')
+    expect(indicator.className).toContain('text-yellow-500')
+    expect(indicator.querySelector('.agent-working-spinner')).not.toBeNull()
+    expect(screen.getByTestId('working-session-count').textContent).toBe('2')
+
+    act(() => {
+      useWorktreeStatusStore.setState({
+        sessionStatuses: { a: { status: 'completed', timestamp: 2 } }
+      })
+    })
+    expect(screen.queryByTestId('working-session-indicator')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Add a working-session spinner and count beside the Projects title.
- Count sessions in `working` or `planning` states only.
- Add coverage for visibility, styling, counting, and state updates.

## Testing

- Added Vitest coverage for the working-session indicator behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI derived from existing session status store; no auth, data, or behavioral changes beyond visibility.
> 
> **Overview**
> The **Projects** sidebar header now shows a **yellow working spinner and numeric badge** when any session is in `working` or `planning`, using the same session-status definition as `useKeepAwake` and the header streaming count.
> 
> The indicator is **hidden when the count is zero** and does not appear in connection-mode (“Select worktrees”) UI. **Vitest** coverage was added for hidden state, count/styling, and reactivity when statuses change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d1d8581c36b829de36834e2af91e13b2a73520d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->