### PR TITLE
Remember last project for pinned-board ticket creation

### DIFF
--- a/src/renderer/src/components/kanban/TicketCreateModal.pinned-default-project.test.tsx
+++ b/src/renderer/src/components/kanban/TicketCreateModal.pinned-default-project.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TicketCreateModal } from './TicketCreateModal'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { usePinnedStore } from '@/stores/usePinnedStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import type { Project } from '@shared/types/project'
+
+vi.mock('@/lib/toast', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+const now = '2026-01-01T00:00:00.000Z'
+const makeProject = (id: string, name: string): Project => ({
+  id,
+  name,
+  path: `/tmp/${id}`,
+  description: null,
+  tags: null,
+  language: 'typescript',
+  custom_icon: null,
+  detected_icon: null,
+  setup_script: null,
+  run_script: null,
+  archive_script: null,
+  worktree_create_script: null,
+  custom_commands: null,
+  auto_assign_port: false,
+  sort_order: 0,
+  created_at: now,
+  last_accessed_at: now
+})
+
+const getSelect = (): HTMLSelectElement =>
+  screen.getByTestId('ticket-create-modal').querySelector('select') as HTMLSelectElement
+
+describe('TicketCreateModal pinned board default project', () => {
+  beforeEach(() => {
+    useProjectStore.setState({
+      projects: [makeProject('project-1', 'Alpha'), makeProject('project-2', 'Beta')]
+    })
+    usePinnedStore.setState({ pinnedProjectIds: new Set(['project-1', 'project-2']) })
+    useKanbanStore.setState({ pinnedBoardLastCreateProjectId: null })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    useProjectStore.setState({ projects: [] })
+    usePinnedStore.setState({ pinnedProjectIds: new Set() })
+    useKanbanStore.setState({ pinnedBoardLastCreateProjectId: null })
+  })
+
+  it('defaults to the first pinned project when nothing was created before', () => {
+    render(<TicketCreateModal open onOpenChange={() => {}} projectId="" isPinnedMode />)
+    expect(getSelect().value).toBe('project-1')
+  })
+
+  it('defaults to the project used for the last created ticket', () => {
+    useKanbanStore.setState({ pinnedBoardLastCreateProjectId: 'project-2' })
+    render(<TicketCreateModal open onOpenChange={() => {}} projectId="" isPinnedMode />)
+    expect(getSelect().value).toBe('project-2')
+  })
+
+  it('falls back to the first project when the remembered one is no longer pinned', () => {
+    useKanbanStore.setState({ pinnedBoardLastCreateProjectId: 'project-gone' })
+    render(<TicketCreateModal open onOpenChange={() => {}} projectId="" isPinnedMode />)
+    expect(getSelect().value).toBe('project-1')
+  })
+
+  it('remembers the selected project after a successful create', async () => {
+    const createTicket = vi.fn().mockResolvedValue({ id: 't1' })
+    useKanbanStore.setState({ createTicket } as never)
+    render(<TicketCreateModal open onOpenChange={() => {}} projectId="" isPinnedMode />)
+
+    fireEvent.change(getSelect(), { target: { value: 'project-2' } })
+    fireEvent.change(screen.getByTestId('ticket-title-input'), { target: { value: 'New' } })
+    fireEvent.click(screen.getByTestId('ticket-create-btn'))
+
+    await waitFor(() => expect(createTicket).toHaveBeenCalled())
+    expect(createTicket.mock.calls[0][0]).toBe('project-2')
+    expect(useKanbanStore.getState().pinnedBoardLastCreateProjectId).toBe('project-2')
+  })
+})

--- a/src/renderer/src/components/kanban/TicketCreateModal.tsx
+++ b/src/renderer/src/components/kanban/TicketCreateModal.tsx
@@ -83,7 +83,21 @@ export function TicketCreateModal({
 
   const isMultiProjectMode = isConnectionMode || !!isPinnedMode
   const availableProjects = isConnectionMode ? connectionProjects : pinnedProjects
-  const initialSelectedProjectId = availableProjects[0]?.id ?? ''
+  // Pinned board: default to the project used for the last created ticket (if still pinned)
+  const pinnedBoardLastCreateProjectId = useKanbanStore((s) => s.pinnedBoardLastCreateProjectId)
+  const setPinnedBoardLastCreateProjectId = useKanbanStore(
+    (s) => s.setPinnedBoardLastCreateProjectId
+  )
+  const initialSelectedProjectId = useMemo(() => {
+    if (
+      isPinnedMode &&
+      pinnedBoardLastCreateProjectId &&
+      availableProjects.some((p) => p.id === pinnedBoardLastCreateProjectId)
+    ) {
+      return pinnedBoardLastCreateProjectId
+    }
+    return availableProjects[0]?.id ?? ''
+  }, [isPinnedMode, pinnedBoardLastCreateProjectId, availableProjects])
   const isDirty =
     title.trim().length > 0 ||
     description.trim().length > 0 ||
@@ -135,11 +149,19 @@ export function TicketCreateModal({
       setShowPreview(false)
       setAttachments([])
       setIsCreating(false)
-      setSelectedProjectId(availableProjects[0]?.id ?? '')
+      setSelectedProjectId(initialSelectedProjectId)
       // Auto-focus the title input after dialog animation
       setTimeout(() => titleInputRef.current?.focus(), 50)
     }
-  }, [open, availableProjects])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only reset on open; initialSelectedProjectId is read at open time
+  }, [open])
+
+  // Keep the selection valid if the project list populates/changes while open
+  useEffect(() => {
+    if (!open || !isMultiProjectMode) return
+    if (selectedProjectId && availableProjects.some((p) => p.id === selectedProjectId)) return
+    setSelectedProjectId(initialSelectedProjectId)
+  }, [open, isMultiProjectMode, selectedProjectId, availableProjects, initialSelectedProjectId])
 
   // ── Image paste/drop ───────────────────────────────────────────────
   const { isDragOver, handlePaste, handleDragOver, handleDragEnter, handleDragLeave, handleDrop } =
