### PR TITLE
Add GitLab merge request support

### DIFF
--- a/src/main/effect/git/facade.ts
+++ b/src/main/effect/git/facade.ts
@@ -77,6 +77,9 @@ export const humanMessage = (error: GitError): string => {
   if (error instanceof GitUnknown && /GitHub CLI is not installed|spawn gh ENOENT|gh: command not found/i.test(stderr)) {
     return 'GitHub CLI is not installed or not in PATH'
   }
+  if (error instanceof GitUnknown && /GitLab CLI \(glab\) is not installed|spawn glab ENOENT|glab: command not found/i.test(stderr)) {
+    return 'GitLab CLI (glab) is not installed or not in PATH'
+  }
   return stderr || (error instanceof Error ? error.message : String(error))
 }
 

--- a/src/main/effect/git/layers.ts
+++ b/src/main/effect/git/layers.ts
@@ -8,6 +8,8 @@ import { Effect, Either, Layer, Ref } from 'effect'
 import simpleGit, { type SimpleGit, type BranchSummary } from 'simple-git'
 
 import { getImageMimeType } from '@shared/types/file-utils'
+import { detectForgeRemote, extractPullRequestUrl, parsePullRequestNumber, pullRequestHeadRef } from '@shared/git-forge'
+import { glabCreateMergeRequest } from '../../services/gitlab-cli'
 import { selectUniqueBreedName } from '../../services/breed-names'
 import { normalizeWorktreePath } from '../../services/path-utils'
 import { classifyGitError } from './classifier'
