### PR TITLE
Show model and effort in right-click drag preview

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -88,6 +88,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { WorktreePickerModal, quickLaunchTicket } from '@/components/kanban/WorktreePickerModal'
 import { useRightButtonDrag } from '@/components/kanban/useRightButtonDrag'
+import { buildQuickLaunchGhostChip } from '@/components/kanban/quickLaunchGhostChip'
 import { Popover, PopoverAnchor } from '@/components/ui/popover'
 import { AttachPRPopover } from '@/components/kanban/AttachPRPopover'
 import { useGitStore } from '@/stores/useGitStore'
@@ -155,6 +156,10 @@ interface KanbanTicketCardProps {
   isPinnedMode?: boolean
   /** Renderer-only identity for duplicate markdown card occurrences. */
   cardIdentityKey?: TicketKey
+}
+
+function decorateRightDragGhost(ghost: HTMLElement): void {
+  ghost.appendChild(buildQuickLaunchGhostChip())
 }
 
 export const KanbanTicketCard = memo(function KanbanTicketCard({
@@ -796,7 +801,10 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
   const { onMouseDown: rightDragMouseDown, onContextMenuCapture: rightDragContextMenuCapture } =
     useRightButtonDrag({
       enabled: !isArchived && !blockingDiagnostic && !connectionId,
-      onDrop: handleRightDrop
+      onDrop: handleRightDrop,
+      // Show the default model + effort the drop will launch with, riding
+      // along under the ghost so it's clear before release
+      decorateGhost: decorateRightDragGhost
     })
 
   // ── Middle-click — select attached worktree (same as sidebar) ─

--- a/src/renderer/src/components/kanban/TicketModelBadge.tsx
+++ b/src/renderer/src/components/kanban/TicketModelBadge.tsx
@@ -21,7 +21,7 @@ import type { KanbanTicket } from '../../../../main/db/types'
  * then to the raw modelId. Fallback models are intentionally absent from the
  * picker catalog, so their name never resolves via findModelInfo.
  */
-function resolveModelDisplayName(providerId: string | null, modelId: string): string {
+export function resolveModelDisplayName(providerId: string | null, modelId: string): string {
   if (providerId) {
     for (const sdk of getAvailableHandoffAgentSdks()) {
       const catalog = getCachedModelCatalog(sdk)

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -305,6 +305,18 @@ function resolveRowDefaultModel(sdk: PickerAgentSdk, mode: PickerMode): Selected
 }
 
 /**
+ * The SDK + model a right-button quick launch will run with: the app default
+ * SDK (terminal degrades to opencode) and that SDK's build-mode default model.
+ * Shared by `quickLaunchTicket` and the drag ghost's "launches with" chip so
+ * what the overlay shows is exactly what gets launched.
+ */
+export function resolveQuickLaunchModel(): { sdk: PickerAgentSdk; model: SelectedModel } {
+  const rawSdk = useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
+  const sdk: PickerAgentSdk = rawSdk === 'terminal' ? 'opencode' : rawSdk
+  return { sdk, model: resolveRowDefaultModel(sdk, 'build') }
+}
+
+/**
  * Start a ticket exactly as the picker would with nothing changed: build mode,
  * a fresh worktree off the remembered/default branch, the prefilled ticket
  * prompt, and the default SDK + model. Used by right-button drags into In
@@ -313,9 +325,7 @@ function resolveRowDefaultModel(sdk: PickerAgentSdk, mode: PickerMode): Selected
 export async function quickLaunchTicket(ticket: KanbanTicket): Promise<boolean> {
   const projectId = ticket.project_id
   const settings = useSettingsStore.getState()
-  const rawSdk = settings.defaultAgentSdk ?? 'opencode'
-  const sdk: PickerAgentSdk = rawSdk === 'terminal' ? 'opencode' : rawSdk
-  const model = resolveRowDefaultModel(sdk, 'build')
+  const { sdk, model } = resolveQuickLaunchModel()
 
   const worktrees = useWorktreeStore.getState().worktreesByProject.get(projectId) ?? []
   const defaultBranch = worktrees.find((w) => w.is_default)?.branch_name ?? 'main'

--- a/src/renderer/src/components/kanban/quickLaunchGhostChip.ts
+++ b/src/renderer/src/components/kanban/quickLaunchGhostChip.ts
@@ -1,0 +1,51 @@
+import { resolveModelIconAsset } from '@/components/worktrees/ModelIcon'
+import { isUltraVariant } from '@/lib/parseProviders'
+import { resolveQuickLaunchModel } from '@/components/kanban/WorktreePickerModal'
+import { resolveModelDisplayName } from '@/components/kanban/TicketModelBadge'
+
+/**
+ * Overlay chip pinned under a right-button drag ghost: "Launches with
+ * <icon> <model> <EFFORT>". Built imperatively because the ghost is a detached
+ * DOM clone (no React tree to render into). Resolves the exact model + effort
+ * `quickLaunchTicket` will use so the drag preview never lies.
+ */
+export function buildQuickLaunchGhostChip(): HTMLElement {
+  const { model } = resolveQuickLaunchModel()
+  const displayName = resolveModelDisplayName(model.providerID, model.modelID)
+  const icon = resolveModelIconAsset(model.providerID, model.modelID)
+
+  const chip = document.createElement('div')
+  chip.setAttribute('data-testid', 'right-drag-launch-chip')
+  chip.className =
+    'absolute left-0 top-full mt-1.5 inline-flex max-w-full items-center gap-1.5 whitespace-nowrap rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium leading-none text-foreground shadow-md'
+
+  const label = document.createElement('span')
+  label.className = 'text-muted-foreground'
+  label.textContent = 'Launches with'
+  chip.appendChild(label)
+
+  if (icon) {
+    const img = document.createElement('img')
+    img.src = icon.src
+    img.alt = icon.alt
+    img.draggable = false
+    img.className = 'h-3 w-3 shrink-0'
+    chip.appendChild(img)
+  }
+
+  const name = document.createElement('span')
+  name.className = 'truncate'
+  name.textContent = displayName
+  chip.appendChild(name)
+
+  if (model.variant) {
+    const variant = document.createElement('span')
+    variant.className = isUltraVariant(model.variant)
+      ? 'text-[10px] font-semibold uppercase text-violet-600 dark:text-violet-300'
+      : 'text-[10px] font-semibold uppercase text-muted-foreground'
+    variant.textContent = model.variant
+    chip.appendChild(variant)
+  }
+
+  return chip
+}

--- a/src/renderer/src/components/kanban/useRightButtonDrag.test.tsx
+++ b/src/renderer/src/components/kanban/useRightButtonDrag.test.tsx
@@ -4,12 +4,14 @@ import { useRightButtonDrag } from './useRightButtonDrag'
 
 function Card({
   onDrop,
-  enabled = true
+  enabled = true,
+  decorateGhost
 }: {
   onDrop: (c: string | null) => void
   enabled?: boolean
+  decorateGhost?: (ghost: HTMLElement) => void
 }) {
-  const drag = useRightButtonDrag({ enabled, onDrop })
+  const drag = useRightButtonDrag({ enabled, onDrop, decorateGhost })
   return (
     <div>
       <div
@@ -65,6 +67,29 @@ describe('useRightButtonDrag', () => {
 
     expect(onDrop).toHaveBeenCalledTimes(1)
     expect(onDrop).toHaveBeenCalledWith('__menu__')
+  })
+
+  it('lets the caller decorate the ghost once it becomes a drag', () => {
+    const decorateGhost = vi.fn((ghost: HTMLElement) => {
+      const chip = document.createElement('div')
+      chip.setAttribute('data-testid', 'chip')
+      ghost.appendChild(chip)
+    })
+    const { getByTestId } = render(<Card onDrop={vi.fn()} decorateGhost={decorateGhost} />)
+    const card = getByTestId('card')
+
+    fireEvent.mouseDown(card, { button: 2, clientX: 10, clientY: 10 })
+    expect(decorateGhost).not.toHaveBeenCalled() // press alone is not a drag
+    fireEvent.mouseMove(window, { clientX: 80, clientY: 60 })
+    expect(decorateGhost).toHaveBeenCalledTimes(1)
+    const chip = document.querySelector('[data-testid="chip"]')
+    expect(chip).not.toBeNull()
+    expect(chip!.parentElement).toBe(decorateGhost.mock.calls[0][0])
+    expect(document.body.contains(chip)).toBe(true) // ghost (and chip) mounted while dragging
+    fireEvent.mouseMove(window, { clientX: 90, clientY: 70 })
+    expect(decorateGhost).toHaveBeenCalledTimes(1) // not re-decorated per move
+    fireEvent.mouseUp(window, { button: 2, clientX: 90, clientY: 70 })
+    expect(document.querySelector('[data-testid="chip"]')).toBeNull() // ghost removed on release
   })
 
   it('leaves left-button presses alone', () => {

--- a/src/renderer/src/components/kanban/useRightButtonDrag.ts
+++ b/src/renderer/src/components/kanban/useRightButtonDrag.ts
@@ -10,6 +10,12 @@ interface RightButtonDragOptions {
   enabled: boolean
   /** Called with the `data-kanban-column` under the pointer on release (null = none). */
   onDrop: (column: string | null) => void
+  /**
+   * Called once when the drag ghost is created, right after it's cloned from
+   * the pressed element and before it's attached — append any overlay (e.g. a
+   * "launches with" chip) to it here.
+   */
+  decorateGhost?: (ghost: HTMLElement) => void
 }
 
 interface RightButtonDragHandlers {
@@ -26,10 +32,13 @@ interface RightButtonDragHandlers {
  */
 export function useRightButtonDrag({
   enabled,
-  onDrop
+  onDrop,
+  decorateGhost
 }: RightButtonDragOptions): RightButtonDragHandlers {
   const onDropRef = useRef(onDrop)
   onDropRef.current = onDrop
+  const decorateGhostRef = useRef(decorateGhost)
+  decorateGhostRef.current = decorateGhost
 
   const pressRef = useRef<{ x: number; y: number; el: HTMLElement } | null>(null)
   const draggingRef = useRef(false)
@@ -87,6 +96,8 @@ export function useRightButtonDrag({
           ghost.style.zIndex = '9999'
           ghost.style.opacity = '0.85'
           ghost.style.margin = '0'
+          ghost.style.overflow = 'visible'
+          decorateGhostRef.current?.(ghost)
           document.body.appendChild(ghost)
           ghostRef.current = ghost
           document.body.style.cursor = 'grabbing'


### PR DESCRIPTION
## Summary

- Display the default model and effort on the right-click drag ghost.
- Share quick-launch model resolution between the drag preview and ticket launch.
- Add ghost decoration support and coverage for its lifecycle.

## Testing

- Added a test covering ghost decoration on drag start and cleanup on release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Kanban UI and drag-preview only; launch behavior is refactored to a shared helper without changing the resolution rules.
> 
> **Overview**
> Right-button drags on kanban tickets now show a **"Launches with"** chip under the drag ghost (model icon, display name, and variant/effort), so users see what will run before dropping on **In Progress**.
> 
> **`resolveQuickLaunchModel`** centralizes default SDK (terminal → opencode) and build-mode default model; **`quickLaunchTicket`** uses it instead of inlined logic, and **`buildQuickLaunchGhostChip`** builds the overlay imperatively from the same resolver plus exported **`resolveModelDisplayName`**.
> 
> **`useRightButtonDrag`** gains optional **`decorateGhost`**, called once when the ghost is created (`overflow: visible` on the clone); **`KanbanTicketCard`** wires it to append the chip. Tests cover decorate-on-drag-start, no re-decoration on move, and cleanup on release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 607a33e18cad2557da7d11ea37c90d8d4d629457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->