### PR TITLE
Add Save & Send and Create & Send ticket actions

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketModal.save-and-send.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.save-and-send.test.tsx
@@ -1,0 +1,432 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { KanbanTicketModal } from './KanbanTicketModal'
+import { ClaudeCliSessionPortalProvider } from '@/contexts/ClaudeCliSessionPortalContext'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useRemoteLaunchStore } from '@/stores/useRemoteLaunchStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { toast } from '@/lib/toast'
+import type { KanbanTicket, Session, Worktree } from '../../../../main/db/types'
+
+vi.mock('@/api/hive-enterprise/client', () => ({
+  isHiveTelemetryEnabled: vi.fn(() => false),
+  recordHivePromptStart: vi.fn(),
+  recordHivePromptIdle: vi.fn(),
+  recordHiveQuestionsAnswered: vi.fn()
+}))
+
+vi.mock('@/components/terminal/TerminalView', () => ({
+  TerminalView: () => <div data-testid="mock-terminal-view" />
+}))
+
+vi.mock('../sessions/MarkdownRenderer', () => ({
+  MarkdownRenderer: ({ content }: { content: string }) => <div>{content}</div>
+}))
+
+vi.mock('./TicketRunButton', () => ({
+  TicketRunButton: () => null
+}))
+
+vi.mock('@/hooks/useTicketRunScript', () => ({
+  useTicketRunScript: () => ({ hasRunScript: false }),
+  useTicketRunScriptHotkey: vi.fn()
+}))
+
+vi.mock('@/hooks/useDropZone', () => ({
+  useDropZone: () => ({ isDragging: false })
+}))
+
+vi.mock('@/hooks/useConflictFixFlow', () => ({
+  useConflictFixFlow: () => ({ startFixFlow: vi.fn(), openAttachedSession: vi.fn() })
+}))
+
+vi.mock('@/hooks/useLifecycleActions', () => ({
+  useLifecycleActions: () => ({
+    hasAttachedPR: false,
+    attachedPR: null,
+    isGitHub: false,
+    loadPRState: vi.fn(),
+    openPRInBrowser: vi.fn(),
+    createCodeReview: vi.fn()
+  })
+}))
+
+vi.mock('@/hooks/usePinAndActivateSession', () => ({
+  usePinAndActivateSession: () => ({ pinAndActivate: vi.fn(), lifecycleLoading: false })
+}))
+
+const quickLaunchMocks = vi.hoisted(() => ({
+  quickLaunchTicket: vi.fn().mockResolvedValue(true),
+  quickLaunchTicketOnConnection: vi.fn().mockResolvedValue(true)
+}))
+
+vi.mock('./WorktreePickerModal', () => quickLaunchMocks)
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn()
+  }
+}))
+
+const terminalApiMocks = vi.hoisted(() => ({
+  createClaudeCli: vi.fn().mockResolvedValue({ success: true, value: { success: true } }),
+  onClaudeSessionId: vi.fn().mockReturnValue(() => {})
+}))
+
+vi.mock('@/api/terminal-api', () => ({
+  terminalApi: terminalApiMocks
+}))
+
+const opencodeApiMocks = vi.hoisted(() => ({
+  abort: vi.fn().mockResolvedValue({ success: true, value: { success: true } }),
+  commands: vi.fn().mockResolvedValue({ success: true, value: { success: true, commands: [] } }),
+  listModels: vi.fn().mockResolvedValue({ success: true, value: { success: true, providers: [] } })
+}))
+
+vi.mock('@/api/opencode-api', () => ({
+  opencodeApi: opencodeApiMocks
+}))
+
+const dbApiMocks = vi.hoisted(() => ({
+  session: {
+    get: vi.fn(),
+    update: vi.fn().mockResolvedValue({ success: true, value: undefined })
+  },
+  worktree: {
+    get: vi.fn().mockResolvedValue(null),
+    getActiveByProject: vi.fn().mockResolvedValue([])
+  },
+  setting: {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+vi.mock('@/api/db-api', () => ({
+  dbApi: dbApiMocks
+}))
+
+const gitApiMocks = vi.hoisted(() => ({
+  listBranchesWithStatus: vi.fn().mockResolvedValue({ success: true, branches: [] }),
+  getBranchDiffFiles: vi.fn().mockResolvedValue({ success: true, files: [] }),
+  onStatusChanged: vi.fn().mockReturnValue(() => {})
+}))
+
+vi.mock('@/api/git-api', () => ({
+  gitApi: gitApiMocks
+}))
+
+const now = '2026-01-01T00:00:00.000Z'
+
+const worktree: Worktree = {
+  id: 'worktree-1',
+  project_id: 'project-1',
+  name: 'Feature',
+  branch_name: 'feature',
+  path: '/repo/feature',
+  status: 'active',
+  is_default: false,
+  branch_renamed: 0,
+  last_message_at: null,
+  session_titles: '[]',
+  last_model_provider_id: null,
+  last_model_id: null,
+  last_model_variant: null,
+  attachments: '[]',
+  pinned: 0,
+  context: null,
+  github_pr_number: null,
+  github_pr_url: null,
+  base_branch: null,
+  created_at: now,
+  last_accessed_at: now
+}
+
+function makeSession(agentSdk: Session['agent_sdk']): Session {
+  return {
+    id: 'session-1',
+    worktree_id: 'worktree-1',
+    project_id: 'project-1',
+    connection_id: null,
+    name: 'Review session',
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: agentSdk,
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: 'anthropic',
+    model_id: 'opus',
+    model_variant: 'high',
+    remote_launch: null,
+    created_at: now,
+    updated_at: now,
+    completed_at: null,
+    pinned_to_board: false
+  }
+}
+
+const todoTicket: KanbanTicket = {
+  id: 'ticket-1',
+  project_id: 'project-1',
+  title: 'Todo ticket',
+  description: 'Original description',
+  attachments: [],
+  column: 'todo',
+  sort_order: 0,
+  current_session_id: null,
+  worktree_id: null,
+  mode: null,
+  plan_ready: false,
+  created_at: now,
+  updated_at: now,
+  column_changed_at: null,
+  archived_at: null,
+  external_provider: null,
+  external_id: null,
+  external_url: null,
+  github_pr_number: null,
+  github_pr_url: null,
+  mark: null,
+  total_tokens: 0,
+  pending_launch_config: null,
+  goal_mode: false,
+  goal_success_criteria: null,
+  note: null,
+  created_from_session: false,
+  auto_approve_plan: false,
+  model_provider_id: null,
+  model_id: null,
+  model_variant: null,
+  variant_group_id: null
+}
+
+const initialSettingsState = useSettingsStore.getState()
+const initialSessionState = useSessionStore.getState()
+const initialWorktreeState = useWorktreeStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialWorktreeStatusState = useWorktreeStatusStore.getState()
+const initialRemoteLaunchState = useRemoteLaunchStore.getState()
+
+function setupStores(session: Session, ticket: KanbanTicket = todoTicket): void {
+  useSettingsStore.setState({
+    availableAgentSdks: { opencode: true, claude: true, codex: true },
+    defaultAgentSdk: 'opencode',
+    selectedModel: null,
+    selectedModelByProvider: {},
+    defaultModels: null,
+    boardMode: 'toggle'
+  })
+  useProjectStore.setState({
+    selectedProjectId: 'project-1',
+    projects: [
+      {
+        id: 'project-1',
+        name: 'Hive',
+        path: '/repo',
+        description: null,
+        tags: null,
+        language: null,
+        custom_icon: null,
+        detected_icon: null,
+        setup_script: null,
+        run_script: null,
+        archive_script: null,
+        worktree_create_script: null,
+        custom_commands: null,
+        auto_assign_port: false,
+        sort_order: 0,
+        created_at: now,
+        last_accessed_at: now
+      }
+    ]
+  })
+  useWorktreeStore.setState({
+    selectedWorktreeId: null,
+    worktreesByProject: new Map([['project-1', [worktree]]]),
+    selectWorktree: vi.fn()
+  })
+  useKanbanStore.setState({
+    selectedTicketId: ticket.id,
+    selectedTicketRef: { projectId: ticket.project_id, ticketId: ticket.id },
+    isBoardViewActive: true,
+    isPinnedBoardActive: false,
+    tickets: new Map([['project-1', [ticket]]]),
+    updateTicket: vi.fn(async () => undefined),
+    moveTicket: vi.fn(async () => undefined),
+    deleteTicket: vi.fn(async () => undefined),
+    relinkTicketsForHandoff: vi.fn(async () => undefined)
+  })
+  useSessionStore.setState({
+    activeSessionId: null,
+    activeWorktreeId: null,
+    sessionsByWorktree: new Map([['worktree-1', [session]]]),
+    sessionsByConnection: new Map(),
+    pendingPlans: new Map(),
+    hydrateSession: vi.fn(),
+    loadSessions: vi.fn(async () => undefined),
+    requestSessionMount: vi.fn(),
+    releaseSessionMount: vi.fn(),
+    setActiveSession: vi.fn(),
+    setActiveWorktree: vi.fn()
+  })
+  useWorktreeStatusStore.setState({
+    sessionStatuses: {},
+    clearSessionStatus: vi.fn()
+  })
+  useRemoteLaunchStore.setState({
+    remoteBySessionId: {},
+    ensureLoaded: vi.fn(async () => undefined),
+    setRemoteInfo: vi.fn()
+  })
+}
+
+function renderModal(): void {
+  render(
+    <ClaudeCliSessionPortalProvider>
+      <KanbanTicketModal />
+    </ClaudeCliSessionPortalProvider>
+  )
+}
+
+describe('KanbanTicketModal edit mode — Save & Send', () => {
+  const initialConnectionState = useConnectionStore.getState()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dbApiMocks.worktree.get.mockResolvedValue(null)
+    dbApiMocks.worktree.getActiveByProject.mockResolvedValue([])
+    dbApiMocks.setting.get.mockResolvedValue(null)
+    dbApiMocks.setting.set.mockResolvedValue(undefined)
+    gitApiMocks.listBranchesWithStatus.mockResolvedValue({ success: true, branches: [] })
+    gitApiMocks.getBranchDiffFiles.mockResolvedValue({ success: true, files: [] })
+    gitApiMocks.onStatusChanged.mockReturnValue(() => {})
+    quickLaunchMocks.quickLaunchTicket.mockResolvedValue(true)
+    quickLaunchMocks.quickLaunchTicketOnConnection.mockResolvedValue(true)
+    useConnectionStore.setState({ selectedConnectionId: null, connections: [] } as never)
+  })
+
+  afterEach(() => {
+    cleanup()
+    useSettingsStore.setState(initialSettingsState, true)
+    useSessionStore.setState(initialSessionState, true)
+    useWorktreeStore.setState(initialWorktreeState, true)
+    useKanbanStore.setState(initialKanbanState, true)
+    useProjectStore.setState(initialProjectState, true)
+    useWorktreeStatusStore.setState(initialWorktreeStatusState, true)
+    useRemoteLaunchStore.setState(initialRemoteLaunchState, true)
+    useConnectionStore.setState(initialConnectionState, true)
+  })
+
+  it('shows Save & Send with shortcut hints for To Do tickets', async () => {
+    setupStores(makeSession('opencode'))
+    renderModal()
+
+    const sendBtn = await screen.findByTestId('ticket-edit-save-send-btn')
+    const saveBtn = screen.getByTestId('ticket-edit-save-btn')
+    expect(sendBtn.querySelector('kbd')?.textContent).toMatch(/⇧|Shift/)
+    expect(saveBtn.querySelector('kbd')?.textContent).toMatch(/↵|Enter/)
+    expect(saveBtn.querySelector('kbd')?.textContent).not.toMatch(/⇧|Shift/)
+  })
+
+  it('hides Save & Send for tickets that are not in To Do', async () => {
+    setupStores(makeSession('opencode'), { ...todoTicket, column: 'done' })
+    renderModal()
+
+    await screen.findByTestId('ticket-edit-save-btn')
+    expect(screen.queryByTestId('ticket-edit-save-send-btn')).toBeNull()
+  })
+
+  it('saves the edited content, closes, then quick-launches with the saved content', async () => {
+    setupStores(makeSession('opencode'))
+    renderModal()
+
+    const sendBtn = await screen.findByTestId('ticket-edit-save-send-btn')
+    const titleInput = screen.getByDisplayValue('Todo ticket')
+    fireEvent.change(titleInput, { target: { value: 'Edited title' } })
+    fireEvent.click(sendBtn)
+
+    const updateTicket = useKanbanStore.getState().updateTicket as ReturnType<typeof vi.fn>
+    await waitFor(() => expect(quickLaunchMocks.quickLaunchTicket).toHaveBeenCalledTimes(1))
+    expect(updateTicket).toHaveBeenCalledWith(
+      'ticket-1',
+      'project-1',
+      expect.objectContaining({ title: 'Edited title', description: 'Original description' })
+    )
+    const launched = quickLaunchMocks.quickLaunchTicket.mock.calls[0][0] as KanbanTicket
+    expect(launched.id).toBe('ticket-1')
+    expect(launched.title).toBe('Edited title')
+    expect(quickLaunchMocks.quickLaunchTicketOnConnection).not.toHaveBeenCalled()
+    // Modal closed (selection cleared)
+    expect(useKanbanStore.getState().selectedTicketRef).toBeNull()
+  })
+
+  it('routes to the connection launcher when a connection board is showing', async () => {
+    setupStores(makeSession('opencode'))
+    useConnectionStore.setState({ selectedConnectionId: 'conn-1' } as never)
+    renderModal()
+
+    fireEvent.click(await screen.findByTestId('ticket-edit-save-send-btn'))
+
+    await waitFor(() =>
+      expect(quickLaunchMocks.quickLaunchTicketOnConnection).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'ticket-1' }),
+        'conn-1'
+      )
+    )
+    expect(quickLaunchMocks.quickLaunchTicket).not.toHaveBeenCalled()
+  })
+
+  it('Cmd+Enter saves only; Cmd+Shift+Enter saves and sends', async () => {
+    setupStores(makeSession('opencode'))
+    renderModal()
+
+    const titleInput = await screen.findByDisplayValue('Todo ticket')
+    fireEvent.keyDown(titleInput, { key: 'Enter', metaKey: true })
+    const updateTicket = useKanbanStore.getState().updateTicket as ReturnType<typeof vi.fn>
+    await waitFor(() => expect(updateTicket).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(useKanbanStore.getState().selectedTicketRef).toBeNull())
+    expect(quickLaunchMocks.quickLaunchTicket).not.toHaveBeenCalled()
+
+    cleanup()
+    vi.clearAllMocks()
+    setupStores(makeSession('opencode'))
+    renderModal()
+
+    const titleInput2 = await screen.findByDisplayValue('Todo ticket')
+    fireEvent.keyDown(titleInput2, { key: 'Enter', ctrlKey: true, shiftKey: true })
+    await waitFor(() => expect(quickLaunchMocks.quickLaunchTicket).toHaveBeenCalledTimes(1))
+    const updateTicket2 = useKanbanStore.getState().updateTicket as ReturnType<typeof vi.fn>
+    expect(updateTicket2).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses to send a blocked ticket', async () => {
+    const blocker: KanbanTicket = {
+      ...todoTicket,
+      id: 'blocker-1',
+      title: 'Blocker',
+      column: 'in_progress'
+    }
+    setupStores(makeSession('opencode'))
+    useKanbanStore.setState({
+      tickets: new Map([['project-1', [todoTicket, blocker]]]),
+      dependencyMap: new Map([['project-1:ticket-1', new Set(['project-1:blocker-1'])]]),
+      simpleModeByProject: {}
+    } as never)
+    renderModal()
+
+    fireEvent.click(await screen.findByTestId('ticket-edit-save-send-btn'))
+
+    await waitFor(() => expect(toast.warning).toHaveBeenCalled())
+    expect(quickLaunchMocks.quickLaunchTicket).not.toHaveBeenCalled()
+    expect(useKanbanStore.getState().updateTicket).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -112,6 +112,9 @@ import { useTicketRemoteLaunch } from '@/hooks/useTicketRemoteLaunch'
 import { buildHandoffPrompt, type HandoffSelectionOverride } from '@/lib/handoffSelection'
 import { canonicalizeTicketTitle, extractPlanTitle } from '@shared/types/branch-utils'
 import type { RemoteLaunchClientInfo } from '@shared/types/remote-launch'
+import { ShortcutHint } from '@/components/ui/shortcut-hint'
+import { submitShortcutLabel } from '@/lib/shortcut-labels'
+import { quickLaunchTicket, quickLaunchTicketOnConnection } from './WorktreePickerModal'
 import type { KanbanTicket, KanbanTicketUpdate, Session, Worktree } from '../../../../main/db/types'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { autoPinBaseWorktree } from '@/lib/auto-pin'
@@ -1582,32 +1585,82 @@ function EditModeContent({
       onAttach: (attachment) => setAttachments((prev) => [...prev, attachment])
     })
 
-  const handleSave = useCallback(async () => {
-    if (!title.trim() || isSaving) return
-    setIsSaving(true)
-    try {
-      await updateTicket(ticket.id, ticket.project_id, {
+  // ── Save & Send ───────────────────────────────────────────────────
+  // Only To Do tickets can be sent straight to In Progress from here; the
+  // launch mirrors a right-button drag (new worktree / connection session,
+  // build mode, default SDK + model). Blocked tickets can't be sent.
+  const isBlockedForSend = useKanbanStore(
+    useCallback(
+      (state) => {
+        if (state.simpleModeByProject[ticket.project_id]) return false
+        const blockers = state.dependencyMap.get(ticketKey(ticket.project_id, ticket.id))
+        if (!blockers?.size) return false
+        for (const blockerKey of blockers) {
+          const ref = parseTicketKey(blockerKey)
+          const blocker = state.tickets.get(ref.projectId)?.find((t) => t.id === ref.ticketId)
+          if (blocker && !isBlockerSatisfied(blocker.column, blocker.mode, followUpTriggerColumn))
+            return true
+        }
+        return false
+      },
+      [ticket.project_id, ticket.id, followUpTriggerColumn]
+    )
+  )
+  // Connection board currently showing (pinned board / project boards launch
+  // a worktree instead) — same routing KanbanTicketCard uses for right-drags.
+  const boardConnectionId = useConnectionStore((s) => s.selectedConnectionId)
+  const isPinnedBoardActive = useKanbanStore((s) => s.isPinnedBoardActive)
+  const sendConnectionId = !isPinnedBoardActive && boardConnectionId ? boardConnectionId : null
+  const canSend = ticket.column === 'todo' && !remoteLaunchInfo
+  const [pendingAction, setPendingAction] = useState<'save' | 'send' | null>(null)
+
+  const submit = useCallback(
+    async (action: 'save' | 'send') => {
+      if (!title.trim() || isSaving) return
+      if (action === 'send' && isBlockedForSend) {
+        toast.warning('Ticket is blocked — resolve its dependencies first')
+        return
+      }
+      setIsSaving(true)
+      setPendingAction(action)
+      const data: KanbanTicketUpdate = {
         title: title.trim(),
         description: description.trim() || null,
         attachments: attachments.map((a) => ({ type: a.type, url: a.url, label: a.label }))
-      })
-      toast.success('Ticket updated')
-      onClose()
-    } catch {
-      toast.error('Failed to update ticket')
-    } finally {
-      setIsSaving(false)
-    }
-  }, [
-    title,
-    description,
-    attachments,
-    isSaving,
-    updateTicket,
-    ticket.id,
-    ticket.project_id,
-    onClose
-  ])
+      }
+      try {
+        await updateTicket(ticket.id, ticket.project_id, data)
+        toast.success('Ticket updated')
+        onClose()
+      } catch {
+        toast.error('Failed to update ticket')
+        return
+      } finally {
+        setIsSaving(false)
+        setPendingAction(null)
+      }
+      if (action === 'send') {
+        // Launch with the just-saved content so the prompt never lags the edit
+        const launchTicket: KanbanTicket = { ...ticket, ...data }
+        if (sendConnectionId) void quickLaunchTicketOnConnection(launchTicket, sendConnectionId)
+        else void quickLaunchTicket(launchTicket)
+      }
+    },
+    [
+      title,
+      description,
+      attachments,
+      isSaving,
+      isBlockedForSend,
+      sendConnectionId,
+      updateTicket,
+      ticket,
+      onClose
+    ]
+  )
+
+  const handleSave = useCallback(() => submit('save'), [submit])
+  const handleSaveAndSend = useCallback(() => submit('send'), [submit])
 
   const handleDelete = useCallback(async () => {
     try {
@@ -1628,10 +1681,13 @@ function EditModeContent({
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && title.trim()) {
         e.preventDefault()
-        handleSave()
+        // Cmd/Ctrl+Shift+Enter saves and sends with the default launch
+        // arguments (To Do tickets only); Cmd/Ctrl+Enter just saves.
+        if (e.shiftKey && canSend) handleSaveAndSend()
+        else handleSave()
       }
     },
-    [handleSave, title]
+    [handleSave, handleSaveAndSend, canSend, title]
   )
 
   return (
@@ -1971,13 +2027,28 @@ function EditModeContent({
           >
             Cancel
           </Button>
+          {canSend && (
+            <Button
+              type="button"
+              variant="secondary"
+              data-testid="ticket-edit-save-send-btn"
+              title="Save the ticket and start it now with the default launch settings"
+              disabled={!title.trim() || isSaving}
+              onClick={handleSaveAndSend}
+            >
+              <Send className="h-3.5 w-3.5" />
+              {pendingAction === 'send' ? 'Sending...' : 'Save & Send'}
+              <ShortcutHint label={submitShortcutLabel({ shift: true })} />
+            </Button>
+          )}
           <Button
             type="button"
             data-testid="ticket-edit-save-btn"
             disabled={!title.trim() || isSaving}
             onClick={handleSave}
           >
-            {isSaving ? 'Saving...' : 'Save'}
+            {pendingAction === 'save' ? 'Saving...' : 'Save'}
+            <ShortcutHint label={submitShortcutLabel()} />
           </Button>
         </div>
       </DialogFooter>

--- a/src/renderer/src/components/kanban/TicketCreateModal.create-and-send.test.tsx
+++ b/src/renderer/src/components/kanban/TicketCreateModal.create-and-send.test.tsx
@@ -1,0 +1,136 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TicketCreateModal } from './TicketCreateModal'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+
+vi.mock('@/lib/toast', () => ({ toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() } }))
+
+const quickLaunchTicket = vi.fn().mockResolvedValue(true)
+const quickLaunchTicketOnConnection = vi.fn().mockResolvedValue(true)
+vi.mock('./WorktreePickerModal', () => ({
+  quickLaunchTicket: (...args: unknown[]) => quickLaunchTicket(...args),
+  quickLaunchTicketOnConnection: (...args: unknown[]) => quickLaunchTicketOnConnection(...args)
+}))
+
+const createdTicket = { id: 't1', project_id: 'project-1', title: 'New', column: 'todo' }
+
+describe('TicketCreateModal — Create & Send', () => {
+  let createTicket: ReturnType<typeof vi.fn>
+  let onOpenChange: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    createTicket = vi.fn().mockResolvedValue(createdTicket)
+    onOpenChange = vi.fn()
+    useKanbanStore.setState({ createTicket } as never)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    useConnectionStore.setState({ connections: [] } as never)
+  })
+
+  const typeTitle = (): void => {
+    fireEvent.change(screen.getByTestId('ticket-title-input'), { target: { value: 'New' } })
+  }
+
+  it('renders both submit buttons with their shortcut hints', () => {
+    render(<TicketCreateModal open onOpenChange={onOpenChange} projectId="project-1" />)
+    const createBtn = screen.getByTestId('ticket-create-btn')
+    const sendBtn = screen.getByTestId('ticket-create-send-btn')
+    expect(createBtn.querySelector('kbd')?.textContent).toMatch(/↵|Enter/)
+    expect(sendBtn.querySelector('kbd')?.textContent).toMatch(/⇧|Shift/)
+    expect(createBtn.querySelector('kbd')?.textContent).not.toMatch(/⇧|Shift/)
+    // Disabled until a title is entered
+    expect(sendBtn).toBeDisabled()
+    typeTitle()
+    expect(sendBtn).not.toBeDisabled()
+  })
+
+  it('Create & Send creates the ticket, closes, then quick-launches it in a new worktree', async () => {
+    render(<TicketCreateModal open onOpenChange={onOpenChange} projectId="project-1" />)
+    typeTitle()
+    fireEvent.click(screen.getByTestId('ticket-create-send-btn'))
+
+    await waitFor(() => expect(quickLaunchTicket).toHaveBeenCalledWith(createdTicket))
+    expect(createTicket).toHaveBeenCalledTimes(1)
+    expect(createTicket.mock.calls[0][1]).toMatchObject({ title: 'New', column: 'todo' })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(quickLaunchTicketOnConnection).not.toHaveBeenCalled()
+  })
+
+  it('routes Create & Send to the connection launcher on connection boards', async () => {
+    useConnectionStore.setState({
+      connections: [
+        {
+          id: 'conn-1',
+          name: 'Conn',
+          members: [{ project_id: 'project-1', project_name: 'Alpha' }]
+        }
+      ]
+    } as never)
+    render(
+      <TicketCreateModal
+        open
+        onOpenChange={onOpenChange}
+        projectId="project-1"
+        connectionId="conn-1"
+      />
+    )
+    typeTitle()
+    fireEvent.click(screen.getByTestId('ticket-create-send-btn'))
+
+    await waitFor(() =>
+      expect(quickLaunchTicketOnConnection).toHaveBeenCalledWith(createdTicket, 'conn-1')
+    )
+    expect(quickLaunchTicket).not.toHaveBeenCalled()
+  })
+
+  it('plain Create never launches', async () => {
+    render(<TicketCreateModal open onOpenChange={onOpenChange} projectId="project-1" />)
+    typeTitle()
+    fireEvent.click(screen.getByTestId('ticket-create-btn'))
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    expect(createTicket).toHaveBeenCalledTimes(1)
+    expect(quickLaunchTicket).not.toHaveBeenCalled()
+    expect(quickLaunchTicketOnConnection).not.toHaveBeenCalled()
+  })
+
+  it('Cmd+Enter creates only; Cmd+Shift+Enter creates and sends', async () => {
+    const { unmount } = render(
+      <TicketCreateModal open onOpenChange={onOpenChange} projectId="project-1" />
+    )
+    typeTitle()
+    fireEvent.keyDown(screen.getByTestId('ticket-title-input'), { key: 'Enter', metaKey: true })
+    await waitFor(() => expect(createTicket).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    expect(quickLaunchTicket).not.toHaveBeenCalled()
+    unmount()
+    vi.clearAllMocks()
+    createTicket.mockResolvedValue(createdTicket)
+
+    render(<TicketCreateModal open onOpenChange={onOpenChange} projectId="project-1" />)
+    typeTitle()
+    fireEvent.keyDown(screen.getByTestId('ticket-title-input'), {
+      key: 'Enter',
+      ctrlKey: true,
+      shiftKey: true
+    })
+    await waitFor(() => expect(quickLaunchTicket).toHaveBeenCalledWith(createdTicket))
+    expect(createTicket).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not launch when creation fails', async () => {
+    createTicket.mockRejectedValue(new Error('boom'))
+    render(<TicketCreateModal open onOpenChange={onOpenChange} projectId="project-1" />)
+    typeTitle()
+    fireEvent.click(screen.getByTestId('ticket-create-send-btn'))
+
+    await waitFor(() => expect(createTicket).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByTestId('ticket-create-send-btn')).not.toBeDisabled())
+    expect(quickLaunchTicket).not.toHaveBeenCalled()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+})

--- a/src/renderer/src/components/kanban/TicketCreateModal.tsx
+++ b/src/renderer/src/components/kanban/TicketCreateModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
-import { Eye, EyeOff } from 'lucide-react'
+import { Eye, EyeOff, Send } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import {
@@ -21,8 +21,12 @@ import { cn } from '@/lib/utils'
 import { TicketAttachmentEditor, MAX_ATTACHMENTS } from './TicketAttachmentEditor'
 import { TicketDiscardChangesDialog } from './TicketDiscardChangesDialog'
 import type { TicketAttachment } from './TicketAttachmentEditor'
+import type { KanbanTicket } from '../../../../main/db/types'
 import { useImagePaste } from '@/hooks/useImagePaste'
 import { attachmentApi } from '@/api/attachment-api'
+import { ShortcutHint } from '@/components/ui/shortcut-hint'
+import { submitShortcutLabel } from '@/lib/shortcut-labels'
+import { quickLaunchTicket, quickLaunchTicketOnConnection } from './WorktreePickerModal'
 
 interface TicketCreateModalProps {
   open: boolean
@@ -44,7 +48,11 @@ export function TicketCreateModal({
   const [description, setDescription] = useState('')
   const [showPreview, setShowPreview] = useState(false)
   const [attachments, setAttachments] = useState<TicketAttachment[]>([])
-  const [isCreating, setIsCreating] = useState(false)
+  // Which submit is in flight — 'send' also launches the ticket right after
+  // creating it (right-button drag defaults: new worktree, build mode,
+  // default SDK/model — or a connection session on connection boards).
+  const [creatingAction, setCreatingAction] = useState<'create' | 'send' | null>(null)
+  const isCreating = creatingAction !== null
   const [selectedProjectId, setSelectedProjectId] = useState('')
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
 
@@ -148,7 +156,7 @@ export function TicketCreateModal({
       setDescription('')
       setShowPreview(false)
       setAttachments([])
-      setIsCreating(false)
+      setCreatingAction(null)
       setSelectedProjectId(initialSelectedProjectId)
       // Auto-focus the title input after dialog animation
       setTimeout(() => titleInputRef.current?.focus(), 50)
@@ -172,44 +180,61 @@ export function TicketCreateModal({
     })
 
   // ── Submission ─────────────────────────────────────────────────────
-  const handleCreate = useCallback(async () => {
-    if (!title.trim() || isCreating) return
+  const submit = useCallback(
+    async (action: 'create' | 'send') => {
+      if (!title.trim() || isCreating) return
 
-    const targetProjectId = isMultiProjectMode ? selectedProjectId : projectId
-    if (!targetProjectId) return
+      const targetProjectId = isMultiProjectMode ? selectedProjectId : projectId
+      if (!targetProjectId) return
 
-    setIsCreating(true)
-    try {
-      await createTicket(targetProjectId, {
-        project_id: targetProjectId,
-        title: title.trim(),
-        description: description.trim() || null,
-        attachments: attachments.map((a) => ({ type: a.type, url: a.url, label: a.label })),
-        column: 'todo'
-      })
-      createdSuccessfully.current = true
-      if (isPinnedMode) setPinnedBoardLastCreateProjectId(targetProjectId)
-      setShowDiscardConfirm(false)
-      toast.success('Ticket created')
-      onOpenChange(false)
-    } catch {
-      toast.error('Failed to create ticket')
-    } finally {
-      setIsCreating(false)
-    }
-  }, [
-    title,
-    description,
-    attachments,
-    isCreating,
-    createTicket,
-    projectId,
-    selectedProjectId,
-    isMultiProjectMode,
-    isPinnedMode,
-    setPinnedBoardLastCreateProjectId,
-    onOpenChange
-  ])
+      setCreatingAction(action)
+      let created: KanbanTicket
+      try {
+        created = await createTicket(targetProjectId, {
+          project_id: targetProjectId,
+          title: title.trim(),
+          description: description.trim() || null,
+          attachments: attachments.map((a) => ({ type: a.type, url: a.url, label: a.label })),
+          column: 'todo'
+        })
+        createdSuccessfully.current = true
+        if (isPinnedMode) setPinnedBoardLastCreateProjectId(targetProjectId)
+        setShowDiscardConfirm(false)
+        toast.success('Ticket created')
+        onOpenChange(false)
+      } catch {
+        toast.error('Failed to create ticket')
+        return
+      } finally {
+        setCreatingAction(null)
+      }
+
+      // Create & Send: launch exactly like a right-button drag into In
+      // Progress. Runs after the modal closes; the launch reports its own
+      // success/failure toasts.
+      if (action === 'send') {
+        if (connectionId) void quickLaunchTicketOnConnection(created, connectionId)
+        else void quickLaunchTicket(created)
+      }
+    },
+    [
+      title,
+      description,
+      attachments,
+      isCreating,
+      createTicket,
+      projectId,
+      selectedProjectId,
+      isMultiProjectMode,
+      isPinnedMode,
+      setPinnedBoardLastCreateProjectId,
+      onOpenChange,
+      connectionId
+    ]
+  )
+
+  const handleCreate = useCallback(() => submit('create'), [submit])
+  const handleCreateAndSend = useCallback(() => submit('send'), [submit])
 
   const closeImmediately = useCallback(() => {
     setShowDiscardConfirm(false)
@@ -241,11 +266,15 @@ export function TicketCreateModal({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && e.metaKey && title.trim()) {
-        handleCreate()
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && title.trim()) {
+        e.preventDefault()
+        // Cmd/Ctrl+Shift+Enter creates and sends with the default launch
+        // arguments; Cmd/Ctrl+Enter just creates.
+        if (e.shiftKey) handleCreateAndSend()
+        else handleCreate()
       }
     },
-    [handleCreate, title]
+    [handleCreate, handleCreateAndSend, title]
   )
 
   const isTitleEmpty = !title.trim()
@@ -374,11 +403,24 @@ export function TicketCreateModal({
           </Button>
           <Button
             type="button"
+            variant="secondary"
+            data-testid="ticket-create-send-btn"
+            title="Create the ticket and start it now with the default launch settings"
+            disabled={isTitleEmpty || isCreating}
+            onClick={handleCreateAndSend}
+          >
+            <Send className="h-3.5 w-3.5" />
+            {creatingAction === 'send' ? 'Sending...' : 'Create & Send'}
+            <ShortcutHint label={submitShortcutLabel({ shift: true })} />
+          </Button>
+          <Button
+            type="button"
             data-testid="ticket-create-btn"
             disabled={isTitleEmpty || isCreating}
             onClick={handleCreate}
           >
-            {isCreating ? 'Creating...' : 'Create'}
+            {creatingAction === 'create' ? 'Creating...' : 'Create'}
+            <ShortcutHint label={submitShortcutLabel()} />
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/renderer/src/components/ui/shortcut-hint.tsx
+++ b/src/renderer/src/components/ui/shortcut-hint.tsx
@@ -1,0 +1,25 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * Small inline keyboard-shortcut badge rendered inside a button next to its
+ * label so the binding is discoverable without hovering.
+ */
+export function ShortcutHint({
+  label,
+  className
+}: {
+  label: string
+  className?: string
+}): React.JSX.Element {
+  return (
+    <kbd
+      aria-hidden="true"
+      className={cn(
+        'ml-1 inline-flex h-4 items-center rounded-[4px] border border-current/20 px-1 font-sans text-[10px] font-medium leading-none opacity-60',
+        className
+      )}
+    >
+      {label}
+    </kbd>
+  )
+}

--- a/src/renderer/src/lib/shortcut-labels.ts
+++ b/src/renderer/src/lib/shortcut-labels.ts
@@ -1,0 +1,10 @@
+import { isMac } from '@/lib/platform'
+
+/**
+ * Platform-aware label for a Cmd/Ctrl(+Shift)+Enter shortcut, e.g. "⌘↵" /
+ * "⌘⇧↵" on macOS and "Ctrl+Enter" / "Ctrl+Shift+Enter" elsewhere.
+ */
+export function submitShortcutLabel(opts: { shift?: boolean } = {}): string {
+  if (isMac()) return `⌘${opts.shift ? '⇧' : ''}↵`
+  return `Ctrl+${opts.shift ? 'Shift+' : ''}Enter`
+}


### PR DESCRIPTION
## Summary

- Add Save & Send to ticket edit modals for To Do tickets.
- Add Create & Send to ticket creation modals.
- Support Cmd/Ctrl+Enter and Cmd/Ctrl+Shift+Enter shortcuts with platform-aware hints.
- Route launches through worktree or connection-board launchers.
- Prevent sending blocked tickets and add comprehensive modal tests.

## Testing

- Added Vitest coverage for save/create, send, shortcut, connection routing, blocked tickets, and failure handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only kanban modal changes reusing existing quick-launch helpers; guarded for blocked tickets and failed create/save. No auth or data-model changes.
> 
> **Overview**
> Adds **Create & Send** and **Save & Send** so users can create or edit a ticket and immediately start it with the same default launch as a right-drag into In Progress (worktree or connection session).
> 
> Ticket create and edit flows share a `submit` path: save/create first, close the modal, then call `quickLaunchTicket` or `quickLaunchTicketOnConnection`. Edit mode only shows send for **To Do** tickets and blocks sends when dependencies are unsatisfied (warning toast, no save). **Cmd/Ctrl+Enter** saves/creates only; **Cmd/Ctrl+Shift+Enter** saves/creates and sends (edit send shortcut gated when send isn’t available).
> 
> New `ShortcutHint` and `submitShortcutLabel` show platform-aware shortcut badges on the primary buttons. Vitest suites cover UI, launch routing, shortcuts, blocked tickets, and create failure (no launch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b20aebabfcc175689aa44c1f1147f63d46f2c63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->