### PR TITLE
Style Pinned Board toggle as primary sidebar navigation

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -692,6 +692,13 @@ export class DatabaseService {
     this.safeAddColumn('worktrees', 'github_pr_url', 'TEXT DEFAULT NULL')
     this.safeAddColumn('worktrees', 'teleported_to', 'TEXT DEFAULT NULL')
     this.safeAddColumn('connections', 'pinned', 'INTEGER NOT NULL DEFAULT 0')
+    this.safeAddColumn('projects', 'kind', "TEXT NOT NULL DEFAULT 'git'")
+    this.safeAddColumn('projects', 'member_project_ids', 'TEXT DEFAULT NULL')
+    this.safeAddColumn(
+      'connections',
+      'saved_project_id',
+      'TEXT DEFAULT NULL REFERENCES projects(id) ON DELETE SET NULL'
+    )
     this.safeAddColumn('projects', 'kanban_simple_mode', 'INTEGER NOT NULL DEFAULT 0')
     this.safeAddColumn('projects', 'kanban_storage_mode', "TEXT NOT NULL DEFAULT 'internal'")
     this.safeAddColumn('projects', 'kanban_markdown_config', 'TEXT DEFAULT NULL')
@@ -1113,6 +1120,36 @@ export class DatabaseService {
     )
 
     return project
+  }
+
+  /**
+   * Create a "connection project": a projects row with kind='connection' that owns a
+   * kanban board for a saved connection. It has NO default worktree and never points
+   * at a git repo — path is a dedicated symlink directory. detected_icon is set to
+   * 'none' so the renderer's favicon scan skips it.
+   */
+  createConnectionProject(data: {
+    name: string
+    path: string
+    member_project_ids: string[]
+  }): Project {
+    const db = this.getDb()
+    const now = new Date().toISOString()
+    // New projects get sort_order 0 (top), bump all others down
+    db.prepare('UPDATE projects SET sort_order = sort_order + 1').run()
+
+    const id = randomUUID()
+    const memberIdsJson = JSON.stringify(data.member_project_ids)
+    db.prepare(
+      `INSERT INTO projects (id, name, path, kind, member_project_ids, description, tags, language, setup_script, run_script, archive_script, worktree_create_script, custom_commands, custom_icon, detected_icon, auto_assign_port, sort_order, created_at, last_accessed_at)
+       VALUES (?, ?, ?, 'connection', ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'none', 0, 0, ?, ?)`
+    ).run(id, data.name, data.path, memberIdsJson, now, now)
+
+    const created = this.getProject(id)
+    if (!created) {
+      throw new Error('Failed to create connection project')
+    }
+    return created
   }
 
   getProject(id: string): Project | null {
@@ -2250,13 +2287,14 @@ export class DatabaseService {
       color: data.color ?? null,
       pinned: 0,
       status: 'active',
+      saved_project_id: data.saved_project_id ?? null,
       created_at: now,
       updated_at: now
     }
 
     db.prepare(
-      `INSERT INTO connections (id, name, custom_name, path, color, status, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO connections (id, name, custom_name, path, color, status, saved_project_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       connection.id,
       connection.name,
@@ -2264,6 +2302,7 @@ export class DatabaseService {
       connection.path,
       connection.color,
       connection.status,
+      connection.saved_project_id,
       connection.created_at,
       connection.updated_at
     )
@@ -2348,6 +2387,10 @@ export class DatabaseService {
     if (data.pinned !== undefined) {
       updates.push('pinned = ?')
       values.push(data.pinned)
+    }
+    if (data.saved_project_id !== undefined) {
+      updates.push('saved_project_id = ?')
+      values.push(data.saved_project_id)
     }
 
     values.push(id)

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -699,6 +699,7 @@ export class DatabaseService {
       'saved_project_id',
       'TEXT DEFAULT NULL REFERENCES projects(id) ON DELETE SET NULL'
     )
+    this.safeAddColumn('connections', 'is_base', 'INTEGER NOT NULL DEFAULT 0')
     this.safeAddColumn('projects', 'kanban_simple_mode', 'INTEGER NOT NULL DEFAULT 0')
     this.safeAddColumn('projects', 'kanban_storage_mode', "TEXT NOT NULL DEFAULT 'internal'")
     this.safeAddColumn('projects', 'kanban_markdown_config', 'TEXT DEFAULT NULL')
@@ -2288,13 +2289,14 @@ export class DatabaseService {
       pinned: 0,
       status: 'active',
       saved_project_id: data.saved_project_id ?? null,
+      is_base: data.is_base ? 1 : 0,
       created_at: now,
       updated_at: now
     }
 
     db.prepare(
-      `INSERT INTO connections (id, name, custom_name, path, color, status, saved_project_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO connections (id, name, custom_name, path, color, status, saved_project_id, is_base, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       connection.id,
       connection.name,
@@ -2303,6 +2305,7 @@ export class DatabaseService {
       connection.color,
       connection.status,
       connection.saved_project_id,
+      connection.is_base,
       connection.created_at,
       connection.updated_at
     )
@@ -2392,6 +2395,10 @@ export class DatabaseService {
       updates.push('saved_project_id = ?')
       values.push(data.saved_project_id)
     }
+    if (data.is_base !== undefined) {
+      updates.push('is_base = ?')
+      values.push(data.is_base ? 1 : 0)
+    }
 
     values.push(id)
     db.prepare(`UPDATE connections SET ${updates.join(', ')} WHERE id = ?`).run(...values)
@@ -2403,6 +2410,40 @@ export class DatabaseService {
     const db = this.getDb()
     const result = db.prepare('DELETE FROM connections WHERE id = ?').run(id)
     return result.changes > 0
+  }
+
+  /**
+   * Demote base instances that lost their project (saved_project_id nulled by the
+   * FK when a project row was deleted by a path that could not take the base
+   * down first, e.g. an older build). They become ordinary, deletable connections.
+   * Returns the number of rows repaired.
+   */
+  clearOrphanedBaseFlags(): number {
+    const db = this.getDb()
+    const result = db
+      .prepare(
+        `UPDATE connections SET is_base = 0, updated_at = ?
+         WHERE is_base = 1 AND saved_project_id IS NULL`
+      )
+      .run(new Date().toISOString())
+    return result.changes
+  }
+
+  /**
+   * The BASE instance of a connection project (connections.is_base = 1 linked via
+   * saved_project_id) — the connection-project twin of a project's default worktree.
+   */
+  getBaseConnectionForProject(projectId: string): ConnectionWithMembers | null {
+    const db = this.getDb()
+    const row = db
+      .prepare(
+        `SELECT * FROM connections
+         WHERE saved_project_id = ? AND is_base = 1 AND status = 'active'
+         ORDER BY created_at ASC LIMIT 1`
+      )
+      .get(projectId) as Connection | undefined
+    if (!row) return null
+    return this.getConnection(row.id)
   }
 
   createConnectionMember(data: ConnectionMemberCreate): ConnectionMember {

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 44
+export const CURRENT_SCHEMA_VERSION = 45
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -726,6 +726,14 @@ DROP TABLE IF EXISTS diff_comments;`
     up: `-- NOTE: ALTER TABLE for projects.kind, projects.member_project_ids and
          -- connections.saved_project_id is handled idempotently by
          -- ensureConnectionTables() in database.ts to avoid "duplicate column" errors.`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 45,
+    name: 'add_connection_base_instances',
+    up: `-- NOTE: ALTER TABLE for connections.is_base (the base instance of a
+         -- connection project, mirroring worktrees.is_default) is handled
+         -- idempotently by ensureConnectionTables() in database.ts.`,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 43
+export const CURRENT_SCHEMA_VERSION = 44
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -719,5 +719,13 @@ DROP TABLE IF EXISTS diff_comments;`
       );
     `,
     down: `DROP TABLE IF EXISTS favorite_tickets;`
+  },
+  {
+    version: 44,
+    name: 'add_connection_projects',
+    up: `-- NOTE: ALTER TABLE for projects.kind, projects.member_project_ids and
+         -- connections.saved_project_id is handled idempotently by
+         -- ensureConnectionTables() in database.ts to avoid "duplicate column" errors.`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -429,6 +429,12 @@ export interface Connection {
   pinned: number // 0 = not pinned, 1 = pinned
   /** Saved-connection project this connection is an instance of (null/absent = ad-hoc connection). */
   saved_project_id?: string | null
+  /**
+   * 1 = the BASE instance of a connection project: its members are each member
+   * project's default worktree. Mirrors worktrees.is_default — it cannot be
+   * deleted/archived and its member set is fixed.
+   */
+  is_base?: number
   created_at: string
   updated_at: string
 }
@@ -439,6 +445,7 @@ export interface ConnectionCreate {
   color?: string | null
   custom_name?: string | null
   saved_project_id?: string | null
+  is_base?: number
 }
 
 export interface ConnectionUpdate {
@@ -449,6 +456,7 @@ export interface ConnectionUpdate {
   status?: 'active' | 'archived'
   pinned?: number
   saved_project_id?: string | null
+  is_base?: number
 }
 
 export interface ConnectionMember {

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -1,10 +1,17 @@
 import type { CustomProjectCommand } from '@shared/lib/custom-commands'
 import type { AgentSdk } from '@shared/types/agent-sdk'
 
+/** Project discriminator: 'git' = a regular repo project, 'connection' = a saved connection project. */
+export type ProjectKind = 'git' | 'connection'
+
 export interface Project {
   id: string
   name: string
   path: string
+  /** 'git' (default) or 'connection' (a saved connection promoted to a project). */
+  kind?: ProjectKind
+  /** connection projects only: JSON array of member project ids (creation order). */
+  member_project_ids?: string | null
   description: string | null
   tags: string | null // JSON array
   language: string | null
@@ -420,6 +427,8 @@ export interface Connection {
   color: string | null // JSON-serialised ConnectionColorQuad
   status: 'active' | 'archived'
   pinned: number // 0 = not pinned, 1 = pinned
+  /** Saved-connection project this connection is an instance of (null/absent = ad-hoc connection). */
+  saved_project_id?: string | null
   created_at: string
   updated_at: string
 }
@@ -429,6 +438,7 @@ export interface ConnectionCreate {
   path: string
   color?: string | null
   custom_name?: string | null
+  saved_project_id?: string | null
 }
 
 export interface ConnectionUpdate {
@@ -438,6 +448,7 @@ export interface ConnectionUpdate {
   color?: string | null
   status?: 'active' | 'archived'
   pinned?: number
+  saved_project_id?: string | null
 }
 
 export interface ConnectionMember {

--- a/src/main/services/connection-ops.base-instance.test.ts
+++ b/src/main/services/connection-ops.base-instance.test.ts
@@ -1,0 +1,423 @@
+import { existsSync, lstatSync, mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { DatabaseService } from '../db/database'
+import type { Project, Worktree } from '../db/types'
+import {
+  BASE_INSTANCE_LOCKED_ERROR,
+  addConnectionMemberOp,
+  createConnectionOp,
+  deleteBaseInstanceForProjectOp,
+  deleteConnectionOp,
+  ensureBaseInstanceForConnectionProjectOp,
+  ensureConnectionProjectBaseInstancesOp,
+  getRecentConnectionsOp,
+  isLockedBaseInstance,
+  removeConnectionMemberOp,
+  saveConnectionAsProjectOp,
+  updateConnectionMembersOp
+} from './connection-ops'
+
+const tempDirs: string[] = []
+const tempHomes: string[] = []
+let databaseLoadError: Error | null = null
+
+const canRunDatabaseTests = (): boolean => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require('better-sqlite3')
+    const db = new Database(':memory:')
+    db.close()
+    return true
+  } catch (error) {
+    databaseLoadError = error as Error
+    return false
+  }
+}
+
+const describeIf = canRunDatabaseTests() ? describe : describe.skip
+
+const makeDb = (): DatabaseService => {
+  const dir = mkdtempSync(join(tmpdir(), 'hive-base-instance-'))
+  tempDirs.push(dir)
+  const db = new DatabaseService(join(dir, 'state.sqlite'))
+  db.init()
+  return db
+}
+
+const stubHome = (): string => {
+  const tempHome = mkdtempSync(join(tmpdir(), 'hive-base-instance-home-'))
+  tempHomes.push(tempHome)
+  vi.stubEnv('HOME', tempHome)
+  return tempHome
+}
+
+const symlinkExists = (path: string): boolean => {
+  try {
+    return lstatSync(path).isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+const seedProject = (db: DatabaseService, name: string): Project =>
+  db.createProject({ name, path: `/tmp/hive-base-instance-fixtures/${name}` })
+
+const seedWorktree = (
+  db: DatabaseService,
+  project: Project,
+  name: string,
+  isDefault = false
+): Worktree =>
+  db.createWorktree({
+    project_id: project.id,
+    name,
+    branch_name: name,
+    path: isDefault
+      ? project.path
+      : `/tmp/hive-base-instance-fixtures/${project.name}/${name}`,
+    is_default: isDefault
+  })
+
+/** Two projects, each with a default ("main") worktree and a feature worktree, connected + saved. */
+const seedSavedProject = async (
+  db: DatabaseService
+): Promise<{
+  projectA: Project
+  projectB: Project
+  defaultA: Worktree
+  defaultB: Worktree
+  featureA: Worktree
+  featureB: Worktree
+  sourceConnectionId: string
+  saved: Awaited<ReturnType<typeof saveConnectionAsProjectOp>>
+}> => {
+  const projectA = seedProject(db, 'proja')
+  const projectB = seedProject(db, 'projb')
+  const defaultA = seedWorktree(db, projectA, 'main', true)
+  const defaultB = seedWorktree(db, projectB, 'master', true)
+  const featureA = seedWorktree(db, projectA, 'feature')
+  const featureB = seedWorktree(db, projectB, 'feature')
+  const created = await createConnectionOp(db, [featureA.id, featureB.id])
+  expect(created.success).toBe(true)
+  const saved = await saveConnectionAsProjectOp(db, created.connection!.id)
+  expect(saved.success).toBe(true)
+  return {
+    projectA,
+    projectB,
+    defaultA,
+    defaultB,
+    featureA,
+    featureB,
+    sourceConnectionId: created.connection!.id,
+    saved
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  for (const tempHome of tempHomes.splice(0)) {
+    rmSync(tempHome, { recursive: true, force: true })
+  }
+})
+
+describeIf('connection project base instances', () => {
+  if (databaseLoadError) {
+    it('skips when better-sqlite3 is not available for this Node runtime', () => {
+      expect(databaseLoadError?.message).toBeTruthy()
+    })
+  }
+
+  it('saveConnectionAsProjectOp creates a base instance over the member default worktrees', async () => {
+    const home = stubHome()
+    const db = makeDb()
+    const { defaultA, defaultB, sourceConnectionId, saved } = await seedSavedProject(db)
+    const projectId = saved.project!.id
+
+    const base = saved.baseConnection
+    expect(base).toBeDefined()
+    expect(base!.is_base).toBe(1)
+    expect(base!.saved_project_id).toBe(projectId)
+    expect(base!.id).not.toBe(sourceConnectionId)
+    expect(base!.members.map((m) => m.worktree_id).sort()).toEqual([defaultA.id, defaultB.id].sort())
+    expect(base!.members.map((m) => m.worktree_branch).sort()).toEqual(['main', 'master'])
+
+    // Lives in the regular connections dir with a symlink per member root
+    expect(base!.path.startsWith(join(home, '.hive', 'connections'))).toBe(true)
+    expect(symlinkExists(join(base!.path, 'proja'))).toBe(true)
+    expect(symlinkExists(join(base!.path, 'projb'))).toBe(true)
+
+    // Queryable as the project's base, listed among active connections, source is NOT base
+    expect(db.getBaseConnectionForProject(projectId)?.id).toBe(base!.id)
+    expect(db.getAllConnections().find((c) => c.id === base!.id)?.is_base).toBe(1)
+    expect(db.getConnection(sourceConnectionId)?.is_base).toBe(0)
+
+    db.close()
+  })
+
+  it('creating the base instance does not bump connection history', async () => {
+    stubHome()
+    const db = makeDb()
+    await seedSavedProject(db)
+
+    // The user-created source connection recorded the project set exactly once;
+    // the structural base instance must not count as another "use".
+    const recent = getRecentConnectionsOp(db)
+    expect(recent.success).toBe(true)
+    expect(recent.entries).toHaveLength(1)
+    expect(recent.entries![0].use_count).toBe(1)
+
+    db.close()
+  })
+
+  it('refuses to delete the base instance unless forced', async () => {
+    stubHome()
+    const db = makeDb()
+    const { saved } = await seedSavedProject(db)
+    const base = saved.baseConnection!
+
+    const refused = await deleteConnectionOp(db, base.id)
+    expect(refused.success).toBe(false)
+    expect(refused.error).toBe(BASE_INSTANCE_LOCKED_ERROR)
+    expect(db.getConnection(base.id)).not.toBeNull()
+    expect(existsSync(base.path)).toBe(true)
+
+    const forced = await deleteConnectionOp(db, base.id, { force: true })
+    expect(forced.success).toBe(true)
+    expect(db.getConnection(base.id)).toBeNull()
+    expect(existsSync(base.path)).toBe(false)
+
+    db.close()
+  })
+
+  it('locks the base instance member set (add / remove / updateMembers)', async () => {
+    stubHome()
+    const db = makeDb()
+    const { defaultA, featureA, saved } = await seedSavedProject(db)
+    const base = saved.baseConnection!
+
+    const added = await addConnectionMemberOp(db, base.id, featureA.id)
+    expect(added.success).toBe(false)
+    expect(added.error).toBe(BASE_INSTANCE_LOCKED_ERROR)
+
+    const removed = await removeConnectionMemberOp(db, base.id, defaultA.id)
+    expect(removed.success).toBe(false)
+    expect(removed.error).toBe(BASE_INSTANCE_LOCKED_ERROR)
+
+    const updated = await updateConnectionMembersOp(db, base.id, [featureA.id])
+    expect(updated.success).toBe(false)
+    expect(updated.error).toBe(BASE_INSTANCE_LOCKED_ERROR)
+
+    expect(db.getConnection(base.id)?.members).toHaveLength(2)
+
+    db.close()
+  })
+
+  it('ensureConnectionProjectBaseInstancesOp heals a connection project that lost its base', async () => {
+    stubHome()
+    const db = makeDb()
+    const { defaultA, defaultB, saved } = await seedSavedProject(db)
+    const projectId = saved.project!.id
+    const originalBaseId = saved.baseConnection!.id
+
+    // Simulate a project saved before base instances existed
+    await deleteConnectionOp(db, originalBaseId, { force: true })
+    expect(db.getBaseConnectionForProject(projectId)).toBeNull()
+
+    await ensureConnectionProjectBaseInstancesOp(db)
+    const healed = db.getBaseConnectionForProject(projectId)
+    expect(healed).not.toBeNull()
+    expect(healed!.id).not.toBe(originalBaseId)
+    expect(healed!.is_base).toBe(1)
+    expect(healed!.members.map((m) => m.worktree_id).sort()).toEqual([defaultA.id, defaultB.id].sort())
+
+    // Idempotent: a second pass keeps the same base and creates nothing new
+    await ensureConnectionProjectBaseInstancesOp(db)
+    expect(db.getBaseConnectionForProject(projectId)?.id).toBe(healed!.id)
+    expect(db.getAllConnections().filter((c) => c.is_base && c.saved_project_id === projectId)).toHaveLength(1)
+
+    db.close()
+  })
+
+  it('skips the base (save still succeeds) when fewer than 2 member default worktrees exist', async () => {
+    stubHome()
+    const db = makeDb()
+    const projectA = seedProject(db, 'proja')
+    const projectB = seedProject(db, 'projb')
+    seedWorktree(db, projectA, 'main', true) // only A has a default worktree
+    const featureA = seedWorktree(db, projectA, 'feature')
+    const featureB = seedWorktree(db, projectB, 'feature')
+
+    const created = await createConnectionOp(db, [featureA.id, featureB.id])
+    const saved = await saveConnectionAsProjectOp(db, created.connection!.id)
+    expect(saved.success).toBe(true)
+    expect(saved.baseConnection).toBeUndefined()
+    expect(db.getBaseConnectionForProject(saved.project!.id)).toBeNull()
+    expect(await ensureBaseInstanceForConnectionProjectOp(db, saved.project!)).toBeNull()
+    // Non-connection projects never get a base
+    expect(await ensureBaseInstanceForConnectionProjectOp(db, projectA)).toBeNull()
+
+    db.close()
+  })
+
+  it('deleteBaseInstanceForProjectOp removes the base (row + dir) and is a no-op without one', async () => {
+    stubHome()
+    const db = makeDb()
+    const { sourceConnectionId, saved } = await seedSavedProject(db)
+    const projectId = saved.project!.id
+    const base = saved.baseConnection!
+
+    expect((await deleteBaseInstanceForProjectOp(db, projectId)).success).toBe(true)
+    expect(db.getBaseConnectionForProject(projectId)).toBeNull()
+    expect(db.getConnection(base.id)).toBeNull()
+    expect(existsSync(base.path)).toBe(false)
+    // The user's own instance is untouched
+    expect(db.getConnection(sourceConnectionId)?.saved_project_id).toBe(projectId)
+
+    expect((await deleteBaseInstanceForProjectOp(db, projectId)).success).toBe(true)
+    expect((await deleteBaseInstanceForProjectOp(db, 'missing-project')).success).toBe(true)
+
+    db.close()
+  })
+})
+
+describeIf('connection project base instance — edge cases', () => {
+  it('promotes a source connection that already spans the member default worktrees (no duplicate)', async () => {
+    stubHome()
+    const db = makeDb()
+    const projectA = seedProject(db, 'proja')
+    const projectB = seedProject(db, 'projb')
+    const defaultA = seedWorktree(db, projectA, 'main', true)
+    const defaultB = seedWorktree(db, projectB, 'main', true)
+
+    // The most common connection: "main" of each project
+    const created = await createConnectionOp(db, [defaultA.id, defaultB.id])
+    const sourceId = created.connection!.id
+    const saved = await saveConnectionAsProjectOp(db, sourceId)
+    expect(saved.success).toBe(true)
+    const projectId = saved.project!.id
+
+    // The source became the base — no byte-identical twin next to it
+    expect(saved.baseConnection?.id).toBe(sourceId)
+    expect(saved.connection?.is_base).toBe(1)
+    const instances = db.getAllConnections().filter((c) => c.saved_project_id === projectId)
+    expect(instances).toHaveLength(1)
+    expect(instances[0].id).toBe(sourceId)
+    expect(db.getBaseConnectionForProject(projectId)?.id).toBe(sourceId)
+
+    // Idempotent: healing does not add another one
+    await ensureConnectionProjectBaseInstancesOp(db)
+    expect(db.getAllConnections().filter((c) => c.saved_project_id === projectId)).toHaveLength(1)
+
+    db.close()
+  })
+
+  it('demotes a stale base (member project removed) so it becomes deletable again', async () => {
+    stubHome()
+    const db = makeDb()
+    const { projectA, saved } = await seedSavedProject(db)
+    const projectId = saved.project!.id
+    const baseId = saved.baseConnection!.id
+
+    // Removing a member project cascades its members out of the base instance
+    db.deleteProject(projectA.id)
+    expect(db.getConnection(baseId)!.members).toHaveLength(1)
+
+    await ensureConnectionProjectBaseInstancesOp(db)
+
+    const stale = db.getConnection(baseId)!
+    expect(stale.is_base).toBe(0)
+    expect(isLockedBaseInstance(stale)).toBe(false)
+    // No base can be built from a single member project
+    expect(db.getBaseConnectionForProject(projectId)).toBeNull()
+    // ...and the degenerate row is no longer refused
+    expect((await deleteConnectionOp(db, baseId)).success).toBe(true)
+
+    db.close()
+  })
+
+  it('rebuilds the base when a member project gets a different default worktree', async () => {
+    stubHome()
+    const db = makeDb()
+    const { projectA, defaultA, defaultB, saved } = await seedSavedProject(db)
+    const projectId = saved.project!.id
+    const originalBaseId = saved.baseConnection!.id
+
+    // Simulate the default worktree moving (re-add / re-clone of the project)
+    db.updateWorktree(defaultA.id, { status: 'archived' })
+    const newDefaultA = seedWorktree(db, projectA, 'main-2', true)
+
+    await ensureConnectionProjectBaseInstancesOp(db)
+
+    const base = db.getBaseConnectionForProject(projectId)!
+    expect(base.id).not.toBe(originalBaseId)
+    expect(base.members.map((m) => m.worktree_id).sort()).toEqual(
+      [newDefaultA.id, defaultB.id].sort()
+    )
+    // The stale one survives as an ordinary connection (it may host sessions)
+    expect(db.getConnection(originalBaseId)?.is_base).toBe(0)
+
+    db.close()
+  })
+
+  it('unlocks and heals an orphaned base whose project vanished (older-build delete)', async () => {
+    stubHome()
+    const db = makeDb()
+    const { saved } = await seedSavedProject(db)
+    const baseId = saved.baseConnection!.id
+
+    // An older build deletes the project row directly: the FK nulls the link
+    // but leaves is_base = 1 behind.
+    db.deleteProject(saved.project!.id)
+    const orphan = db.getConnection(baseId)!
+    expect(orphan.is_base).toBe(1)
+    expect(orphan.saved_project_id).toBeNull()
+    // The lock predicate already treats it as unlocked...
+    expect(isLockedBaseInstance(orphan)).toBe(false)
+    expect((await addConnectionMemberOp(db, baseId, saved.baseConnection!.members[0].worktree_id)).error).not.toBe(
+      BASE_INSTANCE_LOCKED_ERROR
+    )
+
+    // ...and the next listing clears the flag for good
+    await ensureConnectionProjectBaseInstancesOp(db)
+    expect(db.getConnection(baseId)?.is_base).toBe(0)
+    expect((await deleteConnectionOp(db, baseId)).success).toBe(true)
+
+    db.close()
+  })
+
+  it('deleteBaseInstanceForProjectOp demotes instead of leaving a locked row when deletion fails', async () => {
+    stubHome()
+    const db = makeDb()
+    const { saved } = await seedSavedProject(db)
+    const baseId = saved.baseConnection!.id
+
+    const spy = vi.spyOn(db, 'deleteConnection').mockImplementation(() => {
+      throw new Error('EBUSY')
+    })
+    const result = await deleteBaseInstanceForProjectOp(db, saved.project!.id)
+    spy.mockRestore()
+
+    expect(result.success).toBe(false)
+    // Row survived, but is no longer a locked base → deletable once detached
+    const survivor = db.getConnection(baseId)!
+    expect(survivor.is_base).toBe(0)
+    expect((await deleteConnectionOp(db, baseId)).success).toBe(true)
+
+    db.close()
+  })
+})

--- a/src/main/services/connection-ops.save-as-project.test.ts
+++ b/src/main/services/connection-ops.save-as-project.test.ts
@@ -1,0 +1,213 @@
+import { existsSync, lstatSync, mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { DatabaseService } from '../db/database'
+import type { Project, Worktree } from '../db/types'
+import { createConnectionOp, saveConnectionAsProjectOp } from './connection-ops'
+
+const tempDirs: string[] = []
+const tempHomes: string[] = []
+let databaseLoadError: Error | null = null
+
+const canRunDatabaseTests = (): boolean => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require('better-sqlite3')
+    const db = new Database(':memory:')
+    db.close()
+    return true
+  } catch (error) {
+    databaseLoadError = error as Error
+    return false
+  }
+}
+
+const describeIf = canRunDatabaseTests() ? describe : describe.skip
+
+const makeDb = (): DatabaseService => {
+  const dir = mkdtempSync(join(tmpdir(), 'hive-save-as-project-'))
+  tempDirs.push(dir)
+  const db = new DatabaseService(join(dir, 'state.sqlite'))
+  db.init()
+  return db
+}
+
+const stubHome = (): string => {
+  const tempHome = mkdtempSync(join(tmpdir(), 'hive-save-as-project-home-'))
+  tempHomes.push(tempHome)
+  vi.stubEnv('HOME', tempHome)
+  return tempHome
+}
+
+const symlinkExists = (path: string): boolean => {
+  try {
+    return lstatSync(path).isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+const seedProject = (db: DatabaseService, name: string): Project =>
+  db.createProject({ name, path: `/tmp/hive-save-as-project-fixtures/${name}` })
+
+const seedWorktree = (db: DatabaseService, project: Project, name: string): Worktree =>
+  db.createWorktree({
+    project_id: project.id,
+    name,
+    branch_name: name,
+    path: `/tmp/hive-save-as-project-fixtures/${project.name}/${name}`
+  })
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  for (const tempHome of tempHomes.splice(0)) {
+    rmSync(tempHome, { recursive: true, force: true })
+  }
+})
+
+describeIf('saveConnectionAsProjectOp', () => {
+  if (databaseLoadError) {
+    it('skips when better-sqlite3 is not available for this Node runtime', () => {
+      expect(databaseLoadError?.message).toBeTruthy()
+    })
+  }
+
+  it('creates a kind=connection project, links the connection and symlinks member roots', async () => {
+    const home = stubHome()
+    const db = makeDb()
+
+    const projectA = seedProject(db, 'proja')
+    const projectB = seedProject(db, 'projb')
+    const worktreeA = seedWorktree(db, projectA, 'main')
+    const worktreeB = seedWorktree(db, projectB, 'main')
+
+    const created = await createConnectionOp(db, [worktreeA.id, worktreeB.id])
+    expect(created.success).toBe(true)
+    const connectionId = created.connection!.id
+
+    const result = await saveConnectionAsProjectOp(db, connectionId)
+    expect(result.success).toBe(true)
+    const project = result.project!
+    expect(project.kind).toBe('connection')
+    expect(project.detected_icon).toBe('none')
+    expect(project.name).toBe('proja + projb')
+    expect(JSON.parse(project.member_project_ids ?? '[]')).toEqual([projectA.id, projectB.id])
+    // Path is a dedicated dir under ~/.hive/connection-projects with a symlink per member root
+    expect(project.path.startsWith(join(home, '.hive', 'connection-projects'))).toBe(true)
+    expect(existsSync(project.path)).toBe(true)
+    expect(symlinkExists(join(project.path, 'proja'))).toBe(true)
+    expect(symlinkExists(join(project.path, 'projb'))).toBe(true)
+
+    // Source connection linked back as the first instance
+    expect(result.connection?.saved_project_id).toBe(project.id)
+    expect(db.getConnection(connectionId)?.saved_project_id).toBe(project.id)
+
+    // Round-trips through getAllProjects (mapProjectRow spread)
+    const fetched = db.getAllProjects().find((p) => p.id === project.id)
+    expect(fetched?.kind).toBe('connection')
+
+    db.close()
+  })
+
+  it('uses the custom name when the connection was renamed', async () => {
+    stubHome()
+    const db = makeDb()
+
+    const projectA = seedProject(db, 'proja')
+    const projectB = seedProject(db, 'projb')
+    const worktreeA = seedWorktree(db, projectA, 'main')
+    const worktreeB = seedWorktree(db, projectB, 'main')
+
+    const created = await createConnectionOp(db, [worktreeA.id, worktreeB.id])
+    db.updateConnection(created.connection!.id, { custom_name: 'My Stack' })
+
+    const result = await saveConnectionAsProjectOp(db, created.connection!.id)
+    expect(result.success).toBe(true)
+    expect(result.project?.name).toBe('My Stack')
+
+    db.close()
+  })
+
+  it('rejects single-project connections and already-saved connections', async () => {
+    stubHome()
+    const db = makeDb()
+
+    const projectA = seedProject(db, 'proja')
+    const projectB = seedProject(db, 'projb')
+    const worktreeA1 = seedWorktree(db, projectA, 'main')
+    const worktreeA2 = seedWorktree(db, projectA, 'feature')
+    const worktreeB = seedWorktree(db, projectB, 'main')
+
+    const single = await createConnectionOp(db, [worktreeA1.id, worktreeA2.id])
+    const singleResult = await saveConnectionAsProjectOp(db, single.connection!.id)
+    expect(singleResult.success).toBe(false)
+    expect(singleResult.error).toMatch(/at least 2 projects/)
+
+    const multi = await createConnectionOp(db, [worktreeA1.id, worktreeB.id])
+    const first = await saveConnectionAsProjectOp(db, multi.connection!.id)
+    expect(first.success).toBe(true)
+    const second = await saveConnectionAsProjectOp(db, multi.connection!.id)
+    expect(second.success).toBe(false)
+    expect(second.error).toMatch(/already saved/)
+
+    expect((await saveConnectionAsProjectOp(db, 'missing')).success).toBe(false)
+
+    db.close()
+  })
+
+  it('deleting the saved project nulls connections.saved_project_id (instance survives)', async () => {
+    stubHome()
+    const db = makeDb()
+
+    const projectA = seedProject(db, 'proja')
+    const projectB = seedProject(db, 'projb')
+    const worktreeA = seedWorktree(db, projectA, 'main')
+    const worktreeB = seedWorktree(db, projectB, 'main')
+
+    const created = await createConnectionOp(db, [worktreeA.id, worktreeB.id])
+    const saved = await saveConnectionAsProjectOp(db, created.connection!.id)
+    expect(saved.success).toBe(true)
+
+    db.deleteProject(saved.project!.id)
+    const connection = db.getConnection(created.connection!.id)
+    expect(connection).not.toBeNull()
+    expect(connection?.saved_project_id).toBeNull()
+
+    db.close()
+  })
+
+  it('createConnectionOp with savedProjectId links the new connection as an instance', async () => {
+    stubHome()
+    const db = makeDb()
+
+    const projectA = seedProject(db, 'proja')
+    const projectB = seedProject(db, 'projb')
+    const worktreeA = seedWorktree(db, projectA, 'main')
+    const worktreeB = seedWorktree(db, projectB, 'main')
+
+    const source = await createConnectionOp(db, [worktreeA.id, worktreeB.id])
+    const saved = await saveConnectionAsProjectOp(db, source.connection!.id)
+
+    const worktreeA2 = seedWorktree(db, projectA, 'tick')
+    const worktreeB2 = seedWorktree(db, projectB, 'tick')
+    const instance = await createConnectionOp(db, [worktreeA2.id, worktreeB2.id], saved.project!.id)
+    expect(instance.success).toBe(true)
+    expect(instance.connection?.saved_project_id).toBe(saved.project!.id)
+
+    db.close()
+  })
+})

--- a/src/main/services/connection-ops.ts
+++ b/src/main/services/connection-ops.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { createLogger } from './logger'
 import {
   createConnectionDir,
+  createConnectionProjectDir,
   createSymlink,
   removeSymlink,
   deleteConnectionDir,
@@ -11,7 +12,7 @@ import {
   generateConnectionColor
 } from './connection-service'
 import type { DatabaseService } from '../db/database'
-import type { ConnectionWithMembers } from '../db/types'
+import type { ConnectionWithMembers, Project } from '../db/types'
 import type { RecentConnectionEntry, RecentConnectionProject } from '../../shared/types/connection'
 
 const log = createLogger({ component: 'ConnectionOps' })
@@ -96,9 +97,10 @@ export function getPinnedConnectionsOp(db: DatabaseService): ConnectionWithMembe
  */
 export async function createConnectionOp(
   db: DatabaseService,
-  worktreeIds: string[]
+  worktreeIds: string[],
+  savedProjectId?: string | null
 ): Promise<{ success: boolean; connection?: ConnectionWithMembers; error?: string }> {
-  log.info('Creating connection', { worktreeCount: worktreeIds.length })
+  log.info('Creating connection', { worktreeCount: worktreeIds.length, savedProjectId })
   try {
     // Use a short random ID for the directory name (avoids filesystem issues with special chars)
     const dirName = randomUUID().slice(0, 8)
@@ -111,7 +113,12 @@ export async function createConnectionOp(
       .map((c) => c.color)
       .filter((c): c is string => c !== null)
     const color = generateConnectionColor(usedColors)
-    const connection = db.createConnection({ name: dirName, path: dirPath, color })
+    const connection = db.createConnection({
+      name: dirName,
+      path: dirPath,
+      color,
+      saved_project_id: savedProjectId ?? null
+    })
 
     // For each worktree, look up its data, derive symlink name, create symlink + member
     const existingSymlinkNames: string[] = []
@@ -564,6 +571,108 @@ export function setRecentConnectionNoteOp(
     const message = error instanceof Error ? error.message : String(error)
     log.error(
       'Set recent connection note failed',
+      error instanceof Error ? error : new Error(message)
+    )
+    return { success: false, error: message }
+  }
+}
+
+/**
+ * Promote a connection into a standalone "connection project": a projects row
+ * (kind='connection') that owns its own kanban board, listed in the sidebar's
+ * Projects section. The project's path is a dedicated directory of symlinks to
+ * the member project ROOTS (not the connection's worktrees) so it survives the
+ * source connection being deleted. The source connection is linked back via
+ * connections.saved_project_id and becomes the project's first "instance".
+ */
+export async function saveConnectionAsProjectOp(
+  db: DatabaseService,
+  connectionId: string
+): Promise<{
+  success: boolean
+  project?: Project
+  connection?: ConnectionWithMembers
+  error?: string
+}> {
+  log.info('Saving connection as project', { connectionId })
+  let createdDirPath: string | null = null
+  try {
+    const connection = db.getConnection(connectionId)
+    if (!connection) {
+      return { success: false, error: 'Connection not found' }
+    }
+    if (connection.saved_project_id) {
+      return { success: false, error: 'Connection is already saved as a project' }
+    }
+
+    // Distinct member project ids, in member order
+    const memberProjectIds = [...new Set(connection.members.map((m) => m.project_id))]
+    if (memberProjectIds.length < 2) {
+      return { success: false, error: 'Connection needs at least 2 projects to save as a project' }
+    }
+
+    const projects = memberProjectIds
+      .map((id) => db.getProject(id))
+      .filter((p): p is Project => p !== null)
+    if (projects.length !== memberProjectIds.length) {
+      return { success: false, error: 'A member project no longer exists' }
+    }
+
+    // Create the project directory with symlinks to each member project root
+    const dirName = randomUUID().slice(0, 8)
+    const dirPath = createConnectionProjectDir(dirName)
+    createdDirPath = dirPath
+    const existingSymlinkNames: string[] = []
+    const agentsMdMembers: {
+      symlinkName: string
+      projectName: string
+      branchName: string
+      worktreePath: string
+    }[] = []
+    for (const project of projects) {
+      const symlinkName = deriveSymlinkName(project.name, existingSymlinkNames)
+      existingSymlinkNames.push(symlinkName)
+      createSymlink(project.path, join(dirPath, symlinkName))
+      const defaultWorktree = db.getWorktreesByProject(project.id).find((w) => w.is_default)
+      agentsMdMembers.push({
+        symlinkName,
+        projectName: project.name,
+        branchName: defaultWorktree?.branch_name || 'default',
+        worktreePath: project.path
+      })
+    }
+    generateConnectionInstructions(dirPath, agentsMdMembers)
+
+    const name = connection.custom_name || deriveConnectionName(connection)
+    const project = db.createConnectionProject({
+      name,
+      path: dirPath,
+      member_project_ids: memberProjectIds
+    })
+
+    // Link the source connection back to the saved project — it becomes the
+    // project's first instance.
+    db.updateConnection(connectionId, { saved_project_id: project.id })
+    const updatedConnection = db.getConnection(connectionId) ?? undefined
+
+    log.info('Connection saved as project', {
+      connectionId,
+      projectId: project.id,
+      memberCount: memberProjectIds.length
+    })
+    return { success: true, project, connection: updatedConnection }
+  } catch (error) {
+    // Best-effort: don't leak the half-built project directory on failure.
+    if (createdDirPath) {
+      try {
+        deleteConnectionDir(createdDirPath)
+      } catch {
+        // Cleanup is best-effort only.
+      }
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    log.error(
+      'Save connection as project failed',
       error instanceof Error ? error : new Error(message)
     )
     return { success: false, error: message }

--- a/src/main/services/connection-ops.ts
+++ b/src/main/services/connection-ops.ts
@@ -98,9 +98,18 @@ export function getPinnedConnectionsOp(db: DatabaseService): ConnectionWithMembe
 export async function createConnectionOp(
   db: DatabaseService,
   worktreeIds: string[],
-  savedProjectId?: string | null
+  savedProjectId?: string | null,
+  options?: {
+    /**
+     * Create the BASE instance of a connection project (connections.is_base = 1):
+     * members are the member projects' default worktrees. Not recorded in
+     * connection history (it is a structural artifact, not a user launch).
+     */
+    isBase?: boolean
+  }
 ): Promise<{ success: boolean; connection?: ConnectionWithMembers; error?: string }> {
-  log.info('Creating connection', { worktreeCount: worktreeIds.length, savedProjectId })
+  const isBase = options?.isBase === true
+  log.info('Creating connection', { worktreeCount: worktreeIds.length, savedProjectId, isBase })
   try {
     // Use a short random ID for the directory name (avoids filesystem issues with special chars)
     const dirName = randomUUID().slice(0, 8)
@@ -117,7 +126,8 @@ export async function createConnectionOp(
       name: dirName,
       path: dirPath,
       color,
-      saved_project_id: savedProjectId ?? null
+      saved_project_id: savedProjectId ?? null,
+      is_base: isBase ? 1 : 0
     })
 
     // For each worktree, look up its data, derive symlink name, create symlink + member
@@ -156,10 +166,12 @@ export async function createConnectionOp(
       const derivedName = deriveConnectionName(enriched)
       db.updateConnection(connection.id, { name: derivedName })
       generateConnectionInstructions(dirPath, buildAgentsMdMembers(enriched))
-      recordConnectionHistory(
-        db,
-        enriched.members.map((m) => m.project_id)
-      )
+      if (!isBase) {
+        recordConnectionHistory(
+          db,
+          enriched.members.map((m) => m.project_id)
+        )
+      }
     }
 
     // Re-fetch to get the final state with derived name
@@ -177,18 +189,41 @@ export async function createConnectionOp(
   }
 }
 
+/** Error returned by every op that would delete or reshape a connection project's base instance. */
+export const BASE_INSTANCE_LOCKED_ERROR =
+  'The base connection of a connection project cannot be deleted or changed'
+
+/**
+ * A base instance is locked only while its connection project exists. An
+ * is_base row whose saved_project_id was nulled (project removed by a path that
+ * could not take the base down) is an orphan and must stay deletable — the
+ * next listing clears its flag (see ensureConnectionProjectBaseInstancesOp).
+ */
+export function isLockedBaseInstance(connection: {
+  is_base?: number | null
+  saved_project_id?: string | null
+}): boolean {
+  return !!connection.is_base && !!connection.saved_project_id
+}
+
 /**
  * Delete a connection (filesystem directory + DB record).
+ * The base instance of a connection project is refused unless `force` is set
+ * (only the connection project's own removal may take it down).
  */
 export async function deleteConnectionOp(
   db: DatabaseService,
-  connectionId: string
+  connectionId: string,
+  options?: { force?: boolean }
 ): Promise<{ success: boolean; error?: string }> {
   log.info('Deleting connection', { connectionId })
   try {
     const connection = db.getConnection(connectionId)
     if (!connection) {
       return { success: false, error: 'Connection not found' }
+    }
+    if (isLockedBaseInstance(connection) && !options?.force) {
+      return { success: false, error: BASE_INSTANCE_LOCKED_ERROR }
     }
 
     // Remove the filesystem directory (which contains the symlinks)
@@ -269,6 +304,9 @@ export async function addConnectionMemberOp(
     if (!connection) {
       return { success: false, error: 'Connection not found' }
     }
+    if (isLockedBaseInstance(connection)) {
+      return { success: false, error: BASE_INSTANCE_LOCKED_ERROR }
+    }
 
     const worktree = db.getWorktree(worktreeId)
     if (!worktree) {
@@ -340,6 +378,9 @@ export async function removeConnectionMemberOp(
     if (!connection) {
       return { success: false, error: 'Connection not found' }
     }
+    if (isLockedBaseInstance(connection)) {
+      return { success: false, error: BASE_INSTANCE_LOCKED_ERROR }
+    }
 
     // Find the member to get symlink name for removal
     const member = connection.members.find((m) => m.worktree_id === worktreeId)
@@ -399,6 +440,9 @@ export async function updateConnectionMembersOp(
     const connection = db.getConnection(connectionId)
     if (!connection) {
       return { success: false, error: 'Connection not found' }
+    }
+    if (isLockedBaseInstance(connection)) {
+      return { success: false, error: BASE_INSTANCE_LOCKED_ERROR }
     }
 
     const desired = [...new Set(worktreeIds)]
@@ -592,6 +636,8 @@ export async function saveConnectionAsProjectOp(
   success: boolean
   project?: Project
   connection?: ConnectionWithMembers
+  /** The project's base instance (default worktree of every member), when it could be created. */
+  baseConnection?: ConnectionWithMembers
   error?: string
 }> {
   log.info('Saving connection as project', { connectionId })
@@ -653,14 +699,23 @@ export async function saveConnectionAsProjectOp(
     // Link the source connection back to the saved project — it becomes the
     // project's first instance.
     db.updateConnection(connectionId, { saved_project_id: project.id })
+
+    // The project's base instance: each member project's default worktree
+    // connected together — the twin of a regular project's default worktree
+    // (always present, never archivable). Failure here must not fail the save;
+    // getAllConnectionsOp heals a missing base on the next listing. NOTE: this
+    // can PROMOTE the source itself (a connection already spanning the member
+    // default worktrees), so read the source back only afterwards.
+    const baseConnection = (await ensureBaseInstanceForConnectionProjectOp(db, project)) ?? undefined
     const updatedConnection = db.getConnection(connectionId) ?? undefined
 
     log.info('Connection saved as project', {
       connectionId,
       projectId: project.id,
-      memberCount: memberProjectIds.length
+      memberCount: memberProjectIds.length,
+      baseConnectionId: baseConnection?.id ?? null
     })
-    return { success: true, project, connection: updatedConnection }
+    return { success: true, project, connection: updatedConnection, baseConnection }
   } catch (error) {
     // Best-effort: don't leak the half-built project directory on failure.
     if (createdDirPath) {
@@ -675,6 +730,189 @@ export async function saveConnectionAsProjectOp(
       'Save connection as project failed',
       error instanceof Error ? error : new Error(message)
     )
+    return { success: false, error: message }
+  }
+}
+
+// ── Connection project base instances ─────────────────────────────────
+
+/** Parse projects.member_project_ids (JSON id array) defensively. */
+function parseMemberProjectIds(json: string | null | undefined): string[] {
+  if (!json) return []
+  try {
+    const parsed = JSON.parse(json)
+    return Array.isArray(parsed)
+      ? parsed.filter((id): id is string => typeof id === 'string' && id.length > 0)
+      : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * The worktree ids a connection project's base instance is made of: the active
+ * default worktree of every member project that still exists.
+ */
+export function resolveBaseInstanceWorktreeIds(db: DatabaseService, project: Project): string[] {
+  const ids: string[] = []
+  for (const memberId of parseMemberProjectIds(project.member_project_ids)) {
+    const defaultWorktree = db
+      .getWorktreesByProject(memberId)
+      .find((w) => w.is_default && w.status === 'active')
+    if (defaultWorktree) ids.push(defaultWorktree.id)
+  }
+  return ids
+}
+
+function sameWorktreeSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const set = new Set(a)
+  return b.every((id) => set.has(id))
+}
+
+/**
+ * Ensure a connection project has its base instance (connections.is_base = 1)
+ * over the member projects' CURRENT default worktrees:
+ * - an existing base whose member set still matches is returned as-is;
+ * - a stale base (a member project was removed, a default worktree changed) is
+ *   demoted to an ordinary instance — deletable again — and replaced;
+ * - an instance of the project that already spans exactly the default worktrees
+ *   (typically the saved source connection) is promoted instead of duplicated;
+ * - otherwise a new base connection is created.
+ * Returns null (after logging) when fewer than two member default worktrees
+ * resolve — the project is degenerate and has no base.
+ */
+export async function ensureBaseInstanceForConnectionProjectOp(
+  db: DatabaseService,
+  project: Project
+): Promise<ConnectionWithMembers | null> {
+  if (project.kind !== 'connection') return null
+  try {
+    const worktreeIds = resolveBaseInstanceWorktreeIds(db, project)
+    const existing = db.getBaseConnectionForProject(project.id)
+    if (existing) {
+      const memberIds = existing.members.map((m) => m.worktree_id)
+      if (worktreeIds.length >= 2 && sameWorktreeSet(memberIds, worktreeIds)) return existing
+      // Stale: keep the row (it may host sessions) but release the lock.
+      db.updateConnection(existing.id, { is_base: 0 })
+      log.warn('Demoted stale connection project base instance', {
+        projectId: project.id,
+        connectionId: existing.id,
+        members: memberIds.length,
+        expected: worktreeIds.length
+      })
+    }
+
+    if (worktreeIds.length < 2) {
+      log.warn('Connection project has fewer than 2 member default worktrees; skipping base', {
+        projectId: project.id,
+        resolved: worktreeIds.length
+      })
+      return null
+    }
+
+    // Promote an instance that already IS the default-worktree set (e.g. a
+    // connection over main + main that was saved as a project) — never
+    // materialize a byte-identical twin next to it.
+    const promotable = db
+      .getAllConnections()
+      .find(
+        (c) =>
+          c.saved_project_id === project.id &&
+          !c.is_base &&
+          sameWorktreeSet(
+            c.members.map((m) => m.worktree_id),
+            worktreeIds
+          )
+      )
+    if (promotable) {
+      db.updateConnection(promotable.id, { is_base: 1 })
+      log.info('Promoted existing instance to connection project base', {
+        projectId: project.id,
+        connectionId: promotable.id
+      })
+      return db.getConnection(promotable.id)
+    }
+
+    const result = await createConnectionOp(db, worktreeIds, project.id, { isBase: true })
+    if (!result.success || !result.connection) {
+      log.warn('Failed to create connection project base instance', {
+        projectId: project.id,
+        error: result.error
+      })
+      return null
+    }
+    log.info('Created connection project base instance', {
+      projectId: project.id,
+      connectionId: result.connection.id
+    })
+    return result.connection
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log.warn('Ensure base instance failed', { projectId: project.id, error: message })
+    return null
+  }
+}
+
+/**
+ * Heal every connection project that lacks a base instance (projects saved
+ * before base instances existed, or whose base creation failed). Idempotent and
+ * never throws — safe to run on every connection listing.
+ */
+export async function ensureConnectionProjectBaseInstancesOp(db: DatabaseService): Promise<void> {
+  let projects: Project[]
+  try {
+    // Orphans first: is_base rows whose project is gone must become deletable.
+    const repaired = db.clearOrphanedBaseFlags()
+    if (repaired > 0) log.warn('Cleared orphaned connection base flags', { count: repaired })
+    projects = db.getAllProjects().filter((p) => p.kind === 'connection')
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log.warn('Failed to enumerate connection projects for base healing', { error: message })
+    return
+  }
+  for (const project of projects) {
+    await ensureBaseInstanceForConnectionProjectOp(db, project)
+  }
+}
+
+/**
+ * Remove a connection project's base instance (dir + row). Called when the
+ * connection project itself is removed — the only path allowed to take the
+ * base down. Must run BEFORE the project row is deleted (the FK nulls
+ * saved_project_id on cascade, which would orphan an undeletable row).
+ */
+export async function deleteBaseInstanceForProjectOp(
+  db: DatabaseService,
+  projectId: string
+): Promise<{ success: boolean; error?: string }> {
+  let baseId: string | null = null
+  try {
+    const base = db.getBaseConnectionForProject(projectId)
+    if (!base) return { success: true }
+    baseId = base.id
+    const result = await deleteConnectionOp(db, base.id, { force: true })
+    if (!result.success) {
+      // Never leave a locked row behind: demote so it degrades to an ordinary
+      // connection once the FK nulls its saved_project_id.
+      db.updateConnection(base.id, { is_base: 0 })
+      log.warn('Base instance deletion failed; demoted instead', {
+        projectId,
+        connectionId: base.id,
+        error: result.error
+      })
+    }
+    return result
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (baseId) {
+      try {
+        db.updateConnection(baseId, { is_base: 0 })
+      } catch {
+        // Best-effort demotion only.
+      }
+    }
+    log.warn('Failed to delete connection project base instance', { projectId, error: message })
     return { success: false, error: message }
   }
 }

--- a/src/main/services/connection-service.ts
+++ b/src/main/services/connection-service.ts
@@ -37,6 +37,30 @@ export function createConnectionDir(name: string): string {
   return dirPath
 }
 
+const CONNECTION_PROJECTS_DIR_NAME = 'connection-projects'
+
+/**
+ * Base directory for saved-connection PROJECT dirs. Deliberately separate from
+ * the per-connection symlink dirs (~/.hive/connections) so deleting a live
+ * connection can never rm a project's directory out from under it.
+ */
+export function getConnectionProjectsBaseDir(): string {
+  const homeDir = homedir()
+  return join(homeDir, '.hive', CONNECTION_PROJECTS_DIR_NAME)
+}
+
+export function createConnectionProjectDir(name: string): string {
+  const base = getConnectionProjectsBaseDir()
+  if (!existsSync(base)) {
+    mkdirSync(base, { recursive: true })
+    log.info('Created connection-projects base directory', { path: base })
+  }
+  const dirPath = join(base, name)
+  mkdirSync(dirPath, { recursive: true })
+  log.info('Created connection project directory', { name, path: dirPath })
+  return dirPath
+}
+
 export function deleteConnectionDir(connectionPath: string): void {
   if (existsSync(connectionPath)) {
     rmSync(connectionPath, { recursive: true, force: true })

--- a/src/renderer/src/api/connection-api.ts
+++ b/src/renderer/src/api/connection-api.ts
@@ -60,6 +60,8 @@ type ConnectionSaveAsProjectResult = {
   success: boolean
   project?: Project
   connection?: ConnectionWithMembers
+  /** The new project's base instance (member default worktrees), when created. */
+  baseConnection?: ConnectionWithMembers
   error?: string
 }
 

--- a/src/renderer/src/api/connection-api.ts
+++ b/src/renderer/src/api/connection-api.ts
@@ -1,4 +1,5 @@
 import type { ConnectionWithMembers, RecentConnectionEntry } from '@shared/types/connection'
+import type { Project } from '@shared/types/project'
 import { getRendererRpcClient } from './rpc-client'
 
 type ConnectionGetResult = {
@@ -55,15 +56,30 @@ type ConnectionMutationResult = {
   error?: string
 }
 
+type ConnectionSaveAsProjectResult = {
+  success: boolean
+  project?: Project
+  connection?: ConnectionWithMembers
+  error?: string
+}
+
 export const connectionApi = {
   addMember: async (connectionId: string, worktreeId: string): Promise<ConnectionAddMemberResult> =>
     getRendererRpcClient().request<ConnectionAddMemberResult>('connectionOps.addMember', {
       connectionId,
       worktreeId
     }),
-  create: async (worktreeIds: string[]): Promise<ConnectionCreateResult> =>
+  create: async (
+    worktreeIds: string[],
+    opts?: { savedProjectId?: string }
+  ): Promise<ConnectionCreateResult> =>
     getRendererRpcClient().request<ConnectionCreateResult>('connectionOps.create', {
-      worktreeIds
+      worktreeIds,
+      ...(opts?.savedProjectId ? { savedProjectId: opts.savedProjectId } : {})
+    }),
+  saveAsProject: async (connectionId: string): Promise<ConnectionSaveAsProjectResult> =>
+    getRendererRpcClient().request<ConnectionSaveAsProjectResult>('connectionOps.saveAsProject', {
+      connectionId
     }),
   delete: async (connectionId: string): Promise<{ success: boolean; error?: string }> =>
     getRendererRpcClient().request<{ success: boolean; error?: string }>('connectionOps.delete', {

--- a/src/renderer/src/components/connections/ConnectDialog.tsx
+++ b/src/renderer/src/components/connections/ConnectDialog.tsx
@@ -71,6 +71,8 @@ export function ConnectDialog({
     for (const project of projects) {
       // Skip the source worktree's project
       if (project.id === sourceProjectId) continue
+      // Connection projects have no worktrees of their own
+      if (project.kind === 'connection') continue
 
       const worktrees = worktreesByProject.get(project.id) || []
       const activeWorktrees = worktrees.filter((w) => w.status === 'active')

--- a/src/renderer/src/components/connections/ConnectionItem.tsx
+++ b/src/renderer/src/components/connections/ConnectionItem.tsx
@@ -62,11 +62,13 @@ import {
   CARD_TITLE_ROW,
   CARD_TITLE_ROW_LEFT,
   CARD_TITLE_UNREAD,
+  MICRO_BADGE_PRIMARY,
   SidebarAgentRow,
   WorkspaceCardSurface,
   getFlushWorktreeCardPaddingLeft,
   type AgentDotState
 } from '@/components/sidebar'
+import { baseInstanceLabel, isBaseInstance } from '@/lib/connection-project'
 import { ArchiveConfirmDialog } from '@/components/worktrees/ArchiveConfirmDialog'
 import type { DiffStatFile } from '@/components/worktrees/DirtyFilesConfirmDialog'
 import { toast, clipboardToast } from '@/lib/toast'
@@ -96,6 +98,8 @@ interface Connection {
   color: string | null
   /** Saved-connection project this connection is an instance of (null/absent = ad-hoc). */
   saved_project_id?: string | null
+  /** 1 = base instance of a connection project (members = each member project's default worktree). */
+  is_base?: number
   created_at: string
   updated_at: string
   members: ConnectionMemberEnriched[]
@@ -194,6 +198,10 @@ export function ConnectionItem({
   const vimModeEnabled = useSettingsStore((s) => s.vimModeEnabled)
 
   const isSelected = selectedConnectionId === connection.id
+
+  // Base instance of a connection project — the twin of a default worktree:
+  // fixed members, never archived/deleted/renamed, labelled by its branches.
+  const isBase = isBaseInstance(connection)
 
   // Derive display status text (state colour lives in the orca AgentStateDot glyphs)
   const displayStatus =
@@ -446,22 +454,29 @@ export function ConnectionItem({
       branch: m.worktree_branch
     })) || []
 
-  // Display logic: custom name takes priority over project names
+  // Display logic: the base instance shows its member branches ("main"), else
+  // custom name takes priority over project names
   const hasCustomName = !!connection.custom_name
-  const displayName = hasCustomName
-    ? connection.custom_name!
-    : projectNames || connection.name || 'Connection'
+  const displayName = isBase
+    ? baseInstanceLabel(connection.members)
+    : hasCustomName
+      ? connection.custom_name!
+      : projectNames || connection.name || 'Connection'
 
   const menuItems = (
     <>
-      <ContextMenuItem onClick={handleManageWorktrees}>
-        <Settings2 className="h-4 w-4 mr-2" />
-        Connection Worktrees
-      </ContextMenuItem>
-      <ContextMenuItem onClick={handleStartRename}>
-        <Pencil className="h-4 w-4 mr-2" />
-        Rename
-      </ContextMenuItem>
+      {!isBase && (
+        <>
+          <ContextMenuItem onClick={handleManageWorktrees}>
+            <Settings2 className="h-4 w-4 mr-2" />
+            Connection Worktrees
+          </ContextMenuItem>
+          <ContextMenuItem onClick={handleStartRename}>
+            <Pencil className="h-4 w-4 mr-2" />
+            Rename
+          </ContextMenuItem>
+        </>
+      )}
       <ContextMenuItem onClick={handleTogglePin}>
         {isPinned ? <PinOff className="h-4 w-4 mr-2" /> : <Pin className="h-4 w-4 mr-2" />}
         {isPinned ? 'Unpin' : 'Pin'}
@@ -489,22 +504,26 @@ export function ConnectionItem({
         <Copy className="h-4 w-4 mr-2" />
         Copy Path
       </ContextMenuItem>
-      <ContextMenuSeparator />
-      <ContextMenuItem
-        onClick={handleArchiveAll}
-        disabled={isArchivingAll}
-        className="text-destructive focus:text-destructive focus:bg-destructive/10"
-      >
-        <Archive className="h-4 w-4 mr-2" />
-        Archive All
-      </ContextMenuItem>
-      <ContextMenuItem
-        onClick={handleDelete}
-        className="text-destructive focus:text-destructive focus:bg-destructive/10"
-      >
-        <Trash2 className="h-4 w-4 mr-2" />
-        Delete
-      </ContextMenuItem>
+      {!isBase && (
+        <>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            onClick={handleArchiveAll}
+            disabled={isArchivingAll}
+            className="text-destructive focus:text-destructive focus:bg-destructive/10"
+          >
+            <Archive className="h-4 w-4 mr-2" />
+            Archive All
+          </ContextMenuItem>
+          <ContextMenuItem
+            onClick={handleDelete}
+            className="text-destructive focus:text-destructive focus:bg-destructive/10"
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            Delete
+          </ContextMenuItem>
+        </>
+      )}
     </>
   )
 
@@ -516,6 +535,7 @@ export function ConnectionItem({
       style={{ paddingLeft: getFlushWorktreeCardPaddingLeft(0) }}
       onClick={handleClick}
       data-testid={`connection-item-${connection.id}`}
+      data-connection-base={isBase ? '' : undefined}
     >
       <div className={cn(CARD_PARENT_ROW, CARD_PARENT_ROW_ALIGN)}>
         <StatusLane status={connectionStatus} />
@@ -612,6 +632,18 @@ export function ConnectionItem({
                 </div>
               )}
 
+              {/* Base-instance micro badge — the connection-project twin of the
+                  default worktree's "primary" badge */}
+              {isBase && !isRenaming && (
+                <span
+                  className={MICRO_BADGE_PRIMARY}
+                  title="Base connection (default worktree of every member project)"
+                  data-connection-base-badge=""
+                >
+                  primary
+                </span>
+              )}
+
               <div className={CARD_TITLE_ACTIONS}>
                 {/* Hint badge */}
                 {hint && vimModeEnabled && vimMode === 'normal' && (
@@ -636,14 +668,18 @@ export function ConnectionItem({
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent className="w-52" align="end">
-                    <DropdownMenuItem onClick={handleManageWorktrees}>
-                      <Settings2 className="h-4 w-4 mr-2" />
-                      Connection Worktrees
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={handleStartRename}>
-                      <Pencil className="h-4 w-4 mr-2" />
-                      Rename
-                    </DropdownMenuItem>
+                    {!isBase && (
+                      <>
+                        <DropdownMenuItem onClick={handleManageWorktrees}>
+                          <Settings2 className="h-4 w-4 mr-2" />
+                          Connection Worktrees
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={handleStartRename}>
+                          <Pencil className="h-4 w-4 mr-2" />
+                          Rename
+                        </DropdownMenuItem>
+                      </>
+                    )}
                     <DropdownMenuItem onClick={handleTogglePin}>
                       {isPinned ? (
                         <PinOff className="h-4 w-4 mr-2" />
@@ -675,22 +711,26 @@ export function ConnectionItem({
                       <Copy className="h-4 w-4 mr-2" />
                       Copy Path
                     </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      onClick={handleArchiveAll}
-                      disabled={isArchivingAll}
-                      className="text-destructive focus:text-destructive focus:bg-destructive/10"
-                    >
-                      <Archive className="h-4 w-4 mr-2" />
-                      Archive All
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={handleDelete}
-                      className="text-destructive focus:text-destructive focus:bg-destructive/10"
-                    >
-                      <Trash2 className="h-4 w-4 mr-2" />
-                      Delete
-                    </DropdownMenuItem>
+                    {!isBase && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onClick={handleArchiveAll}
+                          disabled={isArchivingAll}
+                          className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                        >
+                          <Archive className="h-4 w-4 mr-2" />
+                          Archive All
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={handleDelete}
+                          className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                        >
+                          <Trash2 className="h-4 w-4 mr-2" />
+                          Delete
+                        </DropdownMenuItem>
+                      </>
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
@@ -717,7 +757,7 @@ export function ConnectionItem({
         <ContextMenuTrigger asChild>
           <TooltipTrigger asChild>{mainContent}</TooltipTrigger>
         </ContextMenuTrigger>
-        {hasCustomName && projectDetails.length > 0 && (
+        {(hasCustomName || isBase) && projectDetails.length > 0 && (
           <TooltipContent side="right" sideOffset={8} className="max-w-xs">
             <div className="space-y-1">
               {projectDetails.map((detail, idx) => (

--- a/src/renderer/src/components/connections/ConnectionItem.tsx
+++ b/src/renderer/src/components/connections/ConnectionItem.tsx
@@ -5,6 +5,7 @@ import {
   Code,
   Copy,
   ExternalLink,
+  FolderPlus,
   Link,
   MoreHorizontal,
   Pencil,
@@ -93,6 +94,8 @@ interface Connection {
   status: 'active' | 'archived'
   path: string
   color: string | null
+  /** Saved-connection project this connection is an instance of (null/absent = ad-hoc). */
+  saved_project_id?: string | null
   created_at: string
   updated_at: string
   members: ConnectionMemberEnriched[]
@@ -147,6 +150,23 @@ export function ConnectionItem({
   const selectConnection = useConnectionStore((s) => s.selectConnection)
   const deleteConnection = useConnectionStore((s) => s.deleteConnection)
   const renameConnection = useConnectionStore((s) => s.renameConnection)
+  const saveConnectionAsProject = useConnectionStore((s) => s.saveConnectionAsProject)
+
+  // "Save as Project" needs >=2 distinct member projects and an unsaved connection
+  const distinctMemberProjectCount = new Set(
+    (connection.members || []).map((m) => m.project_id)
+  ).size
+  const canSaveAsProject = !connection.saved_project_id && distinctMemberProjectCount >= 2
+  const [isSavingAsProject, setIsSavingAsProject] = useState(false)
+  const handleSaveAsProject = useCallback(async (): Promise<void> => {
+    if (isSavingAsProject) return
+    setIsSavingAsProject(true)
+    try {
+      await saveConnectionAsProject(connection.id)
+    } finally {
+      setIsSavingAsProject(false)
+    }
+  }, [isSavingAsProject, saveConnectionAsProject, connection.id])
 
   // Pinned state
   const isPinned = usePinnedStore((s) => s.pinnedConnectionIds.has(connection.id))
@@ -446,6 +466,12 @@ export function ConnectionItem({
         {isPinned ? <PinOff className="h-4 w-4 mr-2" /> : <Pin className="h-4 w-4 mr-2" />}
         {isPinned ? 'Unpin' : 'Pin'}
       </ContextMenuItem>
+      {canSaveAsProject && (
+        <ContextMenuItem onClick={handleSaveAsProject} disabled={isSavingAsProject}>
+          <FolderPlus className="h-4 w-4 mr-2" />
+          Save as Project
+        </ContextMenuItem>
+      )}
       <ContextMenuSeparator />
       <ContextMenuItem onClick={handleOpenInTerminal}>
         <Terminal className="h-4 w-4 mr-2" />
@@ -626,6 +652,12 @@ export function ConnectionItem({
                       )}
                       {isPinned ? 'Unpin' : 'Pin'}
                     </DropdownMenuItem>
+                    {canSaveAsProject && (
+                      <DropdownMenuItem onClick={handleSaveAsProject} disabled={isSavingAsProject}>
+                        <FolderPlus className="h-4 w-4 mr-2" />
+                        Save as Project
+                      </DropdownMenuItem>
+                    )}
                     <DropdownMenuSeparator />
                     <DropdownMenuItem onClick={handleOpenInTerminal}>
                       <Terminal className="h-4 w-4 mr-2" />

--- a/src/renderer/src/components/connections/ConnectionList.tsx
+++ b/src/renderer/src/components/connections/ConnectionList.tsx
@@ -43,7 +43,10 @@ export function ConnectionList(): React.JSX.Element | null {
   const filterActive = !!filterQuery.trim() || activeLanguages.length > 0 || activeSpaceId !== null
 
   const visibleConnections = useMemo(() => {
-    if (!filterActive) return connections
+    // Instances of a saved-connection project live under that project in the
+    // sidebar — the generic Connections section only shows ad-hoc connections.
+    const adHocConnections = connections.filter((c) => !c.saved_project_id)
+    if (!filterActive) return adHocConnections
     const matchingProjectIds = new Set(
       filterProjects(projects, {
         filterQuery,
@@ -52,7 +55,7 @@ export function ConnectionList(): React.JSX.Element | null {
         projectSpaceMap
       }).map((fp) => fp.project.id)
     )
-    return connections.filter((connection) =>
+    return adHocConnections.filter((connection) =>
       connection.members?.some((m) => matchingProjectIds.has(m.project_id))
     )
   }, [

--- a/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
+++ b/src/renderer/src/components/connections/RecentConnectionsDialog.tsx
@@ -96,6 +96,8 @@ export function RecentConnectionsDialog({
   const allProjects = useMemo(() => {
     const byId = new Map<string, RecentConnectionProject>()
     for (const project of storeProjects) {
+      // Connection projects can't be members of a connection themselves
+      if (project.kind === 'connection') continue
       byId.set(project.id, { id: project.id, name: project.name, path: project.path })
     }
     for (const entry of entries) {

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -4,6 +4,7 @@ import { Pin } from 'lucide-react'
 import { byTransitionDesc, parseTicketKey, ticketKey, useKanbanStore } from '@/stores/useKanbanStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { usePinnedStore } from '@/stores/usePinnedStore'
+import { useProjectStore } from '@/stores/useProjectStore'
 import { useBoardChatStore } from '@/stores/useBoardChatStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useFavoriteTicketsStore } from '@/stores/useFavoriteTicketsStore'
@@ -117,6 +118,15 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
   useKanbanStore((state) => state.transitionSortByColumn)
 
   const isConnectionMode = !!connectionId
+  // Board of a saved-connection project (projects.kind === 'connection'):
+  // behaves like a normal single-project board, minus git-repo affordances.
+  const isConnectionProjectBoard = useProjectStore(
+    useCallback(
+      (state) =>
+        !!projectId && state.projects.find((p) => p.id === projectId)?.kind === 'connection',
+      [projectId]
+    )
+  )
   const connectionProjectIds = isConnectionMode && connectionId ? getConnectionProjectIds(connectionId) : []
   const pinnedProjectIdsArray = isPinnedMode ? getPinnedProjectIdsArray() : []
   const watchedProjectIds = isPinnedMode
@@ -558,13 +568,15 @@ export function KanbanBoard({ projectId, connectionId, isPinnedMode }: KanbanBoa
           )}
         >
           <BoardChatLauncher
-            disabled={Boolean(isPinnedMode) || !projectId}
+            disabled={Boolean(isPinnedMode) || !projectId || isConnectionProjectBoard}
             disabledReason={
               isPinnedMode
                 ? 'Board Assistant is not available on pinned multi-project boards yet.'
                 : !projectId
                   ? 'No project selected.'
-                  : undefined
+                  : isConnectionProjectBoard
+                    ? 'Board Assistant is not available on connection project boards yet.'
+                    : undefined
             }
             onClick={() => {
               if (!projectId) return

--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback, useRef, useLayoutEffect } from 'react'
 import { motion } from 'motion/react'
-import { AlertTriangle, ArrowDownWideNarrow, ChevronRight, ChevronDown, FileText, Plus, Zap, Archive } from 'lucide-react'
+import { AlertTriangle, ArrowDownWideNarrow, ChevronRight, ChevronDown, FileText, LayoutGrid, Plus, Zap, Archive } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { openTiledInProgressSessions } from '@/lib/tiled-sessions'
 import { toast } from '@/lib/toast'
 import { lastSendMode } from '@/lib/message-send-times'
 import { Switch } from '@/components/ui/switch'
@@ -909,28 +910,55 @@ export function KanbanColumn({
                 ON (default) = flow mode: automated worktree picker on drop.
                 OFF = simple mode: direct drop, no modal. */}
             {isInProgressColumn && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div ref={toggleRef} className="ml-auto flex shrink-0 items-center gap-1.5">
-                    {transitionSortButton}
-                    <Zap
+              <div ref={toggleRef} className="ml-auto flex shrink-0 items-center gap-1.5">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      data-testid="tile-in-progress-button"
+                      disabled={tickets.length === 0}
+                      onClick={() =>
+                        void openTiledInProgressSessions(
+                          { projectId, connectionId, isPinnedMode },
+                          tickets
+                        )
+                      }
                       className={cn(
-                        'h-3 w-3',
-                        !isSimpleMode ? 'text-amber-500' : 'text-muted-foreground/50'
+                        'flex h-6 w-6 items-center justify-center rounded-md transition-colors',
+                        tickets.length === 0
+                          ? 'cursor-default text-muted-foreground/30'
+                          : 'text-muted-foreground/50 hover:text-muted-foreground hover:bg-accent'
                       )}
-                    />
-                    <Switch
-                      data-testid="simple-mode-toggle"
-                      size="sm"
-                      checked={!isSimpleMode}
-                      onCheckedChange={(checked) => handleSimpleModeToggle(!checked)}
-                    />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="top" sideOffset={8}>
-                  Send to agent when dragged to this column
-                </TooltipContent>
-              </Tooltip>
+                    >
+                      <LayoutGrid className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" sideOffset={8}>
+                    Tile all In Progress sessions in a grid
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex shrink-0 items-center gap-1.5">
+                      {transitionSortButton}
+                      <Zap
+                        className={cn(
+                          'h-3 w-3',
+                          !isSimpleMode ? 'text-amber-500' : 'text-muted-foreground/50'
+                        )}
+                      />
+                      <Switch
+                        data-testid="simple-mode-toggle"
+                        size="sm"
+                        checked={!isSimpleMode}
+                        onCheckedChange={(checked) => handleSimpleModeToggle(!checked)}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" sideOffset={8}>
+                    Send to agent when dragged to this column
+                  </TooltipContent>
+                </Tooltip>
+              </div>
             )}
 
             {/* Archive toggle — right of title, vertically centered */}

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -1021,6 +1021,14 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
   const isSimpleTicket = ticket.current_session_id === null
   const isFlowTicket = ticket.current_session_id !== null
   const isTodo = ticket.column === 'todo'
+  // Connection-project tickets have no single worktree — the assign/pre-assign
+  // worktree flows don't apply to them.
+  const isConnectionProjectTicket = useProjectStore(
+    useCallback(
+      (state) => state.projects.find((p) => p.id === ticket.project_id)?.kind === 'connection',
+      [ticket.project_id]
+    )
+  )
 
   const handleUnassignWorktree = useCallback(async () => {
     try {
@@ -1708,7 +1716,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
           ) : (
             <>
           {/* Todo tickets without worktree: pre-assign */}
-          {isSimpleTicket && isTodo && !ticket.worktree_id && (
+          {isSimpleTicket && isTodo && !ticket.worktree_id && !isConnectionProjectTicket && (
             <ContextMenuItem
               data-testid="ctx-assign-worktree"
               onClick={() => setShowPreAssignPicker(true)}
@@ -1742,7 +1750,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
           )}
 
           {/* Non-todo simple tickets: full assign flow (existing behavior) */}
-          {isSimpleTicket && !isTodo && (
+          {isSimpleTicket && !isTodo && !isConnectionProjectTicket && (
             <ContextMenuItem
               data-testid="ctx-assign-worktree"
               onClick={() => setShowWorktreePicker(true)}

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -1642,7 +1642,13 @@ function EditModeContent({
       if (action === 'send') {
         // Launch with the just-saved content so the prompt never lags the edit
         const launchTicket: KanbanTicket = { ...ticket, ...data }
-        if (sendConnectionId) void quickLaunchTicketOnConnection(launchTicket, sendConnectionId)
+        // Connection-project tickets always launch through the connection-project
+        // pipeline (new worktree per member project) — quickLaunchTicket delegates.
+        const ticketProjectKind = useProjectStore
+          .getState()
+          .projects.find((p) => p.id === ticket.project_id)?.kind
+        if (ticketProjectKind === 'connection') void quickLaunchTicket(launchTicket)
+        else if (sendConnectionId) void quickLaunchTicketOnConnection(launchTicket, sendConnectionId)
         else void quickLaunchTicket(launchTicket)
       }
     },

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -72,7 +72,14 @@ import {
 } from '@shared/types/remote-launch'
 import { FALLBACK_MODELS } from '@shared/model-resolution'
 import { runMultiModelLaunch, type MultiModelLaunchPlan } from '@/lib/multi-model-launch'
-import { computeWorktreeNameSets, getMemberProjects } from '@/lib/connection-project'
+import {
+  baseInstanceLabel,
+  computeWorktreeNameSets,
+  getMemberProjects,
+  isBaseInstance,
+  sortInstancesBaseLast
+} from '@/lib/connection-project'
+import { MICRO_BADGE_PRIMARY } from '@/components/sidebar'
 import {
   launchTicketOnConnectionProject,
   quickLaunchTicketOnConnectionProject,
@@ -753,7 +760,7 @@ export function WorktreePickerModal({
   const instanceConnections = useMemo(
     () =>
       isConnectionProjectMode
-        ? allConnections.filter((c) => c.saved_project_id === projectId)
+        ? sortInstancesBaseLast(allConnections.filter((c) => c.saved_project_id === projectId))
         : [],
     [isConnectionProjectMode, allConnections, projectId]
   )
@@ -2353,7 +2360,9 @@ export function WorktreePickerModal({
                 {instanceConnections.map((conn) => {
                   const isSelected =
                     connTarget.type === 'existing-connection' && connTarget.connectionId === conn.id
+                  const isBase = isBaseInstance(conn)
                   const memberNames = [...new Set(conn.members.map((m) => m.worktree_name))]
+                  const memberProjectNames = [...new Set(conn.members.map((m) => m.project_name))]
                   return (
                     <button
                       key={conn.id}
@@ -2373,11 +2382,22 @@ export function WorktreePickerModal({
                         <Link className="h-3.5 w-3.5" />
                       </span>
                       <span className="min-w-0 flex-1 text-left">
-                        <span className="block truncate font-medium text-foreground">
-                          {conn.custom_name || conn.name}
+                        <span className="flex items-center gap-1.5 font-medium text-foreground">
+                          <span className="truncate">
+                            {isBase ? baseInstanceLabel(conn.members) : conn.custom_name || conn.name}
+                          </span>
+                          {isBase && (
+                            <span
+                              className={MICRO_BADGE_PRIMARY}
+                              title="Base connection (default worktree of every member project)"
+                              data-connection-base-badge=""
+                            >
+                              primary
+                            </span>
+                          )}
                         </span>
                         <span className="block truncate text-xs text-muted-foreground">
-                          {memberNames.join(' · ')}
+                          {isBase ? memberProjectNames.join(' + ') : memberNames.join(' · ')}
                         </span>
                       </span>
                     </button>

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import {
   Hammer,
+  Link,
   Map,
   Plus,
   GitBranch,
@@ -71,6 +72,12 @@ import {
 } from '@shared/types/remote-launch'
 import { FALLBACK_MODELS } from '@shared/model-resolution'
 import { runMultiModelLaunch, type MultiModelLaunchPlan } from '@/lib/multi-model-launch'
+import { computeWorktreeNameSets, getMemberProjects } from '@/lib/connection-project'
+import {
+  launchTicketOnConnectionProject,
+  quickLaunchTicketOnConnectionProject,
+  type ConnectionProjectLaunchTarget
+} from '@/lib/connection-project-launch'
 import {
   launchTicketWithModel,
   resolveBadgeModel,
@@ -331,6 +338,14 @@ export function resolveQuickLaunchModel(): { sdk: PickerAgentSdk; model: Selecte
 export async function quickLaunchTicket(ticket: KanbanTicket): Promise<boolean> {
   const projectId = ticket.project_id
   const settings = useSettingsStore.getState()
+
+  // Connection-project tickets have no worktrees of their own — quick launch
+  // creates a fresh worktree in EACH member project and connects them.
+  const ticketProject = useProjectStore.getState().projects.find((p) => p.id === projectId)
+  if (ticketProject?.kind === 'connection') {
+    return quickLaunchTicketOnConnectionProject(ticket)
+  }
+
   const { sdk, model } = resolveQuickLaunchModel()
 
   const worktrees = useWorktreeStore.getState().worktreesByProject.get(projectId) ?? []
@@ -722,6 +737,61 @@ export function WorktreePickerModal({
     useCallback((state) => state.projects.find((p) => p.id === projectId) ?? null, [projectId])
   )
 
+  // ── Connection-project mode (projects.kind === 'connection') ─────
+  // The board project is a saved connection: instead of picking a worktree,
+  // the ticket launches into a connection INSTANCE (new worktrees in every
+  // member project, an existing same-name worktree set, or a live instance).
+  const isConnectionProjectMode = !isConnectionMode && project?.kind === 'connection'
+  const [connTarget, setConnTarget] = useState<ConnectionProjectLaunchTarget>({ type: 'new' })
+  const allProjects = useProjectStore((state) => state.projects)
+  const memberProjects = useMemo(
+    () => (isConnectionProjectMode && project ? getMemberProjects(project) : []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isConnectionProjectMode, project, allProjects]
+  )
+  const allConnections = useConnectionStore((state) => state.connections)
+  const instanceConnections = useMemo(
+    () =>
+      isConnectionProjectMode
+        ? allConnections.filter((c) => c.saved_project_id === projectId)
+        : [],
+    [isConnectionProjectMode, allConnections, projectId]
+  )
+  // Recompute name sets whenever any member project's worktrees (re)load
+  const worktreesByProjectMap = useWorktreeStore((state) => state.worktreesByProject)
+  const worktreeNameSets = useMemo(() => {
+    if (!isConnectionProjectMode || memberProjects.length < 2) return []
+    const sets = computeWorktreeNameSets(memberProjects)
+    // Hide sets whose exact worktree set is already materialized as an instance
+    const instanceSets = instanceConnections.map(
+      (c) => new Set(c.members.map((m) => m.worktree_id))
+    )
+    return sets.filter((set) => {
+      const ids = set.worktrees.map((w) => w.worktreeId)
+      return !instanceSets.some(
+        (instance) => instance.size === ids.length && ids.every((id) => instance.has(id))
+      )
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isConnectionProjectMode, memberProjects, instanceConnections, worktreesByProjectMap])
+
+  // If the picked target's referent disappears while the modal is open (an
+  // instance deleted, a name-set's worktree archived), fall back to "New".
+  useEffect(() => {
+    if (!open || !isConnectionProjectMode) return
+    if (
+      connTarget.type === 'existing-connection' &&
+      !instanceConnections.some((c) => c.id === connTarget.connectionId)
+    ) {
+      setConnTarget({ type: 'new' })
+    } else if (
+      connTarget.type === 'name-set' &&
+      !worktreeNameSets.some((s) => s.name === connTarget.nameSet.name)
+    ) {
+      setConnTarget({ type: 'new' })
+    }
+  }, [open, isConnectionProjectMode, connTarget, instanceConnections, worktreeNameSets])
+
   const defaultBranchName = useMemo(() => {
     const defaultWt = worktrees.find((w) => w.is_default)
     return defaultWt?.branch_name ?? 'main'
@@ -786,7 +856,7 @@ export function WorktreePickerModal({
   // which doesn't exist on a remote host — remote launches always run stock
   // claude-code-cli, and connection sessions don't support custom providers.
   const effectiveCustomProviderId =
-    !runOnRemote && !isConnectionMode && agentSdk === 'claude-code-cli'
+    !runOnRemote && !isConnectionMode && !isConnectionProjectMode && agentSdk === 'claude-code-cli'
       ? selectedCustomProviderId
       : null
 
@@ -807,6 +877,7 @@ export function WorktreePickerModal({
     !!teleport?.url &&
     !!teleport?.bootstrapToken &&
     !connectionId &&
+    !isConnectionProjectMode &&
     !preAssignOnly &&
     !saveConfigOnly
 
@@ -825,7 +896,8 @@ export function WorktreePickerModal({
   // worktree in the normal or save-config flows (an existing worktree hosts one
   // session; connection/pre-assign never multi-launch, and a remote launch
   // always runs a single claude-code-cli session).
-  const extraRowsVisible = isNewWorktree && !isConnectionMode && !preAssignOnly && !runOnRemote
+  const extraRowsVisible =
+    isNewWorktree && !isConnectionMode && !isConnectionProjectMode && !preAssignOnly && !runOnRemote
   const isMultiModel = extraRowsVisible && extraModelRows.length > 0
   // Goal mode needs EVERY launched SDK to support it — row 1 (already gated
   // below via agentSdk) plus every visible extra row.
@@ -850,7 +922,8 @@ export function WorktreePickerModal({
   // ── Lazy branch loading ────────────────────────────────────────
   useEffect(() => {
     // branches.length guard: only fetch once per modal-open cycle (reset clears branches on close)
-    if (!isNewWorktree || !project?.path || branches.length > 0) return
+    // Connection projects have no git repo at project.path — no branches to list.
+    if (!isNewWorktree || !project?.path || isConnectionProjectMode || branches.length > 0) return
     setBranchesLoading(true)
     gitApi
       .listBranchesWithStatus(project.path)
@@ -904,12 +977,20 @@ export function WorktreePickerModal({
       // id of a previously FAILED launch for this ticket (see
       // _failedRemoteLaunchIdByTicket); otherwise it gets a new one.
       launchIdRef.current = _failedRemoteLaunchIdByTicket[ticket.id] ?? crypto.randomUUID()
-      // Refresh worktree list from git so the picker shows current state
-      if (project?.path) {
+      setConnTarget({ type: 'new' })
+      if (isConnectionProjectMode && project) {
+        // Load each member project's worktrees so name sets + default branches resolve
+        const loadWorktrees = useWorktreeStore.getState().loadWorktrees
+        for (const member of getMemberProjects(project)) {
+          void loadWorktrees(member.id)
+        }
+      } else if (project?.path) {
+        // Refresh worktree list from git so the picker shows current state
         syncWorktrees(projectId, project.path, { force: true })
       }
     }
-  }, [open, ticket, projectId, project?.path, syncWorktrees])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, ticket, projectId, project?.path, isConnectionProjectMode, syncWorktrees])
 
   // ── Apply the ticket's stored goal once the switch is available ──
   // Fires immediately when the default SDK supports goal mode, or later when
@@ -1228,7 +1309,9 @@ export function WorktreePickerModal({
   const canSend =
     (isConnectionMode
       ? !isSending
-      : (selectedWorktreeId !== null || isNewWorktree) && !isSending) &&
+      : isConnectionProjectMode
+        ? !isSending && (connTarget.type !== 'new' || memberProjects.length >= 2)
+        : (selectedWorktreeId !== null || isNewWorktree) && !isSending) &&
     goalCriteriaValid &&
     !remoteSendBlocked
 
@@ -1568,6 +1651,105 @@ export function WorktreePickerModal({
         setIsSending(false)
       }
       return // Don't fall through to worktree logic
+    }
+
+    // ── Connection-project mode path ──────────────────────────────
+    // Launch into a connection instance: new worktrees in every member
+    // project, an existing same-name worktree set, or a live instance.
+    if (isConnectionProjectMode && project) {
+      try {
+        const effectiveModel = selectedModel ?? autoResolvedModel ?? null
+        const launchModel = effectiveModel
+          ? {
+              providerID: effectiveModel.providerID,
+              modelID: effectiveModel.modelID,
+              variant: effectiveModel.variant
+            }
+          : null
+
+        // Save & Queue: serialize a connection-shaped config; auto-launch
+        // replays it through quickLaunchTicketOnConnectionProject.
+        if (saveConfigOnly) {
+          const pendingWorktree =
+            connTarget.type === 'existing-connection'
+              ? { type: 'connection-existing' as const, connectionId: connTarget.connectionId }
+              : connTarget.type === 'name-set'
+                ? {
+                    type: 'connection-worktrees' as const,
+                    worktreeIds: connTarget.nameSet.worktrees.map((w) => w.worktreeId)
+                  }
+                : { type: 'connection-new' as const }
+          const pendingConfig = {
+            worktree: pendingWorktree,
+            prompt: promptText.trim() || buildPrompt(mode, ticket),
+            mode,
+            // Only an EXPLICIT pick is frozen into the queue — null re-resolves
+            // the default model at auto-launch time (same as the worktree path).
+            model: selectedModel
+              ? {
+                  providerID: selectedModel.providerID,
+                  modelID: selectedModel.modelID,
+                  variant: selectedModel.variant
+                }
+              : null,
+            sdk: agentSdk,
+            codexFastMode,
+            goalMode,
+            goalSuccessCriteria: goalMode ? goalCriteria.trim() : null,
+            customProviderId: null
+          }
+          const sortOrder = useKanbanStore
+            .getState()
+            .computeSortOrder(
+              useKanbanStore.getState().getTicketsByColumn(projectId, 'in_progress'),
+              0
+            )
+          await updateTicket(ticket.id, projectId, {
+            pending_launch_config: JSON.stringify(pendingConfig),
+            column: 'in_progress',
+            sort_order: sortOrder,
+            mode,
+            goal_mode: goalMode,
+            goal_success_criteria: goalMode ? goalCriteria.trim() : null,
+            model_provider_id: null,
+            model_id: null,
+            model_variant: null,
+            variant_group_id: null
+          })
+          onSendComplete?.()
+          onOpenChange(false)
+          toast.success('Launch config saved — will auto-launch when dependencies resolve')
+          return
+        }
+
+        const result = await launchTicketOnConnectionProject({
+          ticket,
+          savedProject: project,
+          target: connTarget,
+          options: {
+            mode,
+            sdk: agentSdk,
+            model: launchModel,
+            codexFastMode,
+            promptText,
+            goalMode,
+            goalSuccessCriteria: goalMode ? goalCriteria.trim() : null
+          }
+        })
+        if (!result.success) {
+          toast.error(result.error || 'Failed to start session')
+          return
+        }
+        onSendComplete?.()
+        onOpenChange(false)
+        toast.success('Session started')
+        return
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to start session')
+        return
+      } finally {
+        setIsSending(false)
+      }
     }
 
     try {
@@ -1995,6 +2177,8 @@ export function WorktreePickerModal({
     composedGoalPrompt,
     isConnectionMode,
     connectionId,
+    isConnectionProjectMode,
+    connTarget,
     isRemoteLaunchActive,
     remotePhase,
     resolvedSourceBranch,
@@ -2074,7 +2258,9 @@ export function WorktreePickerModal({
               ? 'Pre-assign a worktree to'
               : isConnectionMode
                 ? 'Start a session for'
-                : 'Pick a worktree for'}{' '}
+                : isConnectionProjectMode
+                  ? 'Pick a workspace for'
+                  : 'Pick a worktree for'}{' '}
             <span className="font-medium text-foreground">{ticket.title}</span>
           </DialogDescription>
           {/* Build/Plan chip toggle — below description to avoid overlapping the X close button */}
@@ -2126,8 +2312,120 @@ export function WorktreePickerModal({
         </DialogHeader>
 
         <div className="space-y-5">
-          {/* ── Worktree list (hidden in connection mode) ────── */}
-          {!isConnectionMode && (
+          {/* ── Connection-project target list ─────────────────── */}
+          {isConnectionProjectMode && (
+            <div className="space-y-2">
+              <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Workspace
+              </label>
+              <div
+                data-testid="connection-target-list"
+                className="max-h-[200px] overflow-y-auto rounded-lg border border-border/60"
+              >
+                {/* "New worktree in each project" — always at top */}
+                <button
+                  data-testid="connection-target-new"
+                  type="button"
+                  onClick={() => setConnTarget({ type: 'new' })}
+                  disabled={memberProjects.length < 2}
+                  className={cn(
+                    'flex w-full items-center gap-3 px-3.5 py-2.5 text-sm transition-colors',
+                    'border-b border-border/40 last:border-b-0',
+                    'hover:bg-muted/30 disabled:opacity-50',
+                    connTarget.type === 'new' && 'bg-secondary ring-1 ring-inset ring-border'
+                  )}
+                >
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-secondary text-foreground">
+                    <Plus className="h-3.5 w-3.5" />
+                  </span>
+                  <span className="min-w-0 flex-1 text-left">
+                    <span className="block font-medium text-foreground">
+                      New worktree in each project
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {memberProjects.map((m) => m.name).join(' + ') || 'No member projects'}
+                      {worktreeNamePreview ? ` — ${worktreeNamePreview}` : ''}
+                    </span>
+                  </span>
+                </button>
+
+                {/* Existing connection instances of this project */}
+                {instanceConnections.map((conn) => {
+                  const isSelected =
+                    connTarget.type === 'existing-connection' && connTarget.connectionId === conn.id
+                  const memberNames = [...new Set(conn.members.map((m) => m.worktree_name))]
+                  return (
+                    <button
+                      key={conn.id}
+                      data-testid={`connection-target-instance-${conn.id}`}
+                      type="button"
+                      onClick={() =>
+                        setConnTarget({ type: 'existing-connection', connectionId: conn.id })
+                      }
+                      className={cn(
+                        'flex w-full items-center gap-3 px-3.5 py-2.5 text-sm transition-colors',
+                        'border-b border-border/40 last:border-b-0',
+                        'hover:bg-muted/30',
+                        isSelected && 'bg-secondary ring-1 ring-inset ring-border'
+                      )}
+                    >
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted/40 text-muted-foreground">
+                        <Link className="h-3.5 w-3.5" />
+                      </span>
+                      <span className="min-w-0 flex-1 text-left">
+                        <span className="block truncate font-medium text-foreground">
+                          {conn.custom_name || conn.name}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {memberNames.join(' · ')}
+                        </span>
+                      </span>
+                    </button>
+                  )
+                })}
+
+                {/* Same-name worktree sets across all member projects */}
+                {worktreeNameSets.map((set) => {
+                  const isSelected =
+                    connTarget.type === 'name-set' && connTarget.nameSet.name === set.name
+                  return (
+                    <button
+                      key={set.name}
+                      data-testid={`connection-target-nameset-${set.name}`}
+                      type="button"
+                      onClick={() => setConnTarget({ type: 'name-set', nameSet: set })}
+                      className={cn(
+                        'flex w-full items-center gap-3 px-3.5 py-2.5 text-sm transition-colors',
+                        'border-b border-border/40 last:border-b-0',
+                        'hover:bg-muted/30',
+                        isSelected && 'bg-secondary ring-1 ring-inset ring-border'
+                      )}
+                    >
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted/40 text-muted-foreground">
+                        <GitBranch className="h-3.5 w-3.5" />
+                      </span>
+                      <span className="min-w-0 flex-1 text-left">
+                        <span className="block truncate font-medium text-foreground">
+                          {set.name}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          exists in all {memberProjects.length} projects
+                        </span>
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+              {memberProjects.length < 2 && (
+                <p className="text-xs text-destructive">
+                  This connection project needs at least 2 existing member projects to launch.
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* ── Worktree list (hidden in connection + connection-project modes) ────── */}
+          {!isConnectionMode && !isConnectionProjectMode && (
             <div className="space-y-2">
               <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                 Worktree

--- a/src/renderer/src/components/layout/LeftSidebar.tsx
+++ b/src/renderer/src/components/layout/LeftSidebar.tsx
@@ -36,7 +36,7 @@ import {
   NAV_LABEL,
   NAV_LIST,
   NAV_ROW,
-  NAV_ROW_ACTIVE,
+  NAV_ROW_ACTIVE_PRIMARY,
   NAV_ROW_INACTIVE,
   SIDEBAR_HEADER,
   SIDEBAR_HEADER_ACTIONS,
@@ -68,7 +68,7 @@ function SidebarNavRow({
       type="button"
       onClick={onClick}
       aria-current={active ? 'page' : undefined}
-      className={cn(NAV_ROW, active ? NAV_ROW_ACTIVE : NAV_ROW_INACTIVE)}
+      className={cn(NAV_ROW, active ? NAV_ROW_ACTIVE_PRIMARY : NAV_ROW_INACTIVE)}
       data-testid={testId}
       title={shortcut ? `${label} (${shortcut})` : undefined}
     >
@@ -81,9 +81,7 @@ function SidebarNavRow({
         <kbd
           className={cn(
             'shrink-0 font-sans text-[11px] font-medium tracking-wide',
-            active
-              ? 'text-worktree-sidebar-accent-foreground/50'
-              : 'text-worktree-sidebar-foreground/35'
+            active ? 'text-current opacity-55' : 'text-worktree-sidebar-foreground/35'
           )}
         >
           {shortcut}
@@ -129,8 +127,8 @@ export function LeftSidebar(): React.JSX.Element {
   const exitConnectionMode = useConnectionStore((s) => s.exitConnectionMode)
   const finalizeConnection = useConnectionStore((s) => s.finalizeConnection)
 
-  // Nav row — Pinned Board toggle (same behavior as the PinnedList header
-  // button: clear file/diff overlays before showing the board, then toggle).
+  // Nav row — Pinned Board toggle (clear file/diff overlays before showing
+  // the board, then toggle).
   const isPinnedBoardActive = useKanbanStore((s) => s.isPinnedBoardActive)
   const togglePinnedBoard = useKanbanStore((s) => s.togglePinnedBoard)
 

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -118,6 +118,26 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const selectedProjectPath = useProjectStore((state) =>
     state.projects.find((p) => p.id === state.selectedProjectId)?.path ?? ''
   )
+  // Connection projects (saved connections) are board-first: selecting one
+  // shows its own kanban board instead of the welcome screen.
+  const selectedProjectKind = useProjectStore(
+    (state) => state.projects.find((p) => p.id === state.selectedProjectId)?.kind ?? 'git'
+  )
+  // When the selected connection is an INSTANCE of a saved-connection project,
+  // its board is the saved project's own board (not the member aggregate).
+  const selectedConnectionSavedProjectId = useConnectionStore(
+    (state) =>
+      state.connections.find((c) => c.id === state.selectedConnectionId)?.saved_project_id ?? null
+  )
+  const savedBoardProjectExists = useProjectStore(
+    (state) =>
+      !!selectedConnectionSavedProjectId &&
+      state.projects.some((p) => p.id === selectedConnectionSavedProjectId)
+  )
+  const connectionBoardProjectId =
+    selectedConnectionSavedProjectId && savedBoardProjectExists
+      ? selectedConnectionSavedProjectId
+      : null
 
   // Subscribe to session maps so terminal list stays reactive
   const sessionsByWorktree = useSessionStore((state) => state.sessionsByWorktree)
@@ -311,8 +331,12 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
       if (selectedProjectId && !selectedConnectionId) {
         return <KanbanBoard projectId={selectedProjectId} projectPath={selectedProjectPath} />
       }
-      // Connection mode: show connection board
+      // Connection mode: show connection board (instances of a saved-connection
+      // project show the saved project's own board instead of the aggregate)
       if (selectedConnectionId && connectionsLoaded) {
+        if (connectionBoardProjectId) {
+          return <KanbanBoard projectId={connectionBoardProjectId} />
+        }
         return <KanbanBoard connectionId={selectedConnectionId} />
       }
       // No project selected: empty state
@@ -342,8 +366,11 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
       return <KanbanBoard projectId={selectedProjectId} projectPath={selectedProjectPath} />
     }
 
-    // Board view — connection-level
+    // Board view — connection-level (saved-project instances show the saved board)
     if (isBoardViewActive && selectedConnectionId && connectionsLoaded && !activeFilePath && !activeDiff && !contextEditorWorktreeId) {
+      if (connectionBoardProjectId) {
+        return <KanbanBoard projectId={connectionBoardProjectId} />
+      }
       return <KanbanBoard connectionId={selectedConnectionId} />
     }
 
@@ -357,6 +384,20 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
           </div>
         </div>
       )
+    }
+
+    // Connection project selected with no worktree/connection: board-first —
+    // its own kanban board IS the main content (there are no sessions to show).
+    if (
+      !selectedWorktreeId &&
+      !selectedConnectionId &&
+      selectedProjectId &&
+      selectedProjectKind === 'connection' &&
+      !activeFilePath &&
+      !activeDiff &&
+      !contextEditorWorktreeId
+    ) {
+      return <KanbanBoard projectId={selectedProjectId} />
     }
 
     // No worktree or connection selected - show welcome message

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -29,6 +29,7 @@ import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalCont
 import { KanbanBoard } from '@/components/kanban/KanbanBoard'
 import { KanbanIcon } from '@/components/kanban/KanbanIcon'
 import { BoardAssistantView } from '@/components/kanban/BoardAssistantView'
+import { TiledSessionsView } from '@/components/sessions/TiledSessionsView'
 import { PRNotificationStack } from '@/components/pr/PRNotificationStack'
 import { MainPaneTerminalPanel } from './MainPaneTerminalPanel'
 
@@ -107,6 +108,8 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const closedTerminalSessionIds = useSessionStore((state) => state.closedTerminalSessionIds)
   const activePinnedSessionId = useSessionStore((state) => state.activePinnedSessionId)
   const activeBoardAssistantProjectId = useSessionStore((state) => state.activeBoardAssistantProjectId)
+  const tiledSessionsTab = useSessionStore((state) => state.tiledSessionsTab)
+  const isTiledSessionsActive = useSessionStore((state) => state.isTiledSessionsActive)
   const isBoardViewActive = useKanbanStore((state) => state.isBoardViewActive)
   const isPinnedBoardActive = useKanbanStore((state) => state.isPinnedBoardActive)
   const connectionsLoaded = useConnectionStore((state) => state.loaded)
@@ -234,6 +237,13 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     useSessionStore.getState().acknowledgeClosedTerminals(closedTerminalSessionIds)
   }, [closedTerminalSessionIds])
 
+  // Mirror the mounted set into the session store — the tiled-sessions
+  // snapshot uses it to decide whether a terminal-backed session is already
+  // running (tiling a non-mounted terminal session would spawn its process).
+  useEffect(() => {
+    useSessionStore.getState().setMountedTerminalMirror(mountedTerminalSessionIds)
+  }, [mountedTerminalSessionIds])
+
   // Determine which terminal session is currently visible (if any).
   // A terminal is visible when it's the active session AND no diff/file/loading overlay is on top.
   const visibleTerminalId = useMemo(() => {
@@ -246,7 +256,12 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     // When the board, pinned board, or board assistant is occupying the main
     // pane, hide all stateful terminal sessions — otherwise the always-mounted
     // terminal would render as flex-1 alongside the board and split the pane.
-    if (isBoardViewActive || isPinnedBoardActive || activeBoardAssistantProjectId) {
+    if (
+      isBoardViewActive ||
+      isPinnedBoardActive ||
+      activeBoardAssistantProjectId ||
+      isTiledSessionsActive
+    ) {
       return null
     }
 
@@ -278,7 +293,8 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     getAgentSdk,
     isBoardViewActive,
     isPinnedBoardActive,
-    activeBoardAssistantProjectId
+    activeBoardAssistantProjectId,
+    isTiledSessionsActive
   ])
 
   const handleCloseDiff = useCallback(() => {
@@ -299,6 +315,13 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     // Board assistant tab is active — render BoardAssistantView in main pane
     if (activeBoardAssistantProjectId && !activeFilePath && !activeDiff && !contextEditorWorktreeId) {
       return <BoardAssistantView key={activeBoardAssistantProjectId} projectId={activeBoardAssistantProjectId} />
+    }
+
+    // Tiled in-progress sessions tab is active — render the grid.
+    // Placed above the board branches: the board's persisted active flags stay
+    // true while the tiled tab temporarily takes the pane.
+    if (isTiledSessionsActive && tiledSessionsTab && !activeFilePath && !activeDiff && !contextEditorWorktreeId) {
+      return <TiledSessionsView tab={tiledSessionsTab} />
     }
 
     // Sticky-tab board mode: render board when BOARD_TAB_ID is the active session
@@ -488,7 +511,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
       data-testid="main-pane"
     >
       <PRNotificationStack />
-      {(selectedWorktreeId || selectedConnectionId) && <SessionTabs />}
+      {(selectedWorktreeId || selectedConnectionId || tiledSessionsTab != null) && <SessionTabs />}
       <div className="flex-1 flex flex-col min-h-0">
         {renderContent()}
         {/* Always-mounted terminal sessions — kept alive to preserve PTY state across tab switches */}

--- a/src/renderer/src/components/layout/PinnedList.tsx
+++ b/src/renderer/src/components/layout/PinnedList.tsx
@@ -86,6 +86,7 @@ import {
   CARD_TITLE_IS_UNREAD,
   CARD_TITLE_ROW,
   CARD_TITLE_ROW_LEFT,
+  MICRO_BADGE_PRIMARY,
   SECTION_HEADER_ACTION_BUTTON,
   SECTION_HEADER_ICON,
   SidebarAgentRow,
@@ -94,6 +95,7 @@ import {
   getFlushWorktreeCardPaddingLeft,
   type AgentDotState
 } from '@/components/sidebar'
+import { baseInstanceLabel, isBaseInstance } from '@/lib/connection-project'
 import { ArchiveConfirmDialog } from '@/components/worktrees/ArchiveConfirmDialog'
 import { AddAttachmentDialog } from '@/components/worktrees/AddAttachmentDialog'
 import { ManageConnectionWorktreesDialog } from '@/components/connections/ManageConnectionWorktreesDialog'
@@ -1098,11 +1100,17 @@ function PinnedConnectionItem({
     ...new Set(connection.members?.map((m: { project_name: string }) => m.project_name) || [])
   ].join(' + ')
 
+  // Base instance of a connection project (twin of a default worktree): shows its
+  // member branches, and is never renamed/reshaped/deleted from here.
+  const isBase = isBaseInstance(connection)
+
   // Display logic: custom name takes priority over project names
   const hasCustomName = !!connection.custom_name
-  const displayName = hasCustomName
-    ? connection.custom_name!
-    : projectNames || connection.name || 'Connection'
+  const displayName = isBase
+    ? baseInstanceLabel(connection.members)
+    : hasCustomName
+      ? connection.custom_name!
+      : projectNames || connection.name || 'Connection'
 
   const displayStatus = statusLabel(connectionStatus)
   const isUnread = connectionStatus === 'unread'
@@ -1114,14 +1122,18 @@ function PinnedConnectionItem({
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const connectionMenuItems = (MenuItem: any, MenuSeparator: any): React.JSX.Element => (
     <>
-      <MenuItem onClick={handleManageWorktrees}>
-        <Settings2 className="h-4 w-4 mr-2" />
-        Connection Worktrees
-      </MenuItem>
-      <MenuItem onClick={handleStartRename}>
-        <Pencil className="h-4 w-4 mr-2" />
-        Rename
-      </MenuItem>
+      {!isBase && (
+        <>
+          <MenuItem onClick={handleManageWorktrees}>
+            <Settings2 className="h-4 w-4 mr-2" />
+            Connection Worktrees
+          </MenuItem>
+          <MenuItem onClick={handleStartRename}>
+            <Pencil className="h-4 w-4 mr-2" />
+            Rename
+          </MenuItem>
+        </>
+      )}
       <MenuItem onClick={handleUnpin}>
         <PinOff className="h-4 w-4 mr-2" />
         Unpin
@@ -1143,14 +1155,18 @@ function PinnedConnectionItem({
         <Copy className="h-4 w-4 mr-2" />
         Copy Path
       </MenuItem>
-      <MenuSeparator />
-      <MenuItem
-        onClick={handleDelete}
-        className="text-destructive focus:text-destructive focus:bg-destructive/10"
-      >
-        <Trash2 className="h-4 w-4 mr-2" />
-        Delete
-      </MenuItem>
+      {!isBase && (
+        <>
+          <MenuSeparator />
+          <MenuItem
+            onClick={handleDelete}
+            className="text-destructive focus:text-destructive focus:bg-destructive/10"
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            Delete
+          </MenuItem>
+        </>
+      )}
     </>
   )
   /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -1235,9 +1251,19 @@ function PinnedConnectionItem({
                   ) : (
                     <span
                       className={isUnread ? CARD_TITLE_IS_UNREAD : CARD_TITLE_IS_DIM}
-                      title={displayName}
+                      // Base rows all read "main" — qualify the hover with the member projects
+                      title={isBase && projectNames ? `${projectNames} — ${displayName}` : displayName}
                     >
                       {displayName}
+                    </span>
+                  )}
+                  {isBase && !isRenaming && (
+                    <span
+                      className={MICRO_BADGE_PRIMARY}
+                      title="Base connection (default worktree of every member project)"
+                      data-connection-base-badge=""
+                    >
+                      primary
                     </span>
                   )}
                 </div>
@@ -1280,7 +1306,7 @@ function PinnedConnectionItem({
                   <SidebarAgentRow
                     leading={<AgentStateDot state={statusToDotState(connectionStatus)} size="sm" />}
                     label={<span data-testid="pinned-status-text">{displayStatus}</span>}
-                    secondary={hasCustomName && projectNames ? projectNames : undefined}
+                    secondary={(hasCustomName || isBase) && projectNames ? projectNames : undefined}
                   />
                 </div>
               )}

--- a/src/renderer/src/components/layout/PinnedList.tsx
+++ b/src/renderer/src/components/layout/PinnedList.tsx
@@ -9,7 +9,6 @@ import {
   ExternalLink,
   Figma,
   GitBranchPlus,
-  KanbanSquare,
   Link,
   MoreHorizontal,
   Pencil,
@@ -56,8 +55,6 @@ import {
 } from '@/stores'
 import { HintBadge } from '@/components/ui/HintBadge'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { useKanbanStore } from '@/stores/useKanbanStore'
-import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import { useScriptStore } from '@/stores/useScriptStore'
 import { useGitStore } from '@/stores/useGitStore'
 import { toast, gitToast, clipboardToast } from '@/lib/toast'
@@ -87,7 +84,6 @@ import {
   CARD_TITLE_ROW,
   CARD_TITLE_ROW_LEFT,
   MICRO_BADGE_PRIMARY,
-  SECTION_HEADER_ACTION_BUTTON,
   SECTION_HEADER_ICON,
   SidebarAgentRow,
   SidebarSectionHeader,
@@ -115,8 +111,6 @@ export function PinnedList(): React.JSX.Element | null {
   const pinnedWorktreeIds = usePinnedStore((s) => s.pinnedWorktreeIds)
   const pinnedConnectionIds = usePinnedStore((s) => s.pinnedConnectionIds)
   const loaded = usePinnedStore((s) => s.loaded)
-  const isPinnedBoardActive = useKanbanStore((s) => s.isPinnedBoardActive)
-  const togglePinnedBoard = useKanbanStore((s) => s.togglePinnedBoard)
 
   // Load pinned items on mount
   useEffect(() => {
@@ -145,39 +139,6 @@ export function PinnedList(): React.JSX.Element | null {
         icon={<Pin className={SECTION_HEADER_ICON} />}
         label="Pinned"
         count={items.length}
-        actions={
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  if (!isPinnedBoardActive) {
-                    const fileStore = useFileViewerStore.getState()
-                    fileStore.setActiveFile(null)
-                    fileStore.clearActiveDiff()
-                    fileStore.closeContextEditor()
-                  }
-                  togglePinnedBoard()
-                }}
-                // data-state=open keeps the orca hover cluster revealed while the board is
-                // active (spread so an inactive button keeps Radix Tooltip's own data-state)
-                {...(isPinnedBoardActive ? { 'data-state': 'open' } : {})}
-                aria-pressed={isPinnedBoardActive}
-                className={cn(
-                  SECTION_HEADER_ACTION_BUTTON,
-                  'inline-flex items-center justify-center',
-                  isPinnedBoardActive && 'bg-accent text-foreground'
-                )}
-              >
-                <KanbanSquare className="size-3.5" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right" sideOffset={4}>
-              Pinned Projects Board
-            </TooltipContent>
-          </Tooltip>
-        }
       />
       {items.map((item) =>
         item.kind === 'worktree' ? (

--- a/src/renderer/src/components/projects/ConnectionInstanceList.tsx
+++ b/src/renderer/src/components/projects/ConnectionInstanceList.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useConnectionStore } from '@/stores'
+import { sortInstancesBaseLast } from '@/lib/connection-project'
 import { ConnectionItem } from '@/components/connections/ConnectionItem'
 import { ManageConnectionWorktreesDialog } from '@/components/connections/ManageConnectionWorktreesDialog'
 
@@ -10,14 +11,15 @@ interface ConnectionInstanceListProps {
 /**
  * The expanded body of a connection project (projects.kind === 'connection')
  * in the sidebar: its live connection instances — one per active worktree set —
- * rendered with the same cards as the Connections section.
+ * rendered with the same cards as the Connections section. The base instance
+ * (member default worktrees) sits last, like a project's default worktree.
  */
 export function ConnectionInstanceList({
   projectId
 }: ConnectionInstanceListProps): React.JSX.Element {
   const connections = useConnectionStore((s) => s.connections)
   const instances = useMemo(
-    () => connections.filter((c) => c.saved_project_id === projectId),
+    () => sortInstancesBaseLast(connections.filter((c) => c.saved_project_id === projectId)),
     [connections, projectId]
   )
 

--- a/src/renderer/src/components/projects/ConnectionInstanceList.tsx
+++ b/src/renderer/src/components/projects/ConnectionInstanceList.tsx
@@ -1,0 +1,58 @@
+import { useMemo, useState } from 'react'
+import { useConnectionStore } from '@/stores'
+import { ConnectionItem } from '@/components/connections/ConnectionItem'
+import { ManageConnectionWorktreesDialog } from '@/components/connections/ManageConnectionWorktreesDialog'
+
+interface ConnectionInstanceListProps {
+  projectId: string
+}
+
+/**
+ * The expanded body of a connection project (projects.kind === 'connection')
+ * in the sidebar: its live connection instances — one per active worktree set —
+ * rendered with the same cards as the Connections section.
+ */
+export function ConnectionInstanceList({
+  projectId
+}: ConnectionInstanceListProps): React.JSX.Element {
+  const connections = useConnectionStore((s) => s.connections)
+  const instances = useMemo(
+    () => connections.filter((c) => c.saved_project_id === projectId),
+    [connections, projectId]
+  )
+
+  const [manageConnectionId, setManageConnectionId] = useState<string | null>(null)
+
+  if (instances.length === 0) {
+    return (
+      <div
+        className="px-3 py-1.5 text-[11px] text-muted-foreground"
+        data-testid={`connection-instance-empty-${projectId}`}
+      >
+        No active connections — launch a ticket to create one
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5" data-testid={`connection-instance-list-${projectId}`}>
+      {instances.map((connection) => (
+        <ConnectionItem
+          key={connection.id}
+          connection={connection}
+          onManageWorktrees={setManageConnectionId}
+        />
+      ))}
+
+      {manageConnectionId && (
+        <ManageConnectionWorktreesDialog
+          connectionId={manageConnectionId}
+          open={!!manageConnectionId}
+          onOpenChange={(open) => {
+            if (!open) setManageConnectionId(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/projects/ProjectItem.tsx
+++ b/src/renderer/src/components/projects/ProjectItem.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown,
   Plus,
   Loader2,
+  Link,
   Pencil,
   Trash2,
   Copy,
@@ -49,6 +50,8 @@ import {
 } from '@/stores'
 import { HintBadge } from '@/components/ui/HintBadge'
 import { WorktreeList, BranchPickerDialog } from '@/components/worktrees'
+import { ConnectionInstanceList } from './ConnectionInstanceList'
+import { getMemberProjects } from '@/lib/connection-project'
 import { LanguageIcon } from './LanguageIcon'
 import { HighlightedText } from './HighlightedText'
 import {
@@ -79,6 +82,10 @@ interface Project {
   id: string
   name: string
   path: string
+  /** 'git' (default) or 'connection' (a saved connection promoted to a project). */
+  kind?: 'git' | 'connection'
+  /** connection projects only: JSON array of member project ids. */
+  member_project_ids?: string | null
   description: string | null
   tags: string | null
   language: string | null
@@ -145,6 +152,16 @@ export const ProjectItem = memo(function ProjectItem({
 
   const connectionModeActive = useConnectionStore((s) => s.connectionModeActive)
 
+  // ── Connection project (saved connection) ─────────────────────────
+  const isConnectionProject = project.kind === 'connection'
+  const instanceCount = useConnectionStore((s) =>
+    isConnectionProject
+      ? s.connections.reduce((n, c) => (c.saved_project_id === project.id ? n + 1 : n), 0)
+      : 0
+  )
+  const quickCreateConnection = useConnectionStore((s) => s.quickCreateConnection)
+  const [isCreatingInstance, setIsCreatingInstance] = useState(false)
+
   const projectSpaceIds = projectSpaceMap[project.id] ?? []
 
   const plusHint = useHintStore((s) => s.hintMap.get('plus:' + project.id))
@@ -180,6 +197,12 @@ export const ProjectItem = memo(function ProjectItem({
   const handleClick = (): void => {
     selectProject(project.id)
     toggleProjectExpanded(project.id)
+    if (isConnectionProject) {
+      // Board-first entity: clear worktree/connection selection so the
+      // project's own kanban board becomes the main-pane content.
+      useConnectionStore.getState().selectConnection(null)
+      useWorktreeStore.getState().selectWorktreeOnly(null)
+    }
   }
 
   const handleToggleExpand = (e: React.MouseEvent): void => {
@@ -242,7 +265,36 @@ export const ProjectItem = memo(function ProjectItem({
     toast.success('Project refreshed')
   }
 
+  const doCreateInstance = useCallback(async (): Promise<void> => {
+    if (isCreatingInstance) return
+    const memberProjects = getMemberProjects(project)
+    if (memberProjects.length < 2) {
+      toast.error('This connection project needs at least 2 existing member projects')
+      return
+    }
+    setIsCreatingInstance(true)
+    const loadingToastId = toast.loading('Creating connection worktrees...')
+    try {
+      const connectionId = await quickCreateConnection(memberProjects, {
+        savedProjectId: project.id
+      })
+      toast.dismiss(loadingToastId)
+      if (connectionId) {
+        toast.success('Connection created')
+      }
+    } catch (error) {
+      toast.dismiss(loadingToastId)
+      toast.error(error instanceof Error ? error.message : 'Failed to create connection')
+    } finally {
+      setIsCreatingInstance(false)
+    }
+  }, [isCreatingInstance, project, quickCreateConnection])
+
   const doCreateWorktree = useCallback(async (): Promise<void> => {
+    if (isConnectionProject) {
+      await doCreateInstance()
+      return
+    }
     if (isCreatingWorktree) return
 
     // Check if repo has any commits before attempting worktree creation
@@ -290,7 +342,7 @@ export const ProjectItem = memo(function ProjectItem({
         error instanceof Error ? error.message : 'Unknown error'
       )
     }
-  }, [isCreatingWorktree, createWorktree, project, autoPullBeforeWorktree])
+  }, [isConnectionProject, doCreateInstance, isCreatingWorktree, createWorktree, project, autoPullBeforeWorktree])
 
   const handleCreateWorktree = useCallback(
     async (e: React.MouseEvent): Promise<void> => {
@@ -370,7 +422,7 @@ export const ProjectItem = memo(function ProjectItem({
     !isEditing && !!plusHint && (inputFocused || (vimModeEnabled && vimMode === 'normal'))
   // Header actions are hover-revealed (orca ProjectHeaderActions); force them
   // visible while a hint badge targets the plus button or a worktree is being created.
-  const forceActionsVisible = showPlusHint || isCreatingWorktree
+  const forceActionsVisible = showPlusHint || isCreatingWorktree || isCreatingInstance
 
   return (
     // Orca group section (virtual-rows.ts): every non-first header carries the
@@ -419,11 +471,15 @@ export const ProjectItem = memo(function ProjectItem({
               {/* Title surface: 16px icon box + 13px semibold label (+ count pill) */}
               <div className={SECTION_HEADER_TITLE_SURFACE}>
                 <div className={cn(SECTION_HEADER_ICON_BOX, SECTION_TONE_NEUTRAL)}>
-                  <LanguageIcon
-                    language={project.language}
-                    customIcon={project.custom_icon}
-                    detectedIcon={project.detected_icon}
-                  />
+                  {isConnectionProject ? (
+                    <Link className="size-3.5 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <LanguageIcon
+                      language={project.language}
+                      customIcon={project.custom_icon}
+                      detectedIcon={project.detected_icon}
+                    />
+                  )}
                 </div>
 
                 {isEditing ? (
@@ -451,11 +507,15 @@ export const ProjectItem = memo(function ProjectItem({
                           {project.name}
                         </span>
                       )}
-                      {worktreeCount > 0 && (
+                      {(isConnectionProject ? instanceCount : worktreeCount) > 0 && (
                         <SidebarCountPill
-                          count={worktreeCount}
+                          count={isConnectionProject ? instanceCount : worktreeCount}
                           className="tabular-nums"
-                          aria-label={`${worktreeCount} ${worktreeCount === 1 ? 'worktree' : 'worktrees'}`}
+                          aria-label={
+                            isConnectionProject
+                              ? `${instanceCount} ${instanceCount === 1 ? 'connection' : 'connections'}`
+                              : `${worktreeCount} ${worktreeCount === 1 ? 'worktree' : 'worktrees'}`
+                          }
                           data-testid={`project-worktree-count-${project.id}`}
                         />
                       )}
@@ -518,16 +578,20 @@ export const ProjectItem = memo(function ProjectItem({
                       SECTION_HEADER_ACTION_BUTTON,
                       forceActionsVisible && 'ml-0 max-w-5 opacity-100'
                     )}
-                    aria-label={`New worktree in ${project.name}`}
+                    aria-label={
+                      isConnectionProject
+                        ? `New connection in ${project.name}`
+                        : `New worktree in ${project.name}`
+                    }
                     onClick={handleCreateWorktree}
                     onContextMenu={(e) => {
                       e.preventDefault()
                       e.stopPropagation()
-                      setBranchPickerOpen(true)
+                      if (!isConnectionProject) setBranchPickerOpen(true)
                     }}
-                    disabled={isCreatingWorktree}
+                    disabled={isCreatingWorktree || isCreatingInstance}
                   >
-                    {isCreatingWorktree ? (
+                    {isCreatingWorktree || isCreatingInstance ? (
                       <Loader2 className="size-3 animate-spin" />
                     ) : (
                       <Plus className="size-3" />
@@ -552,24 +616,28 @@ export const ProjectItem = memo(function ProjectItem({
                 <Copy className="h-4 w-4 mr-2" />
                 Copy Path
               </ContextMenuItem>
-              <ContextMenuItem onClick={() => refreshLanguage(project.id)}>
-                <RefreshCw className="h-4 w-4 mr-2" />
-                Refresh Language
-              </ContextMenuItem>
-              <ContextMenuItem onClick={handleRefreshProject}>
-                <RefreshCw className="h-4 w-4 mr-2" />
-                Refresh Project
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => setBranchPickerOpen(true)}>
-                <GitBranch className="h-4 w-4 mr-2" />
-                New Workspace From...
-              </ContextMenuItem>
-              <ContextMenuItem
-                onClick={() => useProjectStore.getState().openProjectSettings(project.id)}
-              >
-                <Settings className="h-4 w-4 mr-2" />
-                Project Settings
-              </ContextMenuItem>
+              {!isConnectionProject && (
+                <>
+                  <ContextMenuItem onClick={() => refreshLanguage(project.id)}>
+                    <RefreshCw className="h-4 w-4 mr-2" />
+                    Refresh Language
+                  </ContextMenuItem>
+                  <ContextMenuItem onClick={handleRefreshProject}>
+                    <RefreshCw className="h-4 w-4 mr-2" />
+                    Refresh Project
+                  </ContextMenuItem>
+                  <ContextMenuItem onClick={() => setBranchPickerOpen(true)}>
+                    <GitBranch className="h-4 w-4 mr-2" />
+                    New Workspace From...
+                  </ContextMenuItem>
+                  <ContextMenuItem
+                    onClick={() => useProjectStore.getState().openProjectSettings(project.id)}
+                  >
+                    <Settings className="h-4 w-4 mr-2" />
+                    Project Settings
+                  </ContextMenuItem>
+                </>
+              )}
               {spaces.length > 0 && (
                 <>
                   <ContextMenuSub>
@@ -615,8 +683,14 @@ export const ProjectItem = memo(function ProjectItem({
       </div>
 
       {/* Worktree list — orca surface inset for a depth-0 project group is 0;
-          the 6px header→card gap comes from the group's flex gap. */}
-      {isExpanded && <WorktreeList project={project} />}
+          the 6px header→card gap comes from the group's flex gap.
+          Connection projects list their live connection instances instead. */}
+      {isExpanded &&
+        (isConnectionProject ? (
+          <ConnectionInstanceList projectId={project.id} />
+        ) : (
+          <WorktreeList project={project} />
+        ))}
 
       {/* Branch Picker Dialog */}
       <BranchPickerDialog
@@ -639,7 +713,14 @@ export const ProjectItem = memo(function ProjectItem({
                 <p className="font-mono text-xs bg-muted rounded px-2 py-1 break-all">
                   {project.path}
                 </p>
-                <p>Your files on disk will not be affected.</p>
+                {isConnectionProject ? (
+                  <p>
+                    Its board, tickets and sessions will be deleted. Member projects, worktrees and
+                    files on disk will not be affected; its connections become regular connections.
+                  </p>
+                ) : (
+                  <p>Your files on disk will not be affected.</p>
+                )}
               </div>
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
+++ b/src/renderer/src/components/sessions/ClaudeCliSessionView.tsx
@@ -313,7 +313,12 @@ export function ClaudeCliSessionView({
   const pendingPlan = useSessionStore((state) => state.pendingPlans.get(sessionId) ?? null)
   const { getTarget, revision: portalRevision } = useClaudeCliSessionPortal()
   void portalRevision
-  const isMountedInTicketModal = !!getTarget(sessionId)
+  // A portal target can be the ticket modal's slot OR a tiled-sessions grid
+  // tile; modal-specific behavior (question sidebar suppression, handoff
+  // navigation back to the board) must not apply to tiles.
+  const portalTarget = getTarget(sessionId)
+  const isMountedInTicketModal =
+    !!portalTarget && !portalTarget.hasAttribute('data-tiled-sessions-slot')
   const sessionRecord = useSessionStore((state) => state.getSessionById(sessionId))
 
   // While Telegram forwarding is active, AskUserQuestion is intercepted by the

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -30,7 +30,8 @@ import {
   FileSearch,
   GitPullRequest,
   RadioTower,
-  Star
+  Star,
+  LayoutGrid
 } from 'lucide-react'
 import { KanbanIcon } from '@/components/kanban/KanbanIcon'
 import { useSessionStore, BOARD_TAB_ID } from '@/stores/useSessionStore'
@@ -677,6 +678,12 @@ export function SessionTabs(): React.JSX.Element | null {
   const closeBoardAssistantSession = useSessionStore((s) => s.closeBoardAssistantSession)
   const focusBoardAssistantSession = useSessionStore((s) => s.focusBoardAssistantSession)
 
+  // Tiled in-progress sessions tab state
+  const tiledSessionsTab = useSessionStore((state) => state.tiledSessionsTab)
+  const isTiledSessionsActive = useSessionStore((state) => state.isTiledSessionsActive)
+  const focusTiledSessions = useSessionStore((s) => s.focusTiledSessions)
+  const closeTiledSessions = useSessionStore((s) => s.closeTiledSessions)
+
   // Determine whether we are in connection mode or worktree mode
   const isConnectionMode = !!selectedConnectionId && !selectedWorktreeId
 
@@ -1252,8 +1259,14 @@ export function SessionTabs(): React.JSX.Element | null {
     }
   }, [vimModeEnabled, vimMode, sessionHints, setSessionHints, clearSessionHints])
 
-  // Don't render if nothing is selected AND no orphaned sessions
-  if (!selectedWorktreeId && !selectedConnectionId && orphanedSessions.size === 0) {
+  // Don't render if nothing is selected AND no orphaned sessions AND no tiled
+  // tab (a pinned board can open the tiled-sessions tab without a selection)
+  if (
+    !selectedWorktreeId &&
+    !selectedConnectionId &&
+    orphanedSessions.size === 0 &&
+    !tiledSessionsTab
+  ) {
     return null
   }
 
@@ -1540,6 +1553,7 @@ export function SessionTabs(): React.JSX.Element | null {
               onClick={() => {
                 useFileViewerStore.getState().clearActiveViews()
                 useSessionStore.getState().setActivePinnedSession(null)
+                useSessionStore.getState().deactivateTiledSessions()
               }}
               className={tabClass(!isFileTabActive && !activePinnedSessionId)}
             >
@@ -1605,6 +1619,37 @@ export function SessionTabs(): React.JSX.Element | null {
           </div>
         ) : (
           renderSessionTabs()
+        )}
+
+        {/* Tiled in-progress sessions tab — shared across both modes */}
+        {tiledSessionsTab && (
+          <button
+            className={tabClass(isTiledSessionsActive && !isFileTabActive)}
+            onClick={() => {
+              useFileViewerStore.getState().clearActiveViews()
+              clearInlineConnectionSession()
+              focusTiledSessions()
+            }}
+            title={`In Progress — ${tiledSessionsTab.scopeLabel}`}
+            data-testid="tiled-sessions-tab"
+          >
+            <LayoutGrid className="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+            <span className="truncate flex-1">In Progress · {tiledSessionsTab.scopeLabel}</span>
+            {isTiledSessionsActive && !isFileTabActive && <div className={TAB_UNDERLINE_CLASS} />}
+            {/* Close button */}
+            <span
+              className="ml-1 shrink-0 rounded-sm p-0.5 opacity-0 group-hover:opacity-100 hover:bg-accent transition-opacity"
+              onClick={(e) => {
+                e.stopPropagation()
+                closeTiledSessions()
+              }}
+              role="button"
+              tabIndex={-1}
+              data-testid="tiled-sessions-tab-close"
+            >
+              <X className="h-3 w-3" />
+            </span>
+          </button>
         )}
 
         {/* File viewer tabs — always rendered, shared across both modes */}

--- a/src/renderer/src/components/sessions/TiledSessionsView.tsx
+++ b/src/renderer/src/components/sessions/TiledSessionsView.tsx
@@ -1,0 +1,225 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { LayoutGrid, MonitorOff, CircleSlash } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { computeGridLayout } from '@/lib/tiled-sessions'
+import { useSessionStore, type TiledSessionTile, type TiledSessionsTab } from '@/stores/useSessionStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useClaudeCliSessionPortal } from '@/contexts/ClaudeCliSessionPortalContext'
+import { SessionView } from '@/components/sessions'
+
+/**
+ * Portal target for a claude-cli session tile. Mirrors the ticket modal's
+ * ClaudeCliPortalSlot contract exactly: request a mount (keeps the single
+ * always-mounted terminal view alive in MainPane), register this element as
+ * the portal target (the live terminal DOM moves here — no remount, no
+ * respawn), and on unmount unregister + release + conditionally destroy
+ * (no-op for active sessions).
+ */
+function TiledClaudeCliSlot({ sessionId }: { sessionId: string }): React.JSX.Element {
+  const { registerTarget } = useClaudeCliSessionPortal()
+  const requestSessionMount = useSessionStore((s) => s.requestSessionMount)
+  const releaseSessionMount = useSessionStore((s) => s.releaseSessionMount)
+  const targetRef = useRef<HTMLDivElement | null>(null)
+
+  const setTargetRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      targetRef.current = el
+      registerTarget(sessionId, el)
+    },
+    [registerTarget, sessionId]
+  )
+
+  useEffect(() => {
+    requestSessionMount(sessionId)
+    if (targetRef.current) {
+      registerTarget(sessionId, targetRef.current)
+    }
+
+    return () => {
+      registerTarget(sessionId, null)
+      releaseSessionMount(sessionId)
+      // No-op for active sessions; kills the PTY only for completed,
+      // un-engaged sessions (same guard set as the ticket modal slot).
+      void useSessionStore.getState().destroyCompletedSessionTerminal(sessionId)
+    }
+  }, [registerTarget, releaseSessionMount, requestSessionMount, sessionId])
+
+  return (
+    <div
+      ref={setTargetRef}
+      className="flex-1 flex flex-col min-h-0"
+      data-testid={`tiled-claude-cli-slot-${sessionId}`}
+      data-tiled-sessions-slot="true"
+    />
+  )
+}
+
+function TilePlaceholder({
+  icon: Icon,
+  message
+}: {
+  icon: typeof MonitorOff
+  message: string
+}): React.JSX.Element {
+  return (
+    <div className="flex-1 flex items-center justify-center text-muted-foreground">
+      <div className="flex flex-col items-center gap-2 px-4 text-center">
+        <Icon className="h-5 w-5 opacity-50" />
+        <p className="text-xs">{message}</p>
+      </div>
+    </div>
+  )
+}
+
+function TileStatusDot({ sessionId }: { sessionId: string | null }): React.JSX.Element {
+  const status = useWorktreeStatusStore((s) =>
+    sessionId ? (s.sessionStatuses[sessionId]?.status ?? null) : null
+  )
+
+  const isBusy = status === 'working' || status === 'planning' || status === 'answering'
+  const needsAttention =
+    status === 'permission' || status === 'command_approval' || status === 'plan_ready'
+
+  return (
+    <span
+      data-testid="tile-status-dot"
+      data-status={status ?? 'none'}
+      className={cn(
+        'h-1.5 w-1.5 shrink-0 rounded-full',
+        isBusy
+          ? 'bg-emerald-500 animate-pulse'
+          : needsAttention
+            ? 'bg-amber-500'
+            : 'bg-muted-foreground/40'
+      )}
+    />
+  )
+}
+
+function SessionTile({ tile }: { tile: TiledSessionTile }): React.JSX.Element {
+  const isClaudeCli = tile.agentSdk === 'claude-code-cli'
+  const isPlainTerminal = tile.agentSdk === 'terminal'
+
+  // Live check on top of the snapshot: if the session is closed while the tab
+  // is open (its view in MainPane unmounts and the reparented DOM disappears),
+  // swap to a placeholder instead of leaving a dead, empty tile.
+  const liveSessionStatus = useSessionStore((s) =>
+    tile.sessionId ? (s.getSessionById(tile.sessionId)?.status ?? null) : null
+  )
+  const sessionEnded = tile.isRunning && liveSessionStatus !== 'active'
+
+  let content: React.JSX.Element
+  if (!tile.sessionId) {
+    content = <TilePlaceholder icon={CircleSlash} message="No session attached to this ticket" />
+  } else if (sessionEnded) {
+    content = <TilePlaceholder icon={MonitorOff} message="Session ended" />
+  } else if (!tile.isRunning) {
+    content = (
+      <TilePlaceholder
+        icon={MonitorOff}
+        message="Session not running — open its tab to start it"
+      />
+    )
+  } else if (isClaudeCli) {
+    content = <TiledClaudeCliSlot sessionId={tile.sessionId} />
+  } else if (isPlainTerminal) {
+    content = (
+      <TilePlaceholder icon={MonitorOff} message="Terminal session — open its tab to view it" />
+    )
+  } else {
+    content = <SessionView sessionId={tile.sessionId} isVisible />
+  }
+
+  return (
+    <div
+      data-testid={`session-tile-${tile.sessionId ?? tile.ticketIds[0]}`}
+      className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-border bg-background"
+    >
+      {/* Tile title bar — always shows the ticket title; project name on multi-project boards */}
+      <div className="flex h-7 shrink-0 items-center gap-1.5 border-b border-border bg-card px-2">
+        <TileStatusDot sessionId={tile.sessionId} />
+        <span
+          className="min-w-0 flex-1 truncate text-[11px] font-medium text-foreground"
+          title={tile.title}
+          data-testid="tile-title"
+        >
+          {tile.title}
+        </span>
+        {tile.projectName && (
+          <span
+            className="max-w-[40%] shrink-0 truncate rounded-full bg-secondary px-1.5 py-px text-[10px] font-medium text-muted-foreground"
+            title={tile.projectName}
+            data-testid="tile-project-badge"
+          >
+            {tile.projectName}
+          </span>
+        )}
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col">{content}</div>
+    </div>
+  )
+}
+
+/**
+ * Tiled view of the In Progress column's sessions — a snapshot grid opened
+ * from the board's In Progress header. Fully interactive tiles: claude-cli
+ * sessions reparent their live terminal DOM here via the session portal;
+ * chat sessions mount their regular SessionView.
+ */
+export function TiledSessionsView({ tab }: { tab: TiledSessionsTab }): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [dims, setDims] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      const { width, height } = entry.contentRect
+      setDims((prev) =>
+        prev.width === Math.round(width) && prev.height === Math.round(height)
+          ? prev
+          : { width: Math.round(width), height: Math.round(height) }
+      )
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  const tiles = tab.tiles
+  const { cols, rows } = computeGridLayout(tiles.length, dims.width, dims.height)
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex-1 min-h-0 min-w-0 p-1.5"
+      data-testid="tiled-sessions-view"
+    >
+      {tiles.length === 0 ? (
+        <div className="flex h-full items-center justify-center text-muted-foreground">
+          <div className="text-center">
+            <LayoutGrid className="mx-auto mb-3 h-8 w-8 opacity-50" />
+            <p className="text-sm">No in-progress sessions to tile</p>
+          </div>
+        </div>
+      ) : (
+        <div
+          className="grid h-full w-full gap-1.5"
+          style={{
+            gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+            gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))`
+          }}
+          data-testid="tiled-sessions-grid"
+          data-tiled-sessions-grid="true"
+          data-grid-cols={cols}
+          data-grid-rows={rows}
+        >
+          {tiles.map((tile) => (
+            <SessionTile key={tile.sessionId ?? tile.ticketIds[0]} tile={tile} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/sidebar/orca-sidebar.ts
+++ b/src/renderer/src/components/sidebar/orca-sidebar.ts
@@ -131,6 +131,9 @@ export const NAV_ROW_GROUP_INNER_BUTTON =
   'flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left'
 /** SidebarNav.tsx:109 */
 export const NAV_ROW_ACTIVE = 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
+/** Active nav row tinted with the AI action accent (violet) instead of the neutral sidebar accent. */
+export const NAV_ROW_ACTIVE_PRIMARY =
+  'bg-violet-500/15 text-violet-600 dark:bg-violet-400/15 dark:text-violet-300'
 /** SidebarNav.tsx:110 */
 export const NAV_ROW_INACTIVE =
   'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -110,6 +110,16 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   const effectiveVisibleRef = useRef(effectiveVisible)
   effectiveVisibleRef.current = effectiveVisible
 
+  // True when this terminal is portalled into the tiled-sessions grid, where
+  // several terminals are visible at once. Focus-sensitive behaviors
+  // (autofocus-on-visible, the 'edit:paste' IPC broadcast) scope themselves to
+  // grid tiles only, so single-terminal layouts (including the always-visible
+  // bottom/sidebar terminal panel) keep their existing behavior.
+  const isInTiledGrid = useCallback(
+    (): boolean => !!containerRef.current?.closest('[data-tiled-sessions-grid]'),
+    []
+  )
+
   const shiftEnterAsNewlineRef = useRef(shiftEnterAsNewline ?? false)
   shiftEnterAsNewlineRef.current = shiftEnterAsNewline ?? false
 
@@ -124,6 +134,10 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
         }
       },
       focus: () => {
+        // Grid tiles never steal focus programmatically — the user clicks the
+        // tile they want to type into (covers ClaudeCliSessionView's own
+        // visibility focus timer too).
+        if (isInTiledGrid()) return
         backendRef.current?.focus()
       },
       clear: () => {
@@ -172,6 +186,11 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       if (backend && backend.type === 'xterm') {
         ;(backend as XtermBackend).fit()
       }
+      if (isInTiledGrid()) {
+        // Grid tiles don't fight over focus — the user clicks the tile they
+        // want to type into.
+        return
+      }
       if (backend?.type === 'ghostty' && hasFocusedEditableElement()) {
         return
       }
@@ -196,6 +215,12 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     if (!effectiveVisible) return
 
     const cleanup = systemApi.onEditPaste((text) => {
+      // Grid tiles receive the broadcast only when focused, so a paste can't
+      // land in every visible tile at once. Terminals outside the grid keep
+      // their existing behavior.
+      if (isInTiledGrid() && !containerRef.current?.contains(document.activeElement)) {
+        return
+      }
       if (activeBackendTypeRef.current === 'ghostty') {
         terminalApi.ghosttyPasteText(terminalId, text).then(unwrapEnvelope)
       } else if (activeBackendTypeRef.current === 'xterm') {

--- a/src/renderer/src/lib/__tests__/tiled-sessions.test.ts
+++ b/src/renderer/src/lib/__tests__/tiled-sessions.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { KanbanTicket } from '../../../../main/db/types'
+import { computeGridLayout, openTiledInProgressSessions } from '../tiled-sessions'
+import { useSessionStore, type Session } from '@/stores/useSessionStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { usePinnedStore } from '@/stores/usePinnedStore'
+
+const initialSessionState = useSessionStore.getState()
+const initialKanbanState = useKanbanStore.getState()
+const initialProjectState = useProjectStore.getState()
+const initialPinnedState = usePinnedStore.getState()
+
+function makeTicket(overrides: Partial<KanbanTicket>): KanbanTicket {
+  return {
+    id: 'ticket-1',
+    project_id: 'p1',
+    title: 'Ticket',
+    description: null,
+    attachments: [],
+    column: 'in_progress',
+    sort_order: 0,
+    current_session_id: null,
+    worktree_id: null,
+    mode: null,
+    plan_ready: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  } as KanbanTicket
+}
+
+function makeSession(overrides: Partial<Session>): Session {
+  return {
+    id: 'session-1',
+    worktree_id: 'wt1',
+    project_id: 'p1',
+    connection_id: null,
+    name: null,
+    status: 'active',
+    opencode_session_id: null,
+    claude_session_id: null,
+    agent_sdk: 'opencode',
+    mode: 'build',
+    session_type: 'default',
+    model_provider_id: null,
+    model_id: null,
+    model_variant: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    completed_at: null,
+    ...overrides
+  } as Session
+}
+
+describe('computeGridLayout', () => {
+  it('handles degenerate counts', () => {
+    expect(computeGridLayout(0, 1600, 900)).toEqual({ cols: 1, rows: 1 })
+    expect(computeGridLayout(1, 1600, 900)).toEqual({ cols: 1, rows: 1 })
+  })
+
+  it('falls back to a near-square grid when dimensions are unknown', () => {
+    expect(computeGridLayout(5, 0, 0)).toEqual({ cols: 3, rows: 2 })
+    expect(computeGridLayout(9, 0, 0)).toEqual({ cols: 3, rows: 3 })
+  })
+
+  it('tiles a landscape container horizontally first', () => {
+    expect(computeGridLayout(2, 1600, 900)).toEqual({ cols: 2, rows: 1 })
+    expect(computeGridLayout(3, 1600, 900)).toEqual({ cols: 2, rows: 2 })
+    expect(computeGridLayout(4, 1600, 900)).toEqual({ cols: 2, rows: 2 })
+    expect(computeGridLayout(5, 1600, 900)).toEqual({ cols: 3, rows: 2 })
+    expect(computeGridLayout(6, 1600, 900)).toEqual({ cols: 3, rows: 2 })
+  })
+
+  it('tiles a portrait container vertically', () => {
+    expect(computeGridLayout(2, 700, 1600)).toEqual({ cols: 1, rows: 2 })
+  })
+
+  it('never produces fewer cells than tiles', () => {
+    for (let n = 1; n <= 24; n++) {
+      const { cols, rows } = computeGridLayout(n, 1440, 800)
+      expect(cols * rows).toBeGreaterThanOrEqual(n)
+      expect(cols).toBeLessThanOrEqual(n)
+    }
+  })
+})
+
+describe('openTiledInProgressSessions', () => {
+  afterEach(() => {
+    useSessionStore.setState(initialSessionState, true)
+    useKanbanStore.setState(initialKanbanState, true)
+    useProjectStore.setState(initialProjectState, true)
+    usePinnedStore.setState(initialPinnedState, true)
+  })
+
+  it('builds a snapshot for a single-project board (no project names on tiles)', async () => {
+    useProjectStore.setState({
+      projects: [{ id: 'p1', name: 'Acme' }] as never
+    })
+    useKanbanStore.setState({
+      tickets: new Map([
+        [
+          'p1',
+          [
+            makeTicket({
+              id: 't-chat',
+              title: 'Chat ticket',
+              current_session_id: 's-chat',
+              sort_order: 0
+            }),
+            makeTicket({
+              id: 't-cli-running',
+              title: 'CLI running',
+              current_session_id: 's-cli-running',
+              sort_order: 1
+            }),
+            makeTicket({
+              id: 't-cli-idle',
+              title: 'CLI idle',
+              current_session_id: 's-cli-idle',
+              sort_order: 2
+            }),
+            makeTicket({ id: 't-no-session', title: 'No session', sort_order: 3 }),
+            makeTicket({ id: 't-done', title: 'Done ticket', column: 'done', sort_order: 4 })
+          ]
+        ]
+      ])
+    })
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([
+        [
+          'wt1',
+          [
+            makeSession({ id: 's-chat', agent_sdk: 'opencode' }),
+            makeSession({ id: 's-cli-running', agent_sdk: 'claude-code-cli' }),
+            makeSession({ id: 's-cli-idle', agent_sdk: 'claude-code-cli' })
+          ]
+        ]
+      ]),
+      mountedTerminalMirror: new Set(['s-cli-running'])
+    })
+
+    await openTiledInProgressSessions({ projectId: 'p1' })
+
+    const state = useSessionStore.getState()
+    expect(state.isTiledSessionsActive).toBe(true)
+    expect(state.tiledSessionsTab?.scopeLabel).toBe('Acme')
+
+    const tiles = state.tiledSessionsTab?.tiles ?? []
+    expect(tiles.map((t) => t.title)).toEqual([
+      'Chat ticket',
+      'CLI running',
+      'CLI idle',
+      'No session'
+    ])
+    // Single-project board: no project names on tiles
+    expect(tiles.every((t) => t.projectName === null)).toBe(true)
+
+    const byTitle = new Map(tiles.map((t) => [t.title, t]))
+    // Chat session: active status is enough to be running
+    expect(byTitle.get('Chat ticket')?.isRunning).toBe(true)
+    // Terminal-backed: running only when its view/PTY is mounted
+    expect(byTitle.get('CLI running')?.isRunning).toBe(true)
+    expect(byTitle.get('CLI idle')?.isRunning).toBe(false)
+    expect(byTitle.get('No session')?.sessionId).toBeNull()
+    expect(byTitle.get('No session')?.isRunning).toBe(false)
+  })
+
+  it('merges tickets sharing one session into a single tile', async () => {
+    useProjectStore.setState({ projects: [{ id: 'p1', name: 'Acme' }] as never })
+    useKanbanStore.setState({
+      tickets: new Map([
+        [
+          'p1',
+          [
+            makeTicket({ id: 't1', title: 'First', current_session_id: 'shared', sort_order: 0 }),
+            makeTicket({ id: 't2', title: 'Second', current_session_id: 'shared', sort_order: 1 })
+          ]
+        ]
+      ])
+    })
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([['wt1', [makeSession({ id: 'shared' })]]])
+    })
+
+    await openTiledInProgressSessions({ projectId: 'p1' })
+
+    const tiles = useSessionStore.getState().tiledSessionsTab?.tiles ?? []
+    expect(tiles).toHaveLength(1)
+    expect(tiles[0].title).toBe('First · Second')
+    expect(tiles[0].ticketIds).toEqual(['t1', 't2'])
+  })
+
+  it('includes project names on pinned boards', async () => {
+    useProjectStore.setState({
+      projects: [
+        { id: 'p1', name: 'Acme' },
+        { id: 'p2', name: 'Umbrella' }
+      ] as never
+    })
+    usePinnedStore.setState({ pinnedProjectIds: new Set(['p1', 'p2']) } as never)
+    useKanbanStore.setState({
+      tickets: new Map([
+        ['p1', [makeTicket({ id: 'a1', title: 'From Acme', current_session_id: 'sa' })]],
+        [
+          'p2',
+          [
+            makeTicket({
+              id: 'b1',
+              title: 'From Umbrella',
+              project_id: 'p2',
+              current_session_id: 'sb'
+            })
+          ]
+        ]
+      ])
+    })
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([
+        ['wt1', [makeSession({ id: 'sa', project_id: 'p1' })]],
+        ['wt2', [makeSession({ id: 'sb', project_id: 'p2', worktree_id: 'wt2' })]]
+      ])
+    })
+
+    await openTiledInProgressSessions({ projectId: '', isPinnedMode: true })
+
+    const state = useSessionStore.getState()
+    expect(state.tiledSessionsTab?.scopeLabel).toBe('Pinned')
+    const tiles = state.tiledSessionsTab?.tiles ?? []
+    expect(tiles).toHaveLength(2)
+    const byTitle = new Map(tiles.map((t) => [t.title, t]))
+    expect(byTitle.get('From Acme')?.projectName).toBe('Acme')
+    expect(byTitle.get('From Umbrella')?.projectName).toBe('Umbrella')
+  })
+
+  it('marks completed sessions as not running', async () => {
+    useProjectStore.setState({ projects: [{ id: 'p1', name: 'Acme' }] as never })
+    useKanbanStore.setState({
+      tickets: new Map([
+        ['p1', [makeTicket({ id: 't1', title: 'Ended', current_session_id: 's-ended' })]]
+      ])
+    })
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([
+        ['wt1', [makeSession({ id: 's-ended', status: 'completed' })]]
+      ])
+    })
+
+    await openTiledInProgressSessions({ projectId: 'p1' })
+
+    const tiles = useSessionStore.getState().tiledSessionsTab?.tiles ?? []
+    expect(tiles[0].isRunning).toBe(false)
+    expect(tiles[0].sessionId).toBe('s-ended')
+  })
+})

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -24,7 +24,12 @@ export interface PendingLaunchModelEntry {
 }
 
 interface PendingLaunchConfig {
-  worktree: { type: 'new'; sourceBranch: string } | { type: 'existing'; worktreeId: string }
+  worktree:
+    | { type: 'new'; sourceBranch: string }
+    | { type: 'existing'; worktreeId: string }
+    | { type: 'connection-new' }
+    | { type: 'connection-existing'; connectionId: string }
+    | { type: 'connection-worktrees'; worktreeIds: string[] }
   prompt: string
   mode: AutoLaunchMode
   model: { providerID: string; modelID: string; variant?: string } | null
@@ -69,6 +74,41 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
   const project = useProjectStore.getState().projects.find((p) => p.id === ticket.project_id)
   if (!project) {
     console.error('Project not found for auto-launch:', ticket.project_id)
+    return
+  }
+
+  // Connection-project tickets launch into a connection instance (new
+  // worktrees, a specific worktree set, or a live instance) — the connection
+  // pipeline owns everything.
+  if (
+    config.worktree.type === 'connection-new' ||
+    config.worktree.type === 'connection-existing' ||
+    config.worktree.type === 'connection-worktrees'
+  ) {
+    const { quickLaunchTicketOnConnectionProject } = await import(
+      '@/lib/connection-project-launch'
+    )
+    const target =
+      config.worktree.type === 'connection-existing'
+        ? ({ type: 'existing-connection', connectionId: config.worktree.connectionId } as const)
+        : config.worktree.type === 'connection-worktrees'
+          ? ({ type: 'worktree-set', worktreeIds: config.worktree.worktreeIds } as const)
+          : ({ type: 'new' } as const)
+    const ok = await quickLaunchTicketOnConnectionProject(
+      { id: ticket.id, project_id: ticket.project_id, title: ticket.title },
+      {
+        mode: config.mode,
+        sdk: config.sdk,
+        model: config.model,
+        codexFastMode: config.codexFastMode,
+        promptText: config.prompt,
+        goalMode: configGoalMode,
+        goalSuccessCriteria: configGoalSuccessCriteria
+      },
+      target
+    )
+    // quickLaunchTicketOnConnectionProject reports its own success/failure toasts.
+    void ok
     return
   }
 

--- a/src/renderer/src/lib/auto-pin.test.ts
+++ b/src/renderer/src/lib/auto-pin.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const settingsState = {
+  autoPinBaseWorktreeOnBoardPrompt: true
+}
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: { getState: () => settingsState }
+}))
+vi.mock('@/api/hive-enterprise/client', () => ({
+  isForceBoardMode: () => false
+}))
+
+const pinnedState = {
+  pinnedWorktreeIds: new Set<string>(),
+  pinnedConnectionIds: new Set<string>(),
+  isWorktreePinned: vi.fn((id: string) => pinnedState.pinnedWorktreeIds.has(id)),
+  isConnectionPinned: vi.fn((id: string) => pinnedState.pinnedConnectionIds.has(id)),
+  pinWorktree: vi.fn(async () => {}),
+  pinConnection: vi.fn(async () => {})
+}
+vi.mock('@/stores/usePinnedStore', () => ({
+  usePinnedStore: { getState: () => pinnedState }
+}))
+
+const worktreeState = {
+  defaultByProject: new Map<string, { id: string } | null>(),
+  getDefaultWorktree: vi.fn((projectId: string) => worktreeState.defaultByProject.get(projectId) ?? null),
+  loadWorktrees: vi.fn(async () => {})
+}
+vi.mock('@/stores/useWorktreeStore', () => ({
+  useWorktreeStore: { getState: () => worktreeState }
+}))
+
+const projectState = {
+  projects: [] as { id: string; kind?: 'git' | 'connection' }[]
+}
+vi.mock('@/stores/useProjectStore', () => ({
+  useProjectStore: { getState: () => projectState }
+}))
+
+const connectionState = {
+  connections: [] as { id: string; saved_project_id?: string | null; is_base?: number }[],
+  loadConnections: vi.fn(async () => {})
+}
+vi.mock('@/stores/useConnectionStore', () => ({
+  useConnectionStore: { getState: () => connectionState }
+}))
+
+import { autoPinBaseWorktree } from './auto-pin'
+
+const CONN_PROJECT = 'conn-project-1'
+const GIT_PROJECT = 'git-project-1'
+
+describe('autoPinBaseWorktree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    settingsState.autoPinBaseWorktreeOnBoardPrompt = true
+    pinnedState.pinnedWorktreeIds = new Set()
+    pinnedState.pinnedConnectionIds = new Set()
+    worktreeState.defaultByProject = new Map([[GIT_PROJECT, { id: 'wt-default' }]])
+    projectState.projects = [
+      { id: GIT_PROJECT, kind: 'git' },
+      { id: CONN_PROJECT, kind: 'connection' }
+    ]
+    connectionState.connections = [
+      { id: 'inst-1', saved_project_id: CONN_PROJECT, is_base: 0 },
+      { id: 'base-1', saved_project_id: CONN_PROJECT, is_base: 1 },
+      { id: 'adhoc', saved_project_id: null, is_base: 0 }
+    ]
+  })
+
+  it('git project: pins the default worktree (unchanged behavior)', async () => {
+    await autoPinBaseWorktree(GIT_PROJECT)
+
+    expect(pinnedState.pinWorktree).toHaveBeenCalledWith('wt-default')
+    expect(pinnedState.pinConnection).not.toHaveBeenCalled()
+  })
+
+  it('connection project: pins the BASE instance, never another instance', async () => {
+    await autoPinBaseWorktree(CONN_PROJECT)
+
+    expect(pinnedState.pinConnection).toHaveBeenCalledTimes(1)
+    expect(pinnedState.pinConnection).toHaveBeenCalledWith('base-1')
+    expect(pinnedState.pinWorktree).not.toHaveBeenCalled()
+    // The worktree path is never consulted for connection projects
+    expect(worktreeState.loadWorktrees).not.toHaveBeenCalled()
+  })
+
+  it('connection project: no-op when the base instance is already pinned', async () => {
+    pinnedState.pinnedConnectionIds = new Set(['base-1'])
+
+    await autoPinBaseWorktree(CONN_PROJECT)
+
+    expect(pinnedState.pinConnection).not.toHaveBeenCalled()
+  })
+
+  it('connection project: reloads connections when the base is not in the store yet', async () => {
+    connectionState.connections = []
+    connectionState.loadConnections.mockImplementationOnce(async () => {
+      connectionState.connections = [{ id: 'base-1', saved_project_id: CONN_PROJECT, is_base: 1 }]
+    })
+
+    await autoPinBaseWorktree(CONN_PROJECT)
+
+    expect(connectionState.loadConnections).toHaveBeenCalledTimes(1)
+    expect(pinnedState.pinConnection).toHaveBeenCalledWith('base-1')
+  })
+
+  it('connection project: gives up quietly when no base instance exists', async () => {
+    connectionState.connections = [{ id: 'inst-1', saved_project_id: CONN_PROJECT, is_base: 0 }]
+
+    await autoPinBaseWorktree(CONN_PROJECT)
+
+    expect(connectionState.loadConnections).toHaveBeenCalledTimes(1)
+    expect(pinnedState.pinConnection).not.toHaveBeenCalled()
+    expect(pinnedState.pinWorktree).not.toHaveBeenCalled()
+  })
+
+  it('respects the setting for connection projects too', async () => {
+    settingsState.autoPinBaseWorktreeOnBoardPrompt = false
+
+    await autoPinBaseWorktree(CONN_PROJECT)
+    await autoPinBaseWorktree(GIT_PROJECT)
+
+    expect(pinnedState.pinConnection).not.toHaveBeenCalled()
+    expect(pinnedState.pinWorktree).not.toHaveBeenCalled()
+  })
+
+  it('never throws (pin failure is swallowed)', async () => {
+    pinnedState.pinConnection.mockRejectedValueOnce(new Error('boom'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(autoPinBaseWorktree(CONN_PROJECT)).resolves.toBeUndefined()
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+})

--- a/src/renderer/src/lib/auto-pin.ts
+++ b/src/renderer/src/lib/auto-pin.ts
@@ -1,12 +1,18 @@
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { usePinnedStore } from '@/stores/usePinnedStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
 import { isForceBoardMode } from '@/api/hive-enterprise/client'
+import { findBaseInstanceConnection } from '@/lib/connection-project'
 
 /**
  * When the "auto-pin project on board prompts" setting is enabled, pin the
  * project's base (is_default) worktree so the project's tickets appear on the
- * pinned board. Never throws — call fire-and-forget via `void`.
+ * pinned board. Connection projects (projects.kind === 'connection') have no
+ * worktrees — their base INSTANCE (the connection over every member's default
+ * worktree) is pinned instead, which scopes the project onto the pinned board
+ * the same way. Never throws — call fire-and-forget via `void`.
  */
 export async function autoPinBaseWorktree(projectId: string | null | undefined): Promise<void> {
   try {
@@ -15,6 +21,12 @@ export async function autoPinBaseWorktree(projectId: string | null | undefined):
     // is forced on and cannot be disabled.
     const settings = useSettingsStore.getState()
     if (!settings.autoPinBaseWorktreeOnBoardPrompt && !isForceBoardMode(settings)) return
+
+    const project = useProjectStore.getState().projects.find((p) => p.id === projectId)
+    if (project?.kind === 'connection') {
+      await pinConnectionProjectBase(projectId)
+      return
+    }
 
     let base = useWorktreeStore.getState().getDefaultWorktree(projectId)
     if (!base) {
@@ -31,4 +43,19 @@ export async function autoPinBaseWorktree(projectId: string | null | undefined):
   } catch (err) {
     console.error('[auto-pin] failed to auto-pin base worktree:', err)
   }
+}
+
+async function pinConnectionProjectBase(projectId: string): Promise<void> {
+  let base = findBaseInstanceConnection(projectId)
+  if (!base) {
+    // Connections may not be loaded yet, or the base was only just healed
+    // server-side (connectionOps.getAll creates a missing base on listing).
+    await useConnectionStore.getState().loadConnections()
+    base = findBaseInstanceConnection(projectId)
+  }
+  if (!base) return
+
+  const pinned = usePinnedStore.getState()
+  if (pinned.isConnectionPinned(base.id)) return
+  await pinned.pinConnection(base.id)
 }

--- a/src/renderer/src/lib/connection-project-launch.test.ts
+++ b/src/renderer/src/lib/connection-project-launch.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/api/connection-api', () => ({
+  connectionApi: {
+    create: vi.fn(),
+    get: vi.fn(),
+    rename: vi.fn()
+  }
+}))
+vi.mock('@/api/worktree-api', () => ({
+  worktreeApi: {
+    createFromBranch: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+
+import { connectionApi } from '@/api/connection-api'
+import { worktreeApi } from '@/api/worktree-api'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { resolveConnectionForLaunch } from './connection-project-launch'
+import type { WorktreeNameSet } from './connection-project'
+
+const SAVED_ID = 'saved-project-1'
+
+const makeConnection = (
+  id: string,
+  worktreeIds: string[],
+  savedProjectId: string | null = SAVED_ID
+) =>
+  ({
+    id,
+    name: 'a + b',
+    custom_name: null,
+    status: 'active' as const,
+    path: `/tmp/connections/${id}`,
+    color: null,
+    saved_project_id: savedProjectId,
+    created_at: '2026-01-01',
+    updated_at: '2026-01-01',
+    members: worktreeIds.map((worktreeId, i) => ({
+      id: `m-${id}-${i}`,
+      connection_id: id,
+      worktree_id: worktreeId,
+      project_id: `p${i}`,
+      symlink_name: `p${i}`,
+      added_at: '2026-01-01',
+      worktree_name: 'wt',
+      worktree_branch: 'wt',
+      worktree_path: `/tmp/wt/${worktreeId}`,
+      project_name: `p${i}`
+    }))
+  }) as never
+
+const memberProjects = [
+  { id: 'pa', path: '/tmp/alpha', name: 'alpha' },
+  { id: 'pb', path: '/tmp/beta', name: 'beta' }
+]
+
+const makeWorktree = (
+  id: string,
+  projectId: string,
+  name: string,
+  extra: Record<string, unknown> = {}
+) =>
+  ({
+    id,
+    project_id: projectId,
+    name,
+    branch_name: name,
+    path: `/tmp/wt/${projectId}/${name}`,
+    status: 'active',
+    is_default: false,
+    ...extra
+  }) as never
+
+describe('resolveConnectionForLaunch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useConnectionStore.setState({ connections: [] })
+    useWorktreeStore.setState({ worktreesByProject: new Map() })
+  })
+
+  it('existing-connection target returns the live instance without creating anything', async () => {
+    useConnectionStore.setState({ connections: [makeConnection('conn-1', ['w1', 'w2'])] })
+
+    const result = await resolveConnectionForLaunch({
+      savedProjectId: SAVED_ID,
+      memberProjects,
+      target: { type: 'existing-connection', connectionId: 'conn-1' }
+    })
+
+    expect(result).toEqual({ connectionId: 'conn-1', connectionPath: '/tmp/connections/conn-1' })
+    expect(connectionApi.create).not.toHaveBeenCalled()
+  })
+
+  it('name-set target reuses an instance whose worktree set matches exactly', async () => {
+    useConnectionStore.setState({
+      connections: [
+        makeConnection('other', ['w1', 'w2'], null), // ad-hoc — never reused
+        makeConnection('inst', ['w1', 'w2'])
+      ]
+    })
+    const nameSet: WorktreeNameSet = {
+      name: 'ticket-x',
+      worktrees: [
+        { projectId: 'pa', worktreeId: 'w1', worktreePath: '/tmp/wt/pa/ticket-x' },
+        { projectId: 'pb', worktreeId: 'w2', worktreePath: '/tmp/wt/pb/ticket-x' }
+      ]
+    }
+
+    const result = await resolveConnectionForLaunch({
+      savedProjectId: SAVED_ID,
+      memberProjects,
+      target: { type: 'name-set', nameSet }
+    })
+
+    expect(result.connectionId).toBe('inst')
+    expect(connectionApi.create).not.toHaveBeenCalled()
+  })
+
+  it('name-set target creates a linked connection when no instance matches', async () => {
+    vi.mocked(connectionApi.create).mockResolvedValue({
+      success: true,
+      connection: makeConnection('fresh', ['w1', 'w2'])
+    } as never)
+
+    const nameSet: WorktreeNameSet = {
+      name: 'ticket-x',
+      worktrees: [
+        { projectId: 'pa', worktreeId: 'w1', worktreePath: '/tmp/wt/pa/ticket-x' },
+        { projectId: 'pb', worktreeId: 'w2', worktreePath: '/tmp/wt/pb/ticket-x' }
+      ]
+    }
+
+    const result = await resolveConnectionForLaunch({
+      savedProjectId: SAVED_ID,
+      memberProjects,
+      target: { type: 'name-set', nameSet }
+    })
+
+    expect(connectionApi.create).toHaveBeenCalledExactlyOnceWith(['w1', 'w2'], {
+      savedProjectId: SAVED_ID
+    })
+    expect(result.connectionId).toBe('fresh')
+    // Inserted into the store without selection
+    expect(useConnectionStore.getState().connections.some((c) => c.id === 'fresh')).toBe(true)
+    expect(useConnectionStore.getState().selectedConnectionId).not.toBe('fresh')
+  })
+
+  it('new target creates a worktree per member off its default branch, then connects them', async () => {
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        ['pa', [makeWorktree('da', 'pa', 'main', { is_default: true, branch_name: 'main' })]],
+        ['pb', [makeWorktree('db', 'pb', 'develop', { is_default: true, branch_name: 'develop' })]]
+      ])
+    })
+    const loadWorktrees = vi.fn().mockResolvedValue(undefined)
+    useWorktreeStore.setState({ loadWorktrees } as never)
+
+    vi.mocked(worktreeApi.createFromBranch)
+      .mockResolvedValueOnce({
+        success: true,
+        worktree: makeWorktree('na', 'pa', 'ticket-x')
+      } as never)
+      .mockResolvedValueOnce({
+        success: true,
+        worktree: makeWorktree('nb', 'pb', 'ticket-x')
+      } as never)
+    vi.mocked(connectionApi.create).mockResolvedValue({
+      success: true,
+      connection: makeConnection('inst-new', ['na', 'nb'])
+    } as never)
+
+    const result = await resolveConnectionForLaunch({
+      savedProjectId: SAVED_ID,
+      memberProjects,
+      target: { type: 'new' },
+      nameHint: 'ticket-x'
+    })
+
+    expect(worktreeApi.createFromBranch).toHaveBeenNthCalledWith(1, {
+      projectId: 'pa',
+      projectPath: '/tmp/alpha',
+      projectName: 'alpha',
+      branchName: 'main',
+      nameHint: 'ticket-x'
+    })
+    expect(worktreeApi.createFromBranch).toHaveBeenNthCalledWith(2, {
+      projectId: 'pb',
+      projectPath: '/tmp/beta',
+      projectName: 'beta',
+      branchName: 'develop',
+      nameHint: 'ticket-x'
+    })
+    expect(connectionApi.create).toHaveBeenCalledExactlyOnceWith(['na', 'nb'], {
+      savedProjectId: SAVED_ID
+    })
+    expect(result.connectionId).toBe('inst-new')
+  })
+
+  it('new target rolls back already-created worktrees when a later create fails', async () => {
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        ['pa', [makeWorktree('da', 'pa', 'main', { is_default: true, branch_name: 'main' })]],
+        ['pb', [makeWorktree('db', 'pb', 'main', { is_default: true, branch_name: 'main' })]]
+      ]),
+      loadWorktrees: vi.fn().mockResolvedValue(undefined) as never
+    })
+
+    const createdWorktree = makeWorktree('na', 'pa', 'ticket-x') as { id: string; path: string }
+    vi.mocked(worktreeApi.createFromBranch)
+      .mockResolvedValueOnce({ success: true, worktree: createdWorktree } as never)
+      .mockResolvedValueOnce({ success: false, error: 'boom' } as never)
+    vi.mocked(worktreeApi.delete).mockResolvedValue({ success: true } as never)
+
+    const result = await resolveConnectionForLaunch({
+      savedProjectId: SAVED_ID,
+      memberProjects,
+      target: { type: 'new' },
+      nameHint: 'ticket-x'
+    })
+
+    expect(result.connectionId).toBeUndefined()
+    expect(result.error).toContain('beta')
+    expect(worktreeApi.delete).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ worktreeId: 'na', archive: false })
+    )
+    expect(connectionApi.create).not.toHaveBeenCalled()
+  })
+
+  it('new target fails fast with fewer than 2 member projects', async () => {
+    const result = await resolveConnectionForLaunch({
+      savedProjectId: SAVED_ID,
+      memberProjects: [memberProjects[0]],
+      target: { type: 'new' }
+    })
+    expect(result.error).toMatch(/at least 2/)
+    expect(worktreeApi.createFromBranch).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/connection-project-launch.ts
+++ b/src/renderer/src/lib/connection-project-launch.ts
@@ -29,6 +29,7 @@ import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
 import { createPlanFile, exceedsGoalPromptLimit, planFilePrompt } from '@/lib/goal-plan-file'
 import { resolveBadgeModel } from '@/lib/ticket-launch'
+import { autoPinBaseWorktree } from '@/lib/auto-pin'
 import {
   PLAN_MODE_PREFIX,
   getSuperModePrefix,
@@ -38,7 +39,12 @@ import {
 } from '@/lib/constants'
 import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
 import { FALLBACK_MODELS } from '@shared/model-resolution'
-import { getMemberProjects, type MemberProject, type WorktreeNameSet } from '@/lib/connection-project'
+import {
+  getMemberProjects,
+  isBaseInstance,
+  type MemberProject,
+  type WorktreeNameSet
+} from '@/lib/connection-project'
 import type { KanbanTicket, Session } from '../../../main/db/types'
 
 /** Minimal ticket shape the connection-project pipeline needs. */
@@ -395,12 +401,17 @@ export async function startTicketSessionOnConnectionInstance(args: {
       pending_launch_config: null
     })
 
-    // Name the instance after the ticket unless the user already renamed it
+    // Name the instance after the ticket unless the user already renamed it —
+    // never the base instance (it is the project's "main", like a default worktree).
     const connection = useConnectionStore.getState().connections.find((c) => c.id === connectionId)
     const ticketTitle = ticket.title.trim()
-    if (connection && !connection.custom_name && ticketTitle) {
+    if (connection && !isBaseInstance(connection) && !connection.custom_name && ticketTitle) {
       void useConnectionStore.getState().renameConnection(connectionId, ticketTitle)
     }
+
+    // Setting-gated auto-pin: pins the project's base instance so this board
+    // shows on the pinned board (the git-project paths pin the default worktree).
+    void autoPinBaseWorktree(savedProjectId)
 
     const usageProvider = resolveDefaultUsageProvider(sdk)
     if (usageProvider) {

--- a/src/renderer/src/lib/connection-project-launch.ts
+++ b/src/renderer/src/lib/connection-project-launch.ts
@@ -1,0 +1,580 @@
+/**
+ * Ticket launch pipeline for "connection projects" (projects.kind === 'connection').
+ *
+ * A ticket on a connection-project board launches into a live connection
+ * INSTANCE: either a brand-new one (a fresh worktree named after the ticket in
+ * every member project, connected together) or an existing one (a same-name
+ * worktree set across all member projects, or an already-materialized instance
+ * connection of this project). The session is a regular connection session
+ * (sessions.connection_id set, worktree_id null) whose project_id is the saved
+ * project — so tickets/history attribute to the saved board.
+ */
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
+import { connectionApi } from '@/api/connection-api'
+import { worktreeApi } from '@/api/worktree-api'
+import { opencodeApi } from '@/api/opencode-api'
+import { terminalApi } from '@/api/terminal-api'
+import { dbApi } from '@/api/db-api'
+import { unwrapEnvelope } from '@/lib/ipc-envelope'
+import { toast } from '@/lib/toast'
+import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
+import { snapshotTokenBaseline } from '@/lib/token-baselines'
+import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
+import { startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
+import { createPlanFile, exceedsGoalPromptLimit, planFilePrompt } from '@/lib/goal-plan-file'
+import { resolveBadgeModel } from '@/lib/ticket-launch'
+import {
+  PLAN_MODE_PREFIX,
+  getSuperModePrefix,
+  isPlanLike,
+  isSuperMode,
+  baseMode
+} from '@/lib/constants'
+import { canonicalizeTicketTitle } from '@shared/types/branch-utils'
+import { FALLBACK_MODELS } from '@shared/model-resolution'
+import { getMemberProjects, type MemberProject, type WorktreeNameSet } from '@/lib/connection-project'
+import type { KanbanTicket, Session } from '../../../main/db/types'
+
+/** Minimal ticket shape the connection-project pipeline needs. */
+export type ConnectionProjectTicket = Pick<KanbanTicket, 'id' | 'project_id' | 'title'> & {
+  description?: string | null
+  attachments?: KanbanTicket['attachments']
+}
+
+type LaunchMode = 'build' | 'plan' | 'super-plan' | 'super-build'
+type LaunchSdk = 'opencode' | 'claude-code' | 'claude-code-cli' | 'codex'
+
+export type ConnectionProjectLaunchTarget =
+  | { type: 'new' }
+  | { type: 'existing-connection'; connectionId: string }
+  | { type: 'name-set'; nameSet: WorktreeNameSet }
+  /** A specific worktree set (serialized name-set from a queued launch config). */
+  | { type: 'worktree-set'; worktreeIds: string[] }
+
+export interface ConnectionProjectLaunchOptions {
+  mode: LaunchMode
+  sdk: LaunchSdk
+  model: { providerID: string; modelID: string; variant?: string } | null
+  codexFastMode: boolean
+  /** RAW prompt (ticket prompt or user-edited text) — composed per SDK here. */
+  promptText: string
+  goalMode: boolean
+  goalSuccessCriteria: string | null
+}
+
+export interface ConnectionProjectLaunchResult {
+  success: boolean
+  sessionId?: string
+  connectionId?: string
+  error?: string
+}
+
+// ── Prompt composition (mirrors WorktreePickerModal/ticket-launch) ──
+export function buildTicketPrompt(mode: LaunchMode, ticket: ConnectionProjectTicket): string {
+  const prefix =
+    baseMode(mode) === 'build'
+      ? 'Please implement the following ticket.'
+      : 'Please review the following ticket and create a detailed implementation plan.'
+  const description = ticket.description ?? ''
+  const attachments = (ticket.attachments ?? []) as Array<{
+    type: string
+    url: string
+    label: string
+  }>
+
+  let attachmentsXml = ''
+  if (attachments.length > 0) {
+    const items: string[] = []
+    for (const a of attachments) {
+      if (a.type === 'image' || a.type === 'file') {
+        items.push(`<file path="${a.url}">${a.label}</file>`)
+      } else {
+        items.push(`<link type="${a.type}" url="${a.url}">${a.label}</link>`)
+      }
+    }
+    attachmentsXml = `\n<attachments>\n${items.join('\n')}\n</attachments>`
+  }
+
+  return `${prefix}\n\n<ticket title="${ticket.title}">${description}${attachmentsXml}</ticket>`
+}
+
+function wrapGoalPrompt(prompt: string, criteria: string): string {
+  const stripped = prompt.replace(/^\/goal\s+/, '')
+  return `/goal ${stripped}. Goal success criteria: ${criteria}`
+}
+
+function composePromptForSdk(
+  mode: LaunchMode,
+  sessionAgentSdk: string | null | undefined,
+  prompt: string,
+  goalMode: boolean,
+  goalCriteria: string | null,
+  options: { claudeCli: boolean }
+): string | null {
+  const trimmedPrompt = prompt.trim()
+  if (!trimmedPrompt) return null
+
+  const skipPrefix =
+    options.claudeCli ||
+    sessionAgentSdk === 'claude-code' ||
+    sessionAgentSdk === 'codex' ||
+    sessionAgentSdk === 'claude-code-cli'
+  const modePrefix = isSuperMode(mode)
+    ? getSuperModePrefix(mode, sessionAgentSdk)
+    : mode === 'plan' && !skipPrefix
+      ? PLAN_MODE_PREFIX
+      : ''
+  const fullPrompt = modePrefix + trimmedPrompt
+
+  return goalMode && goalCriteria?.trim()
+    ? wrapGoalPrompt(fullPrompt, goalCriteria.trim())
+    : fullPrompt
+}
+
+/** Default SDK + build-mode model, mirroring the picker's quick-launch resolution. */
+function resolveQuickModel(): {
+  sdk: LaunchSdk
+  model: { providerID: string; modelID: string; variant?: string }
+} {
+  const settings = useSettingsStore.getState()
+  const rawSdk = settings.defaultAgentSdk ?? 'opencode'
+  const sdk: LaunchSdk = rawSdk === 'terminal' ? 'opencode' : rawSdk
+  const modeModel = settings.getModelForMode('build')
+  if (modeModel && modeModel.agentSdk === sdk) {
+    return {
+      sdk,
+      model: { providerID: modeModel.providerID, modelID: modeModel.modelID, variant: modeModel.variant }
+    }
+  }
+  const resolved = resolveModelForSdk(sdk) ?? FALLBACK_MODELS[sdk]
+  return {
+    sdk,
+    model: { providerID: resolved.providerID, modelID: resolved.modelID, variant: resolved.variant }
+  }
+}
+
+/** Insert a freshly-created connection into the store WITHOUT selecting it. */
+function insertConnectionLocally(connection: {
+  id: string
+  members?: unknown[]
+}): void {
+  useConnectionStore.setState((state) => {
+    if (state.connections.some((c) => c.id === connection.id)) return state
+    return {
+      connections: [
+        ...state.connections,
+        connection as unknown as (typeof state.connections)[number]
+      ]
+    }
+  })
+}
+
+/**
+ * Create one new worktree per member project (nameHint = ticket slug, base =
+ * each project's default branch) and connect them, linked to the saved project.
+ * Best-effort rollback of created worktrees on failure — mirrors
+ * useConnectionStore.quickCreateConnection but never changes selection.
+ */
+async function createInstanceWithNewWorktrees(
+  savedProjectId: string,
+  memberProjects: MemberProject[],
+  nameHint: string | undefined
+): Promise<{ connectionId?: string; connectionPath?: string; error?: string }> {
+  const { useWorktreeStore, fireSetupScript } = await import('@/stores/useWorktreeStore')
+  const worktreeStore = useWorktreeStore.getState()
+
+  // Ensure member worktrees are loaded so default branches resolve
+  await Promise.all(memberProjects.map((m) => worktreeStore.loadWorktrees(m.id)))
+
+  const created: {
+    project: MemberProject
+    worktree: { id: string; path: string; branch_name: string }
+  }[] = []
+
+  const rollback = async (): Promise<void> => {
+    for (const { project, worktree } of created) {
+      try {
+        const deleteResult = await worktreeApi.delete({
+          worktreeId: worktree.id,
+          worktreePath: worktree.path,
+          branchName: worktree.branch_name,
+          projectPath: project.path,
+          archive: false
+        })
+        if (deleteResult.success) {
+          useWorktreeStore.getState().removeWorktreeFromProject(project.id, worktree.id)
+        }
+      } catch {
+        // Best-effort cleanup only
+      }
+    }
+  }
+
+  for (const project of memberProjects) {
+    const defaultBranch =
+      useWorktreeStore.getState().getDefaultWorktree(project.id)?.branch_name || 'main'
+    const result = await worktreeApi.createFromBranch({
+      projectId: project.id,
+      projectPath: project.path,
+      projectName: project.name,
+      branchName: defaultBranch,
+      ...(nameHint ? { nameHint } : {})
+    })
+    if (!result.success || !result.worktree) {
+      await rollback()
+      return {
+        error: `Failed to create worktree in "${project.name}": ${result.error ?? 'Unknown error'}`
+      }
+    }
+    // Insert WITHOUT selecting (the store's createWorktreeFromBranch action selects)
+    useWorktreeStore.getState().addWorktreeToProject(project.id, result.worktree)
+    created.push({ project, worktree: result.worktree })
+  }
+
+  // Fire setup scripts only after every worktree succeeded (rollback can delete dirs)
+  for (const { project, worktree } of created) {
+    fireSetupScript(project.id, worktree.id, worktree.path)
+  }
+
+  const createResult = await connectionApi.create(
+    created.map((c) => c.worktree.id),
+    { savedProjectId }
+  )
+  if (!createResult.success || !createResult.connection) {
+    await rollback()
+    return { error: createResult.error || 'Failed to create connection' }
+  }
+  insertConnectionLocally(createResult.connection)
+  return { connectionId: createResult.connection.id, connectionPath: createResult.connection.path }
+}
+
+/**
+ * Resolve a launch target to a live connection instance. Name sets reuse an
+ * existing instance of this project when the worktree set matches exactly;
+ * otherwise a new connection is created over the picked worktrees.
+ */
+export async function resolveConnectionForLaunch(args: {
+  savedProjectId: string
+  memberProjects: MemberProject[]
+  target: ConnectionProjectLaunchTarget
+  nameHint?: string
+}): Promise<{ connectionId?: string; connectionPath?: string; error?: string }> {
+  const { savedProjectId, memberProjects, target } = args
+
+  if (target.type === 'existing-connection') {
+    const connection = useConnectionStore
+      .getState()
+      .connections.find((c) => c.id === target.connectionId)
+    if (!connection) return { error: 'Connection no longer exists' }
+    return { connectionId: connection.id, connectionPath: connection.path }
+  }
+
+  if (target.type === 'name-set' || target.type === 'worktree-set') {
+    const worktreeIds =
+      target.type === 'name-set'
+        ? target.nameSet.worktrees.map((w) => w.worktreeId)
+        : target.worktreeIds
+    const wanted = new Set(worktreeIds)
+    // Reuse an existing instance whose member worktree set matches exactly
+    const existing = useConnectionStore.getState().connections.find((c) => {
+      if (c.saved_project_id !== savedProjectId) return false
+      const memberIds = c.members.map((m) => m.worktree_id)
+      return memberIds.length === wanted.size && memberIds.every((id) => wanted.has(id))
+    })
+    if (existing) return { connectionId: existing.id, connectionPath: existing.path }
+
+    const createResult = await connectionApi.create(worktreeIds, { savedProjectId })
+    if (!createResult.success || !createResult.connection) {
+      return { error: createResult.error || 'Failed to create connection' }
+    }
+    insertConnectionLocally(createResult.connection)
+    return {
+      connectionId: createResult.connection.id,
+      connectionPath: createResult.connection.path
+    }
+  }
+
+  if (memberProjects.length < 2) {
+    return { error: 'Connection project needs at least 2 existing member projects' }
+  }
+  return createInstanceWithNewWorktrees(savedProjectId, memberProjects, args.nameHint)
+}
+
+/**
+ * Create the connection session, link the ticket, and deliver the prompt —
+ * the connection-project twin of the picker's connection-mode send path.
+ * Sort order comes from the SAVED project's own board column.
+ */
+export async function startTicketSessionOnConnectionInstance(args: {
+  ticket: ConnectionProjectTicket
+  savedProjectId: string
+  connectionId: string
+  connectionPath: string | undefined
+  options: ConnectionProjectLaunchOptions
+}): Promise<ConnectionProjectLaunchResult> {
+  const { ticket, savedProjectId, connectionId, connectionPath, options } = args
+  const { mode, sdk, model, codexFastMode, goalMode } = options
+  const goalCriteria = options.goalSuccessCriteria?.trim() || null
+  let promptText = options.promptText
+
+  try {
+    // Oversized goal prompts become a PLAN_{uuid}.md in the connection dir
+    if (goalMode && goalCriteria && connectionPath) {
+      const composed = composePromptForSdk(mode, sdk, promptText, goalMode, goalCriteria, {
+        claudeCli: sdk === 'claude-code-cli'
+      })
+      if (exceedsGoalPromptLimit(composed)) {
+        const fileName = await createPlanFile(connectionPath, promptText.trim())
+        promptText = planFilePrompt(fileName)
+      }
+    }
+
+    const cliPendingPrompt =
+      sdk === 'claude-code-cli'
+        ? composePromptForSdk(mode, sdk, promptText, goalMode, goalCriteria, { claudeCli: true })
+        : null
+    const sessionResult = await useSessionStore
+      .getState()
+      .createConnectionSession(connectionId, sdk, mode, {
+        autoFocus: false,
+        ...(model ? { modelOverride: { ...model, agentSdk: sdk } } : {}),
+        ...(cliPendingPrompt ? { pendingMessage: cliPendingPrompt } : {})
+      })
+    if (!sessionResult.success || !sessionResult.session) {
+      return {
+        success: false,
+        error: sessionResult.error || 'Failed to create session',
+        connectionId
+      }
+    }
+
+    const sessionId = sessionResult.session.id
+    const sessionAgentSdk = sessionResult.session.agent_sdk
+
+    // Status tracking BEFORE any async connect so loadSessions can't race it
+    messageSendTimes.set(sessionId, Date.now())
+    userExplicitSendTimes.set(sessionId, Date.now())
+    snapshotTokenBaseline(sessionId)
+    lastSendMode.set(sessionId, isPlanLike(mode) ? 'plan' : 'build')
+    useWorktreeStatusStore
+      .getState()
+      .setSessionStatus(sessionId, isPlanLike(mode) ? 'planning' : 'working')
+
+    if (model) {
+      await useSessionStore.getState().setSessionModel(sessionId, model)
+    }
+
+    const kanban = useKanbanStore.getState()
+    const sortOrder = kanban.computeSortOrder(
+      kanban.getTicketsByColumn(savedProjectId, 'in_progress'),
+      0
+    )
+    const badgeModel = resolveBadgeModel(
+      { sdk, model, codexFastMode, customProviderId: null },
+      sessionResult.session
+    )
+    await kanban.updateTicket(ticket.id, ticket.project_id, {
+      current_session_id: sessionId,
+      worktree_id: null,
+      mode,
+      column: 'in_progress',
+      sort_order: sortOrder,
+      plan_ready: false,
+      goal_mode: goalMode,
+      goal_success_criteria: goalMode ? goalCriteria : null,
+      model_provider_id: badgeModel.providerID,
+      model_id: badgeModel.modelID,
+      model_variant: badgeModel.variant,
+      variant_group_id: null,
+      pending_launch_config: null
+    })
+
+    // Name the instance after the ticket unless the user already renamed it
+    const connection = useConnectionStore.getState().connections.find((c) => c.id === connectionId)
+    const ticketTitle = ticket.title.trim()
+    if (connection && !connection.custom_name && ticketTitle) {
+      void useConnectionStore.getState().renameConnection(connectionId, ticketTitle)
+    }
+
+    const usageProvider = resolveDefaultUsageProvider(sdk)
+    if (usageProvider) {
+      useUsageStore.getState().fetchUsageForProvider(usageProvider)
+    }
+
+    if (useSettingsStore.getState().boardMode === 'sticky-tab') {
+      const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
+      useSessionStore.getState().setActiveSession(BOARD_TAB_ID)
+    }
+
+    if (sessionAgentSdk === 'claude-code-cli') {
+      const outboundPrompt =
+        cliPendingPrompt ??
+        composePromptForSdk(mode, sessionAgentSdk, promptText, goalMode, goalCriteria, {
+          claudeCli: true
+        })
+
+      if (isSuperMode(mode)) {
+        // Await so the persisted mode is committed before the main process
+        // reads it in buildClaudeCliPtySpawn (createClaudeCli).
+        await useSessionStore.getState().setSessionMode(sessionId, baseMode(mode))
+      }
+
+      bumpWorktreeLastMessage({ connectionId })
+      const result = unwrapEnvelope(
+        await terminalApi.createClaudeCli(sessionId, { pendingPrompt: outboundPrompt })
+      )
+      if (!result.success) {
+        return {
+          success: false,
+          error: result.error ?? 'Failed to start Claude CLI',
+          sessionId,
+          connectionId
+        }
+      }
+      if (outboundPrompt) {
+        useSessionStore.getState().dequeuePendingMessage(sessionId)
+      }
+      return { success: true, sessionId, connectionId }
+    }
+
+    if (!connectionPath) return { success: true, sessionId, connectionId }
+
+    const connectResult = unwrapEnvelope(await opencodeApi.connect(connectionPath, sessionId))
+    if (!connectResult.success || !connectResult.sessionId) {
+      return {
+        success: false,
+        error: connectResult.error || 'Failed to start session',
+        sessionId,
+        connectionId
+      }
+    }
+    useSessionStore.getState().setOpenCodeSessionId(sessionId, connectResult.sessionId)
+    await dbApi.session.update<Session>(sessionId, {
+      opencode_session_id: connectResult.sessionId
+    })
+
+    const outboundPrompt = composePromptForSdk(mode, sessionAgentSdk, promptText, goalMode, goalCriteria, {
+      claudeCli: false
+    })
+    if (!outboundPrompt) return { success: true, sessionId, connectionId }
+
+    if (isSuperMode(mode)) {
+      useSessionStore.getState().setSessionMode(sessionId, baseMode(mode))
+    }
+
+    const promptOptions = sessionAgentSdk === 'codex' ? { codexFastMode } : undefined
+    bumpWorktreeLastMessage({ connectionId })
+    startHivePromptTelemetry({
+      sessionId,
+      prompt: outboundPrompt,
+      worktreeId: null,
+      modelId: model?.modelID,
+      providerId: model?.providerID,
+      modelVariant: model?.variant,
+      mode
+    })
+    const promptResult = unwrapEnvelope(
+      await opencodeApi.prompt(
+        connectionPath,
+        connectResult.sessionId,
+        [{ type: 'text', text: outboundPrompt }],
+        model
+          ? { providerID: model.providerID, modelID: model.modelID, variant: model.variant }
+          : undefined,
+        promptOptions
+      )
+    )
+    if (!promptResult.success) {
+      return {
+        success: false,
+        error: promptResult.error || 'Could not send prompt',
+        sessionId,
+        connectionId
+      }
+    }
+
+    return { success: true, sessionId, connectionId }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to start session',
+      connectionId
+    }
+  }
+}
+
+/**
+ * Full launch: resolve/create the connection instance for the target, then
+ * start the ticket session on it.
+ */
+export async function launchTicketOnConnectionProject(args: {
+  ticket: ConnectionProjectTicket
+  savedProject: { id: string; kind?: 'git' | 'connection'; member_project_ids?: string | null }
+  target: ConnectionProjectLaunchTarget
+  options: ConnectionProjectLaunchOptions
+}): Promise<ConnectionProjectLaunchResult> {
+  const memberProjects = getMemberProjects(args.savedProject)
+  const nameHint = canonicalizeTicketTitle(args.ticket.title) || undefined
+  const resolved = await resolveConnectionForLaunch({
+    savedProjectId: args.savedProject.id,
+    memberProjects,
+    target: args.target,
+    nameHint
+  })
+  if (!resolved.connectionId) {
+    return { success: false, error: resolved.error || 'Failed to resolve connection' }
+  }
+  return startTicketSessionOnConnectionInstance({
+    ticket: args.ticket,
+    savedProjectId: args.savedProject.id,
+    connectionId: resolved.connectionId,
+    connectionPath: resolved.connectionPath,
+    options: args.options
+  })
+}
+
+/**
+ * Quick launch (right-drag / Save & Send / Create & Send / auto-launch defaults):
+ * build mode, a NEW worktree per member project named after the ticket, default
+ * SDK + model, the plain ticket prompt. Reports its own toasts.
+ */
+export async function quickLaunchTicketOnConnectionProject(
+  ticket: ConnectionProjectTicket,
+  overrides?: Partial<ConnectionProjectLaunchOptions>,
+  target: ConnectionProjectLaunchTarget = { type: 'new' }
+): Promise<boolean> {
+  const savedProject = useProjectStore.getState().projects.find((p) => p.id === ticket.project_id)
+  if (!savedProject || savedProject.kind !== 'connection') {
+    toast.error('Connection project not found')
+    return false
+  }
+  const { sdk, model } = resolveQuickModel()
+  const options: ConnectionProjectLaunchOptions = {
+    mode: 'build',
+    sdk,
+    model,
+    codexFastMode: useSettingsStore.getState().codexFastMode,
+    promptText: buildTicketPrompt('build', ticket),
+    goalMode: false,
+    goalSuccessCriteria: null,
+    ...overrides
+  }
+  const result = await launchTicketOnConnectionProject({
+    ticket,
+    savedProject,
+    target,
+    options
+  })
+  if (!result.success) {
+    toast.error(result.error || 'Failed to start session')
+    return false
+  }
+  toast.success('Session started')
+  return true
+}

--- a/src/renderer/src/lib/connection-project.test.ts
+++ b/src/renderer/src/lib/connection-project.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it } from 'vitest'
+import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import {
+  baseInstanceLabel,
   computeWorktreeNameSets,
+  findBaseInstanceConnection,
   getMemberProjects,
+  isBaseInstance,
   isConnectionProject,
-  parseMemberProjectIds
+  parseMemberProjectIds,
+  sortInstancesBaseLast
 } from './connection-project'
 
 const makeProject = (id: string, name: string, extra: Record<string, unknown> = {}) =>
@@ -124,5 +129,84 @@ describe('connection-project helpers', () => {
       worktreesByProject: new Map([['a', [makeWorktree('wa1', 'a', 'ticket-x')]]])
     })
     expect(computeWorktreeNameSets(members)).toEqual([])
+  })
+})
+
+describe('connection-project base instance helpers', () => {
+  const makeConnection = (
+    id: string,
+    extra: Record<string, unknown> = {}
+  ): { id: string; saved_project_id?: string | null; is_base?: number } =>
+    ({
+      id,
+      name: id,
+      custom_name: null,
+      status: 'active',
+      path: `/tmp/connections/${id}`,
+      color: null,
+      saved_project_id: 'saved',
+      is_base: 0,
+      created_at: '2026-01-01',
+      updated_at: '2026-01-01',
+      members: [],
+      ...extra
+    }) as never
+
+  beforeEach(() => {
+    useConnectionStore.setState({ connections: [] })
+  })
+
+  it('isBaseInstance requires the flag AND a live connection project', () => {
+    expect(isBaseInstance({ id: 'c', is_base: 1, saved_project_id: 'p' })).toBe(true)
+    expect(isBaseInstance({ id: 'c', is_base: 0, saved_project_id: 'p' })).toBe(false)
+    // Orphan: the project was removed, so the row is an ordinary connection again
+    expect(isBaseInstance({ id: 'c', is_base: 1, saved_project_id: null })).toBe(false)
+    expect(isBaseInstance({ id: 'c', is_base: 1 })).toBe(false)
+    expect(isBaseInstance({ id: 'c' })).toBe(false)
+    expect(isBaseInstance(null)).toBe(false)
+  })
+
+  it('findBaseInstanceConnection returns the base of the given project only', () => {
+    useConnectionStore.setState({
+      connections: [
+        makeConnection('inst'),
+        makeConnection('other-base', { saved_project_id: 'other', is_base: 1 }),
+        makeConnection('base', { is_base: 1 })
+      ] as never
+    })
+    expect(findBaseInstanceConnection('saved')?.id).toBe('base')
+    expect(findBaseInstanceConnection('other')?.id).toBe('other-base')
+    expect(findBaseInstanceConnection('missing')).toBeNull()
+  })
+
+  it('baseInstanceLabel joins the distinct member branches, falling back to "main"', () => {
+    expect(baseInstanceLabel([{ worktree_branch: 'main' }, { worktree_branch: 'main' }])).toBe('main')
+    expect(baseInstanceLabel([{ worktree_branch: 'main' }, { worktree_branch: 'master' }])).toBe(
+      'main + master'
+    )
+    expect(baseInstanceLabel([{ worktree_branch: '' }, { worktree_branch: null }])).toBe('main')
+    expect(baseInstanceLabel([])).toBe('main')
+    expect(baseInstanceLabel(undefined)).toBe('main')
+  })
+
+  it('sortInstancesBaseLast keeps user instances in order and moves the base to the end', () => {
+    const sorted = sortInstancesBaseLast([
+      makeConnection('base', { is_base: 1 }),
+      makeConnection('b'),
+      makeConnection('a')
+    ])
+    expect(sorted.map((c) => c.id)).toEqual(['b', 'a', 'base'])
+    expect(sortInstancesBaseLast([]).length).toBe(0)
+  })
+
+  it('an orphaned base (project removed) sorts and reads as an ordinary instance', () => {
+    const orphan = makeConnection('orphan', { is_base: 1, saved_project_id: null })
+    expect(isBaseInstance(orphan)).toBe(false)
+    expect(sortInstancesBaseLast([orphan, makeConnection('a')]).map((c) => c.id)).toEqual([
+      'orphan',
+      'a'
+    ])
+    useConnectionStore.setState({ connections: [orphan] as never })
+    expect(findBaseInstanceConnection('saved')).toBeNull()
   })
 })

