### PR TITLE
Add tiled In Progress sessions view

### DIFF
--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback, useRef, useLayoutEffect } from 'react'
 import { motion } from 'motion/react'
-import { AlertTriangle, ArrowDownWideNarrow, ChevronRight, ChevronDown, FileText, Plus, Zap, Archive } from 'lucide-react'
+import { AlertTriangle, ArrowDownWideNarrow, ChevronRight, ChevronDown, FileText, LayoutGrid, Plus, Zap, Archive } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { openTiledInProgressSessions } from '@/lib/tiled-sessions'
 import { toast } from '@/lib/toast'
 import { lastSendMode } from '@/lib/message-send-times'
 import { Switch } from '@/components/ui/switch'
@@ -909,28 +910,55 @@ export function KanbanColumn({
                 ON (default) = flow mode: automated worktree picker on drop.
                 OFF = simple mode: direct drop, no modal. */}
             {isInProgressColumn && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div ref={toggleRef} className="ml-auto flex shrink-0 items-center gap-1.5">
-                    {transitionSortButton}
-                    <Zap
+              <div ref={toggleRef} className="ml-auto flex shrink-0 items-center gap-1.5">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      data-testid="tile-in-progress-button"
+                      disabled={tickets.length === 0}
+                      onClick={() =>
+                        void openTiledInProgressSessions(
+                          { projectId, connectionId, isPinnedMode },
+                          tickets
+                        )
+                      }
                       className={cn(
-                        'h-3 w-3',
-                        !isSimpleMode ? 'text-amber-500' : 'text-muted-foreground/50'
+                        'flex h-6 w-6 items-center justify-center rounded-md transition-colors',
+                        tickets.length === 0
+                          ? 'cursor-default text-muted-foreground/30'
+                          : 'text-muted-foreground/50 hover:text-muted-foreground hover:bg-accent'
                       )}
-                    />
-                    <Switch
-                      data-testid="simple-mode-toggle"
-                      size="sm"
-                      checked={!isSimpleMode}
-                      onCheckedChange={(checked) => handleSimpleModeToggle(!checked)}
-                    />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="top" sideOffset={8}>
-                  Send to agent when dragged to this column
-                </TooltipContent>
-              </Tooltip>
+                    >
+                      <LayoutGrid className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" sideOffset={8}>
+                    Tile all In Progress sessions in a grid
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex shrink-0 items-center gap-1.5">
+                      {transitionSortButton}
+                      <Zap
+                        className={cn(
+                          'h-3 w-3',
+                          !isSimpleMode ? 'text-amber-500' : 'text-muted-foreground/50'
+                        )}
+                      />
+                      <Switch
+                        data-testid="simple-mode-toggle"
+                        size="sm"
+                        checked={!isSimpleMode}
+                        onCheckedChange={(checked) => handleSimpleModeToggle(!checked)}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" sideOffset={8}>
+                    Send to agent when dragged to this column
+                  </TooltipContent>
+                </Tooltip>
+              </div>
             )}
 
             {/* Archive toggle — right of title, vertically centered */}

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -29,6 +29,7 @@ import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalCont
 import { KanbanBoard } from '@/components/kanban/KanbanBoard'
 import { KanbanIcon } from '@/components/kanban/KanbanIcon'
 import { BoardAssistantView } from '@/components/kanban/BoardAssistantView'
+import { TiledSessionsView } from '@/components/sessions/TiledSessionsView'
 import { PRNotificationStack } from '@/components/pr/PRNotificationStack'
 import { MainPaneTerminalPanel } from './MainPaneTerminalPanel'
 
@@ -107,6 +108,8 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const closedTerminalSessionIds = useSessionStore((state) => state.closedTerminalSessionIds)
   const activePinnedSessionId = useSessionStore((state) => state.activePinnedSessionId)
   const activeBoardAssistantProjectId = useSessionStore((state) => state.activeBoardAssistantProjectId)
+  const tiledSessionsTab = useSessionStore((state) => state.tiledSessionsTab)
+  const isTiledSessionsActive = useSessionStore((state) => state.isTiledSessionsActive)
   const isBoardViewActive = useKanbanStore((state) => state.isBoardViewActive)
   const isPinnedBoardActive = useKanbanStore((state) => state.isPinnedBoardActive)
   const connectionsLoaded = useConnectionStore((state) => state.loaded)
@@ -234,6 +237,13 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     useSessionStore.getState().acknowledgeClosedTerminals(closedTerminalSessionIds)
   }, [closedTerminalSessionIds])
 
