### PR TITLE
Clear stale exited status when respawned PTY resumes output

### DIFF
--- a/src/renderer/src/components/terminal/backends/XtermBackend.ts
+++ b/src/renderer/src/components/terminal/backends/XtermBackend.ts
@@ -148,6 +148,7 @@ export class XtermBackend implements TerminalBackend {
   private lastSyncedRows = 0
   private rendererKind: 'webgl' | 'dom' = 'dom'
   private terminalId: string = ''
+  private lastReportedStatus: 'creating' | 'running' | 'exited' | null = null
   private shiftEnterAsNewline = false
   private ghosttyConfig: GhosttyTerminalConfig = {}
 
@@ -293,6 +294,11 @@ export class XtermBackend implements TerminalBackend {
     this.terminal = terminal
     this.fitAddon = fitAddon
 
+    const reportStatus = (status: 'creating' | 'running' | 'exited', code?: number): void => {
+      this.lastReportedStatus = status
+      callbacks.onStatusChange(status, code)
+    }
+
     // Wire user input -> PTY
     this.inputDisposable = terminal.onData((data) => {
       terminalApi.write(this.terminalId, data)
@@ -300,23 +306,35 @@ export class XtermBackend implements TerminalBackend {
 
     // Wire PTY output -> terminal display
     this.removeDataListener = terminalApi.onData(this.terminalId, (data) => {
+      // Output only ever comes from a live PTY (the bridge drops its buffers
+      // on exit, so nothing is delivered after `terminal:exit`). The PTY can
+      // be respawned outside this backend's createTerminal path — followup
+      // prompts and pending-message delivery funnel through
+      // createClaudeCliTerminal in the main process — which reuses this
+      // terminalId without any status callback. Data arriving after we
+      // reported 'exited' therefore means a new live process: clear the
+      // exited state (ended overlay, tab pill) or the UI stays greyed out
+      // over a running session.
+      if (this.lastReportedStatus === 'exited') {
+        reportStatus('running')
+      }
       terminal.write(data)
     })
 
     // Wire PTY exit -> status change
     this.removeExitListener = terminalApi.onExit(this.terminalId, (code) => {
       terminal.write(`\r\n\x1b[90m[Process exited with code ${code}]\x1b[0m\r\n`)
-      callbacks.onStatusChange('exited', code)
+      reportStatus('exited', code)
     })
 
     // Create the PTY
-    callbacks.onStatusChange('creating')
+    reportStatus('creating')
     const createTerminal = opts.createTerminal ?? terminalApi.create
     createTerminal(this.terminalId, opts.cwd, opts.shell)
       .then(unwrapEnvelope)
       .then((result) => {
         if (result.success) {
-          callbacks.onStatusChange('running')
+          reportStatus('running')
 
           // Immediately sync PTY size with xterm.js's actual dimensions.
           // The PTY is created with default 80×24, but xterm.js was already fit
@@ -338,7 +356,7 @@ export class XtermBackend implements TerminalBackend {
           })
         } else {
           terminal.write(`\x1b[31mFailed to create terminal: ${result.error}\x1b[0m\r\n`)
-          callbacks.onStatusChange('exited')
+          reportStatus('exited')
         }
       })
 

--- a/test/terminal/xterm-backend-respawn-status.test.ts
+++ b/test/terminal/xterm-backend-respawn-status.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { XtermBackend } from '../../src/renderer/src/components/terminal/backends/XtermBackend'
+
+const mocks = vi.hoisted(() => ({
+  write: vi.fn(),
+  create: vi.fn(),
+  onData: vi.fn(),
+  onExit: vi.fn(),
+  resize: vi.fn(),
+  dataCallback: undefined as ((data: string) => void) | undefined,
+  exitCallback: undefined as ((code: number) => void) | undefined
+}))
+
+vi.mock('@/api/terminal-api', () => ({
+  terminalApi: {
+    write: mocks.write,
+    create: mocks.create,
+    onData: mocks.onData,
+    onExit: mocks.onExit,
+    resize: mocks.resize,
+    logClientDiagnostics: vi.fn()
+  }
+}))
+
+vi.mock('@/api/project-api', () => ({
+  projectApi: {
+    openPath: vi.fn().mockResolvedValue({ success: true }),
+    readFromClipboard: vi.fn().mockResolvedValue('')
+  }
+}))
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class MockTerminal {
+    options: Record<string, unknown> = {}
+
+    attachCustomKeyEventHandler(): void {}
+    loadAddon(): void {}
+    open(): void {}
+    write(): void {}
+    input(): void {}
+    clear(): void {}
+    hasSelection(): boolean {
+      return false
+    }
+    getSelection(): string {
+      return ''
+    }
+    clearSelection(): void {}
+    focus(): void {}
+    dispose(): void {}
+    onData(): { dispose: () => void } {
+      return { dispose: vi.fn() }
+    }
+  }
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class MockFitAddon {
+    fit(): void {}
+    proposeDimensions(): { cols: number; rows: number } {
+      return { cols: 80, rows: 24 }
+    }
+  }
+}))
+
+vi.mock('@xterm/addon-search', () => ({
+  SearchAddon: class MockSearchAddon {
+    clearDecorations(): void {}
+    findNext(): void {}
+    findPrevious(): void {}
+  }
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: class MockWebLinksAddon {}
+}))
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: class MockWebglAddon {
+    onContextLoss(): void {}
+    dispose(): void {}
+  }
+}))
+
+class MockResizeObserver {
+  observe(): void {}
+  disconnect(): void {}
+}
+
+function mountBackend(onStatusChange: ReturnType<typeof vi.fn>): XtermBackend {
+  const backend = new XtermBackend()
+  const container = document.createElement('div')
+  backend.mount(container, { terminalId: 'session-1', cwd: '/tmp/project' }, { onStatusChange })
+  return backend
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('XtermBackend status after out-of-band PTY respawn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.dataCallback = undefined
+    mocks.exitCallback = undefined
+    mocks.create.mockResolvedValue({ success: true })
+    mocks.onData.mockImplementation((_id: string, cb: (data: string) => void) => {
+      mocks.dataCallback = cb
+      return vi.fn()
+    })
+    mocks.onExit.mockImplementation((_id: string, cb: (code: number) => void) => {
+      mocks.exitCallback = cb
+      return vi.fn()
+    })
+    mocks.resize.mockResolvedValue({ success: true })
+
+    Object.defineProperty(window, 'ResizeObserver', {
+      writable: true,
+      configurable: true,
+      value: MockResizeObserver
+    })
+  })
+
+  test('reports running again when data arrives after exit (bridge respawned the PTY)', async () => {
+    const onStatusChange = vi.fn()
+    mountBackend(onStatusChange)
+    await flushMicrotasks()
+    expect(onStatusChange).toHaveBeenCalledWith('running', undefined)
+
+    // PTY dies (ticket done-close, crash, modal-release destroy...)
+    mocks.exitCallback?.(0)
+    expect(onStatusChange).toHaveBeenCalledWith('exited', 0)
+
+    // A followup prompt respawns the PTY through createClaudeCliTerminal in
+    // the main process — no status callback fires, but output starts flowing.
+    onStatusChange.mockClear()
+    mocks.dataCallback?.('claude booting...')
+
+    expect(onStatusChange).toHaveBeenCalledWith('running', undefined)
+  })
+
+  test('does not re-report running for data while already running', async () => {
+    const onStatusChange = vi.fn()
+    mountBackend(onStatusChange)
+    await flushMicrotasks()
+
+    onStatusChange.mockClear()
+    mocks.dataCallback?.('regular output')
+    mocks.dataCallback?.('more output')
+
+    expect(onStatusChange).not.toHaveBeenCalled()
+  })
+
+  test('recovers even when the initial create failed and a later respawn delivers data', async () => {
+    mocks.create.mockResolvedValue({ success: false, error: 'spawn failed' })
+    const onStatusChange = vi.fn()
+    mountBackend(onStatusChange)
+    await flushMicrotasks()
+    expect(onStatusChange).toHaveBeenCalledWith('exited', undefined)
+
+    onStatusChange.mockClear()
+    mocks.dataCallback?.('respawned output')
+
+    expect(onStatusChange).toHaveBeenCalledWith('running', undefined)
+  })
+})


### PR DESCRIPTION
## Summary
- Track the last reported terminal status in `XtermBackend`.
- Restore `running` status when output arrives after an exited PTY is respawned.
- Add regression tests covering out-of-band respawns, normal output, and initial spawn failures.

## Testing
- Added Vitest coverage in `test/terminal/xterm-backend-respawn-status.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renderer-only terminal status wiring with targeted regression tests; no auth, data, or IPC contract changes beyond status callbacks.
> 
> **Overview**
> Fixes terminals staying in an **exited** state (grey overlay, tab pill) when the main process **respawns the PTY** on the same `terminalId` without going through `XtermBackend`'s create flow.
> 
> `XtermBackend` now remembers the last reported status and routes all status updates through a small `reportStatus` helper. When PTY output arrives while the UI still thinks the session is **exited**, it reports **running** again so the shell UI matches a live session.
> 
> Adds Vitest coverage for respawn-after-exit, normal output while running (no extra status noise), and recovery after an initial spawn failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ffbebbd5c36f1f17b5b1a0b3ea0507ca56e6d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->