@@ -831,7 +833,19 @@ const make = Effect.gen(function* () {
             const autoPull = options?.autoPull !== false
             const createScript = options?.worktreeCreateScript ?? null
             let pullResult = { success: true, updated: false }
-            if (prNumber != null) await git.raw(['fetch', 'origin', `pull/${prNumber}/head`])
+            if (prNumber != null) {
+              let headRef = pullRequestHeadRef('github', prNumber)
+              try {
+                const remotes = await git.getRemotes(true)
+                const origin = remotes.find((r) => r.name === 'origin') ?? remotes[0]
+                const originUrl = origin?.refs?.fetch || origin?.refs?.push || null
+                const forge = detectForgeRemote(originUrl)?.forge
+                if (forge) headRef = pullRequestHeadRef(forge, prNumber)
+              } catch {
+                // Fall back to the GitHub ref shape when remotes can't be read.
+              }
+              await git.raw(['fetch', 'origin', headRef])
+            }
             else if (autoPull) {
               try {
                 const remotes = await git.getRemotes()
@@ -1261,8 +1275,36 @@ const make = Effect.gen(function* () {
         if (invalidBranch(options.baseBranch)) {
           return Effect.succeed({ success: false as const, error: 'Invalid branch name' })
         }
-        return writeOp(repoPath, 'gh pr create', async () => {
+        return writeOp(repoPath, 'gh pr create', async (git) => {
           const baseBranch = options.baseBranch.replace(/^[^/]+\//, '')
+
+          let remoteUrl: string | null = null
+          try {
+            const remotes = await git.getRemotes(true)
+            const origin = remotes.find((r) => r.name === 'origin') ?? remotes[0]
+            remoteUrl = origin?.refs?.fetch || origin?.refs?.push || null
+          } catch {
+            remoteUrl = null
+          }
+          const forgeRemote = detectForgeRemote(remoteUrl)
+          if (forgeRemote?.forge === 'gitlab') {
+            const runCommand = (
+              file: string,
+              args: ReadonlyArray<string>,
+              opts: { readonly cwd: string; readonly maxBuffer?: number }
+            ): Promise<{ stdout: string; stderr: string }> =>
+              execFileAsync(file, [...args], { cwd: opts.cwd, ...(opts.maxBuffer ? { maxBuffer: opts.maxBuffer } : {}) })
+            const result = await glabCreateMergeRequest(
+              runCommand,
+              repoPath,
+              { remote: forgeRemote, remoteUrl },
+              { baseBranch, title: options.title, body: options.body }
+            )
+            return result.success
+              ? { success: true as const, url: result.url ?? '', number: result.number }
+              : { success: false as const, error: result.error ?? 'Merge request creation failed', url: result.url, number: result.number }
+          }
+
           const tempDir = mkdtempSync(join(tmpdir(), 'hive-gh-pr-'))
           const tempFile = join(tempDir, 'body.md')
           try {
@@ -1274,14 +1316,12 @@ const make = Effect.gen(function* () {
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error)
             if (/already exists/i.test(message)) {
-              const urlMatch = message.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/)
-              const prUrl = urlMatch?.[0]
-              const numMatch = prUrl?.match(/\/pull\/(\d+)/)
+              const prUrl = extractPullRequestUrl(message) ?? undefined
               return {
                 success: false as const,
                 error: message,
                 url: prUrl,
-                number: numMatch ? parseInt(numMatch[1], 10) : undefined
+                number: parsePullRequestNumber(prUrl) ?? undefined
               }
             }
             throw error
@@ -1296,7 +1336,9 @@ const make = Effect.gen(function* () {
           Effect.mapError((error) =>
             /spawn gh ENOENT|gh: command not found/i.test(error.stderrExcerpt ?? '')
               ? new GitUnknown({ ...error, stderrExcerpt: 'GitHub CLI is not installed or not in PATH' })
-              : error
+              : /spawn glab ENOENT|glab: command not found/i.test(error.stderrExcerpt ?? '')
+                ? new GitUnknown({ ...error, stderrExcerpt: 'GitLab CLI (glab) is not installed or not in PATH' })
+                : error
           )
         )
       }

--- a/src/main/services/__tests__/gitlab-cli.test.ts
+++ b/src/main/services/__tests__/gitlab-cli.test.ts
@@ -1,0 +1,526 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  describeGlabError,
+  GITLAB_MR_DISCUSSIONS_QUERY,
+  gitlabRepoContextFromRemoteUrl,
+  glabCreateMergeRequest,
+  glabFindOpenMergeRequestForBranch,
+  glabGetMergeRequest,
+  glabGetMergeRequestReviewComments,
+  glabListOpenMergeRequests,
+  glabMergeMergeRequest,
+  mapGitLabDiscussionToComments,
+  parseGitLabGlobalId,
+  parseMergeRequestRecord,
+  type CliCommandRunner
+} from '../gitlab-cli'
+
+const CTX = gitlabRepoContextFromRemoteUrl('git@gitlab.tedooo.com:backend/a-team.git')
+
+const runner = (
+  impl: (file: string, args: ReadonlyArray<string>) => Promise<{ stdout: string; stderr: string }>
+): { run: CliCommandRunner; calls: Array<{ file: string; args: ReadonlyArray<string> }> } => {
+  const calls: Array<{ file: string; args: ReadonlyArray<string> }> = []
+  const run: CliCommandRunner = async (file, args, _options) => {
+    calls.push({ file, args })
+    return impl(file, args)
+  }
+  return { run, calls }
+}
+
+const execError = (message: string, stderr = ''): Error & { stderr: string } =>
+  Object.assign(new Error(message), { stderr })
+
+describe('gitlabRepoContextFromRemoteUrl', () => {
+  it('derives host and full path from an scp remote', () => {
+    expect(CTX.remote).toMatchObject({
+      forge: 'gitlab',
+      host: 'gitlab.tedooo.com',
+      path: 'backend/a-team'
+    })
+  })
+})
+
+describe('describeGlabError', () => {
+  it('maps ENOENT to a not-installed message', () => {
+    expect(describeGlabError(execError('spawn glab ENOENT'))).toBe(
+      'GitLab CLI (glab) is not installed'
+    )
+  })
+
+  it('maps unauthenticated hosts to an auth instruction with the host name', () => {
+    const error = execError(
+      'ERROR: none of the git remotes configured for this repository point to a known GitLab host. Please use `glab auth login` to authenticate and configure a new host for glab.'
+    )
+    expect(describeGlabError(error, 'gitlab.tedooo.com')).toBe(
+      'GitLab CLI (glab) is not authenticated for gitlab.tedooo.com. Run `glab auth login --hostname gitlab.tedooo.com` and try again.'
+    )
+  })
+
+  it('maps 401 responses to the auth instruction', () => {
+    expect(describeGlabError(execError('GET https://gitlab.com/api/v4/user: 401'), null)).toContain(
+      'not authenticated'
+    )
+  })
+
+  it('passes other stderr through', () => {
+    expect(describeGlabError(execError('exit status 1', 'something broke'))).toBe('something broke')
+  })
+})
+
+describe('parseMergeRequestRecord', () => {
+  it('parses a snake_case GitLab API record and normalises state', () => {
+    expect(
+      parseMergeRequestRecord({
+        iid: 12,
+        title: 'Add thing',
+        state: 'opened',
+        source_branch: 'feat',
+        target_branch: 'main',
+        web_url: 'https://gitlab.tedooo.com/backend/a-team/-/merge_requests/12',
+        author: { username: 'mor' }
+      })
+    ).toEqual({
+      iid: 12,
+      title: 'Add thing',
+      state: 'OPEN',
+      rawState: 'opened',
+      sourceBranch: 'feat',
+      targetBranch: 'main',
+      webUrl: 'https://gitlab.tedooo.com/backend/a-team/-/merge_requests/12',
+      author: 'mor'
+    })
+  })
+
+  it('normalises merged and closed states', () => {
+    expect(parseMergeRequestRecord({ iid: 1, state: 'merged' })?.state).toBe('MERGED')
+    expect(parseMergeRequestRecord({ iid: 1, state: 'closed' })?.state).toBe('CLOSED')
+    expect(parseMergeRequestRecord({ iid: 1, state: 'locked' })?.state).toBe('OPEN')
+  })
+
+  it('rejects records without an iid', () => {
+    expect(parseMergeRequestRecord({ title: 'x' })).toBeNull()
+    expect(parseMergeRequestRecord(null)).toBeNull()
+  })
+})
+
+describe('glabCreateMergeRequest', () => {
+  it('creates an MR non-interactively and parses the URL from stdout', async () => {
+    const { run, calls } = runner(async () => ({
+      stdout: '!13 Add thing (feat)\n https://gitlab.tedooo.com/backend/a-team/-/merge_requests/13\n',
+      stderr: ''
+    }))
+
+    const result = await glabCreateMergeRequest(run, '/repo', CTX, {
+      baseBranch: 'main',
+      title: 'Add thing',
+      body: 'Body text'
+    })
+
+    expect(result).toEqual({
+      success: true,
+      url: 'https://gitlab.tedooo.com/backend/a-team/-/merge_requests/13',
+      number: 13
+    })
+    expect(calls[0]).toEqual({
+      file: 'glab',
+      args: [
+        'mr',
+        'create',
+        '--target-branch',
+        'main',
+        '--title',
+        'Add thing',
+        '--description',
+        'Body text',
+        '--yes'
+      ]
+    })
+  })
+
+  it('recovers the MR via mr list when stdout has no URL', async () => {
+    const { run, calls } = runner(async (file, args) => {
+      if (file === 'glab' && args[1] === 'create') return { stdout: '!7 Add thing (feat)\n', stderr: '' }
+      if (file === 'git') return { stdout: 'feat\n', stderr: '' }
+      if (file === 'glab' && args[1] === 'list') {
+        return {
+          stdout: JSON.stringify([
+            {
+              iid: 7,
+              state: 'opened',
+              source_branch: 'feat',
+              web_url: 'https://gitlab.tedooo.com/backend/a-team/-/merge_requests/7'
+            }
+          ]),
+          stderr: ''
+        }
+      }
+      throw new Error(`unexpected ${file} ${args.join(' ')}`)
+    })
+
+    const result = await glabCreateMergeRequest(run, '/repo', CTX, {
+      baseBranch: 'main',
+      title: 'Add thing',
+      body: ''
+    })
+
+    expect(result).toEqual({
+      success: true,
+      url: 'https://gitlab.tedooo.com/backend/a-team/-/merge_requests/7',
+      number: 7
+    })
+    expect(calls.map((c) => `${c.file} ${c.args.slice(0, 2).join(' ')}`)).toEqual([
+      'glab mr create',
+      'git branch --show-current',
+      'glab mr list'
+    ])
+  })
+
+  it('returns the existing MR details when one already exists for the branch', async () => {
+    const { run } = runner(async (file, args) => {
+      if (file === 'glab' && args[1] === 'create') {
+        throw execError(
+          'exit status 1',
+          'ERROR: 409 Conflict: Another open merge request already exists for this source branch: !4'
+        )
+      }
+      if (file === 'git') return { stdout: 'feat\n', stderr: '' }
+      throw new Error(`unexpected ${file} ${args.join(' ')}`)
+    })
+
+    const result = await glabCreateMergeRequest(run, '/repo', CTX, {
+      baseBranch: 'main',
+      title: 'Add thing',
+      body: ''
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.number).toBe(4)
+    expect(result.url).toBe('https://gitlab.tedooo.com/backend/a-team/-/merge_requests/4')
+    expect(result.error).toContain('already exists')
+  })
+
+  it('never passes a bare "-" description (glab would open an editor)', async () => {
+    const { run, calls } = runner(async () => ({
+      stdout: 'https://gitlab.tedooo.com/backend/a-team/-/merge_requests/2\n',
+      stderr: ''
+    }))
+
+    await glabCreateMergeRequest(run, '/repo', CTX, { baseBranch: 'main', title: 't', body: '-' })
+
+    const descriptionIndex = calls[0].args.indexOf('--description')
+    expect(calls[0].args[descriptionIndex + 1]).not.toBe('-')
+  })
+
+  it('maps a missing glab binary to the not-installed error', async () => {
+    const { run } = runner(async () => {
+      throw execError('spawn glab ENOENT')
+    })
+
+    const result = await glabCreateMergeRequest(run, '/repo', CTX, {
+      baseBranch: 'main',
+      title: 't',
+      body: ''
+    })
+    expect(result).toEqual({ success: false, error: 'GitLab CLI (glab) is not installed' })
+  })
+})
+
+describe('glabMergeMergeRequest', () => {
+  it('merges with auto-merge disabled and --yes', async () => {
+    const { run, calls } = runner(async () => ({ stdout: '', stderr: '' }))
+    const result = await glabMergeMergeRequest(run, '/repo', CTX, 12)
+    expect(result).toEqual({ success: true })
+    expect(calls[0]).toEqual({
+      file: 'glab',
+      args: ['mr', 'merge', '12', '--yes', '--auto-merge=false']
+    })
+  })
+
+  it('falls back to the plain merge on old glab without --auto-merge', async () => {
+    const { run, calls } = runner(async (_file, args) => {
+      if (args.includes('--auto-merge=false')) {
+        throw execError('unknown flag: --auto-merge')
+      }
+      return { stdout: '', stderr: '' }
+    })
+    const result = await glabMergeMergeRequest(run, '/repo', CTX, 12)
+    expect(result).toEqual({ success: true })
+    expect(calls[1].args).toEqual(['mr', 'merge', '12', '--yes'])
+  })
+
+  it('reports non-mergeable MRs with a helpful message', async () => {
+    const { run } = runner(async () => {
+      throw execError('exit status 1', 'PUT ...: 405 Method Not Allowed')
+    })
+    const result = await glabMergeMergeRequest(run, '/repo', CTX, 12)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('cannot be merged yet')
+  })
+})
+
+describe('glabGetMergeRequest / glabListOpenMergeRequests', () => {
+  it('reads MR state via mr view -F json', async () => {
+    const { run, calls } = runner(async () => ({
+      stdout: JSON.stringify({ iid: 3, title: 'T', state: 'merged', target_branch: 'main' }),
+      stderr: ''
+    }))
+    const mr = await glabGetMergeRequest(run, '/repo', 3)
+    expect(mr).toMatchObject({ iid: 3, state: 'MERGED', targetBranch: 'main' })
+    expect(calls[0].args).toEqual(['mr', 'view', '3', '-F', 'json'])
+  })
+
+  it('lists open MRs and tolerates a notice line before the JSON', async () => {
+    const { run, calls } = runner(async () => ({
+      stdout:
+        'A new version of glab has been released\n' +
+        JSON.stringify([
+          { iid: 5, title: 'Five', state: 'opened', source_branch: 'f5', author: { username: 'a' } },
+          { iid: 4, title: 'Four', state: 'merged', source_branch: 'f4', author: { username: 'b' } }
+        ]),
+      stderr: ''
+    }))
+    const mrs = await glabListOpenMergeRequests(run, '/repo')
+    expect(mrs).toHaveLength(1)
+    expect(mrs[0]).toMatchObject({ iid: 5, author: 'a', sourceBranch: 'f5' })
+    expect(calls[0].args).toEqual(['mr', 'list', '-F', 'json', '--per-page', '100'])
+  })
+
+  it('finds an open MR by source branch', async () => {
+    const { run, calls } = runner(async () => ({
+      stdout: JSON.stringify([
+        { iid: 9, state: 'opened', source_branch: 'feat', web_url: 'https://x/-/merge_requests/9' }
+      ]),
+      stderr: ''
+    }))
+    const mr = await glabFindOpenMergeRequestForBranch(run, '/repo', 'feat')
+    expect(mr?.iid).toBe(9)
+    expect(calls[0].args).toContain('--source-branch')
+  })
+})
+
+describe('parseGitLabGlobalId', () => {
+  it('extracts the numeric tail of a gid', () => {
+    expect(parseGitLabGlobalId('gid://gitlab/DiffNote/12345')).toBe(12345)
+    expect(parseGitLabGlobalId('gid://gitlab/Note/7')).toBe(7)
+    expect(parseGitLabGlobalId('gid://gitlab/Discussion/abcdef')).toBeNull()
+    expect(parseGitLabGlobalId(null)).toBeNull()
+  })
+})
+
+describe('mapGitLabDiscussionToComments', () => {
+  const diffNote = (
+    id: number,
+    body: string,
+    position: Record<string, unknown> | null = {
+      positionType: 'text',
+      newPath: 'src/a.ts',
+      oldPath: 'src/a.ts',
+      newLine: 10,
+      oldLine: null
+    }
+  ) => ({
+    id: `gid://gitlab/DiffNote/${id}`,
+    body,
+    bodyHtml: `<p>${body}</p>`,
+    system: false,
+    createdAt: '2026-08-19T10:00:00Z',
+    updatedAt: '2026-08-19T10:00:00Z',
+    author: { username: 'mor', avatarUrl: '/uploads/avatar.png' },
+    position
+  })
+
+  it('maps a diff discussion thread with replies onto PRReviewComment', () => {
+    const discussion = {
+      id: 'gid://gitlab/Discussion/abc',
+      notes: {
+        nodes: [
+          diffNote(100, 'root comment'),
+          { ...diffNote(101, 'a reply'), position: null }
+        ]
+      }
+    }
+    const comments = mapGitLabDiscussionToComments(discussion, CTX)
+    expect(comments).toHaveLength(2)
+    expect(comments[0]).toMatchObject({
+      id: 100,
+      body: 'root comment',
+      bodyHTML: '<p>root comment</p>',
+      path: 'src/a.ts',
+      line: 10,
+      originalLine: null,
+      side: 'RIGHT',
+      inReplyToId: null,
+      pullRequestReviewId: null,
+      subjectType: 'line',
+      user: {
+        login: 'mor',
+        avatarUrl: 'https://gitlab.tedooo.com/uploads/avatar.png'
+      }
+    })
+    expect(comments[1]).toMatchObject({ id: 101, inReplyToId: 100 })
+  })
+
+  it('marks deleted-line comments as LEFT with originalLine', () => {
+    const discussion = {
+      notes: {
+        nodes: [
+          diffNote(200, 'old side', {
+            positionType: 'text',
+            newPath: 'src/a.ts',
+            oldPath: 'src/a.ts',
+            newLine: null,
+            oldLine: 42
+          })
+        ]
+      }
+    }
+    const [comment] = mapGitLabDiscussionToComments(discussion, CTX)
+    expect(comment).toMatchObject({ side: 'LEFT', line: null, originalLine: 42 })
+  })
+
+  it('maps file-level positions to subjectType file', () => {
+    const discussion = {
+      notes: {
+        nodes: [
+          diffNote(300, 'file note', {
+            positionType: 'file',
+            newPath: 'src/a.ts',
+            oldPath: 'src/a.ts',
+            newLine: null,
+            oldLine: null
+          })
+        ]
+      }
+    }
+    const [comment] = mapGitLabDiscussionToComments(discussion, CTX)
+    expect(comment).toMatchObject({ subjectType: 'file', line: null, originalLine: null })
+  })
+
+  it('drops non-diff discussions and system notes', () => {
+    expect(
+      mapGitLabDiscussionToComments(
+        { notes: { nodes: [{ ...diffNote(400, 'general talk'), position: null }] } },
+        CTX
+      )
+    ).toEqual([])
+    expect(
+      mapGitLabDiscussionToComments(
+        { notes: { nodes: [{ ...diffNote(401, 'changed this line'), system: true }] } },
+        CTX
+      )
+    ).toEqual([])
+  })
+})
+
+describe('glabGetMergeRequestReviewComments', () => {
+  it('queries GraphQL with string variables and pages the discussions connection', async () => {
+    let call = 0
+    const { run, calls } = runner(async () => {
+      call++
+      const page1 = {
+        data: {
+          project: {
+            mergeRequest: {
+              targetBranch: 'main',
+              discussions: {
+                pageInfo: { hasNextPage: true, endCursor: 'CURSOR1' },
+                nodes: [
+                  {
+                    notes: {
+                      nodes: [
+                        {
+                          id: 'gid://gitlab/DiffNote/1',
+                          body: 'first',
+                          system: false,
+                          author: { username: 'a', avatarUrl: 'https://x/a.png' },
+                          position: { positionType: 'text', newPath: 'f.ts', newLine: 1 }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+      const page2 = {
+        data: {
+          project: {
+            mergeRequest: {
+              targetBranch: 'main',
+              discussions: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [
+                  {
+                    notes: {
+                      nodes: [
+                        {
+                          id: 'gid://gitlab/DiffNote/2',
+                          body: 'second',
+                          system: false,
+                          author: { username: 'b', avatarUrl: 'https://x/b.png' },
+                          position: { positionType: 'text', newPath: 'g.ts', newLine: 2 }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+      return { stdout: JSON.stringify(call === 1 ? page1 : page2), stderr: '' }
+    })
+
+    const result = await glabGetMergeRequestReviewComments(run, '/repo', CTX, 12)
+
+    expect(result.success).toBe(true)
+    expect(result.baseBranch).toBe('main')
+    expect(result.comments?.map((c) => c.id)).toEqual([1, 2])
+
+    // Variables travel as raw strings (-f): iid is String! in the schema.
+    expect(calls[0].args).toEqual([
+      'api',
+      'graphql',
+      '-f',
+      `query=${GITLAB_MR_DISCUSSIONS_QUERY}`,
+      '-f',
+      'fullPath=backend/a-team',
+      '-f',
+      'iid=12'
+    ])
+    expect(calls[1].args).toContain('after=CURSOR1')
+  })
+
+  it('surfaces GraphQL errors', async () => {
+    const { run } = runner(async () => ({
+      stdout: JSON.stringify({ errors: [{ message: 'Invalid token' }] }),
+      stderr: ''
+    }))
+    const result = await glabGetMergeRequestReviewComments(run, '/repo', CTX, 12)
+    expect(result).toEqual({ success: false, error: 'Invalid token' })
+  })
+
+  it('reports a missing MR', async () => {
+    const { run } = runner(async () => ({
+      stdout: JSON.stringify({ data: { project: { mergeRequest: null } } }),
+      stderr: ''
+    }))
+    const result = await glabGetMergeRequestReviewComments(run, '/repo', CTX, 999)
+    expect(result).toEqual({ success: false, error: 'Merge request not found' })
+  })
+
+  it('maps a missing glab binary to the not-installed error', async () => {
+    const { run } = runner(async () => {
+      throw execError('spawn glab ENOENT')
+    })
+    const result = await glabGetMergeRequestReviewComments(run, '/repo', CTX, 1)
+    expect(result).toEqual({ success: false, error: 'GitLab CLI (glab) is not installed' })
+  })
+})
+
+// Keep vi imported for parity with sibling test files' patterns.
+void vi

--- a/src/main/services/discord-pr-creator.ts
+++ b/src/main/services/discord-pr-creator.ts
@@ -5,6 +5,7 @@ import {
   type GitPushResult,
   type GitService
 } from './git-service'
+import { detectForge } from '@shared/git-forge'
 import { generatePRContent as defaultGeneratePRContent } from './pr-content-generator'
 import { createLogger } from './logger'
 
@@ -40,6 +41,7 @@ export interface GitServiceLike {
     title: string
     body: string
   }): Promise<{ success: boolean; url?: string; number?: number; error?: string }>
+  getRemoteUrl?(remote?: string): Promise<{ success: boolean; url: string | null }>
 }
 
 export interface CreatePrDeps {
@@ -90,6 +92,14 @@ export async function createPrFromWorktree(
       return { status: 'nothing' }
     }
 
+    let forge: 'github' | 'gitlab' | null = null
+    try {
+      const remote = await git.getRemoteUrl?.()
+      forge = detectForge(remote?.url)
+    } catch {
+      forge = null
+    }
+
     let title = ''
     let body = ''
     try {
@@ -100,7 +110,8 @@ export async function createPrFromWorktree(
         diffSummary: range.diffSummary,
         diffPatch: range.diffPatch,
         provider: 'claude-code',
-        cwd: input.worktreePath
+        cwd: input.worktreePath,
+        ...(forge ? { forge } : {})
       })
       title = content.title
       body = content.body
@@ -145,11 +156,19 @@ function friendly(error: unknown): string {
       message
     )
   ) {
-    return 'This worktree is not connected to a GitHub repository with a usable remote.'
+    return 'This worktree is not connected to a GitHub or GitLab repository with a usable remote.'
   }
 
   if (/github cli is not installed|gh: command not found|spawn gh enoent/i.test(message)) {
     return 'GitHub CLI is not installed or not in PATH.'
+  }
+
+  if (/gitlab cli \(glab\) is not installed|glab: command not found|spawn glab enoent/i.test(message)) {
+    return 'GitLab CLI (glab) is not installed or not in PATH.'
+  }
+
+  if (/glab auth login|none of the git remotes .* known gitlab host/i.test(message)) {
+    return message
   }
 
   if (/gh auth login|authentication required|not logged in|not authenticated/i.test(message)) {

--- a/src/main/services/discord-push.test.ts
+++ b/src/main/services/discord-push.test.ts
@@ -127,7 +127,7 @@ describe('pushWorktree', () => {
     expect(result).toEqual({
       status: 'error',
       message:
-        'Failed to push branch: This worktree is not connected to a GitHub repository with a usable remote.'
+        'Failed to push branch: This worktree is not connected to a GitHub or GitLab repository with a usable remote.'
     })
   })
 })

--- a/src/main/services/discord-push.ts
+++ b/src/main/services/discord-push.ts
@@ -78,7 +78,7 @@ function friendly(error: unknown): string {
       message
     )
   ) {
-    return 'This worktree is not connected to a GitHub repository with a usable remote.'
+    return 'This worktree is not connected to a GitHub or GitLab repository with a usable remote.'
   }
 
   return message

--- a/src/main/services/git-forge-remote.ts
+++ b/src/main/services/git-forge-remote.ts
@@ -1,0 +1,36 @@
+import simpleGit from 'simple-git'
+import { detectForgeRemote, type ForgeRemote, type GitForge } from '@shared/git-forge'
+
+export interface RepoForgeInfo {
+  readonly forge: GitForge
+  readonly remote: ForgeRemote
+  readonly remoteUrl: string
+}
+
+/**
+ * Which PR host (GitHub / GitLab) the repository at `cwd` pushes to, read from
+ * its `origin` remote (falling back to the first remote). Null when there is
+ * no remote, the directory is not a repo, or the host is neither GitHub nor
+ * GitLab — callers treat null as "behave like before" (GitHub / `gh`).
+ *
+ * Never throws.
+ */
+export async function resolveRepoForge(
+  cwd: string,
+  remoteName = 'origin'
+): Promise<RepoForgeInfo | null> {
+  try {
+    const remotes = await simpleGit(cwd).getRemotes(true)
+    if (!Array.isArray(remotes) || remotes.length === 0) return null
+    const target = remotes.find((candidate) => candidate.name === remoteName) ?? remotes[0]
+    const url = target?.refs?.fetch || target?.refs?.push || null
+    if (!url) return null
+    const remote = detectForgeRemote(url)
+    if (!remote) return null
+    return { forge: remote.forge, remote, remoteUrl: url }
+  } catch {
+    return null
+  }
+}
+
+export type ForgeResolver = (cwd: string) => Promise<RepoForgeInfo | null>

--- a/src/main/services/gitlab-cli.ts
+++ b/src/main/services/gitlab-cli.ts
@@ -1,0 +1,557 @@
+/**
+ * GitLab merge-request operations driven through the `glab` CLI.
+ *
+ * Mirrors what the GitHub path does with `gh` (create / merge / list / view /
+ * review comments) so the rest of Hive can stay "PR"-shaped: MR iids are
+ * reported as `number`, `web_url` as `url`, and MR states are normalised to
+ * the GitHub vocabulary (OPEN / MERGED / CLOSED).
+ *
+ * `glab` resolves the GitLab host from the repository's git remotes and needs
+ * `glab auth login --hostname <host>` to have been run once per host — the
+ * error mapper below turns the raw CLI failure into that instruction.
+ *
+ * Every function takes the command runner as a parameter so both the server
+ * RPC domain (injectable `runCommand`) and the Electron main Effect layer can
+ * share one implementation and tests can stub the CLI.
+ */
+import type { PRReviewComment } from '@shared/types/git'
+import {
+  buildPullRequestUrl,
+  buildRepoWebUrl,
+  detectForgeRemote,
+  extractPullRequestUrl,
+  normalizePullRequestState,
+  parsePullRequestNumber,
+  type ForgeRemote
+} from '@shared/git-forge'
+
+export interface CliCommandResult {
+  readonly stdout: string
+  readonly stderr: string
+}
+
+export type CliCommandRunner = (
+  file: string,
+  args: ReadonlyArray<string>,
+  options: { readonly cwd: string; readonly maxBuffer?: number }
+) => Promise<CliCommandResult>
+
+export const GLAB_NOT_INSTALLED_ERROR = 'GitLab CLI (glab) is not installed'
+
+export const glabNotAuthenticatedError = (host?: string | null): string =>
+  host
+    ? `GitLab CLI (glab) is not authenticated for ${host}. Run \`glab auth login --hostname ${host}\` and try again.`
+    : 'GitLab CLI (glab) is not authenticated for this GitLab host. Run `glab auth login --hostname <host>` and try again.'
+
+const errorText = (error: unknown): { message: string; stderr: string } => {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  const stderr =
+    typeof error === 'object' && error !== null && 'stderr' in error
+      ? String((error as { stderr: unknown }).stderr ?? '').trim()
+      : ''
+  return { message, stderr }
+}
+
+const isNotInstalled = (text: string): boolean =>
+  /\bENOENT\b|glab: command not found|spawn glab/i.test(text)
+
+const isNotAuthenticated = (text: string): boolean =>
+  /none of the git remotes .* known gitlab host|glab auth login|\b401\b|unauthorized|no token found|not authenticated|authentication required/i.test(
+    text
+  )
+
+/**
+ * Human-readable message for a failed glab invocation. `host` (when known)
+ * makes the auth instruction copy-pasteable.
+ */
+export function describeGlabError(error: unknown, host?: string | null): string {
+  const { message, stderr } = errorText(error)
+  const combined = `${stderr}\n${message}`
+  if (isNotInstalled(combined)) return GLAB_NOT_INSTALLED_ERROR
+  if (isNotAuthenticated(combined)) return glabNotAuthenticatedError(host)
+  if (/\b404\b|not found/i.test(combined) && /merge.?request/i.test(combined)) {
+    return 'Merge request not found'
+  }
+  return (stderr || message).trim() || 'GitLab CLI (glab) failed'
+}
+
+export const isGlabNotInstalledError = (error: unknown): boolean => {
+  const { message, stderr } = errorText(error)
+  return isNotInstalled(`${stderr}\n${message}`)
+}
+
+// ---------------------------------------------------------------------------
+// JSON helpers — glab `-F json` prints the raw GitLab API object (snake_case);
+// accept camelCase too in case a future glab version reshapes it.
+// ---------------------------------------------------------------------------
+
+type JsonRecord = Record<string, unknown>
+
+const asRecord = (value: unknown): JsonRecord | null =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null
+
+const pick = <T>(record: JsonRecord | null, keys: string[], guard: (v: unknown) => v is T): T | null => {
+  if (!record) return null
+  for (const key of keys) {
+    const value = record[key]
+    if (guard(value)) return value
+  }
+  return null
+}
+
+const isString = (v: unknown): v is string => typeof v === 'string'
+const isNumber = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v)
+
+const parseJsonLoose = (text: string): unknown => {
+  const trimmed = text.trim()
+  if (!trimmed) return null
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    // glab may print a warning/notice line before the JSON (e.g. update
+    // check) — retry from the first JSON bracket.
+    const start = Math.min(
+      ...['{', '['].map((c) => trimmed.indexOf(c)).filter((i) => i >= 0)
+    )
+    if (!Number.isFinite(start)) return null
+    try {
+      return JSON.parse(trimmed.slice(start))
+    } catch {
+      return null
+    }
+  }
+}
+
+export interface GitLabMergeRequestInfo {
+  readonly iid: number
+  readonly title: string
+  /** Normalised: OPEN | MERGED | CLOSED */
+  readonly state: string
+  /** Raw GitLab state: opened | merged | closed | locked */
+  readonly rawState: string
+  readonly sourceBranch: string
+  readonly targetBranch: string
+  readonly webUrl: string
+  readonly author: string
+}
+
+export const parseMergeRequestRecord = (value: unknown): GitLabMergeRequestInfo | null => {
+  const record = asRecord(value)
+  if (!record) return null
+  const iid = pick(record, ['iid', 'number'], isNumber)
+  if (iid === null) return null
+  const author = asRecord(record.author)
+  const rawState = pick(record, ['state'], isString) ?? ''
+  return {
+    iid,
+    title: pick(record, ['title'], isString) ?? '',
+    state: normalizePullRequestState(rawState),
+    rawState,
+    sourceBranch: pick(record, ['source_branch', 'sourceBranch'], isString) ?? '',
+    targetBranch: pick(record, ['target_branch', 'targetBranch'], isString) ?? '',
+    webUrl: pick(record, ['web_url', 'webUrl'], isString) ?? '',
+    author: pick(author, ['username', 'login', 'name'], isString) ?? ''
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Remote resolution
+// ---------------------------------------------------------------------------
+
+export interface GitLabRepoContext {
+  readonly remote: ForgeRemote | null
+  readonly remoteUrl: string | null
+}
+
+const hostOf = (ctx: GitLabRepoContext | null | undefined): string | null =>
+  ctx?.remote?.host ?? null
+
+// ---------------------------------------------------------------------------
+// Operations
+// ---------------------------------------------------------------------------
+
+export interface GitLabCreateMergeRequestOptions {
+  readonly baseBranch: string
+  readonly title: string
+  readonly body: string
+}
+
+export interface GitLabCreateMergeRequestResult {
+  readonly success: boolean
+  readonly url?: string
+  readonly number?: number
+  readonly error?: string
+}
+
+const currentBranch = async (run: CliCommandRunner, cwd: string): Promise<string | null> => {
+  try {
+    const { stdout } = await run('git', ['branch', '--show-current'], { cwd })
+    const name = stdout.trim()
+    return name || null
+  } catch {
+    return null
+  }
+}
+
+/** Open MR whose source branch is `branch`, if any (used to recover "already exists"). */
+export async function glabFindOpenMergeRequestForBranch(
+  run: CliCommandRunner,
+  cwd: string,
+  branch: string
+): Promise<GitLabMergeRequestInfo | null> {
+  try {
+    const { stdout } = await run(
+      'glab',
+      ['mr', 'list', '-F', 'json', '--source-branch', branch, '--per-page', '20'],
+      { cwd, maxBuffer: 8 * 1024 * 1024 }
+    )
+    const parsed = parseJsonLoose(stdout)
+    if (!Array.isArray(parsed)) return null
+    const candidates = parsed
+      .map(parseMergeRequestRecord)
+      .filter((mr): mr is GitLabMergeRequestInfo => mr !== null && mr.sourceBranch === branch)
+    return candidates.find((mr) => mr.rawState === 'opened') ?? candidates[0] ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * `glab mr create` — non-interactive. Prints the MR web URL on stdout; when
+ * an open MR already exists for the branch GitLab answers 409 with
+ * "Another open merge request already exists for this source branch: !N".
+ */
+export async function glabCreateMergeRequest(
+  run: CliCommandRunner,
+  cwd: string,
+  ctx: GitLabRepoContext,
+  options: GitLabCreateMergeRequestOptions
+): Promise<GitLabCreateMergeRequestResult> {
+  const { baseBranch, title } = options
+  // glab treats a description of exactly "-" as "open an editor" — never do that.
+  const body = options.body === '-' ? '- ' : options.body
+  try {
+    const { stdout, stderr } = await run(
+      'glab',
+      [
+        'mr',
+        'create',
+        '--target-branch',
+        baseBranch,
+        '--title',
+        title,
+        '--description',
+        body,
+        '--yes'
+      ],
+      { cwd }
+    )
+    let url = extractPullRequestUrl(stdout) ?? extractPullRequestUrl(stderr)
+    let number = parsePullRequestNumber(url)
+    if (!url || !number) {
+      // Older glab builds print a table rather than the bare URL — look the MR up.
+      const branch = await currentBranch(run, cwd)
+      const mr = branch ? await glabFindOpenMergeRequestForBranch(run, cwd, branch) : null
+      if (mr) {
+        number = mr.iid
+        url = mr.webUrl || buildPullRequestUrl(ctx.remoteUrl, mr.iid) || url
+      }
+    }
+    if (!url || !number) {
+      return {
+        success: false,
+        error: `Merge request was created but its URL could not be determined.\n${(stdout + stderr).trim()}`.trim()
+      }
+    }
+    return { success: true, url, number }
+  } catch (error) {
+    const { message, stderr } = errorText(error)
+    const combined = `${stderr}\n${message}`
+    if (/already exists/i.test(combined)) {
+      const iidMatch = combined.match(/already exists[^!\n]*!(\d+)/i)
+      let number = iidMatch ? parseInt(iidMatch[1], 10) : null
+      let url = extractPullRequestUrl(combined)
+      if (!number && url) number = parsePullRequestNumber(url)
+      if (!number) {
+        const branch = await currentBranch(run, cwd)
+        const mr = branch ? await glabFindOpenMergeRequestForBranch(run, cwd, branch) : null
+        if (mr) {
+          number = mr.iid
+          url = mr.webUrl || url
+        }
+      }
+      if (number && !url) url = buildPullRequestUrl(ctx.remoteUrl, number)
+      return {
+        success: false,
+        error: describeGlabError(error, hostOf(ctx)),
+        ...(url ? { url } : {}),
+        ...(number ? { number } : {})
+      }
+    }
+    return { success: false, error: describeGlabError(error, hostOf(ctx)) }
+  }
+}
+
+/**
+ * `glab mr merge <iid>` — plain merge commit, source branch kept (parity with
+ * `gh pr merge --merge`). Auto-merge is disabled so the call either merges now
+ * or fails; otherwise glab would arm merge-when-pipeline-succeeds and exit 0
+ * while the MR is still open.
+ */
+export async function glabMergeMergeRequest(
+  run: CliCommandRunner,
+  cwd: string,
+  ctx: GitLabRepoContext | null,
+  number: number
+): Promise<{ success: boolean; error?: string }> {
+  const base = ['mr', 'merge', String(number), '--yes']
+  try {
+    await run('glab', [...base, '--auto-merge=false'], { cwd })
+    return { success: true }
+  } catch (error) {
+    const { message, stderr } = errorText(error)
+    if (/unknown flag.*auto-merge/i.test(`${stderr}\n${message}`)) {
+      // Old glab without --auto-merge: fall back to the default behaviour.
+      try {
+        await run('glab', base, { cwd })
+        return { success: true }
+      } catch (retryError) {
+        return { success: false, error: describeMergeError(retryError, hostOf(ctx)) }
+      }
+    }
+    return { success: false, error: describeMergeError(error, hostOf(ctx)) }
+  }
+}
+
+const describeMergeError = (error: unknown, host: string | null): string => {
+  const { message, stderr } = errorText(error)
+  const combined = `${stderr}\n${message}`
+  if (/\b405\b|\b406\b|not mergeable|cannot be merged|merge status/i.test(combined)) {
+    return `Merge request cannot be merged yet (pipeline still running, approvals missing, or conflicts).\n${(stderr || message).trim()}`
+  }
+  return describeGlabError(error, host)
+}
+
+/** `glab mr view <iid> -F json` */
+export async function glabGetMergeRequest(
+  run: CliCommandRunner,
+  cwd: string,
+  number: number
+): Promise<GitLabMergeRequestInfo | null> {
+  const { stdout } = await run('glab', ['mr', 'view', String(number), '-F', 'json'], {
+    cwd,
+    maxBuffer: 8 * 1024 * 1024
+  })
+  return parseMergeRequestRecord(parseJsonLoose(stdout))
+}
+
+/** `glab mr list -F json` — open MRs, newest first (GitLab default order). */
+export async function glabListOpenMergeRequests(
+  run: CliCommandRunner,
+  cwd: string
+): Promise<GitLabMergeRequestInfo[]> {
+  const { stdout } = await run('glab', ['mr', 'list', '-F', 'json', '--per-page', '100'], {
+    cwd,
+    maxBuffer: 16 * 1024 * 1024
+  })
+  const parsed = parseJsonLoose(stdout)
+  if (!Array.isArray(parsed)) return []
+  return parsed
+    .map(parseMergeRequestRecord)
+    .filter((mr): mr is GitLabMergeRequestInfo => mr !== null)
+    .filter((mr) => !mr.rawState || mr.rawState === 'opened' || mr.rawState === 'locked')
+}
+
+// ---------------------------------------------------------------------------
+// Review comments (MR diff discussions)
+// ---------------------------------------------------------------------------
+
+/**
+ * GraphQL mirrors the GitHub path: it is the only API that returns rendered
+ * `bodyHtml`. `truncatedDiffLines` is deliberately NOT requested — older
+ * self-hosted instances lack it and an unknown field fails the whole query.
+ */
+export const GITLAB_MR_DISCUSSIONS_QUERY =
+  'query($fullPath:ID!,$iid:String!,$after:String){project(fullPath:$fullPath){mergeRequest(iid:$iid){targetBranch discussions(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{id notes(first:100){nodes{id body bodyHtml system createdAt updatedAt author{username avatarUrl}position{positionType filePath oldPath newPath oldLine newLine}}}}}}}}'
+
+interface GqlNote {
+  readonly id?: string
+  readonly body?: string | null
+  readonly bodyHtml?: string | null
+  readonly system?: boolean
+  readonly createdAt?: string
+  readonly updatedAt?: string
+  readonly author?: { readonly username?: string; readonly avatarUrl?: string | null } | null
+  readonly position?: {
+    readonly positionType?: string
+    readonly filePath?: string | null
+    readonly oldPath?: string | null
+    readonly newPath?: string | null
+    readonly oldLine?: number | null
+    readonly newLine?: number | null
+  } | null
+}
+
+interface GqlDiscussion {
+  readonly id?: string
+  readonly notes?: { readonly nodes?: ReadonlyArray<GqlNote | null> | null } | null
+}
+
+interface GqlDiscussionsPage {
+  readonly errors?: ReadonlyArray<{ readonly message?: string }>
+  readonly data?: {
+    readonly project?: {
+      readonly mergeRequest?: {
+        readonly targetBranch?: string | null
+        readonly discussions?: {
+          readonly pageInfo?: { readonly hasNextPage?: boolean; readonly endCursor?: string | null }
+          readonly nodes?: ReadonlyArray<GqlDiscussion | null> | null
+        } | null
+      } | null
+    } | null
+  }
+}
+
+/** `gid://gitlab/DiffNote/123` → 123 */
+export const parseGitLabGlobalId = (gid: string | null | undefined): number | null => {
+  if (!gid) return null
+  const match = /(\d+)\s*$/.exec(gid)
+  if (!match) return null
+  const value = parseInt(match[1], 10)
+  return Number.isFinite(value) ? value : null
+}
+
+const absoluteAvatarUrl = (avatarUrl: string | null | undefined, ctx: GitLabRepoContext): string => {
+  if (!avatarUrl) return ''
+  if (/^https?:\/\//i.test(avatarUrl)) return avatarUrl
+  if (!ctx.remote) return avatarUrl
+  const origin = buildRepoWebUrl({ ...ctx.remote, path: '' }).replace(/\/+$/, '')
+  return avatarUrl.startsWith('/') ? `${origin}${avatarUrl}` : `${origin}/${avatarUrl}`
+}
+
+/**
+ * Map one GraphQL discussion onto the renderer's PRReviewComment shape.
+ * Only diff-anchored discussions (root note carries a `position`) are kept —
+ * GitHub's reviewThreads likewise exclude general conversation comments.
+ */
+export const mapGitLabDiscussionToComments = (
+  discussion: GqlDiscussion,
+  ctx: GitLabRepoContext
+): PRReviewComment[] => {
+  const notes = (discussion.notes?.nodes ?? []).filter(
+    (note): note is GqlNote => !!note && !note.system
+  )
+  if (notes.length === 0) return []
+  const root = notes[0]
+  const position = root.position ?? notes.find((n) => n.position)?.position ?? null
+  if (!position) return []
+
+  const rootId = parseGitLabGlobalId(root.id)
+  if (rootId === null) return []
+  const path = position.newPath || position.oldPath || position.filePath || ''
+  const line = typeof position.newLine === 'number' ? position.newLine : null
+  const originalLine = typeof position.oldLine === 'number' ? position.oldLine : null
+  const side: 'LEFT' | 'RIGHT' = line === null && originalLine !== null ? 'LEFT' : 'RIGHT'
+  const subjectType: 'line' | 'file' = position.positionType === 'text' ? 'line' : 'file'
+
+  const comments: PRReviewComment[] = []
+  notes.forEach((note, index) => {
+    const id = parseGitLabGlobalId(note.id)
+    if (id === null) return
+    comments.push({
+      id,
+      body: note.body ?? '',
+      bodyHTML: note.bodyHtml ?? '',
+      path,
+      line: subjectType === 'line' ? line : null,
+      originalLine: subjectType === 'line' ? originalLine : null,
+      side,
+      diffHunk: '',
+      user: {
+        login: note.author?.username ?? 'ghost',
+        avatarUrl: absoluteAvatarUrl(note.author?.avatarUrl, ctx)
+      },
+      createdAt: note.createdAt ?? '',
+      updatedAt: note.updatedAt ?? '',
+      inReplyToId: index === 0 ? null : rootId,
+      pullRequestReviewId: null,
+      subjectType
+    })
+  })
+  return comments
+}
+
+export interface GitLabReviewCommentsResult {
+  readonly success: boolean
+  readonly comments?: PRReviewComment[]
+  readonly baseBranch?: string
+  readonly error?: string
+}
+
+/**
+ * Fetch every diff discussion of an MR through `glab api graphql`, paging
+ * the `discussions` connection manually (the `$after` variable is omitted on
+ * the first page so it resolves to null).
+ */
+export async function glabGetMergeRequestReviewComments(
+  run: CliCommandRunner,
+  cwd: string,
+  ctx: GitLabRepoContext,
+  number: number
+): Promise<GitLabReviewCommentsResult> {
+  const fullPath = ctx.remote?.path
+  if (!fullPath) {
+    return { success: false, error: 'Could not determine the GitLab project path from the origin remote' }
+  }
+  try {
+    const comments: PRReviewComment[] = []
+    let baseBranch: string | undefined
+    let after: string | null = null
+    for (let page = 0; page < 50; page++) {
+      const args = [
+        'api',
+        'graphql',
+        '-f',
+        `query=${GITLAB_MR_DISCUSSIONS_QUERY}`,
+        '-f',
+        `fullPath=${fullPath}`,
+        '-f',
+        `iid=${number}`
+      ]
+      if (after) args.push('-f', `after=${after}`)
+      const { stdout } = await run('glab', args, { cwd, maxBuffer: 16 * 1024 * 1024 })
+      const response = parseJsonLoose(stdout) as GqlDiscussionsPage | null
+      if (!response) {
+        return { success: false, error: 'Unexpected response from glab api graphql' }
+      }
+      if (response.errors?.length) {
+        return { success: false, error: response.errors[0]?.message ?? 'GraphQL error' }
+      }
+      const mergeRequest = response.data?.project?.mergeRequest
+      if (!mergeRequest) return { success: false, error: 'Merge request not found' }
+      if (mergeRequest.targetBranch) baseBranch = mergeRequest.targetBranch
+      for (const discussion of mergeRequest.discussions?.nodes ?? []) {
+        if (discussion) comments.push(...mapGitLabDiscussionToComments(discussion, ctx))
+      }
+      const pageInfo = mergeRequest.discussions?.pageInfo
+      if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break
+      after = pageInfo.endCursor
+    }
+    return { success: true, comments, baseBranch }
+  } catch (error) {
+    return { success: false, error: describeGlabError(error, hostOf(ctx)) }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: build a GitLabRepoContext from a remote URL
+// ---------------------------------------------------------------------------
+
+export const gitlabRepoContextFromRemoteUrl = (
+  remoteUrl: string | null | undefined
+): GitLabRepoContext => ({
+  remote: detectForgeRemote(remoteUrl),
+  remoteUrl: remoteUrl ?? null
+})

--- a/src/main/services/pr-content-generator.ts
+++ b/src/main/services/pr-content-generator.ts
@@ -1,6 +1,7 @@
 import { generateText } from './text-generation-router'
 import { createLogger } from './logger'
 import type { AgentSdkId } from './agent-sdk-types'
+import type { GitForge } from '@shared/git-forge'
 
 const log = createLogger({ component: 'PRContentGenerator' })
 
@@ -9,13 +10,17 @@ const MAX_DIFF_SUMMARY_LENGTH = 12 * 1024
 const MAX_DIFF_PATCH_LENGTH = 40 * 1024
 const MAX_TITLE_LENGTH = 256
 
-const SYSTEM_PROMPT = `You write GitHub pull request content.
+const buildSystemPrompt = (forge: GitForge): string => `You write ${
+  forge === 'gitlab' ? 'GitLab merge request' : 'GitHub pull request'
+} content.
 Return a JSON object with keys: title, body.
 Rules:
 - title should be concise and specific
 - body must be markdown with headings '## Summary' and '## Testing'
 - under Summary, provide short bullet points
 - under Testing, include bullet points with concrete checks or 'Not run'`
+
+const SYSTEM_PROMPT = buildSystemPrompt('github')
 
 export const PR_CONTENT_JSON_SCHEMA = JSON.stringify({
   type: 'object',
@@ -39,6 +44,8 @@ export interface GeneratePRContentOptions {
   /** Reasoning-effort level; falls back to the router's default ('low'). */
   effort?: string
   cwd: string
+  /** PR host the content is for — GitLab remotes get "merge request" wording. Defaults to GitHub. */
+  forge?: GitForge
 }
 
 export interface PRContent {
@@ -56,8 +63,18 @@ export interface PRContent {
  * Returns null if generation fails or the response cannot be parsed.
  */
 export async function generatePRContent(options: GeneratePRContentOptions): Promise<PRContent> {
-  const { baseBranch, headBranch, commitSummary, diffSummary, diffPatch, provider, model, effort, cwd } =
-    options
+  const {
+    baseBranch,
+    headBranch,
+    commitSummary,
+    diffSummary,
+    diffPatch,
+    provider,
+    model,
+    effort,
+    cwd,
+    forge = 'github'
+  } = options
 
   const truncatedCommitSummary = truncate(commitSummary, MAX_COMMIT_SUMMARY_LENGTH)
   const truncatedDiffSummary = truncate(diffSummary, MAX_DIFF_SUMMARY_LENGTH)
@@ -75,11 +92,11 @@ ${truncatedDiffSummary}
 Diff patch:
 ${truncatedDiffPatch}`
 
-  log.info('Generating PR content', { baseBranch, headBranch, provider, model, effort, cwd })
+  log.info('Generating PR content', { baseBranch, headBranch, provider, model, effort, cwd, forge })
 
   const response = await generateText(
     prompt,
-    SYSTEM_PROMPT,
+    forge === 'github' ? SYSTEM_PROMPT : buildSystemPrompt(forge),
     provider,
     {
       cwd,

--- a/src/renderer/src/components/kanban/AttachPRPopover.tsx
+++ b/src/renderer/src/components/kanban/AttachPRPopover.tsx
@@ -8,6 +8,7 @@ import { useProjectStore } from '@/stores/useProjectStore'
 import { useGitStore } from '@/stores/useGitStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import type { KanbanTicket } from '../../../../main/db/types'
+import { buildPullRequestUrl } from '@shared/git-forge'
 import { gitApi } from '@/api/git-api'
 import { kanbanApi } from '@/api/kanban-api'
 
@@ -64,8 +65,8 @@ export function AttachPRPopover({ ticket, open, onOpenChange }: AttachPRPopoverP
     for (const wt of worktrees) {
       const info = useGitStore.getState().remoteInfo.get(wt.id)
       if (info?.url) {
-        const match = info.url.match(/github\.com[/:]([^/]+)\/([^/.]+)/)
-        if (match) return `https://github.com/${match[1]}/${match[2]}/pull/${prNumber}`
+        const url = buildPullRequestUrl(info.url, prNumber)
+        if (url) return url
       }
     }
     return ''

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -639,7 +639,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
         if (!worktrees) return false
         return worktrees.some((wt) => {
           const info = state.remoteInfo.get(wt.id)
-          return info?.hasRemote === true && info.isGitHub === true
+          return info?.hasRemote === true && info.supportsPR === true
         })
       },
       [ticket.project_id]

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -19,6 +19,7 @@ import {
   Archive,
   Loader2,
   Github,
+  Gitlab,
   Upload,
   Lock,
   Plus,
@@ -1985,7 +1986,7 @@ function EditModeContent({
           )}
           {ticket.column === 'done' &&
             ticket.worktree_id &&
-            lifecycle.isGitHub &&
+            lifecycle.supportsPR &&
             lifecycle.hasAttachedPR &&
             lifecycle.prLiveState?.state !== 'MERGED' &&
             lifecycle.prLiveState?.state !== 'CLOSED' && (
@@ -3515,7 +3516,12 @@ function ReviewModeContent({
                 onClick={() => lifecycle.openPRInBrowser()}
                 className="inline-flex items-center gap-1 rounded-full bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted/60 transition-colors"
               >
-                <Github className="h-3 w-3" />#{lifecycle.attachedPR.number}
+                {lifecycle.forge === 'gitlab' ? (
+                  <Gitlab className="h-3 w-3" />
+                ) : (
+                  <Github className="h-3 w-3" />
+                )}
+                #{lifecycle.attachedPR.number}
               </button>
             )}
             <JumpToSessionButton ticket={ticket} onClose={onClose} />
@@ -3597,7 +3603,7 @@ function ReviewModeContent({
           </Button>
         )}
         {ticket.worktree_id &&
-          lifecycle.isGitHub &&
+          lifecycle.supportsPR &&
           !lifecycle.hasAttachedPR &&
           (isCreatingPR ? (
             <Button type="button" variant="outline" className="gap-1.5" disabled>
@@ -3627,7 +3633,7 @@ function ReviewModeContent({
             </Button>
           ))}
         {ticket.worktree_id &&
-          lifecycle.isGitHub &&
+          lifecycle.supportsPR &&
           lifecycle.hasAttachedPR &&
           lifecycle.prLiveState?.state !== 'MERGED' &&
           lifecycle.prLiveState?.state !== 'CLOSED' && (

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -149,7 +149,7 @@ export function Header(): React.JSX.Element {
   )
   const isConnectionMode = !!selectedConnectionId && !selectedWorktreeId
 
-  // Pre-warm GitHub remote detection for connection members so the PR button
+  // Pre-warm remote-forge detection for connection members so the PR button
   // can appear as soon as a connection is selected
   useEffect(() => {
     if (!isConnectionMode || !selectedConnection) return
@@ -160,9 +160,9 @@ export function Header(): React.JSX.Element {
     }
   }, [isConnectionMode, selectedConnection])
 
-  const connectionHasGitHubMember = useGitStore((s) =>
+  const connectionHasPRMember = useGitStore((s) =>
     isConnectionMode && selectedConnection
-      ? selectedConnection.members.some((m) => s.remoteInfo.get(m.worktree_id)?.isGitHub)
+      ? selectedConnection.members.some((m) => s.remoteInfo.get(m.worktree_id)?.supportsPR)
       : false
   )
 
@@ -176,7 +176,7 @@ export function Header(): React.JSX.Element {
 
   // Destructure lifecycle state for template use
   const {
-    attachedPR, hasAttachedPR, prLiveState, isGitHub,
+    attachedPR, hasAttachedPR, prLiveState, supportsPR,
     isMergingPR, isArchiving: isArchivingWorktree, branchInfo, remoteBranches,
     prTargetBranch, reviewTargetBranch, isCleanTree
   } = lifecycle
@@ -402,7 +402,7 @@ export function Header(): React.JSX.Element {
         }
       >
         {/* Connection PR button — creates one PR per connected project with changes */}
-        {isConnectionMode && connectionHasGitHubMember && (
+        {isConnectionMode && connectionHasPRMember && (
           <Button
             size="sm"
             variant="outline"
@@ -420,7 +420,7 @@ export function Header(): React.JSX.Element {
           </Button>
         )}
         {!isConnectionMode &&
-          isGitHub &&
+          supportsPR &&
           hasAttachedPR &&
           prLiveState?.state === 'MERGED' &&
           !lifecycle.isDefault && (
@@ -450,7 +450,7 @@ export function Header(): React.JSX.Element {
             </Button>
           )}
         {!isConnectionMode &&
-          isGitHub &&
+          supportsPR &&
           hasAttachedPR &&
           prLiveState?.state !== 'MERGED' &&
           prLiveState?.state !== 'CLOSED' &&
@@ -570,7 +570,7 @@ export function Header(): React.JSX.Element {
           </>
         )}
         {/* PR Badge with Popover Picker — shown when a PR is attached */}
-        {!isConnectionMode && isGitHub && hasAttachedPR && (
+        {!isConnectionMode && supportsPR && hasAttachedPR && (
           <ContextMenu>
             <Popover open={prPickerOpen} onOpenChange={setPrPickerOpen}>
               <ContextMenuTrigger asChild>
@@ -678,7 +678,7 @@ export function Header(): React.JSX.Element {
           </ContextMenu>
         )}
         {/* Create PR button — shown when no PR attached */}
-        {!isConnectionMode && isGitHub && !hasAttachedPR && (
+        {!isConnectionMode && supportsPR && !hasAttachedPR && (
           <Popover open={prPickerOpen} onOpenChange={setPrPickerOpen}>
             <PopoverAnchor asChild>
               <Button

--- a/src/renderer/src/components/pr/ConnectionPRModal.tsx
+++ b/src/renderer/src/components/pr/ConnectionPRModal.tsx
@@ -31,6 +31,7 @@ import {
   createConnectionPRs,
   emitArchivePrompts,
   isPRWorthy,
+  memberSupportsPR,
   type MemberAssessment
 } from '@/lib/connection-pr'
 import { useGitStore, type GitFileStatus } from '@/stores/useGitStore'
@@ -118,7 +119,7 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
     setIncludeByWorktree((prev) => {
       const next = new Map(prev)
       for (const a of worthy) {
-        if (!next.has(a.worktreeId)) next.set(a.worktreeId, a.isGitHub)
+        if (!next.has(a.worktreeId)) next.set(a.worktreeId, memberSupportsPR(a))
       }
       return next
     })
@@ -196,7 +197,7 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
   useEffect(() => {
     if (phase !== 'form') return
     for (const assessment of eligible) {
-      if (!assessment.isGitHub) continue
+      if (!memberSupportsPR(assessment)) continue
       if (remoteBranchesByWorktree.has(assessment.worktreeId)) continue
       gitApi
         .listBranchesWithStatus(assessment.worktreePath)
@@ -293,7 +294,9 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
   // ── Create PRs (background — closes modal immediately) ──────────
   const includedCount = useMemo(
     () =>
-      eligible.filter((a) => a.isGitHub && (includeByWorktree.get(a.worktreeId) ?? a.isGitHub))
+      eligible.filter(
+        (a) => memberSupportsPR(a) && (includeByWorktree.get(a.worktreeId) ?? memberSupportsPR(a))
+      )
         .length,
     [eligible, includeByWorktree]
   )
@@ -305,12 +308,12 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
     const plans = eligible.map((assessment) => ({
       assessment,
       baseBranch: baseBranchByWorktree.get(assessment.worktreeId) ?? assessment.defaultBase,
-      include: includeByWorktree.get(assessment.worktreeId) ?? assessment.isGitHub
+      include: includeByWorktree.get(assessment.worktreeId) ?? memberSupportsPR(assessment)
     }))
 
     // Persist the selected target branches like the single-worktree flow
     for (const plan of plans) {
-      if (!plan.include || !plan.assessment.isGitHub) continue
+      if (!plan.include || !memberSupportsPR(plan.assessment)) continue
       const normalized = plan.baseBranch.startsWith('origin/')
         ? plan.baseBranch
         : `origin/${plan.baseBranch}`
@@ -525,7 +528,7 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
 
   // ── Render: Form phase ──────────────────────────────────────────
   const renderFormRow = (assessment: MemberAssessment): React.JSX.Element => {
-    const included = includeByWorktree.get(assessment.worktreeId) ?? assessment.isGitHub
+    const included = includeByWorktree.get(assessment.worktreeId) ?? memberSupportsPR(assessment)
     const baseBranch = baseBranchByWorktree.get(assessment.worktreeId) ?? assessment.defaultBase
     const rawOptions = remoteBranchesByWorktree.get(assessment.worktreeId) ?? []
     const options = rawOptions.includes(baseBranch) ? rawOptions : [baseBranch, ...rawOptions]
@@ -544,7 +547,7 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
         <div className="flex items-center gap-2 min-w-0">
           <Checkbox
             checked={included}
-            disabled={!assessment.isGitHub}
+            disabled={!memberSupportsPR(assessment)}
             onCheckedChange={(checked) =>
               setIncludeByWorktree((prev) =>
                 new Map(prev).set(assessment.worktreeId, checked === true)
@@ -562,8 +565,8 @@ export function ConnectionPRModal({ connectionId }: ConnectionPRModalProps): Rea
           </span>
         </div>
 
-        {!assessment.isGitHub ? (
-          <p className="text-xs text-amber-500">No GitHub remote — PR will be skipped</p>
+        {!memberSupportsPR(assessment) ? (
+          <p className="text-xs text-amber-500">No GitHub or GitLab remote — PR will be skipped</p>
         ) : assessment.attachedPR ? (
           <p className="text-xs text-blue-400">
             PR #{assessment.attachedPR.number} attached — will push updates

--- a/src/renderer/src/components/pr/PRNotificationStack.tsx
+++ b/src/renderer/src/components/pr/PRNotificationStack.tsx
@@ -246,7 +246,7 @@ function PRNotificationCard({
             )}
           >
             <ExternalLink className="h-3 w-3" />
-            Open on GitHub
+            {/\/merge_requests\//.test(prUrl) ? 'Open on GitLab' : 'Open on GitHub'}
           </a>
         )}
         {showMergeButton && (

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -87,6 +87,7 @@ import { useWorktreeStore, useDropAttachmentStore } from '@/stores'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { usePRReviewStore } from '@/stores/usePRReviewStore'
+import { useGitStore } from '@/stores/useGitStore'
 import { useDiffCommentStore } from '@/stores/useDiffCommentStore'
 import { useFileTreeStore } from '@/stores/useFileTreeStore'
 import { mapOpencodeMessagesToSessionViewMessages } from '@/lib/opencode-transcript'
@@ -570,6 +571,10 @@ function ErrorState({ message, onRetry }: ErrorStateProps): React.JSX.Element {
 const PrCommentAttachments = memo(function PrCommentAttachments(): React.JSX.Element | null {
   const attachedComments = usePRReviewStore((s) => s.attachedComments)
   const removeAttachment = usePRReviewStore((s) => s.removeAttachment)
+  const attachedFromWorktreeId = usePRReviewStore((s) => s.attachedFromWorktreeId)
+  const commentForge = useGitStore((s) =>
+    attachedFromWorktreeId ? (s.remoteInfo.get(attachedFromWorktreeId)?.forge ?? null) : null
+  )
 
   if (attachedComments.length === 0) return null
 
@@ -583,7 +588,7 @@ const PrCommentAttachments = memo(function PrCommentAttachments(): React.JSX.Ele
             className="group relative flex flex-col gap-1 px-3 py-2 rounded-lg bg-background border border-border text-sm max-w-[400px] min-w-[220px]"
           >
             <div className="flex items-center gap-2">
-              <ProviderIcon provider="github" />
+              <ProviderIcon provider={commentForge ?? 'github'} />
               <img
                 src={c.user.avatarUrl}
                 alt={c.user.login}

--- a/src/renderer/src/components/sessions/UserMessageAttachmentCards.tsx
+++ b/src/renderer/src/components/sessions/UserMessageAttachmentCards.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import { KanbanSquare, FileText, MessageSquareText, X } from 'lucide-react'
 import { ProviderIcon } from '@/components/ui/provider-icon'
+import { useGitStore } from '@/stores/useGitStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import type {
   ParsedTicket,
   ParsedPrComment,
@@ -25,6 +27,12 @@ export function UserMessageAttachmentCards({
   dataAttachments,
   diffComments
 }: UserMessageAttachmentCardsProps): React.JSX.Element | null {
+  // Forge of the selected worktree's remote — picks the GitLab icon for MR
+  // comment cards; historical messages always belong to the viewed worktree.
+  const selectedWorktreeId = useWorktreeStore((s) => s.selectedWorktreeId)
+  const prForge = useGitStore((s) =>
+    selectedWorktreeId ? (s.remoteInfo.get(selectedWorktreeId)?.forge ?? null) : null
+  )
   const [expandedImage, setExpandedImage] = useState<{ dataUrl: string; name: string } | null>(null)
   useGhosttySuppression('image-lightbox', expandedImage !== null)
 
@@ -85,7 +93,7 @@ export function UserMessageAttachmentCards({
               data-testid="parsed-pr-comment-card"
             >
               <div className="flex items-center gap-2">
-                <ProviderIcon provider="github" />
+                <ProviderIcon provider={prForge ?? 'github'} />
                 <span className="font-medium text-foreground truncate">{c.author}</span>
               </div>
               <span className="text-xs text-muted-foreground truncate">

--- a/src/renderer/src/components/ui/provider-icon.tsx
+++ b/src/renderer/src/components/ui/provider-icon.tsx
@@ -1,4 +1,4 @@
-import { Github, type LucideIcon } from 'lucide-react'
+import { Github, Gitlab, type LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import jiraIcon from '@/assets/provider-icons/jira.svg'
 
@@ -17,6 +17,12 @@ const PROVIDER_CONFIG: Record<string, ProviderConfig> = {
     bg: 'bg-neutral-200 dark:bg-neutral-700',
     color: 'text-neutral-700 dark:text-neutral-200',
     label: 'GitHub',
+  },
+  gitlab: {
+    Icon: Gitlab,
+    bg: 'bg-orange-100 dark:bg-orange-950',
+    color: 'text-orange-600 dark:text-orange-400',
+    label: 'GitLab',
   },
   jira: {
     imgSrc: jiraIcon,

--- a/src/renderer/src/hooks/useLifecycleActions.ts
+++ b/src/renderer/src/hooks/useLifecycleActions.ts
@@ -14,6 +14,7 @@ import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
 import { moveWorktreeTicketsToMerged } from '@/lib/pr-merge-ticket-move'
+import { buildPullRequestUrl, type GitForge } from '@shared/git-forge'
 import { systemApi } from '@/api/system-api'
 import { opencodeApi } from '@/api/opencode-api'
 import { dbApi } from '@/api/db-api'
@@ -38,6 +39,10 @@ interface LifecycleActions {
   hasAttachedPR: boolean
   prLiveState: { state?: string; title?: string } | null
   isGitHub: boolean
+  /** PR host of this worktree's remote ('github' | 'gitlab'), null when unsupported. */
+  forge: GitForge | null
+  /** True when the remote supports Hive's PR flows (GitHub or GitLab). */
+  supportsPR: boolean
   isMergingPR: boolean
   isArchiving: boolean
   branchInfo: { name?: string; tracking?: string | null } | null
@@ -131,6 +136,8 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
 
   // --- Derived state ---
   const isGitHub = remoteInfo?.isGitHub ?? false
+  const forge = remoteInfo?.forge ?? null
+  const supportsPR = remoteInfo?.supportsPR ?? false
   const attachedPR = storeAttachedPR ?? null
   const hasAttachedPR = !!storeAttachedPR
   const isCleanTree = !fileStatuses || fileStatuses.length === 0
@@ -379,7 +386,7 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
     (prNumber: number) => {
       if (!worktreeId || !remoteInfo?.url) return
       const cleanUrl = remoteInfo.url.replace(/\.git$/, '')
-      const prUrl = `${cleanUrl}/pull/${prNumber}`
+      const prUrl = buildPullRequestUrl(remoteInfo.url, prNumber) ?? `${cleanUrl}/pull/${prNumber}`
       useGitStore.getState().attachPR(worktreeId, prNumber, prUrl)
     },
     [worktreeId, remoteInfo?.url]
@@ -474,6 +481,8 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
       hasAttachedPR: false,
       prLiveState: null,
       isGitHub: false,
+      forge: null,
+      supportsPR: false,
       isMergingPR: false,
       isArchiving: false,
       branchInfo: null,
@@ -502,6 +511,8 @@ export function useLifecycleActions(worktreeId: string | null): LifecycleActions
     hasAttachedPR,
     prLiveState,
     isGitHub,
+    forge,
+    supportsPR,
     isMergingPR,
     isArchiving,
     branchInfo,

--- a/src/renderer/src/lib/__tests__/connection-pr.test.ts
+++ b/src/renderer/src/lib/__tests__/connection-pr.test.ts
@@ -398,7 +398,7 @@ describe('connection-pr', () => {
       expect(callsTo('gitOps.createPR')).toHaveLength(0)
       expect(callsTo('gitOps.push')).toHaveLength(0)
       expect(notifications()[0]).toMatchObject({ status: 'info', worktreeId: 'wt-a' })
-      expect(String(notifications()[0].message)).toContain('no GitHub remote')
+      expect(String(notifications()[0].message)).toContain('no GitHub or GitLab remote')
     })
 
     it('does nothing for members the user excluded', async () => {

--- a/src/renderer/src/lib/connection-pr.ts
+++ b/src/renderer/src/lib/connection-pr.ts
@@ -1,3 +1,4 @@
+import type { GitForge } from '@shared/git-forge'
 import { gitApi } from '@/api/git-api'
 import { runCreatePRPipeline } from '@/lib/pr-pipeline'
 import type { PRContentProvider } from '@/lib/pr-content-provider'
@@ -9,6 +10,11 @@ import { useWorktreeStore } from '@/stores/useWorktreeStore'
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+/** True when Hive can drive PRs for this member (GitHub or GitLab remote). */
+export function memberSupportsPR(assessment: MemberAssessment): boolean {
+  return assessment.supportsPR ?? assessment.isGitHub
+}
 
 /** The slice of a connection member the PR flow needs */
 export interface ConnectionPRMember {
@@ -28,6 +34,10 @@ export interface MemberAssessment {
   branchName: string
   isDefaultWorktree: boolean
   isGitHub: boolean
+  /** PR host of the member's remote; null when neither GitHub nor GitLab. */
+  forge?: GitForge | null
+  /** True when Hive can open PRs/MRs on this member's remote. */
+  supportsPR?: boolean
   hasUncommitted: boolean
   /** Commits ahead of defaultBase (`getRangeDiff`) — 0 on backend errors */
   commitsAhead: number
@@ -101,6 +111,8 @@ async function assessMember(member: ConnectionPRMember): Promise<MemberAssessmen
     branchName: member.worktree_branch,
     isDefaultWorktree,
     isGitHub: false,
+    forge: null,
+    supportsPR: false,
     hasUncommitted: false,
     commitsAhead: 0,
     trackingAhead: 0,
@@ -113,7 +125,10 @@ async function assessMember(member: ConnectionPRMember): Promise<MemberAssessmen
     if (!gitStore.remoteInfo.get(member.worktree_id)) {
       await gitStore.checkRemoteInfo(member.worktree_id, member.worktree_path)
     }
-    const isGitHub = useGitStore.getState().remoteInfo.get(member.worktree_id)?.isGitHub ?? false
+    const memberRemote = useGitStore.getState().remoteInfo.get(member.worktree_id)
+    const isGitHub = memberRemote?.isGitHub ?? false
+    const forge = memberRemote?.forge ?? null
+    const supportsPR = memberRemote?.supportsPR ?? false
 
     const [hasUncommitted, rangeDiff] = await Promise.all([
       gitApi.hasUncommittedChanges(member.worktree_path),
@@ -127,6 +142,8 @@ async function assessMember(member: ConnectionPRMember): Promise<MemberAssessmen
     return {
       ...base,
       isGitHub,
+      forge,
+      supportsPR,
       hasUncommitted,
       commitsAhead: rangeDiff.commitCount,
       trackingAhead
@@ -243,12 +260,12 @@ export async function createConnectionPRs(options: CreateConnectionPRsOptions): 
       const assessment = plan.assessment
       const prefix = `${assessment.projectName}: `
 
-      if (!assessment.isGitHub) {
+      if (!memberSupportsPR(assessment)) {
         // Committed in the commit phase, but there is no remote to PR against
         if (assessment.hasUncommitted || assessment.commitsAhead > 0) {
           show({
             status: 'info',
-            message: `${prefix}committed — no GitHub remote, PR skipped`,
+            message: `${prefix}committed — no GitHub or GitLab remote, PR skipped`,
             worktreeId: assessment.worktreeId
           })
         }

--- a/src/renderer/src/lib/pr-pipeline.ts
+++ b/src/renderer/src/lib/pr-pipeline.ts
@@ -1,3 +1,4 @@
+import { buildPullRequestUrl, extractPullRequestUrl } from '@shared/git-forge'
 import { gitApi } from '@/api/git-api'
 import { useGitStore } from '@/stores/useGitStore'
 import { usePRNotificationStore } from '@/stores/usePRNotificationStore'
@@ -131,22 +132,33 @@ export async function runCreatePRPipeline(
       let existingUrl = createResult.url
 
       if (!existingNumber) {
-        // Fallback: parse the error message ([\s\S] to match across newlines)
+        // Fallback: parse the error message ([\s\S] to match across newlines).
+        // Covers gh ("...pull/12 already exists"), GitLab ("Another open merge
+        // request already exists for this source branch: !12"), and prose
+        // ("pull request #12 ... already").
         const errMsg = createResult.error ?? ''
         const alreadyExistsMatch = errMsg.match(
-          /already exists[\s\S]*?\/pull\/(\d+)|pull request.*?#(\d+).*?already/i
+          /already exists[\s\S]*?\/(?:pull|merge_requests)\/(\d+)|already exists[^!\n]*!(\d+)|pull request.*?#(\d+).*?already/i
         )
         if (alreadyExistsMatch) {
-          existingNumber = parseInt(alreadyExistsMatch[1] || alreadyExistsMatch[2], 10)
+          existingNumber = parseInt(
+            alreadyExistsMatch[1] || alreadyExistsMatch[2] || alreadyExistsMatch[3],
+            10
+          )
           if (!existingUrl) {
-            const urlMatch = errMsg.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/)
-            existingUrl = urlMatch?.[0] ?? `https://github.com/unknown/pull/${existingNumber}`
+            existingUrl = extractPullRequestUrl(errMsg) ?? undefined
           }
         }
       }
 
       if (existingNumber) {
-        existingUrl = existingUrl ?? `https://github.com/unknown/pull/${existingNumber}`
+        if (!existingUrl) {
+          // Build from the worktree's remote when the backend/error gave no URL.
+          const remoteUrl = useGitStore.getState().remoteInfo.get(worktreeId)?.url ?? null
+          existingUrl =
+            buildPullRequestUrl(remoteUrl, existingNumber) ??
+            `https://github.com/unknown/pull/${existingNumber}`
+        }
 
         // Auto-attach the existing PR
         await attachPR(worktreeId, existingNumber, existingUrl)

--- a/src/renderer/src/stores/useGitStore.ts
+++ b/src/renderer/src/stores/useGitStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { detectForge, type GitForge } from '@shared/git-forge'
 import { useWorktreeStore } from './useWorktreeStore'
 import { useKanbanStore } from './useKanbanStore'
 import { dbApi } from '@/api/db-api'
@@ -38,6 +39,10 @@ interface GitBranchInfo {
 interface RemoteInfo {
   hasRemote: boolean
   isGitHub: boolean
+  /** PR host of the remote: github.com -> 'github', any other host containing "gitlab" -> 'gitlab'. */
+  forge: GitForge | null
+  /** True when Hive can drive PRs/MRs for this remote (GitHub or GitLab). */
+  supportsPR: boolean
   url: string | null
 }
 
@@ -468,9 +473,12 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
   checkRemoteInfo: async (worktreeId: string, worktreePath: string) => {
     try {
       const result = await gitApi.getRemoteUrl(worktreePath)
+      const forge = detectForge(result.url)
       const info: RemoteInfo = {
         hasRemote: !!result.url,
         isGitHub: result.url?.includes('github.com') ?? false,
+        forge,
+        supportsPR: forge !== null,
         url: result.url ?? null
       }
       set((state) => {
@@ -482,7 +490,13 @@ export const useGitStore = create<GitStoreState>()((set, get) => ({
       // Non-critical — default to no remote
       set((state) => {
         const newRemoteInfo = new Map(state.remoteInfo)
-        newRemoteInfo.set(worktreeId, { hasRemote: false, isGitHub: false, url: null })
+        newRemoteInfo.set(worktreeId, {
+          hasRemote: false,
+          isGitHub: false,
+          forge: null,
+          supportsPR: false,
+          url: null
+        })
         return { remoteInfo: newRemoteInfo }
       })
     }

--- a/src/renderer/src/stores/usePRReviewStore.ts
+++ b/src/renderer/src/stores/usePRReviewStore.ts
@@ -15,6 +15,8 @@ interface PRReviewStoreState {
 
   // Attached comments for session input (persists across tab switches)
   attachedComments: PRReviewComment[]
+  /** Worktree the attached comments came from — lets the UI pick the forge icon. */
+  attachedFromWorktreeId: string | null
 
   // Actions
   fetchComments: (worktreeId: string, projectPath: string, prNumber: number) => Promise<void>
@@ -42,6 +44,7 @@ export const usePRReviewStore = create<PRReviewStoreState>((set, get) => ({
   selectedCommentIds: new Set(),
   hiddenReviewers: new Set(),
   attachedComments: [],
+  attachedFromWorktreeId: null,
 
   fetchComments: async (worktreeId, projectPath, prNumber) => {
     set((s) => {
@@ -150,6 +153,7 @@ export const usePRReviewStore = create<PRReviewStoreState>((set, get) => ({
 
     set({
       attachedComments: [...state.attachedComments, ...newAttachments],
+      attachedFromWorktreeId: worktreeId,
       selectedCommentIds: new Set()
     })
   },
@@ -161,7 +165,7 @@ export const usePRReviewStore = create<PRReviewStoreState>((set, get) => ({
   },
 
   clearAttachments: () => {
-    set({ attachedComments: [], selectedCommentIds: new Set() })
+    set({ attachedComments: [], selectedCommentIds: new Set(), attachedFromWorktreeId: null })
   },
 
   getVisibleComments: (worktreeId) => {

--- a/src/server/__tests__/git-ops-rpc.test.ts
+++ b/src/server/__tests__/git-ops-rpc.test.ts
@@ -1709,3 +1709,237 @@ describe('git ops RPC domain', () => {
     expect(process.send).not.toHaveBeenCalled()
   })
 })
+
+describe('git ops RPC domain — GitLab dispatch', () => {
+  const GITLAB_FORGE = {
+    forge: 'gitlab' as const,
+    remote: {
+      forge: 'gitlab' as const,
+      protocol: 'scp' as const,
+      host: 'gitlab.tedooo.com',
+      port: null,
+      path: 'backend/a-team'
+    },
+    remoteUrl: 'git@gitlab.tedooo.com:backend/a-team.git'
+  }
+  const resolveForge = async (): Promise<typeof GITLAB_FORGE> => GITLAB_FORGE
+
+  it('creates a merge request through glab for GitLab remotes', async () => {
+    const calls: Array<{ file: string; args: ReadonlyArray<string> }> = []
+    const runCommand = vi.fn(async (file: string, args: ReadonlyArray<string>) => {
+      calls.push({ file, args })
+      return {
+        stdout: 'https://gitlab.tedooo.com/backend/a-team/-/merge_requests/13\n',
+        stderr: ''
+      }
+    })
+    const service = makeLiveGitOpsRpcService({ runCommand, resolveForge })
+
+    const result = await Effect.runPromise(
+      service.createPR('/tmp/hive', 'origin/main', 'Add RPC', 'Body text')
+    )
+
+    expect(result).toEqual({
+      success: true,
+      url: 'https://gitlab.tedooo.com/backend/a-team/-/merge_requests/13',
+      number: 13
+    })
+    expect(calls).toEqual([
+      {
+        file: 'glab',
+        args: [
+          'mr',
+          'create',
+          '--target-branch',
+          'main',
+          '--title',
+          'Add RPC',
+          '--description',
+          'Body text',
+          '--yes'
+        ]
+      }
+    ])
+  })
+
+  it('returns existing merge request details when glab reports a conflict', async () => {
+    const runCommand = vi.fn(async (file: string, args: ReadonlyArray<string>) => {
+      if (file === 'glab' && args[1] === 'create') {
+        throw Object.assign(new Error('exit status 1'), {
+          stderr:
+            'ERROR: 409 Conflict: Another open merge request already exists for this source branch: !4'
+        })
+      }
+      if (file === 'git') return { stdout: 'feat\n', stderr: '' }
+      return { stdout: '', stderr: '' }
+    })
+    const service = makeLiveGitOpsRpcService({ runCommand, resolveForge })
+
+    const result = await Effect.runPromise(
+      service.createPR('/tmp/hive', 'main', 'Add RPC', 'Body text')
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.number).toBe(4)
+    expect(result.url).toBe('https://gitlab.tedooo.com/backend/a-team/-/merge_requests/4')
+  })
+
+  it('merges a merge request via glab and syncs the local target branch', async () => {
+    const calls: Array<{ file: string; args: ReadonlyArray<string> }> = []
+    const runCommand = vi.fn(async (file: string, args: ReadonlyArray<string>) => {
+      calls.push({ file, args })
+      if (file === 'glab' && args[1] === 'view') {
+        return {
+          stdout: JSON.stringify({ iid: 12, title: 'T', state: 'merged', target_branch: 'main' }),
+          stderr: ''
+        }
+      }
+      if (file === 'git' && args.join(' ') === 'worktree list --porcelain') {
+        return {
+          stdout: ['worktree /tmp/hive-main', 'HEAD abc123', 'branch refs/heads/main'].join('\n'),
+          stderr: ''
+        }
+      }
+      if (file === 'git' && args.join(' ') === 'branch --show-current') {
+        return { stdout: 'feature\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+    const service = makeLiveGitOpsRpcService({ runCommand, resolveForge })
+
+    const result = await Effect.runPromise(service.prMerge('/tmp/hive-feature', 12))
+
+    expect(result).toEqual({ success: true })
+    expect(calls[0]).toEqual({
+      file: 'glab',
+      args: ['mr', 'merge', '12', '--yes', '--auto-merge=false']
+    })
+    expect(calls.some((c) => c.file === 'git' && c.args[0] === 'worktree')).toBe(true)
+    expect(calls.at(-1)).toEqual({ file: 'git', args: ['merge', 'feature'], cwd: undefined })
+  })
+
+  it('lists open merge requests via glab mr list', async () => {
+    const runCommand = vi.fn(async (file: string, args: ReadonlyArray<string>) => {
+      if (file === 'git') return { stdout: '', stderr: '' }
+      if (file === 'glab' && args[1] === 'list') {
+        return {
+          stdout: JSON.stringify([
+            {
+              iid: 5,
+              title: 'Five',
+              state: 'opened',
+              source_branch: 'f5',
+              author: { username: 'mor' }
+            }
+          ]),
+          stderr: ''
+        }
+      }
+      throw new Error(`unexpected ${file} ${args.join(' ')}`)
+    })
+    const service = makeLiveGitOpsRpcService({ runCommand, resolveForge })
+
+    await expect(Effect.runPromise(service.listPRs('/tmp/hive'))).resolves.toEqual({
+      success: true,
+      prs: [{ number: 5, title: 'Five', author: 'mor', headRefName: 'f5' }]
+    })
+  })
+
+  it('reads merge request state via glab mr view', async () => {
+    const runCommand = vi.fn(async () => ({
+      stdout: JSON.stringify({ iid: 12, title: 'The MR', state: 'opened' }),
+      stderr: ''
+    }))
+    const service = makeLiveGitOpsRpcService({ runCommand, resolveForge })
+
+    await expect(Effect.runPromise(service.getPRState('/tmp/hive', 12))).resolves.toEqual({
+      success: true,
+      state: 'OPEN',
+      title: 'The MR'
+    })
+  })
+
+  it('fetches merge request review comments via glab api graphql', async () => {
+    const runCommand = vi.fn(async (file: string, args: ReadonlyArray<string>) => {
+      expect(file).toBe('glab')
+      expect(args.slice(0, 2)).toEqual(['api', 'graphql'])
+      return {
+        stdout: JSON.stringify({
+          data: {
+            project: {
+              mergeRequest: {
+                targetBranch: 'main',
+                discussions: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [
+                    {
+                      notes: {
+                        nodes: [
+                          {
+                            id: 'gid://gitlab/DiffNote/321',
+                            body: 'nit',
+                            bodyHtml: '<p>nit</p>',
+                            system: false,
+                            createdAt: '2026-08-19T10:00:00Z',
+                            updatedAt: '2026-08-19T10:00:00Z',
+                            author: { username: 'rev', avatarUrl: '/uploads/a.png' },
+                            position: {
+                              positionType: 'text',
+                              newPath: 'src/a.ts',
+                              oldPath: 'src/a.ts',
+                              newLine: 7,
+                              oldLine: null
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }),
+        stderr: ''
+      }
+    })
+    const service = makeLiveGitOpsRpcService({ runCommand, resolveForge })
+
+    const result = await Effect.runPromise(service.getPRReviewComments('/tmp/hive', 12))
+
+    expect(result.success).toBe(true)
+    expect(result.baseBranch).toBe('main')
+    expect(result.comments).toEqual([
+      {
+        id: 321,
+        body: 'nit',
+        bodyHTML: '<p>nit</p>',
+        path: 'src/a.ts',
+        line: 7,
+        originalLine: null,
+        side: 'RIGHT',
+        diffHunk: '',
+        user: { login: 'rev', avatarUrl: 'https://gitlab.tedooo.com/uploads/a.png' },
+        createdAt: '2026-08-19T10:00:00Z',
+        updatedAt: '2026-08-19T10:00:00Z',
+        inReplyToId: null,
+        pullRequestReviewId: null,
+        subjectType: 'line'
+      }
+    ])
+  })
+
+  it('reports glab-not-installed errors from listPRs', async () => {
+    const runCommand = vi.fn(async (file: string) => {
+      if (file === 'git') return { stdout: '', stderr: '' }
+      throw Object.assign(new Error('spawn glab ENOENT'), { code: 'ENOENT' })
+    })
+    const service = makeLiveGitOpsRpcService({ runCommand, resolveForge })
+
+    await expect(Effect.runPromise(service.listPRs('/tmp/hive'))).resolves.toEqual({
+      success: false,
+      prs: [],
+      error: 'GitLab CLI (glab) is not installed'
+    })
+  })
+})

--- a/src/server/rpc/domains/git-ops.ts
+++ b/src/server/rpc/domains/git-ops.ts
@@ -21,7 +21,17 @@ import { isDesktopCommandResult, makeDesktopCommandRequest } from '@shared/deskt
 import { GIT_STATUS_CHANGED_CHANNEL } from '@shared/git-events'
 import { getImageMimeType } from '@shared/types/file-utils'
 import type { GitBranchInfo, GitFileStatus, PRReviewComment } from '@shared/types/git'
+import { extractPullRequestUrl, parsePullRequestNumber } from '@shared/git-forge'
 import { telemetryService } from '../../../main/services/telemetry-service'
+import { resolveRepoForge, type ForgeResolver } from '../../../main/services/git-forge-remote'
+import {
+  describeGlabError,
+  glabCreateMergeRequest,
+  glabGetMergeRequest,
+  glabGetMergeRequestReviewComments,
+  glabListOpenMergeRequests,
+  glabMergeMergeRequest
+} from '../../../main/services/gitlab-cli'
 import type { EventBus } from '../../events/event-bus'
 import type { RpcHandler } from '../router'
 
@@ -575,6 +585,12 @@ export interface GitOpsRpcServiceDependencies {
   readonly runCommand?: CommandRunner
   readonly track?: (event: string, properties?: Record<string, unknown>) => void
   readonly eventBus?: EventBus
+  /**
+   * Which PR host (GitHub via `gh`, GitLab via `glab`) a repository pushes to.
+   * Defaults to reading the `origin` remote; null (no remote / unknown host)
+   * keeps the historical GitHub behaviour.
+   */
+  readonly resolveForge?: ForgeResolver
   readonly generatePRContent?: (options: {
     readonly baseBranch: string
     readonly headBranch: string
@@ -594,6 +610,7 @@ export const makeLiveGitOpsRpcService = (
   const runCommand = dependencies.runCommand ?? execFileAsync
   const track = dependencies.track ?? telemetryService.track.bind(telemetryService)
   const eventBus = dependencies.eventBus
+  const resolveForge = dependencies.resolveForge ?? resolveRepoForge
   const applyHunkPatch = async (
     worktreePath: string,
     patch: string,
@@ -1486,6 +1503,15 @@ export const makeLiveGitOpsRpcService = (
           }
 
           const normalizedBaseBranch = baseBranch.replace(/^[^/]+\//, '')
+          const forgeInfo = await resolveForge(worktreePath)
+          if (forgeInfo?.forge === 'gitlab') {
+            return glabCreateMergeRequest(runCommand, worktreePath, forgeInfo, {
+              baseBranch: normalizedBaseBranch,
+              title,
+              body
+            })
+          }
+
           const tempDir = mkdtempSync(join(tmpdir(), 'hive-gh-pr-'))
           const tempFile = join(tempDir, 'body.md')
 
@@ -1511,15 +1537,9 @@ export const makeLiveGitOpsRpcService = (
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error)
             if (/already exists/i.test(message)) {
-              const urlMatch = message.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/)
-              const url = urlMatch?.[0]
-              const numberMatch = url?.match(/\/pull\/(\d+)/)
-              return {
-                success: false,
-                error: message,
-                url,
-                number: numberMatch ? parseInt(numberMatch[1], 10) : undefined
-              }
+              const url = extractPullRequestUrl(message) ?? undefined
+              const number = parsePullRequestNumber(url) ?? undefined
+              return { success: false, error: message, url, number }
             }
 
             return { success: false, error: message }
@@ -1590,13 +1610,15 @@ export const makeLiveGitOpsRpcService = (
               headBranch = 'HEAD'
             }
 
+            const forgeInfo = await resolveForge(worktreePath)
             const generator =
               dependencies.generatePRContent ??
               (async (options) => {
                 const module = await import('../../../main/services/pr-content-generator')
                 return module.generatePRContent({
                   ...options,
-                  provider: options.provider as never
+                  provider: options.provider as never,
+                  ...(forgeInfo ? { forge: forgeInfo.forge } : {})
                 })
               })
             const result = await generator({
@@ -1628,16 +1650,36 @@ export const makeLiveGitOpsRpcService = (
       Effect.tryPromise({
         try: async (): Promise<GitOperationResult> => {
           try {
-            await runCommand('gh', ['pr', 'merge', String(prNumber), '--merge'], {
-              cwd: worktreePath
-            })
+            const forgeInfo = await resolveForge(worktreePath)
+            let targetBranch: string
+            if (forgeInfo?.forge === 'gitlab') {
+              const merged = await glabMergeMergeRequest(
+                runCommand,
+                worktreePath,
+                forgeInfo,
+                prNumber
+              )
+              if (!merged.success) return { success: false, error: merged.error }
+              let mergedRequest: Awaited<ReturnType<typeof glabGetMergeRequest>> = null
+              try {
+                mergedRequest = await glabGetMergeRequest(runCommand, worktreePath, prNumber)
+              } catch {
+                mergedRequest = null
+              }
+              targetBranch = mergedRequest?.targetBranch ?? ''
+            } else {
+              await runCommand('gh', ['pr', 'merge', String(prNumber), '--merge'], {
+                cwd: worktreePath
+              })
 
-            const prInfoResult = await runCommand(
-              'gh',
-              ['pr', 'view', String(prNumber), '--json', 'baseRefName', '-q', '.baseRefName'],
-              { cwd: worktreePath }
-            )
-            const targetBranch = prInfoResult.stdout.trim()
+              const prInfoResult = await runCommand(
+                'gh',
+                ['pr', 'view', String(prNumber), '--json', 'baseRefName', '-q', '.baseRefName'],
+                { cwd: worktreePath }
+              )
+              targetBranch = prInfoResult.stdout.trim()
+            }
+            if (!targetBranch) return { success: true }
 
             const worktreeListResult = await runCommand(
               'git',
@@ -1707,6 +1749,28 @@ export const makeLiveGitOpsRpcService = (
     listPRs: (projectPath) =>
       Effect.tryPromise({
         try: async (): Promise<GitListPullRequestsResult> => {
+          const forgeInfo = await resolveForge(projectPath)
+          if (forgeInfo?.forge === 'gitlab') {
+            try {
+              await runCommand('git', ['fetch', 'origin'], { cwd: projectPath })
+            } catch {
+              // Listing still works against the API when the fetch fails (offline remote refs are cosmetic).
+            }
+            try {
+              const mergeRequests = await glabListOpenMergeRequests(runCommand, projectPath)
+              return {
+                success: true,
+                prs: mergeRequests.map((mr) => ({
+                  number: mr.iid,
+                  title: mr.title,
+                  author: mr.author,
+                  headRefName: mr.sourceBranch
+                }))
+              }
+            } catch (error) {
+              return { success: false, prs: [], error: describeGlabError(error, forgeInfo.remote.host) }
+            }
+          }
           try {
             await runCommand('git', ['fetch', 'origin'], { cwd: projectPath })
             const { stdout } = await runCommand(
@@ -1765,6 +1829,16 @@ export const makeLiveGitOpsRpcService = (
     getPRState: (projectPath, prNumber) =>
       Effect.tryPromise({
         try: async (): Promise<GitPullRequestStateResult> => {
+          const forgeInfo = await resolveForge(projectPath)
+          if (forgeInfo?.forge === 'gitlab') {
+            try {
+              const mergeRequest = await glabGetMergeRequest(runCommand, projectPath, prNumber)
+              if (!mergeRequest) return { success: false, error: 'Merge request not found' }
+              return { success: true, state: mergeRequest.state, title: mergeRequest.title }
+            } catch (error) {
+              return { success: false, error: describeGlabError(error, forgeInfo.remote.host) }
+            }
+          }
           try {
             const { stdout } = await runCommand(
               'gh',
@@ -1785,6 +1859,15 @@ export const makeLiveGitOpsRpcService = (
     getPRReviewComments: (projectPath, prNumber) =>
       Effect.tryPromise({
         try: async (): Promise<GitPullRequestReviewCommentsResult> => {
+          const forgeInfo = await resolveForge(projectPath)
+          if (forgeInfo?.forge === 'gitlab') {
+            return glabGetMergeRequestReviewComments(
+              runCommand,
+              projectPath,
+              forgeInfo,
+              prNumber
+            )
+          }
           try {
             const { stdout: repoInfo } = await runCommand(
               'gh',

--- a/src/shared/__tests__/git-forge.test.ts
+++ b/src/shared/__tests__/git-forge.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPullRequestUrl,
+  buildRepoWebUrl,
+  detectForge,
+  detectForgeFromHost,
+  detectForgeFromPullRequestUrl,
+  detectForgeRemote,
+  extractPullRequestUrl,
+  normalizePullRequestState,
+  parseGitRemoteUrl,
+  parsePullRequestNumber,
+  pullRequestHeadRef
+} from '../git-forge'
+
+describe('parseGitRemoteUrl', () => {
+  it('parses https URLs with nested groups and .git suffix', () => {
+    expect(parseGitRemoteUrl('https://gitlab.com/group/sub/project.git')).toEqual({
+      protocol: 'https',
+      host: 'gitlab.com',
+      port: null,
+      path: 'group/sub/project'
+    })
+  })
+
+  it('parses scp-like ssh URLs', () => {
+    expect(parseGitRemoteUrl('git@gitlab.tedooo.com:backend/a-team.git')).toEqual({
+      protocol: 'scp',
+      host: 'gitlab.tedooo.com',
+      port: null,
+      path: 'backend/a-team'
+    })
+    expect(parseGitRemoteUrl('git@github.com:acme/hive.git')).toEqual({
+      protocol: 'scp',
+      host: 'github.com',
+      port: null,
+      path: 'acme/hive'
+    })
+  })
+
+  it('parses ssh:// URLs with ports', () => {
+    expect(parseGitRemoteUrl('ssh://git@gitlab.tedooo.com:2222/group/project.git')).toEqual({
+      protocol: 'ssh',
+      host: 'gitlab.tedooo.com',
+      port: 2222,
+      path: 'group/project'
+    })
+  })
+
+  it('strips userinfo including tokens with colons', () => {
+    expect(parseGitRemoteUrl('https://oauth2:glpat-abc:def@gitlab.example.com/g/p.git')).toEqual({
+      protocol: 'https',
+      host: 'gitlab.example.com',
+      port: null,
+      path: 'g/p'
+    })
+  })
+
+  it('handles trailing slashes, mixed case hosts and scp-like without user', () => {
+    expect(parseGitRemoteUrl('https://GitHub.com/Acme/Hive/')).toEqual({
+      protocol: 'https',
+      host: 'github.com',
+      port: null,
+      path: 'Acme/Hive'
+    })
+    expect(parseGitRemoteUrl('gitlab.com:group/project')).toEqual({
+      protocol: 'scp',
+      host: 'gitlab.com',
+      port: null,
+      path: 'group/project'
+    })
+  })
+
+  it('returns null for empty, local and windows-drive inputs', () => {
+    expect(parseGitRemoteUrl('')).toBeNull()
+    expect(parseGitRemoteUrl(null)).toBeNull()
+    expect(parseGitRemoteUrl(undefined)).toBeNull()
+    expect(parseGitRemoteUrl('/Users/me/repo')).toBeNull()
+    expect(parseGitRemoteUrl('C:\\repos\\thing')).toBeNull()
+    expect(parseGitRemoteUrl('../relative/repo')).toBeNull()
+  })
+})
+
+describe('detectForgeFromHost / detectForge', () => {
+  it('classifies github.com as github', () => {
+    expect(detectForgeFromHost('github.com')).toBe('github')
+    expect(detectForgeFromHost('GITHUB.COM')).toBe('github')
+    expect(detectForgeFromHost('www.github.com')).toBe('github')
+  })
+
+  it('classifies any non-github host containing "gitlab" as gitlab', () => {
+    expect(detectForgeFromHost('gitlab.com')).toBe('gitlab')
+    expect(detectForgeFromHost('gitlab.tedooo.com')).toBe('gitlab')
+    expect(detectForgeFromHost('my-gitlab.internal')).toBe('gitlab')
+    expect(detectForgeFromHost('code.GitLab.example.org')).toBe('gitlab')
+  })
+
+  it('returns null for other hosts', () => {
+    expect(detectForgeFromHost('bitbucket.org')).toBeNull()
+    expect(detectForgeFromHost('git.example.com')).toBeNull()
+    expect(detectForgeFromHost('')).toBeNull()
+    expect(detectForgeFromHost(null)).toBeNull()
+  })
+
+  it('detects from full remote URLs', () => {
+    expect(detectForge('git@github.com:acme/hive.git')).toBe('github')
+    expect(detectForge('https://github.com/acme/hive')).toBe('github')
+    expect(detectForge('git@gitlab.tedooo.com:backend/a-team.git')).toBe('gitlab')
+    expect(detectForge('https://gitlab.com/group/sub/project.git')).toBe('gitlab')
+    expect(detectForge('ssh://git@gitlab.example.com:2222/g/p.git')).toBe('gitlab')
+    expect(detectForge('git@bitbucket.org:acme/hive.git')).toBeNull()
+    expect(detectForge(null)).toBeNull()
+    expect(detectForge('/local/path')).toBeNull()
+  })
+
+  it('detectForgeRemote carries host and path', () => {
+    expect(detectForgeRemote('git@gitlab.tedooo.com:backend/a-team.git')).toEqual({
+      forge: 'gitlab',
+      protocol: 'scp',
+      host: 'gitlab.tedooo.com',
+      port: null,
+      path: 'backend/a-team'
+    })
+    expect(detectForgeRemote('git@bitbucket.org:acme/hive.git')).toBeNull()
+  })
+})
+
+describe('URL builders', () => {
+  it('builds repo web URLs, keeping non-standard http(s) ports only', () => {
+    expect(buildRepoWebUrl(detectForgeRemote('git@github.com:acme/hive.git')!)).toBe(
+      'https://github.com/acme/hive'
+    )
+    expect(
+      buildRepoWebUrl(detectForgeRemote('ssh://git@gitlab.tedooo.com:2222/backend/a-team.git')!)
+    ).toBe('https://gitlab.tedooo.com/backend/a-team')
+    expect(buildRepoWebUrl(detectForgeRemote('http://gitlab.local:8080/g/p.git')!)).toBe(
+      'http://gitlab.local:8080/g/p'
+    )
+  })
+
+  it('builds PR / MR URLs per forge', () => {
+    expect(buildPullRequestUrl('git@github.com:acme/hive.git', 42)).toBe(
+      'https://github.com/acme/hive/pull/42'
+    )
+    expect(buildPullRequestUrl('https://github.com/acme/hive', 7)).toBe(
+      'https://github.com/acme/hive/pull/7'
+    )
+    expect(buildPullRequestUrl('git@gitlab.tedooo.com:backend/a-team.git', 12)).toBe(
+      'https://gitlab.tedooo.com/backend/a-team/-/merge_requests/12'
+    )
+    expect(buildPullRequestUrl('https://gitlab.com/group/sub/project.git', 3)).toBe(
+      'https://gitlab.com/group/sub/project/-/merge_requests/3'
+    )
+    expect(buildPullRequestUrl('git@bitbucket.org:acme/hive.git', 1)).toBeNull()
+    expect(buildPullRequestUrl(null, 1)).toBeNull()
+  })
+
+  it('returns the right head ref per forge', () => {
+    expect(pullRequestHeadRef('github', 5)).toBe('pull/5/head')
+    expect(pullRequestHeadRef('gitlab', 5)).toBe('merge-requests/5/head')
+  })
+})
+
+describe('URL parsing', () => {
+  it('extracts PR / MR URLs from CLI output', () => {
+    expect(
+      extractPullRequestUrl(
+        'a pull request for branch "f" into branch "main" already exists:\nhttps://github.com/acme/hive/pull/42\n'
+      )
+    ).toBe('https://github.com/acme/hive/pull/42')
+    expect(extractPullRequestUrl('https://gitlab.com/g/p/-/merge_requests/9\n')).toBe(
+      'https://gitlab.com/g/p/-/merge_requests/9'
+    )
+    expect(extractPullRequestUrl('see https://gitlab.tedooo.com/backend/x/merge_requests/3.')).toBe(
+      'https://gitlab.tedooo.com/backend/x/merge_requests/3'
+    )
+    expect(extractPullRequestUrl('nothing here')).toBeNull()
+    expect(extractPullRequestUrl(null)).toBeNull()
+  })
+
+  it('parses PR / MR numbers from URLs', () => {
+    expect(parsePullRequestNumber('https://github.com/acme/hive/pull/42')).toBe(42)
+    expect(parsePullRequestNumber('https://gitlab.com/g/p/-/merge_requests/9')).toBe(9)
+    expect(parsePullRequestNumber('https://gitlab.com/g/p/merge_requests/9/diffs')).toBe(9)
+    expect(parsePullRequestNumber('https://github.com/acme/hive/pull/42#issuecomment-1')).toBe(42)
+    expect(parsePullRequestNumber('https://github.com/acme/hive')).toBeNull()
+    expect(parsePullRequestNumber(null)).toBeNull()
+  })
+
+  it('detects the forge of a PR URL', () => {
+    expect(detectForgeFromPullRequestUrl('https://github.com/acme/hive/pull/42')).toBe('github')
+    expect(detectForgeFromPullRequestUrl('https://gitlab.tedooo.com/b/x/-/merge_requests/3')).toBe(
+      'gitlab'
+    )
+    expect(detectForgeFromPullRequestUrl('https://gitlab.com/g/p')).toBe('gitlab')
+    expect(detectForgeFromPullRequestUrl('https://example.com/x')).toBeNull()
+  })
+})
+
+describe('normalizePullRequestState', () => {
+  it('maps gitlab states onto the github vocabulary', () => {
+    expect(normalizePullRequestState('opened')).toBe('OPEN')
+    expect(normalizePullRequestState('locked')).toBe('OPEN')
+    expect(normalizePullRequestState('merged')).toBe('MERGED')
+    expect(normalizePullRequestState('closed')).toBe('CLOSED')
+  })
+
+  it('passes github states through upper-cased', () => {
+    expect(normalizePullRequestState('OPEN')).toBe('OPEN')
+    expect(normalizePullRequestState('MERGED')).toBe('MERGED')
+    expect(normalizePullRequestState('CLOSED')).toBe('CLOSED')
+    expect(normalizePullRequestState('')).toBe('')
+    expect(normalizePullRequestState(undefined)).toBe('')
+  })
+})

--- a/src/shared/git-forge.ts
+++ b/src/shared/git-forge.ts
@@ -1,0 +1,212 @@
+/**
+ * Git "forge" detection — which pull-request host a remote lives on.
+ *
+ * Hive speaks to GitHub through `gh` and to GitLab through `glab`; everything
+ * that needs to branch on the host (PR creation/merge/list/state, review
+ * comments, PR URL construction, `pull/N/head` vs `merge-requests/N/head`
+ * fetch refs) goes through the helpers in this file so the rule lives in one
+ * place.
+ *
+ * Rule (product decision): `github.com` is GitHub; any OTHER host whose name
+ * contains "gitlab" anywhere (gitlab.com, gitlab.example.com, my-gitlab.corp)
+ * is GitLab. Everything else is unsupported — no PR button.
+ *
+ * Pure module: safe to import from main, server and renderer.
+ */
+
+export type GitForge = 'github' | 'gitlab'
+
+export interface ParsedGitRemote {
+  /** 'ssh' | 'https' | 'http' | 'git' | 'file' | 'scp' (git@host:path form) | other scheme */
+  readonly protocol: string
+  /** Lower-cased host name, without port or userinfo */
+  readonly host: string
+  /** Explicit port when the URL carried one, else null */
+  readonly port: number | null
+  /** Repository path: no leading slash, no trailing slash, no `.git` suffix */
+  readonly path: string
+}
+
+export interface ForgeRemote extends ParsedGitRemote {
+  readonly forge: GitForge
+}
+
+export const FORGE_LABEL: Readonly<Record<GitForge, string>> = {
+  github: 'GitHub',
+  gitlab: 'GitLab'
+}
+
+export const FORGE_CLI: Readonly<Record<GitForge, string>> = {
+  github: 'gh',
+  gitlab: 'glab'
+}
+
+const SCHEME_URL = /^([A-Za-z][A-Za-z0-9+.-]*):\/\/(.+)$/
+// user@host:path or host:path — but never a Windows drive (C:\...) or a scheme URL.
+const SCP_LIKE = /^(?:([^@/\s]+)@)?([^:/\s]+):(?!\/\/)(.*)$/
+
+const stripPathDecorations = (path: string): string =>
+  path
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .replace(/\.git$/i, '')
+    .replace(/\/+$/, '')
+
+/**
+ * Parse a git remote URL into protocol/host/port/path. Handles
+ * `https://host/group/sub/repo.git`, `ssh://git@host:2222/group/repo`,
+ * `git@host:group/sub/repo.git`, `host:group/repo`, and URLs carrying
+ * userinfo (`https://oauth2:token@host/g/p.git`). Returns null for anything
+ * it cannot make sense of (local paths, empty strings). Never throws.
+ */
+export function parseGitRemoteUrl(url: string | null | undefined): ParsedGitRemote | null {
+  if (!url) return null
+  const trimmed = url.trim()
+  if (!trimmed) return null
+
+  const scheme = SCHEME_URL.exec(trimmed)
+  if (scheme) {
+    const protocol = scheme[1].toLowerCase()
+    // Strip userinfo (user@ or user:pass@) — it may contain ':' so cut at the
+    // last '@' before the first '/'.
+    let rest = scheme[2]
+    const firstSlash = rest.indexOf('/')
+    const authority = firstSlash === -1 ? rest : rest.slice(0, firstSlash)
+    const at = authority.lastIndexOf('@')
+    if (at !== -1) rest = rest.slice(at + 1)
+
+    const slash = rest.indexOf('/')
+    const hostPort = slash === -1 ? rest : rest.slice(0, slash)
+    const rawPath = slash === -1 ? '' : rest.slice(slash + 1)
+    if (!hostPort) return null
+
+    let host = hostPort
+    let port: number | null = null
+    const portMatch = /^(.+):(\d+)$/.exec(hostPort)
+    if (portMatch) {
+      host = portMatch[1]
+      port = parseInt(portMatch[2], 10)
+    }
+    // IPv6 literal `[::1]`
+    host = host.replace(/^\[(.*)\]$/, '$1').toLowerCase()
+    if (!host) return null
+    return { protocol, host, port, path: stripPathDecorations(rawPath) }
+  }
+
+  const scp = SCP_LIKE.exec(trimmed)
+  if (scp) {
+    const host = scp[2].toLowerCase()
+    // `C:\path` / `c:/path` — a Windows drive, not a host.
+    if (/^[a-z]$/.test(host)) return null
+    return { protocol: 'scp', host, port: null, path: stripPathDecorations(scp[3]) }
+  }
+
+  return null
+}
+
+/**
+ * Classify a host name. `github.com` (and `www.github.com`) → GitHub. Any other
+ * host containing "gitlab" anywhere → GitLab. Else null (no PR support).
+ */
+export function detectForgeFromHost(host: string | null | undefined): GitForge | null {
+  if (!host) return null
+  const normalized = host.trim().toLowerCase().replace(/\.$/, '')
+  if (!normalized) return null
+  if (normalized === 'github.com' || normalized === 'www.github.com') return 'github'
+  if (normalized.includes('gitlab')) return 'gitlab'
+  return null
+}
+
+/** Parse a remote URL and classify its host in one go. */
+export function detectForgeRemote(url: string | null | undefined): ForgeRemote | null {
+  const parsed = parseGitRemoteUrl(url)
+  if (!parsed) return null
+  const forge = detectForgeFromHost(parsed.host)
+  if (!forge) return null
+  return { ...parsed, forge }
+}
+
+/** Convenience: which forge a remote URL belongs to, or null. */
+export function detectForge(url: string | null | undefined): GitForge | null {
+  return detectForgeRemote(url)?.forge ?? null
+}
+
+/**
+ * Browser URL of the repository on its forge, e.g.
+ * `https://github.com/owner/repo` or `https://gitlab.example.com/group/sub/repo`.
+ * Non-standard ports are preserved for self-hosted GitLab over http(s).
+ */
+export function buildRepoWebUrl(remote: ForgeRemote): string {
+  const isHttp = remote.protocol === 'http' || remote.protocol === 'https'
+  const scheme = remote.protocol === 'http' ? 'http' : 'https'
+  const port = isHttp && remote.port ? `:${remote.port}` : ''
+  return `${scheme}://${remote.host}${port}/${remote.path}`
+}
+
+/**
+ * Browser URL for PR/MR `number` in the repository behind `remoteUrl`.
+ * GitHub: `.../pull/N`; GitLab: `.../-/merge_requests/N`. Null when the remote
+ * is not on a supported forge.
+ */
+export function buildPullRequestUrl(
+  remoteUrl: string | null | undefined,
+  number: number
+): string | null {
+  const remote = detectForgeRemote(remoteUrl)
+  if (!remote || !remote.path) return null
+  const base = buildRepoWebUrl(remote)
+  return remote.forge === 'github' ? `${base}/pull/${number}` : `${base}/-/merge_requests/${number}`
+}
+
+const GITHUB_PR_URL = /https?:\/\/[^\s"'<>]+\/pull\/(\d+)/
+const GITLAB_MR_URL = /https?:\/\/[^\s"'<>]+\/merge_requests\/(\d+)/
+
+/**
+ * Find the first PR/MR web URL inside free text (CLI stdout/stderr). Trailing
+ * punctuation from prose ("...pull/12.") is trimmed.
+ */
+export function extractPullRequestUrl(text: string | null | undefined): string | null {
+  if (!text) return null
+  const match = GITHUB_PR_URL.exec(text) ?? GITLAB_MR_URL.exec(text)
+  if (!match) return null
+  return match[0].replace(/[.,;:)\]]+$/, '')
+}
+
+/** PR/MR number from a GitHub `/pull/N` or GitLab `/merge_requests/N` URL. */
+export function parsePullRequestNumber(url: string | null | undefined): number | null {
+  if (!url) return null
+  const match = /\/(?:pull|merge_requests)\/(\d+)(?:[/?#]|$)/.exec(url)
+  if (!match) return null
+  const value = parseInt(match[1], 10)
+  return Number.isFinite(value) && value > 0 ? value : null
+}
+
+/** Which forge a PR/MR web URL points at (by URL shape, then by host). */
+export function detectForgeFromPullRequestUrl(url: string | null | undefined): GitForge | null {
+  if (!url) return null
+  if (/\/merge_requests\/\d+/.test(url)) return 'gitlab'
+  if (/\/pull\/\d+/.test(url)) return 'github'
+  return detectForge(url)
+}
+
+/**
+ * Remote ref that fetches the head of PR/MR `number`:
+ * GitHub `pull/N/head`, GitLab `merge-requests/N/head`.
+ */
+export function pullRequestHeadRef(forge: GitForge, number: number): string {
+  return forge === 'gitlab' ? `merge-requests/${number}/head` : `pull/${number}/head`
+}
+
+/**
+ * Normalise a forge-specific PR/MR state into the GitHub-style upper-case
+ * vocabulary the UI already understands: OPEN | MERGED | CLOSED.
+ * GitLab reports `opened` / `merged` / `closed` / `locked`.
+ */
+export function normalizePullRequestState(state: string | null | undefined): string {
+  const value = (state ?? '').trim().toLowerCase()
+  if (!value) return ''
+  if (value === 'opened' || value === 'open' || value === 'locked') return 'OPEN'
+  if (value === 'merged') return 'MERGED'
+  if (value === 'closed') return 'CLOSED'
+  return value.toUpperCase()
+}

--- a/test/phase-12/renderer-api-cleanup.test.ts
+++ b/test/phase-12/renderer-api-cleanup.test.ts
@@ -20812,9 +20812,8 @@ describe('renderer API cleanup', () => {
     expect(remoteInfoSource).toContain('hasRemote: !!result.url')
     expect(remoteInfoSource).toContain("isGitHub: result.url?.includes('github.com') ?? false")
     expect(remoteInfoSource).toContain('url: result.url ?? null')
-    expect(remoteInfoSource).toContain(
-      'newRemoteInfo.set(worktreeId, { hasRemote: false, isGitHub: false, url: null })'
-    )
+    expect(remoteInfoSource).toContain('hasRemote: false,')
+    expect(remoteInfoSource).toContain('supportsPR: false,')
     expect(remoteInfoSource).not.toContain('window.gitOps.getRemoteUrl')
     expect(remoteInfoSource).not.toContain('unwrapEnvelope(await')
   })

--- a/test/phase-18/session-10/pr-github-backend.test.ts
+++ b/test/phase-18/session-10/pr-github-backend.test.ts
@@ -246,6 +246,8 @@ describe('Session 10: PR to GitHub Backend', () => {
       expect(info).toEqual({
         hasRemote: true,
         isGitHub: true,
+        forge: 'github',
+        supportsPR: true,
         url: 'git@github.com:org/repo.git'
       })
     })
@@ -263,11 +265,13 @@ describe('Session 10: PR to GitHub Backend', () => {
       expect(info).toEqual({
         hasRemote: true,
         isGitHub: true,
+        forge: 'github',
+        supportsPR: true,
         url: 'https://github.com/org/repo.git'
       })
     })
 
-    test('checkRemoteInfo detects non-GitHub remote', async () => {
+    test('checkRemoteInfo detects GitLab remote as PR-capable', async () => {
       gitApiMocks.getRemoteUrl.mockResolvedValue({
         success: true,
         url: 'https://gitlab.com/org/repo.git',
@@ -280,7 +284,28 @@ describe('Session 10: PR to GitHub Backend', () => {
       expect(info).toEqual({
         hasRemote: true,
         isGitHub: false,
+        forge: 'gitlab',
+        supportsPR: true,
         url: 'https://gitlab.com/org/repo.git'
+      })
+    })
+
+    test('checkRemoteInfo detects self-hosted GitLab from SSH URL', async () => {
+      gitApiMocks.getRemoteUrl.mockResolvedValue({
+        success: true,
+        url: 'git@gitlab.tedooo.com:backend/a-team.git',
+        remote: 'origin'
+      })
+
+      await useGitStore.getState().checkRemoteInfo('wt-gl', '/test/path')
+
+      const info = useGitStore.getState().remoteInfo.get('wt-gl')
+      expect(info).toEqual({
+        hasRemote: true,
+        isGitHub: false,
+        forge: 'gitlab',
+        supportsPR: true,
+        url: 'git@gitlab.tedooo.com:backend/a-team.git'
       })
     })
 
@@ -297,6 +322,8 @@ describe('Session 10: PR to GitHub Backend', () => {
       expect(info).toEqual({
         hasRemote: false,
         isGitHub: false,
+        forge: null,
+        supportsPR: false,
         url: null
       })
     })
@@ -310,6 +337,8 @@ describe('Session 10: PR to GitHub Backend', () => {
       expect(info).toEqual({
         hasRemote: false,
         isGitHub: false,
+        forge: null,
+        supportsPR: false,
         url: null
       })
     })
@@ -355,7 +384,7 @@ describe('Session 10: PR to GitHub Backend', () => {
       expect(useGitStore.getState().prTargetBranch.get('wt-1')).toBe('origin/release')
     })
 
-    test('checkRemoteInfo detects Bitbucket as non-GitHub', async () => {
+    test('checkRemoteInfo detects Bitbucket as unsupported for PRs', async () => {
       gitApiMocks.getRemoteUrl.mockResolvedValue({
         success: true,
         url: 'git@bitbucket.org:org/repo.git',
@@ -366,6 +395,8 @@ describe('Session 10: PR to GitHub Backend', () => {
 
       const info = useGitStore.getState().remoteInfo.get('wt-7')
       expect(info?.isGitHub).toBe(false)
+      expect(info?.forge).toBeNull()
+      expect(info?.supportsPR).toBe(false)
       expect(info?.hasRemote).toBe(true)
     })
   })


### PR DESCRIPTION
## Summary
- Add GitLab forge detection and `glab`-based merge request creation, merging, listing, and review comment retrieval.
- Support GitLab remotes throughout git operations, PR workflows, notifications, and renderer UI.
- Normalize GitHub and GitLab forge URLs, states, errors, and pull request metadata.
- Add comprehensive GitLab CLI, forge parsing, git operations, and RPC tests.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core PR create/merge/list/review paths and depends on `glab` auth per host; GitHub remains the default when forge is unknown, with substantial new test coverage.
> 
> **Overview**
> **GitLab merge requests** are supported end-to-end alongside GitHub: remotes on `github.com` or any host containing `gitlab` are classified via new shared `@shared/git-forge` helpers (URLs, fetch refs `pull/N/head` vs `merge-requests/N/head`, state normalization, CLI error parsing).
> 
> **Backend** gains a `gitlab-cli` module (create/merge/list/view MRs, GraphQL review comments) used from the git-ops RPC layer and the Effect `Git` layer when `origin` resolves to GitLab; GitHub continues to use `gh`. Worktree creation from a PR number now fetches the correct head ref per forge. Discord PR creation and AI PR copy can pass `forge` for merge-request wording.
> 
> **Renderer** replaces GitHub-only gates (`isGitHub`) with `supportsPR` / `forge` on `remoteInfo`, shows GitLab icons and “Open on GitLab” links, and broadens connection/multi-repo PR flows and “already exists” recovery to GitLab MR URLs and `!N` conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b28f3e9ab7d765bd15ee3bcfd5054642c29ff916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->