### PR TITLE
Enable right-click drag quick launch on connection boards

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.right-drag-connection.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.right-drag-connection.test.tsx
@@ -1,0 +1,111 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { KanbanTicket } from '../../../../main/db/types'
+
+const { quickLaunchTicket, quickLaunchTicketOnConnection } = vi.hoisted(() => ({
+  quickLaunchTicket: vi.fn(async () => true),
+  quickLaunchTicketOnConnection: vi.fn(async () => true)
+}))
+
+vi.mock('@/components/kanban/WorktreePickerModal', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./WorktreePickerModal')>()
+  return { ...actual, quickLaunchTicket, quickLaunchTicketOnConnection }
+})
+
+import { KanbanTicketCard } from './KanbanTicketCard'
+
+const now = '2026-01-01T00:00:00.000Z'
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'project-1',
+    title: 'Connection ticket',
+    description: null,
+    attachments: [],
+    column: 'todo',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: null,
+    mode: 'build',
+    plan_ready: false,
+    created_at: now,
+    updated_at: now,
+    column_changed_at: null,
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
+    created_from_session: false,
+    auto_approve_plan: false,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
+    ...overrides
+  }
+}
+
+function rightDragInto(card: HTMLElement, column: HTMLElement): void {
+  // jsdom has no layout — resolve hit-testing by x coordinate
+  const original = document.elementFromPoint
+  document.elementFromPoint = (x: number) => (x >= 300 ? column : card)
+  try {
+    fireEvent.mouseDown(card, { button: 2, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(window, { clientX: 350, clientY: 50 })
+    fireEvent.mouseUp(window, { button: 2, clientX: 350, clientY: 50 })
+  } finally {
+    document.elementFromPoint = original
+  }
+}
+
+describe('KanbanTicketCard right-button drag on a connection board', () => {
+  afterEach(() => {
+    cleanup()
+    quickLaunchTicket.mockClear()
+    quickLaunchTicketOnConnection.mockClear()
+  })
+
+  it('quick-launches on the connection when dropped into In Progress', () => {
+    const ticket = makeTicket()
+    render(
+      <>
+        <KanbanTicketCard ticket={ticket} connectionId="conn-1" />
+        <div data-kanban-column="in_progress" />
+      </>
+    )
+    const card = screen.getByTestId('kanban-ticket-ticket-1')
+    const column = document.querySelector('[data-kanban-column="in_progress"]') as HTMLElement
+
+    rightDragInto(card, column)
+
+    expect(quickLaunchTicketOnConnection).toHaveBeenCalledTimes(1)
+    expect(quickLaunchTicketOnConnection).toHaveBeenCalledWith(ticket, 'conn-1')
+    expect(quickLaunchTicket).not.toHaveBeenCalled()
+  })
+
+  it('still uses the worktree quick launch on a regular board', () => {
+    const ticket = makeTicket()
+    render(
+      <>
+        <KanbanTicketCard ticket={ticket} />
+        <div data-kanban-column="in_progress" />
+      </>
+    )
+    const card = screen.getByTestId('kanban-ticket-ticket-1')
+    const column = document.querySelector('[data-kanban-column="in_progress"]') as HTMLElement
+
+    rightDragInto(card, column)
+
+    expect(quickLaunchTicket).toHaveBeenCalledTimes(1)
+    expect(quickLaunchTicketOnConnection).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -86,7 +86,11 @@ import {
   AlertDialogAction,
   AlertDialogCancel
 } from '@/components/ui/alert-dialog'
-import { WorktreePickerModal, quickLaunchTicket } from '@/components/kanban/WorktreePickerModal'
+import {
+  WorktreePickerModal,
+  quickLaunchTicket,
+  quickLaunchTicketOnConnection
+} from '@/components/kanban/WorktreePickerModal'
 import { useRightButtonDrag } from '@/components/kanban/useRightButtonDrag'
 import { buildQuickLaunchGhostChip } from '@/components/kanban/quickLaunchGhostChip'
 import { Popover, PopoverAnchor } from '@/components/ui/popover'
@@ -795,13 +799,16 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
         toast.warning('Ticket is blocked — resolve its dependencies first')
         return
       }
-      void quickLaunchTicket(ticket)
+      // Connection boards have no worktree to create — start a connection
+      // session instead (same defaults, mirrors the picker's connection path)
+      if (connectionId) void quickLaunchTicketOnConnection(ticket, connectionId)
+      else void quickLaunchTicket(ticket)
     },
-    [ticket, isBlocked]
+    [ticket, isBlocked, connectionId]
   )
   const { onMouseDown: rightDragMouseDown, onContextMenuCapture: rightDragContextMenuCapture } =
     useRightButtonDrag({
-      enabled: !isArchived && !blockingDiagnostic && !connectionId,
+      enabled: !isArchived && !blockingDiagnostic,
       onDrop: handleRightDrop,
       // Show the default model + effort the drop will launch with, riding
       // along under the ghost so it's clear before release

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -373,6 +373,155 @@ export async function quickLaunchTicket(ticket: KanbanTicket): Promise<boolean> 
   return true
 }
 
+/**
+ * Connection-board twin of `quickLaunchTicket`: start the ticket on the
+ * connection exactly as the picker's connection path would with nothing
+ * changed — build mode, the prefilled ticket prompt, the default SDK + model,
+ * a fresh connection session (worktree_id stays null). Used by right-button
+ * drags into In Progress on connection boards, which skip the modal entirely.
+ */
+export async function quickLaunchTicketOnConnection(
+  ticket: KanbanTicket,
+  connectionId: string
+): Promise<boolean> {
+  const mode: PickerMode = 'build'
+  const settings = useSettingsStore.getState()
+  const { sdk: agentSdk, model } = resolveQuickLaunchModel()
+  const codexFastMode = settings.codexFastMode
+  const promptText = buildPrompt(mode, ticket)
+
+  try {
+    const connection = useConnectionStore
+      .getState()
+      .connections.find((c) => c.id === connectionId)
+    const connectionPath = connection?.path
+
+    const cliPendingPrompt =
+      agentSdk === 'claude-code-cli'
+        ? composePromptForSdk(mode, agentSdk, promptText, false, '', { claudeCli: true })
+        : null
+    const sessionResult = await useSessionStore
+      .getState()
+      .createConnectionSession(connectionId, agentSdk, mode, {
+        modelOverride: { ...model, agentSdk },
+        ...(cliPendingPrompt ? { pendingMessage: cliPendingPrompt } : {})
+      })
+    if (!sessionResult.success || !sessionResult.session) {
+      toast.error(sessionResult.error || 'Failed to create session')
+      return false
+    }
+
+    const sessionId = sessionResult.session.id
+    const sessionAgentSdk = sessionResult.session.agent_sdk
+
+    messageSendTimes.set(sessionId, Date.now())
+    userExplicitSendTimes.set(sessionId, Date.now())
+    snapshotTokenBaseline(sessionId)
+    lastSendMode.set(sessionId, completionSendMode(mode))
+    useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+
+    await useSessionStore.getState().setSessionModel(sessionId, model)
+
+    const kanban = useKanbanStore.getState()
+    const sortOrder = kanban.computeSortOrder(
+      kanban.getTicketsByColumnForConnection(connectionId, 'in_progress'),
+      0
+    )
+    const badgeModel = resolveBadgeModel(
+      { sdk: agentSdk, model, codexFastMode },
+      sessionResult.session
+    )
+    await kanban.updateTicket(ticket.id, ticket.project_id, {
+      current_session_id: sessionId,
+      worktree_id: null,
+      mode,
+      column: 'in_progress',
+      sort_order: sortOrder,
+      plan_ready: false,
+      goal_mode: false,
+      goal_success_criteria: null,
+      model_provider_id: badgeModel.providerID,
+      model_id: badgeModel.modelID,
+      model_variant: badgeModel.variant,
+      variant_group_id: null,
+      pending_launch_config: null
+    })
+
+    const ticketTitle = ticket.title.trim()
+    if (connection && !connection.custom_name && ticketTitle) {
+      void useConnectionStore.getState().renameConnection(connectionId, ticketTitle)
+    }
+
+    void autoPinBaseWorktree(ticket.project_id)
+
+    const usageProvider = resolveDefaultUsageProvider(agentSdk)
+    if (usageProvider) {
+      useUsageStore.getState().fetchUsageForProvider(usageProvider)
+    }
+
+    if (useSettingsStore.getState().boardMode === 'sticky-tab') {
+      const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
+      useSessionStore.getState().setActiveSession(BOARD_TAB_ID)
+    }
+    toast.success('Session started')
+
+    if (sessionAgentSdk === 'claude-code-cli') {
+      const outboundPrompt =
+        cliPendingPrompt ??
+        composePromptForSdk(mode, sessionAgentSdk, promptText, false, '', { claudeCli: true })
+      bumpWorktreeLastMessage({ connectionId })
+      const result = unwrapEnvelope(
+        await terminalApi.createClaudeCli(sessionId, { pendingPrompt: outboundPrompt })
+      )
+      if (result.success && outboundPrompt) {
+        useSessionStore.getState().dequeuePendingMessage(sessionId)
+      }
+      return true
+    }
+
+    if (!connectionPath) return true
+
+    const connectResult = unwrapEnvelope(await opencodeApi.connect(connectionPath, sessionId))
+    if (!connectResult.success || !connectResult.sessionId) {
+      toast.error(connectResult.error || 'Failed to start session')
+      return false
+    }
+    useSessionStore.getState().setOpenCodeSessionId(sessionId, connectResult.sessionId)
+    await dbApi.session.update<Session>(sessionId, {
+      opencode_session_id: connectResult.sessionId
+    })
+
+    const outboundPrompt = composePromptForSdk(mode, sessionAgentSdk, promptText, false, '', {
+      claudeCli: false
+    })
+    if (!outboundPrompt) return true
+    const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
+    bumpWorktreeLastMessage({ connectionId })
+    startHivePromptTelemetry({
+      sessionId,
+      prompt: outboundPrompt,
+      worktreeId: null,
+      modelId: model.modelID,
+      providerId: model.providerID,
+      modelVariant: model.variant,
+      mode
+    })
+    unwrapEnvelope(
+      await opencodeApi.prompt(
+        connectionPath,
+        connectResult.sessionId,
+        [{ type: 'text', text: outboundPrompt }],
+        toRequestModel(model),
+        promptOptions
+      )
+    )
+    return true
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : 'Failed to start session')
+    return false
+  }
+}
+
 // ── SDK toggle button group (shared by row 1 and each extra row) ────
 interface SdkToggleGroupProps {
   value: PickerAgentSdk


### PR DESCRIPTION
## Summary
- Enable right-button drag quick launch for tickets on connection boards.
- Start connection sessions directly with default build-mode launch settings.
- Preserve existing worktree quick-launch behavior on regular boards.
- Add coverage for both connection and regular board flows.

## Testing
- Added Vitest coverage for right-button drag behavior on connection and regular boards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large session-launch path (OpenCode/Claude CLI connect, ticket updates, prompts) parallel to the picker; mistakes could start wrong sessions or leave tickets in a bad state, though behavior is intended to mirror the existing connection modal flow.
> 
> **Overview**
> **Right-button drag into In Progress** now works on **connection boards**, not only project boards with worktrees.
> 
> On connection boards, dropping a ticket calls new **`quickLaunchTicketOnConnection`**, which starts a **connection session** with the same defaults as skipping the worktree picker (build mode, default SDK/model, prefilled prompt, ticket moved to In Progress with `worktree_id` null). Regular boards still call **`quickLaunchTicket`** (new worktree path).
> 
> **`KanbanTicketCard`** no longer disables right-drag when `connectionId` is set; the drop handler branches on `connectionId`. Vitest coverage asserts the correct quick-launch helper per board type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b339efff4a14a5cdbd4e751fae4be55ceda405c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->