### PR TITLE
Report app version to Hive Enterprise

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2,8 +2,10 @@ import { useEffect, useRef, useState } from 'react'
 import {
   isHiveTelemetryEnabled,
   markHiveOrgPolicySettled,
-  refreshHiveEnterpriseOrg
+  refreshHiveEnterpriseOrg,
+  reportHiveAppVersion
 } from '@/api/hive-enterprise/client'
+import { updaterApi } from '@/api/updater-api'
 import { AppLayout } from '@/components/layout'
 import { DesktopWindowEscapeChrome } from '@/components/layout/DesktopWindowEscapeChrome'
 import { ErrorBoundary } from '@/components/error'
@@ -43,6 +45,7 @@ function App(): React.JSX.Element {
     didRefreshHiveOrg.current = true
     void refreshHiveEnterpriseOrg().finally(markHiveOrgPolicySettled)
     void reportActiveAccountsSnapshot()
+    void updaterApi.getVersion().then(reportHiveAppVersion).catch(() => {})
   }, [hiveAuthToken, hiveOrganizationId, settingsLoading])
 
   if (!ready) return <DesktopWindowEscapeChrome boot />

--- a/src/renderer/src/api/hive-enterprise/client.ts
+++ b/src/renderer/src/api/hive-enterprise/client.ts
@@ -8,7 +8,8 @@ import {
   RecordPromptIdleDocument,
   RecordPromptStartDocument,
   RecordQuestionsAnsweredDocument,
-  ReportActiveAccountsDocument
+  ReportActiveAccountsDocument,
+  ReportAppVersionDocument
 } from './operations'
 import type {
   GqlHiveEnterpriseListAccountMembersQuery,
@@ -20,7 +21,9 @@ import type {
   GqlHiveEnterpriseRecordQuestionsAnsweredMutation,
   GqlHiveEnterpriseRecordQuestionsAnsweredMutationVariables,
   GqlHiveEnterpriseReportActiveAccountsMutation,
-  GqlHiveEnterpriseReportActiveAccountsMutationVariables
+  GqlHiveEnterpriseReportActiveAccountsMutationVariables,
+  GqlHiveEnterpriseReportAppVersionMutation,
+  GqlHiveEnterpriseReportAppVersionMutationVariables
 } from './generated'
 
 type TelemetryGateSettings = Pick<AppSettings, 'hiveAuthToken' | 'hiveOrganizationId'>
@@ -245,6 +248,26 @@ export async function fetchHiveAccountMembers(): Promise<
   } catch (error) {
     console.warn('[HiveEnterprise] listAccountMembers failed:', error)
     return null
+  }
+}
+
+/**
+ * Report the running app version so the org's members page can show which
+ * version each member last launched. Fired once per launch (and after an org
+ * login) from App; fire-and-forget — a failure only loses this launch's
+ * report. Echoes org settings back like the other telemetry mutations.
+ */
+export async function reportHiveAppVersion(version: string): Promise<void> {
+  const settings = useSettingsStore.getState()
+  if (!isHiveTelemetryEnabled(settings)) return
+  try {
+    const data = await requestWithRefresh<
+      GqlHiveEnterpriseReportAppVersionMutation,
+      GqlHiveEnterpriseReportAppVersionMutationVariables
+    >(ReportAppVersionDocument, { version })
+    await reconcileOrgSettings(data.reportAppVersion)
+  } catch (error) {
+    console.warn('[HiveEnterprise] reportAppVersion failed:', error)
   }
 }
 

--- a/src/renderer/src/api/hive-enterprise/generated.ts
+++ b/src/renderer/src/api/hive-enterprise/generated.ts
@@ -61,6 +61,8 @@ export type GqlMember = {
   __typename?: 'Member';
   email: Scalars['String']['output'];
   id: Scalars['InteractId']['output'];
+  lastAppVersion?: Maybe<Scalars['String']['output']>;
+  lastAppVersionAt?: Maybe<Scalars['String']['output']>;
   name?: Maybe<Scalars['String']['output']>;
   picture?: Maybe<Scalars['String']['output']>;
   role: GqlUserRole;
@@ -83,6 +85,7 @@ export type GqlMutation = {
   recordQuestionsAnswered: GqlQuestionAnsweredResult;
   removeMember: Scalars['Boolean']['output'];
   reportActiveAccounts: GqlReportActiveAccountsResult;
+  reportAppVersion: GqlPromptMutationResult;
   reportSessionUsage: GqlPromptMutationResult;
 };
 
@@ -131,6 +134,11 @@ export type GqlMutationRemoveMemberArgs = {
 
 export type GqlMutationReportActiveAccountsArgs = {
   accounts: Array<GqlActiveAccountInput>;
+};
+
+
+export type GqlMutationReportAppVersionArgs = {
+  version: Scalars['String']['input'];
 };
 
 
@@ -377,6 +385,26 @@ export type GqlHiveEnterpriseReportActiveAccountsMutation = (
     { __typename?: 'ReportActiveAccountsResult' }
     & Pick<
       GqlReportActiveAccountsResult,
+      | 'recorded'
+      | 'storePrompts'
+      | 'recordQuestions'
+      | 'forceBoardMode'
+      | 'minAppVersion'
+    >
+  ) }
+);
+
+export type GqlHiveEnterpriseReportAppVersionMutationVariables = Exact<{
+  version: Scalars['String']['input'];
+}>;
+
+
+export type GqlHiveEnterpriseReportAppVersionMutation = (
+  { __typename?: 'Mutation' }
+  & { reportAppVersion: (
+    { __typename?: 'PromptMutationResult' }
+    & Pick<
+      GqlPromptMutationResult,
       | 'recorded'
       | 'storePrompts'
       | 'recordQuestions'

--- a/src/renderer/src/api/hive-enterprise/operations.ts
+++ b/src/renderer/src/api/hive-enterprise/operations.ts
@@ -65,6 +65,18 @@ export const ReportActiveAccountsDocument = /* GraphQL */ `
   }
 `
 
+export const ReportAppVersionDocument = /* GraphQL */ `
+  mutation HiveEnterpriseReportAppVersion($version: String!) {
+    reportAppVersion(version: $version) {
+      recorded
+      storePrompts
+      recordQuestions
+      forceBoardMode
+      minAppVersion
+    }
+  }
+`
+
 export const CreateAccountShareDocument = /* GraphQL */ `
   mutation HiveEnterpriseCreateAccountShare($provider: AccountProvider!, $encryptedPayload: String!) {
     createAccountShare(provider: $provider, encryptedPayload: $encryptedPayload) {


### PR DESCRIPTION
## Summary
- Report the running app version to Hive Enterprise after app initialization.
- Add the GraphQL mutation and generated types for app version reporting.
- Reconcile organization settings from the mutation response.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, fire-and-forget telemetry addition gated on existing org login; no changes to auth or local enforcement beyond reusing the standard org-settings reconcile path.
> 
> **Overview**
> When a user is signed into Hive Enterprise, the app now **reports the running desktop version** once per launch (alongside the existing org refresh and active-accounts snapshot). The version comes from `updaterApi.getVersion()` and is sent via a new **`reportAppVersion`** GraphQL mutation; failures are ignored so startup is unaffected.
> 
> The Hive Enterprise client adds **`reportHiveAppVersion`**, following the same telemetry gate and **org-settings reconciliation** pattern as other mutations (`storePrompts`, `minAppVersion`, etc.). Generated types also expose **`lastAppVersion`** / **`lastAppVersionAt`** on members for the org members UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4977990587fb0100234ed65b2b6940407978d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->