### PR TITLE
Dim accounts that cannot be auto-switch targets

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.right-drag-connection.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.right-drag-connection.test.tsx
@@ -1,0 +1,111 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { KanbanTicket } from '../../../../main/db/types'
+
+const { quickLaunchTicket, quickLaunchTicketOnConnection } = vi.hoisted(() => ({
+  quickLaunchTicket: vi.fn(async () => true),
+  quickLaunchTicketOnConnection: vi.fn(async () => true)
+}))
+
+vi.mock('@/components/kanban/WorktreePickerModal', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./WorktreePickerModal')>()
+  return { ...actual, quickLaunchTicket, quickLaunchTicketOnConnection }
+})
+
+import { KanbanTicketCard } from './KanbanTicketCard'
+
+const now = '2026-01-01T00:00:00.000Z'
+
+function makeTicket(overrides: Partial<KanbanTicket> = {}): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'project-1',
+    title: 'Connection ticket',
+    description: null,
+    attachments: [],
+    column: 'todo',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: null,
+    mode: 'build',
+    plan_ready: false,
+    created_at: now,
+    updated_at: now,
+    column_changed_at: null,
+    archived_at: null,
+    external_provider: null,
+    external_id: null,
+    external_url: null,
+    github_pr_number: null,
+    github_pr_url: null,
+    mark: null,
+    total_tokens: 0,
+    pending_launch_config: null,
+    goal_mode: false,
+    goal_success_criteria: null,
+    note: null,
+    created_from_session: false,
+    auto_approve_plan: false,
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    variant_group_id: null,
+    ...overrides
+  }
+}
+
+function rightDragInto(card: HTMLElement, column: HTMLElement): void {
+  // jsdom has no layout — resolve hit-testing by x coordinate
+  const original = document.elementFromPoint
+  document.elementFromPoint = (x: number) => (x >= 300 ? column : card)
+  try {
+    fireEvent.mouseDown(card, { button: 2, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(window, { clientX: 350, clientY: 50 })
+    fireEvent.mouseUp(window, { button: 2, clientX: 350, clientY: 50 })
+  } finally {
+    document.elementFromPoint = original
+  }
+}
+
+describe('KanbanTicketCard right-button drag on a connection board', () => {
+  afterEach(() => {
+    cleanup()
+    quickLaunchTicket.mockClear()
+    quickLaunchTicketOnConnection.mockClear()
+  })
+
+  it('quick-launches on the connection when dropped into In Progress', () => {
+    const ticket = makeTicket()
+    render(
+      <>
+        <KanbanTicketCard ticket={ticket} connectionId="conn-1" />
+        <div data-kanban-column="in_progress" />
+      </>
+    )
+    const card = screen.getByTestId('kanban-ticket-ticket-1')
+    const column = document.querySelector('[data-kanban-column="in_progress"]') as HTMLElement
+
+    rightDragInto(card, column)
+
+    expect(quickLaunchTicketOnConnection).toHaveBeenCalledTimes(1)
+    expect(quickLaunchTicketOnConnection).toHaveBeenCalledWith(ticket, 'conn-1')
+    expect(quickLaunchTicket).not.toHaveBeenCalled()
+  })
+
+  it('still uses the worktree quick launch on a regular board', () => {
+    const ticket = makeTicket()
+    render(
+      <>
+        <KanbanTicketCard ticket={ticket} />
+        <div data-kanban-column="in_progress" />
+      </>
+    )
+    const card = screen.getByTestId('kanban-ticket-ticket-1')
+    const column = document.querySelector('[data-kanban-column="in_progress"]') as HTMLElement
+
+    rightDragInto(card, column)
+
+    expect(quickLaunchTicket).toHaveBeenCalledTimes(1)
+    expect(quickLaunchTicketOnConnection).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -86,7 +86,11 @@ import {
   AlertDialogAction,
   AlertDialogCancel
 } from '@/components/ui/alert-dialog'
-import { WorktreePickerModal, quickLaunchTicket } from '@/components/kanban/WorktreePickerModal'
+import {
+  WorktreePickerModal,
+  quickLaunchTicket,
+  quickLaunchTicketOnConnection
+} from '@/components/kanban/WorktreePickerModal'
 import { useRightButtonDrag } from '@/components/kanban/useRightButtonDrag'
 import { buildQuickLaunchGhostChip } from '@/components/kanban/quickLaunchGhostChip'
 import { Popover, PopoverAnchor } from '@/components/ui/popover'
@@ -795,13 +799,16 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
         toast.warning('Ticket is blocked — resolve its dependencies first')
         return
       }
-      void quickLaunchTicket(ticket)
+      // Connection boards have no worktree to create — start a connection
+      // session instead (same defaults, mirrors the picker's connection path)
+      if (connectionId) void quickLaunchTicketOnConnection(ticket, connectionId)
+      else void quickLaunchTicket(ticket)
     },
-    [ticket, isBlocked]
+    [ticket, isBlocked, connectionId]
   )
   const { onMouseDown: rightDragMouseDown, onContextMenuCapture: rightDragContextMenuCapture } =
     useRightButtonDrag({
-      enabled: !isArchived && !blockingDiagnostic && !connectionId,
+      enabled: !isArchived && !blockingDiagnostic,
       onDrop: handleRightDrop,
       // Show the default model + effort the drop will launch with, riding
       // along under the ghost so it's clear before release

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -373,6 +373,155 @@ export async function quickLaunchTicket(ticket: KanbanTicket): Promise<boolean> 
   return true
 }
 
+/**
+ * Connection-board twin of `quickLaunchTicket`: start the ticket on the
+ * connection exactly as the picker's connection path would with nothing
+ * changed — build mode, the prefilled ticket prompt, the default SDK + model,
+ * a fresh connection session (worktree_id stays null). Used by right-button
+ * drags into In Progress on connection boards, which skip the modal entirely.
+ */
+export async function quickLaunchTicketOnConnection(
+  ticket: KanbanTicket,
+  connectionId: string
+): Promise<boolean> {
+  const mode: PickerMode = 'build'
+  const settings = useSettingsStore.getState()
+  const { sdk: agentSdk, model } = resolveQuickLaunchModel()
+  const codexFastMode = settings.codexFastMode
+  const promptText = buildPrompt(mode, ticket)
+
+  try {
+    const connection = useConnectionStore
+      .getState()
+      .connections.find((c) => c.id === connectionId)
+    const connectionPath = connection?.path
+
+    const cliPendingPrompt =
+      agentSdk === 'claude-code-cli'
+        ? composePromptForSdk(mode, agentSdk, promptText, false, '', { claudeCli: true })
+        : null
+    const sessionResult = await useSessionStore
+      .getState()
+      .createConnectionSession(connectionId, agentSdk, mode, {
+        modelOverride: { ...model, agentSdk },
+        ...(cliPendingPrompt ? { pendingMessage: cliPendingPrompt } : {})
+      })
+    if (!sessionResult.success || !sessionResult.session) {
+      toast.error(sessionResult.error || 'Failed to create session')
+      return false
+    }
+
+    const sessionId = sessionResult.session.id
+    const sessionAgentSdk = sessionResult.session.agent_sdk
+
+    messageSendTimes.set(sessionId, Date.now())
+    userExplicitSendTimes.set(sessionId, Date.now())
+    snapshotTokenBaseline(sessionId)
+    lastSendMode.set(sessionId, completionSendMode(mode))
+    useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'working')
+
+    await useSessionStore.getState().setSessionModel(sessionId, model)
+
+    const kanban = useKanbanStore.getState()
+    const sortOrder = kanban.computeSortOrder(
+      kanban.getTicketsByColumnForConnection(connectionId, 'in_progress'),
+      0
+    )
+    const badgeModel = resolveBadgeModel(
+      { sdk: agentSdk, model, codexFastMode },
+      sessionResult.session
+    )
+    await kanban.updateTicket(ticket.id, ticket.project_id, {
+      current_session_id: sessionId,
+      worktree_id: null,
+      mode,
+      column: 'in_progress',
+      sort_order: sortOrder,
+      plan_ready: false,
+      goal_mode: false,
+      goal_success_criteria: null,
+      model_provider_id: badgeModel.providerID,
+      model_id: badgeModel.modelID,
+      model_variant: badgeModel.variant,
+      variant_group_id: null,
+      pending_launch_config: null
+    })
+
+    const ticketTitle = ticket.title.trim()
+    if (connection && !connection.custom_name && ticketTitle) {
+      void useConnectionStore.getState().renameConnection(connectionId, ticketTitle)
+    }
+
+    void autoPinBaseWorktree(ticket.project_id)
+
+    const usageProvider = resolveDefaultUsageProvider(agentSdk)
+    if (usageProvider) {
+      useUsageStore.getState().fetchUsageForProvider(usageProvider)
+    }
+
+    if (useSettingsStore.getState().boardMode === 'sticky-tab') {
+      const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
+      useSessionStore.getState().setActiveSession(BOARD_TAB_ID)
+    }
+    toast.success('Session started')
+
+    if (sessionAgentSdk === 'claude-code-cli') {
+      const outboundPrompt =
+        cliPendingPrompt ??
+        composePromptForSdk(mode, sessionAgentSdk, promptText, false, '', { claudeCli: true })
+      bumpWorktreeLastMessage({ connectionId })
+      const result = unwrapEnvelope(
+        await terminalApi.createClaudeCli(sessionId, { pendingPrompt: outboundPrompt })
+      )
+      if (result.success && outboundPrompt) {
+        useSessionStore.getState().dequeuePendingMessage(sessionId)
+      }
+      return true
+    }
+
+    if (!connectionPath) return true
+
+    const connectResult = unwrapEnvelope(await opencodeApi.connect(connectionPath, sessionId))
+    if (!connectResult.success || !connectResult.sessionId) {
+      toast.error(connectResult.error || 'Failed to start session')
+      return false
+    }
+    useSessionStore.getState().setOpenCodeSessionId(sessionId, connectResult.sessionId)
+    await dbApi.session.update<Session>(sessionId, {
+      opencode_session_id: connectResult.sessionId
+    })
+
+    const outboundPrompt = composePromptForSdk(mode, sessionAgentSdk, promptText, false, '', {
+      claudeCli: false
+    })
+    if (!outboundPrompt) return true
+    const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
+    bumpWorktreeLastMessage({ connectionId })
+    startHivePromptTelemetry({
+      sessionId,
+      prompt: outboundPrompt,
+      worktreeId: null,
+      modelId: model.modelID,
+      providerId: model.providerID,
+      modelVariant: model.variant,
+      mode
+    })
+    unwrapEnvelope(
+      await opencodeApi.prompt(
+        connectionPath,
+        connectResult.sessionId,
+        [{ type: 'text', text: outboundPrompt }],
+        toRequestModel(model),
+        promptOptions
+      )
+    )
+    return true
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : 'Failed to start session')
+    return false
+  }
+}
+
 // ── SDK toggle button group (shared by row 1 and each extra row) ────
 interface SdkToggleGroupProps {
   value: PickerAgentSdk

--- a/src/renderer/src/components/layout/UsageIndicator.test.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { ProviderUsageBlock, UsageAccountRow } from './UsageIndicator'
+import { autoSwitchIneligibilityReason } from '@/lib/auto-switch-score'
 import { useAccountStore, useUsageStore } from '@/stores'
 import { useAccountScheduleStore } from '@/stores/useAccountScheduleStore'
 import type { AccountMemberInfo } from './MemberAvatarStack'
@@ -523,6 +524,102 @@ describe('UsageAccountRow', () => {
     expect(screen.queryByTestId('member-avatar')).toBeNull()
     expect(screen.queryByTestId('member-avatar-stack-loading')).toBeNull()
   })
+
+  it('renders a non-blocking opacity overlay when given an auto-switch ineligibility reason', async () => {
+    const user = userEvent.setup()
+    const onSwitch = vi.fn()
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-2',
+          email: 'other@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+        onSwitch={onSwitch}
+        autoSwitchIneligibleReason="At 85% — auto-switch only targets accounts below 80%"
+      />
+    )
+
+    const overlay = screen.getByTestId('auto-switch-ineligible-overlay')
+    expect(overlay.getAttribute('title')).toBe(
+      'At 85% — auto-switch only targets accounts below 80%'
+    )
+    expect(overlay.className).toContain('pointer-events-none')
+    // The overlay dims but doesn't block: manual switching still works.
+    await user.click(screen.getByRole('button', { name: /switch to other@example.com/i }))
+    expect(onSwitch).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders no overlay without an ineligibility reason', () => {
+    render(
+      <UsageAccountRow
+        row={{
+          id: 'acc-2',
+          email: 'other@example.com',
+          usage: sampleUsage,
+          status: 'ok',
+          lastError: null,
+          isActive: false,
+          isRefreshing: false
+        }}
+      />
+    )
+    expect(screen.queryByTestId('auto-switch-ineligible-overlay')).toBeNull()
+  })
+})
+
+describe('autoSwitchIneligibilityReason', () => {
+  const now = Date.now()
+  const base = { status: 'ok' as const, isActive: false }
+
+  it('is null when auto-switch is not armed', () => {
+    const usage: UsageData = {
+      five_hour: { utilization: 95, resets_at: inOneHour() },
+      seven_day: { utilization: 10, resets_at: inOneDay() }
+    }
+    expect(autoSwitchIneligibilityReason({ ...base, usage }, undefined, now)).toBeNull()
+  })
+
+  it('flags an account whose max window is at or over the threshold', () => {
+    const usage: UsageData = {
+      five_hour: { utilization: 20, resets_at: inOneHour() },
+      seven_day: { utilization: 80, resets_at: inOneDay() }
+    }
+    expect(autoSwitchIneligibilityReason({ ...base, usage }, 80, now)).toMatch(/At 80%/)
+    expect(autoSwitchIneligibilityReason({ ...base, usage }, 81, now)).toBeNull()
+  })
+
+  it('ignores windows whose reset time has already passed', () => {
+    const usage: UsageData = {
+      five_hour: { utilization: 99, resets_at: oneHourAgo() },
+      seven_day: { utilization: 10, resets_at: inOneDay() }
+    }
+    expect(autoSwitchIneligibilityReason({ ...base, usage }, 80, now)).toBeNull()
+  })
+
+  it('never flags the active account, and does not flag unknown usage', () => {
+    const usage: UsageData = {
+      five_hour: { utilization: 99, resets_at: inOneHour() },
+      seven_day: { utilization: 10, resets_at: inOneDay() }
+    }
+    expect(
+      autoSwitchIneligibilityReason({ ...base, usage, isActive: true }, 80, now)
+    ).toBeNull()
+    expect(autoSwitchIneligibilityReason({ ...base, usage: null }, 80, now)).toBeNull()
+  })
+
+  it('flags stale and errored accounts', () => {
+    expect(
+      autoSwitchIneligibilityReason({ ...base, usage: null, status: 'stale' }, 80, now)
+    ).toMatch(/expired/i)
+    expect(
+      autoSwitchIneligibilityReason({ ...base, usage: null, status: 'error' }, 80, now)
+    ).toMatch(/refresh failed/i)
+  })
 })
 
 describe('UsageAccountRow refresh countdown', () => {
@@ -962,6 +1059,60 @@ describe('ProviderUsageBlock provider toggle', () => {
     await user.hover(screen.getByTestId('usage-trigger-openai'))
     await screen.findByText('OpenAI API Usage')
     expect(screen.queryByTestId('auto-switch-controls')).toBeNull()
+  })
+
+  it('dims saved accounts over the armed auto-switch threshold, but not the active or viable ones', async () => {
+    const user = userEvent.setup()
+    useAccountScheduleStore.setState({
+      schedules: {},
+      autoSwitch: { openai: { provider: 'openai', thresholdPercent: 80, createdAt: Date.now() } }
+    })
+    const usageAt = (percent: number): OpenAIUsageData => ({
+      ...sampleOpenAIUsage,
+      rate_limit: {
+        ...sampleOpenAIUsage.rate_limit,
+        primary_window: { ...sampleOpenAIUsage.rate_limit.primary_window!, used_percent: percent }
+      }
+    })
+    const account = (id: string, email: string, percent: number) => ({
+      id,
+      provider: 'openai' as const,
+      email,
+      last_usage: usageAt(percent),
+      last_fetched_at: null,
+      status: 'ok' as const,
+      last_error: null,
+      created_at: new Date().toISOString(),
+      plan: 'plus'
+    })
+    useUsageStore.setState((state) => ({
+      savedAccounts: {
+        ...state.savedAccounts,
+        openai: [
+          account('openai-active', 'openai@example.com', 95),
+          account('openai-over', 'over@example.com', 90),
+          account('openai-under', 'under@example.com', 30)
+        ]
+      }
+    }))
+
+    render(
+      <ProviderUsageBlock provider="openai" isExplicitlySelected toggleProviders={['openai']} />
+    )
+    await user.hover(screen.getByTestId('usage-trigger-openai'))
+    await screen.findByText('OpenAI API Usage')
+
+    const overlays = screen.getAllByTestId('auto-switch-ineligible-overlay')
+    expect(overlays).toHaveLength(1)
+    expect(overlays[0].getAttribute('title')).toMatch(/At 90%.*below 80%/)
+    const dimmedRow = overlays[0].parentElement!
+    expect(dimmedRow.textContent).toContain('over@example.com')
+
+    // Disarming removes the layer.
+    act(() => useAccountScheduleStore.setState({ schedules: {}, autoSwitch: {} }))
+    await waitFor(() =>
+      expect(screen.queryByTestId('auto-switch-ineligible-overlay')).toBeNull()
+    )
   })
 
   it('keeps the provider toggle outside the scroll container', async () => {

--- a/src/renderer/src/components/layout/UsageIndicator.tsx
+++ b/src/renderer/src/components/layout/UsageIndicator.tsx
@@ -18,6 +18,7 @@ import { MemberAvatarStack, type AccountMemberInfo } from './MemberAvatarStack'
 import { cn } from '@/lib/utils'
 import { Loader2, RefreshCw, Shuffle, Timer } from 'lucide-react'
 import { useAccountScheduleStore } from '@/stores/useAccountScheduleStore'
+import { autoSwitchIneligibilityReason } from '@/lib/auto-switch-score'
 import {
   AutoSwitchControls,
   ScheduleSwitchForm,
@@ -271,6 +272,11 @@ export interface UsageAccountRowProps {
   onSignInAgain?: () => void
   members?: AccountMemberInfo[]
   membersLoading?: boolean
+  /**
+   * When auto-switch is armed and this account can't be its target, the
+   * reason — renders a translucent layer over the row (controls stay usable).
+   */
+  autoSwitchIneligibleReason?: string | null
 }
 
 export function UsageAccountRow({
@@ -283,7 +289,8 @@ export function UsageAccountRow({
   onRefresh,
   onSignInAgain,
   members,
-  membersLoading = false
+  membersLoading = false,
+  autoSwitchIneligibleReason = null
 }: UsageAccountRowProps): React.JSX.Element {
   const fiveHour = usageWindowDisplay(row.usage?.five_hour, 'five_hour')
   const sevenDay = usageWindowDisplay(row.usage?.seven_day, 'seven_day')
@@ -301,7 +308,21 @@ export function UsageAccountRow({
         'relative rounded-md border border-border bg-background/40 px-2 py-1.5',
         highlightActive && row.isActive && 'ring-1 ring-ring/50'
       )}
+      data-auto-switch-ineligible={autoSwitchIneligibleReason ? 'true' : undefined}
     >
+      {autoSwitchIneligibleReason && (
+        <div
+          className="pointer-events-none absolute inset-0 z-10 flex items-start justify-end rounded-md bg-background/60 p-1"
+          data-testid="auto-switch-ineligible-overlay"
+          title={autoSwitchIneligibleReason}
+          aria-label={autoSwitchIneligibleReason}
+        >
+          <span className="inline-flex items-center gap-1 rounded-full bg-muted px-1.5 py-px text-[9px] font-medium text-muted-foreground shadow-sm">
+            <Shuffle className="h-2.5 w-2.5" />
+            Not a switch target
+          </span>
+        </div>
+      )}
       <div className="flex items-center justify-between gap-2">
         <div
           className={cn(
@@ -587,7 +608,10 @@ function ProviderUsagePopoverBody({ provider }: { provider: UsageProvider }): Re
   )
   const startLogin = useLoginStore((s) => s.startLogin)
   const isLoginActive = useLoginStore((s) => s.activeLogin !== null)
-  const autoSwitchArmed = useAccountScheduleStore((s) => s.autoSwitch[provider] !== undefined)
+  const autoSwitchThreshold = useAccountScheduleStore(
+    (s) => s.autoSwitch[provider]?.thresholdPercent
+  )
+  const autoSwitchArmed = autoSwitchThreshold !== undefined
   const telemetryEnabled = useSettingsStore((s) => isHiveTelemetryEnabled(s))
   const {
     membersByAccount,
@@ -632,6 +656,7 @@ function ProviderUsagePopoverBody({ provider }: { provider: UsageProvider }): Re
   // ring) so it's visible at the popover's natural top scroll position.
   const orderedRows = [...accountRows].sort((a, b) => Number(b.isActive) - Number(a.isActive))
   const highlightActive = accountRows.length > 1
+  const nowMs = Date.now()
 
   const membersFor = (rowEmail: string | null): AccountMemberInfo[] | undefined => {
     if (!telemetryEnabled) return undefined
@@ -677,6 +702,11 @@ function ProviderUsagePopoverBody({ provider }: { provider: UsageProvider }): Re
             onSignInAgain={() => startLogin(provider, row.email ?? undefined)}
             members={membersFor(row.email)}
             membersLoading={membersLoading}
+            autoSwitchIneligibleReason={autoSwitchIneligibilityReason(
+              row,
+              autoSwitchThreshold,
+              nowMs
+            )}
           />
         ))
       ) : (

--- a/src/renderer/src/components/pr/ConnectionPRModal.tsx
+++ b/src/renderer/src/components/pr/ConnectionPRModal.tsx
@@ -348,6 +348,26 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
     setOpen(false)
   }, [setOpen])
 
+  // ── Cmd/Ctrl+Enter submits the current phase's primary action ───
+  const canCommitAndContinue =
+    !!commitSummary.trim() && membersWithStagedFiles.length > 0 && !isCommitting
+  const canCreate = includedCount > 0
+  const handleDialogKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== 'Enter' || !(e.metaKey || e.ctrlKey)) return
+      if (phase === 'commit') {
+        if (!canCommitAndContinue) return
+        e.preventDefault()
+        void handleCommitAndContinue()
+      } else if (phase === 'form') {
+        if (!canCreate) return
+        e.preventDefault()
+        handleCreate()
+      }
+    },
+    [phase, canCommitAndContinue, canCreate, handleCommitAndContinue, handleCreate]
+  )
+
   // ── Render: Loading ─────────────────────────────────────────────
   const renderLoading = (): React.JSX.Element => (
     <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
@@ -669,9 +689,7 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
             </Button>
             <Button
               onClick={handleCommitAndContinue}
-              disabled={
-                !commitSummary.trim() || membersWithStagedFiles.length === 0 || isCommitting
-              }
+              disabled={!canCommitAndContinue}
               data-testid="connection-pr-commit-button"
             >
               {isCommitting ? (
@@ -696,7 +714,7 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
             </Button>
             <Button
               onClick={handleCreate}
-              disabled={includedCount === 0}
+              disabled={!canCreate}
               data-testid="connection-pr-create-button"
             >
               <GitPullRequest className="h-4 w-4 mr-1.5" />
@@ -709,7 +727,11 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => setOpen(isOpen, isOpen ? connectionId : undefined)}>
-      <DialogContent className="sm:max-w-xl" data-testid="connection-pr-modal">
+      <DialogContent
+        className="sm:max-w-xl"
+        data-testid="connection-pr-modal"
+        onKeyDown={handleDialogKeyDown}
+      >
         <DialogHeader>
           <DialogTitle>
             <span className="flex items-center gap-2">

--- a/src/renderer/src/components/pr/CreatePRModal.tsx
+++ b/src/renderer/src/components/pr/CreatePRModal.tsx
@@ -326,6 +326,25 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
     setOpen(false)
   }, [setOpen])
 
+  // ── Cmd/Ctrl+Enter submits the current phase's primary action ───
+  const canCommitAndContinue = !!commitSummary.trim() && stagedCount > 0 && !isCommitting
+  const canCreate = !!baseBranch
+  const handleDialogKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== 'Enter' || !(e.metaKey || e.ctrlKey)) return
+      if (phase === 'commit') {
+        if (!canCommitAndContinue) return
+        e.preventDefault()
+        void handleCommitAndContinue()
+      } else if (phase === 'form') {
+        if (!canCreate) return
+        e.preventDefault()
+        void handleCreate()
+      }
+    },
+    [phase, canCommitAndContinue, canCreate, handleCommitAndContinue, handleCreate]
+  )
+
   // ── Render: Commit ──────────────────────────────────────────────
   const renderCommit = (): React.JSX.Element => (
     <>
@@ -558,10 +577,7 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
             <Button variant="ghost" onClick={handleSkipCommit}>
               Skip
             </Button>
-            <Button
-              onClick={handleCommitAndContinue}
-              disabled={!commitSummary.trim() || stagedCount === 0 || isCommitting}
-            >
+            <Button onClick={handleCommitAndContinue} disabled={!canCommitAndContinue}>
               {isCommitting ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
@@ -582,7 +598,7 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
             <Button variant="ghost" onClick={handleCancel}>
               Cancel
             </Button>
-            <Button onClick={handleCreate} disabled={!baseBranch}>
+            <Button onClick={handleCreate} disabled={!canCreate}>
               <GitPullRequest className="h-4 w-4 mr-1.5" />
               Create Pull Request
             </Button>
@@ -593,7 +609,7 @@ export function CreatePRModal({ worktreeId, worktreePath }: CreatePRModalProps):
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg" onKeyDown={handleDialogKeyDown}>
         <DialogHeader>
           <DialogTitle>
             <span className="flex items-center gap-2">

--- a/src/renderer/src/components/pr/__tests__/ConnectionPRModal.test.tsx
+++ b/src/renderer/src/components/pr/__tests__/ConnectionPRModal.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { resetRendererRpcClientForTests, setRendererRpcClient } from '../../../api/rpc-client'
 import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
@@ -161,6 +161,40 @@ describe('ConnectionPRModal', () => {
     })
     expect(screen.queryByTestId('connection-pr-row-wt-b')).not.toBeInTheDocument()
     expect(screen.getByText(/2 commits ahead/)).toBeInTheDocument()
+  })
+
+  it('submits the form phase with Cmd+Enter', async () => {
+    mockResponses({ commitCount: { '/repo/a': 2 } })
+
+    render(<ConnectionPRModal connectionId="conn-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('connection-pr-create-button')).toBeInTheDocument()
+    })
+
+    fireEvent.keyDown(screen.getByTestId('connection-pr-modal'), { key: 'Enter', metaKey: true })
+
+    await waitFor(() => {
+      expect(useGitStore.getState().connectionPRModalOpen).toBe(false)
+    })
+    expect(useGitStore.getState().prTargetBranch.get('wt-a')).toBe('origin/main')
+  })
+
+  it('ignores Cmd+Enter in the form phase when nothing is included', async () => {
+    mockResponses({ commitCount: { '/repo/a': 2 } })
+
+    render(<ConnectionPRModal connectionId="conn-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('connection-pr-create-button')).toBeInTheDocument()
+    })
+    // Uncheck the only eligible member
+    fireEvent.click(screen.getByRole('checkbox'))
+    expect(screen.getByTestId('connection-pr-create-button')).toBeDisabled()
+
+    fireEvent.keyDown(screen.getByTestId('connection-pr-modal'), { key: 'Enter', metaKey: true })
+
+    expect(useGitStore.getState().connectionPRModalOpen).toBe(true)
   })
 
   it('closes with archive prompts when every member is clean', async () => {

--- a/src/renderer/src/components/pr/__tests__/CreatePRModal.test.tsx
+++ b/src/renderer/src/components/pr/__tests__/CreatePRModal.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '../../../api/rpc-client'
+import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useGitStore } from '@/stores/useGitStore'
+import { CreatePRModal } from '../CreatePRModal'
+
+vi.mock('@/lib/pr-pipeline', () => ({
+  runCreatePRPipeline: vi.fn().mockResolvedValue(undefined)
+}))
+
+let request: ReturnType<typeof vi.fn>
+
+function mockResponses(spec: { hasUncommitted?: boolean; files?: unknown[] }): void {
+  request.mockImplementation((method: string) => {
+    switch (method) {
+      case 'gitOps.hasUncommittedChanges':
+        return Promise.resolve(spec.hasUncommitted ?? false)
+      case 'gitOps.getRangeDiff':
+        return Promise.resolve({
+          commitSummary: '',
+          diffSummary: '',
+          diffPatch: '',
+          commitCount: 1
+        })
+      case 'gitOps.getBranchInfo':
+        return Promise.resolve({
+          success: true,
+          branch: { name: 'feat', tracking: null, ahead: 0, behind: 0 }
+        })
+      case 'gitOps.getFileStatuses':
+        return Promise.resolve({ success: true, files: spec.files ?? [] })
+      case 'gitOps.listBranchesWithStatus':
+        return Promise.resolve({
+          success: true,
+          branches: [{ name: 'origin/main', isRemote: true }]
+        })
+      case 'gitOps.commit':
+        return Promise.resolve({ success: true, commitHash: 'abcdef1234' })
+      default:
+        return Promise.resolve([])
+    }
+  })
+}
+
+describe('CreatePRModal Cmd+Enter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    request = vi.fn().mockResolvedValue([])
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        [
+          'proj-a',
+          [
+            { id: 'wt-default', path: '/proj/a', branch_name: 'main', is_default: true },
+            { id: 'wt-a', path: '/repo/a', branch_name: 'feat', is_default: false }
+          ]
+        ]
+      ])
+    } as never)
+    useProjectStore.setState({ projects: [{ id: 'proj-a', path: '/proj/a' }] } as never)
+    useGitStore.setState({
+      fileStatusesByWorktree: new Map(),
+      branchInfoByWorktree: new Map(),
+      prTargetBranch: new Map(),
+      reviewTargetBranch: new Map(),
+      isCommitting: false,
+      createPRModalOpen: true
+    })
+    usePRNotificationStore.setState({ notifications: [] })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+  })
+
+  it('creates the PR from the form phase with Cmd+Enter', async () => {
+    mockResponses({})
+
+    render(<CreatePRModal worktreeId="wt-a" worktreePath="/repo/a" />)
+
+    const dialog = await screen.findByRole('dialog')
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create pull request/i })).toBeEnabled()
+    })
+
+    fireEvent.keyDown(dialog, { key: 'Enter', metaKey: true })
+
+    await waitFor(() => {
+      expect(useGitStore.getState().createPRModalOpen).toBe(false)
+    })
+    expect(useGitStore.getState().prTargetBranch.get('wt-a')).toBe('origin/main')
+  })
+
+  it('commits from the commit phase with Cmd+Enter and advances to the form', async () => {
+    mockResponses({ hasUncommitted: true })
+    // Seed staged files directly — loadFileStatuses is TTL-cached across tests
+    useGitStore.setState({
+      fileStatusesByWorktree: new Map([
+        ['/repo/a', [{ path: '/repo/a/x.ts', relativePath: 'x.ts', status: 'M', staged: true }]]
+      ])
+    } as never)
+
+    render(<CreatePRModal worktreeId="wt-a" worktreePath="/repo/a" />)
+
+    const dialog = await screen.findByRole('dialog')
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /commit & continue/i })).toBeInTheDocument()
+    })
+
+    // Empty summary → Cmd+Enter is a no-op
+    fireEvent.keyDown(dialog, { key: 'Enter', metaKey: true })
+    expect(request).not.toHaveBeenCalledWith('gitOps.commit', expect.anything())
+
+    fireEvent.change(screen.getByPlaceholderText(/summary/i), { target: { value: 'Fix thing' } })
+    fireEvent.keyDown(dialog, { key: 'Enter', metaKey: true })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        'gitOps.commit',
+        expect.objectContaining({ worktreePath: '/repo/a', message: 'Fix thing' })
+      )
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create pull request/i })).toBeInTheDocument()
+    })
+    expect(useGitStore.getState().createPRModalOpen).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/auto-switch-score.ts
+++ b/src/renderer/src/lib/auto-switch-score.ts
@@ -1,4 +1,4 @@
-import type { UsageData } from '@shared/types/usage'
+import type { SavedUsageStatus, UsageData } from '@shared/types/usage'
 
 // How much each window's remaining headroom counts toward an account's score.
 // The 5h window dominates: it resets within hours, so headroom there is worth
