### PR TITLE
Add Hive Enterprise forced update enforcement

### DIFF
--- a/src/renderer/src/api/hive-enterprise/client.ts
+++ b/src/renderer/src/api/hive-enterprise/client.ts
@@ -1,5 +1,6 @@
 import { GraphQLClient } from 'graphql-request'
 import { useSettingsStore, type AppSettings } from '@/stores/useSettingsStore'
+import { compareAppVersions } from '@/lib/version-compare'
 import {
   CreateAccountShareDocument,
   ListAccountMembersDocument,
@@ -40,6 +41,35 @@ type ForceBoardModeSettings = TelemetryGateSettings &
  */
 export function isForceBoardMode(settings: ForceBoardModeSettings): boolean {
   return isHiveTelemetryEnabled(settings) && settings.hiveOrganizationForceBoardMode === true
+}
+
+type ForceUpdateSettings = TelemetryGateSettings &
+  Pick<AppSettings, 'hiveOrganizationMinAppVersion'>
+
+/**
+ * Org policy: the minimum app version members must run before continuing to
+ * use Hive. Null when not signed in to an organization or when the org does
+ * not enforce one — the token+orgId gate means logging out clears a stale
+ * policy, like the other org settings.
+ */
+export function requiredHiveMinAppVersion(settings: ForceUpdateSettings): string | null {
+  if (!isHiveTelemetryEnabled(settings)) return null
+  const minVersion = settings.hiveOrganizationMinAppVersion?.trim()
+  return minVersion ? minVersion : null
+}
+
+/**
+ * True when the org enforces a minimum app version and the running app is
+ * older than it. `currentVersion` is null until the updater RPC answers —
+ * treated as "not required" so enforcement never fires on unknown versions.
+ */
+export function isHiveUpdateRequired(
+  settings: ForceUpdateSettings,
+  currentVersion: string | null
+): boolean {
+  const minVersion = requiredHiveMinAppVersion(settings)
+  if (!minVersion || !currentVersion) return false
+  return compareAppVersions(currentVersion, minVersion) < 0
 }
 
 // Enforcement of org policy reads the locally persisted flag, which can be one
@@ -251,7 +281,8 @@ export async function completeHiveEnterpriseLogin(token: string): Promise<void> 
     hiveOrganizationName: me?.organization?.name ?? null,
     hiveOrganizationStorePrompts: me?.organization?.storePrompts ?? true,
     hiveOrganizationRecordQuestions: me?.organization?.recordQuestions ?? true,
-    hiveOrganizationForceBoardMode: me?.organization?.forceBoardMode ?? false
+    hiveOrganizationForceBoardMode: me?.organization?.forceBoardMode ?? false,
+    hiveOrganizationMinAppVersion: me?.organization?.minAppVersion ?? null
   })
 }
 
@@ -261,6 +292,7 @@ async function reconcileOrgSettings(result: {
   storePrompts?: boolean | null
   recordQuestions?: boolean | null
   forceBoardMode?: boolean | null
+  minAppVersion?: string | null
 }): Promise<void> {
   const state = useSettingsStore.getState()
   const updates: Partial<AppSettings> = {}
@@ -282,6 +314,14 @@ async function reconcileOrgSettings(result: {
   ) {
     updates.hiveOrganizationForceBoardMode = result.forceBoardMode
   }
+  // Absent (old server) is not the same as null (policy cleared) — only
+  // reconcile when the server actually sent the field.
+  if (
+    result.minAppVersion !== undefined &&
+    (result.minAppVersion ?? null) !== state.hiveOrganizationMinAppVersion
+  ) {
+    updates.hiveOrganizationMinAppVersion = result.minAppVersion ?? null
+  }
   if (Object.keys(updates).length > 0) {
     await useSettingsStore.getState().updateSettings(updates)
   }
@@ -298,7 +338,8 @@ export async function refreshHiveEnterpriseOrg(): Promise<void> {
       hiveOrganizationName: me?.organization?.name ?? null,
       hiveOrganizationStorePrompts: me?.organization?.storePrompts ?? true,
       hiveOrganizationRecordQuestions: me?.organization?.recordQuestions ?? true,
-      hiveOrganizationForceBoardMode: me?.organization?.forceBoardMode ?? false
+      hiveOrganizationForceBoardMode: me?.organization?.forceBoardMode ?? false,
+      hiveOrganizationMinAppVersion: me?.organization?.minAppVersion ?? null
     })
   } catch (error) {
     console.warn('[HiveEnterprise] org refresh failed:', error)

--- a/src/renderer/src/api/hive-enterprise/generated.ts
+++ b/src/renderer/src/api/hive-enterprise/generated.ts
@@ -142,6 +142,7 @@ export type GqlOrganization = {
   __typename?: 'Organization';
   forceBoardMode: Scalars['Boolean']['output'];
   id: Scalars['InteractId']['output'];
+  minAppVersion?: Maybe<Scalars['String']['output']>;
   name: Scalars['String']['output'];
   recordQuestions: Scalars['Boolean']['output'];
   storePrompts: Scalars['Boolean']['output'];
@@ -158,6 +159,7 @@ export type GqlPromptIdleInput = {
 export type GqlPromptMutationResult = {
   __typename?: 'PromptMutationResult';
   forceBoardMode: Scalars['Boolean']['output'];
+  minAppVersion?: Maybe<Scalars['String']['output']>;
   recordQuestions: Scalars['Boolean']['output'];
   recorded: Scalars['Boolean']['output'];
   storePrompts: Scalars['Boolean']['output'];
@@ -190,6 +192,7 @@ export type GqlPromptStartInput = {
 export type GqlPromptStartResult = {
   __typename?: 'PromptStartResult';
   forceBoardMode: Scalars['Boolean']['output'];
+  minAppVersion?: Maybe<Scalars['String']['output']>;
   promptId?: Maybe<Scalars['InteractId']['output']>;
   recordQuestions: Scalars['Boolean']['output'];
   recorded: Scalars['Boolean']['output'];
@@ -227,6 +230,7 @@ export type GqlQuestionAnsweredInput = {
 export type GqlQuestionAnsweredResult = {
   __typename?: 'QuestionAnsweredResult';
   forceBoardMode: Scalars['Boolean']['output'];
+  minAppVersion?: Maybe<Scalars['String']['output']>;
   recordQuestions: Scalars['Boolean']['output'];
   recorded: Scalars['Boolean']['output'];
   storePrompts: Scalars['Boolean']['output'];
@@ -235,6 +239,7 @@ export type GqlQuestionAnsweredResult = {
 export type GqlReportActiveAccountsResult = {
   __typename?: 'ReportActiveAccountsResult';
   forceBoardMode: Scalars['Boolean']['output'];
+  minAppVersion?: Maybe<Scalars['String']['output']>;
   recordQuestions: Scalars['Boolean']['output'];
   recorded: Scalars['Boolean']['output'];
   storePrompts: Scalars['Boolean']['output'];
@@ -294,6 +299,7 @@ export type GqlHiveEnterpriseMeQuery = (
         | 'storePrompts'
         | 'recordQuestions'
         | 'forceBoardMode'
+        | 'minAppVersion'
       >
     )> }
   )> }
@@ -315,6 +321,7 @@ export type GqlHiveEnterpriseRecordPromptStartMutation = (
       | 'storePrompts'
       | 'recordQuestions'
       | 'forceBoardMode'
+      | 'minAppVersion'
     >
   ) }
 );
@@ -334,6 +341,7 @@ export type GqlHiveEnterpriseRecordPromptIdleMutation = (
       | 'storePrompts'
       | 'recordQuestions'
       | 'forceBoardMode'
+      | 'minAppVersion'
     >
   ) }
 );
@@ -353,6 +361,7 @@ export type GqlHiveEnterpriseRecordQuestionsAnsweredMutation = (
       | 'storePrompts'
       | 'recordQuestions'
       | 'forceBoardMode'
+      | 'minAppVersion'
     >
   ) }
 );
@@ -372,6 +381,7 @@ export type GqlHiveEnterpriseReportActiveAccountsMutation = (
       | 'storePrompts'
       | 'recordQuestions'
       | 'forceBoardMode'
+      | 'minAppVersion'
     >
   ) }
 );