--- a/src/renderer/src/lib/connection-project.test.ts
+++ b/src/renderer/src/lib/connection-project.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import {
+  computeWorktreeNameSets,
+  getMemberProjects,
+  isConnectionProject,
+  parseMemberProjectIds
+} from './connection-project'
+
+const makeProject = (id: string, name: string, extra: Record<string, unknown> = {}) =>
+  ({
+    id,
+    name,
+    path: `/tmp/${name}`,
+    description: null,
+    tags: null,
+    language: null,
+    custom_icon: null,
+    detected_icon: null,
+    setup_script: null,
+    run_script: null,
+    archive_script: null,
+    worktree_create_script: null,
+    custom_commands: null,
+    auto_assign_port: false,
+    sort_order: 0,
+    created_at: '2026-01-01',
+    last_accessed_at: '2026-01-01',
+    ...extra
+  }) as never
+
+const makeWorktree = (
+  id: string,
+  projectId: string,
+  name: string,
+  extra: Record<string, unknown> = {}
+) =>
+  ({
+    id,
+    project_id: projectId,
+    name,
+    branch_name: name,
+    path: `/tmp/wt/${projectId}/${name}`,
+    status: 'active',
+    is_default: false,
+    ...extra
+  }) as never
+
+describe('connection-project helpers', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ projects: [] })
+    useWorktreeStore.setState({ worktreesByProject: new Map() })
+  })
+
+  it('parseMemberProjectIds tolerates null/garbage and filters non-strings', () => {
+    expect(parseMemberProjectIds(null)).toEqual([])
+    expect(parseMemberProjectIds(undefined)).toEqual([])
+    expect(parseMemberProjectIds('not json')).toEqual([])
+    expect(parseMemberProjectIds('{"a":1}')).toEqual([])
+    expect(parseMemberProjectIds('["a", 2, "", "b"]')).toEqual(['a', 'b'])
+  })
+
+  it('isConnectionProject discriminates on kind', () => {
+    expect(isConnectionProject({ id: 'p', kind: 'connection' })).toBe(true)
+    expect(isConnectionProject({ id: 'p', kind: 'git' })).toBe(false)
+    expect(isConnectionProject({ id: 'p' })).toBe(false)
+    expect(isConnectionProject(null)).toBe(false)
+  })
+
+  it('getMemberProjects resolves member ids in order and drops removed projects', () => {
+    useProjectStore.setState({
+      projects: [makeProject('b', 'beta'), makeProject('a', 'alpha')]
+    })
+    const saved = {
+      id: 'saved',
+      kind: 'connection' as const,
+      member_project_ids: JSON.stringify(['a', 'gone', 'b'])
+    }
+    expect(getMemberProjects(saved).map((m) => m.id)).toEqual(['a', 'b'])
+  })
+
+  it('computeWorktreeNameSets intersects names across ALL members, excluding default/archived', () => {
+    const members = [
+      { id: 'a', path: '/tmp/alpha', name: 'alpha' },
+      { id: 'b', path: '/tmp/beta', name: 'beta' }
+    ]
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([
+        [
+          'a',
+          [
+            makeWorktree('wa1', 'a', 'ticket-x'),
+            makeWorktree('wa2', 'a', 'only-in-a'),
+            makeWorktree('wa3', 'a', 'archived-both', { status: 'archived' }),
+            makeWorktree('wa4', 'a', '(no-worktree)', { is_default: true })
+          ]
+        ],
+        [
+          'b',
+          [
+            makeWorktree('wb1', 'b', 'ticket-x'),
+            makeWorktree('wb2', 'b', 'archived-both'),
+            makeWorktree('wb3', 'b', '(no-worktree)', { is_default: true })
+          ]
+        ]
+      ])
+    })
+
+    const sets = computeWorktreeNameSets(members)
+    expect(sets.map((s) => s.name)).toEqual(['ticket-x'])
+    expect(sets[0].worktrees).toEqual([
+      { projectId: 'a', worktreeId: 'wa1', worktreePath: '/tmp/wt/a/ticket-x' },
+      { projectId: 'b', worktreeId: 'wb1', worktreePath: '/tmp/wt/b/ticket-x' }
+    ])
+  })
+
+  it('computeWorktreeNameSets returns [] when a member has no loaded worktrees', () => {
+    const members = [
+      { id: 'a', path: '/tmp/alpha', name: 'alpha' },
+      { id: 'b', path: '/tmp/beta', name: 'beta' }
+    ]
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([['a', [makeWorktree('wa1', 'a', 'ticket-x')]]])
+    })
+    expect(computeWorktreeNameSets(members)).toEqual([])
+  })
+})

