### PR TITLE
Enforce organization Force Board Mode policy

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
-import { isHiveTelemetryEnabled, refreshHiveEnterpriseOrg } from '@/api/hive-enterprise/client'
+import {
+  isHiveTelemetryEnabled,
+  markHiveOrgPolicySettled,
+  refreshHiveEnterpriseOrg
+} from '@/api/hive-enterprise/client'
 import { AppLayout } from '@/components/layout'
 import { DesktopWindowEscapeChrome } from '@/components/layout/DesktopWindowEscapeChrome'
 import { ErrorBoundary } from '@/components/error'
@@ -31,9 +35,13 @@ function App(): React.JSX.Element {
 
   useEffect(() => {
     if (settingsLoading || didRefreshHiveOrg.current) return
-    if (!isHiveTelemetryEnabled({ hiveAuthToken, hiveOrganizationId })) return
+    if (!isHiveTelemetryEnabled({ hiveAuthToken, hiveOrganizationId })) {
+      // No org login — nothing to sync; unblock auto-start waiters right away.
+      markHiveOrgPolicySettled()
+      return
+    }
     didRefreshHiveOrg.current = true
-    void refreshHiveEnterpriseOrg()
+    void refreshHiveEnterpriseOrg().finally(markHiveOrgPolicySettled)
     void reportActiveAccountsSnapshot()
   }, [hiveAuthToken, hiveOrganizationId, settingsLoading])
 

--- a/src/renderer/src/api/hive-enterprise/client.ts
+++ b/src/renderer/src/api/hive-enterprise/client.ts
@@ -28,6 +28,54 @@ export function isHiveTelemetryEnabled(settings: TelemetryGateSettings): boolean
   return Boolean(settings.hiveAuthToken && settings.hiveOrganizationId)
 }
 
+type ForceBoardModeSettings = TelemetryGateSettings &
+  Pick<AppSettings, 'hiveOrganizationForceBoardMode'>
+
+/**
+ * Org policy: when the organization has "Force board mode" enabled, members
+ * can only start sessions from a board ticket — the new-session button and
+ * shortcuts are disabled, no first session auto-opens, and auto-pinning the
+ * project on board prompts is always on. Only applies while logged in to an
+ * organization.
+ */
+export function isForceBoardMode(settings: ForceBoardModeSettings): boolean {
+  return isHiveTelemetryEnabled(settings) && settings.hiveOrganizationForceBoardMode === true
+}
+
+// Enforcement of org policy reads the locally persisted flag, which can be one
+// launch behind when an admin changed it while the app was closed. Auto-start
+// waits (bounded) on this promise so the startup refresh gets a chance to land
+// before the first session would be auto-created.
+let resolveStartupOrgPolicy: () => void = () => {}
+const startupOrgPolicySettled = new Promise<void>((resolve) => {
+  resolveStartupOrgPolicy = resolve
+})
+
+const STARTUP_ORG_POLICY_TIMEOUT_MS = 5000
+
+/**
+ * Mark the startup org-policy sync as finished. Called by App once the
+ * startup refresh completes — or immediately when no refresh will run (not
+ * signed in to an organization). Idempotent.
+ */
+export function markHiveOrgPolicySettled(): void {
+  resolveStartupOrgPolicy()
+}
+
+/**
+ * Resolves once the startup org-policy sync has settled, but never blocks
+ * longer than a few seconds — a hung refresh falls back to the locally
+ * persisted policy. Resolves immediately for users without an org login.
+ */
+export function whenHiveOrgPolicySettled(): Promise<void> {
+  const settings = useSettingsStore.getState()
+  if (!settings.isLoading && !isHiveTelemetryEnabled(settings)) return Promise.resolve()
+  return Promise.race([
+    startupOrgPolicySettled,
+    new Promise<void>((resolve) => setTimeout(resolve, STARTUP_ORG_POLICY_TIMEOUT_MS))
+  ])
+}
+
 function endpointFromSettings(settings: AppSettings): string {
   return `${settings.hiveEnterpriseServerUrl.replace(/\/+$/, '')}/api/graphql`
 }
@@ -202,7 +250,8 @@ export async function completeHiveEnterpriseLogin(token: string): Promise<void> 
     hiveOrganizationId: me?.organization?.id ?? null,
     hiveOrganizationName: me?.organization?.name ?? null,
     hiveOrganizationStorePrompts: me?.organization?.storePrompts ?? true,
-    hiveOrganizationRecordQuestions: me?.organization?.recordQuestions ?? true
+    hiveOrganizationRecordQuestions: me?.organization?.recordQuestions ?? true,
+    hiveOrganizationForceBoardMode: me?.organization?.forceBoardMode ?? false
   })
 }
 