--- a/src/renderer/src/api/hive-enterprise/operations.ts
+++ b/src/renderer/src/api/hive-enterprise/operations.ts
@@ -10,6 +10,7 @@ export const MeDocument = /* GraphQL */ `
         storePrompts
         recordQuestions
         forceBoardMode
+        minAppVersion
       }
     }
   }
@@ -23,6 +24,7 @@ export const RecordPromptStartDocument = /* GraphQL */ `
       storePrompts
       recordQuestions
       forceBoardMode
+      minAppVersion
     }
   }
 `
@@ -34,6 +36,7 @@ export const RecordPromptIdleDocument = /* GraphQL */ `
       storePrompts
       recordQuestions
       forceBoardMode
+      minAppVersion
     }
   }
 `
@@ -45,6 +48,7 @@ export const RecordQuestionsAnsweredDocument = /* GraphQL */ `
       storePrompts
       recordQuestions
       forceBoardMode
+      minAppVersion
     }
   }
 `
@@ -56,6 +60,7 @@ export const ReportActiveAccountsDocument = /* GraphQL */ `
       storePrompts
       recordQuestions
       forceBoardMode
+      minAppVersion
     }
   }
 `

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -22,6 +22,8 @@ import { useWindowFocusRefresh } from '@/hooks/useWindowFocusRefresh'
 import { useWorktreeWatcher } from '@/hooks/useWorktreeWatcher'
 import { useConnectionWatcher } from '@/hooks/useConnectionWatcher'
 import { useAutoUpdate } from '@/hooks/useAutoUpdate'
+import { useForceUpdateGuard } from '@/hooks/useForceUpdateGuard'
+import { ForceUpdateModal } from '@/components/update/ForceUpdateModal'
 import { useKeepAwake } from '@/hooks/useKeepAwake'
 import { useSleepWhenIdle } from '@/hooks/useSleepWhenIdle'
 import { useAccountScheduleRunner } from '@/hooks/useAccountScheduleRunner'
@@ -149,6 +151,8 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
   useConnectionWatcher()
   // Auto-update notifications
   useAutoUpdate()
+  // Org policy: block usage until the app meets the org's minimum version
+  useForceUpdateGuard()
   // Keep the computer awake while any session is actively streaming (opt-in via settings)
   useKeepAwake()
   // One-shot sleep after all sessions have been idle for a continuous minute.
@@ -325,6 +329,9 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
             </ErrorBoundary>
           )}
           <AgentSetupGuard />
+          <ErrorBoundary componentName="ForceUpdateModal" fallback={null}>
+            <ForceUpdateModal />
+          </ErrorBoundary>
           <HelpOverlay />
           <QuitConfirmationOverlay />
         </div>

--- a/src/renderer/src/components/settings/SettingsHiveEnterprise.tsx
+++ b/src/renderer/src/components/settings/SettingsHiveEnterprise.tsx
@@ -28,7 +28,8 @@ export function SettingsHiveEnterprise(): React.JSX.Element {
         hiveOrganizationName: me?.organization?.name ?? null,
         hiveOrganizationStorePrompts: me?.organization?.storePrompts ?? true,
         hiveOrganizationRecordQuestions: me?.organization?.recordQuestions ?? true,
-        hiveOrganizationForceBoardMode: me?.organization?.forceBoardMode ?? false
+        hiveOrganizationForceBoardMode: me?.organization?.forceBoardMode ?? false,
+        hiveOrganizationMinAppVersion: me?.organization?.minAppVersion ?? null
       })
       toast.success('Hive Enterprise account refreshed')
     } catch (error) {

--- a/src/renderer/src/components/update/ForceUpdateModal.tsx
+++ b/src/renderer/src/components/update/ForceUpdateModal.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react'
+import { DownloadCloud } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { updaterApi } from '@/api/updater-api'
+import { useForceUpdateStore, forceUpdateSnoozeLockMs } from '@/stores/useForceUpdateStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useUpdateStore } from '@/stores/useUpdateStore'
+
+// A manual check's result toasts arrive via useAutoUpdate; this window only
+// bounds the local "Checking…" button state when no event lands.
+const CHECKING_RESET_MS = 10_000
+
+/**
+ * Org policy blocker: the organization requires a newer app version. The
+ * dialog is deliberately non-dismissable (controlled `open`, no
+ * `onOpenChange`) — the only ways out are updating or the snooze button,
+ * which stays disabled for an exponentially growing period per prior snooze.
+ */
+export function ForceUpdateModal(): React.JSX.Element | null {
+  const modalOpen = useForceUpdateStore((state) => state.modalOpen)
+  const modalOpenedAt = useForceUpdateStore((state) => state.modalOpenedAt)
+  const requiredVersion = useForceUpdateStore((state) => state.requiredVersion)
+  const currentVersion = useForceUpdateStore((state) => state.currentVersion)
+  const snoozeCount = useForceUpdateStore((state) => state.snoozeCount)
+  const snooze = useForceUpdateStore((state) => state.snooze)
+  const orgName = useSettingsStore((state) => state.hiveOrganizationName)
+
+  const updateStatus = useUpdateStore((state) => state.status)
+  const percent = useUpdateStore((state) => state.percent)
+  const downloadFailed = useUpdateStore((state) => state.downloadFailed)
+  const startDownload = useUpdateStore((state) => state.startDownload)
+  const installUpdate = useUpdateStore((state) => state.installUpdate)
+
+  const [checking, setChecking] = useState(false)
+  const [now, setNow] = useState(() => Date.now())
+
+  const snoozeLockMs = forceUpdateSnoozeLockMs(snoozeCount)
+  const snoozeLockRemainingMs =
+    modalOpen && modalOpenedAt !== null ? Math.max(0, modalOpenedAt + snoozeLockMs - now) : 0
+  const snoozeLocked = snoozeLockRemainingMs > 0
+
+  // Re-anchor the countdown clock each time the modal opens.
+  useEffect(() => {
+    if (modalOpen) setNow(Date.now())
+  }, [modalOpen])
+
+  useEffect(() => {
+    if (!modalOpen || !snoozeLocked) return
+    const timer = setInterval(() => setNow(Date.now()), 250)
+    return () => clearInterval(timer)
+  }, [modalOpen, snoozeLocked])
+
+  // If no update is known when the blocker opens, look for one right away.
+  useEffect(() => {
+    if (!modalOpen) return
+    if (useUpdateStore.getState().status !== 'idle') return
+    setChecking(true)
+    void updaterApi.checkForUpdate({ manual: false }).catch(() => {})
+  }, [modalOpen])
+
+  // The check's outcome arrives via updater events (not the RPC reply); stop
+  // the spinner when the store leaves idle, or give up after a bound.
+  useEffect(() => {
+    if (!checking) return
+    if (updateStatus !== 'idle') {
+      setChecking(false)
+      return
+    }
+    const timer = setTimeout(() => setChecking(false), CHECKING_RESET_MS)
+    return () => clearTimeout(timer)
+  }, [checking, updateStatus])
+
+  if (!modalOpen || !requiredVersion) return null
+
+  const snoozeSeconds = Math.ceil(snoozeLockRemainingMs / 1000)
+
+  const handleCheck = (): void => {
+    setChecking(true)
+    void updaterApi.checkForUpdate({ manual: false }).catch(() => {})
+  }
+
+  let primaryAction: React.JSX.Element
+  if (updateStatus === 'downloaded') {
+    primaryAction = (
+      <Button data-testid="force-update-primary" onClick={installUpdate}>
+        Restart to update
+      </Button>
+    )
+  } else if (updateStatus === 'downloading') {
+    primaryAction = (
+      <Button data-testid="force-update-primary" disabled>
+        Downloading… {Math.round(percent)}%
+      </Button>
+    )
+  } else if (updateStatus === 'available') {
+    primaryAction = (
+      <Button data-testid="force-update-primary" onClick={startDownload}>
+        {downloadFailed ? 'Retry download' : 'Download update'}
+      </Button>
+    )
+  } else {
+    primaryAction = (
+      <Button data-testid="force-update-primary" onClick={handleCheck} disabled={checking}>
+        {checking ? 'Checking…' : 'Check for updates'}
+      </Button>
+    )
+  }
+
+  return (
+    <AlertDialog open={true}>
+      <AlertDialogContent data-testid="force-update-modal">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <DownloadCloud className="size-5 text-primary" />
+            Update required
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {orgName ?? 'Your organization'} requires Hive {requiredVersion} or newer. You&apos;re
+            currently on {currentVersion ?? 'an older version'}. Update to keep using Hive.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {updateStatus === 'downloading' && (
+          <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              data-testid="force-update-progress-fill"
+              className="h-full bg-primary transition-all"
+              style={{ width: `${Math.min(100, Math.max(0, percent))}%` }}
+            />
+          </div>
+        )}
+        {updateStatus === 'idle' && !checking && (
+          <p className="text-xs text-muted-foreground">
+            No update found yet — it may still be rolling out. Try again in a moment.
+          </p>
+        )}
+        <AlertDialogFooter>
+          <Button
+            data-testid="force-update-snooze"
+            variant="outline"
+            disabled={snoozeLocked}
+            onClick={() => snooze()}
+          >
+            {snoozeLocked ? `Snooze (${snoozeSeconds}s)` : 'Snooze'}
+          </Button>
+          {primaryAction}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/src/hooks/useAutoUpdate.ts
+++ b/src/renderer/src/hooks/useAutoUpdate.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { toast } from '@/lib/toast'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useUpdateStore } from '@/stores/useUpdateStore'
+import { useForceUpdateStore } from '@/stores/useForceUpdateStore'
 import { updaterApi } from '@/api/updater-api'
 
 export function useAutoUpdate(): void {
@@ -15,8 +16,11 @@ export function useAutoUpdate(): void {
         const isManual = data.isManualCheck ?? false
 
         // Suppress for "Skip this version" — a legacy setting written by the
-        // removed toast UI; still respected, but nothing sets it anymore
-        if (skippedUpdateVersion === data.version && !isManual) return
+        // removed toast UI; still respected, but nothing sets it anymore.
+        // Never suppress while the org's forced update is enforcing: the
+        // blocking modal needs the available state to offer the download.
+        const forceUpdateActive = useForceUpdateStore.getState().requiredVersion !== null
+        if (skippedUpdateVersion === data.version && !isManual && !forceUpdateActive) return
 
         useUpdateStore.getState().setAvailable(data.version, { revealDismissed: isManual })
         if (isManual) {

--- a/src/renderer/src/hooks/useForceUpdateGuard.ts
+++ b/src/renderer/src/hooks/useForceUpdateGuard.ts
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react'
+import { systemApi } from '@/api/system-api'
+import { updaterApi } from '@/api/updater-api'
+import {
+  isHiveUpdateRequired,
+  refreshHiveEnterpriseOrg,
+  requiredHiveMinAppVersion,
+  whenHiveOrgPolicySettled
+} from '@/api/hive-enterprise/client'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStatusStore, type SessionStatusType } from '@/stores/useWorktreeStatusStore'
+import {
+  FORCE_UPDATE_CHECK_INTERVAL_MS,
+  useForceUpdateStore
+} from '@/stores/useForceUpdateStore'
+
+// A session in any of these states is actively in progress — the org's forced
+// update must not interrupt it. Same set as useSleepWhenIdle's non-idle check.
+const ACTIVE_SESSION_STATUSES = new Set<SessionStatusType>([
+  'working',
+  'planning',
+  'answering',
+  'permission',
+  'command_approval'
+])
+
+/**
+ * Org policy: enforce the organization's minimum app version. Checks on
+ * launch (after the startup org refresh settles) and re-fetches the policy on
+ * window focus at most once per hour. When the running version is older, a
+ * blocking update modal opens — deferred while any session is actively
+ * running or while a snooze is in effect, and re-opened as soon as the
+ * blocker clears.
+ */
+export function useForceUpdateGuard(): void {
+  const [policySettled, setPolicySettled] = useState(false)
+  const [snoozeExpiryTick, setSnoozeExpiryTick] = useState(0)
+
+  const settingsLoading = useSettingsStore((state) => state.isLoading)
+  const hiveAuthToken = useSettingsStore((state) => state.hiveAuthToken)
+  const hiveOrganizationId = useSettingsStore((state) => state.hiveOrganizationId)
+  const hiveOrganizationMinAppVersion = useSettingsStore(
+    (state) => state.hiveOrganizationMinAppVersion
+  )
+  const currentVersion = useForceUpdateStore((state) => state.currentVersion)
+  const modalOpen = useForceUpdateStore((state) => state.modalOpen)
+  const snoozedUntil = useForceUpdateStore((state) => state.snoozedUntil)
+  const anySessionActive = useWorktreeStatusStore((state) =>
+    Object.values(state.sessionStatuses).some(
+      (entry) => entry && ACTIVE_SESSION_STATUSES.has(entry.status)
+    )
+  )
+
+  // Learn the running app version once.
+  useEffect(() => {
+    let cancelled = false
+    updaterApi
+      .getVersion()
+      .then((version) => {
+        if (!cancelled) useForceUpdateStore.getState().setCurrentVersion(version)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Launch check: wait (bounded) for the startup org refresh so a policy
+  // changed while the app was closed neither flashes nor misses the modal.
+  useEffect(() => {
+    let cancelled = false
+    void whenHiveOrgPolicySettled().then(() => {
+      if (cancelled) return
+      useForceUpdateStore.getState().markChecked()
+      setPolicySettled(true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Refocus check, at most once per hour. The refresh writes into the
+  // settings store, so evaluation below reacts on its own.
+  useEffect(() => {
+    return systemApi.onWindowFocused(() => {
+      const { lastCheckAt } = useForceUpdateStore.getState()
+      if (lastCheckAt !== null && Date.now() - lastCheckAt < FORCE_UPDATE_CHECK_INTERVAL_MS) return
+      useForceUpdateStore.getState().markChecked()
+      void refreshHiveEnterpriseOrg()
+    })
+  }, [])
+
+  useEffect((): (() => void) | undefined => {
+    if (!policySettled || settingsLoading) return undefined
+    const policySettings = { hiveAuthToken, hiveOrganizationId, hiveOrganizationMinAppVersion }
+    const store = useForceUpdateStore.getState()
+    if (!isHiveUpdateRequired(policySettings, currentVersion)) {
+      // Policy cleared (admin lowered/removed it, or logout) — stand down.
+      store.clearEnforcement()
+      return undefined
+    }
+    const minVersion = requiredHiveMinAppVersion(policySettings)
+    if (!minVersion) return undefined
+    // A running session defers enforcement — including standing the modal
+    // down if a session turns active while it is open (sessions can start
+    // with no user input, e.g. a queued follow-up draining or a background
+    // task waking its session; the blocker must never sit over a live
+    // session's permission prompt). Re-runs when the selector flips idle.
+    if (anySessionActive) {
+      store.deferForActiveSession()
+      return undefined
+    }
+    if (modalOpen) {
+      // Keep the displayed requirement current if the admin bumped it.
+      store.openModal(minVersion)
+      return undefined
+    }
+    const now = Date.now()
+    if (snoozedUntil !== null && snoozedUntil > now) {
+      const timer = setTimeout(
+        () => setSnoozeExpiryTick((tick) => tick + 1),
+        snoozedUntil - now + 250
+      )
+      return () => clearTimeout(timer)
+    }
+    store.openModal(minVersion)
+    return undefined
+  }, [
+    policySettled,
+    settingsLoading,
+    hiveAuthToken,
+    hiveOrganizationId,
+    hiveOrganizationMinAppVersion,
+    currentVersion,
+    modalOpen,
+    anySessionActive,
+    snoozedUntil,
+    snoozeExpiryTick
+  ])
+}

--- a/src/renderer/src/lib/version-compare.ts
+++ b/src/renderer/src/lib/version-compare.ts
@@ -1,0 +1,58 @@
+interface ParsedVersion {
+  core: number[]
+  prerelease: string[]
+}
+
+function parseVersion(raw: string): ParsedVersion {
+  const cleaned = raw.trim().replace(/^v/i, '')
+  const dashIndex = cleaned.indexOf('-')
+  const core = dashIndex === -1 ? cleaned : cleaned.slice(0, dashIndex)
+  const prerelease = dashIndex === -1 ? [] : cleaned.slice(dashIndex + 1).split('.')
+  const coreParts = core.split('.').map((segment) => {
+    const value = Number.parseInt(segment, 10)
+    return Number.isFinite(value) ? value : 0
+  })
+  return { core: coreParts, prerelease }
+}
+
+/**
+ * Minimal semver-ish comparison for Hive app versions ("1.2.34",
+ * "1.3.0-canary.2"). Returns negative when a < b, 0 when equal, positive when
+ * a > b. Org admins type minimum versions by hand, so malformed segments
+ * compare as 0 instead of throwing — enforcement must never crash on junk.
+ */
+export function compareAppVersions(a: string, b: string): number {
+  const pa = parseVersion(a)
+  const pb = parseVersion(b)
+  const coreLength = Math.max(pa.core.length, pb.core.length)
+  for (let i = 0; i < coreLength; i++) {
+    const diff = (pa.core[i] ?? 0) - (pb.core[i] ?? 0)
+    if (diff !== 0) return diff
+  }
+  // Same core: a release outranks any of its prereleases (1.3.0 > 1.3.0-canary.1).
+  if (pa.prerelease.length === 0 && pb.prerelease.length === 0) return 0
+  if (pa.prerelease.length === 0) return 1
+  if (pb.prerelease.length === 0) return -1
+  const preLength = Math.max(pa.prerelease.length, pb.prerelease.length)
+  for (let i = 0; i < preLength; i++) {
+    const sa = pa.prerelease[i]
+    const sb = pb.prerelease[i]
+    // Semver: a shorter prerelease list sorts before a longer one.
+    if (sa === undefined) return -1
+    if (sb === undefined) return 1
+    const aNumeric = /^\d+$/.test(sa)
+    const bNumeric = /^\d+$/.test(sb)
+    if (aNumeric && bNumeric) {
+      const diff = Number.parseInt(sa, 10) - Number.parseInt(sb, 10)
+      if (diff !== 0) return diff
+    } else if (aNumeric) {
+      // Semver: numeric identifiers sort before alphanumeric ones.
+      return -1
+    } else if (bNumeric) {
+      return 1
+    } else if (sa !== sb) {
+      return sa < sb ? -1 : 1
+    }
+  }
+  return 0
+}

--- a/src/renderer/src/stores/useForceUpdateStore.ts
+++ b/src/renderer/src/stores/useForceUpdateStore.ts
@@ -1,0 +1,101 @@
+import { create } from 'zustand'
+
+/** Snooze always hides the modal for 2 minutes (or until conditions are met). */
+export const FORCE_UPDATE_SNOOZE_MS = 2 * 60 * 1000
+/** Re-fetch the org's minimum-version policy at most once per hour on refocus. */
+export const FORCE_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000
+
+const SNOOZE_LOCK_BASE_MS = 10_000
+const SNOOZE_LOCK_MAX_MS = 2 * 60 * 1000
+
+/**
+ * How long the snooze button stays disabled after the modal (re)opens:
+ * instant on first open, then 10s, 20s, 40s, 80s… doubling per prior snooze
+ * until pinned at 2 minutes.
+ */
+export function forceUpdateSnoozeLockMs(snoozeCount: number): number {
+  if (snoozeCount <= 0) return 0
+  return Math.min(SNOOZE_LOCK_MAX_MS, SNOOZE_LOCK_BASE_MS * 2 ** (snoozeCount - 1))
+}
+
+interface ForceUpdateStoreState {
+  /** Running app version, learned from the updater RPC; null until it answers. */
+  currentVersion: string | null
+  modalOpen: boolean
+  /** When the modal last opened — anchors the snooze-lock countdown. */
+  modalOpenedAt: number | null
+  /** Org minimum version the open modal is enforcing. */
+  requiredVersion: string | null
+  snoozeCount: number
+  snoozedUntil: number | null
+  /** Last time the policy was checked (launch or focus refresh). */
+  lastCheckAt: number | null
+
+  setCurrentVersion: (version: string) => void
+  markChecked: (now?: number) => void
+  openModal: (requiredVersion: string, now?: number) => void
+  snooze: (now?: number) => void
+  deferForActiveSession: () => void
+  clearEnforcement: () => void
+}
+
+export const useForceUpdateStore = create<ForceUpdateStoreState>()((set, get) => ({
+  currentVersion: null,
+  modalOpen: false,
+  modalOpenedAt: null,
+  requiredVersion: null,
+  snoozeCount: 0,
+  snoozedUntil: null,
+  lastCheckAt: null,
+
+  setCurrentVersion: (version) => {
+    set({ currentVersion: version })
+  },
+
+  markChecked: (now = Date.now()) => {
+    set({ lastCheckAt: now })
+  },
+
+  openModal: (requiredVersion, now = Date.now()) => {
+    if (get().modalOpen) {
+      // Admin bumped the minimum while the modal is up — refresh the copy but
+      // keep modalOpenedAt so the snooze lock doesn't restart.
+      if (get().requiredVersion !== requiredVersion) set({ requiredVersion })
+      return
+    }
+    set({ modalOpen: true, modalOpenedAt: now, requiredVersion, snoozedUntil: null })
+  },
+
+  snooze: (now = Date.now()) => {
+    const { modalOpen, snoozeCount } = get()
+    if (!modalOpen) return
+    set({
+      modalOpen: false,
+      modalOpenedAt: null,
+      snoozeCount: snoozeCount + 1,
+      snoozedUntil: now + FORCE_UPDATE_SNOOZE_MS
+    })
+  },
+
+  // A session became active while the modal was up — stand down without
+  // spending a snooze (count and any pending snooze window untouched), so
+  // the modal reopens as soon as sessions go idle again.
+  deferForActiveSession: () => {
+    if (!get().modalOpen) return
+    set({ modalOpen: false, modalOpenedAt: null })
+  },
+
+  clearEnforcement: () => {
+    const { modalOpen, requiredVersion, snoozeCount, snoozedUntil } = get()
+    if (!modalOpen && requiredVersion === null && snoozeCount === 0 && snoozedUntil === null) {
+      return
+    }
+    set({
+      modalOpen: false,
+      modalOpenedAt: null,
+      requiredVersion: null,
+      snoozeCount: 0,
+      snoozedUntil: null
+    })
+  }
+}))

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -174,6 +174,7 @@ export interface AppSettings {
   hiveOrganizationStorePrompts: boolean
   hiveOrganizationRecordQuestions: boolean
   hiveOrganizationForceBoardMode: boolean
+  hiveOrganizationMinAppVersion: string | null
 
   // Tips
   tipsEnabled: boolean
@@ -274,6 +275,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   hiveOrganizationStorePrompts: true,
   hiveOrganizationRecordQuestions: true,
   hiveOrganizationForceBoardMode: false,
+  hiveOrganizationMinAppVersion: null,
   tipsEnabled: true,
   telegramConfig: null,
   teleport: null,
@@ -487,6 +489,7 @@ function extractSettings(state: SettingsState): AppSettings {
     hiveOrganizationStorePrompts: state.hiveOrganizationStorePrompts,
     hiveOrganizationRecordQuestions: state.hiveOrganizationRecordQuestions,
     hiveOrganizationForceBoardMode: state.hiveOrganizationForceBoardMode,
+    hiveOrganizationMinAppVersion: state.hiveOrganizationMinAppVersion,
     tipsEnabled: state.tipsEnabled,
     telegramConfig: null,
     teleport: state.teleport,
@@ -858,6 +861,7 @@ export const useSettingsStore = create<SettingsState>()(
         hiveOrganizationStorePrompts: state.hiveOrganizationStorePrompts,
         hiveOrganizationRecordQuestions: state.hiveOrganizationRecordQuestions,
         hiveOrganizationForceBoardMode: state.hiveOrganizationForceBoardMode,
+        hiveOrganizationMinAppVersion: state.hiveOrganizationMinAppVersion,
         tipsEnabled: state.tipsEnabled,
         pet: state.pet,
         environmentVariables: state.environmentVariables,

--- a/test/update-pill/use-auto-update.test.ts
+++ b/test/update-pill/use-auto-update.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { useAutoUpdate } from '@/hooks/useAutoUpdate'
 import { useUpdateStore } from '@/stores/useUpdateStore'
+import { useForceUpdateStore } from '@/stores/useForceUpdateStore'
 import { toast } from '@/lib/toast'
 import type {
   UpdaterAvailablePayload,
@@ -90,6 +91,7 @@ describe('useAutoUpdate', () => {
       downloadFailed: false,
       dismissedVersion: null
     })
+    useForceUpdateStore.getState().clearEnforcement()
   })
 
   it('drives the update store through the full update lifecycle', () => {
@@ -121,6 +123,15 @@ describe('useAutoUpdate', () => {
       description: 'Download it from the button at the bottom of the sidebar',
       action: expect.objectContaining({ label: 'Download' })
     })
+  })
+
+  it('ignores a stale skipped version while a forced update is enforcing', () => {
+    renderHook(() => useAutoUpdate())
+    mockSkippedUpdateVersion = '1.3.0'
+    useForceUpdateStore.getState().openModal('1.3.0')
+
+    handlers.available?.({ version: '1.3.0' })
+    expect(useUpdateStore.getState().status).toBe('available')
   })
 
   it('reports the actual download state when a manual check re-announces', () => {

--- a/test/update/force-update-gate.test.ts
+++ b/test/update/force-update-gate.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { isHiveUpdateRequired, requiredHiveMinAppVersion } from '@/api/hive-enterprise/client'
+
+const mockSettings: Record<string, unknown> = {}
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: Object.assign(
+    (selector?: (s: unknown) => unknown) => (selector ? selector(mockSettings) : mockSettings),
+    {
+      getState: () => mockSettings
+    }
+  )
+}))
+
+const orgSettings = {
+  hiveAuthToken: 'token-1',
+  hiveOrganizationId: 'org-1',
+  hiveOrganizationMinAppVersion: '1.5.0'
+}
+
+describe('requiredHiveMinAppVersion', () => {
+  it('returns the org minimum only while logged in to an org', () => {
+    expect(requiredHiveMinAppVersion(orgSettings)).toBe('1.5.0')
+    expect(requiredHiveMinAppVersion({ ...orgSettings, hiveAuthToken: null })).toBeNull()
+    expect(requiredHiveMinAppVersion({ ...orgSettings, hiveOrganizationId: null })).toBeNull()
+  })
+
+  it('treats null/blank policy values as not enforced', () => {
+    expect(
+      requiredHiveMinAppVersion({ ...orgSettings, hiveOrganizationMinAppVersion: null })
+    ).toBeNull()
+    expect(
+      requiredHiveMinAppVersion({ ...orgSettings, hiveOrganizationMinAppVersion: '   ' })
+    ).toBeNull()
+  })
+})
+
+describe('isHiveUpdateRequired', () => {
+  it('requires an update only when the running version is older than the minimum', () => {
+    expect(isHiveUpdateRequired(orgSettings, '1.4.9')).toBe(true)
+    expect(isHiveUpdateRequired(orgSettings, '1.5.0')).toBe(false)
+    expect(isHiveUpdateRequired(orgSettings, '1.5.1')).toBe(false)
+    expect(isHiveUpdateRequired(orgSettings, '2.0.0')).toBe(false)
+  })
+
+  it('never fires while the running version is unknown', () => {
+    expect(isHiveUpdateRequired(orgSettings, null)).toBe(false)
+  })
+
+  it('never fires without an org login or an enforced minimum', () => {
+    expect(isHiveUpdateRequired({ ...orgSettings, hiveAuthToken: null }, '1.0.0')).toBe(false)
+    expect(
+      isHiveUpdateRequired({ ...orgSettings, hiveOrganizationMinAppVersion: null }, '1.0.0')
+    ).toBe(false)
+  })
+
+  it('counts a prerelease of the minimum as older than it', () => {
+    expect(isHiveUpdateRequired(orgSettings, '1.5.0-canary.3')).toBe(true)
+  })
+})

--- a/test/update/force-update-guard.test.tsx
+++ b/test/update/force-update-guard.test.tsx
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useForceUpdateGuard } from '@/hooks/useForceUpdateGuard'
+import { FORCE_UPDATE_SNOOZE_MS, useForceUpdateStore } from '@/stores/useForceUpdateStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+
+let focusCallback: (() => void) | null = null
+
+vi.mock('@/api/system-api', () => ({
+  systemApi: {
+    onWindowFocused: (callback: () => void): (() => void) => {
+      focusCallback = callback
+      return () => {
+        focusCallback = null
+      }
+    }
+  }
+}))
+
+const getVersionMock = vi.fn(() => Promise.resolve('1.0.0'))
+
+vi.mock('@/api/updater-api', () => ({
+  updaterApi: {
+    getVersion: (): Promise<string> => getVersionMock(),
+    checkForUpdate: vi.fn(() => Promise.resolve())
+  }
+}))
+
+const refreshOrgMock = vi.fn(() => Promise.resolve())
+
+vi.mock('@/api/hive-enterprise/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/hive-enterprise/client')>()
+  return {
+    ...actual,
+    whenHiveOrgPolicySettled: (): Promise<void> => Promise.resolve(),
+    refreshHiveEnterpriseOrg: (): Promise<void> => refreshOrgMock()
+  }
+})
+
+vi.mock('@/stores/useSettingsStore', async () => {
+  const { create } = await import('zustand')
+  return {
+    useSettingsStore: create(() => ({
+      isLoading: false,
+      hiveAuthToken: 'token-1' as string | null,
+      hiveOrganizationId: 'org-1' as string | null,
+      hiveOrganizationMinAppVersion: null as string | null,
+      hiveOrganizationName: 'Acme' as string | null
+    }))
+  }
+})
+
+vi.mock('@/stores/useWorktreeStatusStore', async () => {
+  const { create } = await import('zustand')
+  return {
+    useWorktreeStatusStore: create(() => ({
+      sessionStatuses: {} as Record<string, { status: string; timestamp: number } | null>
+    }))
+  }
+})
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function working(): { status: 'working'; timestamp: number } {
+  return { status: 'working', timestamp: 0 }
+}
+
+describe('useForceUpdateGuard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    focusCallback = null
+    getVersionMock.mockImplementation(() => Promise.resolve('1.0.0'))
+    useSettingsStore.setState({
+      isLoading: false,
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1',
+      hiveOrganizationMinAppVersion: null
+    })
+    useWorktreeStatusStore.setState({ sessionStatuses: {} })
+    useForceUpdateStore.setState({
+      currentVersion: null,
+      modalOpen: false,
+      modalOpenedAt: null,
+      requiredVersion: null,
+      snoozeCount: 0,
+      snoozedUntil: null,
+      lastCheckAt: null
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('opens the blocking modal on launch when the app is older than the org minimum', async () => {
+    useSettingsStore.setState({ hiveOrganizationMinAppVersion: '2.0.0' })
+    renderHook(() => useForceUpdateGuard())
+    await flush()
+    const state = useForceUpdateStore.getState()
+    expect(state.modalOpen).toBe(true)
+    expect(state.requiredVersion).toBe('2.0.0')
+    expect(state.lastCheckAt).not.toBeNull()
+  })
+
+  it('stays quiet when the app already meets the minimum', async () => {
+    useSettingsStore.setState({ hiveOrganizationMinAppVersion: '0.5.0' })
+    renderHook(() => useForceUpdateGuard())
+    await flush()
+    expect(useForceUpdateStore.getState().modalOpen).toBe(false)
+  })
+
+  it('stays quiet without an org login even when a stale minimum is cached', async () => {
+    useSettingsStore.setState({ hiveAuthToken: null, hiveOrganizationMinAppVersion: '2.0.0' })
+    renderHook(() => useForceUpdateGuard())
+    await flush()
+    expect(useForceUpdateStore.getState().modalOpen).toBe(false)
+  })
+
+  it('defers the modal while a session is actively running and opens once it goes idle', async () => {
+    useWorktreeStatusStore.setState({ sessionStatuses: { s1: working() } })
+    useSettingsStore.setState({ hiveOrganizationMinAppVersion: '2.0.0' })
+    renderHook(() => useForceUpdateGuard())
+    await flush()
+    expect(useForceUpdateStore.getState().modalOpen).toBe(false)
+
+    await act(async () => {
+      useWorktreeStatusStore.setState({
+        sessionStatuses: { s1: { status: 'completed', timestamp: 0 } }
+      })
+    })
+    await flush()
+    expect(useForceUpdateStore.getState().modalOpen).toBe(true)
+  })
+
+  it('reopens the modal 2 minutes after a snooze', async () => {
+    useSettingsStore.setState({ hiveOrganizationMinAppVersion: '2.0.0' })
+    renderHook(() => useForceUpdateGuard())
+    await flush()
+    expect(useForceUpdateStore.getState().modalOpen).toBe(true)
+
+    await act(async () => {
+      useForceUpdateStore.getState().snooze()
+    })
+    expect(useForceUpdateStore.getState().modalOpen).toBe(false)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FORCE_UPDATE_SNOOZE_MS + 1_000)
+    })
+    expect(useForceUpdateStore.getState().modalOpen).toBe(true)
+    expect(useForceUpdateStore.getState().snoozeCount).toBe(1)
+  })
+
+  it('after a snooze expires mid-session, reopens only once the session goes idle', async () => {
+    useSettingsStore.setState({ hiveOrganizationMinAppVersion: '2.0.0' })
+    renderHook(() => useForceUpdateGuard())
+    await flush()
+
+    await act(async () => {
+      useForceUpdateStore.getState().snooze()
+      useWorktreeStatusStore.setState({ sessionStatuses: { s1: working() } })
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FORCE_UPDATE_SNOOZE_MS + 1_000)
+    })
+    expect(useForceUpdateStore.getState().modalOpen).toBe(false)
+
+    await act(async () => {
+      useWorktreeStatusStore.setState({ sessionStatuses: {} })
+    })
+    await flush()
+    expect(useForceUpdateStore.getState().modalOpen).toBe(true)
+  })
+
+  it('stands the modal down when a session turns active and reopens on idle, without spending a snooze', async () => {
+    useSettingsStore.setState({ hiveOrganizationMinAppVersion: '2.0.0' })
+    renderHook(() => useForceUpdateGuard())
+    await flush()
+    expect(useForceUpdateStore.getState().modalOpen).toBe(true)
+
+    await act(async () => {
+      useWorktreeStatusStore.setState({ sessionStatuses: { s1: working() } })
+    })
+    await flush()
+    expect(useForceUpdateStore.getState().modalOpen).toBe(false)
+    expect(useForceUpdateStore.getState().snoozeCount).toBe(0)
+
+    await act(async () => {
+      useWorktreeStatusStore.setState({ sessionStatuses: {} })
+    })
+    await flush()
+    expect(useForceUpdateStore.getState().modalOpen).toBe(true)
+  })
+
+  it('closes the modal and resets snoozes when the admin clears the policy', async () => {
+    useSettingsStore.setState({ hiveOrganizationMinAppVersion: '2.0.0' })
+    renderHook(() => useForceUpdateGuard())
+    await flush()
+    expect(useForceUpdateStore.getState().modalOpen).toBe(true)
+
+    await act(async () => {
+      useSettingsStore.setState({ hiveOrganizationMinAppVersion: null })
+    })
+    await flush()
+    const state = useForceUpdateStore.getState()
+    expect(state.modalOpen).toBe(false)
+    expect(state.requiredVersion).toBeNull()
+    expect(state.snoozeCount).toBe(0)
+  })
+
+  it('re-fetches org settings on focus at most once per hour', async () => {
+    renderHook(() => useForceUpdateGuard())
+    await flush()
+    refreshOrgMock.mockClear()
+
+    // The launch check just happened — a focus right after is throttled.
+    act(() => focusCallback?.())
+    expect(refreshOrgMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(61 * 60 * 1000)
+    })
+    act(() => focusCallback?.())
+    expect(refreshOrgMock).toHaveBeenCalledTimes(1)
+
+    // Another focus straight away stays throttled.
+    act(() => focusCallback?.())
+    expect(refreshOrgMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/update/force-update-modal.test.tsx
+++ b/test/update/force-update-modal.test.tsx
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ForceUpdateModal } from '@/components/update/ForceUpdateModal'
+import { useForceUpdateStore } from '@/stores/useForceUpdateStore'
+import { useUpdateStore } from '@/stores/useUpdateStore'
+
+const checkForUpdateMock = vi.fn(() => Promise.resolve())
+const downloadUpdateMock = vi.fn(() => Promise.resolve())
+const installUpdateMock = vi.fn(() => Promise.resolve())
+
+vi.mock('@/api/updater-api', () => ({
+  updaterApi: {
+    checkForUpdate: (options?: { manual?: boolean }): Promise<void> => checkForUpdateMock(options),
+    downloadUpdate: (): Promise<void> => downloadUpdateMock(),
+    installUpdate: (): Promise<void> => installUpdateMock()
+  }
+}))
+
+const mockSettings: Record<string, unknown> = { hiveOrganizationName: 'Acme' }
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: Object.assign(
+    (selector?: (s: unknown) => unknown) => (selector ? selector(mockSettings) : mockSettings),
+    {
+      getState: () => mockSettings
+    }
+  )
+}))
+
+function openModal(overrides: Partial<ReturnType<typeof useForceUpdateStore.getState>> = {}): void {
+  useForceUpdateStore.setState({
+    currentVersion: '1.0.0',
+    modalOpen: true,
+    modalOpenedAt: Date.now(),
+    requiredVersion: '2.0.0',
+    snoozeCount: 0,
+    snoozedUntil: null,
+    lastCheckAt: null,
+    ...overrides
+  })
+}
+
+describe('ForceUpdateModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useForceUpdateStore.setState({
+      currentVersion: '1.0.0',
+      modalOpen: false,
+      modalOpenedAt: null,
+      requiredVersion: null,
+      snoozeCount: 0,
+      snoozedUntil: null,
+      lastCheckAt: null
+    })
+    useUpdateStore.setState({
+      status: 'idle',
+      version: null,
+      percent: 0,
+      downloadFailed: false,
+      dismissedVersion: null
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders nothing while enforcement is not active', () => {
+    render(<ForceUpdateModal />)
+    expect(screen.queryByTestId('force-update-modal')).not.toBeInTheDocument()
+  })
+
+  it('shows the org requirement and auto-checks for an update when none is known', () => {
+    openModal()
+    render(<ForceUpdateModal />)
+    expect(screen.getByTestId('force-update-modal')).toBeInTheDocument()
+    expect(screen.getByText(/Acme requires Hive 2\.0\.0 or newer/)).toBeInTheDocument()
+    expect(screen.getByText(/currently on 1\.0\.0/)).toBeInTheDocument()
+    expect(checkForUpdateMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('force-update-primary')).toBeDisabled()
+    expect(screen.getByTestId('force-update-primary')).toHaveTextContent('Checking…')
+  })
+
+  it('snooze is instantly available before any snooze and hides the modal for 2 minutes', () => {
+    openModal()
+    render(<ForceUpdateModal />)
+    const snooze = screen.getByTestId('force-update-snooze')
+    expect(snooze).toBeEnabled()
+    fireEvent.click(snooze)
+    const state = useForceUpdateStore.getState()
+    expect(state.modalOpen).toBe(false)
+    expect(state.snoozeCount).toBe(1)
+    expect(state.snoozedUntil).toBeGreaterThan(Date.now())
+  })
+
+  it('after one snooze the button reopens locked for 10s, counting down', () => {
+    vi.useFakeTimers()
+    openModal({ snoozeCount: 1, modalOpenedAt: Date.now() })
+    render(<ForceUpdateModal />)
+    const snooze = screen.getByTestId('force-update-snooze')
+    expect(snooze).toBeDisabled()
+    expect(snooze).toHaveTextContent('Snooze (10s)')
+
+    act(() => {
+      vi.advanceTimersByTime(10_500)
+    })
+    expect(screen.getByTestId('force-update-snooze')).toBeEnabled()
+    expect(screen.getByTestId('force-update-snooze')).toHaveTextContent('Snooze')
+  })
+
+  it('locks snooze for the full 2 minutes once the backoff is pinned', () => {
+    vi.useFakeTimers()
+    openModal({ snoozeCount: 9, modalOpenedAt: Date.now() })
+    render(<ForceUpdateModal />)
+    expect(screen.getByTestId('force-update-snooze')).toBeDisabled()
+    expect(screen.getByTestId('force-update-snooze')).toHaveTextContent('Snooze (120s)')
+  })
+
+  it('offers the download when an update is available and starts it on click', () => {
+    useUpdateStore.setState({ status: 'available', version: '2.1.0' })
+    openModal()
+    render(<ForceUpdateModal />)
+    expect(checkForUpdateMock).not.toHaveBeenCalled()
+    const primary = screen.getByTestId('force-update-primary')
+    expect(primary).toHaveTextContent('Download update')
+    fireEvent.click(primary)
+    expect(downloadUpdateMock).toHaveBeenCalledTimes(1)
+    expect(useUpdateStore.getState().status).toBe('downloading')
+  })
+
+  it('shows download progress and installs once downloaded', () => {
+    useUpdateStore.setState({ status: 'downloading', percent: 40 })
+    openModal()
+    render(<ForceUpdateModal />)
+    expect(screen.getByTestId('force-update-primary')).toBeDisabled()
+    expect(screen.getByTestId('force-update-primary')).toHaveTextContent('Downloading… 40%')
+    expect(screen.getByTestId('force-update-progress-fill')).toBeInTheDocument()
+
+    act(() => {
+      useUpdateStore.getState().setDownloaded('2.1.0')
+    })
+    const primary = screen.getByTestId('force-update-primary')
+    expect(primary).toHaveTextContent('Restart to update')
+    fireEvent.click(primary)
+    expect(installUpdateMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/update/force-update-store.test.ts
+++ b/test/update/force-update-store.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  FORCE_UPDATE_SNOOZE_MS,
+  forceUpdateSnoozeLockMs,
+  useForceUpdateStore
+} from '@/stores/useForceUpdateStore'
+
+function resetStore(): void {
+  useForceUpdateStore.setState({
+    currentVersion: null,
+    modalOpen: false,
+    modalOpenedAt: null,
+    requiredVersion: null,
+    snoozeCount: 0,
+    snoozedUntil: null,
+    lastCheckAt: null
+  })
+}
+
+describe('forceUpdateSnoozeLockMs', () => {
+  it('is instant at first, then doubles from 10s and pins at 2 minutes', () => {
+    expect(forceUpdateSnoozeLockMs(0)).toBe(0)
+    expect(forceUpdateSnoozeLockMs(1)).toBe(10_000)
+    expect(forceUpdateSnoozeLockMs(2)).toBe(20_000)
+    expect(forceUpdateSnoozeLockMs(3)).toBe(40_000)
+    expect(forceUpdateSnoozeLockMs(4)).toBe(80_000)
+    expect(forceUpdateSnoozeLockMs(5)).toBe(120_000)
+    expect(forceUpdateSnoozeLockMs(6)).toBe(120_000)
+    expect(forceUpdateSnoozeLockMs(50)).toBe(120_000)
+  })
+})
+
+describe('useForceUpdateStore', () => {
+  beforeEach(resetStore)
+
+  it('opens the modal, clears any pending snooze, and anchors the open time', () => {
+    useForceUpdateStore.setState({ snoozedUntil: 999 })
+    useForceUpdateStore.getState().openModal('1.5.0', 1_000)
+    const state = useForceUpdateStore.getState()
+    expect(state.modalOpen).toBe(true)
+    expect(state.modalOpenedAt).toBe(1_000)
+    expect(state.requiredVersion).toBe('1.5.0')
+    expect(state.snoozedUntil).toBeNull()
+  })
+
+  it('re-opening while open updates the required version without restarting the lock anchor', () => {
+    useForceUpdateStore.getState().openModal('1.5.0', 1_000)
+    useForceUpdateStore.getState().openModal('1.6.0', 2_000)
+    const state = useForceUpdateStore.getState()
+    expect(state.requiredVersion).toBe('1.6.0')
+    expect(state.modalOpenedAt).toBe(1_000)
+  })
+
+  it('snooze closes the modal for 2 minutes and increments the count', () => {
+    useForceUpdateStore.getState().openModal('1.5.0', 1_000)
+    useForceUpdateStore.getState().snooze(5_000)
+    const state = useForceUpdateStore.getState()
+    expect(state.modalOpen).toBe(false)
+    expect(state.snoozeCount).toBe(1)
+    expect(state.snoozedUntil).toBe(5_000 + FORCE_UPDATE_SNOOZE_MS)
+  })
+
+  it('snooze is a no-op while the modal is closed', () => {
+    useForceUpdateStore.getState().snooze(5_000)
+    expect(useForceUpdateStore.getState().snoozeCount).toBe(0)
+    expect(useForceUpdateStore.getState().snoozedUntil).toBeNull()
+  })
+
+  it('successive snoozes keep doubling the lock the modal reopens with', () => {
+    for (let i = 1; i <= 3; i++) {
+      useForceUpdateStore.getState().openModal('1.5.0', i * 10_000)
+      useForceUpdateStore.getState().snooze(i * 10_000)
+    }
+    expect(useForceUpdateStore.getState().snoozeCount).toBe(3)
+    expect(forceUpdateSnoozeLockMs(useForceUpdateStore.getState().snoozeCount)).toBe(40_000)
+  })
+
+  it('deferForActiveSession closes the modal without touching the snooze state', () => {
+    useForceUpdateStore.getState().openModal('1.5.0', 1_000)
+    useForceUpdateStore.getState().snooze(2_000)
+    useForceUpdateStore.getState().openModal('1.5.0', 3_000)
+    useForceUpdateStore.getState().deferForActiveSession()
+    const state = useForceUpdateStore.getState()
+    expect(state.modalOpen).toBe(false)
+    expect(state.snoozeCount).toBe(1)
+    expect(state.requiredVersion).toBe('1.5.0')
+  })
+
+  it('deferForActiveSession is a no-op while the modal is closed', () => {
+    useForceUpdateStore.getState().deferForActiveSession()
+    expect(useForceUpdateStore.getState().modalOpen).toBe(false)
+    expect(useForceUpdateStore.getState().snoozeCount).toBe(0)
+  })
+
+  it('clearEnforcement resets modal, snooze count, and pending snooze', () => {
+    useForceUpdateStore.getState().openModal('1.5.0', 1_000)
+    useForceUpdateStore.getState().snooze(2_000)
+    useForceUpdateStore.getState().clearEnforcement()
+    const state = useForceUpdateStore.getState()
+    expect(state.modalOpen).toBe(false)
+    expect(state.requiredVersion).toBeNull()
+    expect(state.snoozeCount).toBe(0)
+    expect(state.snoozedUntil).toBeNull()
+  })
+
+  it('clearEnforcement leaves lastCheckAt and currentVersion alone', () => {
+    useForceUpdateStore.getState().setCurrentVersion('1.2.3')
+    useForceUpdateStore.getState().markChecked(42)
+    useForceUpdateStore.getState().openModal('1.5.0')
+    useForceUpdateStore.getState().clearEnforcement()
+    expect(useForceUpdateStore.getState().currentVersion).toBe('1.2.3')
+    expect(useForceUpdateStore.getState().lastCheckAt).toBe(42)
+  })
+})

--- a/test/update/version-compare.test.ts
+++ b/test/update/version-compare.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { compareAppVersions } from '@/lib/version-compare'
+
+describe('compareAppVersions', () => {
+  it('orders plain numeric versions', () => {
+    expect(compareAppVersions('1.2.3', '1.2.4')).toBeLessThan(0)
+    expect(compareAppVersions('1.2.4', '1.2.3')).toBeGreaterThan(0)
+    expect(compareAppVersions('1.2.3', '1.2.3')).toBe(0)
+    expect(compareAppVersions('1.10.0', '1.9.9')).toBeGreaterThan(0)
+    expect(compareAppVersions('2.0.0', '1.99.99')).toBeGreaterThan(0)
+  })
+
+  it('treats missing segments as zero', () => {
+    expect(compareAppVersions('1.2', '1.2.0')).toBe(0)
+    expect(compareAppVersions('1.2', '1.2.1')).toBeLessThan(0)
+    expect(compareAppVersions('1.3', '1.2.9')).toBeGreaterThan(0)
+  })
+
+  it('ignores a leading v and surrounding whitespace', () => {
+    expect(compareAppVersions('v1.2.3', '1.2.3')).toBe(0)
+    expect(compareAppVersions(' 1.2.3 ', '1.2.3')).toBe(0)
+  })
+
+  it('ranks a release above its prereleases', () => {
+    expect(compareAppVersions('1.3.0-canary.1', '1.3.0')).toBeLessThan(0)
+    expect(compareAppVersions('1.3.0', '1.3.0-canary.1')).toBeGreaterThan(0)
+    // ...but a prerelease of a NEWER core still wins.
+    expect(compareAppVersions('1.4.0-canary.1', '1.3.0')).toBeGreaterThan(0)
+  })
+
+  it('orders prerelease identifiers numerically then lexically', () => {
+    expect(compareAppVersions('1.3.0-canary.2', '1.3.0-canary.10')).toBeLessThan(0)
+    expect(compareAppVersions('1.3.0-alpha', '1.3.0-beta')).toBeLessThan(0)
+    expect(compareAppVersions('1.3.0-canary', '1.3.0-canary.1')).toBeLessThan(0)
+    expect(compareAppVersions('1.3.0-canary.1', '1.3.0-canary.1')).toBe(0)
+  })
+
+  it('never throws on junk — malformed segments compare as zero', () => {
+    expect(compareAppVersions('banana', '0.0.0')).toBe(0)
+    expect(compareAppVersions('1.x.3', '1.0.3')).toBe(0)
+    expect(compareAppVersions('', '0')).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Add organization minimum-version policy support through Hive Enterprise GraphQL settings.
- Compare app versions and enforce updates with a non-dismissable modal, download/install actions, and escalating snooze delays.
- Defer enforcement during active sessions and re-check policy on window focus.
- Add comprehensive coverage for version comparison, guard behavior, modal interactions, store state, and update handling.

## Testing
- Added Vitest coverage for forced update gating, guard behavior, modal UI, store transitions, version comparison, and auto-update integration.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Blocks the main UI for org members on outdated builds and ties behavior to version parsing and session-state deferral; mistakes could strand users or interrupt live work, though snooze and active-session deferral limit blast radius.
> 
> **Overview**
> Adds **Hive Enterprise minimum app version** policy: the org’s `minAppVersion` is synced from GraphQL (login, org refresh, and telemetry echo responses) into `hiveOrganizationMinAppVersion`, with helpers to decide when the running build is below the floor.
> 
> When enforcement applies, **`useForceUpdateGuard`** (wired from `AppLayout`) compares the live app version to the policy after startup org policy settles, re-fetches on window focus (hourly cap), and opens a **non-dismissable `ForceUpdateModal`** that drives check/download/restart via the existing updater. Enforcement **defers during active sessions** (modal stands down without consuming snooze), honors **2-minute snoozes** with **escalating snooze-button lock**, and clears when the policy is removed or the app is new enough. **`useAutoUpdate`** no longer suppresses “skipped version” while a forced update is active so the modal can reach `available`.
> 
> New **`compareAppVersions`** handles semver-ish strings safely for hand-entered minimums. Vitest covers gating, guard timing, modal UX, store transitions, version compare, and auto-update integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ad7a9e00c8c013fb6b63b88e64fdad0a68302c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->