### PR TITLE
Add Cmd/Ctrl+P shortcut to toggle pinned board

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -296,7 +296,7 @@ export function buildMenu(mainWindow: BrowserWindow, isDev: boolean): Menu {
       submenu: [
         {
           label: 'Command Palette',
-          accelerator: 'CmdOrCtrl+P',
+          accelerator: 'CmdOrCtrl+O',
           click: () => send('menu:command-palette')
         },
         {
@@ -310,6 +310,11 @@ export function buildMenu(mainWindow: BrowserWindow, isDev: boolean): Menu {
           click: () => send('menu:session-history')
         },
         { type: 'separator' },
+        {
+          label: 'Toggle Pinned Board',
+          accelerator: 'CmdOrCtrl+P',
+          click: () => send('menu:toggle-pinned-board')
+        },
         {
           label: 'Toggle Left Sidebar',
           accelerator: 'CmdOrCtrl+B',

--- a/src/renderer/src/components/layout/LeftSidebar.tsx
+++ b/src/renderer/src/components/layout/LeftSidebar.tsx
@@ -5,6 +5,8 @@ import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useShortcutStore } from '@/stores/useShortcutStore'
+import { formatBinding, getShortcutDefinition } from '@/lib/keyboard-shortcuts'
 import { ResizeHandle } from './ResizeHandle'
 import { KanbanSquare, Link, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -51,13 +53,15 @@ function SidebarNavRow({
   label,
   active,
   onClick,
-  testId
+  testId,
+  shortcut
 }: {
   icon: typeof KanbanSquare
   label: string
   active: boolean
   onClick: () => void
   testId: string
+  shortcut?: string
 }): React.JSX.Element {
   return (
     <button
@@ -66,12 +70,25 @@ function SidebarNavRow({
       aria-current={active ? 'page' : undefined}
       className={cn(NAV_ROW, active ? NAV_ROW_ACTIVE : NAV_ROW_INACTIVE)}
       data-testid={testId}
+      title={shortcut ? `${label} (${shortcut})` : undefined}
     >
       <Icon
         className={cn(NAV_ICON, !active && NAV_ICON_INACTIVE)}
         strokeWidth={active ? NAV_ICON_STROKE_ACTIVE : NAV_ICON_STROKE_INACTIVE}
       />
       <span className={NAV_LABEL}>{label}</span>
+      {shortcut && (
+        <kbd
+          className={cn(
+            'shrink-0 font-sans text-[11px] font-medium tracking-wide',
+            active
+              ? 'text-worktree-sidebar-accent-foreground/50'
+              : 'text-worktree-sidebar-foreground/35'
+          )}
+        >
+          {shortcut}
+        </kbd>
+      )}
     </button>
   )
 }
@@ -116,6 +133,12 @@ export function LeftSidebar(): React.JSX.Element {
   // button: clear file/diff overlays before showing the board, then toggle).
   const isPinnedBoardActive = useKanbanStore((s) => s.isPinnedBoardActive)
   const togglePinnedBoard = useKanbanStore((s) => s.togglePinnedBoard)
+
+  // Effective Cmd+P binding (respects user overrides), shown on the nav row
+  const pinnedBoardBinding =
+    useShortcutStore((s) => s.customBindings['nav:toggle-pinned-board']) ??
+    getShortcutDefinition('nav:toggle-pinned-board')?.defaultBinding
+  const pinnedBoardShortcut = pinnedBoardBinding ? formatBinding(pinnedBoardBinding) : undefined
 
   const handlePinnedBoardClick = useCallback((): void => {
     if (!isPinnedBoardActive) {
@@ -206,6 +229,7 @@ export function LeftSidebar(): React.JSX.Element {
             active={isPinnedBoardActive}
             onClick={handlePinnedBoardClick}
             testId="sidebar-nav-pinned-board"
+            shortcut={pinnedBoardShortcut}
           />
           {projectCount > 1 && <ProjectFilter value={filterQuery} onChange={setFilterQuery} />}
           {activeLanguages.length > 0 && (

--- a/src/renderer/src/components/terminal/backends/XtermBackend.ts
+++ b/src/renderer/src/components/terminal/backends/XtermBackend.ts
@@ -116,6 +116,7 @@ function isAppShortcut(e: KeyboardEvent): boolean {
   if (e.metaKey && e.key === 'h' && !e.shiftKey) return true
   if (e.metaKey && e.key === 'm') return true
   if (e.metaKey && e.key === 'n') return true
+  if (e.metaKey && e.key === 'o') return true
   if (e.metaKey && e.key === 'p') return true
   if (e.metaKey && e.shiftKey && e.key === 'P') return true
   if (e.metaKey && (e.key === '[' || e.key === ']')) return true

--- a/src/renderer/src/hooks/useCommands.ts
+++ b/src/renderer/src/hooks/useCommands.ts
@@ -237,6 +237,24 @@ export function useCommands() {
         },
         isVisible: () => true
       },
+      {
+        id: 'kanban:toggle-pinned',
+        label: 'Toggle Pinned Board',
+        description: 'Show or hide the pinned board',
+        category: 'navigation',
+        icon: 'KanbanIcon',
+        shortcut: getDisplayString('nav:toggle-pinned-board'),
+        keywords: ['kanban', 'board', 'pinned', 'pinboard', 'toggle'],
+        action: () => {
+          const kanban = useKanbanStore.getState()
+          if (!kanban.isPinnedBoardActive) {
+            useFileViewerStore.getState().clearActiveViews()
+          }
+          kanban.togglePinnedBoard()
+          closeCommandPalette()
+        },
+        isVisible: () => true
+      },
 
       // =====================
       // ACTION COMMANDS

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -138,6 +138,22 @@ function createNewSession(): void {
 }
 
 /**
+ * Toggles the pinned board, mirroring the sidebar "Pinned Board" nav row:
+ * clear file/diff overlays before showing the board so it becomes visible.
+ * Shared between the keyboard shortcut and the View menu item.
+ */
+function togglePinnedBoard(): void {
+  const kanban = useKanbanStore.getState()
+  if (!kanban.isPinnedBoardActive) {
+    const fileStore = useFileViewerStore.getState()
+    fileStore.setActiveFile(null)
+    fileStore.clearActiveDiff()
+    fileStore.closeContextEditor()
+  }
+  kanban.togglePinnedBoard()
+}
+
+/**
  * Cycles to the next/previous session tab in the current worktree or connection.
  * Wraps around at the ends. Shared between session:next and session:previous shortcuts.
  */
@@ -757,6 +773,12 @@ function getShortcutHandlers(
       }
     },
     {
+      id: 'nav:toggle-pinned-board',
+      binding: getEffectiveBinding('nav:toggle-pinned-board'),
+      allowInInput: true,
+      handler: togglePinnedBoard
+    },
+    {
       id: 'nav:session-history',
       binding: getEffectiveBinding('nav:session-history'),
       allowInInput: false,
@@ -1154,6 +1176,10 @@ function useMenuActionListeners(): void {
 
     on('menu:command-palette', () => {
       useCommandPaletteStore.getState().toggle()
+    })
+
+    on('menu:toggle-pinned-board', () => {
+      togglePinnedBoard()
     })
 
     on('menu:session-history', () => {

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -132,6 +132,13 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     label: 'Open Command Palette',
     description: 'Open the command palette',
     category: 'navigation',
+    defaultBinding: { key: 'o', modifiers: ['meta'] }
+  },
+  {
+    id: 'nav:toggle-pinned-board',
+    label: 'Toggle Pinned Board',
+    description: 'Show or hide the pinned board',
+    category: 'navigation',
     defaultBinding: { key: 'p', modifiers: ['meta'] }
   },
   {


### PR DESCRIPTION
## Summary
- Add Cmd/Ctrl+P shortcut and menu action for toggling the pinned board.
- Register the action in keyboard shortcuts and the command palette.
- Display the effective pinned-board shortcut in the left sidebar.
- Move the command palette shortcut to Cmd/Ctrl+O.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only shortcut rebinding and UI wiring; no auth, data, or persistence changes beyond existing shortcut overrides.
> 
> **Overview**
> **Cmd/Ctrl+P** now toggles the **Pinned Board**, wired through the shortcut registry, View menu, command palette (`kanban:toggle-pinned`), and a shared handler that clears file/diff overlays before showing the board (same idea as the sidebar nav row).
> 
> **Cmd/Ctrl+O** replaces **P** as the default for the **command palette** in `keyboard-shortcuts`, the Electron View menu, and xterm’s app-shortcut passthrough so terminals don’t swallow those keys.
> 
> The left sidebar **Pinned Board** row shows the effective shortcut (including user overrides) as a `kbd` hint and tooltip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cefcd347195adf5c9bb3b531a9fc973aef2a6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->