### PR TITLE
Add Cmd/Ctrl+Enter submission to PR modals

### DIFF
--- a/src/renderer/src/components/pr/ConnectionPRModal.tsx
+++ b/src/renderer/src/components/pr/ConnectionPRModal.tsx
@@ -348,6 +348,26 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
     setOpen(false)
   }, [setOpen])
 
+  // ── Cmd/Ctrl+Enter submits the current phase's primary action ───
+  const canCommitAndContinue =
+    !!commitSummary.trim() && membersWithStagedFiles.length > 0 && !isCommitting
+  const canCreate = includedCount > 0
+  const handleDialogKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== 'Enter' || !(e.metaKey || e.ctrlKey)) return
+      if (phase === 'commit') {
+        if (!canCommitAndContinue) return
+        e.preventDefault()
+        void handleCommitAndContinue()
+      } else if (phase === 'form') {
+        if (!canCreate) return
+        e.preventDefault()
+        handleCreate()
+      }
+    },
+    [phase, canCommitAndContinue, canCreate, handleCommitAndContinue, handleCreate]
+  )
+
   // ── Render: Loading ─────────────────────────────────────────────
   const renderLoading = (): React.JSX.Element => (
     <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
@@ -669,9 +689,7 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
             </Button>
             <Button
               onClick={handleCommitAndContinue}
-              disabled={
-                !commitSummary.trim() || membersWithStagedFiles.length === 0 || isCommitting
-              }
+              disabled={!canCommitAndContinue}
               data-testid="connection-pr-commit-button"
             >
               {isCommitting ? (
@@ -696,7 +714,7 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
             </Button>
             <Button
               onClick={handleCreate}
-              disabled={includedCount === 0}
+              disabled={!canCreate}
               data-testid="connection-pr-create-button"
             >
               <GitPullRequest className="h-4 w-4 mr-1.5" />
@@ -709,7 +727,11 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => setOpen(isOpen, isOpen ? connectionId : undefined)}>
-      <DialogContent className="sm:max-w-xl" data-testid="connection-pr-modal">
+      <DialogContent
+        className="sm:max-w-xl"
+        data-testid="connection-pr-modal"
+        onKeyDown={handleDialogKeyDown}
+      >
         <DialogHeader>
           <DialogTitle>
             <span className="flex items-center gap-2">

--- a/src/renderer/src/components/pr/CreatePRModal.tsx
+++ b/src/renderer/src/components/pr/CreatePRModal.tsx
@@ -326,6 +326,25 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
     setOpen(false)
   }, [setOpen])
 