@@ -166,6 +188,7 @@ export function TicketCreateModal({
         column: 'todo'
       })
       createdSuccessfully.current = true
+      if (isPinnedMode) setPinnedBoardLastCreateProjectId(targetProjectId)
       setShowDiscardConfirm(false)
       toast.success('Ticket created')
       onOpenChange(false)
@@ -183,6 +206,8 @@ export function TicketCreateModal({
     projectId,
     selectedProjectId,
     isMultiProjectMode,
+    isPinnedMode,
+    setPinnedBoardLastCreateProjectId,
     onOpenChange
   ])
 

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -229,6 +229,8 @@ interface KanbanState {
   simpleModeByProject: Record<string, boolean>
   /** Per-board+column "sort by latest transition" toggle (transitionSortKey) — persisted */
   transitionSortByColumn: Record<string, boolean>
+  /** Project chosen the last time a ticket was created from the pinned board — persisted */
+  pinnedBoardLastCreateProjectId: string | null
   /** Currently selected ticket ID for the detail modal (null = closed) */
   selectedTicketId: string | null
   selectedTicketRef: TicketRef | null
@@ -285,6 +287,7 @@ interface KanbanState {
   reorderTicket: (ticketId: string, projectId: string, newSortOrder: number) => Promise<void>
   toggleBoardView: () => void
   setSimpleMode: (projectId: string, enabled: boolean) => Promise<void>
+  setPinnedBoardLastCreateProjectId: (projectId: string | null) => void
   setTransitionSort: (projectId: string, column: KanbanTicketColumn, enabled: boolean) => void
   archiveTicket: (ticketId: string, projectId: string) => Promise<void>
   archiveAllDone: (projectId: string, includeMerged?: boolean) => Promise<number>
@@ -387,6 +390,7 @@ export const useKanbanStore = create<KanbanState>()(
       isPinnedBoardActive: false,
       simpleModeByProject: {} as Record<string, boolean>,
       transitionSortByColumn: {} as Record<string, boolean>,
+      pinnedBoardLastCreateProjectId: null,
       selectedTicketId: null,
       selectedTicketRef: null,
       isDragging: false,
@@ -1213,6 +1217,11 @@ export const useKanbanStore = create<KanbanState>()(
         }))
       },
 
+      // ── setPinnedBoardLastCreateProjectId ────────────────────────
+      setPinnedBoardLastCreateProjectId: (projectId: string | null) => {
+        set({ pinnedBoardLastCreateProjectId: projectId })
+      },
+
       // ── setSimpleMode ────────────────────────────────────────────
       setSimpleMode: async (projectId: string, enabled: boolean) => {
         set((state) => ({
@@ -2005,7 +2014,8 @@ export const useKanbanStore = create<KanbanState>()(
         isBoardViewActive: state.isBoardViewActive,
         isPinnedBoardActive: state.isPinnedBoardActive,
         simpleModeByProject: state.simpleModeByProject,
-        transitionSortByColumn: state.transitionSortByColumn
+        transitionSortByColumn: state.transitionSortByColumn,
+        pinnedBoardLastCreateProjectId: state.pinnedBoardLastCreateProjectId
       })
     }
   )


### PR DESCRIPTION
## Summary
- Default pinned-board ticket creation to the last used pinned project.
- Fall back to the first pinned project when the remembered project is unavailable.
- Persist the selected project after successful ticket creation.
- Add focused component tests for defaulting, fallback, and persistence.

## Testing
- Added Vitest coverage for pinned-board project selection and successful ticket creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI preference in the kanban create flow with localStorage persistence; no changes to ticket APIs or security-sensitive paths.
> 
> **Overview**
> **Pinned-board ticket creation** now remembers which project you last used and pre-selects it the next time you open the create modal, instead of always defaulting to the first pinned project.
> 
> The choice is stored in **`pinnedBoardLastCreateProjectId`** on the kanban store (persisted under `hive-kanban` in localStorage) and updated only after a **successful** create in pinned mode. If that project is no longer pinned, the modal falls back to the first available pinned project. A small effect keeps the project dropdown valid if the pinned list loads or changes while the modal is open.
> 
> Vitest coverage was added for defaulting, fallback, and post-create persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae389c77d32a33da87441adc640b53a5812ef9f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->