@@ -95,4 +95,29 @@ export function scoreAccountHeadroom(usage: UsageData, nowMs: number): number {
     (score, c) => score * Math.pow(c.headroom, c.weight / totalWeight),
     1
   )
+}
+
+/**
+ * Why an account can't be an auto-switch target right now, mirroring the
+ * candidate filter in useAccountScheduleStore's sweep: the token must be
+ * valid and every usage window must sit below the armed threshold. Null when
+ * the account is (or may turn out to be, once refreshed) a viable target —
+ * unknown usage is not dimmed since the sweep refreshes it before deciding.
+ * The active account is never a candidate, but it's the one being left, so
+ * it isn't dimmed either.
+ */
+export function autoSwitchIneligibilityReason(
+  row: { usage: UsageData | null; status: SavedUsageStatus; isActive: boolean },
+  thresholdPercent: number | undefined,
+  nowMs: number
+): string | null {
+  if (thresholdPercent === undefined || row.isActive) return null
+  if (row.status === 'stale') return 'Expired — not an auto-switch target'
+  if (row.status === 'error') return 'Refresh failed — not an auto-switch target'
+  if (!row.usage) return null
+  const maxPercent = getMaxUsagePercent(row.usage, nowMs)
+  if (maxPercent !== null && maxPercent >= thresholdPercent) {
+    return `At ${Math.round(maxPercent)}% — auto-switch only targets accounts below ${thresholdPercent}%`
+  }
+  return null
 }


