### PR TITLE
Add Super Build mode toggle and session support

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -367,7 +367,7 @@ export class DatabaseService {
       sort_order: row.sort_order as number,
       current_session_id: (row.current_session_id as string) ?? null,
       worktree_id: (row.worktree_id as string) ?? null,
-      mode: (row.mode as 'build' | 'plan' | 'super-plan') ?? null,
+      mode: (row.mode as 'build' | 'plan' | 'super-plan' | 'super-build') ?? null,
       plan_ready: !!(row.plan_ready as number),
       created_at: row.created_at as string,
       updated_at: row.updated_at as string,
@@ -3407,7 +3407,7 @@ export class DatabaseService {
       ticket_id: data.ticket_id,
       content: data.content,
       role: role as 'user' | 'assistant',
-      mode: data.mode as 'build' | 'plan' | 'super-plan',
+      mode: data.mode as 'build' | 'plan' | 'super-plan' | 'super-build',
       session_id: sessionId,
       source: source as 'direct' | 'supercharge' | 'error_retry',
       created_at: now

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -155,7 +155,7 @@ export interface DiscordResourceCreate {
   created_at?: string
 }
 
-export type SessionMode = 'build' | 'plan' | 'super-plan'
+export type SessionMode = 'build' | 'plan' | 'super-plan' | 'super-build'
 export type SessionType = 'default' | 'board-assistant'
 
 export interface Session {
@@ -506,7 +506,7 @@ export interface KanbanTicket {
   sort_order: number
   current_session_id: string | null
   worktree_id: string | null
-  mode: 'build' | 'plan' | 'super-plan' | null
+  mode: 'build' | 'plan' | 'super-plan' | 'super-build' | null
   plan_ready: boolean // Mapped from INTEGER 0/1 in DB
   created_at: string
   updated_at: string
@@ -545,7 +545,7 @@ export interface KanbanTicketCreate {
   sort_order?: number
   current_session_id?: string | null
   worktree_id?: string | null
-  mode?: 'build' | 'plan' | 'super-plan' | null
+  mode?: 'build' | 'plan' | 'super-plan' | 'super-build' | null
   plan_ready?: boolean
   external_provider?: string | null
   external_id?: string | null
@@ -569,7 +569,7 @@ export interface KanbanTicketUpdate {
   sort_order?: number
   current_session_id?: string | null
   worktree_id?: string | null
-  mode?: 'build' | 'plan' | 'super-plan' | null
+  mode?: 'build' | 'plan' | 'super-plan' | 'super-build' | null
   plan_ready?: boolean
   github_pr_number?: number | null
   github_pr_url?: string | null
@@ -641,7 +641,7 @@ export interface KanbanTicketBatchCreateItem {
   sort_order?: number
   current_session_id?: string | null
   worktree_id?: string | null
-  mode?: 'build' | 'plan' | 'super-plan' | null
+  mode?: 'build' | 'plan' | 'super-plan' | 'super-build' | null
   plan_ready?: boolean
   external_provider?: string | null
   external_id?: string | null
@@ -721,7 +721,7 @@ export interface MarkdownCardDiagnostic {
 export interface PendingLaunchConfig {
   worktree: { type: 'new'; sourceBranch: string } | { type: 'existing'; worktreeId: string }
   prompt: string
-  mode: 'build' | 'plan' | 'super-plan'
+  mode: 'build' | 'plan' | 'super-plan' | 'super-build'
   model: { providerID: string; modelID: string; variant?: string } | null
   sdk: 'opencode' | 'claude-code' | 'codex'
   codexFastMode: boolean
@@ -735,7 +735,7 @@ export interface TicketFollowupMessage {
   ticket_id: string
   content: string
   role: 'user' | 'assistant'
-  mode: 'build' | 'plan' | 'super-plan'
+  mode: 'build' | 'plan' | 'super-plan' | 'super-build'
   session_id: string | null
   source: 'direct' | 'supercharge' | 'error_retry'
   created_at: string
@@ -745,7 +745,7 @@ export interface TicketFollowupMessageCreate {
   ticket_id: string
   content: string
   role?: 'user' | 'assistant'
-  mode: 'build' | 'plan' | 'super-plan'
+  mode: 'build' | 'plan' | 'super-plan' | 'super-build'
   session_id?: string | null
   source?: 'direct' | 'supercharge' | 'error_retry'
 }

--- a/src/main/services/kanban-backend.ts
+++ b/src/main/services/kanban-backend.ts
@@ -75,7 +75,7 @@ const VALID_COLUMNS = new Set<KanbanTicketColumn>([
   'merged',
   'done'
 ])
-const VALID_MODES = new Set(['build', 'plan', 'super-plan'])
+const VALID_MODES = new Set(['build', 'plan', 'super-plan', 'super-build'])
 const VALID_MARKS = new Set(['common', 'rare', 'epic', 'legendary'])
 
 type Frontmatter = Record<string, unknown>
@@ -2396,7 +2396,7 @@ function validateKnownFrontmatter(frontmatter: Frontmatter, ticketId: string | n
     invalid('column', 'todo, in_progress, review, merged, or done')
   }
   if ('mode' in frontmatter && frontmatter.mode !== null && !asMode(frontmatter.mode)) {
-    invalid('mode', 'build, plan, super-plan, or null')
+    invalid('mode', 'build, plan, super-plan, super-build, or null')
   }
   if ('sort_order' in frontmatter && asNumber(frontmatter.sort_order) === null) {
     invalid('sort_order', 'a finite number')

--- a/src/main/services/teleport-remote-client.ts
+++ b/src/main/services/teleport-remote-client.ts
@@ -17,7 +17,7 @@ export interface TeleportRemoteReceiveParams {
     id: string | null
     variant: string | null
   }
-  mode: 'build' | 'plan' | 'super-plan'
+  mode: 'build' | 'plan' | 'super-plan' | 'super-build'
 }
 
 export interface TeleportRemoteReceiveResult {

--- a/src/renderer/src/api/db-api.ts
+++ b/src/renderer/src/api/db-api.ts
@@ -76,7 +76,7 @@ type SessionCreateData = {
   claude_session_id?: string | null
   agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   custom_provider_id?: string | null
-  mode?: 'build' | 'plan' | 'super-plan'
+  mode?: 'build' | 'plan' | 'super-plan' | 'super-build'
   session_type?: 'default' | 'board-assistant'
   model_provider_id?: string | null
   model_id?: string | null
@@ -91,7 +91,7 @@ type SessionUpdateData = {
   claude_session_id?: string | null
   agent_sdk?: 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
   custom_provider_id?: string | null
-  mode?: 'build' | 'plan' | 'super-plan'
+  mode?: 'build' | 'plan' | 'super-plan' | 'super-build'
   session_type?: 'default' | 'board-assistant'
   model_provider_id?: string | null
   model_id?: string | null

--- a/src/renderer/src/components/kanban/FollowupInput.tsx
+++ b/src/renderer/src/components/kanban/FollowupInput.tsx
@@ -10,7 +10,7 @@ import { MAX_ATTACHMENTS } from '@/lib/file-attachment-utils'
 import { toast } from '@/lib/toast'
 import { Tip } from '@/components/ui/Tip'
 
-type FollowUpMode = 'build' | 'plan' | 'super-plan'
+type FollowUpMode = 'build' | 'plan' | 'super-plan' | 'super-build'
 
 interface FollowupInputProps {
   text: string
@@ -100,9 +100,16 @@ export function FollowupInput({
     [onAttach, attachments.length]
   )
 
-  const ModeIcon = followUpMode === 'build' ? Hammer : followUpMode === 'plan' ? Map : Sparkles
+  const ModeIcon =
+    followUpMode === 'build' ? Hammer : followUpMode === 'plan' ? Map : Sparkles
   const modeLabel =
-    followUpMode === 'build' ? 'Build' : followUpMode === 'plan' ? 'Plan' : 'Super Plan'
+    followUpMode === 'build'
+      ? 'Build'
+      : followUpMode === 'plan'
+        ? 'Plan'
+        : followUpMode === 'super-build'
+          ? 'Super Build'
+          : 'Super Plan'
 
   return (
     <div className="space-y-1.5 flex-shrink-0">
@@ -112,7 +119,10 @@ export function FollowupInput({
           Followup
         </label>
         {!hideModeToggle && (
-          <Tip tipId="super-plan-shortcut" enabled={followUpMode === 'super-plan'}>
+          <Tip
+            tipId="super-plan-shortcut"
+            enabled={followUpMode === 'super-plan' || followUpMode === 'super-build'}
+          >
             <button
               data-testid={`${testIdPrefix}-mode-toggle`}
               data-mode={followUpMode}

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -665,6 +665,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     if (ticket.current_session_id && ticket.mode === 'build') return 'blue'
     if (ticket.current_session_id && ticket.mode === 'plan') return 'violet'
     if (ticket.current_session_id && ticket.mode === 'super-plan') return 'violet'
+    if (ticket.current_session_id && ticket.mode === 'super-build') return 'blue'
     return 'default'
   }, [ticket.column, ticket.mode, ticket.plan_ready, ticket.current_session_id])
 

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -75,7 +75,14 @@ import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/mes
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
 import { markClaudeCliPromptStarted } from '@/lib/claude-cli-send-tracking'
-import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
+import {
+  PLAN_MODE_PREFIX,
+  getSuperModePrefix,
+  isPlanLike,
+  isSuperMode,
+  baseMode,
+  toggleSuper
+} from '@/lib/constants'
 import { buildSdkPlanImplementationPrompt } from '@/lib/proposedPlan'
 import { toast } from '@/lib/toast'
 import {
@@ -123,7 +130,7 @@ import { terminalApi } from '@/api/terminal-api'
 
 // ── Types ───────────────────────────────────────────────────────────
 type ModalMode = 'edit' | 'plan_review' | 'review' | 'error' | 'question'
-type FollowUpMode = 'build' | 'plan' | 'super-plan'
+type FollowUpMode = 'build' | 'plan' | 'super-plan' | 'super-build'
 type ResolvedModalWorktree = Pick<Worktree, 'id' | 'path' | 'branch_name' | 'project_id'> &
   Partial<Pick<Worktree, 'base_branch'>>
 
@@ -436,18 +443,17 @@ async function sendFollowupToSession(opts: {
 
   // Claude Code & Codex handle plan mode via the SDK — don't prepend the text prefix
   const skipPrefix = session.agent_sdk === 'claude-code' || session.agent_sdk === 'codex'
-  const modePrefix =
-    opts.followUpMode === 'super-plan'
-      ? getSuperPlanModePrefix(session.agent_sdk)
-      : opts.followUpMode === 'plan' && !skipPrefix
-        ? PLAN_MODE_PREFIX
-        : ''
+  const modePrefix = isSuperMode(opts.followUpMode)
+    ? getSuperModePrefix(opts.followUpMode, session.agent_sdk)
+    : opts.followUpMode === 'plan' && !skipPrefix
+      ? PLAN_MODE_PREFIX
+      : ''
   const fullPrompt = modePrefix + opts.prompt
 
-  // Auto-revert super-plan → plan immediately (one-shot mode).
+  // Auto-revert super modes to their base mode immediately (one-shot mode).
   // The prefix is already captured in fullPrompt above.
-  if (opts.followUpMode === 'super-plan') {
-    useSessionStore.getState().setSessionMode(opts.sessionId, 'plan')
+  if (isSuperMode(opts.followUpMode)) {
+    useSessionStore.getState().setSessionMode(opts.sessionId, baseMode(opts.followUpMode))
   }
 
   if (!opts.skipSendBookkeeping) {
@@ -2097,14 +2103,16 @@ function PlanReviewModeContent({
   const { isDragging } = useDropZone({ onDrop: handleDropFiles, containerRef: dropZoneRef })
 
   const toggleMode = useCallback(() => {
-    setFollowUpMode((prev) => (prev === 'build' ? 'plan' : 'build'))
+    setFollowUpMode((prev) =>
+      prev === 'build' ? 'plan' : prev === 'super-build' ? 'super-plan' : 'build'
+    )
   }, [])
 
   const toggleSuperMode = useCallback(() => {
-    setFollowUpMode((prev) => (prev === 'super-plan' ? 'plan' : 'super-plan'))
+    setFollowUpMode((prev) => toggleSuper(prev) as FollowUpMode)
   }, [])
 
-  // Tab key toggles mode, Shift+Tab toggles super-plan
+  // Tab key toggles mode, Shift+Tab toggles super
   useEffect(() => {
     if (isClaudeCliPlanSession) return
     const handler = (e: KeyboardEvent): void => {
@@ -3274,14 +3282,16 @@ function ReviewModeContent({
   }, [dualPane, resolvedWorktree?.path, resolvedBaseBranch])
 
   const toggleMode = useCallback(() => {
-    setFollowUpMode((prev) => (prev === 'build' ? 'plan' : 'build'))
+    setFollowUpMode((prev) =>
+      prev === 'build' ? 'plan' : prev === 'super-build' ? 'super-plan' : 'build'
+    )
   }, [])
 
   const toggleSuperMode = useCallback(() => {
-    setFollowUpMode((prev) => (prev === 'super-plan' ? 'plan' : 'super-plan'))
+    setFollowUpMode((prev) => toggleSuper(prev) as FollowUpMode)
   }, [])
 
-  // Tab key toggles mode, Shift+Tab toggles super-plan.
+  // Tab key toggles mode, Shift+Tab toggles super.
   // Claude CLI sessions manage plan/build inside the terminal — leave
   // Tab/Shift+Tab alone so the embedded terminal receives them.
   useEffect(() => {
@@ -3674,14 +3684,16 @@ function ErrorModeContent({
   const { isDragging } = useDropZone({ onDrop: handleDropFiles, containerRef: dropZoneRef })
 
   const toggleMode = useCallback(() => {
-    setFollowUpMode((prev) => (prev === 'build' ? 'plan' : 'build'))
+    setFollowUpMode((prev) =>
+      prev === 'build' ? 'plan' : prev === 'super-build' ? 'super-plan' : 'build'
+    )
   }, [])
 
   const toggleSuperMode = useCallback(() => {
-    setFollowUpMode((prev) => (prev === 'super-plan' ? 'plan' : 'super-plan'))
+    setFollowUpMode((prev) => toggleSuper(prev) as FollowUpMode)
   }, [])
 
-  // Tab key toggles mode, Shift+Tab toggles super-plan
+  // Tab key toggles mode, Shift+Tab toggles super
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {
       if (e.key === 'Tab' && !e.ctrlKey && !e.metaKey && !e.altKey) {

--- a/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.claude-cli.test.tsx
@@ -94,7 +94,7 @@ const initialUsageState = useUsageStore.getState()
 const initialWorktreeStatusState = useWorktreeStatusStore.getState()
 
 type TestAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
-type TestSessionMode = 'build' | 'plan' | 'super-plan'
+type TestSessionMode = 'build' | 'plan' | 'super-plan' | 'super-build'
 
 const baseTicket: KanbanTicket = {
   id: 'ticket-1',

--- a/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.multi-model.test.tsx
@@ -103,7 +103,7 @@ const initialUsageState = useUsageStore.getState()
 const initialWorktreeStatusState = useWorktreeStatusStore.getState()
 
 type TestAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex' | 'terminal'
-type TestSessionMode = 'build' | 'plan' | 'super-plan'
+type TestSessionMode = 'build' | 'plan' | 'super-plan' | 'super-build'
 
 const baseTicket: KanbanTicket = {
   id: 'ticket-1',

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -43,7 +43,14 @@ import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/mes
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
 import { autoPinBaseWorktree } from '@/lib/auto-pin'
-import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
+import {
+  PLAN_MODE_PREFIX,
+  getSuperModePrefix,
+  isPlanLike,
+  isSuperMode,
+  baseMode,
+  toggleSuper
+} from '@/lib/constants'
 import { toast } from '@/lib/toast'
 import { opencodeApi } from '@/api/opencode-api'
 import { dbApi } from '@/api/db-api'
@@ -84,7 +91,7 @@ const EMPTY_ARRAY: readonly never[] = []
 const EMPTY_CUSTOM_PROVIDERS: CustomClaudeProvider[] = []
 
 // ── Types ───────────────────────────────────────────────────────────
-type PickerMode = 'build' | 'plan' | 'super-plan'
+type PickerMode = 'build' | 'plan' | 'super-plan' | 'super-build'
 type PickerAgentSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex'
 
 function completionSendMode(mode: PickerMode): 'build' | 'plan' {
@@ -151,7 +158,7 @@ export function _resetLastSourceBranch(): void {
 
 // ── Prompt template builders ────────────────────────────────────────
 function getModePrefix(mode: PickerMode): string {
-  return mode === 'build'
+  return baseMode(mode) === 'build'
     ? 'Please implement the following ticket.'
     : 'Please review the following ticket and create a detailed implementation plan.'
 }
@@ -159,7 +166,7 @@ function getModePrefix(mode: PickerMode): string {
 function swapModePrefix(text: string, fromMode: PickerMode, toMode: PickerMode): string {
   const fromPrefix = getModePrefix(fromMode)
   const toPrefix = getModePrefix(toMode)
-  if (fromPrefix === toPrefix) return text // plan ↔ super-plan: same prefix
+  if (fromPrefix === toPrefix) return text // same base mode (e.g. plan ↔ super-plan): same prefix
   if (text.startsWith(fromPrefix)) {
     return toPrefix + text.slice(fromPrefix.length) // swap prefix, keep the rest
   }
@@ -212,12 +219,11 @@ function composePromptForSdk(
     sessionAgentSdk === 'claude-code' ||
     sessionAgentSdk === 'codex' ||
     sessionAgentSdk === 'claude-code-cli'
-  const modePrefix =
-    mode === 'super-plan'
-      ? getSuperPlanModePrefix(sessionAgentSdk)
-      : mode === 'plan' && !skipPrefix
-        ? PLAN_MODE_PREFIX
-        : ''
+  const modePrefix = isSuperMode(mode)
+    ? getSuperModePrefix(mode, sessionAgentSdk)
+    : mode === 'plan' && !skipPrefix
+      ? PLAN_MODE_PREFIX
+      : ''
   const fullPrompt = modePrefix + trimmedPrompt
 
   return goalMode && goalCriteria.trim()
@@ -785,9 +791,9 @@ export function WorktreePickerModal({
     setGoalMode(false)
     setGoalCriteria('')
     setMode((prev) => {
-      if (prev !== 'super-plan') return prev
+      if (!isSuperMode(prev)) return prev
       setSuperArmed(false)
-      return 'plan'
+      return baseMode(prev)
     })
     // A model picked for a different SDK isn't valid for claude-code-cli —
     // same reset `handleSdkChange` does on an explicit SDK switch.
@@ -900,7 +906,14 @@ export function WorktreePickerModal({
   // ── Handle mode toggle ──────────────────────────────────────────
   const toggleMode = useCallback(() => {
     setMode((prev) => {
-      const next: PickerMode = prev === 'build' ? (superArmed ? 'super-plan' : 'plan') : 'build'
+      const next: PickerMode =
+        prev === 'build'
+          ? superArmed
+            ? 'super-plan'
+            : 'plan'
+          : prev === 'super-build'
+            ? 'super-plan'
+            : 'build'
       setPromptText((current) => swapModePrefix(current, prev, next))
       setGoalMode(false)
       setGoalCriteria('')
@@ -909,27 +922,28 @@ export function WorktreePickerModal({
   }, [superArmed])
 
   // ── Handle SUPER toggle ─────────────────────────────────────────
-  const toggleSuper = useCallback(() => {
-    if (runOnRemote) return // super-plan is unavailable for remote launches
-    if (mode === 'plan') {
-      setMode('super-plan')
-      setSuperArmed(true)
+  const toggleSuperButton = useCallback(() => {
+    if (runOnRemote) return // super modes are unavailable for remote launches
+    const next = toggleSuper(mode) as PickerMode
+    setMode(next)
+    setSuperArmed(isSuperMode(next))
+    if (isSuperMode(next)) {
       setGoalMode(false)
       setGoalCriteria('')
-    } else if (mode === 'super-plan') {
-      setMode('plan')
-      setSuperArmed(false)
     }
   }, [mode, runOnRemote])
 
-  // ── Handle Shift+Tab super-plan shortcut ─────────────────────
+  // ── Handle Shift+Tab super shortcut (build ↔ super-build, plan ↔ super-plan) ──
   const toggleSuperShortcut = useCallback(() => {
-    if (runOnRemote) return // super-plan is unavailable for remote launches
+    if (runOnRemote) return // super modes are unavailable for remote launches
     setMode((prev) => {
-      const next: PickerMode = prev === 'super-plan' ? 'plan' : 'super-plan'
+      const next = toggleSuper(prev) as PickerMode
       setPromptText((current) => swapModePrefix(current, prev, next))
-      setGoalMode(false)
-      setGoalCriteria('')
+      setSuperArmed(isSuperMode(next))
+      if (isSuperMode(next)) {
+        setGoalMode(false)
+        setGoalCriteria('')
+      }
       return next
     })
   }, [runOnRemote])
@@ -991,7 +1005,7 @@ export function WorktreePickerModal({
   // ── Handle Tab / Shift+Tab keys ─────────────────────────────────
   // Must use window-level capture-phase listener to beat SessionView's
   // global Tab handler which also uses capture and stops propagation.
-  // Tab = toggle build↔plan, Shift+Tab = toggle ±super-plan.
+  // Tab = toggle build↔plan, Shift+Tab = toggle ±super.
   useEffect(() => {
     if (!open || preAssignOnly) return
     const handler = (e: KeyboardEvent): void => {
@@ -1316,10 +1330,10 @@ export function WorktreePickerModal({
               claudeCli: true
             })
 
-          if (mode === 'super-plan') {
+          if (isSuperMode(mode)) {
             // Await so the persisted mode is committed before the main process
             // reads it in buildClaudeCliPtySpawn (createClaudeCli).
-            await useSessionStore.getState().setSessionMode(sessionId, 'plan')
+            await useSessionStore.getState().setSessionMode(sessionId, baseMode(mode))
           }
 
           bumpWorktreeLastMessage({ connectionId })
@@ -1361,8 +1375,8 @@ export function WorktreePickerModal({
           if (!outboundPrompt) return
           const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
 
-          if (mode === 'super-plan') {
-            useSessionStore.getState().setSessionMode(sessionId, 'plan')
+          if (isSuperMode(mode)) {
+            useSessionStore.getState().setSessionMode(sessionId, baseMode(mode))
           }
           if (!connectResult.sessionId) {
             throw new Error('Missing opencode session id')
@@ -1713,10 +1727,10 @@ export function WorktreePickerModal({
             claudeCli: true
           })
 
-        if (mode === 'super-plan') {
+        if (isSuperMode(mode)) {
           // Await so the persisted mode is committed before the main process
           // reads it in buildClaudeCliPtySpawn (createClaudeCli).
-          await useSessionStore.getState().setSessionMode(sessionId, 'plan')
+          await useSessionStore.getState().setSessionMode(sessionId, baseMode(mode))
         }
 
         bumpWorktreeLastMessage({ worktreeId })
@@ -1760,10 +1774,10 @@ export function WorktreePickerModal({
         if (!outboundPrompt) return
         const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
 
-        // Auto-revert super-plan → plan immediately (one-shot mode).
+        // Auto-revert super modes to their base mode immediately (one-shot mode).
         // The prefix is already captured in fullPrompt above.
-          if (mode === 'super-plan') {
-            useSessionStore.getState().setSessionMode(sessionId, 'plan')
+          if (isSuperMode(mode)) {
+            useSessionStore.getState().setSessionMode(sessionId, baseMode(mode))
           }
           if (!connectResult.sessionId) {
             throw new Error('Missing opencode session id')
@@ -1867,8 +1881,8 @@ export function WorktreePickerModal({
   ])
 
   // ── Mode toggle chip ────────────────────────────────────────────
-  const ModeIcon = mode === 'build' ? Hammer : Map
-  const modeLabel = mode === 'build' ? 'Build' : 'Plan'
+  const ModeIcon = baseMode(mode) === 'build' ? Hammer : Map
+  const modeLabel = baseMode(mode) === 'build' ? 'Build' : 'Plan'
 
   // Block Esc / overlay-click / X-button close while a remote launch is in
   // flight — the RPC keeps running server-side regardless, but v1 keeps the
@@ -1915,9 +1929,11 @@ export function WorktreePickerModal({
                 className={cn(
                   'flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors',
                   'border select-none',
-                  mode === 'build'
-                    ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
-                    : 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
+                  isSuperMode(mode)
+                    ? 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20'
+                    : mode === 'build'
+                      ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
+                      : 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
                 )}
                 title={`${modeLabel} mode`}
                 aria-label={`Current mode: ${modeLabel}. Click to switch`}
@@ -1925,27 +1941,20 @@ export function WorktreePickerModal({
                 <ModeIcon className="h-3.5 w-3.5" aria-hidden="true" />
                 <span>{modeLabel}</span>
               </button>
-              <div
-                className={cn(
-                  'transition-all duration-200 overflow-hidden',
-                  mode === 'plan' || mode === 'super-plan'
-                    ? 'opacity-100 translate-x-0 max-w-[80px]'
-                    : 'opacity-0 -translate-x-2 max-w-0 pointer-events-none'
-                )}
-              >
+              <div className="transition-all duration-200 overflow-hidden opacity-100 translate-x-0 max-w-[80px]">
                 <button
                   type="button"
-                  onClick={toggleSuper}
+                  onClick={toggleSuperButton}
                   disabled={runOnRemote}
-                  aria-pressed={mode === 'super-plan'}
-                  aria-label={`Super mode ${mode === 'super-plan' ? 'enabled' : 'disabled'}`}
+                  aria-pressed={isSuperMode(mode)}
+                  aria-label={`Super mode ${isSuperMode(mode) ? 'enabled' : 'disabled'}`}
                   data-testid="wt-picker-super-toggle"
                   title={runOnRemote ? 'Not available for remote launches' : undefined}
                   className={cn(
                     'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors',
                     'border select-none whitespace-nowrap',
                     'disabled:opacity-40 disabled:cursor-not-allowed',
-                    mode === 'super-plan'
+                    isSuperMode(mode)
                       ? 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20 super-sparkle'
                       : 'bg-muted/50 border-border text-muted-foreground hover:bg-muted hover:text-foreground'
                   )}

--- a/src/renderer/src/components/sessions/IndeterminateProgressBar.tsx
+++ b/src/renderer/src/components/sessions/IndeterminateProgressBar.tsx
@@ -74,10 +74,10 @@ export function IndeterminateProgressBar({
         ? 'bg-amber-500'
         : isReviewing
           ? 'bg-emerald-500'
-          : mode === 'build'
-            ? 'bg-blue-500'
-            : mode === 'super-plan'
-              ? 'bg-orange-500'
+          : mode === 'super-plan' || mode === 'super-build'
+            ? 'bg-orange-500'
+            : mode === 'build'
+              ? 'bg-blue-500'
               : 'bg-violet-500'
 
   return (

--- a/src/renderer/src/components/sessions/MessageRenderer.tsx
+++ b/src/renderer/src/components/sessions/MessageRenderer.tsx
@@ -7,6 +7,7 @@ import { ForkMessageButton } from './ForkMessageButton'
 import {
   PLAN_MODE_PREFIX,
   ASK_MODE_PREFIX,
+  stripSuperBuildModePrefix,
   stripSuperPlanModePrefix
 } from '@/lib/constants'
 import type { OpenCodeMessage } from './SessionView'
@@ -66,6 +67,7 @@ export const MessageRenderer = memo(function MessageRenderer({
 }: MessageRendererProps): React.JSX.Element {
   // For user messages, check if there's a mode prefix (possibly after attachments)
   let isSuperPlanMode = false
+  let isSuperBuildMode = false
   let isPlanMode = false
   let isAskMode = false
   let displayContent = message.content
@@ -75,9 +77,13 @@ export const MessageRenderer = memo(function MessageRenderer({
 
     // Check for mode prefixes in order (longest first to avoid false positives)
     const strippedSuperPlan = stripSuperPlanModePrefix(remaining)
+    const strippedSuperBuild = strippedSuperPlan === null ? stripSuperBuildModePrefix(remaining) : null
     if (strippedSuperPlan !== null) {
       isSuperPlanMode = true
       displayContent = prefix + strippedSuperPlan
+    } else if (strippedSuperBuild !== null) {
+      isSuperBuildMode = true
+      displayContent = prefix + strippedSuperBuild
     } else if (remaining.startsWith(PLAN_MODE_PREFIX)) {
       isPlanMode = true
       displayContent = prefix + remaining.slice(PLAN_MODE_PREFIX.length)
@@ -111,6 +117,7 @@ export const MessageRenderer = memo(function MessageRenderer({
           timestamp={message.timestamp}
           isPlanMode={isPlanMode}
           isSuperPlanMode={isSuperPlanMode}
+          isSuperBuildMode={isSuperBuildMode}
           isAskMode={isAskMode}
           isSteered={message.steered}
         />

--- a/src/renderer/src/components/sessions/ModeToggle.tsx
+++ b/src/renderer/src/components/sessions/ModeToggle.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react'
-import { Hammer, Map, Sparkles } from 'lucide-react'
+import { Hammer, Map } from 'lucide-react'
 import { useSessionStore, type SessionMode } from '@/stores/useSessionStore'
+import { baseMode, isSuperMode } from '@shared/agent-mode-prefixes'
 import { cn } from '@/lib/utils'
 
 interface ModeToggleProps {
@@ -8,7 +9,7 @@ interface ModeToggleProps {
 }
 
 const MODE_CONFIG: Record<
-  SessionMode,
+  'build' | 'plan',
   { label: string; icon: typeof Hammer; description: string }
 > = {
   build: {
@@ -20,11 +21,6 @@ const MODE_CONFIG: Record<
     label: 'Plan',
     icon: Map,
     description: 'Plan and design before implementing'
-  },
-  'super-plan': {
-    label: 'Super Plan',
-    icon: Sparkles,
-    description: 'Deep-dive interview to refine the plan'
   }
 }
 
@@ -33,11 +29,14 @@ export const ModeToggle = memo(function ModeToggle({
 }: ModeToggleProps): React.JSX.Element {
   const rawMode = useSessionStore((state) => state.modeBySession.get(sessionId))
   const mode: SessionMode =
-    rawMode === 'plan' ? 'plan' : rawMode === 'super-plan' ? 'super-plan' : 'build'
+    rawMode === 'plan' || rawMode === 'super-plan' || rawMode === 'super-build'
+      ? rawMode
+      : 'build'
   const toggleSessionMode = useSessionStore((state) => state.toggleSessionMode)
 
-  const config = MODE_CONFIG[mode === 'super-plan' ? 'plan' : mode] ?? MODE_CONFIG.build
+  const config = MODE_CONFIG[baseMode(mode)] ?? MODE_CONFIG.build
   const Icon = config.icon
+  const isSuper = isSuperMode(mode)
 
   return (
     <button
@@ -46,14 +45,14 @@ export const ModeToggle = memo(function ModeToggle({
       className={cn(
         'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium tracking-[0.01em] transition-colors',
         'border select-none',
-        mode === 'build'
-          ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
-          : mode === 'super-plan'
-            ? 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20'
+        isSuper
+          ? 'bg-orange-500/10 border-orange-500/30 text-orange-500 hover:bg-orange-500/20'
+          : mode === 'build'
+            ? 'bg-blue-500/10 border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
             : 'bg-violet-500/10 border-violet-500/30 text-violet-500 hover:bg-violet-500/20'
       )}
-      title={`${config.description} (Tab to toggle, Shift+Tab for Super Plan)`}
-      aria-label={`Current mode: ${config.label}. Click to switch to ${mode === 'build' ? 'Plan' : 'Build'} mode`}
+      title={`${config.description} (Tab to toggle, Shift+Tab for Super)`}
+      aria-label={`Current mode: ${config.label}. Click to switch to ${baseMode(mode) === 'build' ? 'Plan' : 'Build'} mode`}
       data-testid="mode-toggle"
       data-mode={mode}
     >

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -135,7 +135,9 @@ import type { ToolStatus, ToolUseInfo } from './ToolCard'
 import {
   PLAN_MODE_PREFIX,
   ASK_MODE_PREFIX,
-  getSuperPlanModePrefix,
+  getSuperModePrefix,
+  isSuperMode,
+  baseMode,
   stripPlanModePrefix,
   isPlanLike
 } from '@/lib/constants'
@@ -3500,8 +3502,8 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
               .setSessionStatus(sessionId, isPlanLike(currentMode) ? 'planning' : 'working')
             // Apply mode prefix for OpenCode sessions (Claude Code uses native plan mode)
             const modePrefix =
-              currentMode === 'super-plan'
-                ? getSuperPlanModePrefix(sessionAgentSdk)
+              isSuperMode(currentMode)
+                ? getSuperModePrefix(currentMode, sessionAgentSdk)
                 : currentMode === 'plan' && !skipPlanModePrefix
                   ? PLAN_MODE_PREFIX
                   : ''
@@ -4714,10 +4716,11 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
         .getState()
         .setSessionStatus(sessionId, isPlanLike(currentModeForStatus) ? 'planning' : 'working')
 
-      // Auto-revert super-plan → plan immediately (one-shot mode).
+      // Auto-revert super modes to their base mode immediately (one-shot mode):
+      // super-plan → plan, super-build → build.
       // The captured `currentModeForStatus` preserves the original mode for prefix logic below.
-      if (currentModeForStatus === 'super-plan') {
-        useSessionStore.getState().setSessionMode(sessionId, 'plan')
+      if (isSuperMode(currentModeForStatus)) {
+        useSessionStore.getState().setSessionMode(sessionId, baseMode(currentModeForStatus))
       }
 
       try {
@@ -4738,8 +4741,8 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
         // instead of only appearing after a session reload from disk.
         const optimisticMode = currentModeForStatus
         const optimisticModePrefix =
-          optimisticMode === 'super-plan'
-            ? getSuperPlanModePrefix(sessionAgentSdk)
+          isSuperMode(optimisticMode)
+            ? getSuperModePrefix(optimisticMode, sessionAgentSdk)
             : optimisticMode === 'plan' && !skipPlanModePrefix
               ? PLAN_MODE_PREFIX
               : ''
@@ -4882,8 +4885,8 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
             } else {
               // Unknown command — send as regular prompt (SDK may handle it)
               const modePrefix =
-                currentModeForStatus === 'super-plan'
-                  ? getSuperPlanModePrefix(sessionAgentSdk)
+                isSuperMode(currentModeForStatus)
+                  ? getSuperModePrefix(currentModeForStatus, sessionAgentSdk)
                   : currentModeForStatus === 'plan' && !skipPlanModePrefix
                     ? PLAN_MODE_PREFIX
                     : ''
@@ -4923,8 +4926,8 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
           } else {
             // Regular prompt — existing code (with mode prefix, attachments, etc.)
             const modePrefix =
-              currentModeForStatus === 'super-plan'
-                ? getSuperPlanModePrefix(sessionAgentSdk)
+              isSuperMode(currentModeForStatus)
+                ? getSuperModePrefix(currentModeForStatus, sessionAgentSdk)
                 : currentModeForStatus === 'plan' && !skipPlanModePrefix
                   ? PLAN_MODE_PREFIX
                   : ''
@@ -5833,7 +5836,7 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
     [handleAttach]
   )
 
-  // Global Tab/Shift+Tab key handler — toggles Build/Plan mode or Super-Plan
+  // Global Tab/Shift+Tab key handler — Tab toggles Build/Plan, Shift+Tab toggles Super
   const toggleSessionMode = useSessionStore((state) => state.toggleSessionMode)
   const toggleSuperPlanShortcut = useSessionStore((state) => state.toggleSuperPlanShortcut)
   useEffect(() => {
@@ -5841,7 +5844,7 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
       if (e.key !== 'Tab' || e.ctrlKey || e.metaKey || e.altKey) return
 
       // Don't intercept plain Tab inside the ticket creation modal — it needs
-      // natural tab navigation. Shift+Tab still toggles super-plan mode.
+      // natural tab navigation. Shift+Tab still toggles super mode.
       const createModal = document.querySelector('[data-testid="ticket-create-modal"]')
       if (createModal?.contains(document.activeElement) && !e.shiftKey) return
 
@@ -6456,10 +6459,10 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
               'focus-within:shadow-[0_0_0_3px_color-mix(in_srgb,var(--ring)_18%,transparent)]',
               isBashMode
                 ? 'border-border focus-within:border-[color-mix(in_srgb,var(--ring)_60%,transparent)]'
-                : mode === 'build'
-                  ? 'border-blue-500/25'
-                  : mode === 'super-plan'
-                    ? 'border-orange-500/25'
+                : isSuperMode(mode)
+                  ? 'border-orange-500/25'
+                  : mode === 'build'
+                    ? 'border-blue-500/25'
                     : 'border-violet-500/25'
             )}
           >

--- a/src/renderer/src/components/sessions/SuperToggle.tsx
+++ b/src/renderer/src/components/sessions/SuperToggle.tsx
@@ -15,19 +15,11 @@ export const SuperToggle = memo(function SuperToggle({
   const session = useSessionStore((state) => state.getSessionById(sessionId))
   const hasPendingPrompt = useSessionStore((state) => state.pendingMessages.has(sessionId))
 
-  const visible = mode === 'plan' || mode === 'super-plan'
   const disabled = session?.agent_sdk === 'claude-code-cli' && !hasPendingPrompt
-  const isOn = mode === 'super-plan'
+  const isOn = mode === 'super-plan' || mode === 'super-build'
 
   return (
-    <div
-      className={cn(
-        'transition-all duration-200 overflow-hidden',
-        visible
-          ? 'opacity-100 translate-x-0 max-w-[80px]'
-          : 'opacity-0 -translate-x-2 max-w-0 pointer-events-none'
-      )}
-    >
+    <div className="transition-all duration-200 overflow-hidden opacity-100 translate-x-0 max-w-[80px]">
       <Tip tipId="super-plan-shortcut" enabled={isOn}>
         <button
           type="button"
@@ -35,7 +27,7 @@ export const SuperToggle = memo(function SuperToggle({
           disabled={disabled}
           aria-pressed={isOn}
           aria-label={`Super mode ${isOn ? 'enabled' : 'disabled'} (Shift+Tab to toggle)`}
-          title="Toggle super-plan mode (Shift+Tab)"
+          title="Toggle super mode (Shift+Tab)"
           data-testid="super-toggle"
           className={cn(
             'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium tracking-[0.01em] transition-colors',

--- a/src/renderer/src/components/sessions/UserBubble.tsx
+++ b/src/renderer/src/components/sessions/UserBubble.tsx
@@ -8,6 +8,7 @@ interface UserBubbleProps {
   timestamp: string
   isPlanMode?: boolean
   isSuperPlanMode?: boolean
+  isSuperBuildMode?: boolean
   isAskMode?: boolean
   isSteered?: boolean
 }
@@ -16,6 +17,7 @@ export const UserBubble = memo(function UserBubble({
   content,
   isPlanMode,
   isSuperPlanMode,
+  isSuperBuildMode,
   isAskMode,
   isSteered
 }: UserBubbleProps): React.JSX.Element {
@@ -47,7 +49,7 @@ export const UserBubble = memo(function UserBubble({
       <div
         className={cn(
           'max-w-[80%] rounded-[10px] border px-3 py-2',
-          isSuperPlanMode
+          isSuperPlanMode || isSuperBuildMode
             ? 'bg-secondary border-border text-foreground'
             : isPlanMode
               ? 'bg-violet-500/10 border-violet-500/20 text-foreground'
@@ -62,6 +64,14 @@ export const UserBubble = memo(function UserBubble({
             data-testid="super-plan-mode-badge"
           >
             SUPER PLAN
+          </span>
+        )}
+        {isSuperBuildMode && (
+          <span
+            className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-semibold bg-orange-500/15 text-orange-400 mb-1"
+            data-testid="super-build-mode-badge"
+          >
+            SUPER BUILD
           </span>
         )}
         {isPlanMode && (

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -5,7 +5,7 @@ import { launchTicketWithModel, type LaunchModelConfig } from '@/lib/ticket-laun
 import { runMultiModelLaunch } from '@/lib/multi-model-launch'
 import type { HandoffAgentSdk } from '@shared/types/agent-sdk'
 
-type AutoLaunchMode = 'build' | 'plan' | 'super-plan'
+type AutoLaunchMode = 'build' | 'plan' | 'super-plan' | 'super-build'
 
 interface AutoLaunchTicket {
   id: string

--- a/src/renderer/src/lib/blocker-utils.ts
+++ b/src/renderer/src/lib/blocker-utils.ts
@@ -3,7 +3,7 @@ import type { FollowUpTriggerColumn } from '@/stores/useSettingsStore'
 
 export function isBlockerSatisfied(
   blockerColumn: KanbanTicketColumn,
-  blockerMode: 'build' | 'plan' | 'super-plan' | null,
+  blockerMode: 'build' | 'plan' | 'super-plan' | 'super-build' | null,
   triggerColumn: FollowUpTriggerColumn
 ): boolean {
   // A merged blocker's work already landed on the base branch, so it

--- a/src/renderer/src/lib/constants.ts
+++ b/src/renderer/src/lib/constants.ts
@@ -1,23 +1,43 @@
 import {
+  CODEX_SUPER_BUILD_MODE_PREFIX,
   CODEX_SUPER_PLAN_MODE_PREFIX,
   PLAN_MODE_PREFIX,
+  SUPER_BUILD_MODE_PREFIX,
   SUPER_PLAN_MODE_PREFIX
 } from '@shared/agent-mode-prefixes'
 
 export {
+  CODEX_SUPER_BUILD_MODE_PREFIX,
   CODEX_SUPER_PLAN_MODE_PREFIX,
   PLAN_MODE_PREFIX,
+  SUPER_BUILD_MODE_PREFIX,
   SUPER_PLAN_MODE_PREFIX,
-  getSuperPlanModePrefix
+  getSuperPlanModePrefix,
+  getSuperBuildModePrefix,
+  getSuperModePrefix,
+  isSuperMode,
+  baseMode,
+  toggleSuper
 } from '@shared/agent-mode-prefixes'
 
 export const ASK_MODE_PREFIX =
   '[Mode: Ask] You are in question-answering mode. The user wants information only. Do NOT make any code changes, do NOT use file editing tools, do NOT modify any files. Simply answer the question directly and concisely.\n\n'
 
 const SUPER_PLAN_MODE_PREFIXES = [CODEX_SUPER_PLAN_MODE_PREFIX, SUPER_PLAN_MODE_PREFIX]
+const SUPER_BUILD_MODE_PREFIXES = [CODEX_SUPER_BUILD_MODE_PREFIX, SUPER_BUILD_MODE_PREFIX]
 
 export function stripSuperPlanModePrefix(value: string): string | null {
   for (const prefix of SUPER_PLAN_MODE_PREFIXES) {
+    if (value.startsWith(prefix)) {
+      return value.slice(prefix.length)
+    }
+  }
+
+  return null
+}
+
+export function stripSuperBuildModePrefix(value: string): string | null {
+  for (const prefix of SUPER_BUILD_MODE_PREFIXES) {
     if (value.startsWith(prefix)) {
       return value.slice(prefix.length)
     }
@@ -30,6 +50,10 @@ export function stripModePrefix(value: string): string {
   const superPlanStripped = stripSuperPlanModePrefix(value)
   if (superPlanStripped !== null) {
     return superPlanStripped
+  }
+  const superBuildStripped = stripSuperBuildModePrefix(value)
+  if (superBuildStripped !== null) {
+    return superBuildStripped
   }
   if (value.startsWith(PLAN_MODE_PREFIX)) {
     return value.slice(PLAN_MODE_PREFIX.length)

--- a/src/renderer/src/lib/handoffSelection.ts
+++ b/src/renderer/src/lib/handoffSelection.ts
@@ -104,7 +104,7 @@ function normalizeHandoffSdk(
   return 'opencode'
 }
 
-function getModeDefaultKey(mode: 'build' | 'plan' | 'super-plan' | undefined): 'build' | 'plan' {
+function getModeDefaultKey(mode: 'build' | 'plan' | 'super-plan' | 'super-build' | undefined): 'build' | 'plan' {
   return mode === 'plan' || mode === 'super-plan' ? 'plan' : 'build'
 }
 
@@ -148,7 +148,7 @@ function getWorktreeFallbackModel(worktreeId?: string): SelectedModel | null {
 function resolveSessionSelection(opts: {
   worktreeId?: string
   agentSdk?: AgentSdk
-  mode?: 'build' | 'plan' | 'super-plan'
+  mode?: 'build' | 'plan' | 'super-plan' | 'super-build'
   explicitSdk?: boolean
 }): EffectiveHandoffSelection {
   // Discord mirrors the data-driven subset of this chain in src/shared/model-resolution.ts.
@@ -422,7 +422,7 @@ export function getEffectiveHandoffSelection(opts: {
 export function resolveSessionCreationSelection(opts: {
   worktreeId?: string
   agentSdkOverride?: AgentSdk
-  initialMode?: 'build' | 'plan' | 'super-plan'
+  initialMode?: 'build' | 'plan' | 'super-plan' | 'super-build'
   modelOverride?: SelectedModel
   /** claude-code-cli only: resolve the model from this provider's declared list. */
   customProviderId?: string | null

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -50,8 +50,8 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   },
   {
     id: 'session:super-plan-toggle',
-    label: 'Toggle Super Plan',
-    description: 'Toggle super-plan mode (Shift+Tab)',
+    label: 'Toggle Super Mode',
+    description: 'Toggle super mode — super-build or super-plan (Shift+Tab)',
     category: 'session',
     defaultBinding: { key: 'Tab', modifiers: ['shift'] }
   },

--- a/src/renderer/src/lib/multi-model-launch.ts
+++ b/src/renderer/src/lib/multi-model-launch.ts
@@ -12,7 +12,7 @@ import { canonicalizeModelSlug, canonicalizeTicketTitle } from '@shared/types/br
 import { FALLBACK_MODELS } from '@shared/model-resolution'
 import { dbApi } from '@/api/db-api'
 
-type LaunchMode = 'build' | 'plan' | 'super-plan'
+type LaunchMode = 'build' | 'plan' | 'super-plan' | 'super-build'
 
 export interface MultiModelLaunchPlan {
   /** The original ticket — becomes entries[0]'s ticket. */

--- a/src/renderer/src/lib/ticket-launch.ts
+++ b/src/renderer/src/lib/ticket-launch.ts
@@ -15,7 +15,13 @@ import { resolveCustomProviderSelectedModel } from '@/lib/handoffSelection'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
-import { PLAN_MODE_PREFIX, getSuperPlanModePrefix, isPlanLike } from '@/lib/constants'
+import {
+  PLAN_MODE_PREFIX,
+  getSuperModePrefix,
+  isPlanLike,
+  isSuperMode,
+  baseMode
+} from '@/lib/constants'
 import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { opencodeApi } from '@/api/opencode-api'
@@ -27,7 +33,7 @@ import { FALLBACK_MODELS } from '@shared/model-resolution'
 import type { HandoffAgentSdk } from '@shared/types/agent-sdk'
 import type { KanbanTicketUpdate } from '../../../main/db/types'
 
-type LaunchMode = 'build' | 'plan' | 'super-plan'
+type LaunchMode = 'build' | 'plan' | 'super-plan' | 'super-build'
 
 export interface LaunchModelConfig {
   sdk: HandoffAgentSdk
@@ -81,12 +87,11 @@ function composeLaunchPrompt(
     sessionAgentSdk === 'claude-code' ||
     sessionAgentSdk === 'codex' ||
     sessionAgentSdk === 'claude-code-cli'
-  const modePrefix =
-    mode === 'super-plan'
-      ? getSuperPlanModePrefix(sessionAgentSdk)
-      : mode === 'plan' && !skipPrefix
-        ? PLAN_MODE_PREFIX
-        : ''
+  const modePrefix = isSuperMode(mode)
+    ? getSuperModePrefix(mode, sessionAgentSdk)
+    : mode === 'plan' && !skipPrefix
+      ? PLAN_MODE_PREFIX
+      : ''
   const fullPrompt = modePrefix + trimmedPrompt
 
   return goalMode && goalSuccessCriteria
@@ -353,10 +358,10 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
           claudeCli: true
         })
 
-      if (spec.mode === 'super-plan') {
+      if (isSuperMode(spec.mode)) {
         // Await so the persisted mode is committed before the main process
         // reads it in buildClaudeCliPtySpawn (createClaudeCli).
-        await useSessionStore.getState().setSessionMode(sessionId, 'plan')
+        await useSessionStore.getState().setSessionMode(sessionId, baseMode(spec.mode))
       }
 
       bumpWorktreeLastMessage({ worktreeId })
@@ -411,8 +416,8 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
 
       const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
 
-      if (spec.mode === 'super-plan') {
-        useSessionStore.getState().setSessionMode(sessionId, 'plan')
+      if (isSuperMode(spec.mode)) {
+        useSessionStore.getState().setSessionMode(sessionId, baseMode(spec.mode))
       }
 
       bumpWorktreeLastMessage({ worktreeId })

--- a/src/renderer/src/lib/tip-definitions.ts
+++ b/src/renderer/src/lib/tip-definitions.ts
@@ -58,7 +58,7 @@ export const TIP_DEFINITIONS: Record<string, TipDefinition> = {
   },
   'super-plan-shortcut': {
     id: 'super-plan-shortcut',
-    description: 'Press Shift+Tab to toggle Super Plan mode.',
+    description: 'Press Shift+Tab to toggle Super mode.',
     trigger: 'action',
     priority: 6,
     side: 'top'

--- a/src/renderer/src/stores/store-coordination.ts
+++ b/src/renderer/src/stores/store-coordination.ts
@@ -38,8 +38,8 @@ export function clearConnectionSelection(): void {
 
 export interface KanbanSessionEvent {
   type: 'session_completed' | 'session_error' | 'plan_ready' | 'plan_followup' | 'supercharge' | 'mode_change' | 'implement' | 'session_working' | 'status_cleared'
-  /** The mode the session was running in (build / plan) — relevant for completed events */
-  sessionMode?: 'build' | 'plan'
+  /** The mode the session was running in — relevant for completed / mode_change events */
+  sessionMode?: 'build' | 'plan' | 'super-plan' | 'super-build'
   /** For supercharge: the newly-created session that replaces the old one */
   newSessionId?: string
   /**

--- a/src/renderer/src/stores/useSessionHistoryStore.ts
+++ b/src/renderer/src/stores/useSessionHistoryStore.ts
@@ -16,7 +16,7 @@ interface SessionWithWorktree {
   opencode_session_id: string | null
   claude_session_id: string | null
   agent_sdk: AgentSdk
-  mode: 'build' | 'plan' | 'super-plan'
+  mode: 'build' | 'plan' | 'super-plan' | 'super-build'
   session_type: 'default' | 'board-assistant'
   model_provider_id: string | null
   model_id: string | null

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -22,6 +22,7 @@ import { parseRemoteLaunch } from '@shared/types/remote-launch'
 import { opencodeApi } from '@/api/opencode-api'
 import { type AgentSdk, isTerminalBacked } from '@shared/types/agent-sdk'
 import { CUSTOM_MODEL_PROVIDER_ID } from '@shared/types/custom-provider'
+import { isSuperMode, toggleSuper } from '@shared/agent-mode-prefixes'
 
 /**
  * Push the follow-up-message queue state for a session into the backend.
@@ -100,7 +101,7 @@ function getUnavailableProviderError(sdk: AgentSdk): string | null {
 }
 
 // Session mode type
-export type SessionMode = 'build' | 'plan' | 'super-plan'
+export type SessionMode = 'build' | 'plan' | 'super-plan' | 'super-build'
 
 // Pending plan approval state (from ExitPlanMode blocking tool)
 export interface PendingPlan {
@@ -1537,6 +1538,7 @@ export const useSessionStore = create<SessionState>()(
 
       // Toggle session mode between build and plan/super-plan (2-way cycle)
       // From 'build': go to 'super-plan' if superArmed, else 'plan'
+      // From 'super-build': go to 'super-plan' (super carries over)
       // From 'plan' or 'super-plan': go to 'build'
       toggleSessionMode: async (sessionId: string) => {
         const currentMode = get().modeBySession.get(sessionId) || 'build'
@@ -1544,6 +1546,8 @@ export const useSessionStore = create<SessionState>()(
         let newMode: SessionMode
         if (currentMode === 'build') {
           newMode = get().getSuperArmed(sessionId) ? 'super-plan' : 'plan'
+        } else if (currentMode === 'super-build') {
+          newMode = 'super-plan'
         } else {
           // 'plan' or 'super-plan' → back to 'build'
           newMode = 'build'
@@ -1572,24 +1576,14 @@ export const useSessionStore = create<SessionState>()(
         notifyKanbanSessionSync(sessionId, { type: 'mode_change', sessionMode: newMode })
       },
 
-      // Toggle super mode for a session (only works when in plan modes)
-      // 'plan' → 'super-plan' (superArmed = true)
-      // 'super-plan' → 'plan' (superArmed = false)
+      // Toggle super mode for a session, preserving the plan/build base mode:
+      // 'plan' ↔ 'super-plan', 'build' ↔ 'super-build'
+      // superArmed tracks whether the new mode is a super mode.
       toggleSuperMode: async (sessionId: string) => {
         const currentMode = get().modeBySession.get(sessionId) || 'build'
 
-        let newMode: SessionMode
-        let newSuperArmed: boolean
-        if (currentMode === 'plan') {
-          newMode = 'super-plan'
-          newSuperArmed = true
-        } else if (currentMode === 'super-plan') {
-          newMode = 'plan'
-          newSuperArmed = false
-        } else {
-          // Only works in plan modes; do nothing
-          return
-        }
+        const newMode: SessionMode = toggleSuper(currentMode)
+        const newSuperArmed = isSuperMode(newMode)
 
         // Update both maps atomically
         set((state) => {
@@ -1614,26 +1608,11 @@ export const useSessionStore = create<SessionState>()(
         notifyKanbanSessionSync(sessionId, { type: 'mode_change', sessionMode: newMode })
       },
 
-      // Toggle super-plan shortcut: super-plan → plan, everything else → super-plan
-      // Unlike toggleSuperMode, this does NOT mutate superArmedBySession
+      // Shift+Tab shortcut: toggle super on/off while preserving the plan/build
+      // base mode ('build' ↔ 'super-build', 'plan' ↔ 'super-plan'). Same
+      // semantics as the SUPER button, so just delegate.
       toggleSuperPlanShortcut: async (sessionId: string) => {
-        const currentMode = get().modeBySession.get(sessionId) || 'build'
-        const newMode: SessionMode = currentMode === 'super-plan' ? 'plan' : 'super-plan'
-
-        set((state) => {
-          const newModeMap = new Map(state.modeBySession)
-          newModeMap.set(sessionId, newMode)
-          return { modeBySession: newModeMap }
-        })
-
-        try {
-          await dbApi.session.update<Session>(sessionId, { mode: newMode })
-        } catch (error) {
-          console.error('Failed to persist session mode:', error)
-        }
-
-        await get().applyModeDefaultModel(sessionId, newMode)
-        notifyKanbanSessionSync(sessionId, { type: 'mode_change', sessionMode: newMode })
+        await get().toggleSuperMode(sessionId)
       },
 
       // Set session mode explicitly (also applies mode-specific model default)

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -323,7 +323,7 @@ interface SettingsState extends AppSettings {
     model: SelectedModel | null
   ) => Promise<void>
   getModelForMode: (
-    mode: 'build' | 'plan' | 'super-plan' | 'ask' | 'review'
+    mode: 'build' | 'plan' | 'super-plan' | 'super-build' | 'ask' | 'review'
   ) => SelectedModel | null
   setLastHandoffOverride: (value: AppSettings['lastHandoffOverride']) => void
   toggleFavoriteModel: (providerID: string, modelID: string) => void
@@ -697,10 +697,10 @@ export const useSettingsStore = create<SettingsState>()(
         await saveToDatabase(settings)
       },
 
-      getModelForMode: (mode: 'build' | 'plan' | 'super-plan' | 'ask' | 'review') => {
+      getModelForMode: (mode: 'build' | 'plan' | 'super-plan' | 'super-build' | 'ask' | 'review') => {
         // Return only the mode-specific default (no global fallback).
         // Callers that need a fallback chain should check selectedModel separately.
-        const key = mode === 'super-plan' ? 'plan' : mode
+        const key = mode === 'super-plan' ? 'plan' : mode === 'super-build' ? 'build' : mode
         return get().defaultModels?.[key] ?? null
       },
 

--- a/src/server/rpc/domains/backup-ops.ts
+++ b/src/server/rpc/domains/backup-ops.ts
@@ -171,7 +171,7 @@ const backupTicketSchema = z
     description: z.string().nullable(),
     column: z.enum(['todo', 'in_progress', 'review', 'merged', 'done']),
     sort_order: z.number(),
-    mode: z.enum(['build', 'plan', 'super-plan']).nullable(),
+    mode: z.enum(['build', 'plan', 'super-plan', 'super-build']).nullable(),
     mark: z.string().nullable(),
     total_tokens: z.number(),
     archived_at: z.string().nullable(),

--- a/src/server/rpc/domains/db.ts
+++ b/src/server/rpc/domains/db.ts
@@ -292,7 +292,7 @@ const worktreePinnedParamsSchema = z
   .object({ worktreeId: z.string(), pinned: z.boolean() })
   .strict()
 const agentSdkSchema = z.enum(['opencode', 'claude-code', 'claude-code-cli', 'codex', 'terminal'])
-const sessionModeSchema = z.enum(['build', 'plan', 'super-plan'])
+const sessionModeSchema = z.enum(['build', 'plan', 'super-plan', 'super-build'])
 const sessionTypeSchema = z.enum(['default', 'board-assistant'])
 const sessionCreateParamsSchema = z.object({
   worktree_id: z.string().nullable(),

--- a/src/server/rpc/domains/kanban.ts
+++ b/src/server/rpc/domains/kanban.ts
@@ -205,7 +205,7 @@ export interface KanbanRpcService {
 }
 
 const ticketColumnSchema = z.enum(['todo', 'in_progress', 'review', 'merged', 'done'])
-const sessionModeSchema = z.enum(['build', 'plan', 'super-plan'])
+const sessionModeSchema = z.enum(['build', 'plan', 'super-plan', 'super-build'])
 const ticketMarkSchema = z.enum(['common', 'rare', 'epic', 'legendary'])
 
 const kanbanTicketCreateSchema = z

--- a/src/server/rpc/domains/teleport-ops.ts
+++ b/src/server/rpc/domains/teleport-ops.ts
@@ -127,7 +127,7 @@ const receiveParamsSchema = z
     claudeSessionId: z.string().min(1),
     transcript: z.string(),
     model: modelSchema,
-    mode: z.enum(['build', 'plan', 'super-plan'])
+    mode: z.enum(['build', 'plan', 'super-plan', 'super-build'])
   })
   .strict() satisfies z.ZodType<TeleportReceiveParams>
 

--- a/src/shared/agent-mode-prefixes.ts
+++ b/src/shared/agent-mode-prefixes.ts
@@ -7,20 +7,72 @@ export const SUPER_PLAN_MODE_PREFIX =
 export const CODEX_SUPER_PLAN_MODE_PREFIX =
   'Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.\n\nIf a question can be answered by exploring the codebase, explore the codebase instead.\nAll questions should be asked using the request_user_input tool if possible\n\n'
 
+// Super-build: the same relentless interview as super-plan, but in build mode —
+// no plan is produced; once every question is resolved the agent implements.
+export const SUPER_BUILD_MODE_PREFIX =
+  'Before doing anything, interview me relentlessly about every aspect of this task until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.\n\nIf a question can be answered by exploring the codebase, explore the codebase instead.\nAll questions should be asked using the AskUserQuestion tool if possible\nOnly start implementing once every question has been resolved.\n\n'
+
+export const CODEX_SUPER_BUILD_MODE_PREFIX =
+  'Before doing anything, interview me relentlessly about every aspect of this task until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.\n\nIf a question can be answered by exploring the codebase, explore the codebase instead.\nAll questions should be asked using the request_user_input tool if possible\nOnly start implementing once every question has been resolved.\n\n'
+
 // Header that introduces the raw plan in a plan→implementor handoff prompt. Shared so the
 // renderer (which writes it in buildHandoffPrompt) and the main process (which detects and
 // strips it when externalizing oversized claude-cli goal handoffs) can't drift apart.
 export const HANDOFF_PLAN_PROMPT_HEADER = 'Implement the following plan\n'
 
+export type AgentMode = 'build' | 'plan' | 'super-plan' | 'super-build'
+
+/** Plan-like modes drive plan permission mode / planning status. */
+export function isPlanLikeMode(mode: string | null | undefined): boolean {
+  return mode === 'plan' || mode === 'super-plan'
+}
+
+/** Super modes are one-shot: they prefix the next prompt with the interview
+ * instructions and then revert to their base mode. */
+export function isSuperMode(mode: string | null | undefined): mode is 'super-plan' | 'super-build' {
+  return mode === 'super-plan' || mode === 'super-build'
+}
+
+/** Base (non-super) mode: super-plan → plan, super-build → build. */
+export function baseMode(mode: AgentMode | null | undefined): 'build' | 'plan' {
+  return isPlanLikeMode(mode) ? 'plan' : 'build'
+}
+
+/** Toggle super on/off while preserving plan/build. */
+export function toggleSuper(mode: AgentMode | null | undefined): AgentMode {
+  switch (mode) {
+    case 'plan':
+      return 'super-plan'
+    case 'super-plan':
+      return 'plan'
+    case 'super-build':
+      return 'build'
+    default:
+      return 'super-build'
+  }
+}
+
 export function getSuperPlanModePrefix(agentSdk: string | null | undefined): string {
   return agentSdk === 'codex' ? CODEX_SUPER_PLAN_MODE_PREFIX : SUPER_PLAN_MODE_PREFIX
 }
 
-export function applyModePrefix(
-  text: string,
-  mode: 'build' | 'plan' | 'super-plan' | null | undefined
+export function getSuperBuildModePrefix(agentSdk: string | null | undefined): string {
+  return agentSdk === 'codex' ? CODEX_SUPER_BUILD_MODE_PREFIX : SUPER_BUILD_MODE_PREFIX
+}
+
+/** Prefix for a super mode (super-plan / super-build); '' for anything else. */
+export function getSuperModePrefix(
+  mode: string | null | undefined,
+  agentSdk: string | null | undefined
 ): string {
+  if (mode === 'super-plan') return getSuperPlanModePrefix(agentSdk)
+  if (mode === 'super-build') return getSuperBuildModePrefix(agentSdk)
+  return ''
+}
+
+export function applyModePrefix(text: string, mode: AgentMode | null | undefined): string {
   if (mode === 'plan') return PLAN_MODE_PREFIX + text
   if (mode === 'super-plan') return SUPER_PLAN_MODE_PREFIX + text
+  if (mode === 'super-build') return SUPER_BUILD_MODE_PREFIX + text
   return text
 }

--- a/src/shared/types/backup.ts
+++ b/src/shared/types/backup.ts
@@ -47,7 +47,7 @@ export interface BackupTicket {
   description: string | null
   column: 'todo' | 'in_progress' | 'review' | 'merged' | 'done'
   sort_order: number
-  mode: 'build' | 'plan' | 'super-plan' | null
+  mode: 'build' | 'plan' | 'super-plan' | 'super-build' | null
   mark: string | null // 'common'|'rare'|'epic'|'legendary'
   total_tokens: number
   archived_at: string | null


### PR DESCRIPTION
## Summary

- Add `super-build` as a supported session and Kanban mode.
- Extend mode toggles and Shift+Tab shortcuts to switch Super Build and Super Plan.
- Add Super Build prompt prefixes, one-shot mode reset, persistence, and UI styling.
- Update ticket, worktree, message rendering, and backend validation for the new mode.

## Testing

- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide but mechanical type and prompt-path updates across session send, Kanban launch, and persistence; wrong prefix or one-shot revert could mis-route agent behavior without a schema migration.
> 
> **Overview**
> Adds **`super-build`**, a one-shot “interview then implement” mode parallel to **`super-plan`**. Shared helpers in `@shared/agent-mode-prefixes` (`isSuperMode`, `baseMode`, `toggleSuper`, `getSuperModePrefix`) replace ad hoc `super-plan`-only checks so prompts revert to **build** or **plan** after send.
> 
> **Shift+Tab** now toggles super on the current base mode (`build` ↔ `super-build`, `plan` ↔ `super-plan`). The **SUPER** control stays visible in build and plan; session store `toggleSuperMode` and Shift+Tab both use `toggleSuper`. Kanban launch, followups, RPC/backup schemas, and markdown card validation accept the new mode; UI shows orange super styling, **SUPER BUILD** badges, and blue in-progress borders for active super-build tickets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3e91ff5f9ac084bee8e117794b1697a0a7a068c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->