+  // ── Cmd/Ctrl+Enter submits the current phase's primary action ───
+  const canCommitAndContinue = !!commitSummary.trim() && stagedCount > 0 && !isCommitting
+  const canCreate = !!baseBranch
+  const handleDialogKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== 'Enter' || !(e.metaKey || e.ctrlKey)) return
+      if (phase === 'commit') {
+        if (!canCommitAndContinue) return
+        e.preventDefault()
+        void handleCommitAndContinue()
+      } else if (phase === 'form') {
+        if (!canCreate) return
+        e.preventDefault()
+        void handleCreate()
+      }
+    },
+    [phase, canCommitAndContinue, canCreate, handleCommitAndContinue, handleCreate]
+  )
+
   // ── Render: Commit ──────────────────────────────────────────────
   const renderCommit = (): React.JSX.Element => (
     <>
@@ -558,10 +577,7 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
             <Button variant="ghost" onClick={handleSkipCommit}>
               Skip
             </Button>
-            <Button
-              onClick={handleCommitAndContinue}
-              disabled={!commitSummary.trim() || stagedCount === 0 || isCommitting}
-            >
+            <Button onClick={handleCommitAndContinue} disabled={!canCommitAndContinue}>
               {isCommitting ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
@@ -582,7 +598,7 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
             <Button variant="ghost" onClick={handleCancel}>
               Cancel
             </Button>
-            <Button onClick={handleCreate} disabled={!baseBranch}>
+            <Button onClick={handleCreate} disabled={!canCreate}>
               <GitPullRequest className="h-4 w-4 mr-1.5" />
               Create Pull Request
             </Button>
@@ -593,7 +609,7 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg" onKeyDown={handleDialogKeyDown}>
         <DialogHeader>
           <DialogTitle>
             <span className="flex items-center gap-2">

--- a/src/renderer/src/components/pr/__tests__/ConnectionPRModal.test.tsx
+++ b/src/renderer/src/components/pr/__tests__/ConnectionPRModal.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { resetRendererRpcClientForTests, setRendererRpcClient } from '../../../api/rpc-client'
 import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
@@ -161,6 +161,40 @@ describe('ConnectionPRModal', () => {
     })
     expect(screen.queryByTestId('connection-pr-row-wt-b')).not.toBeInTheDocument()
     expect(screen.getByText(/2 commits ahead/)).toBeInTheDocument()
+  })
+
+  it('submits the form phase with Cmd+Enter', async () => {
+    mockResponses({ commitCount: { '/repo/a': 2 } })
+
+    render(<ConnectionPRModal connectionId="conn-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('connection-pr-create-button')).toBeInTheDocument()
+    })
+
+    fireEvent.keyDown(screen.getByTestId('connection-pr-modal'), { key: 'Enter', metaKey: true })
+
+    await waitFor(() => {
+      expect(useGitStore.getState().connectionPRModalOpen).toBe(false)
+    })
+    expect(useGitStore.getState().prTargetBranch.get('wt-a')).toBe('origin/main')
+  })
+
+  it('ignores Cmd+Enter in the form phase when nothing is included', async () => {
+    mockResponses({ commitCount: { '/repo/a': 2 } })
+
+    render(<ConnectionPRModal connectionId="conn-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('connection-pr-create-button')).toBeInTheDocument()
+    })
+    // Uncheck the only eligible member
+    fireEvent.click(screen.getByRole('checkbox'))
+    expect(screen.getByTestId('connection-pr-create-button')).toBeDisabled()
+
+    fireEvent.keyDown(screen.getByTestId('connection-pr-modal'), { key: 'Enter', metaKey: true })
+
+    expect(useGitStore.getState().connectionPRModalOpen).toBe(true)
   })
 
   it('closes with archive prompts when every member is clean', async () => {

--- a/src/renderer/src/components/pr/__tests__/CreatePRModal.test.tsx
+++ b/src/renderer/src/components/pr/__tests__/CreatePRModal.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '../../../api/rpc-client'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useGitStore } from '@/stores/useGitStore'
+import { CreatePRModal } from '../CreatePRModal'
+
+vi.mock('@/lib/pr-pipeline', () => ({
+  runCreatePRPipeline: vi.fn().mockResolvedValue(undefined)
+}))
+
+let request: ReturnType<typeof vi.fn>
+
+function mockResponses(spec: { hasUncommitted?: boolean; files?: unknown[] }): void {
+  request.mockImplementation((method: string) => {
+    switch (method) {
+      case 'gitOps.hasUncommittedChanges':
+        return Promise.resolve(spec.hasUncommitted ?? false)
+      case 'gitOps.getRangeDiff':
+        return Promise.resolve({
+          commitSummary: '',
+          diffSummary: '',
+          diffPatch: '',
+          commitCount: 1
+        })
+      case 'gitOps.getBranchInfo':
+        return Promise.resolve({
+          success: true,
+          branch: { name: 'feat', tracking: null, ahead: 0, behind: 0 }
+        })
+      case 'gitOps.getFileStatuses':
+        return Promise.resolve({ success: true, files: spec.files ?? [] })
+      case 'gitOps.listBranchesWithStatus':
+        return Promise.resolve({
+          success: true,
+          branches: [{ name: 'origin/main', isRemote: true }]
+        })
+      case 'gitOps.commit':
+        return Promise.resolve({ success: true, commitHash: 'abcdef1234' })
+      default:
+        return Promise.resolve([])
+    }
+  })
+}
+
+describe('CreatePRModal Cmd+Enter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    request = vi.fn().mockResolvedValue([])
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        [
+          'proj-a',
+          [
+            { id: 'wt-default', path: '/proj/a', branch_name: 'main', is_default: true },
+            { id: 'wt-a', path: '/repo/a', branch_name: 'feat', is_default: false }
+          ]
+        ]
+      ])
+    } as never)
+    useProjectStore.setState({ projects: [{ id: 'proj-a', path: '/proj/a' }] } as never)
+    useGitStore.setState({
+      fileStatusesByWorktree: new Map(),
+      branchInfoByWorktree: new Map(),
+      prTargetBranch: new Map(),
+      reviewTargetBranch: new Map(),
+      isCommitting: false,
+      createPRModalOpen: true
+    })
+    usePRNotificationStore.setState({ notifications: [] })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+  })
+
+  it('creates the PR from the form phase with Cmd+Enter', async () => {
+    mockResponses({})
+
+    render(<CreatePRModal worktreeId="wt-a" worktreePath="/repo/a" />)
+
+    const dialog = await screen.findByRole('dialog')
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create pull request/i })).toBeEnabled()
+    })
+
+    fireEvent.keyDown(dialog, { key: 'Enter', metaKey: true })
+
+    await waitFor(() => {
+      expect(useGitStore.getState().createPRModalOpen).toBe(false)
+    })
+    expect(useGitStore.getState().prTargetBranch.get('wt-a')).toBe('origin/main')
+  })
+
+  it('commits from the commit phase with Cmd+Enter and advances to the form', async () => {
+    mockResponses({ hasUncommitted: true })
+    // Seed staged files directly — loadFileStatuses is TTL-cached across tests
+    useGitStore.setState({
+      fileStatusesByWorktree: new Map([
+        ['/repo/a', [{ path: '/repo/a/x.ts', relativePath: 'x.ts', status: 'M', staged: true }]]
+      ])
+    } as never)
+
+    render(<CreatePRModal worktreeId="wt-a" worktreePath="/repo/a" />)
+
+    const dialog = await screen.findByRole('dialog')
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /commit & continue/i })).toBeInTheDocument()
+    })
+
+    // Empty summary → Cmd+Enter is a no-op
+    fireEvent.keyDown(dialog, { key: 'Enter', metaKey: true })
+    expect(request).not.toHaveBeenCalledWith('gitOps.commit', expect.anything())
+
+    fireEvent.change(screen.getByPlaceholderText(/summary/i), { target: { value: 'Fix thing' } })
+    fireEvent.keyDown(dialog, { key: 'Enter', metaKey: true })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        'gitOps.commit',
+        expect.objectContaining({ worktreePath: '/repo/a', message: 'Fix thing' })
+      )
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create pull request/i })).toBeInTheDocument()
+    })
+    expect(useGitStore.getState().createPRModalOpen).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Add Cmd/Ctrl+Enter shortcuts for commit and PR creation phases.
- Reuse primary-action validation to prevent submission when inputs are incomplete.
- Add coverage for valid and ignored keyboard submissions.

## Testing
- Added Vitest coverage for CreatePRModal and ConnectionPRModal keyboard submission flows.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only keyboard shortcuts that call existing commit/PR handlers with the same guards as the footer buttons; no new git or auth paths.
> 
> **Overview**
> **Cmd/Ctrl+Enter** now triggers the same primary action as the footer buttons in **Create Pull Request** and **connection multi-PR** dialogs: **Commit & Continue** on the commit step and **Create** on the form step.
> 
> Both modals extract shared **`canCommitAndContinue`** / **`canCreate`** flags (matching the existing button `disabled` rules) and a **`handleDialogKeyDown`** on **`DialogContent`** so keyboard submit is ignored when validation would block the button. Vitest coverage was added for successful submits and for ignored shortcuts when nothing is included or the commit summary is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4e1f9f2e7c2ffa8510a58a6d58c4f8e0ba5bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->