### PR DESCRIPTION
## Summary

- Dim saved accounts in the usage popover when they exceed the armed auto-switch threshold.
- Keep active accounts and manual switching controls usable.
- Add ineligibility reasons for threshold, stale, and refresh-error states.
- Add coverage for overlays, eligibility logic, and disarming auto-switch.

## Testing

- Added and updated Vitest coverage in `UsageIndicator.test.tsx`.
- Verified overlays are non-blocking and disappear when auto-switch is disarmed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large connection quick-launch path parallel to existing session startup and touches account-switch eligibility UI; behavior is covered by new tests but session orchestration mistakes could affect launches.
> 
> **Overview**
> This PR bundles **usage popover** work with several **kanban** improvements.
> 
> **Auto-switch visibility:** When auto-switch is armed, saved accounts that cannot be chosen as targets get a translucent **“Not a switch target”** overlay (threshold, stale token, or refresh error). Overlays use `pointer-events-none` so manual switch/refresh still work; the active account is never dimmed. Logic lives in new `autoSwitchIneligibilityReason` in `auto-switch-score.ts`, wired from `UsageIndicator`.
> 
> **Connection boards:** Right-drag into **In Progress** is enabled on connection boards (previously disabled). Drops call new `quickLaunchTicketOnConnection` instead of worktree `quickLaunchTicket`, starting a connection session with the same default build/model path as the picker.
> 
> **Pinned board create:** `TicketCreateModal` remembers `pinnedBoardLastCreateProjectId` in persisted kanban state so the project picker defaults to the last project used for a successful create (with fallback if that project is no longer pinned).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit def4fa7b1c74bc39acbf731332baca49231c07af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->