+  // Mirror the mounted set into the session store — the tiled-sessions
+  // snapshot uses it to decide whether a terminal-backed session is already
+  // running (tiling a non-mounted terminal session would spawn its process).
+  useEffect(() => {
+    useSessionStore.getState().setMountedTerminalMirror(mountedTerminalSessionIds)
+  }, [mountedTerminalSessionIds])
+
   // Determine which terminal session is currently visible (if any).
   // A terminal is visible when it's the active session AND no diff/file/loading overlay is on top.
   const visibleTerminalId = useMemo(() => {
@@ -246,7 +256,12 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     // When the board, pinned board, or board assistant is occupying the main
     // pane, hide all stateful terminal sessions — otherwise the always-mounted
     // terminal would render as flex-1 alongside the board and split the pane.
-    if (isBoardViewActive || isPinnedBoardActive || activeBoardAssistantProjectId) {
+    if (
+      isBoardViewActive ||
+      isPinnedBoardActive ||
+      activeBoardAssistantProjectId ||
+      isTiledSessionsActive
+    ) {
       return null
     }
 
@@ -278,7 +293,8 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     getAgentSdk,
     isBoardViewActive,
     isPinnedBoardActive,
-    activeBoardAssistantProjectId
+    activeBoardAssistantProjectId,
+    isTiledSessionsActive
   ])
 
   const handleCloseDiff = useCallback(() => {
@@ -299,6 +315,13 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     // Board assistant tab is active — render BoardAssistantView in main pane
     if (activeBoardAssistantProjectId && !activeFilePath && !activeDiff && !contextEditorWorktreeId) {
       return <BoardAssistantView key={activeBoardAssistantProjectId} projectId={activeBoardAssistantProjectId} />
+    }
+
+    // Tiled in-progress sessions tab is active — render the grid.
+    // Placed above the board branches: the board's persisted active flags stay
+    // true while the tiled tab temporarily takes the pane.
+    if (isTiledSessionsActive && tiledSessionsTab && !activeFilePath && !activeDiff && !contextEditorWorktreeId) {
+      return <TiledSessionsView tab={tiledSessionsTab} />
     }
 
     // Sticky-tab board mode: render board when BOARD_TAB_ID is the active session
@@ -488,7 +511,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
       data-testid="main-pane"
     >
       <PRNotificationStack />
-      {(selectedWorktreeId || selectedConnectionId) && <SessionTabs />}
+      {(selectedWorktreeId || selectedConnectionId || tiledSessionsTab != null) && <SessionTabs />}
       <div className="flex-1 flex flex-col min-h-0">
         {renderContent()}
         {/* Always-mounted terminal sessions — kept alive to preserve PTY state across tab switches */}

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -313,7 +313,12 @@ export function ClaudeCliSessionView({
   const pendingPlan = useSessionStore((state) => state.pendingPlans.get(sessionId) ?? null)
   const { getTarget, revision: portalRevision } = useClaudeCliSessionPortal()
   void portalRevision
-  const isMountedInTicketModal = !!getTarget(sessionId)
+  // A portal target can be the ticket modal's slot OR a tiled-sessions grid
+  // tile; modal-specific behavior (question sidebar suppression, handoff
+  // navigation back to the board) must not apply to tiles.
+  const portalTarget = getTarget(sessionId)
+  const isMountedInTicketModal =
+    !!portalTarget && !portalTarget.hasAttribute('data-tiled-sessions-slot')
   const sessionRecord = useSessionStore((state) => state.getSessionById(sessionId))
 
   // While Telegram forwarding is active, AskUserQuestion is intercepted by the

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -30,7 +30,8 @@ import {
   FileSearch,
   GitPullRequest,
   RadioTower,
-  Star
+  Star,
+  LayoutGrid
 } from 'lucide-react'
 import { KanbanIcon } from '@/components/kanban/KanbanIcon'
 import { useSessionStore, BOARD_TAB_ID } from '@/stores/useSessionStore'
@@ -677,6 +678,12 @@ export function SessionTabs(): React.JSX.Element | null {
   const closeBoardAssistantSession = useSessionStore((s) => s.closeBoardAssistantSession)
   const focusBoardAssistantSession = useSessionStore((s) => s.focusBoardAssistantSession)
 
+  // Tiled in-progress sessions tab state
+  const tiledSessionsTab = useSessionStore((state) => state.tiledSessionsTab)
+  const isTiledSessionsActive = useSessionStore((state) => state.isTiledSessionsActive)
+  const focusTiledSessions = useSessionStore((s) => s.focusTiledSessions)
+  const closeTiledSessions = useSessionStore((s) => s.closeTiledSessions)
+
   // Determine whether we are in connection mode or worktree mode
   const isConnectionMode = !!selectedConnectionId && !selectedWorktreeId
 
@@ -1252,8 +1259,14 @@ export function SessionTabs(): React.JSX.Element | null {
     }
   }, [vimModeEnabled, vimMode, sessionHints, setSessionHints, clearSessionHints])
 
-  // Don't render if nothing is selected AND no orphaned sessions
-  if (!selectedWorktreeId && !selectedConnectionId && orphanedSessions.size === 0) {
+  // Don't render if nothing is selected AND no orphaned sessions AND no tiled
+  // tab (a pinned board can open the tiled-sessions tab without a selection)
+  if (
+    !selectedWorktreeId &&
+    !selectedConnectionId &&
+    orphanedSessions.size === 0 &&
+    !tiledSessionsTab
+  ) {
     return null
   }
 
@@ -1540,6 +1553,7 @@ export function SessionTabs(): React.JSX.Element | null {
               onClick={() => {
                 useFileViewerStore.getState().clearActiveViews()
                 useSessionStore.getState().setActivePinnedSession(null)
+                useSessionStore.getState().deactivateTiledSessions()
               }}
               className={tabClass(!isFileTabActive && !activePinnedSessionId)}
             >
@@ -1605,6 +1619,37 @@ export function SessionTabs(): React.JSX.Element | null {
           </div>
         ) : (
           renderSessionTabs()
+        )}
+
+        {/* Tiled in-progress sessions tab — shared across both modes */}
+        {tiledSessionsTab && (
+          <button
+            className={tabClass(isTiledSessionsActive && !isFileTabActive)}
+            onClick={() => {
+              useFileViewerStore.getState().clearActiveViews()
+              clearInlineConnectionSession()
+              focusTiledSessions()
+            }}
+            title={`In Progress — ${tiledSessionsTab.scopeLabel}`}
+            data-testid="tiled-sessions-tab"
+          >
+            <LayoutGrid className="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+            <span className="truncate flex-1">In Progress · {tiledSessionsTab.scopeLabel}</span>
+            {isTiledSessionsActive && !isFileTabActive && <div className={TAB_UNDERLINE_CLASS} />}
+            {/* Close button */}
+            <span
+              className="ml-1 shrink-0 rounded-sm p-0.5 opacity-0 group-hover:opacity-100 hover:bg-accent transition-opacity"
+              onClick={(e) => {
+                e.stopPropagation()
+                closeTiledSessions()
+              }}
+              role="button"
+              tabIndex={-1}
+              data-testid="tiled-sessions-tab-close"
+            >
+              <X className="h-3 w-3" />
+            </span>
+          </button>
         )}
 
         {/* File viewer tabs — always rendered, shared across both modes */}

--- a/src/renderer/src/components/sessions/TiledSessionsView.tsx
+++ b/src/renderer/src/components/sessions/TiledSessionsView.tsx
@@ -1,0 +1,225 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { LayoutGrid, MonitorOff, CircleSlash } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { computeGridLayout } from '@/lib/tiled-sessions'
+import { useSessionStore, type TiledSessionTile, type TiledSessionsTab } from '@/stores/useSessionStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalContext'
+import { SessionView } from '@/components/sessions'
+
+/**
+ * Portal target for a claude-cli session tile. Mirrors the ticket modal's
+ * ClaudeCliPortalSlot contract exactly: request a mount (keeps the single
+ * always-mounted terminal view alive in MainPane), register this element as
+ * the portal target (the live terminal DOM moves here — no remount, no
+ * respawn), and on unmount unregister + release + conditionally destroy
+ * (no-op for active sessions).
+ */
+function TiledClaudeCliSlot({ sessionId }: { sessionId: string }): React.JSX.Element {
+  const { registerTarget } = useClaudeCliSessionPortal()
+  const requestSessionMount = useSessionStore((s) => s.requestSessionMount)
+  const releaseSessionMount = useSessionStore((s) => s.releaseSessionMount)
+  const targetRef = useRef<HTMLDivElement | null>(null)
+
+  const setTargetRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      targetRef.current = el
+      registerTarget(sessionId, el)
+    },
+    [registerTarget, sessionId]
+  )
+
+  useEffect(() => {
+    requestSessionMount(sessionId)
+    if (targetRef.current) {
+      registerTarget(sessionId, targetRef.current)
+    }
+
+    return () => {
+      registerTarget(sessionId, null)
+      releaseSessionMount(sessionId)
+      // No-op for active sessions; kills the PTY only for completed,
+      // un-engaged sessions (same guard set as the ticket modal slot).
+      void useSessionStore.getState().destroyCompletedSessionTerminal(sessionId)
+    }
+  }, [registerTarget, releaseSessionMount, requestSessionMount, sessionId])
+
+  return (
+    <div
+      ref={setTargetRef}
+      className="flex-1 flex flex-col min-h-0"
+      data-testid={`tiled-claude-cli-slot-${sessionId}`}
+      data-tiled-sessions-slot="true"
+    />
+  )
+}
+
+function TilePlaceholder({
+  icon: Icon,
+  message
+}: {
+  icon: typeof MonitorOff
+  message: string
+}): React.JSX.Element {
+  return (
+    <div className="flex-1 flex items-center justify-center text-muted-foreground">
+      <div className="flex flex-col items-center gap-2 px-4 text-center">
+        <Icon className="h-5 w-5 opacity-50" />
+        <p className="text-xs">{message}</p>
+      </div>
+    </div>
+  )
+}
+
+function TileStatusDot({ sessionId }: { sessionId: string | null }): React.JSX.Element {
+  const status = useWorktreeStatusStore((s) =>
+    sessionId ? (s.sessionStatuses[sessionId]?.status ?? null) : null
+  )
+
+  const isBusy = status === 'working' || status === 'planning' || status === 'answering'
+  const needsAttention =
+    status === 'permission' || status === 'command_approval' || status === 'plan_ready'
+
+  return (
+    <span
+      data-testid="tile-status-dot"
+      data-status={status ?? 'none'}
+      className={cn(
+        'h-1.5 w-1.5 shrink-0 rounded-full',
+        isBusy
+          ? 'bg-emerald-500 animate-pulse'
+          : needsAttention
+            ? 'bg-amber-500'
+            : 'bg-muted-foreground/40'
+      )}
+    />
+  )
+}
+
+function SessionTile({ tile }: { tile: TiledSessionTile }): React.JSX.Element {
+  const isClaudeCli = tile.agentSdk === 'claude-code-cli'
+  const isPlainTerminal = tile.agentSdk === 'terminal'
+
+  // Live check on top of the snapshot: if the session is closed while the tab
+  // is open (its view in MainPane unmounts and the reparented DOM disappears),
+  // swap to a placeholder instead of leaving a dead, empty tile.
+  const liveSessionStatus = useSessionStore((s) =>
+    tile.sessionId ? (s.getSessionById(tile.sessionId)?.status ?? null) : null
+  )
+  const sessionEnded = tile.isRunning && liveSessionStatus !== 'active'
+
+  let content: React.JSX.Element
+  if (!tile.sessionId) {
+    content = <TilePlaceholder icon={CircleSlash} message="No session attached to this ticket" />
+  } else if (sessionEnded) {
+    content = <TilePlaceholder icon={MonitorOff} message="Session ended" />
+  } else if (!tile.isRunning) {
+    content = (
+      <TilePlaceholder
+        icon={MonitorOff}
+        message="Session not running — open its tab to start it"
+      />
+    )
+  } else if (isClaudeCli) {
+    content = <TiledClaudeCliSlot sessionId={tile.sessionId} />
+  } else if (isPlainTerminal) {
+    content = (
+      <TilePlaceholder icon={MonitorOff} message="Terminal session — open its tab to view it" />
+    )
+  } else {
+    content = <SessionView sessionId={tile.sessionId} isVisible />
+  }
+
+  return (
+    <div
+      data-testid={`session-tile-${tile.sessionId ?? tile.ticketIds[0]}`}
+      className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-border bg-background"
+    >
+      {/* Tile title bar — always shows the ticket title; project name on multi-project boards */}
+      <div className="flex h-7 shrink-0 items-center gap-1.5 border-b border-border bg-card px-2">
+        <TileStatusDot sessionId={tile.sessionId} />
+        <span
+          className="min-w-0 flex-1 truncate text-[11px] font-medium text-foreground"
+          title={tile.title}
+          data-testid="tile-title"
+        >
+          {tile.title}
+        </span>
+        {tile.projectName && (
+          <span
+            className="max-w-[40%] shrink-0 truncate rounded-full bg-secondary px-1.5 py-px text-[10px] font-medium text-muted-foreground"
+            title={tile.projectName}
+            data-testid="tile-project-badge"
+          >
+            {tile.projectName}
+          </span>
+        )}
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col">{content}</div>
+    </div>
+  )
+}
+
+/**
+ * Tiled view of the In Progress column's sessions — a snapshot grid opened
+ * from the board's In Progress header. Fully interactive tiles: claude-cli
+ * sessions reparent their live terminal DOM here via the session portal;
+ * chat sessions mount their regular SessionView.
+ */
+export function TiledSessionsView({ tab }: { tab: TiledSessionsTab }): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [dims, setDims] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      const { width, height } = entry.contentRect
+      setDims((prev) =>
+        prev.width === Math.round(width) && prev.height === Math.round(height)
+          ? prev
+          : { width: Math.round(width), height: Math.round(height) }
+      )
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  const tiles = tab.tiles
+  const { cols, rows } = computeGridLayout(tiles.length, dims.width, dims.height)
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex-1 min-h-0 min-w-0 p-1.5"
+      data-testid="tiled-sessions-view"
+    >
+      {tiles.length === 0 ? (
+        <div className="flex h-full items-center justify-center text-muted-foreground">
+          <div className="text-center">
+            <LayoutGrid className="mx-auto mb-3 h-8 w-8 opacity-50" />
+            <p className="text-sm">No in-progress sessions to tile</p>
+          </div>
+        </div>
+      ) : (
+        <div
+          className="grid h-full w-full gap-1.5"
+          style={{
+            gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+            gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))`
+          }}
+          data-testid="tiled-sessions-grid"
+          data-tiled-sessions-grid="true"
+          data-grid-cols={cols}
+          data-grid-rows={rows}
+        >
+          {tiles.map((tile) => (
+            <SessionTile key={tile.sessionId ?? tile.ticketIds[0]} tile={tile} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -110,6 +110,16 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   const effectiveVisibleRef = useRef(effectiveVisible)
   effectiveVisibleRef.current = effectiveVisible
 
+  // True when this terminal is portalled into the tiled-sessions grid, where
+  // several terminals are visible at once. Focus-sensitive behaviors
+  // (autofocus-on-visible, the 'edit:paste' IPC broadcast) scope themselves to
+  // grid tiles only, so single-terminal layouts (including the always-visible
+  // bottom/sidebar terminal panel) keep their existing behavior.
+  const isInTiledGrid = useCallback(
+    (): boolean => !!containerRef.current?.closest('[data-tiled-sessions-grid]'),
+    []
+  )
+
   const shiftEnterAsNewlineRef = useRef(shiftEnterAsNewline ?? false)
   shiftEnterAsNewlineRef.current = shiftEnterAsNewline ?? false
 
@@ -124,6 +134,10 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
         }
       },
       focus: () => {
+        // Grid tiles never steal focus programmatically — the user clicks the
+        // tile they want to type into (covers ClaudeCliSessionView's own
+        // visibility focus timer too).
+        if (isInTiledGrid()) return
         backendRef.current?.focus()
       },
       clear: () => {
@@ -172,6 +186,11 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       if (backend && backend.type === 'xterm') {
         ;(backend as XtermBackend).fit()
       }
+      if (isInTiledGrid()) {
+        // Grid tiles don't fight over focus — the user clicks the tile they
+        // want to type into.
+        return
+      }
       if (backend?.type === 'ghostty' && hasFocusedEditableElement()) {
         return
       }
@@ -196,6 +215,12 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     if (!effectiveVisible) return
 
     const cleanup = systemApi.onEditPaste((text) => {
+      // Grid tiles receive the broadcast only when focused, so a paste can't
+      // land in every visible tile at once. Terminals outside the grid keep
+      // their existing behavior.
+      if (isInTiledGrid() && !containerRef.current?.contains(document.activeElement)) {
+        return
+      }
       if (activeBackendTypeRef.current === 'ghostty') {
         terminalApi.ghosttyPasteText(terminalId, text).then(unwrapEnvelope)
       } else if (activeBackendTypeRef.current === 'xterm') {

--- a/src/renderer/src/lib/__tests__/tiled-sessions.test.ts
+++ b/src/renderer/src/lib/__tests__/tiled-sessions.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { KanbanTicket } from '../../../../main/db/types'
+import { computeGridLayout, openTiledInProgressSessions } from '../tiled-sessions'
+import { useSessionStore, type Session } from '@/stores/useSessionStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { usePinnedStore } from '@/stores/usePinnedStore'
+
+const initialSessionState = useSessionStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialPinnedState = usePinnedStore.getState()
+
+function makeTicket(overrides: Partial<KanbanTicket>): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'p1',
+    title: 'Ticket',
+    description: null,
+    attachments: [],
+    column: 'in_progress',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: null,
+    mode: null,
+    plan_ready: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  } as KanbanTicket
+}
+
+function makeSession(overrides: Partial<Session>): Session {
+  return {
+    id: 'session-1',
+    worktree_id: 'wt1',
+    project_id: 'p1',
+    connection_id: null,
+    name: null,
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'opencode',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    ...overrides
+  } as Session
+}
+
+describe('computeGridLayout', () => {
+  it('handles degenerate counts', () => {
+    expect(computeGridLayout(0, 1600, 900)).toEqual({ cols: 1, rows: 1 })
+    expect(computeGridLayout(1, 1600, 900)).toEqual({ cols: 1, rows: 1 })
+  })
+
+  it('falls back to a near-square grid when dimensions are unknown', () => {
+    expect(computeGridLayout(5, 0, 0)).toEqual({ cols: 3, rows: 2 })
+    expect(computeGridLayout(9, 0, 0)).toEqual({ cols: 3, rows: 3 })
+  })
+
+  it('tiles a landscape container horizontally first', () => {
+    expect(computeGridLayout(2, 1600, 900)).toEqual({ cols: 2, rows: 1 })
+    expect(computeGridLayout(3, 1600, 900)).toEqual({ cols: 2, rows: 2 })
+    expect(computeGridLayout(4, 1600, 900)).toEqual({ cols: 2, rows: 2 })
+    expect(computeGridLayout(5, 1600, 900)).toEqual({ cols: 3, rows: 2 })
+    expect(computeGridLayout(6, 1600, 900)).toEqual({ cols: 3, rows: 2 })
+  })
+
+  it('tiles a portrait container vertically', () => {
+    expect(computeGridLayout(2, 700, 1600)).toEqual({ cols: 1, rows: 2 })
+  })
+
+  it('never produces fewer cells than tiles', () => {
+    for (let n = 1; n <= 24; n++) {
+      const { cols, rows } = computeGridLayout(n, 1440, 800)
+      expect(cols * rows).toBeGreaterThanOrEqual(n)
+      expect(cols).toBeLessThanOrEqual(n)
+    }
+  })
+})
+
+describe('openTiledInProgressSessions', () => {
+  afterEach(() => {
+    useSessionStore.setState(initialSessionState, true)
+    useKanbanStore.setState(initialKanbanState, true)
+    useProjectStore.setState(initialProjectState, true)
+    usePinnedStore.setState(initialPinnedState, true)
+  })
+
+  it('builds a snapshot for a single-project board (no project names on tiles)', async () => {
+    useProjectStore.setState({
+      projects: [{ id: 'p1', name: 'Acme' }] as never
+    })
+    useKanbanStore.setState({
+      tickets: new Map([
+        [
+          'p1',
+          [
+            makeTicket({
+              id: 't-chat',
+              title: 'Chat ticket',
+              current_session_id: 's-chat',
+              sort_order: 0
+            }),
+            makeTicket({
+              id: 't-cli-running',
+              title: 'CLI running',
+              current_session_id: 's-cli-running',
+              sort_order: 1
+            }),
+            makeTicket({
+              id: 't-cli-idle',
+              title: 'CLI idle',
+              current_session_id: 's-cli-idle',
+              sort_order: 2
+            }),
+            makeTicket({ id: 't-no-session', title: 'No session', sort_order: 3 }),
+            makeTicket({ id: 't-done', title: 'Done ticket', column: 'done', sort_order: 4 })
+          ]
+        ]
+      ])
+    })
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([
+        [
+          'wt1',
+          [
+            makeSession({ id: 's-chat', agent_sdk: 'opencode' }),
+            makeSession({ id: 's-cli-running', agent_sdk: 'claude-code-cli' }),
+            makeSession({ id: 's-cli-idle', agent_sdk: 'claude-code-cli' })
+          ]
+        ]
+      ]),
+      mountedTerminalMirror: new Set(['s-cli-running'])
+    })
+
+    await openTiledInProgressSessions({ projectId: 'p1' })
+
+    const state = useSessionStore.getState()
+    expect(state.isTiledSessionsActive).toBe(true)
+    expect(state.tiledSessionsTab?.scopeLabel).toBe('Acme')
+
+    const tiles = state.tiledSessionsTab?.tiles ?? []
+    expect(tiles.map((t) => t.title)).toEqual([
+      'Chat ticket',
+      'CLI running',
+      'CLI idle',
+      'No session'
+    ])
+    // Single-project board: no project names on tiles
+    expect(tiles.every((t) => t.projectName === null)).toBe(true)
+
+    const byTitle = new Map(tiles.map((t) => [t.title, t]))
+    // Chat session: active status is enough to be running
+    expect(byTitle.get('Chat ticket')?.isRunning).toBe(true)
+    // Terminal-backed: running only when its view/PTY is mounted
+    expect(byTitle.get('CLI running')?.isRunning).toBe(true)
+    expect(byTitle.get('CLI idle')?.isRunning).toBe(false)
+    expect(byTitle.get('No session')?.sessionId).toBeNull()
+    expect(byTitle.get('No session')?.isRunning).toBe(false)
+  })
+
+  it('merges tickets sharing one session into a single tile', async () => {
+    useProjectStore.setState({ projects: [{ id: 'p1', name: 'Acme' }] as never })
+    useKanbanStore.setState({
+      tickets: new Map([
+        [
+          'p1',
+          [
+            makeTicket({ id: 't1', title: 'First', current_session_id: 'shared', sort_order: 0 }),
+            makeTicket({ id: 't2', title: 'Second', current_session_id: 'shared', sort_order: 1 })
+          ]
+        ]
+      ])
+    })
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([['wt1', [makeSession({ id: 'shared' })]]])
+    })
+
+    await openTiledInProgressSessions({ projectId: 'p1' })
+
+    const tiles = useSessionStore.getState().tiledSessionsTab?.tiles ?? []
+    expect(tiles).toHaveLength(1)
+    expect(tiles[0].title).toBe('First · Second')
+    expect(tiles[0].ticketIds).toEqual(['t1', 't2'])
+  })
+
+  it('includes project names on pinned boards', async () => {
+    useProjectStore.setState({
+      projects: [
+        { id: 'p1', name: 'Acme' },
+        { id: 'p2', name: 'Umbrella' }
+      ] as never
+    })
+    usePinnedStore.setState({ pinnedProjectIds: new Set(['p1', 'p2']) } as never)
+    useKanbanStore.setState({
+      tickets: new Map([
+        ['p1', [makeTicket({ id: 'a1', title: 'From Acme', current_session_id: 'sa' })]],
+        [
+          'p2',
+          [
+            makeTicket({
+              id: 'b1',
+              title: 'From Umbrella',
+              project_id: 'p2',
+              current_session_id: 'sb'
+            })
+          ]
+        ]
+      ])
+    })
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([
+        ['wt1', [makeSession({ id: 'sa', project_id: 'p1' })]],
+        ['wt2', [makeSession({ id: 'sb', project_id: 'p2', worktree_id: 'wt2' })]]
+      ])
+    })
+
+    await openTiledInProgressSessions({ projectId: '', isPinnedMode: true })
+
+    const state = useSessionStore.getState()
+    expect(state.tiledSessionsTab?.scopeLabel).toBe('Pinned')
+    const tiles = state.tiledSessionsTab?.tiles ?? []
+    expect(tiles).toHaveLength(2)
+    const byTitle = new Map(tiles.map((t) => [t.title, t]))
+    expect(byTitle.get('From Acme')?.projectName).toBe('Acme')
+    expect(byTitle.get('From Umbrella')?.projectName).toBe('Umbrella')
+  })
+
+  it('marks completed sessions as not running', async () => {
+    useProjectStore.setState({ projects: [{ id: 'p1', name: 'Acme' }] as never })
+    useKanbanStore.setState({
+      tickets: new Map([
+        ['p1', [makeTicket({ id: 't1', title: 'Ended', current_session_id: 's-ended' })]]
+      ])
+    })
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([
+        ['wt1', [makeSession({ id: 's-ended', status: 'completed' })]]
+      ])
+    })
+
+    await openTiledInProgressSessions({ projectId: 'p1' })
+
+    const tiles = useSessionStore.getState().tiledSessionsTab?.tiles ?? []
+    expect(tiles[0].isRunning).toBe(false)
+    expect(tiles[0].sessionId).toBe('s-ended')
+  })
+})

--- a/src/renderer/src/lib/tiled-sessions.ts
+++ b/src/renderer/src/lib/tiled-sessions.ts
@@ -1,0 +1,161 @@
+import type { KanbanTicket } from '../../../main/db/types'
+import { isTerminalBacked } from '@shared/types/agent-sdk'
+import { dbApi } from '@/api/db-api'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import {
+  useSessionStore,
+  type Session,
+  type TiledSessionTile
+} from '@/stores/useSessionStore'
+
+/** Board scope the tile button was clicked from (mirrors KanbanColumn props) */
+export interface TiledScopeInput {
+  /** '' on multi-project boards (pinned/connection) — same convention as KanbanColumn */
+  projectId: string
+  connectionId?: string
+  isPinnedMode?: boolean
+}
+
+/**
+ * Compute the optimal near-square grid for `count` tiles in a `width`x`height`
+ * container: picks the column count that maximizes how close each tile gets to
+ * the ideal aspect ratio, weighted by cell utilization (fewer empty cells).
+ */
+export function computeGridLayout(
+  count: number,
+  width: number,
+  height: number,
+  idealTileAspect = 1.5
+): { cols: number; rows: number } {
+  if (count <= 0) return { cols: 1, rows: 1 }
+  if (width <= 0 || height <= 0) {
+    const cols = Math.ceil(Math.sqrt(count))
+    return { cols, rows: Math.ceil(count / cols) }
+  }
+
+  let bestCols = 1
+  let bestRows = count
+  let bestScore = -Infinity
+  for (let cols = 1; cols <= count; cols++) {
+    const rows = Math.ceil(count / cols)
+    const tileAspect = width / cols / (height / rows)
+    // 1 when the tile hits the ideal aspect, decaying toward 0 either way
+    const aspectScore =
+      tileAspect >= idealTileAspect ? idealTileAspect / tileAspect : tileAspect / idealTileAspect
+    // Penalize layouts with many empty cells (e.g. 5 tiles in a 3x2 grid is fine,
+    // 5 tiles in a 4x2 grid wastes 3 cells)
+    const utilization = count / (cols * rows)
+    const score = aspectScore * utilization
+    if (score > bestScore) {
+      bestScore = score
+      bestCols = cols
+      bestRows = rows
+    }
+  }
+  return { cols: bestCols, rows: bestRows }
+}
+
+/** Resolve the in-progress tickets for a board scope */
+function getInProgressTickets(scope: TiledScopeInput): KanbanTicket[] {
+  const kanban = useKanbanStore.getState()
+  if (scope.isPinnedMode) return kanban.getTicketsByColumnForPinned('in_progress')
+  if (scope.connectionId) {
+    return kanban.getTicketsByColumnForConnection(scope.connectionId, 'in_progress')
+  }
+  return kanban.getTicketsByColumn(scope.projectId, 'in_progress')
+}
+
+function getScopeLabel(scope: TiledScopeInput): string {
+  if (scope.isPinnedMode) return 'Pinned'
+  if (scope.connectionId) {
+    const connection = useConnectionStore
+      .getState()
+      .connections.find((c) => c.id === scope.connectionId)
+    return connection?.custom_name || connection?.name || 'Connection'
+  }
+  const project = useProjectStore.getState().projects.find((p) => p.id === scope.projectId)
+  return project?.name ?? 'Project'
+}
+
+/** Store-scan first, DB fallback (+ hydrate) — same pattern as KanbanTicketModal */
+async function resolveSession(sessionId: string): Promise<Session | null> {
+  const store = useSessionStore.getState()
+  const inMemory = store.getSessionById(sessionId)
+  if (inMemory) return inMemory
+  try {
+    const dbSession = await dbApi.session.get<Session>(sessionId)
+    if (dbSession) {
+      // Insert into the store so downstream lookups (SessionView routing,
+      // MainPane getAgentSdk) can find it.
+      useSessionStore.getState().hydrateSession(dbSession)
+      return dbSession
+    }
+  } catch {
+    // Session row missing — treat as no session
+  }
+  return null
+}
+
+/**
+ * Build a snapshot of the board's In Progress column and open it as the
+ * tiled-sessions tab. Snapshot semantics: the grid is fixed to the column's
+ * contents at click time (no live re-flow).
+ */
+export async function openTiledInProgressSessions(
+  scope: TiledScopeInput,
+  /** The tickets the column currently displays (search-filtered). Falls back
+   * to a fresh store query when omitted. */
+  columnTickets?: KanbanTicket[]
+): Promise<void> {
+  const tickets = columnTickets ?? getInProgressTickets(scope)
+  const isMultiProject = !!scope.connectionId || !!scope.isPinnedMode
+  const projects = useProjectStore.getState().projects
+
+  const tiles: TiledSessionTile[] = []
+  const tileBySessionId = new Map<string, TiledSessionTile>()
+
+  for (const ticket of tickets) {
+    // One session can serve several tickets (pre-assign / bulk handoff) —
+    // merge those tickets into a single tile with joined titles.
+    const sharedTile = ticket.current_session_id
+      ? tileBySessionId.get(ticket.current_session_id)
+      : undefined
+    if (sharedTile) {
+      sharedTile.ticketIds.push(ticket.id)
+      sharedTile.title = `${sharedTile.title} · ${ticket.title}`
+      continue
+    }
+
+    const session = ticket.current_session_id
+      ? await resolveSession(ticket.current_session_id)
+      : null
+
+    const agentSdk = session?.agent_sdk ?? null
+    // Terminal-backed sessions spawn their process when their view mounts, so
+    // "running" means the view/PTY is already mounted this run. Chat sessions
+    // don't spawn OS processes on mount — active status is enough.
+    const isRunning =
+      !!session &&
+      session.status === 'active' &&
+      (!isTerminalBacked(agentSdk) ||
+        useSessionStore.getState().mountedTerminalMirror.has(session.id))
+
+    const tile: TiledSessionTile = {
+      ticketIds: [ticket.id],
+      title: ticket.title,
+      projectId: ticket.project_id,
+      projectName: isMultiProject
+        ? (projects.find((p) => p.id === ticket.project_id)?.name ?? null)
+        : null,
+      sessionId: session?.id ?? null,
+      agentSdk,
+      isRunning
+    }
+    tiles.push(tile)
+    if (session) tileBySessionId.set(session.id, tile)
+  }
+
+  useSessionStore.getState().openTiledSessions({ scopeLabel: getScopeLabel(scope), tiles })
+}

--- a/src/renderer/src/stores/__tests__/useSessionStore.tiled-sessions.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.tiled-sessions.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { useSessionStore, type TiledSessionsTab } from '../useSessionStore'
+
+const initialSessionState = useSessionStore.getState()
+
+const sampleTab: TiledSessionsTab = {
+  scopeLabel: 'Acme',
+  tiles: [
+    {
+      ticketIds: ['t1'],
+      title: 'Fix the login flow',
+      projectId: 'p1',
+      projectName: null,
+      sessionId: 's1',
+      agentSdk: 'claude-code-cli',
+      isRunning: true
+    }
+  ]
+}
+
+describe('useSessionStore tiled sessions tab', () => {
+  afterEach(() => {
+    useSessionStore.setState(initialSessionState, true)
+  })
+
+  it('openTiledSessions activates the tab and clears rival active states', () => {
+    useSessionStore.setState({
+      activeSessionId: 'other-session',
+      activePinnedSessionId: 'pinned-session',
+      inlineConnectionSessionId: 'inline-session',
+      activeBoardAssistantProjectId: 'p9'
+    })
+
+    useSessionStore.getState().openTiledSessions(sampleTab)
+
+    const state = useSessionStore.getState()
+    expect(state.tiledSessionsTab).toEqual(sampleTab)
+    expect(state.isTiledSessionsActive).toBe(true)
+    expect(state.activeSessionId).toBeNull()
+    expect(state.activePinnedSessionId).toBeNull()
+    expect(state.inlineConnectionSessionId).toBeNull()
+    expect(state.activeBoardAssistantProjectId).toBeNull()
+  })
+
+  it('focusTiledSessions is a no-op without a tab and re-activates with one', () => {
+    useSessionStore.getState().focusTiledSessions()
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+
+    useSessionStore.getState().openTiledSessions(sampleTab)
+    useSessionStore.getState().deactivateTiledSessions()
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+    expect(useSessionStore.getState().tiledSessionsTab).toEqual(sampleTab)
+
+    useSessionStore.getState().focusTiledSessions()
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(true)
+  })
+
+  it('closeTiledSessions restores the persisted active session for the scope', () => {
+    useSessionStore.setState({
+      activeWorktreeId: 'wt1',
+      activeSessionByWorktree: { wt1: 'restored-session' },
+      sessionsByWorktree: new Map([
+        ['wt1', [{ id: 'restored-session', status: 'active' } as never]]
+      ])
+    })
+    useSessionStore.getState().openTiledSessions(sampleTab)
+
+    useSessionStore.getState().closeTiledSessions()
+
+    const state = useSessionStore.getState()
+    expect(state.tiledSessionsTab).toBeNull()
+    expect(state.isTiledSessionsActive).toBe(false)
+    expect(state.activeSessionId).toBe('restored-session')
+  })
+
+  it('closeTiledSessions falls back when the persisted session is stale', () => {
+    useSessionStore.setState({
+      activeWorktreeId: 'wt1',
+      activeSessionByWorktree: { wt1: 'closed-session' },
+      sessionsByWorktree: new Map([
+        ['wt1', [{ id: 'other-session', status: 'active' } as never]]
+      ])
+    })
+    useSessionStore.getState().openTiledSessions(sampleTab)
+
+    useSessionStore.getState().closeTiledSessions()
+
+    const state = useSessionStore.getState()
+    // Stale persisted id is rejected; sticky-tab default falls back to the board
+    expect(state.activeSessionId).not.toBe('closed-session')
+  })
+
+  it('any raw write of a non-null activeSessionId deactivates the tiled tab (invariant subscription)', () => {
+    useSessionStore.getState().openTiledSessions(sampleTab)
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(true)
+
+    // Bypass all activator actions — write the field directly, as
+    // reopenSession/createSession/closeOtherSessions do.
+    useSessionStore.setState({ activeSessionId: 'raw-write-session' })
+
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+    expect(useSessionStore.getState().tiledSessionsTab).toEqual(sampleTab)
+  })
+
+  it('closeTiledSessions while inactive clears the tab without touching the active session', () => {
+    useSessionStore.getState().openTiledSessions(sampleTab)
+    useSessionStore.getState().setActiveSession('other-session')
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+
+    useSessionStore.getState().closeTiledSessions()
+
+    const state = useSessionStore.getState()
+    expect(state.tiledSessionsTab).toBeNull()
+    expect(state.activeSessionId).toBe('other-session')
+  })
+
+  it('rival activators deactivate but keep the tab; null-clears do not deactivate', () => {
+    useSessionStore.getState().openTiledSessions(sampleTab)
+
+    // Null-clears must NOT deactivate (they are clears, not activations)
+    useSessionStore.getState().setActivePinnedSession(null)
+    useSessionStore.getState().setInlineConnectionSession(null)
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(true)
+
+    // Activating a pinned session deactivates
+    useSessionStore.getState().setActivePinnedSession('pinned-1')
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+    expect(useSessionStore.getState().tiledSessionsTab).toEqual(sampleTab)
+
+    // Re-focus, then an inline connection session deactivates
+    useSessionStore.getState().focusTiledSessions()
+    useSessionStore.getState().setInlineConnectionSession('inline-1')
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+
+    // Re-focus, then setActiveSession deactivates
+    useSessionStore.getState().focusTiledSessions()
+    useSessionStore.getState().setActiveSession('session-1')
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+
+    // Re-focus, then a scope switch deactivates
+    useSessionStore.getState().focusTiledSessions()
+    useSessionStore.getState().setActiveWorktree('wt-2')
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+  })
+
+  it('setMountedTerminalMirror snapshots the mounted id list as a Set', () => {
+    useSessionStore.getState().setMountedTerminalMirror(['a', 'b', 'a'])
+    expect(useSessionStore.getState().mountedTerminalMirror).toEqual(new Set(['a', 'b']))
+
+    useSessionStore.getState().setMountedTerminalMirror([])
+    expect(useSessionStore.getState().mountedTerminalMirror.size).toBe(0)
+  })
+})

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -1204,7 +1204,15 @@ export const useKanbanStore = create<KanbanState>()(
 
       // ── toggleBoardView ──────────────────────────────────────────
       toggleBoardView: () => {
-        set((state) => ({ isBoardViewActive: !state.isBoardViewActive }))
+        // If the tiled-sessions tab holds the pane, the user's intent is
+        // "show the board": deactivate the tiled tab and force the board ON
+        // (toggling would flip an already-true persisted flag to false with
+        // no visible change). Dynamic import avoids a store dependency cycle.
+        void import('./useSessionStore').then(({ useSessionStore }) => {
+          const wasTiled = useSessionStore.getState().isTiledSessionsActive
+          if (wasTiled) useSessionStore.getState().deactivateTiledSessions()
+          set((state) => ({ isBoardViewActive: wasTiled ? true : !state.isBoardViewActive }))
+        })
       },
 
       // ── setTransitionSort ────────────────────────────────────────
@@ -1741,7 +1749,12 @@ export const useKanbanStore = create<KanbanState>()(
 
       // ── togglePinnedBoard ────────────────────────────────────────
       togglePinnedBoard: () => {
-        set((state) => ({ isPinnedBoardActive: !state.isPinnedBoardActive }))
+        // Same intent resolution as toggleBoardView (see comment there).
+        void import('./useSessionStore').then(({ useSessionStore }) => {
+          const wasTiled = useSessionStore.getState().isTiledSessionsActive
+          if (wasTiled) useSessionStore.getState().deactivateTiledSessions()
+          set((state) => ({ isPinnedBoardActive: wasTiled ? true : !state.isPinnedBoardActive }))
+        })
       },
 
       // ── loadTicketsForPinnedProjects ─────────────────────────────

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -110,6 +110,28 @@ export interface PendingPlan {
   toolUseID: string
 }
 
+// One tile in the tiled in-progress sessions view. Snapshot data resolved at
+// open time (ticket titles, project names, session identity, running state).
+export interface TiledSessionTile {
+  /** Tickets represented by this tile (several tickets can share one session) */
+  ticketIds: string[]
+  /** Joined ticket title(s) — always shown on the tile */
+  title: string
+  projectId: string
+  /** Project name — set on multi-project boards (pinned/connection), null otherwise */
+  projectName: string | null
+  sessionId: string | null
+  agentSdk: AgentSdk | null
+  /** Whether the session can be tiled live (chat: active; terminal-backed: PTY mounted) */
+  isRunning: boolean
+}
+
+export interface TiledSessionsTab {
+  /** Board scope the snapshot was taken from — shown in the tab title */
+  scopeLabel: string
+  tiles: TiledSessionTile[]
+}
+
 export interface CodexThreadGoal {
   threadId: string
   objective: string
@@ -123,7 +145,7 @@ export interface CodexThreadGoal {
 }
 
 // Session type matching the database schema
-interface Session {
+export interface Session {
   id: string
   worktree_id: string | null
   project_id: string
@@ -200,6 +222,16 @@ interface SessionState {
   // Board assistant state — project-scoped, one per project
   boardAssistantByProject: Map<string, Session>
   activeBoardAssistantProjectId: string | null
+
+  // Tiled in-progress sessions tab — snapshot taken when the user clicks the
+  // tile button on a board's In Progress column header. Not persisted.
+  tiledSessionsTab: TiledSessionsTab | null
+  isTiledSessionsActive: boolean
+  // Mirror of MainPane's mountedTerminalSessionIds — terminal-backed sessions
+  // whose views (and thus PTYs) were mounted this run and not closed. Used to
+  // decide whether a terminal-backed session is "already running" (tiling a
+  // non-mounted terminal session would spawn its process).
+  mountedTerminalMirror: Set<string>
 
   // Actions
   acknowledgeClosedTerminals: (ids: Set<string>) => void
@@ -304,6 +336,13 @@ interface SessionState {
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
   closeBoardAssistantSession: (projectId: string) => Promise<{ success: boolean; error?: string }>
   focusBoardAssistantSession: (projectId: string) => void
+
+  // Tiled sessions tab actions
+  openTiledSessions: (tab: TiledSessionsTab) => void
+  focusTiledSessions: () => void
+  deactivateTiledSessions: () => void
+  closeTiledSessions: () => void
+  setMountedTerminalMirror: (ids: readonly string[]) => void
   clearBoardAssistantFocus: () => void
 
   // Connection session actions
@@ -421,6 +460,10 @@ export const useSessionStore = create<SessionState>()(
       // Board assistant state
       boardAssistantByProject: new Map(),
       activeBoardAssistantProjectId: null,
+
+      tiledSessionsTab: null,
+      isTiledSessionsActive: false,
+      mountedTerminalMirror: new Set<string>(),
 
       acknowledgeClosedTerminals: (ids: Set<string>) => {
         set((state) => {
@@ -559,9 +602,15 @@ export const useSessionStore = create<SessionState>()(
               }
             }
 
-            // Set active session if none selected and sessions exist
+            // Set active session if none selected and sessions exist.
+            // Skip while the tiled-sessions tab holds the pane — it nulls
+            // activeSessionId on purpose; restoring here would fight it.
             let activeSessionId = state.activeSessionId
-            if (state.activeWorktreeId === worktreeId && !activeSessionId) {
+            if (
+              state.activeWorktreeId === worktreeId &&
+              !activeSessionId &&
+              !state.isTiledSessionsActive
+            ) {
               // Try to restore persisted active session
               const persistedSessionId = state.activeSessionByWorktree[worktreeId]
               const boardMode = useSettingsStore.getState().boardMode
@@ -1309,6 +1358,7 @@ export const useSessionStore = create<SessionState>()(
           set((state) => ({
             activeSessionId: sessionId,
             activeBoardAssistantProjectId: null,
+            isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive,
             activeSessionByWorktree: {
               ...state.activeSessionByWorktree,
               [worktreeId]: sessionId
@@ -1318,13 +1368,18 @@ export const useSessionStore = create<SessionState>()(
           set((state) => ({
             activeSessionId: sessionId,
             activeBoardAssistantProjectId: null,
+            isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive,
             activeSessionByConnection: {
               ...state.activeSessionByConnection,
               [connectionId]: sessionId
             }
           }))
         } else {
-          set({ activeSessionId: sessionId, activeBoardAssistantProjectId: null })
+          set((state) => ({
+            activeSessionId: sessionId,
+            activeBoardAssistantProjectId: null,
+            isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive
+          }))
         }
       },
 
@@ -1338,7 +1393,8 @@ export const useSessionStore = create<SessionState>()(
           activeWorktreeId: worktreeId,
           activeConnectionId: null,
           inlineConnectionSessionId: null,
-          activeBoardAssistantProjectId: null
+          activeBoardAssistantProjectId: null,
+          isTiledSessionsActive: false
         })
 
         if (worktreeId) {
@@ -2180,7 +2236,8 @@ export const useSessionStore = create<SessionState>()(
               // Clear other active states so the board assistant view shows
               activeSessionId: null,
               activePinnedSessionId: null,
-              inlineConnectionSessionId: null
+              inlineConnectionSessionId: null,
+              isTiledSessionsActive: false
             }
           })
 
@@ -2301,7 +2358,8 @@ export const useSessionStore = create<SessionState>()(
           // Clear other active states so the board assistant view shows
           activeSessionId: null,
           activePinnedSessionId: null,
-          inlineConnectionSessionId: null
+          inlineConnectionSessionId: null,
+          isTiledSessionsActive: false
         })
       },
 
@@ -2309,10 +2367,92 @@ export const useSessionStore = create<SessionState>()(
         set({ activeBoardAssistantProjectId: null })
       },
 
+      // ─── Tiled in-progress sessions tab ─────────────────────────────────
+      // Opens (or replaces) the tiled-sessions tab with a fresh snapshot and
+      // activates it. Mirrors focusBoardAssistantSession: activating a tab
+      // kind means setting its own flag AND clearing every competing flag.
+      openTiledSessions: (tab: TiledSessionsTab) => {
+        // Clear file/diff/context overlays so the tiled view takes the pane
+        import('./useFileViewerStore').then(({ useFileViewerStore }) => {
+          useFileViewerStore.getState().clearActiveViews()
+        })
+        set({
+          tiledSessionsTab: tab,
+          isTiledSessionsActive: true,
+          activeSessionId: null,
+          activePinnedSessionId: null,
+          inlineConnectionSessionId: null,
+          activeBoardAssistantProjectId: null
+        })
+      },
+
+      // Re-activate an existing tiled tab (tab strip click)
+      focusTiledSessions: () => {
+        if (!get().tiledSessionsTab) return
+        set({
+          isTiledSessionsActive: true,
+          activeSessionId: null,
+          activePinnedSessionId: null,
+          inlineConnectionSessionId: null,
+          activeBoardAssistantProjectId: null
+        })
+      },
+
+      // Deactivate without closing — a rival tab/view took the pane.
+      deactivateTiledSessions: () => {
+        set({ isTiledSessionsActive: false })
+      },
+
+      // Close the tiled tab. If it was active, restore the previously active
+      // session for the current scope (same restore as closeBoardAssistantSession).
+      closeTiledSessions: () => {
+        set((state) => {
+          if (!state.isTiledSessionsActive) {
+            return { tiledSessionsTab: null, isTiledSessionsActive: false }
+          }
+          const worktreeId = state.activeWorktreeId
+          const connectionId = state.activeConnectionId
+          const boardMode = useSettingsStore.getState().boardMode
+          const scopeSessions = worktreeId
+            ? state.sessionsByWorktree.get(worktreeId)
+            : connectionId
+              ? state.sessionsByConnection.get(connectionId)
+              : null
+          let restoredSessionId =
+            (worktreeId ? state.activeSessionByWorktree[worktreeId] : null) ??
+            (connectionId ? state.activeSessionByConnection[connectionId] : null) ??
+            null
+          // The persisted entry can be stale (session closed while the tiled
+          // tab was open) — validate it, then fall back like closeSession does.
+          const restoredIsValid =
+            restoredSessionId === BOARD_TAB_ID
+              ? boardMode === 'sticky-tab'
+              : !!restoredSessionId && !!scopeSessions?.some((sess) => sess.id === restoredSessionId)
+          if (!restoredIsValid) {
+            restoredSessionId =
+              boardMode === 'sticky-tab' && (worktreeId || connectionId)
+                ? BOARD_TAB_ID
+                : (scopeSessions?.[0]?.id ?? null)
+          }
+          return {
+            tiledSessionsTab: null,
+            isTiledSessionsActive: false,
+            activeSessionId: restoredSessionId
+          }
+        })
+      },
+
+      setMountedTerminalMirror: (ids: readonly string[]) => {
+        set({ mountedTerminalMirror: new Set(ids) })
+      },
+
       // ─── Inline connection session actions ─────────────────────────────
 
       setInlineConnectionSession: (sessionId: string | null) => {
-        set({ inlineConnectionSessionId: sessionId })
+        set((state) => ({
+          inlineConnectionSessionId: sessionId,
+          isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive
+        }))
       },
 
       clearInlineConnectionSession: () => {
@@ -2411,7 +2551,11 @@ export const useSessionStore = create<SessionState>()(
 
             // Set active session if in connection context
             let activeSessionId = state.activeSessionId
-            if (state.activeConnectionId === connectionId && !activeSessionId) {
+            if (
+              state.activeConnectionId === connectionId &&
+              !activeSessionId &&
+              !state.isTiledSessionsActive
+            ) {
               const persistedSessionId = state.activeSessionByConnection[connectionId]
               const boardMode = useSettingsStore.getState().boardMode
 
@@ -2577,13 +2721,17 @@ export const useSessionStore = create<SessionState>()(
         if (sessionId && connectionId) {
           set((state) => ({
             activeSessionId: sessionId,
+            isTiledSessionsActive: false,
             activeSessionByConnection: {
               ...state.activeSessionByConnection,
               [connectionId]: sessionId
             }
           }))
         } else {
-          set({ activeSessionId: sessionId })
+          set((state) => ({
+            activeSessionId: sessionId,
+            isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive
+          }))
         }
       },
 
@@ -2593,7 +2741,7 @@ export const useSessionStore = create<SessionState>()(
 
         if (connectionId === state.activeConnectionId) return
 
-        set({ activeConnectionId: connectionId, activeWorktreeId: null })
+        set({ activeConnectionId: connectionId, activeWorktreeId: null, isTiledSessionsActive: false })
 
         if (connectionId) {
           const existingSessions = (state.sessionsByConnection.get(connectionId) || []).filter(
@@ -2769,7 +2917,10 @@ export const useSessionStore = create<SessionState>()(
       },
 
       setActivePinnedSession: (sessionId: string | null) => {
-        set({ activePinnedSessionId: sessionId })
+        set((state) => ({
+          activePinnedSessionId: sessionId,
+          isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive
+        }))
       },
 
       loadPinnedSessions: async (worktreeId: string) => {
@@ -2812,6 +2963,24 @@ declare global {
     __hive_useSessionStore__?: typeof useSessionStore
   }
 }
+
+// ─── Tiled-sessions activation invariant ────────────────────────────────────
+// The tiled tab occupies the main pane only while nothing else claims it.
+// Individual activators (setActiveSession & co.) clear the flag explicitly,
+// but several code paths write activeSessionId directly (reopenSession,
+// createSession autoFocus, closeOtherSessions, openOrphanedSession, ...).
+// This subscription is the safety net: any transition to a non-null
+// activeSessionId while the tiled tab is active deactivates it, so two views
+// can never claim the pane at once.
+useSessionStore.subscribe((state, prevState) => {
+  if (
+    state.isTiledSessionsActive &&
+    state.activeSessionId !== null &&
+    state.activeSessionId !== prevState.activeSessionId
+  ) {
+    useSessionStore.setState({ isTiledSessionsActive: false })
+  }
+})
 
 if (import.meta.env.DEV && typeof window !== 'undefined') {
   window.__hive_useSessionStore__ = useSessionStore


### PR DESCRIPTION
## Summary
- Add a tiled grid view for active In Progress sessions.
- Add session tab state, focus, and close handling for tiled views.
- Preserve live Claude CLI terminals through portal-based tile mounting.
- Add responsive grid layout and session status indicators.
- Add unit tests for grid layout and tile snapshot behavior.

## Testing
- Added Vitest coverage for grid layout calculations and tiled session snapshots.
- Not run: full test suite and manual UI verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-pane rendering, session activation invariants, and Claude CLI portal targets alongside terminal focus/paste behavior; mistakes could split the pane or affect modal vs tile session UX, though the change is UI-scoped with unit tests for layout and store behavior.
> 
> **Overview**
> Adds a **tiled grid** for In Progress work from the kanban board: a new **In Progress · {scope}** tab in the session strip and a **grid button** on the In Progress column header (alongside the existing flow-mode toggle).
> 
> Clicking the button builds a **snapshot** of the column’s tickets (respecting search-filtered tickets when passed from the column), merges tickets that share a session, and opens `TiledSessionsView` with a responsive layout. **Chat/SDK sessions** render live `SessionView` tiles; **Claude CLI** tiles reparent the existing terminal via the session portal (`data-tiled-sessions-slot`) without respawning PTYs. Plain terminals and unmounted terminal-backed sessions show placeholders so tiling does not spawn new processes.
> 
> **Session store** gains `tiledSessionsTab`, activation/focus/close actions, and a `mountedTerminalMirror` fed from `MainPane` so “running” reflects mounted PTYs. Tiled view competes with board assistant and normal sessions via explicit clears plus a subscription safety net. **Board toggles** deactivate the tiled tab when returning to the board. **TerminalView** limits autofocus and paste handling inside the grid so multiple visible tiles do not fight for focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 298b14d27266adab04f0179d9b007a37b15f83a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->