@@ -211,6 +260,7 @@ export async function completeHiveEnterpriseLogin(token: string): Promise<void> 
 async function reconcileOrgSettings(result: {
   storePrompts?: boolean | null
   recordQuestions?: boolean | null
+  forceBoardMode?: boolean | null
 }): Promise<void> {
   const state = useSettingsStore.getState()
   const updates: Partial<AppSettings> = {}
@@ -225,6 +275,12 @@ async function reconcileOrgSettings(result: {
     result.recordQuestions !== state.hiveOrganizationRecordQuestions
   ) {
     updates.hiveOrganizationRecordQuestions = result.recordQuestions
+  }
+  if (
+    typeof result.forceBoardMode === 'boolean' &&
+    result.forceBoardMode !== state.hiveOrganizationForceBoardMode
+  ) {
+    updates.hiveOrganizationForceBoardMode = result.forceBoardMode
   }
   if (Object.keys(updates).length > 0) {
     await useSettingsStore.getState().updateSettings(updates)
@@ -241,7 +297,8 @@ export async function refreshHiveEnterpriseOrg(): Promise<void> {
       hiveOrganizationId: me?.organization?.id ?? null,
       hiveOrganizationName: me?.organization?.name ?? null,
       hiveOrganizationStorePrompts: me?.organization?.storePrompts ?? true,
-      hiveOrganizationRecordQuestions: me?.organization?.recordQuestions ?? true
+      hiveOrganizationRecordQuestions: me?.organization?.recordQuestions ?? true,
+      hiveOrganizationForceBoardMode: me?.organization?.forceBoardMode ?? false
     })
   } catch (error) {
     console.warn('[HiveEnterprise] org refresh failed:', error)

--- a/src/renderer/src/api/hive-enterprise/generated.ts
+++ b/src/renderer/src/api/hive-enterprise/generated.ts
@@ -27,8 +27,20 @@ export type GqlAccountProvider =
   | 'anthropic'
   | 'openai';
 
+export type GqlAccountShare = {
+  __typename?: 'AccountShare';
+  expiresAt: Scalars['String']['output'];
+  token: Scalars['String']['output'];
+};
+
 export type GqlActiveAccountInput = {
   email: Scalars['String']['input'];
+  provider: GqlAccountProvider;
+};
+
+export type GqlClaimedAccountShare = {
+  __typename?: 'ClaimedAccountShare';
+  encryptedPayload: Scalars['String']['output'];
   provider: GqlAccountProvider;
 };
 
@@ -54,8 +66,16 @@ export type GqlMember = {
   role: GqlUserRole;
 };
 
+export type GqlModelPrices = {
+  __typename?: 'ModelPrices';
+  fetchedAt: Scalars['String']['output'];
+  pricesJson: Scalars['String']['output'];
+};
+
 export type GqlMutation = {
   __typename?: 'Mutation';
+  claimAccountShare?: Maybe<GqlClaimedAccountShare>;
+  createAccountShare: GqlAccountShare;
   createOrganization: GqlOrganization;
   inviteMember: GqlInvite;
   recordPromptIdle: GqlPromptMutationResult;
@@ -63,6 +83,18 @@ export type GqlMutation = {
   recordQuestionsAnswered: GqlQuestionAnsweredResult;
   removeMember: Scalars['Boolean']['output'];
   reportActiveAccounts: GqlReportActiveAccountsResult;
+  reportSessionUsage: GqlPromptMutationResult;
+};
+
+
+export type GqlMutationClaimAccountShareArgs = {
+  token: Scalars['String']['input'];
+};
+
+
+export type GqlMutationCreateAccountShareArgs = {
+  encryptedPayload: Scalars['String']['input'];
+  provider: GqlAccountProvider;
 };
 
 
@@ -101,8 +133,14 @@ export type GqlMutationReportActiveAccountsArgs = {
   accounts: Array<GqlActiveAccountInput>;
 };
 
+
+export type GqlMutationReportSessionUsageArgs = {
+  input: GqlSessionUsageReportInput;
+};
+
 export type GqlOrganization = {
   __typename?: 'Organization';
+  forceBoardMode: Scalars['Boolean']['output'];
   id: Scalars['InteractId']['output'];
   name: Scalars['String']['output'];
   recordQuestions: Scalars['Boolean']['output'];
@@ -119,6 +157,7 @@ export type GqlPromptIdleInput = {
 
 export type GqlPromptMutationResult = {
   __typename?: 'PromptMutationResult';
+  forceBoardMode: Scalars['Boolean']['output'];
   recordQuestions: Scalars['Boolean']['output'];
   recorded: Scalars['Boolean']['output'];
   storePrompts: Scalars['Boolean']['output'];
@@ -150,6 +189,7 @@ export type GqlPromptStartInput = {
 
 export type GqlPromptStartResult = {
   __typename?: 'PromptStartResult';
+  forceBoardMode: Scalars['Boolean']['output'];
   promptId?: Maybe<Scalars['InteractId']['output']>;
   recordQuestions: Scalars['Boolean']['output'];
   recorded: Scalars['Boolean']['output'];
@@ -164,6 +204,7 @@ export type GqlQuery = {
   listOrganizations: Array<GqlOrganization>;
   listUsers: Array<GqlMember>;
   me?: Maybe<GqlUser>;
+  modelPrices?: Maybe<GqlModelPrices>;
 };
 
 
@@ -185,6 +226,7 @@ export type GqlQuestionAnsweredInput = {
 
 export type GqlQuestionAnsweredResult = {
   __typename?: 'QuestionAnsweredResult';
+  forceBoardMode: Scalars['Boolean']['output'];
   recordQuestions: Scalars['Boolean']['output'];
   recorded: Scalars['Boolean']['output'];
   storePrompts: Scalars['Boolean']['output'];
@@ -192,9 +234,32 @@ export type GqlQuestionAnsweredResult = {
 
 export type GqlReportActiveAccountsResult = {
   __typename?: 'ReportActiveAccountsResult';
+  forceBoardMode: Scalars['Boolean']['output'];
   recordQuestions: Scalars['Boolean']['output'];
   recorded: Scalars['Boolean']['output'];
   storePrompts: Scalars['Boolean']['output'];
+};
+
+export type GqlSessionUsageReportInput = {
+  agentSdk?: InputMaybe<Scalars['String']['input']>;
+  buckets: Array<GqlUsageBucketInput>;
+  gitRemoteUrl?: InputMaybe<Scalars['String']['input']>;
+  mode?: InputMaybe<Scalars['String']['input']>;
+  projectName?: InputMaybe<Scalars['String']['input']>;
+  projectPath?: InputMaybe<Scalars['String']['input']>;
+  provider: Scalars['String']['input'];
+  sessionId: Scalars['String']['input'];
+  worktreeBranch?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type GqlUsageBucketInput = {
+  bucketTs: Scalars['String']['input'];
+  cacheReadTokens: Scalars['Int']['input'];
+  cacheWriteTokens: Scalars['Int']['input'];
+  costUsd: Scalars['Float']['input'];
+  inputTokens: Scalars['Int']['input'];
+  model: Scalars['String']['input'];
+  outputTokens: Scalars['Int']['input'];
 };
 
 export type GqlUser = {
@@ -228,6 +293,7 @@ export type GqlHiveEnterpriseMeQuery = (
         | 'name'
         | 'storePrompts'
         | 'recordQuestions'
+        | 'forceBoardMode'
       >
     )> }
   )> }
@@ -248,6 +314,7 @@ export type GqlHiveEnterpriseRecordPromptStartMutation = (
       | 'promptId'
       | 'storePrompts'
       | 'recordQuestions'
+      | 'forceBoardMode'
     >
   ) }
 );
@@ -261,7 +328,13 @@ export type GqlHiveEnterpriseRecordPromptIdleMutation = (
   { __typename?: 'Mutation' }
   & { recordPromptIdle: (
     { __typename?: 'PromptMutationResult' }
-    & Pick<GqlPromptMutationResult, 'recorded' | 'storePrompts' | 'recordQuestions'>
+    & Pick<
+      GqlPromptMutationResult,
+      | 'recorded'
+      | 'storePrompts'
+      | 'recordQuestions'
+      | 'forceBoardMode'
+    >
   ) }
 );
 
@@ -274,7 +347,13 @@ export type GqlHiveEnterpriseRecordQuestionsAnsweredMutation = (
   { __typename?: 'Mutation' }
   & { recordQuestionsAnswered: (
     { __typename?: 'QuestionAnsweredResult' }
-    & Pick<GqlQuestionAnsweredResult, 'recorded' | 'storePrompts' | 'recordQuestions'>
+    & Pick<
+      GqlQuestionAnsweredResult,
+      | 'recorded'
+      | 'storePrompts'
+      | 'recordQuestions'
+      | 'forceBoardMode'
+    >
   ) }
 );
 
@@ -287,7 +366,27 @@ export type GqlHiveEnterpriseReportActiveAccountsMutation = (
   { __typename?: 'Mutation' }
   & { reportActiveAccounts: (
     { __typename?: 'ReportActiveAccountsResult' }
-    & Pick<GqlReportActiveAccountsResult, 'recorded' | 'storePrompts' | 'recordQuestions'>
+    & Pick<
+      GqlReportActiveAccountsResult,
+      | 'recorded'
+      | 'storePrompts'
+      | 'recordQuestions'
+      | 'forceBoardMode'
+    >
+  ) }
+);
+
+export type GqlHiveEnterpriseCreateAccountShareMutationVariables = Exact<{
+  provider: GqlAccountProvider;
+  encryptedPayload: Scalars['String']['input'];
+}>;
+
+
+export type GqlHiveEnterpriseCreateAccountShareMutation = (
+  { __typename?: 'Mutation' }
+  & { createAccountShare: (
+    { __typename?: 'AccountShare' }
+    & Pick<GqlAccountShare, 'token' | 'expiresAt'>
   ) }
 );
 

--- a/src/renderer/src/api/hive-enterprise/operations.ts
+++ b/src/renderer/src/api/hive-enterprise/operations.ts
@@ -9,6 +9,7 @@ export const MeDocument = /* GraphQL */ `
         name
         storePrompts
         recordQuestions
+        forceBoardMode
       }
     }
   }
@@ -21,6 +22,7 @@ export const RecordPromptStartDocument = /* GraphQL */ `
       promptId
       storePrompts
       recordQuestions
+      forceBoardMode
     }
   }
 `
@@ -31,6 +33,7 @@ export const RecordPromptIdleDocument = /* GraphQL */ `
       recorded
       storePrompts
       recordQuestions
+      forceBoardMode
     }
   }
 `
@@ -41,6 +44,7 @@ export const RecordQuestionsAnsweredDocument = /* GraphQL */ `
       recorded
       storePrompts
       recordQuestions
+      forceBoardMode
     }
   }
 `
@@ -51,6 +55,7 @@ export const ReportActiveAccountsDocument = /* GraphQL */ `
       recorded
       storePrompts
       recordQuestions
+      forceBoardMode
     }
   }
 `

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -24,6 +24,7 @@ import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { usePinnedStore } from '@/stores/usePinnedStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { isForceBoardMode } from '@/api/hive-enterprise/client'
 import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalContext'
 import { KanbanBoard } from '@/components/kanban/KanbanBoard'
 import { KanbanIcon } from '@/components/kanban/KanbanIcon'
@@ -111,6 +112,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const connectionsLoaded = useConnectionStore((state) => state.loaded)
   const pinnedStoreLoaded = usePinnedStore((state) => state.loaded)
   const boardMode = useSettingsStore((s) => s.boardMode)
+  const forceBoardMode = useSettingsStore(isForceBoardMode)
   const terminalPosition = useSettingsStore((s) => s.terminalPosition)
   const selectedProjectId = useProjectStore((state) => state.selectedProjectId)
   const selectedProjectPath = useProjectStore((state) =>
@@ -462,7 +464,11 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
         <div className="flex-1 flex items-center justify-center text-muted-foreground">
           <div className="text-center">
             <p className="text-lg font-medium">No active session</p>
-            <p className="text-sm mt-2">Click the + button above to create a new session.</p>
+            <p className="text-sm mt-2">
+              {forceBoardMode
+                ? 'Your organization requires sessions to be started from a board ticket.'
+                : 'Click the + button above to create a new session.'}
+            </p>
           </div>
         </div>
       )

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -46,6 +46,7 @@ import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { isForceBoardMode, whenHiveOrgPolicySettled } from '@/api/hive-enterprise/client'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useFavoriteTicketsStore } from '@/stores/useFavoriteTicketsStore'
@@ -719,6 +720,9 @@ export function SessionTabs(): React.JSX.Element | null {
   // Auto-start runs as a direct follow-up to loadSessions (not a separate effect) to
   // eliminate race conditions between the two async operations.
   const autoStartSession = useSettingsStore((state) => state.autoStartSession)
+  // Org "Force board mode" policy: sessions may only be started from a board
+  // ticket — hides the new-session button and suppresses auto-start.
+  const forceBoardMode = useSettingsStore(isForceBoardMode)
   const availableAgentSdks = useSettingsStore((state) => state.availableAgentSdks)
   const defaultAgentSdk = useSettingsStore((state) => state.defaultAgentSdk)
   const rawCustomProviders = useSettingsStore((state) => state.customProviders)
@@ -749,11 +753,18 @@ export function SessionTabs(): React.JSX.Element | null {
       if (cancelled) return
 
       // After sessions are loaded, check if auto-start is needed
-      if (!autoStartSession) return
+      if (!autoStartSession || forceBoardMode) return
       if (autoStartedRef.current === selectedWorktreeId) return
 
       const sessions = useSessionStore.getState().sessionsByWorktree.get(selectedWorktreeId) || []
       if (sessions.length > 0) return
+
+      // Wait (bounded) for the startup org-policy sync, then re-check with
+      // fresh state: a "Force board mode" enabled while the app was closed
+      // must suppress this launch's auto-start too, not just the next one.
+      await whenHiveOrgPolicySettled()
+      if (cancelled) return
+      if (isForceBoardMode(useSettingsStore.getState())) return
 
       autoStartedRef.current = selectedWorktreeId
       await createSession(selectedWorktreeId, project.id, undefined, undefined, {
@@ -774,7 +785,15 @@ export function SessionTabs(): React.JSX.Element | null {
     return () => {
       cancelled = true
     }
-  }, [selectedWorktreeId, project, loadSessions, autoStartSession, createSession, isConnectionMode])
+  }, [
+    selectedWorktreeId,
+    project,
+    loadSessions,
+    autoStartSession,
+    forceBoardMode,
+    createSession,
+    isConnectionMode
+  ])
 
   // Load sessions when connection changes (connection mode)
   useEffect(() => {
@@ -787,12 +806,17 @@ export function SessionTabs(): React.JSX.Element | null {
       if (cancelled) return
 
       // Auto-start a session if auto-start is enabled and no sessions exist
-      if (!autoStartSession) return
+      if (!autoStartSession || forceBoardMode) return
       if (autoStartedRef.current === selectedConnectionId) return
 
       const sessions =
         useSessionStore.getState().sessionsByConnection.get(selectedConnectionId) || []
       if (sessions.length > 0) return
+
+      // Same startup-policy wait as the worktree path above.
+      await whenHiveOrgPolicySettled()
+      if (cancelled) return
+      if (isForceBoardMode(useSettingsStore.getState())) return
 
       autoStartedRef.current = selectedConnectionId
       await createConnectionSession(selectedConnectionId)
@@ -806,6 +830,7 @@ export function SessionTabs(): React.JSX.Element | null {
     isConnectionMode,
     loadConnectionSessions,
     autoStartSession,
+    forceBoardMode,
     createConnectionSession
   ])
 
@@ -1380,8 +1405,10 @@ export function SessionTabs(): React.JSX.Element | null {
       className="flex items-center h-8 shrink-0 bg-card border-b border-border"
       data-testid="session-tabs"
     >
-      {/* New session / new ticket button - on the left */}
-      {boardMode === 'sticky-tab' || !isBoardViewActive ? (
+      {/* New session / new ticket button - on the left. Force board mode
+          removes the session-create button entirely — sessions can only be
+          started from a board ticket — but keeps the ticket-create button. */}
+      {!forceBoardMode && (boardMode === 'sticky-tab' || !isBoardViewActive) ? (
         /* Session create button with right-click provider menu */
         <Tip tipId="provider-right-click" enabled={multipleProvidersAvailable}>
           <div className="shrink-0 h-full">

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -10,6 +10,7 @@ import type { UsageProvider } from '@shared/types/usage'
 import claudeIcon from '@/assets/model-icons/claude.svg'
 import openaiIcon from '@/assets/model-icons/openai.svg'
 import { isAgentSdkAvailable } from '@/lib/agent-sdk-availability'
+import { isForceBoardMode } from '@/api/hive-enterprise/client'
 
 export function SettingsGeneral(): React.JSX.Element {
   const { setTheme } = useThemeStore()
@@ -39,6 +40,9 @@ export function SettingsGeneral(): React.JSX.Element {
     setActiveSection
   } = useSettingsStore()
   const { resetToDefaults: resetShortcuts } = useShortcutStore()
+  // Org "Force board mode" policy overrides auto-start (off) and auto-pin (on);
+  // both toggles are locked while it is active.
+  const forceBoardMode = useSettingsStore(isForceBoardMode)
 
   const handleResetAll = (): void => {
     resetToDefaults()
@@ -99,23 +103,30 @@ export function SettingsGeneral(): React.JSX.Element {
         <div>
           <label className="text-sm font-medium">Auto-start session</label>
           <p className="text-xs text-muted-foreground">
-            Automatically create a session when selecting a worktree with none
+            {forceBoardMode
+              ? 'Disabled by your organization (Force board mode)'
+              : 'Automatically create a session when selecting a worktree with none'}
           </p>
         </div>
         <button
           role="switch"
-          aria-checked={autoStartSession}
+          aria-checked={forceBoardMode ? false : autoStartSession}
+          disabled={forceBoardMode}
           onClick={() => updateSetting('autoStartSession', !autoStartSession)}
           className={cn(
-            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
-            autoStartSession ? 'bg-primary' : 'bg-muted'
+            'relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors',
+            forceBoardMode
+              ? 'bg-muted cursor-not-allowed opacity-50'
+              : autoStartSession
+                ? 'bg-primary cursor-pointer'
+                : 'bg-muted cursor-pointer'
           )}
           data-testid="auto-start-session-toggle"
         >
           <span
             className={cn(
               'pointer-events-none block h-4 w-4 rounded-full bg-background ring-0 transition-transform',
-              autoStartSession ? 'translate-x-4' : 'translate-x-0'
+              !forceBoardMode && autoStartSession ? 'translate-x-4' : 'translate-x-0'
             )}
           />
         </button>
@@ -219,26 +230,32 @@ export function SettingsGeneral(): React.JSX.Element {
         <div>
           <label className="text-sm font-medium">Auto-pin project on board prompts</label>
           <p className="text-xs text-muted-foreground">
-            When a board action sends a prompt for a ticket, automatically pin the project's base
-            worktree so its tickets appear on the pinned board.
+            {forceBoardMode
+              ? 'Enabled by your organization (Force board mode)'
+              : "When a board action sends a prompt for a ticket, automatically pin the project's base worktree so its tickets appear on the pinned board."}
           </p>
         </div>
         <button
           role="switch"
-          aria-checked={autoPinBaseWorktreeOnBoardPrompt}
+          aria-checked={forceBoardMode ? true : autoPinBaseWorktreeOnBoardPrompt}
+          disabled={forceBoardMode}
           onClick={() =>
             updateSetting('autoPinBaseWorktreeOnBoardPrompt', !autoPinBaseWorktreeOnBoardPrompt)
           }
           className={cn(
-            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
-            autoPinBaseWorktreeOnBoardPrompt ? 'bg-primary' : 'bg-muted'
+            'relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors',
+            forceBoardMode
+              ? 'bg-primary cursor-not-allowed opacity-50'
+              : autoPinBaseWorktreeOnBoardPrompt
+                ? 'bg-primary cursor-pointer'
+                : 'bg-muted cursor-pointer'
           )}
           data-testid="auto-pin-base-worktree-toggle"
         >
           <span
             className={cn(
               'pointer-events-none block h-4 w-4 rounded-full bg-background ring-0 transition-transform',
-              autoPinBaseWorktreeOnBoardPrompt ? 'translate-x-4' : 'translate-x-0'
+              forceBoardMode || autoPinBaseWorktreeOnBoardPrompt ? 'translate-x-4' : 'translate-x-0'
             )}
           />
         </button>

--- a/src/renderer/src/components/settings/SettingsHiveEnterprise.tsx
+++ b/src/renderer/src/components/settings/SettingsHiveEnterprise.tsx
@@ -26,7 +26,9 @@ export function SettingsHiveEnterprise(): React.JSX.Element {
         hiveLoggedInEmail: me?.email ?? null,
         hiveOrganizationId: me?.organization?.id ?? null,
         hiveOrganizationName: me?.organization?.name ?? null,
-        hiveOrganizationStorePrompts: me?.organization?.storePrompts ?? true
+        hiveOrganizationStorePrompts: me?.organization?.storePrompts ?? true,
+        hiveOrganizationRecordQuestions: me?.organization?.recordQuestions ?? true,
+        hiveOrganizationForceBoardMode: me?.organization?.forceBoardMode ?? false
       })
       toast.success('Hive Enterprise account refreshed')
     } catch (error) {

--- a/src/renderer/src/hooks/useCommands.ts
+++ b/src/renderer/src/hooks/useCommands.ts
@@ -16,6 +16,7 @@ import { useGitStore } from '@/stores/useGitStore'
 import { useShortcutStore } from '@/stores/useShortcutStore'
 import { useCommandPaletteStore, type Command } from '@/stores/useCommandPaletteStore'
 import { commandRegistry, fuzzySearch } from '@/lib/command-registry'
+import { isForceBoardMode } from '@/api/hive-enterprise/client'
 import { THEME_PRESETS, getThemeById } from '@/lib/themes'
 import { toast } from '@/lib/toast'
 import { revealLabel, fileManagerName } from '@/lib/platform'
@@ -249,6 +250,14 @@ export function useCommands() {
         shortcut: getDisplayString('session:new'),
         keywords: ['new', 'create', 'session', 'chat'],
         action: async () => {
+          // Org "Force board mode" policy: guard at execution too — the
+          // palette's command list is memoized, so a policy that flips on
+          // mid-session can leave a stale, still-selectable entry behind.
+          if (isForceBoardMode(useSettingsStore.getState())) {
+            toast.error('Your organization requires sessions to be started from a board ticket')
+            closeCommandPalette()
+            return
+          }
           if (!activeWorktreeId || !selectedProjectId) {
             toast.error('Please select a worktree first')
             return
@@ -261,7 +270,10 @@ export function useCommands() {
           }
           closeCommandPalette()
         },
-        isEnabled: () => activeWorktreeId !== null && selectedProjectId !== null
+        isEnabled: () => activeWorktreeId !== null && selectedProjectId !== null,
+        // Org "Force board mode" policy: sessions may only be started from a
+        // board ticket.
+        isVisible: () => !isForceBoardMode(useSettingsStore.getState())
       },
       {
         id: 'action:close-session',

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -23,6 +23,7 @@ import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useTerminalTabStore } from '@/stores/useTerminalTabStore'
 import { useTerminalStore } from '@/stores/useTerminalStore'
 import { eventMatchesBinding, type KeyBinding } from '@/lib/keyboard-shortcuts'
+import { isForceBoardMode } from '@/api/hive-enterprise/client'
 import { toast } from '@/lib/toast'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { systemApi } from '@/api/system-api'
@@ -101,6 +102,13 @@ function handleRunProject(): void {
  * Shared between the keyboard shortcut handler and the main-process IPC listener.
  */
 function createNewSession(): void {
+  // Org "Force board mode" policy: sessions may only be started from a board
+  // ticket, so the shortcut (and the File menu item that forwards to it) is a
+  // no-op beyond explaining why.
+  if (isForceBoardMode(useSettingsStore.getState())) {
+    toast.error('Your organization requires sessions to be started from a board ticket')
+    return
+  }
   const { selectedWorktreeId, worktreesByProject } = useWorktreeStore.getState()
   if (!selectedWorktreeId) {
     toast.error('Please select a worktree first')

--- a/src/renderer/src/lib/auto-pin.ts
+++ b/src/renderer/src/lib/auto-pin.ts
@@ -1,6 +1,7 @@
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { usePinnedStore } from '@/stores/usePinnedStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { isForceBoardMode } from '@/api/hive-enterprise/client'
 
 /**
  * When the "auto-pin project on board prompts" setting is enabled, pin the
@@ -10,7 +11,10 @@ import { useWorktreeStore } from '@/stores/useWorktreeStore'
 export async function autoPinBaseWorktree(projectId: string | null | undefined): Promise<void> {
   try {
     if (!projectId) return
-    if (!useSettingsStore.getState().autoPinBaseWorktreeOnBoardPrompt) return
+    // Org "Force board mode" policy pins unconditionally — the local setting
+    // is forced on and cannot be disabled.
+    const settings = useSettingsStore.getState()
+    if (!settings.autoPinBaseWorktreeOnBoardPrompt && !isForceBoardMode(settings)) return
 
     let base = useWorktreeStore.getState().getDefaultWorktree(projectId)
     if (!base) {

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -173,6 +173,7 @@ export interface AppSettings {
   hiveOrganizationName: string | null
   hiveOrganizationStorePrompts: boolean
   hiveOrganizationRecordQuestions: boolean
+  hiveOrganizationForceBoardMode: boolean
 
   // Tips
   tipsEnabled: boolean
@@ -272,6 +273,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   hiveOrganizationName: null,
   hiveOrganizationStorePrompts: true,
   hiveOrganizationRecordQuestions: true,
+  hiveOrganizationForceBoardMode: false,
   tipsEnabled: true,
   telegramConfig: null,
   teleport: null,
@@ -484,6 +486,7 @@ function extractSettings(state: SettingsState): AppSettings {
     hiveOrganizationName: state.hiveOrganizationName,
     hiveOrganizationStorePrompts: state.hiveOrganizationStorePrompts,
     hiveOrganizationRecordQuestions: state.hiveOrganizationRecordQuestions,
+    hiveOrganizationForceBoardMode: state.hiveOrganizationForceBoardMode,
     tipsEnabled: state.tipsEnabled,
     telegramConfig: null,
     teleport: state.teleport,
@@ -854,6 +857,7 @@ export const useSettingsStore = create<SettingsState>()(
         hiveOrganizationName: state.hiveOrganizationName,
         hiveOrganizationStorePrompts: state.hiveOrganizationStorePrompts,
         hiveOrganizationRecordQuestions: state.hiveOrganizationRecordQuestions,
+        hiveOrganizationForceBoardMode: state.hiveOrganizationForceBoardMode,
         tipsEnabled: state.tipsEnabled,
         pet: state.pet,
         environmentVariables: state.environmentVariables,

--- a/test/kanban/force-board-mode-auto-pin.test.ts
+++ b/test/kanban/force-board-mode-auto-pin.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { autoPinBaseWorktree } from '@/lib/auto-pin'
+import { isForceBoardMode } from '@/api/hive-enterprise/client'
+
+let mockSettings: Record<string, unknown> = {}
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: Object.assign(
+    (selector?: (s: unknown) => unknown) => (selector ? selector(mockSettings) : mockSettings),
+    {
+      getState: () => mockSettings
+    }
+  )
+}))
+
+const mockPinWorktree = vi.fn().mockResolvedValue(undefined)
+const mockIsWorktreePinned = vi.fn().mockReturnValue(false)
+
+vi.mock('@/stores/usePinnedStore', () => ({
+  usePinnedStore: {
+    getState: () => ({
+      pinWorktree: mockPinWorktree,
+      isWorktreePinned: mockIsWorktreePinned
+    })
+  }
+}))
+
+const mockGetDefaultWorktree = vi.fn()
+
+vi.mock('@/stores/useWorktreeStore', () => ({
+  useWorktreeStore: {
+    getState: () => ({
+      getDefaultWorktree: mockGetDefaultWorktree,
+      loadWorktrees: vi.fn().mockResolvedValue(undefined)
+    })
+  }
+}))
+
+describe('isForceBoardMode', () => {
+  it('is false unless logged in to an org with the policy enabled', () => {
+    const enabled = {
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1',
+      hiveOrganizationForceBoardMode: true
+    }
+    expect(isForceBoardMode(enabled)).toBe(true)
+    expect(isForceBoardMode({ ...enabled, hiveAuthToken: null })).toBe(false)
+    expect(isForceBoardMode({ ...enabled, hiveOrganizationId: null })).toBe(false)
+    expect(isForceBoardMode({ ...enabled, hiveOrganizationForceBoardMode: false })).toBe(false)
+  })
+})
+
+describe('autoPinBaseWorktree under org Force board mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsWorktreePinned.mockReturnValue(false)
+    mockGetDefaultWorktree.mockReturnValue({ id: 'base-worktree-1' })
+    mockSettings = {
+      autoPinBaseWorktreeOnBoardPrompt: false,
+      hiveAuthToken: null,
+      hiveOrganizationId: null,
+      hiveOrganizationForceBoardMode: false
+    }
+  })
+
+  it('does not pin when the local setting is off and the policy is off', async () => {
+    await autoPinBaseWorktree('project-1')
+
+    expect(mockPinWorktree).not.toHaveBeenCalled()
+  })
+
+  it('pins even with the local setting off when the policy is on', async () => {
+    mockSettings = {
+      autoPinBaseWorktreeOnBoardPrompt: false,
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1',
+      hiveOrganizationForceBoardMode: true
+    }
+
+    await autoPinBaseWorktree('project-1')
+
+    expect(mockPinWorktree).toHaveBeenCalledWith('base-worktree-1')
+  })
+
+  it('still pins from the local setting alone', async () => {
+    mockSettings = {
+      autoPinBaseWorktreeOnBoardPrompt: true,
+      hiveAuthToken: null,
+      hiveOrganizationId: null,
+      hiveOrganizationForceBoardMode: false
+    }
+
+    await autoPinBaseWorktree('project-1')
+
+    expect(mockPinWorktree).toHaveBeenCalledWith('base-worktree-1')
+  })
+})

--- a/test/kanban/force-board-mode-shortcuts.test.tsx
+++ b/test/kanban/force-board-mode-shortcuts.test.tsx
@@ -1,0 +1,160 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('@/api/settings-api', () => ({
+  settingsApi: {
+    onSettingsUpdated: vi.fn(() => vi.fn())
+  }
+}))
+
+vi.mock('@/api/db-api', () => ({
+  dbApi: {
+    setting: {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue(undefined)
+    }
+  }
+}))
+
+vi.mock('@/api/pet-api', () => ({
+  petApi: {
+    updateSettings: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+const onNewSessionShortcut = vi.fn(() => vi.fn())
+
+vi.mock('@/api/system-api', () => ({
+  systemApi: {
+    onNewSessionShortcut: (listener: () => void) => onNewSessionShortcut(listener),
+    onFileSearchShortcut: vi.fn(() => vi.fn()),
+    onCloseSessionShortcut: vi.fn(() => vi.fn()),
+    onMenuAction: vi.fn(() => vi.fn()),
+    updateMenuState: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+import { useKeyboardShortcuts } from '../../src/renderer/src/hooks/useKeyboardShortcuts'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { toast } from '@/lib/toast'
+import {
+  resetRendererRpcClientForTests,
+  setRendererRpcClient
+} from '../../src/renderer/src/api/rpc-client'
+
+function ShortcutHarness(): React.JSX.Element {
+  useKeyboardShortcuts()
+  return <div>shortcut-harness</div>
+}
+
+describe('new-session shortcut under org Force board mode', () => {
+  let createSession: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setRendererRpcClient({
+      request: vi.fn().mockResolvedValue(undefined),
+      subscribe: vi.fn().mockReturnValue(() => {})
+    })
+
+    createSession = vi.fn().mockResolvedValue({ success: true })
+    useSessionStore.setState({ createSession })
+    useWorktreeStore.setState({
+      selectedWorktreeId: 'worktree-1',
+      worktreesByProject: new Map([
+        [
+          'project-1',
+          [
+            {
+              id: 'worktree-1',
+              project_id: 'project-1',
+              name: 'main',
+              branch_name: 'main',
+              path: '/repo/hive',
+              status: 'active',
+              is_default: true,
+              branch_renamed: 0,
+              last_message_at: null,
+              session_titles: '[]',
+              last_model_provider_id: null,
+              last_model_id: null,
+              last_model_variant: null,
+              created_at: '2026-05-29T00:00:00.000Z',
+              last_accessed_at: '2026-05-29T00:00:00.000Z',
+              github_pr_number: null,
+              github_pr_url: null
+            }
+          ]
+        ]
+      ])
+    })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+  })
+
+  function fireMenuNewSessionShortcut(): void {
+    render(<ShortcutHarness />)
+    expect(onNewSessionShortcut).toHaveBeenCalled()
+    const listener = onNewSessionShortcut.mock.calls[0][0] as unknown as () => void
+    listener()
+  }
+
+  test('blocks the Cmd+T / File-menu new-session shortcut with an explanation when the policy is on', () => {
+    useSettingsStore.setState({
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1',
+      hiveOrganizationForceBoardMode: true
+    })
+
+    fireMenuNewSessionShortcut()
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Your organization requires sessions to be started from a board ticket'
+    )
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  test('creates a session through the shortcut when the policy is off', () => {
+    useSettingsStore.setState({
+      hiveAuthToken: null,
+      hiveOrganizationId: null,
+      hiveOrganizationForceBoardMode: false
+    })
+
+    fireMenuNewSessionShortcut()
+
+    expect(createSession).toHaveBeenCalledWith('worktree-1', 'project-1')
+  })
+
+  // Source-level check (same style as the phase suites for useCommands): the
+  // palette command list is memoized, so the New Session command must be gated
+  // at execution too, not just via isVisible.
+  test('command palette New Session is gated at both visibility and execution', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../src/renderer/src/hooks/useCommands.ts'),
+      'utf-8'
+    )
+    const start = source.indexOf("id: 'action:new-session'")
+    const end = source.indexOf("id: 'action:close-session'")
+    expect(start).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(start)
+    const command = source.slice(start, end)
+    expect(command).toContain('isVisible: () => !isForceBoardMode(useSettingsStore.getState())')
+    expect(command).toContain(
+      "toast.error('Your organization requires sessions to be started from a board ticket')"
+    )
+  })
+})

--- a/test/kanban/force-board-mode.test.tsx
+++ b/test/kanban/force-board-mode.test.tsx
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import type { ReactNode } from 'react'
+import { SessionTabs } from '../../src/renderer/src/components/sessions/SessionTabs'
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+import { BOARD_TAB_ID, useSessionStore } from '@/stores/useSessionStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useFileViewerStore } from '@/stores/useFileViewerStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onClick
+  }: {
+    children: ReactNode
+    onClick?: () => void | Promise<void>
+  }) => (
+    <button type="button" onClick={() => void onClick?.()}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@/components/kanban/TicketCreateModal', () => ({
+  TicketCreateModal: () => null
+}))
+
+vi.mock('@/components/kanban/ImportTicketsModal', () => ({
+  ImportTicketsModal: () => null
+}))
+
+vi.mock('@/components/kanban/JiraImportModal', () => ({
+  JiraImportModal: () => null
+}))
+
+vi.mock('@/components/kanban/HiveImportModal', () => ({
+  HiveImportModal: () => null
+}))
+
+// Mutable settings state so individual tests can flip the org policy on/off.
+let mockSettings: Record<string, unknown> = {}
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: Object.assign(
+    (selector: (state: Record<string, unknown>) => unknown) => selector(mockSettings),
+    {
+      getState: () => mockSettings
+    }
+  )
+}))
+
+function baseSettings(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    autoStartSession: false,
+    availableAgentSdks: { opencode: true, claude: false, codex: false },
+    boardMode: 'sticky-tab',
+    defaultAgentSdk: 'opencode',
+    selectedModel: null,
+    hiveAuthToken: null,
+    hiveOrganizationId: null,
+    hiveOrganizationForceBoardMode: false,
+    ...overrides
+  }
+}
+
+function forcedBoardModeSettings(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return baseSettings({
+    hiveAuthToken: 'token-1',
+    hiveOrganizationId: 'org-1',
+    hiveOrganizationForceBoardMode: true,
+    ...overrides
+  })
+}
+
+function setupStores(): void {
+  setRendererRpcClient({
+    request: vi.fn(() => Promise.resolve(undefined)),
+    subscribe: vi.fn()
+  })
+
+  useConnectionStore.setState({
+    selectedConnectionId: null,
+    connections: []
+  })
+  useFileViewerStore.setState({
+    openFiles: new Map(),
+    activeFilePath: null,
+    activeDiff: null
+  })
+  useKanbanStore.setState({
+    isBoardViewActive: false
+  })
+  useProjectStore.setState({
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '/repo/hive',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: '2026-05-29T00:00:00.000Z',
+        last_accessed_at: '2026-05-29T00:00:00.000Z'
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    selectedWorktreeId: 'worktree-1',
+    worktreesByProject: new Map([
+      [
+        'project-1',
+        [
+          {
+            id: 'worktree-1',
+            project_id: 'project-1',
+            name: 'main',
+            branch_name: 'main',
+            path: '/repo/hive',
+            status: 'active',
+            is_default: true,
+            branch_renamed: 0,
+            last_message_at: null,
+            session_titles: '[]',
+            last_model_provider_id: null,
+            last_model_id: null,
+            last_model_variant: null,
+            created_at: '2026-05-29T00:00:00.000Z',
+            last_accessed_at: '2026-05-29T00:00:00.000Z',
+            github_pr_number: null,
+            github_pr_url: null
+          }
+        ]
+      ]
+    ])
+  })
+  useSessionStore.setState({
+    activeSessionId: BOARD_TAB_ID,
+    activeWorktreeId: 'worktree-1',
+    activeSessionByWorktree: { 'worktree-1': BOARD_TAB_ID },
+    activePinnedSessionId: null,
+    inlineConnectionSessionId: null,
+    orphanedSessions: new Set(),
+    pinnedSessionIds: new Set(),
+    sessionsByWorktree: new Map(),
+    tabOrderByWorktree: new Map(),
+    sessionsByConnection: new Map(),
+    tabOrderByConnection: new Map(),
+    loadSessions: vi.fn().mockResolvedValue(undefined),
+    createSession: vi.fn().mockResolvedValue({ success: true })
+  })
+}
+
+describe('SessionTabs under org Force board mode', () => {
+  beforeEach(() => {
+    mockSettings = baseSettings()
+    setupStores()
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+    vi.clearAllMocks()
+  })
+
+  test('shows the new-session + button when the policy is off', () => {
+    render(<SessionTabs />)
+
+    expect(screen.getByTestId('create-session')).toBeInTheDocument()
+  })
+
+  test('hides the new-session + button when the policy is on', () => {
+    mockSettings = forcedBoardModeSettings()
+
+    render(<SessionTabs />)
+
+    expect(screen.queryByTestId('create-session')).not.toBeInTheDocument()
+  })
+
+  test('keeps the ticket-create + button in toggle-mode board view when the policy is on', () => {
+    mockSettings = forcedBoardModeSettings({ boardMode: 'toggle' })
+    useKanbanStore.setState({ isBoardViewActive: true })
+
+    render(<SessionTabs />)
+
+    expect(screen.queryByTestId('create-session')).not.toBeInTheDocument()
+    expect(screen.getByTestId('kanban-add-ticket-btn')).toBeInTheDocument()
+  })
+
+  test('does not honor a stale forced flag after logging out of the organization', () => {
+    mockSettings = forcedBoardModeSettings({ hiveAuthToken: null, hiveOrganizationId: null })
+
+    render(<SessionTabs />)
+
+    expect(screen.getByTestId('create-session')).toBeInTheDocument()
+  })
+
+  test('suppresses auto-start of a first session when the policy is on', async () => {
+    mockSettings = forcedBoardModeSettings({ autoStartSession: true })
+    const createSession = vi.fn().mockResolvedValue({ success: true })
+    const loadSessions = vi.fn().mockResolvedValue(undefined)
+    useSessionStore.setState({ createSession, loadSessions })
+
+    render(<SessionTabs />)
+
+    await waitFor(() => {
+      expect(loadSessions).toHaveBeenCalled()
+    })
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  test('still auto-starts a first session when the policy is off', async () => {
+    mockSettings = baseSettings({ autoStartSession: true })
+    const createSession = vi.fn().mockResolvedValue({ success: true })
+    const loadSessions = vi.fn().mockResolvedValue(undefined)
+    useSessionStore.setState({ createSession, loadSessions })
+
+    render(<SessionTabs />)
+
+    await waitFor(() => {
+      expect(createSession).toHaveBeenCalledWith('worktree-1', 'project-1', undefined, undefined, {
+        autoFocus: false
+      })
+    })
+  })
+
+  function enterConnectionMode(): {
+    loadConnectionSessions: ReturnType<typeof vi.fn>
+    createConnectionSession: ReturnType<typeof vi.fn>
+  } {
+    const loadConnectionSessions = vi.fn().mockResolvedValue(undefined)
+    const createConnectionSession = vi.fn().mockResolvedValue({ success: true })
+    useWorktreeStore.setState({ selectedWorktreeId: null })
+    useConnectionStore.setState({
+      selectedConnectionId: 'connection-1',
+      connections: [
+        {
+          id: 'connection-1',
+          name: 'Connection 1',
+          created_at: '2026-05-29T00:00:00.000Z',
+          members: []
+        }
+      ]
+    })
+    useSessionStore.setState({
+      activeWorktreeId: null,
+      activeConnectionId: 'connection-1',
+      setActiveConnection: vi.fn(),
+      loadConnectionSessions,
+      createConnectionSession
+    })
+    return { loadConnectionSessions, createConnectionSession }
+  }
+
+  test('suppresses auto-start of a first connection session when the policy is on', async () => {
+    mockSettings = forcedBoardModeSettings({ autoStartSession: true })
+    const { loadConnectionSessions, createConnectionSession } = enterConnectionMode()
+
+    render(<SessionTabs />)
+
+    await waitFor(() => {
+      expect(loadConnectionSessions).toHaveBeenCalledWith('connection-1')
+    })
+    expect(createConnectionSession).not.toHaveBeenCalled()
+  })
+
+  test('still auto-starts a first connection session when the policy is off', async () => {
+    mockSettings = baseSettings({ autoStartSession: true })
+    const { createConnectionSession } = enterConnectionMode()
+
+    render(<SessionTabs />)
+
+    await waitFor(() => {
+      expect(createConnectionSession).toHaveBeenCalledWith('connection-1')
+    })
+  })
+})

--- a/test/settings/force-board-mode-toggles.test.tsx
+++ b/test/settings/force-board-mode-toggles.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockUpdateSetting = vi.fn()
+let mockSettingsState: Record<string, unknown> = {}
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: Object.assign(
+    (selector?: (s: unknown) => unknown) => {
+      return selector ? selector(mockSettingsState) : mockSettingsState
+    },
+    {
+      getState: () => mockSettingsState
+    }
+  )
+}))
+
+vi.mock('@/stores/useThemeStore', () => ({
+  useThemeStore: () => ({ setTheme: vi.fn() })
+}))
+
+vi.mock('@/stores/useShortcutStore', () => ({
+  useShortcutStore: () => ({ resetToDefaults: vi.fn() })
+}))
+
+vi.mock('@/lib/themes', () => ({
+  DEFAULT_THEME_ID: 'default'
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+function baseState(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    autoStartSession: true,
+    autoPullBeforeWorktree: true,
+    boardMode: 'sticky-tab',
+    followUpTriggerColumn: 'done',
+    autoPinBaseWorktreeOnBoardPrompt: false,
+    automaticallyCreateTicket: false,
+    showMergedColumn: false,
+    vimModeEnabled: false,
+    keepAwakeEnabled: false,
+    mergeConflictMode: 'always-ask',
+    tipsEnabled: true,
+    warnBeforeQuitting: true,
+    breedType: 'dogs',
+    showModelIcons: false,
+    showModelProvider: false,
+    usageIndicatorMode: 'current-agent',
+    usageIndicatorProviders: [],
+    defaultAgentSdk: 'opencode',
+    availableAgentSdks: null,
+    stripAtMentions: true,
+    hiveAuthToken: null,
+    hiveOrganizationId: null,
+    hiveOrganizationForceBoardMode: false,
+    updateSetting: mockUpdateSetting,
+    resetToDefaults: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('SettingsGeneral under org Force board mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSettingsState = baseState()
+  })
+
+  it('keeps both toggles interactive when the policy is off', async () => {
+    const { SettingsGeneral } = await import('@/components/settings/SettingsGeneral')
+    render(<SettingsGeneral />)
+
+    const autoStart = screen.getByTestId('auto-start-session-toggle')
+    const autoPin = screen.getByTestId('auto-pin-base-worktree-toggle')
+
+    expect(autoStart).toHaveAttribute('aria-checked', 'true')
+    expect(autoStart).not.toBeDisabled()
+    expect(autoPin).toHaveAttribute('aria-checked', 'false')
+    expect(autoPin).not.toBeDisabled()
+
+    await userEvent.click(autoPin)
+    expect(mockUpdateSetting).toHaveBeenCalledWith('autoPinBaseWorktreeOnBoardPrompt', true)
+  })
+
+  it('locks auto-start off and auto-pin on when the policy is on', async () => {
+    mockSettingsState = baseState({
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1',
+      hiveOrganizationForceBoardMode: true
+    })
+    const { SettingsGeneral } = await import('@/components/settings/SettingsGeneral')
+    render(<SettingsGeneral />)
+
+    const autoStart = screen.getByTestId('auto-start-session-toggle')
+    const autoPin = screen.getByTestId('auto-pin-base-worktree-toggle')
+
+    expect(autoStart).toHaveAttribute('aria-checked', 'false')
+    expect(autoStart).toBeDisabled()
+    expect(autoPin).toHaveAttribute('aria-checked', 'true')
+    expect(autoPin).toBeDisabled()
+
+    expect(screen.getByText('Disabled by your organization (Force board mode)')).toBeInTheDocument()
+    expect(screen.getByText('Enabled by your organization (Force board mode)')).toBeInTheDocument()
+
+    await userEvent.click(autoStart)
+    await userEvent.click(autoPin)
+    expect(mockUpdateSetting).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- Syncs the Hive Enterprise `forceBoardMode` organization policy into local settings.
- Prevents direct session creation, auto-start, and new-session shortcuts when enforced.
- Requires sessions to start from board tickets and forces project auto-pinning.
- Adds coverage for policy toggles, session creation paths, shortcuts, auto-start, and auto-pin behavior.

## Testing

- Added Vitest coverage in `test/kanban/force-board-mode*.test.*` and `test/settings/force-board-mode-toggles.test.tsx`.
- Not run: full test suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how sessions are created at startup and across UI entry points; bounded startup wait could briefly delay auto-start, but board-ticket flows remain the intended path when enforced.
> 
> **Overview**
> Adds Hive Enterprise **Force board mode**: when an org enables it, members must start work from board tickets instead of ad-hoc sessions.
> 
> **Policy sync:** `forceBoardMode` is stored in settings, loaded on login/org refresh, and kept in sync via telemetry mutation echoes. Startup calls `markHiveOrgPolicySettled` / `whenHiveOrgPolicySettled` (5s cap) so first-launch auto-start can wait for a fresh org refresh instead of trusting a stale local flag.
> 
> **Enforcement:** `isForceBoardMode` gates the new-session **+** button, keyboard/menu shortcuts, command palette “New Session”, and worktree/connection **auto-start**. Empty-state copy explains the org requirement. **Auto-pin on board prompts** is forced on; **auto-start** is forced off, with both toggles disabled in General settings when the policy is active.
> 
> **Tests:** Vitest coverage for tabs, shortcuts, settings toggles, and `autoPinBaseWorktree`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f85fed2753255b90d1341a897f97bf9cb219a20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->