--- a/src/renderer/src/lib/connection-project.ts
+++ b/src/renderer/src/lib/connection-project.ts
@@ -1,0 +1,102 @@
+/**
+ * Helpers for "connection projects" — saved connections promoted to standalone
+ * sidebar projects (projects.kind === 'connection'). A connection project owns
+ * its own kanban board; each launch materializes a live `connections` row (an
+ * "instance") linked back via connections.saved_project_id.
+ */
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+export interface MemberProject {
+  id: string
+  path: string
+  name: string
+}
+
+interface ProjectLike {
+  id: string
+  kind?: 'git' | 'connection'
+  member_project_ids?: string | null
+}
+
+export function isConnectionProject(project: ProjectLike | null | undefined): boolean {
+  return project?.kind === 'connection'
+}
+
+/** Parse the JSON member id list stored on a connection project row. */
+export function parseMemberProjectIds(memberProjectIdsJson: string | null | undefined): string[] {
+  if (!memberProjectIdsJson) return []
+  try {
+    const parsed = JSON.parse(memberProjectIdsJson)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((id): id is string => typeof id === 'string' && id.length > 0)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Resolve a connection project's member projects against the project store,
+ * silently dropping members that have since been removed from Hive.
+ */
+export function getMemberProjects(project: ProjectLike): MemberProject[] {
+  const ids = parseMemberProjectIds(project.member_project_ids)
+  const projects = useProjectStore.getState().projects
+  const byId = new Map(projects.map((p) => [p.id, p]))
+  const members: MemberProject[] = []
+  for (const id of ids) {
+    const member = byId.get(id)
+    if (member) members.push({ id: member.id, path: member.path, name: member.name })
+  }
+  return members
+}
+
+export interface WorktreeNameSet {
+  name: string
+  /** One entry per member project, in member order. */
+  worktrees: { projectId: string; worktreeId: string; worktreePath: string }[]
+}
+
+/**
+ * Worktree names that exist (active, non-default) in EVERY member project —
+ * the "same name worktrees" the existing-worktree picker offers. Requires the
+ * member projects' worktrees to already be loaded into the worktree store.
+ */
+export function computeWorktreeNameSets(memberProjects: MemberProject[]): WorktreeNameSet[] {
+  if (memberProjects.length === 0) return []
+  const worktreesByProject = useWorktreeStore.getState().worktreesByProject
+
+  const nameMaps = memberProjects.map((member) => {
+    const map = new Map<string, { worktreeId: string; worktreePath: string }>()
+    for (const wt of worktreesByProject.get(member.id) ?? []) {
+      if (wt.is_default || wt.status !== 'active') continue
+      // First worktree wins on (unlikely) duplicate names within one project
+      if (!map.has(wt.name)) map.set(wt.name, { worktreeId: wt.id, worktreePath: wt.path })
+    }
+    return map
+  })
+
+  const sets: WorktreeNameSet[] = []
+  const [first, ...rest] = nameMaps
+  for (const [name, firstEntry] of first) {
+    const entries = [
+      { projectId: memberProjects[0].id, worktreeId: firstEntry.worktreeId, worktreePath: firstEntry.worktreePath }
+    ]
+    let inAll = true
+    for (let i = 0; i < rest.length; i++) {
+      const entry = rest[i].get(name)
+      if (!entry) {
+        inAll = false
+        break
+      }
+      entries.push({
+        projectId: memberProjects[i + 1].id,
+        worktreeId: entry.worktreeId,
+        worktreePath: entry.worktreePath
+      })
+    }
+    if (inAll) sets.push({ name, worktrees: entries })
+  }
+  sets.sort((a, b) => a.name.localeCompare(b.name))
+  return sets
+}

--- a/src/renderer/src/lib/connection-project.ts
+++ b/src/renderer/src/lib/connection-project.ts
@@ -4,6 +4,7 @@
  * its own kanban board; each launch materializes a live `connections` row (an
  * "instance") linked back via connections.saved_project_id.
  */
+import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 
@@ -21,6 +22,56 @@ interface ProjectLike {
 
 export function isConnectionProject(project: ProjectLike | null | undefined): boolean {
   return project?.kind === 'connection'
+}
+
+// ── Base instance ──────────────────────────────────────────────────
+// A connection project's BASE instance (connections.is_base = 1) is the twin
+// of a git project's default worktree: each member project's default worktree
+// connected together. Always present, never archivable/deletable, fixed members.
+
+interface ConnectionInstanceLike {
+  id: string
+  saved_project_id?: string | null
+  is_base?: number
+}
+
+/**
+ * Base only while its connection project still exists — an is_base row whose
+ * saved_project_id was nulled is an orphan the backend heals on the next
+ * listing; until then it must behave like an ordinary (deletable) connection.
+ */
+export function isBaseInstance(connection: ConnectionInstanceLike | null | undefined): boolean {
+  return !!connection?.is_base && !!connection?.saved_project_id
+}
+
+type ConnectionRecord = ReturnType<typeof useConnectionStore.getState>['connections'][number]
+
+/** The base instance of a connection project from the connection store (null when not loaded/missing). */
+export function findBaseInstanceConnection(projectId: string): ConnectionRecord | null {
+  return (
+    useConnectionStore
+      .getState()
+      .connections.find((c) => c.saved_project_id === projectId && isBaseInstance(c)) ?? null
+  )
+}
+
+/**
+ * Sidebar/picker label for a base instance: the distinct member default branch
+ * names ("main", or "main + master"), mirroring how a default worktree shows its
+ * branch name rather than a connection-style "proj-a + proj-b".
+ */
+export function baseInstanceLabel(
+  members: ReadonlyArray<{ worktree_branch?: string | null }> | null | undefined
+): string {
+  const branches = [
+    ...new Set((members ?? []).map((m) => m.worktree_branch?.trim()).filter(Boolean))
+  ]
+  return branches.join(' + ') || 'main'
+}
+
+/** Order instances like worktrees: user instances first (input order), the base instance last. */
+export function sortInstancesBaseLast<T extends ConnectionInstanceLike>(instances: T[]): T[] {
+  return [...instances.filter((c) => !isBaseInstance(c)), ...instances.filter((c) => isBaseInstance(c))]
 }
 
 /** Parse the JSON member id list stored on a connection project row. */

--- a/src/renderer/src/lib/tiled-sessions.ts
+++ b/src/renderer/src/lib/tiled-sessions.ts
@@ -1,0 +1,161 @@
+import type { KanbanTicket } from '../../../main/db/types'
+import { isTerminalBacked } from '@shared/types/agent-sdk'
+import { dbApi } from '@/api/db-api'
+import { useKanbanStore } from '@/stores/useKanbanStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import {
+  useSessionStore,
+  type Session,
+  type TiledSessionTile
+} from '@/stores/useSessionStore'
+
+/** Board scope the tile button was clicked from (mirrors KanbanColumn props) */
+export interface TiledScopeInput {
+  /** '' on multi-project boards (pinned/connection) — same convention as KanbanColumn */
+  projectId: string
+  connectionId?: string
+  isPinnedMode?: boolean
+}
+
+/**
+ * Compute the optimal near-square grid for `count` tiles in a `width`x`height`
+ * container: picks the column count that maximizes how close each tile gets to
+ * the ideal aspect ratio, weighted by cell utilization (fewer empty cells).
+ */
+export function computeGridLayout(
+  count: number,
+  width: number,
+  height: number,
+  idealTileAspect = 1.5
+): { cols: number; rows: number } {
+  if (count <= 0) return { cols: 1, rows: 1 }
+  if (width <= 0 || height <= 0) {
+    const cols = Math.ceil(Math.sqrt(count))
+    return { cols, rows: Math.ceil(count / cols) }
+  }
+
+  let bestCols = 1
+  let bestRows = count
+  let bestScore = -Infinity
+  for (let cols = 1; cols <= count; cols++) {
+    const rows = Math.ceil(count / cols)
+    const tileAspect = width / cols / (height / rows)
+    // 1 when the tile hits the ideal aspect, decaying toward 0 either way
+    const aspectScore =
+      tileAspect >= idealTileAspect ? idealTileAspect / tileAspect : tileAspect / idealTileAspect
+    // Penalize layouts with many empty cells (e.g. 5 tiles in a 3x2 grid is fine,
+    // 5 tiles in a 4x2 grid wastes 3 cells)
+    const utilization = count / (cols * rows)
+    const score = aspectScore * utilization
+    if (score > bestScore) {
+      bestScore = score
+      bestCols = cols
+      bestRows = rows
+    }
+  }
+  return { cols: bestCols, rows: bestRows }
+}
+
+/** Resolve the in-progress tickets for a board scope */
+function getInProgressTickets(scope: TiledScopeInput): KanbanTicket[] {
+  const kanban = useKanbanStore.getState()
+  if (scope.isPinnedMode) return kanban.getTicketsByColumnForPinned('in_progress')
+  if (scope.connectionId) {
+    return kanban.getTicketsByColumnForConnection(scope.connectionId, 'in_progress')
+  }
+  return kanban.getTicketsByColumn(scope.projectId, 'in_progress')
+}
+
+function getScopeLabel(scope: TiledScopeInput): string {
+  if (scope.isPinnedMode) return 'Pinned'
+  if (scope.connectionId) {
+    const connection = useConnectionStore
+      .getState()
+      .connections.find((c) => c.id === scope.connectionId)
+    return connection?.custom_name || connection?.name || 'Connection'
+  }
+  const project = useProjectStore.getState().projects.find((p) => p.id === scope.projectId)
+  return project?.name ?? 'Project'
+}
+
+/** Store-scan first, DB fallback (+ hydrate) — same pattern as KanbanTicketModal */
+async function resolveSession(sessionId: string): Promise<Session | null> {
+  const store = useSessionStore.getState()
+  const inMemory = store.getSessionById(sessionId)
+  if (inMemory) return inMemory
+  try {
+    const dbSession = await dbApi.session.get<Session>(sessionId)
+    if (dbSession) {
+      // Insert into the store so downstream lookups (SessionView routing,
+      // MainPane getAgentSdk) can find it.
+      useSessionStore.getState().hydrateSession(dbSession)
+      return dbSession
+    }
+  } catch {
+    // Session row missing — treat as no session
+  }
+  return null
+}
+
+/**
+ * Build a snapshot of the board's In Progress column and open it as the
+ * tiled-sessions tab. Snapshot semantics: the grid is fixed to the column's
+ * contents at click time (no live re-flow).
+ */
+export async function openTiledInProgressSessions(
+  scope: TiledScopeInput,
+  /** The tickets the column currently displays (search-filtered). Falls back
+   * to a fresh store query when omitted. */
+  columnTickets?: KanbanTicket[]
+): Promise<void> {
+  const tickets = columnTickets ?? getInProgressTickets(scope)
+  const isMultiProject = !!scope.connectionId || !!scope.isPinnedMode
+  const projects = useProjectStore.getState().projects
+
+  const tiles: TiledSessionTile[] = []
+  const tileBySessionId = new Map<string, TiledSessionTile>()
+
+  for (const ticket of tickets) {
+    // One session can serve several tickets (pre-assign / bulk handoff) —
+    // merge those tickets into a single tile with joined titles.
+    const sharedTile = ticket.current_session_id
+      ? tileBySessionId.get(ticket.current_session_id)
+      : undefined
+    if (sharedTile) {
+      sharedTile.ticketIds.push(ticket.id)
+      sharedTile.title = `${sharedTile.title} · ${ticket.title}`
+      continue
+    }
+
+    const session = ticket.current_session_id
+      ? await resolveSession(ticket.current_session_id)
+      : null
+
+    const agentSdk = session?.agent_sdk ?? null
+    // Terminal-backed sessions spawn their process when their view mounts, so
+    // "running" means the view/PTY is already mounted this run. Chat sessions
+    // don't spawn OS processes on mount — active status is enough.
+    const isRunning =
+      !!session &&
+      session.status === 'active' &&
+      (!isTerminalBacked(agentSdk) ||
+        useSessionStore.getState().mountedTerminalMirror.has(session.id))
+
+    const tile: TiledSessionTile = {
+      ticketIds: [ticket.id],
+      title: ticket.title,
+      projectId: ticket.project_id,
+      projectName: isMultiProject
+        ? (projects.find((p) => p.id === ticket.project_id)?.name ?? null)
+        : null,
+      sessionId: session?.id ?? null,
+      agentSdk,
+      isRunning
+    }
+    tiles.push(tile)
+    if (session) tileBySessionId.set(session.id, tile)
+  }
+
+  useSessionStore.getState().openTiledSessions({ scopeLabel: getScopeLabel(scope), tiles })
+}

--- a/src/renderer/src/stores/__tests__/useSessionStore.tiled-sessions.test.ts
+++ b/src/renderer/src/stores/__tests__/useSessionStore.tiled-sessions.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { useSessionStore, type TiledSessionsTab } from '../useSessionStore'
+
+const initialSessionState = useSessionStore.getState()
+
+const sampleTab: TiledSessionsTab = {
+  scopeLabel: 'Acme',
+  tiles: [
+    {
+      ticketIds: ['t1'],
+      title: 'Fix the login flow',
+      projectId: 'p1',
+      projectName: null,
+      sessionId: 's1',
+      agentSdk: 'claude-code-cli',
+      isRunning: true
+    }
+  ]
+}
+
+describe('useSessionStore tiled sessions tab', () => {
+  afterEach(() => {
+    useSessionStore.setState(initialSessionState, true)
+  })
+
+  it('openTiledSessions activates the tab and clears rival active states', () => {
+    useSessionStore.setState({
+      activeSessionId: 'other-session',
+      activePinnedSessionId: 'pinned-session',
+      inlineConnectionSessionId: 'inline-session',
+      activeBoardAssistantProjectId: 'p9'
+    })
+
+    useSessionStore.getState().openTiledSessions(sampleTab)
+
+    const state = useSessionStore.getState()
+    expect(state.tiledSessionsTab).toEqual(sampleTab)
+    expect(state.isTiledSessionsActive).toBe(true)
+    expect(state.activeSessionId).toBeNull()
+    expect(state.activePinnedSessionId).toBeNull()
+    expect(state.inlineConnectionSessionId).toBeNull()
+    expect(state.activeBoardAssistantProjectId).toBeNull()
+  })
+
+  it('focusTiledSessions is a no-op without a tab and re-activates with one', () => {
+    useSessionStore.getState().focusTiledSessions()
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+
+    useSessionStore.getState().openTiledSessions(sampleTab)
+    useSessionStore.getState().deactivateTiledSessions()
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+    expect(useSessionStore.getState().tiledSessionsTab).toEqual(sampleTab)
+
+    useSessionStore.getState().focusTiledSessions()
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(true)
+  })
+
+  it('closeTiledSessions restores the persisted active session for the scope', () => {
+    useSessionStore.setState({
+      activeWorktreeId: 'wt1',
+      activeSessionByWorktree: { wt1: 'restored-session' },
+      sessionsByWorktree: new Map([
+        ['wt1', [{ id: 'restored-session', status: 'active' } as never]]
+      ])
+    })
+    useSessionStore.getState().openTiledSessions(sampleTab)
+
+    useSessionStore.getState().closeTiledSessions()
+
+    const state = useSessionStore.getState()
+    expect(state.tiledSessionsTab).toBeNull()
+    expect(state.isTiledSessionsActive).toBe(false)
+    expect(state.activeSessionId).toBe('restored-session')
+  })
+
+  it('closeTiledSessions falls back when the persisted session is stale', () => {
+    useSessionStore.setState({
+      activeWorktreeId: 'wt1',
+      activeSessionByWorktree: { wt1: 'closed-session' },
+      sessionsByWorktree: new Map([
+        ['wt1', [{ id: 'other-session', status: 'active' } as never]]
+      ])
+    })
+    useSessionStore.getState().openTiledSessions(sampleTab)
+
+    useSessionStore.getState().closeTiledSessions()
+
+    const state = useSessionStore.getState()
+    // Stale persisted id is rejected; sticky-tab default falls back to the board
+    expect(state.activeSessionId).not.toBe('closed-session')
+  })
+
+  it('any raw write of a non-null activeSessionId deactivates the tiled tab (invariant subscription)', () => {
+    useSessionStore.getState().openTiledSessions(sampleTab)
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(true)
+
+    // Bypass all activator actions — write the field directly, as
+    // reopenSession/createSession/closeOtherSessions do.
+    useSessionStore.setState({ activeSessionId: 'raw-write-session' })
+
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+    expect(useSessionStore.getState().tiledSessionsTab).toEqual(sampleTab)
+  })
+
+  it('closeTiledSessions while inactive clears the tab without touching the active session', () => {
+    useSessionStore.getState().openTiledSessions(sampleTab)
+    useSessionStore.getState().setActiveSession('other-session')
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+
+    useSessionStore.getState().closeTiledSessions()
+
+    const state = useSessionStore.getState()
+    expect(state.tiledSessionsTab).toBeNull()
+    expect(state.activeSessionId).toBe('other-session')
+  })
+
+  it('rival activators deactivate but keep the tab; null-clears do not deactivate', () => {
+    useSessionStore.getState().openTiledSessions(sampleTab)
+
+    // Null-clears must NOT deactivate (they are clears, not activations)
+    useSessionStore.getState().setActivePinnedSession(null)
+    useSessionStore.getState().setInlineConnectionSession(null)
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(true)
+
+    // Activating a pinned session deactivates
+    useSessionStore.getState().setActivePinnedSession('pinned-1')
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+    expect(useSessionStore.getState().tiledSessionsTab).toEqual(sampleTab)
+
+    // Re-focus, then an inline connection session deactivates
+    useSessionStore.getState().focusTiledSessions()
+    useSessionStore.getState().setInlineConnectionSession('inline-1')
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+
+    // Re-focus, then setActiveSession deactivates
+    useSessionStore.getState().focusTiledSessions()
+    useSessionStore.getState().setActiveSession('session-1')
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+
+    // Re-focus, then a scope switch deactivates
+    useSessionStore.getState().focusTiledSessions()
+    useSessionStore.getState().setActiveWorktree('wt-2')
+    expect(useSessionStore.getState().isTiledSessionsActive).toBe(false)
+  })
+
+  it('setMountedTerminalMirror snapshots the mounted id list as a Set', () => {
+    useSessionStore.getState().setMountedTerminalMirror(['a', 'b', 'a'])
+    expect(useSessionStore.getState().mountedTerminalMirror).toEqual(new Set(['a', 'b']))
+
+    useSessionStore.getState().setMountedTerminalMirror([])
+    expect(useSessionStore.getState().mountedTerminalMirror.size).toBe(0)
+  })
+})

--- a/src/renderer/src/stores/store-coordination.ts
+++ b/src/renderer/src/stores/store-coordination.ts
@@ -146,3 +146,21 @@ export function registerKanbanModelSync(fn: KanbanModelSyncFn): void {
 export function notifyKanbanModelSync(sessionId: string, model: KanbanModelSyncModel): void {
   _kanbanModelSync?.(sessionId, model)
 }
+
+// ── Pinned ↔ Connection: resolve a connection's saved (connection) project ──
+// usePinnedStore derives `pinnedProjectIds` from pinned connections too (an
+// instance of a connection project pins that project's board onto the pinned
+// board). The connection store registers the lookup so the pinned store never
+// imports it (useConnectionStore → useKanbanStore → usePinnedStore would cycle).
+type ConnectionSavedProjectResolver = (connectionId: string) => string | null | undefined
+
+let _resolveConnectionSavedProjectId: ConnectionSavedProjectResolver | null = null
+
+export function registerConnectionSavedProjectResolver(fn: ConnectionSavedProjectResolver): void {
+  _resolveConnectionSavedProjectId = fn
+}
+
+/** The connection project a connection is an instance of, or null (ad-hoc / unknown). */
+export function resolveConnectionSavedProjectId(connectionId: string): string | null {
+  return _resolveConnectionSavedProjectId?.(connectionId) ?? null
+}

--- a/src/renderer/src/stores/useConnectionStore.save-as-project.test.ts
+++ b/src/renderer/src/stores/useConnectionStore.save-as-project.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
+
+vi.mock('@/api/settings-api', () => ({
+  settingsApi: { onSettingsUpdated: vi.fn(() => vi.fn()) }
+}))
+vi.mock('@/api/pet-api', () => ({
+  petApi: { updateSettings: vi.fn() }
+}))
+vi.mock('@/lib/toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn() }
+}))
+
+const worktreeStoreMocks = vi.hoisted(() => ({
+  selectWorktreeOnly: vi.fn(),
+  loadWorktrees: vi.fn()
+}))
+vi.mock('./useWorktreeStore', () => ({
+  useWorktreeStore: {
+    getState: vi.fn(() => ({
+      worktreesByProject: new Map(),
+      loadWorktrees: worktreeStoreMocks.loadWorktrees,
+      selectWorktreeOnly: worktreeStoreMocks.selectWorktreeOnly
+    }))
+  },
+  fireSetupScript: vi.fn()
+}))
+vi.mock('./useKanbanStore', () => ({
+  useKanbanStore: {
+    getState: vi.fn(() => ({ isPinnedBoardActive: false, togglePinnedBoard: vi.fn() }))
+  }
+}))
+
+const projectStoreMocks = vi.hoisted(() => ({
+  selectProject: vi.fn(),
+  setState: vi.fn(),
+  state: { projects: [] as unknown[], expandedProjectIds: new Set<string>() }
+}))
+vi.mock('./useProjectStore', () => ({
+  useProjectStore: {
+    getState: vi.fn(() => ({ ...projectStoreMocks.state, selectProject: projectStoreMocks.selectProject })),
+    setState: projectStoreMocks.setState
+  }
+}))
+
+import { useConnectionStore } from './useConnectionStore'
+import { usePinnedStore } from './usePinnedStore'
+
+const PROJECT_ID = 'saved-project-1'
+
+const makeConnection = (id: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  name: 'a + b',
+  custom_name: null,
+  status: 'active' as const,
+  path: `/tmp/connections/${id}`,
+  color: null,
+  pinned: 0,
+  saved_project_id: null as string | null,
+  is_base: 0,
+  created_at: '2026-01-01',
+  updated_at: '2026-01-01',
+  members: [],
+  ...extra
+})
+
+const project = { id: PROJECT_ID, name: 'a + b', kind: 'connection', path: '/tmp/cp/x' }
+
+describe('useConnectionStore.saveConnectionAsProject', () => {
+  let request: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    request = vi.fn(async (method: string) => {
+      if (method === 'connectionOps.saveAsProject') {
+        return {
+          success: true,
+          project,
+          connection: makeConnection('source', { saved_project_id: PROJECT_ID }),
+          baseConnection: makeConnection('base', { saved_project_id: PROJECT_ID, is_base: 1 })
+        }
+      }
+      if (method === 'db.worktree.getPinned') return []
+      if (method === 'connectionOps.getPinned') {
+        // Server view after the save: the (pinned) source is now an instance
+        return [makeConnection('source', { saved_project_id: PROJECT_ID, pinned: 1 })]
+      }
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    useConnectionStore.setState({
+      connections: [makeConnection('source'), makeConnection('other')],
+      selectedConnectionId: 'source'
+    })
+    usePinnedStore.setState({
+      pinnedConnectionIds: new Set(),
+      pinnedWorktreeIds: new Set(),
+      pinnedProjectIds: new Set(),
+      loaded: true
+    })
+  })
+
+  afterEach(() => {
+    resetRendererRpcClientForTests()
+  })
+
+  it('links the source, inserts the base instance locally and selects the new project', async () => {
+    const id = await useConnectionStore.getState().saveConnectionAsProject('source')
+    expect(id).toBe(PROJECT_ID)
+
+    const connections = useConnectionStore.getState().connections
+    expect(connections.find((c) => c.id === 'source')?.saved_project_id).toBe(PROJECT_ID)
+    const base = connections.find((c) => c.id === 'base')
+    expect(base?.is_base).toBe(1)
+    expect(base?.saved_project_id).toBe(PROJECT_ID)
+    expect(connections.find((c) => c.id === 'other')?.saved_project_id).toBeNull()
+
+    // Board-first: project selected, connection/worktree selection cleared
+    expect(projectStoreMocks.selectProject).toHaveBeenCalledWith(PROJECT_ID)
+    expect(useConnectionStore.getState().selectedConnectionId).toBeNull()
+    expect(worktreeStoreMocks.selectWorktreeOnly).toHaveBeenCalledWith(null)
+    // Source was not pinned → no pinned refetch
+    expect(request).not.toHaveBeenCalledWith('connectionOps.getPinned', expect.anything())
+  })
+
+  it('does not duplicate an already-present base instance', async () => {
+    useConnectionStore.setState({
+      connections: [
+        makeConnection('source'),
+        makeConnection('base', { saved_project_id: PROJECT_ID, is_base: 1 })
+      ]
+    })
+
+    await useConnectionStore.getState().saveConnectionAsProject('source')
+
+    expect(useConnectionStore.getState().connections.filter((c) => c.id === 'base')).toHaveLength(1)
+  })
+
+  it('refreshes the pinned scope when the source connection was already pinned', async () => {
+    usePinnedStore.setState({ pinnedConnectionIds: new Set(['source']) })
+
+    await useConnectionStore.getState().saveConnectionAsProject('source')
+    // loadPinned is fire-and-forget — let it settle
+    await new Promise((r) => setTimeout(r, 0))
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(request).toHaveBeenCalledWith('connectionOps.getPinned', expect.anything())
+    expect(usePinnedStore.getState().pinnedProjectIds.has(PROJECT_ID)).toBe(true)
+  })
+
+  it('surfaces a failed save without touching local state', async () => {
+    request.mockImplementation(async (method: string) =>
+      method === 'connectionOps.saveAsProject' ? { success: false, error: 'nope' } : null
+    )
+
+    const id = await useConnectionStore.getState().saveConnectionAsProject('source')
+
+    expect(id).toBeNull()
+    expect(useConnectionStore.getState().connections.find((c) => c.id === 'source')?.saved_project_id).toBeNull()
+    expect(useConnectionStore.getState().connections.some((c) => c.id === 'base')).toBe(false)
+  })
+})

--- a/src/renderer/src/stores/useConnectionStore.ts
+++ b/src/renderer/src/stores/useConnectionStore.ts
@@ -27,6 +27,8 @@ interface Connection {
   status: 'active' | 'archived'
   path: string
   color: string | null
+  /** Saved-connection project this connection is an instance of (null/absent = ad-hoc). */
+  saved_project_id?: string | null
   created_at: string
   updated_at: string
   members: ConnectionMemberEnriched[]
@@ -50,14 +52,19 @@ interface ConnectionState {
 
   // Actions
   loadConnections: () => Promise<void>
-  createConnection: (worktreeIds: string[]) => Promise<string | null>
+  createConnection: (
+    worktreeIds: string[],
+    opts?: { savedProjectId?: string }
+  ) => Promise<string | null>
   deleteConnection: (connectionId: string) => Promise<void>
   addMember: (connectionId: string, worktreeId: string) => Promise<void>
   removeMember: (connectionId: string, worktreeId: string) => Promise<void>
   updateConnectionMembers: (connectionId: string, desiredWorktreeIds: string[]) => Promise<boolean>
   quickCreateConnection: (
-    projects: { id: string; path: string; name: string }[]
+    projects: { id: string; path: string; name: string }[],
+    opts?: { savedProjectId?: string }
   ) => Promise<string | null>
+  saveConnectionAsProject: (connectionId: string) => Promise<string | null>
   selectConnection: (id: string | null) => void
 
   // Rename
@@ -105,9 +112,9 @@ export const useConnectionStore = create<ConnectionState>()(
         }
       },
 
-      createConnection: async (worktreeIds: string[]) => {
+      createConnection: async (worktreeIds: string[], opts?: { savedProjectId?: string }) => {
         try {
-          const result = await connectionApi.create(worktreeIds)
+          const result = await connectionApi.create(worktreeIds, opts)
           if (!result.success || !result.connection) {
             toast.error(`Failed to create connection: ${result.error || 'Unknown error'}`)
             return null
@@ -275,7 +282,10 @@ export const useConnectionStore = create<ConnectionState>()(
         }
       },
 
-      quickCreateConnection: async (projects: { id: string; path: string; name: string }[]) => {
+      quickCreateConnection: async (
+        projects: { id: string; path: string; name: string }[],
+        opts?: { savedProjectId?: string }
+      ) => {
         if (projects.length < 2) {
           return null
         }
@@ -334,7 +344,10 @@ export const useConnectionStore = create<ConnectionState>()(
           fireSetupScript(project.id, worktree.id, worktree.path)
         }
 
-        const connectionId = await get().createConnection(created.map((c) => c.worktree.id))
+        const connectionId = await get().createConnection(
+          created.map((c) => c.worktree.id),
+          opts
+        )
         if (!connectionId) {
           // createConnection already surfaced its own error toast — just undo the worktrees.
           await rollback()
@@ -342,6 +355,51 @@ export const useConnectionStore = create<ConnectionState>()(
         }
 
         return connectionId
+      },
+
+      saveConnectionAsProject: async (connectionId: string) => {
+        try {
+          const result = await connectionApi.saveAsProject(connectionId)
+          if (!result.success || !result.project) {
+            toast.error(result.error || 'Failed to save connection as project')
+            return null
+          }
+          const project = result.project
+
+          // Mirror the linked connection locally (it becomes the project's first instance)
+          if (result.connection) {
+            const updated = result.connection
+            set((state) => ({
+              connections: state.connections.map((c) => (c.id === connectionId ? updated : c))
+            }))
+          } else {
+            set((state) => ({
+              connections: state.connections.map((c) =>
+                c.id === connectionId ? { ...c, saved_project_id: project.id } : c
+              )
+            }))
+          }
+
+          // Insert + select the new project (dynamic import avoids a store cycle)
+          const { useProjectStore } = await import('./useProjectStore')
+          const projectStore = useProjectStore.getState()
+          useProjectStore.setState((state) => ({
+            projects: [project, ...state.projects],
+            expandedProjectIds: new Set([...state.expandedProjectIds, project.id])
+          }))
+          projectStore.selectProject(project.id)
+          // Board-first entity: clear connection selection so its board shows
+          get().selectConnection(null)
+          const { useWorktreeStore } = await import('./useWorktreeStore')
+          useWorktreeStore.getState().selectWorktreeOnly(null)
+
+          toast.success(`Saved "${project.name}" as a project`)
+          return project.id
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          toast.error(`Failed to save connection as project: ${message}`)
+          return null
+        }
       },
 
       renameConnection: async (connectionId: string, customName: string | null) => {

--- a/src/renderer/src/stores/useConnectionStore.ts
+++ b/src/renderer/src/stores/useConnectionStore.ts
@@ -1,7 +1,11 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { toast } from '@/lib/toast'
-import { registerConnectionClear, clearWorktreeSelection } from './store-coordination'
+import {
+  registerConnectionClear,
+  registerConnectionSavedProjectResolver,
+  clearWorktreeSelection
+} from './store-coordination'
 import { useKanbanStore } from './useKanbanStore'
 import { connectionApi } from '@/api/connection-api'
 import { worktreeApi } from '@/api/worktree-api'
@@ -29,6 +33,8 @@ interface Connection {
   color: string | null
   /** Saved-connection project this connection is an instance of (null/absent = ad-hoc). */
   saved_project_id?: string | null
+  /** 1 = base instance of a connection project (members = each member project's default worktree). */
+  is_base?: number
   created_at: string
   updated_at: string
   members: ConnectionMemberEnriched[]
@@ -379,6 +385,28 @@ export const useConnectionStore = create<ConnectionState>()(
               )
             }))
           }
+          // The project's base instance (member default worktrees) — upsert without
+          // selecting. It may BE the source connection (a connection already spanning
+          // the member default worktrees is promoted rather than duplicated), so
+          // replace an existing row instead of skipping it.
+          const baseConnection = result.baseConnection
+          if (baseConnection) {
+            set((state) =>
+              state.connections.some((c) => c.id === baseConnection.id)
+                ? {
+                    connections: state.connections.map((c) =>
+                      c.id === baseConnection.id ? baseConnection : c
+                    )
+                  }
+                : { connections: [...state.connections, baseConnection] }
+            )
+          }
+          // The source connection may already be pinned: it is now an instance of
+          // the new project, so the pinned board scope must pick the project up.
+          const { usePinnedStore } = await import('./usePinnedStore')
+          if (usePinnedStore.getState().isConnectionPinned(connectionId)) {
+            void usePinnedStore.getState().loadPinned()
+          }
 
           // Insert + select the new project (dynamic import avoids a store cycle)
           const { useProjectStore } = await import('./useProjectStore')
@@ -497,3 +525,10 @@ export const useConnectionStore = create<ConnectionState>()(
 
 // Register the connection-clear callback so useWorktreeStore can call it synchronously
 registerConnectionClear(() => useConnectionStore.setState({ selectedConnectionId: null }))
+
+// Let usePinnedStore map pinned connections → their connection project (pinned board scope)
+registerConnectionSavedProjectResolver(
+  (connectionId) =>
+    useConnectionStore.getState().connections.find((c) => c.id === connectionId)
+      ?.saved_project_id ?? null
+)

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -1204,7 +1204,15 @@ export const useKanbanStore = create<KanbanState>()(
 
       // ── toggleBoardView ──────────────────────────────────────────
       toggleBoardView: () => {
-        set((state) => ({ isBoardViewActive: !state.isBoardViewActive }))
+        // If the tiled-sessions tab holds the pane, the user's intent is
+        // "show the board": deactivate the tiled tab and force the board ON
+        // (toggling would flip an already-true persisted flag to false with
+        // no visible change). Dynamic import avoids a store dependency cycle.
+        void import('./useSessionStore').then(({ useSessionStore }) => {
+          const wasTiled = useSessionStore.getState().isTiledSessionsActive
+          if (wasTiled) useSessionStore.getState().deactivateTiledSessions()
+          set((state) => ({ isBoardViewActive: wasTiled ? true : !state.isBoardViewActive }))
+        })
       },
 
       // ── setTransitionSort ────────────────────────────────────────
@@ -1741,7 +1749,12 @@ export const useKanbanStore = create<KanbanState>()(
 
       // ── togglePinnedBoard ────────────────────────────────────────
       togglePinnedBoard: () => {
-        set((state) => ({ isPinnedBoardActive: !state.isPinnedBoardActive }))
+        // Same intent resolution as toggleBoardView (see comment there).
+        void import('./useSessionStore').then(({ useSessionStore }) => {
+          const wasTiled = useSessionStore.getState().isTiledSessionsActive
+          if (wasTiled) useSessionStore.getState().deactivateTiledSessions()
+          set((state) => ({ isPinnedBoardActive: wasTiled ? true : !state.isPinnedBoardActive }))
+        })
       },
 
       // ── loadTicketsForPinnedProjects ─────────────────────────────

--- a/src/renderer/src/stores/usePinnedStore.connection.test.ts
+++ b/src/renderer/src/stores/usePinnedStore.connection.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
 import { usePinnedStore } from './usePinnedStore'
+import { registerConnectionSavedProjectResolver } from './store-coordination'
 
 vi.mock('./useWorktreeStore', () => ({
   useWorktreeStore: {
@@ -66,5 +67,99 @@ describe('usePinnedStore connection pinning', () => {
       pinned: false
     })
     expect(usePinnedStore.getState().pinnedConnectionIds.has('connection-1')).toBe(false)
+  })
+})
+
+describe('usePinnedStore connection-project scoping', () => {
+  let request: ReturnType<typeof vi.fn>
+  const savedProjectByConnection: Record<string, string | null> = {
+    'base-1': 'conn-project-1',
+    'inst-1': 'conn-project-1',
+    adhoc: null
+  }
+
+  beforeEach(() => {
+    request = vi.fn(async (method: string) => {
+      if (method === 'connectionOps.setPinned') return { success: true }
+      if (method === 'db.worktree.getPinned') return [{ id: 'wt-1', project_id: 'git-project-1' }]
+      if (method === 'connectionOps.getPinned') {
+        return [
+          { id: 'base-1', saved_project_id: 'conn-project-1', is_base: 1, members: [] },
+          { id: 'adhoc', saved_project_id: null, is_base: 0, members: [] }
+        ]
+      }
+      return null
+    })
+    setRendererRpcClient({ request, subscribe: vi.fn() })
+    registerConnectionSavedProjectResolver((id) => savedProjectByConnection[id] ?? null)
+    usePinnedStore.setState({
+      pinnedConnectionIds: new Set(),
+      pinnedWorktreeIds: new Set(),
+      pinnedProjectIds: new Set(),
+      loaded: false
+    })
+  })
+
+  afterEach(() => {
+    registerConnectionSavedProjectResolver(() => null)
+    resetRendererRpcClientForTests()
+  })
+
+  it('pinning an instance of a connection project scopes that project onto the pinned board', async () => {
+    await usePinnedStore.getState().pinConnection('base-1')
+
+    expect(usePinnedStore.getState().pinnedConnectionIds.has('base-1')).toBe(true)
+    expect(usePinnedStore.getState().pinnedProjectIds.has('conn-project-1')).toBe(true)
+  })
+
+  it('pinning an ad-hoc connection adds no project', async () => {
+    await usePinnedStore.getState().pinConnection('adhoc')
+
+    expect(usePinnedStore.getState().pinnedConnectionIds.has('adhoc')).toBe(true)
+    expect(usePinnedStore.getState().pinnedProjectIds.size).toBe(0)
+  })
+
+  it('keeps the project while another instance of it is still pinned, drops it on the last unpin', async () => {
+    await usePinnedStore.getState().pinConnection('base-1')
+    await usePinnedStore.getState().pinConnection('inst-1')
+    expect(usePinnedStore.getState().pinnedProjectIds.has('conn-project-1')).toBe(true)
+
+    await usePinnedStore.getState().unpinConnection('inst-1')
+    expect(usePinnedStore.getState().pinnedProjectIds.has('conn-project-1')).toBe(true)
+
+    await usePinnedStore.getState().unpinConnection('base-1')
+    expect(usePinnedStore.getState().pinnedProjectIds.has('conn-project-1')).toBe(false)
+  })
+
+  it('removeConnection (local, on delete) drops the project the same way', async () => {
+    await usePinnedStore.getState().pinConnection('inst-1')
+    expect(usePinnedStore.getState().pinnedProjectIds.has('conn-project-1')).toBe(true)
+
+    usePinnedStore.getState().removeConnection('inst-1')
+    expect(usePinnedStore.getState().pinnedConnectionIds.has('inst-1')).toBe(false)
+    expect(usePinnedStore.getState().pinnedProjectIds.has('conn-project-1')).toBe(false)
+  })
+
+  it('does not disturb worktree-derived project ids', async () => {
+    usePinnedStore.setState({
+      pinnedWorktreeIds: new Set(['wt-1']),
+      pinnedProjectIds: new Set(['git-project-1'])
+    })
+
+    await usePinnedStore.getState().pinConnection('base-1')
+    await usePinnedStore.getState().unpinConnection('base-1')
+
+    expect(usePinnedStore.getState().pinnedProjectIds.has('git-project-1')).toBe(true)
+    expect(usePinnedStore.getState().pinnedProjectIds.has('conn-project-1')).toBe(false)
+  })
+
+  it('loadPinned derives connection-project ids from pinned instances (plus worktree projects)', async () => {
+    await usePinnedStore.getState().loadPinned()
+
+    const state = usePinnedStore.getState()
+    expect(state.loaded).toBe(true)
+    expect(state.pinnedConnectionIds).toEqual(new Set(['base-1', 'adhoc']))
+    expect(state.pinnedWorktreeIds).toEqual(new Set(['wt-1']))
+    expect(state.pinnedProjectIds).toEqual(new Set(['git-project-1', 'conn-project-1']))
   })
 })

--- a/src/renderer/src/stores/usePinnedStore.ts
+++ b/src/renderer/src/stores/usePinnedStore.ts
@@ -3,6 +3,7 @@ import { toast } from '@/lib/toast'
 import { useWorktreeStore } from './useWorktreeStore'
 import { dbApi } from '@/api/db-api'
 import { connectionApi } from '@/api/connection-api'
+import { resolveConnectionSavedProjectId } from './store-coordination'
 
 interface PinnedState {
   pinnedWorktreeIds: Set<string>
@@ -39,6 +40,16 @@ function findProjectIdForWorktree(worktreeId: string): string | undefined {
   return undefined
 }
 
+/**
+ * The connection project (projects.kind === 'connection') a pinned connection is
+ * an instance of — pinning any instance scopes that project's board onto the
+ * pinned board, exactly like pinning any worktree does for a git project.
+ * Resolved through store-coordination (registered by useConnectionStore).
+ */
+function findSavedProjectIdForConnection(connectionId: string): string | undefined {
+  return resolveConnectionSavedProjectId(connectionId) ?? undefined
+}
+
 export const usePinnedStore = create<PinnedState>()((set, get) => ({
   pinnedWorktreeIds: new Set<string>(),
   pinnedConnectionIds: new Set<string>(),
@@ -69,6 +80,10 @@ export const usePinnedStore = create<PinnedState>()((set, get) => ({
 
       // Derive project IDs directly from the fetched pinned worktrees (which have project_id)
       const projectIds = new Set(pinnedWorktrees.map((wt) => wt.project_id))
+      // ...plus the connection projects whose instances are pinned
+      for (const connection of pinnedConnections) {
+        if (connection.saved_project_id) projectIds.add(connection.saved_project_id)
+      }
 
       set({
         pinnedWorktreeIds: worktreeIds,
@@ -122,10 +137,13 @@ export const usePinnedStore = create<PinnedState>()((set, get) => ({
   pinConnection: async (id: string) => {
     const result = await connectionApi.setPinned(id, true)
     if (result.success) {
+      const savedProjectId = findSavedProjectIdForConnection(id)
       set((state) => {
         const next = new Set(state.pinnedConnectionIds)
         next.add(id)
-        return { pinnedConnectionIds: next }
+        const nextProjectIds = new Set(state.pinnedProjectIds)
+        if (savedProjectId) nextProjectIds.add(savedProjectId)
+        return { pinnedConnectionIds: next, pinnedProjectIds: nextProjectIds }
       })
     } else {
       toast.error(result.error || 'Failed to pin connection')
@@ -135,10 +153,18 @@ export const usePinnedStore = create<PinnedState>()((set, get) => ({
   unpinConnection: async (id: string) => {
     const result = await connectionApi.setPinned(id, false)
     if (result.success) {
+      const savedProjectId = findSavedProjectIdForConnection(id)
       set((state) => {
         const next = new Set(state.pinnedConnectionIds)
         next.delete(id)
-        return { pinnedConnectionIds: next }
+        const nextProjectIds = new Set(state.pinnedProjectIds)
+        if (savedProjectId) {
+          const projectStillPinned = [...next].some(
+            (cid) => findSavedProjectIdForConnection(cid) === savedProjectId
+          )
+          if (!projectStillPinned) nextProjectIds.delete(savedProjectId)
+        }
+        return { pinnedConnectionIds: next, pinnedProjectIds: nextProjectIds }
       })
     } else {
       toast.error(result.error || 'Failed to unpin connection')
@@ -163,11 +189,21 @@ export const usePinnedStore = create<PinnedState>()((set, get) => ({
   },
 
   removeConnection: (id: string) => {
+    // Resolve BEFORE the caller drops the connection from its store (callers
+    // invoke this first, so the lookup still sees the row).
+    const savedProjectId = findSavedProjectIdForConnection(id)
     set((state) => {
       if (!state.pinnedConnectionIds.has(id)) return state
       const next = new Set(state.pinnedConnectionIds)
       next.delete(id)
-      return { pinnedConnectionIds: next }
+      const nextProjectIds = new Set(state.pinnedProjectIds)
+      if (savedProjectId) {
+        const projectStillPinned = [...next].some(
+          (cid) => findSavedProjectIdForConnection(cid) === savedProjectId
+        )
+        if (!projectStillPinned) nextProjectIds.delete(savedProjectId)
+      }
+      return { pinnedConnectionIds: next, pinnedProjectIds: nextProjectIds }
     })
   },
 

--- a/src/renderer/src/stores/useProjectStore.ts
+++ b/src/renderer/src/stores/useProjectStore.ts
@@ -11,6 +11,10 @@ interface Project {
   id: string
   name: string
   path: string
+  /** 'git' (default) or 'connection' (a saved connection promoted to a project). */
+  kind?: 'git' | 'connection'
+  /** connection projects only: JSON array of member project ids (creation order). */
+  member_project_ids?: string | null
   description: string | null
   tags: string | null
   language: string | null
@@ -211,6 +215,31 @@ export const useProjectStore = create<ProjectState>()(
       // Remove a project
       removeProject: async (id: string) => {
         try {
+          const removed = get().projects.find((p) => p.id === id)
+          // Connection projects: close active sessions on their instance
+          // connections BEFORE the DB cascade deletes the session rows —
+          // otherwise the agent processes keep running orphaned.
+          if (removed?.kind === 'connection') {
+            try {
+              const [{ useConnectionStore }, { useSessionStore }] = await Promise.all([
+                import('./useConnectionStore'),
+                import('./useSessionStore')
+              ])
+              const instances = useConnectionStore
+                .getState()
+                .connections.filter((c) => c.saved_project_id === id)
+              for (const instance of instances) {
+                const sessions = await dbApi.session.getActiveByConnection<{ id: string }>(
+                  instance.id
+                )
+                for (const session of sessions) {
+                  await useSessionStore.getState().closeSession(session.id, { stopRemote: true })
+                }
+              }
+            } catch {
+              // Best-effort — removal proceeds even if a session close fails.
+            }
+          }
           const success = await dbApi.project.delete(id)
           if (success) {
             set((state) => {
@@ -223,6 +252,14 @@ export const useProjectStore = create<ProjectState>()(
                 editingProjectId: state.editingProjectId === id ? null : state.editingProjectId
               }
             })
+            // Deleting a connection project detaches its instances server-side
+            // (connections.saved_project_id → NULL). Reload so they reappear in
+            // the Connections section instead of vanishing until next launch.
+            if (removed?.kind === 'connection') {
+              import('./useConnectionStore')
+                .then(({ useConnectionStore }) => useConnectionStore.getState().loadConnections())
+                .catch(() => {})
+            }
           }
           return success
         } catch {

--- a/src/renderer/src/stores/useProjectStore.ts
+++ b/src/renderer/src/stores/useProjectStore.ts
@@ -253,11 +253,16 @@ export const useProjectStore = create<ProjectState>()(
               }
             })
             // Deleting a connection project detaches its instances server-side
-            // (connections.saved_project_id → NULL). Reload so they reappear in
-            // the Connections section instead of vanishing until next launch.
+            // (connections.saved_project_id → NULL) and takes its base instance
+            // down. Reload so they reappear in the Connections section instead of
+            // vanishing until next launch, then refetch pinned state so a pinned
+            // base / instance no longer scopes the removed project onto the
+            // pinned board.
             if (removed?.kind === 'connection') {
               import('./useConnectionStore')
                 .then(({ useConnectionStore }) => useConnectionStore.getState().loadConnections())
+                .then(() => import('./usePinnedStore'))
+                .then(({ usePinnedStore }) => usePinnedStore.getState().loadPinned())
                 .catch(() => {})
             }
           }

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -110,6 +110,28 @@ export interface PendingPlan {
   toolUseID: string
 }
 
+// One tile in the tiled in-progress sessions view. Snapshot data resolved at
+// open time (ticket titles, project names, session identity, running state).
+export interface TiledSessionTile {
+  /** Tickets represented by this tile (several tickets can share one session) */
+  ticketIds: string[]
+  /** Joined ticket title(s) — always shown on the tile */
+  title: string
+  projectId: string
+  /** Project name — set on multi-project boards (pinned/connection), null otherwise */
+  projectName: string | null
+  sessionId: string | null
+  agentSdk: AgentSdk | null
+  /** Whether the session can be tiled live (chat: active; terminal-backed: PTY mounted) */
+  isRunning: boolean
+}
+
+export interface TiledSessionsTab {
+  /** Board scope the snapshot was taken from — shown in the tab title */
+  scopeLabel: string
+  tiles: TiledSessionTile[]
+}
+
 export interface CodexThreadGoal {
   threadId: string
   objective: string
@@ -123,7 +145,7 @@ export interface CodexThreadGoal {
 }
 
 // Session type matching the database schema
-interface Session {
+export interface Session {
   id: string
   worktree_id: string | null
   project_id: string
@@ -200,6 +222,16 @@ interface SessionState {
   // Board assistant state — project-scoped, one per project
   boardAssistantByProject: Map<string, Session>
   activeBoardAssistantProjectId: string | null
+
+  // Tiled in-progress sessions tab — snapshot taken when the user clicks the
+  // tile button on a board's In Progress column header. Not persisted.
+  tiledSessionsTab: TiledSessionsTab | null
+  isTiledSessionsActive: boolean
+  // Mirror of MainPane's mountedTerminalSessionIds — terminal-backed sessions
+  // whose views (and thus PTYs) were mounted this run and not closed. Used to
+  // decide whether a terminal-backed session is "already running" (tiling a
+  // non-mounted terminal session would spawn its process).
+  mountedTerminalMirror: Set<string>
 
   // Actions
   acknowledgeClosedTerminals: (ids: Set<string>) => void
@@ -304,6 +336,13 @@ interface SessionState {
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
   closeBoardAssistantSession: (projectId: string) => Promise<{ success: boolean; error?: string }>
   focusBoardAssistantSession: (projectId: string) => void
+
+  // Tiled sessions tab actions
+  openTiledSessions: (tab: TiledSessionsTab) => void
+  focusTiledSessions: () => void
+  deactivateTiledSessions: () => void
+  closeTiledSessions: () => void
+  setMountedTerminalMirror: (ids: readonly string[]) => void
   clearBoardAssistantFocus: () => void
 
   // Connection session actions
@@ -421,6 +460,10 @@ export const useSessionStore = create<SessionState>()(
       // Board assistant state
       boardAssistantByProject: new Map(),
       activeBoardAssistantProjectId: null,
+
+      tiledSessionsTab: null,
+      isTiledSessionsActive: false,
+      mountedTerminalMirror: new Set<string>(),
 
       acknowledgeClosedTerminals: (ids: Set<string>) => {
         set((state) => {
@@ -559,9 +602,15 @@ export const useSessionStore = create<SessionState>()(
               }
             }
 
-            // Set active session if none selected and sessions exist
+            // Set active session if none selected and sessions exist.
+            // Skip while the tiled-sessions tab holds the pane — it nulls
+            // activeSessionId on purpose; restoring here would fight it.
             let activeSessionId = state.activeSessionId
-            if (state.activeWorktreeId === worktreeId && !activeSessionId) {
+            if (
+              state.activeWorktreeId === worktreeId &&
+              !activeSessionId &&
+              !state.isTiledSessionsActive
+            ) {
               // Try to restore persisted active session
               const persistedSessionId = state.activeSessionByWorktree[worktreeId]
               const boardMode = useSettingsStore.getState().boardMode
@@ -1309,6 +1358,7 @@ export const useSessionStore = create<SessionState>()(
           set((state) => ({
             activeSessionId: sessionId,
             activeBoardAssistantProjectId: null,
+            isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive,
             activeSessionByWorktree: {
               ...state.activeSessionByWorktree,
               [worktreeId]: sessionId
@@ -1318,13 +1368,18 @@ export const useSessionStore = create<SessionState>()(
           set((state) => ({
             activeSessionId: sessionId,
             activeBoardAssistantProjectId: null,
+            isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive,
             activeSessionByConnection: {
               ...state.activeSessionByConnection,
               [connectionId]: sessionId
             }
           }))
         } else {
-          set({ activeSessionId: sessionId, activeBoardAssistantProjectId: null })
+          set((state) => ({
+            activeSessionId: sessionId,
+            activeBoardAssistantProjectId: null,
+            isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive
+          }))
         }
       },
 
@@ -1338,7 +1393,8 @@ export const useSessionStore = create<SessionState>()(
           activeWorktreeId: worktreeId,
           activeConnectionId: null,
           inlineConnectionSessionId: null,
-          activeBoardAssistantProjectId: null
+          activeBoardAssistantProjectId: null,
+          isTiledSessionsActive: false
         })
 
         if (worktreeId) {
@@ -2180,7 +2236,8 @@ export const useSessionStore = create<SessionState>()(
               // Clear other active states so the board assistant view shows
               activeSessionId: null,
               activePinnedSessionId: null,
-              inlineConnectionSessionId: null
+              inlineConnectionSessionId: null,
+              isTiledSessionsActive: false
             }
           })
 
@@ -2301,7 +2358,8 @@ export const useSessionStore = create<SessionState>()(
           // Clear other active states so the board assistant view shows
           activeSessionId: null,
           activePinnedSessionId: null,
-          inlineConnectionSessionId: null
+          inlineConnectionSessionId: null,
+          isTiledSessionsActive: false
         })
       },
 
@@ -2309,10 +2367,92 @@ export const useSessionStore = create<SessionState>()(
         set({ activeBoardAssistantProjectId: null })
       },
 
+      // ─── Tiled in-progress sessions tab ─────────────────────────────────
+      // Opens (or replaces) the tiled-sessions tab with a fresh snapshot and
+      // activates it. Mirrors focusBoardAssistantSession: activating a tab
+      // kind means setting its own flag AND clearing every competing flag.
+      openTiledSessions: (tab: TiledSessionsTab) => {
+        // Clear file/diff/context overlays so the tiled view takes the pane
+        import('./useFileViewerStore').then(({ useFileViewerStore }) => {
+          useFileViewerStore.getState().clearActiveViews()
+        })
+        set({
+          tiledSessionsTab: tab,
+          isTiledSessionsActive: true,
+          activeSessionId: null,
+          activePinnedSessionId: null,
+          inlineConnectionSessionId: null,
+          activeBoardAssistantProjectId: null
+        })
+      },
+
+      // Re-activate an existing tiled tab (tab strip click)
+      focusTiledSessions: () => {
+        if (!get().tiledSessionsTab) return
+        set({
+          isTiledSessionsActive: true,
+          activeSessionId: null,
+          activePinnedSessionId: null,
+          inlineConnectionSessionId: null,
+          activeBoardAssistantProjectId: null
+        })
+      },
+
+      // Deactivate without closing — a rival tab/view took the pane.
+      deactivateTiledSessions: () => {
+        set({ isTiledSessionsActive: false })
+      },
+
+      // Close the tiled tab. If it was active, restore the previously active
+      // session for the current scope (same restore as closeBoardAssistantSession).
+      closeTiledSessions: () => {
+        set((state) => {
+          if (!state.isTiledSessionsActive) {
+            return { tiledSessionsTab: null, isTiledSessionsActive: false }
+          }
+          const worktreeId = state.activeWorktreeId
+          const connectionId = state.activeConnectionId
+          const boardMode = useSettingsStore.getState().boardMode
+          const scopeSessions = worktreeId
+            ? state.sessionsByWorktree.get(worktreeId)
+            : connectionId
+              ? state.sessionsByConnection.get(connectionId)
+              : null
+          let restoredSessionId =
+            (worktreeId ? state.activeSessionByWorktree[worktreeId] : null) ??
+            (connectionId ? state.activeSessionByConnection[connectionId] : null) ??
+            null
+          // The persisted entry can be stale (session closed while the tiled
+          // tab was open) — validate it, then fall back like closeSession does.
+          const restoredIsValid =
+            restoredSessionId === BOARD_TAB_ID
+              ? boardMode === 'sticky-tab'
+              : !!restoredSessionId && !!scopeSessions?.some((sess) => sess.id === restoredSessionId)
+          if (!restoredIsValid) {
+            restoredSessionId =
+              boardMode === 'sticky-tab' && (worktreeId || connectionId)
+                ? BOARD_TAB_ID
+                : (scopeSessions?.[0]?.id ?? null)
+          }
+          return {
+            tiledSessionsTab: null,
+            isTiledSessionsActive: false,
+            activeSessionId: restoredSessionId
+          }
+        })
+      },
+
+      setMountedTerminalMirror: (ids: readonly string[]) => {
+        set({ mountedTerminalMirror: new Set(ids) })
+      },
+
       // ─── Inline connection session actions ─────────────────────────────
 
       setInlineConnectionSession: (sessionId: string | null) => {
-        set({ inlineConnectionSessionId: sessionId })
+        set((state) => ({
+          inlineConnectionSessionId: sessionId,
+          isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive
+        }))
       },
 
       clearInlineConnectionSession: () => {
@@ -2411,7 +2551,11 @@ export const useSessionStore = create<SessionState>()(
 
             // Set active session if in connection context
             let activeSessionId = state.activeSessionId
-            if (state.activeConnectionId === connectionId && !activeSessionId) {
+            if (
+              state.activeConnectionId === connectionId &&
+              !activeSessionId &&
+              !state.isTiledSessionsActive
+            ) {
               const persistedSessionId = state.activeSessionByConnection[connectionId]
               const boardMode = useSettingsStore.getState().boardMode
 
@@ -2577,13 +2721,17 @@ export const useSessionStore = create<SessionState>()(
         if (sessionId && connectionId) {
           set((state) => ({
             activeSessionId: sessionId,
+            isTiledSessionsActive: false,
             activeSessionByConnection: {
               ...state.activeSessionByConnection,
               [connectionId]: sessionId
             }
           }))
         } else {
-          set({ activeSessionId: sessionId })
+          set((state) => ({
+            activeSessionId: sessionId,
+            isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive
+          }))
         }
       },
 
@@ -2593,7 +2741,7 @@ export const useSessionStore = create<SessionState>()(
 
         if (connectionId === state.activeConnectionId) return
 
-        set({ activeConnectionId: connectionId, activeWorktreeId: null })
+        set({ activeConnectionId: connectionId, activeWorktreeId: null, isTiledSessionsActive: false })
 
         if (connectionId) {
           const existingSessions = (state.sessionsByConnection.get(connectionId) || []).filter(
@@ -2769,7 +2917,10 @@ export const useSessionStore = create<SessionState>()(
       },
 
       setActivePinnedSession: (sessionId: string | null) => {
-        set({ activePinnedSessionId: sessionId })
+        set((state) => ({
+          activePinnedSessionId: sessionId,
+          isTiledSessionsActive: sessionId ? false : state.isTiledSessionsActive
+        }))
       },
 
       loadPinnedSessions: async (worktreeId: string) => {
@@ -2812,6 +2963,24 @@ declare global {
     __hive_useSessionStore__?: typeof useSessionStore
   }
 }
+
+// ─── Tiled-sessions activation invariant ────────────────────────────────────
+// The tiled tab occupies the main pane only while nothing else claims it.
+// Individual activators (setActiveSession & co.) clear the flag explicitly,
+// but several code paths write activeSessionId directly (reopenSession,
+// createSession autoFocus, closeOtherSessions, openOrphanedSession, ...).
+// This subscription is the safety net: any transition to a non-null
+// activeSessionId while the tiled tab is active deactivates it, so two views
+// can never claim the pane at once.
+useSessionStore.subscribe((state, prevState) => {
+  if (
+    state.isTiledSessionsActive &&
+    state.activeSessionId !== null &&
+    state.activeSessionId !== prevState.activeSessionId
+  ) {
+    useSessionStore.setState({ isTiledSessionsActive: false })
+  }
+})
 
 if (import.meta.env.DEV && typeof window !== 'undefined') {
   window.__hive_useSessionStore__ = useSessionStore

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -2475,7 +2475,10 @@ export const useSessionStore = create<SessionState>()(
             return { success: false, error: result.error || 'Connection has no members' }
           }
 
-          const projectId = result.connection.members[0].project_id
+          // Instances of a saved-connection project attribute their sessions to the
+          // saved project (its board/history), falling back to the first member.
+          const projectId =
+            result.connection.saved_project_id ?? result.connection.members[0].project_id
 
           const { agentSdk: defaultAgentSdk, model: defaultModel } =
             resolveSessionCreationSelection({

--- a/src/server/rpc/domains/backup-ops.ts
+++ b/src/server/rpc/domains/backup-ops.ts
@@ -415,7 +415,9 @@ async function buildBackupProject(
 
 async function exportBackup(deps: BackupOpsDeps): Promise<BackupExportResult> {
   try {
-    const projects = deps.db.getAllProjects()
+    // Connection projects (kind='connection') are machine-local composites of
+    // other projects — they have no git repo and are excluded from backups.
+    const projects = deps.db.getAllProjects().filter((p) => p.kind !== 'connection')
     const backupProjects: BackupFile['projects'] = []
     const warnings: string[] = []
     for (const project of projects) {
@@ -515,6 +517,7 @@ async function buildHiveRemoteMap(
 ): Promise<Map<string, { project: Project; rawRemote: string | null }>> {
   const map = new Map<string, { project: Project; rawRemote: string | null }>()
   for (const project of deps.db.getAllProjects()) {
+    if (project.kind === 'connection') continue
     const rawRemote = await getRemoteUrlSafe(deps, project.path)
     const normalized = normalizeGitRemoteUrl(rawRemote)
     if (normalized !== null && !map.has(normalized)) {

--- a/src/server/rpc/domains/connection-ops.ts
+++ b/src/server/rpc/domains/connection-ops.ts
@@ -12,12 +12,14 @@ import {
   removeConnectionMemberOp,
   removeWorktreeFromAllConnectionsOp,
   renameConnectionOp,
+  saveConnectionAsProjectOp,
   setConnectionPinnedOp,
   setRecentConnectionNoteOp,
   updateConnectionMembersOp
 } from '../../../main/services/connection-ops'
 import { telemetryService } from '../../../main/services/telemetry-service'
 import type { ConnectionWithMembers, RecentConnectionEntry } from '../../../shared/types/connection'
+import type { Project } from '../../../shared/types/project'
 import type { RpcHandler } from '../router'
 
 export interface ConnectionOpsCreateResult {
@@ -99,10 +101,22 @@ export interface ConnectionOpsSetRecentNoteResult {
   readonly error?: string
 }
 
+export interface ConnectionOpsSaveAsProjectResult {
+  readonly success: boolean
+  readonly project?: Project
+  readonly connection?: ConnectionWithMembers
+  readonly error?: string
+}
+
 export interface ConnectionOpsRpcService {
   readonly create: (
-    worktreeIds: string[]
+    worktreeIds: string[],
+    savedProjectId?: string | null
   ) => Effect.Effect<ConnectionOpsCreateResult, unknown, never>
+  /** Optional so fully-enumerated test mocks keep compiling (same pattern as WorktreeOps getContext?). */
+  readonly saveAsProject?: (
+    connectionId: string
+  ) => Effect.Effect<ConnectionOpsSaveAsProjectResult, unknown, never>
   readonly addMember: (
     connectionId: string,
     worktreeId: string
@@ -146,7 +160,12 @@ export interface ConnectionOpsRpcService {
 }
 
 const emptyParamsSchema = z.union([z.object({}).strict(), z.undefined(), z.null()])
-const createParamsSchema = z.object({ worktreeIds: z.array(z.string().min(1)) }).strict()
+const createParamsSchema = z
+  .object({
+    worktreeIds: z.array(z.string().min(1)),
+    savedProjectId: z.string().min(1).optional()
+  })
+  .strict()
 const connectionIdParamsSchema = z.object({ connectionId: z.string().min(1) }).strict()
 const connectionPathParamsSchema = z.object({ connectionPath: z.string().min(1) }).strict()
 const worktreeIdParamsSchema = z.object({ worktreeId: z.string().min(1) }).strict()
@@ -182,13 +201,25 @@ const setRecentNoteParamsSchema = z
   .strict()
 
 export const makeLiveConnectionOpsRpcService = (): ConnectionOpsRpcService => ({
-  create: (worktreeIds) =>
+  create: (worktreeIds, savedProjectId) =>
     Effect.tryPromise({
       try: async () => {
         const db = getDatabase()
-        const result = await createConnectionOp(db, worktreeIds)
+        const result = await createConnectionOp(db, worktreeIds, savedProjectId)
         if (result.success) {
           telemetryService.track('connection_created')
+        }
+        return result
+      },
+      catch: (cause) => cause
+    }),
+  saveAsProject: (connectionId) =>
+    Effect.tryPromise({
+      try: async () => {
+        const db = getDatabase()
+        const result = await saveConnectionAsProjectOp(db, connectionId)
+        if (result.success) {
+          telemetryService.track('connection_saved_as_project')
         }
         return result
       },
@@ -300,11 +331,30 @@ export const makeConnectionOpsRpcHandlers = (
       'connectionOps.create',
       (params) =>
         Effect.gen(function* () {
-          const { worktreeIds } = yield* Effect.try({
+          const { worktreeIds, savedProjectId } = yield* Effect.try({
             try: () => createParamsSchema.parse(params),
             catch: (cause) => cause
           })
-          return yield* service.create(worktreeIds)
+          // Only pass savedProjectId when present so existing single-arg
+          // call-shape expectations (test spies) stay intact.
+          return yield* (savedProjectId !== undefined
+            ? service.create(worktreeIds, savedProjectId)
+            : service.create(worktreeIds))
+        })
+    ],
+    [
+      'connectionOps.saveAsProject',
+      (params) =>
+        Effect.gen(function* () {
+          const { connectionId } = yield* Effect.try({
+            try: () => connectionIdParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          const saveAsProject = service.saveAsProject
+          if (!saveAsProject) {
+            return yield* Effect.fail(new Error('saveAsProject not supported'))
+          }
+          return yield* saveAsProject(connectionId)
         })
     ],
     [

--- a/src/server/rpc/domains/connection-ops.ts
+++ b/src/server/rpc/domains/connection-ops.ts
@@ -5,6 +5,7 @@ import {
   addConnectionMemberOp,
   createConnectionOp,
   deleteConnectionOp,
+  ensureConnectionProjectBaseInstancesOp,
   getAllConnectionsOp,
   getConnectionOp,
   getPinnedConnectionsOp,
@@ -105,6 +106,8 @@ export interface ConnectionOpsSaveAsProjectResult {
   readonly success: boolean
   readonly project?: Project
   readonly connection?: ConnectionWithMembers
+  /** The new project's base instance (member default worktrees), when created. */
+  readonly baseConnection?: ConnectionWithMembers
   readonly error?: string
 }
 
@@ -289,9 +292,15 @@ export const makeLiveConnectionOpsRpcService = (): ConnectionOpsRpcService => ({
       catch: (cause) => cause
     }),
   getAll: () =>
-    Effect.sync(() => {
-      const db = getDatabase()
-      return getAllConnectionsOp(db)
+    Effect.tryPromise({
+      try: async () => {
+        const db = getDatabase()
+        // Self-heal: connection projects saved before base instances existed
+        // (or whose base creation failed) get their base on the next listing.
+        await ensureConnectionProjectBaseInstancesOp(db)
+        return getAllConnectionsOp(db)
+      },
+      catch: (cause) => cause
     }),
   get: (connectionId) =>
     Effect.sync(() => {

--- a/src/server/rpc/domains/db.ts
+++ b/src/server/rpc/domains/db.ts
@@ -474,6 +474,14 @@ export const makeLiveDbRpcService = (): DbRpcService => ({
         const { getDatabase } = await import('../../../main/db')
         const db = getDatabase()
         const project = db.getProject(id)
+        // Connection projects: take down the base instance (the only path allowed
+        // to) BEFORE the row goes — the FK would otherwise null saved_project_id
+        // and leave an undeletable orphan connection behind.
+        if (project?.kind === 'connection') {
+          const { deleteBaseInstanceForProjectOp } =
+            await import('../../../main/services/connection-ops')
+          await deleteBaseInstanceForProjectOp(db, id)
+        }
         const deleted = db.deleteProject(id)
         // Connection projects own a dedicated symlink dir under
         // ~/.hive/connection-projects — clean it up so it doesn't leak.

--- a/src/server/rpc/domains/db.ts
+++ b/src/server/rpc/domains/db.ts
@@ -472,7 +472,23 @@ export const makeLiveDbRpcService = (): DbRpcService => ({
     Effect.tryPromise({
       try: async () => {
         const { getDatabase } = await import('../../../main/db')
-        return getDatabase().deleteProject(id)
+        const db = getDatabase()
+        const project = db.getProject(id)
+        const deleted = db.deleteProject(id)
+        // Connection projects own a dedicated symlink dir under
+        // ~/.hive/connection-projects — clean it up so it doesn't leak.
+        if (deleted && project?.kind === 'connection') {
+          const { deleteConnectionDir, getConnectionProjectsBaseDir } =
+            await import('../../../main/services/connection-service')
+          if (project.path.startsWith(getConnectionProjectsBaseDir())) {
+            try {
+              deleteConnectionDir(project.path)
+            } catch {
+              // Directory cleanup is best-effort.
+            }
+          }
+        }
+        return deleted
       },
       catch: (cause) => cause
     }),

--- a/src/shared/types/connection.ts
+++ b/src/shared/types/connection.ts
@@ -6,6 +6,8 @@ export interface Connection {
   path: string
   color: string | null
   pinned: number
+  /** Saved-connection project this connection is an instance of (null/absent = ad-hoc connection). */
+  saved_project_id?: string | null
   created_at: string
   updated_at: string
 }

--- a/src/shared/types/connection.ts
+++ b/src/shared/types/connection.ts
@@ -8,6 +8,8 @@ export interface Connection {
   pinned: number
   /** Saved-connection project this connection is an instance of (null/absent = ad-hoc connection). */
   saved_project_id?: string | null
+  /** 1 = base instance of a connection project (members = each member project's default worktree). */
+  is_base?: number
   created_at: string
   updated_at: string
 }

--- a/src/shared/types/project.ts
+++ b/src/shared/types/project.ts
@@ -1,9 +1,15 @@
 import type { CustomProjectCommand } from '@shared/lib/custom-commands'
 
+export type ProjectKind = 'git' | 'connection'
+
 export interface Project {
   id: string
   name: string
   path: string
+  /** 'git' (default) or 'connection' (a saved connection promoted to a project). */
+  kind?: ProjectKind
+  /** connection projects only: JSON array of member project ids (creation order). */
+  member_project_ids?: string | null
   description: string | null
   tags: string | null
   language: string | null


### PR DESCRIPTION
## Summary
- Move the Pinned Board toggle from the Pinned section header into the main sidebar navigation.
- Apply the primary violet active-state styling to the Pinned Board nav row.
- Remove obsolete board toggle imports and header action logic from `PinnedList`.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SQLite schema, on-disk connection dirs/symlinks, and non-trivial base-instance lifecycle (FK orphans, healing, forced deletes); launch and auto-pin paths add new branches but are covered by extensive tests.
> 
> **Overview**
> Adds **connection projects**: multi-repo connections can be promoted to sidebar projects (`kind='connection'`) with their own kanban board, dedicated `~/.hive/connection-projects` symlink dirs, and `connections.saved_project_id` linking live instances. **Save as Project** is exposed on connection cards; saved instances move under the project in the sidebar while ad-hoc connections stay in the Connections section.
> 
> Each connection project gets a **base instance** (`is_base`) over member projects’ default worktrees—locked like a default worktree (no delete/rename/member edits unless forced), created or **promoted** from an existing matching instance on save, and **healed** on connection listing when missing or stale. Schema bumps to v45; `auto-pin` pins the base connection for connection projects.
> 
> **Kanban / launch**: connection-project tickets launch via a workspace picker (new worktrees per member, existing instance, or shared name-set); worktree assign flows are skipped on those tickets. Selecting a connection-project instance shows the saved project’s board in the main pane.
> 
> Also adds an **In Progress tiled sessions** grid (board header control, session tab, Claude CLI portal tiles) and a violet **primary** active style for the Pinned Board nav row (board toggle removed from the Pinned section header).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a371764b71b3b3a5c84f7bbc004a93ae89e2162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->