### PR TITLE
fix: keep the permission channel alive while background agents run

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -499,6 +499,7 @@ app
     const claudeImpl = new ClaudeCodeImplementer()
     claudeImpl.setDatabaseService(getDatabase())
     claudeImpl.setClaudeBinaryPath(claudeBinaryPath)
+    claudeImpl.setHeadless(isHeadless)
     setRouterClaudeBinaryPath(claudeBinaryPath)
     openCodeService.setOpenCodeLaunchSpec(openCodeLaunchSpec)
     setRouterOpenCodeLaunchSpec(openCodeLaunchSpec)

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -1250,8 +1250,17 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     this.closePromptInput(session, 'new prompt started')
     retiredController?.abort()
 
-    if (session.subscription) {
-      await session.subscription.abort()
+    // Bounded like the stop path: a wedged child process must not keep the new
+    // prompt from ever reaching sdk.query(). The query.close() below kills it
+    // either way.
+    const subscription = session.subscription
+    if (subscription) {
+      const closed = await runBoundedAbortStep(() => subscription.abort())
+      if (!closed) {
+        log.warn('Prompt: previous turn teardown did not settle in time', {
+          hiveSessionId: session.hiveSessionId
+        })
+      }
       session.subscription = null
     }
 

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -1224,8 +1224,41 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
   }
 
   /**
+   * Close stdin and tear the message stream down. Bounded, because a wedged
+   * child process must not block the caller: the stop button has to stay
+   * responsive, and a superseding prompt has to reach sdk.query().
+   *
+   * Shared by both paths that end a turn. Reply to anything the CLI is blocked
+   * on (denyPendingRequests) before calling this: once the stream is gone the
+   * replies cannot reach the CLI, which is what makes it report
+   * "Tool permission request failed: AbortError: Stream closed".
+   */
+  private async teardownStream(session: ClaudeSessionState, reason: string): Promise<void> {
+    this.closePromptInput(session, reason)
+
+    const subscription = session.subscription
+    if (!subscription) return
+
+    const closed = await runBoundedAbortStep(() => subscription.abort())
+    if (!closed) {
+      log.warn('Stream teardown did not settle in time', {
+        hiveSessionId: session.hiveSessionId,
+        reason
+      })
+    }
+    session.subscription = null
+  }
+
+  /**
    * Shut down the turn that is still holding this session, if any. Only a turn
    * whose background work outlived its result can still be here.
+   *
+   * Same shape as abort(): reply to pending requests, then tear the stream
+   * down. It differs on purpose in three places. It skips the graceful
+   * interrupt and the reply-flush wait, because a new prompt is waiting and the
+   * process is about to be killed regardless. It closes the query rather than
+   * only dropping the handle, so the old process cannot outlive the new one.
+   * And it hands ownership over first, which abort() must not do.
    */
   private async retirePreviousTurn(session: ClaudeSessionState): Promise<void> {
     if (!session.promptInput && !session.query) return
@@ -1235,34 +1268,17 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       liveBackgroundTasks: [...(session.liveBackgroundTasks ?? [])]
     })
 
-    // Reply to whatever the old turn was blocked on while its transport is
-    // still up, same reason as abort(): an unanswered request never resolves
-    // and its prompt would sit in the UI over the new turn.
     this.denyPendingRequests(session, 'superseded by a new prompt')
 
     // Hand ownership over before tearing anything down. The old finisher wakes
-    // from the interrupt below, and while it still holds this controller it
+    // from the teardown below, and while it still holds this controller it
     // passes ownsSession(), so it would publish idle over the turn that is
     // starting and null out its query handle.
     const retiredController = session.abortController
     session.abortController = null
-
-    this.closePromptInput(session, 'new prompt started')
     retiredController?.abort()
 
-    // Bounded like the stop path: a wedged child process must not keep the new
-    // prompt from ever reaching sdk.query(). The query.close() below kills it
-    // either way.
-    const subscription = session.subscription
-    if (subscription) {
-      const closed = await runBoundedAbortStep(() => subscription.abort())
-      if (!closed) {
-        log.warn('Prompt: previous turn teardown did not settle in time', {
-          hiveSessionId: session.hiveSessionId
-        })
-      }
-      session.subscription = null
-    }
+    await this.teardownStream(session, 'new prompt started')
 
     if (session.query) {
       try {
@@ -1310,21 +1326,9 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       session.abortController.abort()
     }
 
-    // Stdin can go now: the pending replies above are already flushed, and with
-    // it still open the CLI would idle instead of exiting.
-    this.closePromptInput(session, 'session aborted')
-
-    const subscription = session.subscription
-    if (subscription) {
-      const closed = await runBoundedAbortStep(() => subscription.abort())
-      if (!closed) {
-        log.warn('Abort: stream teardown did not settle in time', {
-          worktreePath,
-          agentSessionId
-        })
-      }
-      session.subscription = null
-    }
+    // The pending replies above are already flushed, so stdin can go. With it
+    // still open the CLI would idle instead of exiting.
+    await this.teardownStream(session, 'session aborted')
 
     session.query = null
     this.emitStatus(session.hiveSessionId, 'idle')

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -47,8 +47,13 @@ const log = createLogger({ component: 'ClaudeCodeImplementer' })
  * the CLI reports every change of its background-task set, so the normal path
  * closes on the next result. Without the net, one lost report would keep the
  * session busy and the CLI process alive forever.
+ *
+ * Deliberately generous. Closing too early brings back the bug this whole
+ * mechanism exists to fix, and real sessions do go quiet for minutes at a time
+ * (the longest gap between SDK messages in a day of logs here was 406s), while
+ * closing too late only leaves a session busy that Stop can end at any time.
  */
-const BACKGROUND_WORK_SILENCE_TIMEOUT_MS = 600_000
+const BACKGROUND_WORK_SILENCE_TIMEOUT_MS = 1_800_000
 
 /**
  * How long the CLI must stay quiet after a result before Hive closes stdin.
@@ -1227,10 +1232,23 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
 
     log.info('Prompt: retiring the previous turn before starting a new one', {
       hiveSessionId: session.hiveSessionId,
-      liveBackgroundTasks: [...session.liveBackgroundTasks]
+      liveBackgroundTasks: [...(session.liveBackgroundTasks ?? [])]
     })
 
+    // Reply to whatever the old turn was blocked on while its transport is
+    // still up, same reason as abort(): an unanswered request never resolves
+    // and its prompt would sit in the UI over the new turn.
+    this.denyPendingRequests(session, 'superseded by a new prompt')
+
+    // Hand ownership over before tearing anything down. The old finisher wakes
+    // from the interrupt below, and while it still holds this controller it
+    // passes ownsSession(), so it would publish idle over the turn that is
+    // starting and null out its query handle.
+    const retiredController = session.abortController
+    session.abortController = null
+
     this.closePromptInput(session, 'new prompt started')
+    retiredController?.abort()
 
     if (session.subscription) {
       await session.subscription.abort()
@@ -2420,6 +2438,14 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
             if (session.pendingQuestion?.requestId !== requestId) return
             session.pendingQuestion = null
             this.pendingQuestionSessions.delete(requestId)
+            // question.rejected is what drops the prompt from the renderer's
+            // question store. Without it a late-arriving client still sees the
+            // question, answering it fails, and the session stays blocked.
+            this.sendToRenderer('opencode:stream', {
+              type: 'question.rejected',
+              sessionId: session.hiveSessionId,
+              data: { requestId, id: requestId }
+            })
             resolve({ answers: [], timedOut: true })
           }
         )
@@ -3722,6 +3748,11 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       clearTimeout(session.pendingCloseTimer)
       session.pendingCloseTimer = null
     }
+    // Closing stdin ends this CLI process, so nothing it reported as running is
+    // running any more. Report that before returning: the level signal is
+    // per-process and says nothing at startup, so a stale count would otherwise
+    // sit in the UI until the next task happens to start.
+    this.clearBackgroundWork(session)
     if (!session.promptInput) return
 
     log.info('Prompt: closing stdin to the CLI', {
@@ -3731,6 +3762,27 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     })
     session.promptInput.close()
     session.promptInput = null
+  }
+
+  /**
+   * Drop the session's background work and tell the renderer it is gone. No-op
+   * when nothing was running, so sessions whose CLI never reports background
+   * work never publish an event at all.
+   */
+  private clearBackgroundWork(session: ClaudeSessionState): void {
+    // Optional read: teardown also runs for sessions that never started a turn.
+    if (!session.liveBackgroundTasks?.size) return
+
+    log.info('Prompt: background work ended with the CLI process', {
+      hiveSessionId: session.hiveSessionId,
+      liveBackgroundTasks: [...session.liveBackgroundTasks]
+    })
+    session.liveBackgroundTasks = new Set()
+    this.sendToRenderer('opencode:stream', {
+      type: 'session.background_work',
+      sessionId: session.hiveSessionId,
+      data: { runningShells: 0, runningMonitors: 0, runningSubagents: 0 }
+    })
   }
 
   private armBackgroundWorkWatchdog(session: ClaudeSessionState): void {

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -19,6 +19,7 @@ import { Options, PermissionMode } from '@anthropic-ai/claude-agent-sdk'
 import { CommandFilterService, type CommandFilterSettings } from './command-filter-service'
 import { APP_SETTINGS_DB_KEY } from '@shared/types/settings'
 import type { OpenCodeStreamEvent } from '@shared/types/opencode'
+import type { ClaudeCliBackgroundWorkPayload } from '@shared/types/claude-cli-background-work'
 import { Cause, Exit } from 'effect'
 import {
   claudeAgentFacade,
@@ -39,6 +40,35 @@ import {
 } from './claude-abort'
 
 const log = createLogger({ component: 'ClaudeCodeImplementer' })
+
+/**
+ * How long the CLI may stay completely silent after a result that left
+ * background work running before Hive closes stdin anyway. Pure safety net:
+ * the CLI reports every change of its background-task set, so the normal path
+ * closes on the next result. Without the net, one lost report would keep the
+ * session busy and the CLI process alive forever.
+ */
+const BACKGROUND_WORK_SILENCE_TIMEOUT_MS = 600_000
+
+/**
+ * How long the CLI must stay quiet after a result before Hive closes stdin.
+ *
+ * A result is not always the end. The CLI starts a follow-up turn on its own
+ * when a background task finished mid-turn, too late to be folded into the
+ * running turn: its notification is queued and delivered as a fresh turn. That
+ * turn is already queued when the result lands, so it announces itself within
+ * tens of milliseconds. Waiting a moment tells "done" from "about to continue"
+ * without guessing at the queue.
+ */
+const CLOSE_AFTER_RESULT_QUIET_MS = 1_500
+
+/**
+ * How long a headless run waits for a client to answer a question, plan or
+ * permission request. Headless Hive still serves the web UI, so an attached
+ * browser client can answer, but with nothing attached the wait would never
+ * end and the session would sit dead with no sign of why.
+ */
+const HEADLESS_INTERACTION_TIMEOUT_MS = 300_000
 
 const CLAUDE_EFFORT_VARIANTS = { low: {}, medium: {}, high: {} }
 const CLAUDE_OPUS_EFFORT_VARIANTS = { low: {}, medium: {}, high: {}, xhigh: {}, max: {} }
@@ -106,12 +136,22 @@ interface RewindFilesResult {
 export interface PendingQuestionState {
   requestId: string
   questions: { question: string; header: string }[]
-  resolve: (response: { answers: string[][]; rejected?: boolean }) => void
+  resolve: (response: { answers: string[][]; rejected?: boolean; timedOut?: boolean }) => void
 }
 
 export interface PendingPlanApprovalState {
   requestId: string
   resolve: (response: { approved: boolean; feedback?: string }) => void
+}
+
+/**
+ * The stdin stream of one prompt turn. It yields the user message and then
+ * stays open: the CLI's permission channel runs over stdin, so closing it ends
+ * every later permission request with "AbortError: Stream closed".
+ */
+interface PromptInputStream {
+  readonly iterable: AsyncIterable<Record<string, unknown>>
+  readonly close: () => void
 }
 
 export interface ClaudeSessionState {
@@ -149,6 +189,14 @@ export interface ClaudeSessionState {
   titleDeferred: boolean
   /** Accumulated stderr output from the Claude Code process for the current prompt */
   stderrBuffer: string[]
+  /** Open stdin of the current prompt turn; closing it lets the CLI exit */
+  promptInput: PromptInputStream | null
+  /** Task ids the CLI currently reports as live background work */
+  liveBackgroundTasks: Set<string>
+  /** Close lined up after a result, cancelled if the CLI keeps talking */
+  pendingCloseTimer: NodeJS.Timeout | null
+  /** Safety net that closes stdin if background work never reports done */
+  backgroundWorkWatchdog: NodeJS.Timeout | null
 }
 
 export class ClaudeCodeImplementer implements AgentSdkImplementer {
@@ -186,6 +234,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         remember?: 'allow' | 'block'
         pattern?: string
         patterns?: string[]
+        timedOut?: boolean
       }) => void
       toolName: string
       input: Record<string, unknown>
@@ -193,6 +242,8 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       hiveSessionId: string
     }
   >()
+  /** True when Hive runs without a window (--headless / HIVE_HEADLESS=1) */
+  private headless = false
 
   setDatabaseService(db: DatabaseService): void {
     this.dbService = db
@@ -200,6 +251,10 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
 
   setClaudeBinaryPath(path: string | null): void {
     this.claudeBinaryPath = path
+  }
+
+  setHeadless(headless: boolean): void {
+    this.headless = headless
   }
 
   // ── Lifecycle ────────────────────────────────────────────────────
@@ -229,7 +284,11 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       pendingFork: false,
       pendingResumeSessionAt: null,
       titleDeferred: false,
-      stderrBuffer: []
+      stderrBuffer: [],
+      promptInput: null,
+      liveBackgroundTasks: new Set(),
+      pendingCloseTimer: null,
+      backgroundWorkWatchdog: null
     }
     this.sessions.set(key, state)
 
@@ -282,7 +341,11 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       pendingFork: false,
       pendingResumeSessionAt: null,
       titleDeferred: false,
-      stderrBuffer: []
+      stderrBuffer: [],
+      promptInput: null,
+      liveBackgroundTasks: new Set(),
+      pendingCloseTimer: null,
+      backgroundWorkWatchdog: null
     }
     this.sessions.set(key, state)
 
@@ -298,6 +361,8 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       log.warn('Disconnect: session not found, ignoring', { worktreePath, agentSessionId })
       return
     }
+
+    this.closePromptInput(session, 'session disconnected')
 
     if (session.query) {
       try {
@@ -327,6 +392,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
   async cleanup(): Promise<void> {
     log.info('Cleaning up all Claude Code sessions', { count: this.sessions.size })
     for (const [key, session] of this.sessions) {
+      this.closePromptInput(session, 'app cleanup')
       if (session.query) {
         try {
           session.query.close()
@@ -366,6 +432,11 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     if (!session) {
       throw new Error(`Prompt failed: session not found for ${worktreePath} / ${agentSessionId}`)
     }
+
+    // A previous turn can still hold the CLI open for background work. Each
+    // prompt gets its own query, so retire the old one first: two live
+    // processes on one session would both resume the same transcript.
+    await this.retirePreviousTurn(session)
 
     // Clear revert boundary — a new prompt invalidates prior undo state
     session.revertMessageID = null
@@ -588,16 +659,20 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         hasFileAttachments: !!contentBlocks
       })
 
-      // When file attachments are present, use AsyncIterable<SDKUserMessage> prompt path
-      // with proper Anthropic content blocks (base64 images/documents);
-      // otherwise use the plain string path (preserves all existing behavior).
-      const sdkPrompt = contentBlocks
-        ? this.createUserMessageIterable(contentBlocks, session.claudeSessionId)
-        : prompt
+      // File attachments travel as Anthropic content blocks (base64
+      // images/documents), everything else as one text block.
+      const promptInput = this.createPromptInputStream(
+        contentBlocks ?? prompt,
+        session.claudeSessionId
+      )
+      session.promptInput = promptInput
+      // The CLI reports background work per process, so start from empty.
+      session.liveBackgroundTasks = new Set()
 
-      const queryData = sdk.query({ prompt: sdkPrompt as never, options }) as AsyncIterable<
-        Record<string, unknown>
-      >
+      const queryData = sdk.query({
+        prompt: promptInput.iterable as never,
+        options
+      }) as AsyncIterable<Record<string, unknown>>
       session.pendingFork = false
       session.query = queryData as unknown as ClaudeQuery
 
@@ -620,6 +695,8 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
             log.info('Prompt: aborted or superseded, breaking loop')
             return
           }
+
+          this.trackBackgroundWork(session, sdkMessage)
 
           const msgType = sdkMessage.type as string
 
@@ -972,6 +1049,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
           // result-text emission for all subsequent non-streamed results.
           if (msgType === 'result') {
             hasStreamedContent = false
+            this.closePromptInputWhenIdle(session)
           }
         }
       })
@@ -1082,6 +1160,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
           this.emitStatus(session.hiveSessionId, 'idle')
         } finally {
           if (ownsSession()) {
+            this.closePromptInput(session, 'turn finished')
             session.lastQuery = session.query
             session.query = null
           }
@@ -1132,9 +1211,42 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         })
       }
       this.emitStatus(session.hiveSessionId, 'idle')
+      this.closePromptInput(session, 'prompt failed to start')
       session.lastQuery = session.query
       session.query = null
       throw error
+    }
+  }
+
+  /**
+   * Shut down the turn that is still holding this session, if any. Only a turn
+   * whose background work outlived its result can still be here.
+   */
+  private async retirePreviousTurn(session: ClaudeSessionState): Promise<void> {
+    if (!session.promptInput && !session.query) return
+
+    log.info('Prompt: retiring the previous turn before starting a new one', {
+      hiveSessionId: session.hiveSessionId,
+      liveBackgroundTasks: [...session.liveBackgroundTasks]
+    })
+
+    this.closePromptInput(session, 'new prompt started')
+
+    if (session.subscription) {
+      await session.subscription.abort()
+      session.subscription = null
+    }
+
+    if (session.query) {
+      try {
+        session.query.close()
+      } catch {
+        log.warn('Prompt: query.close() on the previous turn threw, ignoring', {
+          hiveSessionId: session.hiveSessionId
+        })
+      }
+      session.lastQuery = session.query
+      session.query = null
     }
   }
 
@@ -1170,6 +1282,10 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     if (session.abortController) {
       session.abortController.abort()
     }
+
+    // Stdin can go now: the pending replies above are already flushed, and with
+    // it still open the CLI would idle instead of exiting.
+    this.closePromptInput(session, 'session aborted')
 
     const subscription = session.subscription
     if (subscription) {
@@ -2056,6 +2172,8 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     const sessionKey = this.getSessionKey(session.worktreePath, session.claudeSessionId)
     this.pendingPlanSessions.set(requestId, sessionKey)
 
+    let cancelHeadlessTimeout: () => void = () => {}
+
     // Block execution with a Promise that waits for user response
     const userResponse = await new Promise<{ approved: boolean; feedback?: string }>((resolve) => {
       session.pendingPlanApproval = { requestId, resolve }
@@ -2102,7 +2220,25 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         }
       }
       options.signal.addEventListener('abort', onAbort, { once: true })
+
+      cancelHeadlessTimeout = this.armHeadlessInteractionTimeout(
+        session,
+        'plan approval',
+        requestId,
+        () => {
+          if (session.pendingPlanApproval?.requestId !== requestId) return
+          session.pendingPlanApproval = null
+          this.pendingPlanSessions.delete(requestId)
+          this.sendToRenderer('opencode:stream', {
+            type: 'plan.resolved',
+            sessionId: session.hiveSessionId,
+            data: { approved: false, aborted: true }
+          })
+          resolve({ approved: false, feedback: headlessTimeoutMessage('plan approval') })
+        }
+      )
     })
+    cancelHeadlessTimeout()
 
     // Clean up tracking state
     session.pendingPlanApproval = null
@@ -2139,6 +2275,10 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     | { behavior: 'deny'; message: string }
   > {
     return async (toolName, input, options) => {
+      // A decision request proves the CLI is working, so never close stdin
+      // from under it: the answer travels back over that same stdin.
+      this.holdPromptInputOpen(session, `permission request for ${toolName}`)
+
       // Handle ExitPlanMode — blocks until user approves or rejects the plan
       if (toolName === 'ExitPlanMode') {
         return this.handleExitPlanMode(session, input, options)
@@ -2231,47 +2371,68 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       const sessionKey = this.getSessionKey(session.worktreePath, session.claudeSessionId)
       this.pendingQuestionSessions.set(requestId, sessionKey)
 
+      let cancelHeadlessTimeout: () => void = () => {}
+
       // Block execution with a Promise that waits for user response
-      const userResponse = await new Promise<{ answers: string[][]; rejected?: boolean }>(
-        (resolve) => {
-          session.pendingQuestion = {
-            requestId,
-            questions: sdkQuestions.map((q) => ({ question: q.question, header: q.header })),
-            resolve
-          }
-
-          // Emit question.asked event to renderer (matches OpenCode event format)
-          this.sendToRenderer('opencode:stream', {
-            type: 'question.asked',
-            sessionId: session.hiveSessionId,
-            data: questionRequest
-          })
-
-          log.info('canUseTool: emitted question.asked, waiting for response', {
-            requestId,
-            hiveSessionId: session.hiveSessionId
-          })
-
-          this.maybeNotifyUserFeedbackNeeded(session.hiveSessionId, 'question')
-
-          // If the session is aborted while waiting, auto-reject
-          const onAbort = (): void => {
-            if (session.pendingQuestion?.requestId === requestId) {
-              log.info('canUseTool: session aborted while question pending, auto-rejecting', {
-                requestId
-              })
-              session.pendingQuestion = null
-              this.pendingQuestionSessions.delete(requestId)
-              resolve({ answers: [], rejected: true })
-            }
-          }
-          options.signal.addEventListener('abort', onAbort, { once: true })
+      const userResponse = await new Promise<{
+        answers: string[][]
+        rejected?: boolean
+        timedOut?: boolean
+      }>((resolve) => {
+        session.pendingQuestion = {
+          requestId,
+          questions: sdkQuestions.map((q) => ({ question: q.question, header: q.header })),
+          resolve
         }
-      )
+
+        // Emit question.asked event to renderer (matches OpenCode event format)
+        this.sendToRenderer('opencode:stream', {
+          type: 'question.asked',
+          sessionId: session.hiveSessionId,
+          data: questionRequest
+        })
+
+        log.info('canUseTool: emitted question.asked, waiting for response', {
+          requestId,
+          hiveSessionId: session.hiveSessionId
+        })
+
+        this.maybeNotifyUserFeedbackNeeded(session.hiveSessionId, 'question')
+
+        // If the session is aborted while waiting, auto-reject
+        const onAbort = (): void => {
+          if (session.pendingQuestion?.requestId === requestId) {
+            log.info('canUseTool: session aborted while question pending, auto-rejecting', {
+              requestId
+            })
+            session.pendingQuestion = null
+            this.pendingQuestionSessions.delete(requestId)
+            resolve({ answers: [], rejected: true })
+          }
+        }
+        options.signal.addEventListener('abort', onAbort, { once: true })
+
+        cancelHeadlessTimeout = this.armHeadlessInteractionTimeout(
+          session,
+          'question',
+          requestId,
+          () => {
+            if (session.pendingQuestion?.requestId !== requestId) return
+            session.pendingQuestion = null
+            this.pendingQuestionSessions.delete(requestId)
+            resolve({ answers: [], timedOut: true })
+          }
+        )
+      })
+      cancelHeadlessTimeout()
 
       // Clean up tracking state
       session.pendingQuestion = null
       this.pendingQuestionSessions.delete(requestId)
+
+      if (userResponse.timedOut) {
+        return { behavior: 'deny' as const, message: headlessTimeoutMessage('question') }
+      }
 
       if (userResponse.rejected) {
         log.info('canUseTool: AskUserQuestion rejected by user', { requestId })
@@ -2361,12 +2522,16 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
 
     this.maybeNotifyUserFeedbackNeeded(session.hiveSessionId, 'permission')
 
-    // Block execution with a Promise that waits for user response (no timeout, like questions)
+    let cancelHeadlessTimeout: () => void = () => {}
+
+    // Block execution with a Promise that waits for user response
+    // (only headless runs time out, see armHeadlessInteractionTimeout)
     const userResponse = await new Promise<{
       approved: boolean
       remember?: 'allow' | 'block'
       pattern?: string
       patterns?: string[]
+      timedOut?: boolean
     }>((resolve) => {
       this.pendingApprovals.set(requestId, {
         resolve: (response) => {
@@ -2402,10 +2567,31 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         }
       }
       options.signal.addEventListener('abort', onAbort, { once: true })
+
+      cancelHeadlessTimeout = this.armHeadlessInteractionTimeout(
+        session,
+        'command approval',
+        requestId,
+        () => {
+          if (!this.pendingApprovals.has(requestId)) return
+          this.sendToRenderer('opencode:stream', {
+            type: 'command.approval_replied',
+            sessionId: session.hiveSessionId,
+            data: { requestId, id: requestId, approved: false }
+          })
+          this.pendingApprovals.delete(requestId)
+          resolve({ approved: false, timedOut: true })
+        }
+      )
     })
+    cancelHeadlessTimeout()
 
     // Clean up tracking state
     this.pendingApprovals.delete(requestId)
+
+    if (userResponse.timedOut) {
+      return { behavior: 'deny' as const, message: headlessTimeoutMessage('command approval') }
+    }
 
     // Handle "remember" choice - update settings with user-selected pattern(s)
     if (userResponse.remember) {
@@ -3393,35 +3579,212 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
   }
 
   /**
-   * Create an AsyncIterable that yields a single SDKUserMessage with the given content blocks.
-   * Used when the prompt contains file attachments that need structured content blocks
-   * instead of a plain text string.
+   * Build the stdin stream for one prompt turn: one SDKUserMessage, then the
+   * stream parks until close() is called.
+   *
+   * A plain string prompt would make the SDK run in single-turn mode and close
+   * stdin on the first result. Stdin also carries the permission channel, so
+   * every later decision request would fail with "AbortError: Stream closed",
+   * and background subagents keep asking long after the result. An iterable
+   * that simply ends is no better: the SDK closes stdin once it is exhausted.
    */
-  private createUserMessageIterable(
-    contentBlocks: Array<Record<string, unknown>>,
+  private createPromptInputStream(
+    content: string | Array<Record<string, unknown>>,
     sessionId: string
-  ): AsyncIterable<Record<string, unknown>> {
+  ): PromptInputStream {
     const message = {
       type: 'user' as const,
       message: {
         role: 'user' as const,
-        content: contentBlocks
+        content: typeof content === 'string' ? [{ type: 'text', text: content }] : content
       },
       parent_tool_use_id: null,
       session_id: sessionId
     }
 
-    return {
-      [Symbol.asyncIterator]() {
-        let done = false
-        return {
-          async next() {
-            if (done) return { value: undefined, done: true as const }
-            done = true
-            return { value: message, done: false as const }
-          }
-        }
-      }
+    let release: () => void = () => {}
+    const closed = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    async function* stream(): AsyncGenerator<Record<string, unknown>> {
+      yield message
+      await closed
+    }
+
+    return { iterable: stream(), close: () => release() }
+  }
+
+  // ── Background work and stdin lifetime ───────────────────────────
+
+  /**
+   * Mirror the CLI's live background work into the session, and treat any
+   * output as proof that the CLI is not done: a close lined up after a result
+   * is called off and the silence watchdog starts over.
+   *
+   * `background_tasks_changed` carries the full live set on every membership
+   * change (replace semantics), so a single lost message cannot wedge the
+   * count. That is why the per-task start/stop events are not tracked. CLI
+   * builds that do not send it leave the set empty, so stdin closes on the
+   * result exactly as it did before.
+   */
+  private trackBackgroundWork(
+    session: ClaudeSessionState,
+    sdkMessage: Record<string, unknown>
+  ): void {
+    this.holdPromptInputOpen(session, 'CLI is still sending messages')
+
+    if (sdkMessage.type !== 'system' || sdkMessage.subtype !== 'background_tasks_changed') return
+
+    const tasks = (Array.isArray(sdkMessage.tasks) ? sdkMessage.tasks : []).filter(
+      (task): task is { task_id: string; task_type?: string } =>
+        typeof (task as { task_id?: unknown }).task_id === 'string' &&
+        (task as { task_id: string }).task_id.length > 0
+    )
+    session.liveBackgroundTasks = new Set(tasks.map((task) => task.task_id))
+
+    log.debug('Prompt: background work changed', {
+      hiveSessionId: session.hiveSessionId,
+      liveBackgroundTasks: [...session.liveBackgroundTasks]
+    })
+
+    // A background subagent writes to its own transcript, so between the result
+    // and its follow-up turn there is nothing to draw. Report the same counts
+    // the claude-cli hook path reports, so both feed one store and one set of
+    // indicators instead of the UI looking finished.
+    const isShell = (type?: string): boolean => !!type && /bash|shell/.test(type)
+    const isMonitor = (type?: string): boolean => !!type && /monitor/.test(type)
+    const work: Omit<ClaudeCliBackgroundWorkPayload, 'sessionId'> = {
+      runningShells: tasks.filter((t) => isShell(t.task_type)).length,
+      runningMonitors: tasks.filter((t) => isMonitor(t.task_type)).length,
+      runningSubagents: tasks.filter((t) => !isShell(t.task_type) && !isMonitor(t.task_type)).length
+    }
+    this.sendToRenderer('opencode:stream', {
+      type: 'session.background_work',
+      sessionId: session.hiveSessionId,
+      data: work
+    })
+  }
+
+  /**
+   * Decide what a result means for stdin.
+   *
+   * A result is not the end of the work. Background subagents outlive it and
+   * still need the permission channel, and the CLI itself may start a
+   * follow-up turn to deliver a background task's notification. So stdin only
+   * closes on a result that leaves no live background work and is followed by
+   * a moment of quiet.
+   */
+  private closePromptInputWhenIdle(session: ClaudeSessionState): void {
+    if (!session.promptInput) return
+
+    if (session.liveBackgroundTasks.size > 0) {
+      log.info('Prompt: result arrived while background work runs, keeping stdin open', {
+        hiveSessionId: session.hiveSessionId,
+        liveBackgroundTasks: [...session.liveBackgroundTasks]
+      })
+      this.armBackgroundWorkWatchdog(session)
+      return
+    }
+
+    this.clearBackgroundWorkWatchdog(session)
+    if (session.pendingCloseTimer) clearTimeout(session.pendingCloseTimer)
+    session.pendingCloseTimer = setTimeout(() => {
+      session.pendingCloseTimer = null
+      this.closePromptInput(session, 'result, then the CLI went quiet')
+    }, CLOSE_AFTER_RESULT_QUIET_MS)
+    session.pendingCloseTimer.unref?.()
+  }
+
+  /**
+   * Call off a close lined up after a result, because something proved the CLI
+   * is still working. Re-arms the silence watchdog so a turn that never ends
+   * cannot leave stdin open forever.
+   */
+  private holdPromptInputOpen(session: ClaudeSessionState, reason: string): void {
+    const closeWasPending = session.pendingCloseTimer !== null
+    if (closeWasPending) {
+      clearTimeout(session.pendingCloseTimer!)
+      session.pendingCloseTimer = null
+      log.info('Prompt: CLI kept working after the result, keeping stdin open', {
+        hiveSessionId: session.hiveSessionId,
+        reason
+      })
+    }
+    if (closeWasPending || session.backgroundWorkWatchdog) {
+      this.armBackgroundWorkWatchdog(session)
     }
   }
+
+  private closePromptInput(session: ClaudeSessionState, reason: string): void {
+    this.clearBackgroundWorkWatchdog(session)
+    if (session.pendingCloseTimer) {
+      clearTimeout(session.pendingCloseTimer)
+      session.pendingCloseTimer = null
+    }
+    if (!session.promptInput) return
+
+    log.info('Prompt: closing stdin to the CLI', {
+      hiveSessionId: session.hiveSessionId,
+      reason,
+      liveBackgroundTasks: [...session.liveBackgroundTasks]
+    })
+    session.promptInput.close()
+    session.promptInput = null
+  }
+
+  private armBackgroundWorkWatchdog(session: ClaudeSessionState): void {
+    this.clearBackgroundWorkWatchdog(session)
+    session.backgroundWorkWatchdog = setTimeout(() => {
+      session.backgroundWorkWatchdog = null
+      log.warn('Prompt: background work went silent, closing stdin anyway', {
+        hiveSessionId: session.hiveSessionId,
+        liveBackgroundTasks: [...session.liveBackgroundTasks],
+        silenceMs: BACKGROUND_WORK_SILENCE_TIMEOUT_MS
+      })
+      this.closePromptInput(session, 'background work silent for too long')
+    }, BACKGROUND_WORK_SILENCE_TIMEOUT_MS)
+    session.backgroundWorkWatchdog.unref?.()
+  }
+
+  private clearBackgroundWorkWatchdog(session: ClaudeSessionState): void {
+    if (!session.backgroundWorkWatchdog) return
+    clearTimeout(session.backgroundWorkWatchdog)
+    session.backgroundWorkWatchdog = null
+  }
+
+  /**
+   * Time-box a wait for a user decision when Hive runs headless. Returns a
+   * canceller, and is a no-op with a window attached: there a request may
+   * legitimately sit unanswered for hours.
+   */
+  private armHeadlessInteractionTimeout(
+    session: ClaudeSessionState,
+    kind: string,
+    requestId: string,
+    onTimeout: () => void
+  ): () => void {
+    if (!this.headless) return () => {}
+
+    const timer = setTimeout(() => {
+      log.error(
+        `Headless: no client answered the ${kind} request`,
+        new Error(`Headless ${kind} request timed out`),
+        {
+          hiveSessionId: session.hiveSessionId,
+          requestId,
+          timeoutMs: HEADLESS_INTERACTION_TIMEOUT_MS
+        }
+      )
+      onTimeout()
+    }, HEADLESS_INTERACTION_TIMEOUT_MS)
+    timer.unref?.()
+
+    return () => clearTimeout(timer)
+  }
+}
+
+function headlessTimeoutMessage(kind: string): string {
+  const minutes = Math.round(HEADLESS_INTERACTION_TIMEOUT_MS / 60_000)
+  return `No Hive client answered this ${kind} request within ${minutes} minutes. Hive runs headless, so there may be no user attached. Continue without it or stop and report what you need.`
 }

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -1224,14 +1224,28 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
   }
 
   /**
+   * Reply to whatever the CLI is blocked on, and give those replies time to
+   * reach it. They go out over stdin asynchronously, so tearing the stream down
+   * first makes the CLI record "Tool permission request failed: AbortError:
+   * Stream closed" for the tool call instead of the denial we sent.
+   *
+   * Always call this before teardownStream().
+   */
+  private async denyAndFlushPendingRequests(
+    session: ClaudeSessionState,
+    reason: string
+  ): Promise<void> {
+    const denied = this.denyPendingRequests(session, reason)
+    if (denied === 0) return
+    await new Promise((resolve) => setTimeout(resolve, ABORT_REPLY_FLUSH_MS))
+  }
+
+  /**
    * Close stdin and tear the message stream down. Bounded, because a wedged
    * child process must not block the caller: the stop button has to stay
    * responsive, and a superseding prompt has to reach sdk.query().
    *
-   * Shared by both paths that end a turn. Reply to anything the CLI is blocked
-   * on (denyPendingRequests) before calling this: once the stream is gone the
-   * replies cannot reach the CLI, which is what makes it report
-   * "Tool permission request failed: AbortError: Stream closed".
+   * Shared by both paths that end a turn.
    */
   private async teardownStream(session: ClaudeSessionState, reason: string): Promise<void> {
     this.closePromptInput(session, reason)
@@ -1254,11 +1268,10 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
    * whose background work outlived its result can still be here.
    *
    * Same shape as abort(): reply to pending requests, then tear the stream
-   * down. It differs on purpose in three places. It skips the graceful
-   * interrupt and the reply-flush wait, because a new prompt is waiting and the
-   * process is about to be killed regardless. It closes the query rather than
-   * only dropping the handle, so the old process cannot outlive the new one.
-   * And it hands ownership over first, which abort() must not do.
+   * down. It differs on purpose in two places. It skips the graceful interrupt,
+   * because a prompt is waiting and this process is being closed outright
+   * rather than asked to stop. And it hands ownership over first, which abort()
+   * must not do.
    */
   private async retirePreviousTurn(session: ClaudeSessionState): Promise<void> {
     if (!session.promptInput && !session.query) return
@@ -1268,7 +1281,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       liveBackgroundTasks: [...(session.liveBackgroundTasks ?? [])]
     })
 
-    this.denyPendingRequests(session, 'superseded by a new prompt')
+    await this.denyAndFlushPendingRequests(session, 'superseded by a new prompt')
 
     // Hand ownership over before tearing anything down. The old finisher wakes
     // from the teardown below, and while it still holds this controller it
@@ -1300,14 +1313,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
       return false
     }
 
-    // Reply to whatever the CLI is blocked on *before* the transport goes away.
-    // Killing the stream with a permission request still in flight is what makes
-    // Claude report "Tool permission request failed: AbortError: Stream closed"
-    // as a failed tool call.
-    const denied = this.denyPendingRequests(session, 'abort')
-    if (denied > 0) {
-      await new Promise((resolve) => setTimeout(resolve, ABORT_REPLY_FLUSH_MS))
-    }
+    await this.denyAndFlushPendingRequests(session, 'abort')
 
     // Graceful interrupt first, while the stream is still alive. Every step is
     // bounded: a wedged child process must not keep the stop button spinning.
@@ -3798,10 +3804,31 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
     })
   }
 
+  /** True while the CLI is blocked on a decision from a person. */
+  private hasPendingInteraction(session: ClaudeSessionState): boolean {
+    if (session.pendingQuestion || session.pendingPlanApproval) return true
+    for (const pending of this.pendingApprovals.values()) {
+      if (pending.hiveSessionId === session.hiveSessionId) return true
+    }
+    return false
+  }
+
   private armBackgroundWorkWatchdog(session: ClaudeSessionState): void {
     this.clearBackgroundWorkWatchdog(session)
     session.backgroundWorkWatchdog = setTimeout(() => {
       session.backgroundWorkWatchdog = null
+
+      // A request waiting on a person explains the silence, and with a window
+      // attached that wait is allowed to last hours. Closing stdin here would
+      // break the very request being waited on, so give it another window.
+      if (this.hasPendingInteraction(session)) {
+        log.info('Prompt: background work silent while a request waits on the user', {
+          hiveSessionId: session.hiveSessionId
+        })
+        this.armBackgroundWorkWatchdog(session)
+        return
+      }
+
       log.warn('Prompt: background work went silent, closing stdin anyway', {
         hiveSessionId: session.hiveSessionId,
         liveBackgroundTasks: [...session.liveBackgroundTasks],

--- a/src/renderer/src/components/sessions/BackgroundWorkIndicator.test.tsx
+++ b/src/renderer/src/components/sessions/BackgroundWorkIndicator.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { BackgroundWorkIndicator } from './BackgroundWorkIndicator'
+import { countBackgroundWork, useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+
+const setWork = (work: {
+  runningShells: number
+  runningMonitors: number
+  runningSubagents: number
+}): void => {
+  useWorktreeStatusStore.setState({ backgroundWorkBySession: { 'session-1': work } })
+}
+
+describe('BackgroundWorkIndicator', () => {
+  afterEach(() => {
+    cleanup()
+    useWorktreeStatusStore.setState({ backgroundWorkBySession: {} })
+  })
+
+  // Wording matches the kanban card's badges for the same store entry.
+  it('names a single running subagent', () => {
+    setWork({ runningShells: 0, runningMonitors: 0, runningSubagents: 1 })
+
+    render(<BackgroundWorkIndicator sessionId="session-1" />)
+
+    expect(screen.getByTestId('background-work-indicator')).toHaveTextContent('1 subagent running')
+  })
+
+  it('lists each kind of background work that is running', () => {
+    setWork({ runningShells: 1, runningMonitors: 1, runningSubagents: 3 })
+
+    render(<BackgroundWorkIndicator sessionId="session-1" />)
+
+    expect(screen.getByTestId('background-work-indicator')).toHaveTextContent(
+      '3 subagents, 1 background shell, 1 monitor running'
+    )
+  })
+
+  it('renders nothing once the session reports no background work', () => {
+    // What the main process sends when the live set drains: all counts zero,
+    // which drops the store entry and returns the composer to normal.
+    setWork({ runningShells: 0, runningMonitors: 0, runningSubagents: 0 })
+
+    render(<BackgroundWorkIndicator sessionId="session-1" />)
+
+    expect(screen.queryByTestId('background-work-indicator')).toBeNull()
+  })
+
+  it('renders nothing for a session with no entry', () => {
+    render(<BackgroundWorkIndicator sessionId="other-session" />)
+
+    expect(screen.queryByTestId('background-work-indicator')).toBeNull()
+  })
+})
+
+// This total is what keeps the composer's progress bar alive past the result.
+describe('countBackgroundWork', () => {
+  it('totals every kind of live background work', () => {
+    expect(countBackgroundWork({ runningShells: 1, runningMonitors: 1, runningSubagents: 2 })).toBe(
+      4
+    )
+  })
+
+  it('is zero when the session has no background work', () => {
+    expect(countBackgroundWork(undefined)).toBe(0)
+    expect(countBackgroundWork({ runningShells: 0, runningMonitors: 0, runningSubagents: 0 })).toBe(
+      0
+    )
+  })
+})

--- a/src/renderer/src/components/sessions/BackgroundWorkIndicator.tsx
+++ b/src/renderer/src/components/sessions/BackgroundWorkIndicator.tsx
@@ -1,0 +1,52 @@
+import { useCallback } from 'react'
+
+import { countBackgroundWork, useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+
+/**
+ * What is still running in the background for this session. Wording matches the
+ * kanban card's background-work badges, since it is the same state.
+ */
+function label(work: { runningSubagents: number; runningShells: number; runningMonitors: number }) {
+  const parts: string[] = []
+  if (work.runningSubagents > 0) {
+    parts.push(work.runningSubagents === 1 ? '1 subagent' : `${work.runningSubagents} subagents`)
+  }
+  if (work.runningShells > 0) {
+    parts.push(
+      work.runningShells === 1 ? '1 background shell' : `${work.runningShells} background shells`
+    )
+  }
+  if (work.runningMonitors > 0) {
+    parts.push(work.runningMonitors === 1 ? '1 monitor' : `${work.runningMonitors} monitors`)
+  }
+  return `${parts.join(', ')} running`
+}
+
+/**
+ * Live background work of a session: subagents and shells that outlive the
+ * turn's result. Their output goes to their own transcript, so without this the
+ * composer looks finished while work is still going on.
+ */
+export function BackgroundWorkIndicator({
+  sessionId
+}: {
+  sessionId: string | null | undefined
+}): React.JSX.Element | null {
+  const work = useWorktreeStatusStore(
+    useCallback(
+      (state) => (sessionId ? state.backgroundWorkBySession[sessionId] : undefined),
+      [sessionId]
+    )
+  )
+
+  if (countBackgroundWork(work) === 0 || !work) return null
+
+  return (
+    <span
+      className="text-[10px] whitespace-nowrap text-muted-foreground/70"
+      data-testid="background-work-indicator"
+    >
+      {label(work)}
+    </span>
+  )
+}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -45,6 +45,7 @@ import { ScrollToBottomFab } from './ScrollToBottomFab'
 import { PlanReadyImplementFab } from './PlanReadyImplementFab'
 import { SavePlanAsFileModal } from './SavePlanAsFileModal'
 import { IndeterminateProgressBar } from './IndeterminateProgressBar'
+import { BackgroundWorkIndicator } from './BackgroundWorkIndicator'
 import { TaskListWidget } from './TaskListWidget'
 import { GoalStatusWidget } from './GoalStatusWidget'
 import { ClaudeCliSessionView } from './ClaudeCliSessionView'
@@ -57,6 +58,7 @@ import type { FlatFile } from '@/lib/file-search-utils'
 import { useSessionStore } from '@/stores/useSessionStore'
 import type { CodexThreadGoal } from '@/stores/useSessionStore'
 import {
+  countBackgroundWork,
   markNextWorkingStatusExplicit,
   useWorktreeStatusStore
 } from '@/stores/useWorktreeStatusStore'
@@ -741,6 +743,15 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
     isStreamingRef.current = isStreaming
   }, [isStreaming])
   const [isCompacting, setIsCompacting] = useState(false)
+  // Background subagents keep working after the turn's result, and their output
+  // goes to their own transcript. Without this the composer looks idle for
+  // minutes until their follow-up turn lands.
+  const backgroundWorkCount = useWorktreeStatusStore(
+    useCallback(
+      (state) => countBackgroundWork(state.backgroundWorkBySession[sessionId]),
+      [sessionId]
+    )
+  )
   const {
     runs: bashRuns,
     isRunning: isBashRunning,
@@ -6575,7 +6586,10 @@ function LegacySessionView({ sessionId }: SessionViewProps): React.JSX.Element {
                 </span>
               </div>
               <div className="flex items-center gap-1.5">
-                {isStreaming && (
+                {/* Background work outlives the turn's result, so the bar has to
+                    survive it too: it is the only thing still running. */}
+                <BackgroundWorkIndicator sessionId={sessionId} />
+                {(isStreaming || backgroundWorkCount > 0) && (
                   <IndeterminateProgressBar
                     mode={mode}
                     isAsking={!!activeQuestion}

--- a/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
+++ b/src/renderer/src/hooks/useOpenCodeGlobalListener.ts
@@ -5,7 +5,8 @@ import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useGitStore } from '@/stores/useGitStore'
 import {
   markNextWorkingStatusExplicit,
-  useWorktreeStatusStore
+  useWorktreeStatusStore,
+  type SessionBackgroundWork
 } from '@/stores/useWorktreeStatusStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useQuestionStore } from '@/stores/useQuestionStore'
@@ -330,6 +331,19 @@ export function useOpenCodeGlobalListener(): void {
 
       if (event.type === 'session.rate_limit') {
         useUsageStore.getState().setAnthropicRateLimit(event.data as AnthropicRateLimitInfo)
+        return
+      }
+
+      // Live background work of a Claude SDK session. Same counts the claude-cli
+      // path publishes, so the same store entry and badges cover both. The event
+      // carries the full set, so it also reports the drop back to zero.
+      if (event.type === 'session.background_work') {
+        const data = event.data as Partial<SessionBackgroundWork> | undefined
+        useWorktreeStatusStore.getState().setSessionBackgroundWork(sessionId, {
+          runningShells: data?.runningShells ?? 0,
+          runningMonitors: data?.runningMonitors ?? 0,
+          runningSubagents: data?.runningSubagents ?? 0
+        })
         return
       }
 

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -60,8 +60,9 @@ export interface SessionBackgroundWork {
 interface WorktreeStatusState {
   // sessionId → status info (null means no status / cleared)
   sessionStatuses: Record<string, SessionStatusEntry | null>
-  // sessionId → live background shell/monitor counts (claude-cli only; entries
-  // are dropped when both counts reach zero)
+  // sessionId → live background subagent/shell/monitor counts, reported by both
+  // the claude-cli hook path and the Claude SDK path (entries are dropped when
+  // all counts reach zero)
   backgroundWorkBySession: Record<string, SessionBackgroundWork>
   // worktreeId → epoch ms of last message activity
   lastMessageTimeByWorktree: Record<string, number>
@@ -491,6 +492,16 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
     return worktreeId in get().reviewSessionByWorktree
   }
 }))
+
+/**
+ * Total live background work (subagents, shells, monitors). Activity indicators
+ * that must outlive a turn's result read this, since background work keeps
+ * going after it.
+ */
+export function countBackgroundWork(work: SessionBackgroundWork | undefined): number {
+  if (!work) return 0
+  return work.runningSubagents + work.runningShells + work.runningMonitors
+}
 
 declare global {
   interface Window {

--- a/test/phase-21/session-4/claude-prompt-stdin.test.ts
+++ b/test/phase-21/session-4/claude-prompt-stdin.test.ts
@@ -262,6 +262,41 @@ describe('ClaudeCodeImplementer – prompt stdin lifetime', () => {
     second.endStream()
   })
 
+  it('starts the new prompt even when the retired turn refuses to tear down', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const first = createOpenQueryIterator()
+    mockQuery.mockReturnValue(first.iterator)
+
+    await impl.prompt('/proj', sessionId, 'launch a background agent')
+    first.emit(backgroundTasks('task-1'))
+    first.emit(result())
+    await vi.waitFor(() => {
+      expect((impl as any).getSession('/proj', 'sdk-1')?.liveBackgroundTasks.size).toBe(1)
+    })
+
+    // A wedged child process must not stop the replacement prompt from being
+    // dispatched, the same reason the stop path bounds every teardown step.
+    const session = (impl as any).getSession('/proj', 'sdk-1')
+    session.subscription = { abort: vi.fn(() => new Promise(() => {})), awaitDone: vi.fn() }
+
+    const second = createOpenQueryIterator()
+    mockQuery.mockReturnValue(second.iterator)
+
+    vi.useFakeTimers()
+    try {
+      const pending = impl.prompt('/proj', 'sdk-1', 'a new prompt while it runs')
+      await vi.advanceTimersByTimeAsync(10_000)
+      await expect(pending).resolves.toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(mockQuery).toHaveBeenCalledTimes(2)
+
+    first.endStream()
+    second.endStream()
+  })
+
   it('reports live background work to the renderer, split by kind', async () => {
     const { sessionId } = await impl.connect('/proj', 'hive-1')
     const stream = createOpenQueryIterator()

--- a/test/phase-21/session-4/claude-prompt-stdin.test.ts
+++ b/test/phase-21/session-4/claude-prompt-stdin.test.ts
@@ -190,6 +190,78 @@ describe('ClaudeCodeImplementer – prompt stdin lifetime', () => {
     stream.endStream()
   })
 
+  it('reports background work as gone when the turn is torn down with work still live', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const stream = createOpenQueryIterator()
+    mockQuery.mockReturnValue(stream.iterator)
+
+    await impl.prompt('/proj', sessionId, 'launch a background agent')
+    readPromptInput()
+
+    stream.emit(backgroundTasks('task-1'))
+    await vi.waitFor(() => {
+      expect((impl as any).getSession('/proj', 'sdk-1')?.liveBackgroundTasks.size).toBe(1)
+    })
+
+    // Stop kills the CLI process, so nothing it reported is running any more.
+    // Without a terminal zero the renderer keeps the indicator and the kanban
+    // badges forever: the store only drops the entry on all-zero counts.
+    await impl.abort('/proj', 'sdk-1')
+
+    const last = publishedEvents()
+      .filter((e) => e.type === 'session.background_work')
+      .pop()
+    expect(last.data).toEqual({
+      runningSubagents: 0,
+      runningShells: 0,
+      runningMonitors: 0
+    })
+    expect((impl as any).getSession('/proj', 'sdk-1')?.liveBackgroundTasks.size).toBe(0)
+
+    stream.endStream()
+  })
+
+  it('does not let a retired turn report idle over the prompt that replaced it', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const first = createOpenQueryIterator()
+    mockQuery.mockReturnValue(first.iterator)
+
+    await impl.prompt('/proj', sessionId, 'launch a background agent')
+    first.emit(backgroundTasks('task-1'))
+    first.emit(result())
+    await vi.waitFor(() => {
+      expect((impl as any).getSession('/proj', 'sdk-1')?.liveBackgroundTasks.size).toBe(1)
+    })
+
+    // Ownership has to change hands before the old stream is torn down. If it
+    // does not, the retired finisher wakes from the interrupt still owning the
+    // session and reports idle over the turn that is starting. Record what the
+    // session held at the moment of teardown, which is when the finisher wakes.
+    const session = (impl as any).getSession('/proj', 'sdk-1')
+    const retiredController = session.abortController
+    let stillOwnedAtTeardown: boolean | null = null
+    first.iterator.return = vi.fn(async () => {
+      stillOwnedAtTeardown = session.abortController === retiredController
+      return { done: true, value: undefined }
+    })
+
+    const second = createOpenQueryIterator()
+    mockQuery.mockReturnValue(second.iterator)
+    await impl.prompt('/proj', 'sdk-1', 'a new prompt while it runs')
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    expect(stillOwnedAtTeardown).toBe(false)
+    expect(retiredController.signal.aborted).toBe(true)
+
+    const statuses = publishedEvents()
+      .filter((e) => e.type === 'session.status')
+      .map((e) => e.statusPayload?.type)
+    expect(statuses[statuses.length - 1]).toBe('busy')
+
+    first.endStream()
+    second.endStream()
+  })
+
   it('reports live background work to the renderer, split by kind', async () => {
     const { sessionId } = await impl.connect('/proj', 'hive-1')
     const stream = createOpenQueryIterator()

--- a/test/phase-21/session-4/claude-prompt-stdin.test.ts
+++ b/test/phase-21/session-4/claude-prompt-stdin.test.ts
@@ -1,0 +1,277 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn()
+}))
+vi.mock('../../../src/main/services/claude-sdk-loader', () => ({
+  loadClaudeSDK: vi.fn().mockResolvedValue({ query: mockQuery })
+}))
+
+vi.mock('../../../src/main/services/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+vi.mock('../../../src/main/services/agent-event-bus', () => ({
+  agentEventBus: { publish: vi.fn() }
+}))
+
+vi.mock('../../../src/main/desktop/backend-event-publisher', () => ({
+  publishDesktopBackendEvent: vi.fn()
+}))
+
+import { ClaudeCodeImplementer } from '../../../src/main/services/claude-code-implementer'
+import { agentEventBus } from '../../../src/main/services/agent-event-bus'
+
+/**
+ * Query stub whose output stream stays open until endStream() is called, so a
+ * test can keep feeding messages after a `result` the way the CLI does while
+ * background subagents are still running.
+ */
+function createOpenQueryIterator() {
+  const pending: Array<Record<string, unknown>> = []
+  let deliver: (() => void) | null = null
+  let ended = false
+
+  const iterator = {
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn(),
+    async next(): Promise<IteratorResult<Record<string, unknown>>> {
+      while (pending.length === 0 && !ended) {
+        await new Promise<void>((resolve) => {
+          deliver = resolve
+        })
+      }
+      if (pending.length > 0) return { done: false, value: pending.shift()! }
+      return { done: true, value: undefined }
+    },
+    return: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+    [Symbol.asyncIterator]() {
+      return iterator
+    }
+  }
+
+  return {
+    iterator,
+    emit(message: Record<string, unknown>) {
+      pending.push(message)
+      deliver?.()
+      deliver = null
+    },
+    endStream() {
+      ended = true
+      deliver?.()
+      deliver = null
+    }
+  }
+}
+
+/** Reads the prompt AsyncIterable the implementer handed to sdk.query(). */
+function readPromptInput() {
+  const prompt = mockQuery.mock.calls[0][0].prompt as AsyncIterable<Record<string, unknown>>
+  const iterator = prompt[Symbol.asyncIterator]()
+  let closed = false
+  const first = iterator.next()
+  const drained = first
+    .then(() => iterator.next())
+    .then(() => {
+      closed = true
+    })
+  return { first, isClosed: () => closed, drained }
+}
+
+const backgroundTasks = (...ids: string[]) => ({
+  type: 'system',
+  subtype: 'background_tasks_changed',
+  session_id: 'sdk-1',
+  tasks: ids.map((id) => ({ task_id: id }))
+})
+
+const result = () => ({ type: 'result', subtype: 'success', session_id: 'sdk-1', result: 'done' })
+
+/** The CLI announcing a follow-up turn it queued while the last one ran. */
+const followUpTurn = () => ({ type: 'system', subtype: 'init', session_id: 'sdk-1', tools: [] })
+
+/** stdin closes a moment after the result, so give the grace period room. */
+const expectClosed = (input: { isClosed: () => boolean }) =>
+  vi.waitFor(() => expect(input.isClosed()).toBe(true), { timeout: 5000, interval: 25 })
+
+const publishedEvents = (): Array<Record<string, any>> =>
+  (agentEventBus.publish as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0])
+
+describe('ClaudeCodeImplementer – prompt stdin lifetime', () => {
+  let impl: ClaudeCodeImplementer
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    impl = new ClaudeCodeImplementer()
+  })
+
+  it('sends the prompt as an AsyncIterable, never as a plain string', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const stream = createOpenQueryIterator()
+    mockQuery.mockReturnValue(stream.iterator)
+
+    await impl.prompt('/proj', sessionId, 'hello there')
+
+    const prompt = mockQuery.mock.calls[0][0].prompt
+    expect(typeof prompt).not.toBe('string')
+
+    const { first } = readPromptInput()
+    expect((await first).value).toMatchObject({
+      type: 'user',
+      parent_tool_use_id: null,
+      message: { role: 'user', content: [{ type: 'text', text: 'hello there' }] }
+    })
+
+    stream.endStream()
+  })
+
+  it('closes stdin on a result that leaves no background work', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const stream = createOpenQueryIterator()
+    mockQuery.mockReturnValue(stream.iterator)
+
+    await impl.prompt('/proj', sessionId, 'hi')
+    const input = readPromptInput()
+
+    stream.emit(result())
+    await expectClosed(input)
+
+    stream.endStream()
+  })
+
+  it('keeps stdin open when the CLI starts a follow-up turn after the result', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const stream = createOpenQueryIterator()
+    mockQuery.mockReturnValue(stream.iterator)
+
+    await impl.prompt('/proj', sessionId, 'hi')
+    const input = readPromptInput()
+
+    // A background task finished mid-turn, so the set is already empty here.
+    stream.emit(result())
+    stream.emit(followUpTurn())
+
+    await new Promise((resolve) => setTimeout(resolve, 2500))
+    expect(input.isClosed()).toBe(false)
+
+    stream.emit(result())
+    await expectClosed(input)
+
+    stream.endStream()
+  })
+
+  it('keeps stdin open while background work runs, and closes on the result after it ends', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const stream = createOpenQueryIterator()
+    mockQuery.mockReturnValue(stream.iterator)
+
+    await impl.prompt('/proj', sessionId, 'launch a background agent')
+    const input = readPromptInput()
+
+    stream.emit(backgroundTasks('task-1'))
+    stream.emit(result())
+    await vi.waitFor(() => {
+      expect((impl as any).getSession('/proj', 'sdk-1')?.liveBackgroundTasks.size).toBe(1)
+    })
+    expect(input.isClosed()).toBe(false)
+
+    // The background agent finishes and wakes the CLI for one more turn.
+    stream.emit(backgroundTasks())
+    stream.emit(result())
+    await expectClosed(input)
+
+    stream.endStream()
+  })
+
+  it('reports live background work to the renderer, split by kind', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const stream = createOpenQueryIterator()
+    mockQuery.mockReturnValue(stream.iterator)
+
+    await impl.prompt('/proj', sessionId, 'launch a background agent')
+    const input = readPromptInput()
+
+    stream.emit({
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      session_id: 'sdk-1',
+      tasks: [
+        { task_id: 'agent-1', task_type: 'local_agent' },
+        { task_id: 'shell-1', task_type: 'local_bash' }
+      ]
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        publishedEvents().find((event) => event.type === 'session.background_work')
+      ).toBeDefined()
+    })
+
+    const event = publishedEvents().find((e) => e.type === 'session.background_work')!
+    expect(event.sessionId).toBe('hive-1')
+    expect(event.data).toEqual({
+      runningSubagents: 1,
+      runningShells: 1,
+      runningMonitors: 0
+    })
+
+    // Draining reports zeros, which is what clears the renderer's indicator.
+    stream.emit(backgroundTasks())
+    await vi.waitFor(() => {
+      const all = publishedEvents().filter((e) => e.type === 'session.background_work')
+      expect(all[all.length - 1].data).toEqual({
+        runningSubagents: 0,
+        runningShells: 0,
+        runningMonitors: 0
+      })
+    })
+
+    stream.emit(result())
+    await expectClosed(input)
+    stream.endStream()
+  })
+
+  it('stays silent for CLI builds that never report background work', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const stream = createOpenQueryIterator()
+    mockQuery.mockReturnValue(stream.iterator)
+
+    await impl.prompt('/proj', sessionId, 'hi')
+    const input = readPromptInput()
+
+    stream.emit(result())
+    await expectClosed(input)
+
+    expect(publishedEvents().some((e) => e.type === 'session.background_work')).toBe(false)
+
+    stream.endStream()
+  })
+
+  it('closes stdin when the session is aborted mid background work', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const stream = createOpenQueryIterator()
+    mockQuery.mockReturnValue(stream.iterator)
+
+    await impl.prompt('/proj', sessionId, 'hi')
+    const input = readPromptInput()
+
+    stream.emit(backgroundTasks('task-1'))
+    stream.emit(result())
+    await vi.waitFor(() => {
+      expect((impl as any).getSession('/proj', 'sdk-1')?.liveBackgroundTasks.size).toBe(1)
+    })
+    expect(input.isClosed()).toBe(false)
+
+    await impl.abort('/proj', 'sdk-1')
+    await expectClosed(input)
+
+    stream.endStream()
+  })
+})

--- a/test/phase-21/session-4/claude-prompt-stdin.test.ts
+++ b/test/phase-21/session-4/claude-prompt-stdin.test.ts
@@ -262,6 +262,44 @@ describe('ClaudeCodeImplementer – prompt stdin lifetime', () => {
     second.endStream()
   })
 
+  it('holds stdin open past the silence watchdog while a request waits on the user', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const stream = createOpenQueryIterator()
+    mockQuery.mockReturnValue(stream.iterator)
+
+    await impl.prompt('/proj', sessionId, 'launch a background agent')
+    const input = readPromptInput()
+
+    // Fake timers have to be installed before the watchdog is armed, or it is
+    // left on a real timer that fake time never reaches.
+    vi.useFakeTimers()
+    try {
+      stream.emit(backgroundTasks('task-1'))
+      stream.emit(result())
+      await vi.advanceTimersByTimeAsync(10)
+
+      const session = (impl as any).getSession('/proj', 'sdk-1')
+      expect(session.backgroundWorkWatchdog).toBeTruthy()
+
+      // The CLI is silent because it is waiting for an answer, not because it
+      // is wedged, and with a window attached that wait may last hours.
+      // Closing stdin here would break the very request being waited on.
+      session.pendingQuestion = { requestId: 'q-1', questions: [], resolve: vi.fn() }
+      await vi.advanceTimersByTimeAsync(45 * 60_000)
+      expect(input.isClosed()).toBe(false)
+      expect(session.backgroundWorkWatchdog).toBeTruthy()
+
+      // Once it is answered, the watchdog is free to end a silent turn again.
+      session.pendingQuestion = null
+      await vi.advanceTimersByTimeAsync(45 * 60_000)
+      expect(input.isClosed()).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    stream.endStream()
+  })
+
   it('retires the previous turn in the same order the stop path uses', async () => {
     const { sessionId } = await impl.connect('/proj', 'hive-1')
     const first = createOpenQueryIterator()

--- a/test/phase-21/session-4/claude-prompt-stdin.test.ts
+++ b/test/phase-21/session-4/claude-prompt-stdin.test.ts
@@ -262,6 +262,53 @@ describe('ClaudeCodeImplementer – prompt stdin lifetime', () => {
     second.endStream()
   })
 
+  it('retires the previous turn in the same order the stop path uses', async () => {
+    const { sessionId } = await impl.connect('/proj', 'hive-1')
+    const first = createOpenQueryIterator()
+    mockQuery.mockReturnValue(first.iterator)
+
+    await impl.prompt('/proj', sessionId, 'launch a background agent')
+    first.emit(backgroundTasks('task-1'))
+    first.emit(result())
+    await vi.waitFor(() => {
+      expect((impl as any).getSession('/proj', 'sdk-1')?.liveBackgroundTasks.size).toBe(1)
+    })
+
+    // Mirrors test/claude-code-abort-ordering.test.ts. The deny has to land
+    // while the stream is still up, or the CLI reports the reply as
+    // "Tool permission request failed: AbortError: Stream closed".
+    const order: string[] = []
+    const session = (impl as any).getSession('/proj', 'sdk-1')
+    session.pendingQuestion = {
+      requestId: 'q-1',
+      questions: [],
+      resolve: () => order.push('question-rejected')
+    }
+    session.abortController.signal.addEventListener('abort', () => order.push('controller-abort'))
+    session.subscription = {
+      abort: vi.fn(async () => {
+        order.push('subscription-abort')
+      }),
+      awaitDone: vi.fn()
+    }
+    session.query = {
+      close: vi.fn(() => order.push('query-close')),
+      interrupt: vi.fn()
+    }
+
+    mockQuery.mockReturnValue(createOpenQueryIterator().iterator)
+    await impl.prompt('/proj', 'sdk-1', 'a new prompt while it runs')
+
+    expect(order).toEqual([
+      'question-rejected',
+      'controller-abort',
+      'subscription-abort',
+      'query-close'
+    ])
+
+    first.endStream()
+  })
+
   it('starts the new prompt even when the retired turn refuses to tear down', async () => {
     const { sessionId } = await impl.connect('/proj', 'hive-1')
     const first = createOpenQueryIterator()


### PR DESCRIPTION
## Description

Background subagents lost the permission channel partway through a turn. Every `Edit`, `Write` or `Bash` call needing a live decision failed with `Tool permission request failed: AbortError: Stream closed`, while `Read` and allow-listed commands kept working, which made it look random. In one recorded session, 102 of 560 tool calls failed and 3 of 6 parallel edit agents wrote nothing.

Cause chain: Hive passed a plain string as `prompt` to `sdk.query()`. The SDK treats a string as a single-turn query and closes stdin on the first `result`. The CLI then sets `inputClosed = true`, and since the permission channel runs over stdin, every later request throws immediately. Background subagents outlive the result, so they kept running against a channel that could only throw. This never happened in the interactive CLI or the VS Code extension because those are TTY sessions with no stream-json control protocol on stdin.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX improvement

## Changes Made

- The prompt is now always an AsyncIterable that yields the user message and then parks, so stdin stays open past the result. An iterable that simply ends is not enough: the SDK closes stdin as soon as it is exhausted.
- stdin closes on a `result` that leaves no live background work and is followed by 1.5s of quiet. The CLI reports its full live task set on every change (`background_tasks_changed`, replace semantics), so a lost message cannot wedge the count. The quiet period exists because the CLI starts a follow-up turn on its own when a background task finished mid-turn, and it announces that within tens of milliseconds.
- A permission request also calls off a pending close, since the answer travels back over that same stdin.
- A 10-minute silence watchdog closes stdin anyway if background work never reports done, so a lost report cannot keep a session busy forever.
- Headless runs no longer block forever on `AskUserQuestion`, `ExitPlanMode` and command approvals. Headless still serves the web UI, so requests are not denied outright, they are time-boxed to 5 minutes and then denied with a message the agent can act on, plus a logged error.
- A new prompt retires a turn that is still holding the session, and the finisher checks it still owns the session before clearing status or the query handle.
- UI: live background work is published as `session.background_work` and written to the existing `backgroundWorkBySession` store, the same one the claude-cli hook path fills. The composer's progress bar now survives the result while work is running, and a small label says what is running ("3 subagents, 1 background shell running"), using the same wording as the kanban card badges. As a side effect the kanban background-work badges now light up for SDK sessions too.
- CLI builds that never send `background_tasks_changed` keep the previous behaviour exactly: the live set stays empty, so stdin closes on the result and no event is published.

## Testing

### Test Configuration

- **OS**: macOS
- **Test Type**: Unit + manual

### Test Steps

1. Ask a session to launch background subagents that edit files, and let the turn's result arrive while they keep working.
2. Watch that their `Edit`/`Write`/`Bash` calls still get permission decisions after the result.
3. Watch the composer keep showing activity, with the running count, until the follow-up turn lands.
4. Send a new prompt while background work runs, and press stop mid-work, to check the session still shuts down cleanly.

### Test Results

- [x] All existing tests pass (no new failures against the same base; the repo's pre-existing failures are unchanged)
- [x] New tests added
- [x] Manual testing completed

Verified against claude CLI 2.1.232 by reproducing the exact failure shape: a background task finishing mid-turn, its notification queued, and the follow-up turn needing a `Write`. With the old timing the permission request never arrives and the file is not written. With the fix the request arrives with stdin open, the file is written, and stdin closes after that turn's result. Confirmed again in normal use over several days: a result arriving with a live subagent keeps stdin open, and the subagent reports back two minutes later with no failures.

New tests: `claude-prompt-stdin.test.ts` covers the iterable prompt, closing on a clean result, staying open during background work, staying open when the CLI starts a follow-up turn, closing on abort, the published counts, and silence for CLIs that never report. `BackgroundWorkIndicator.test.tsx` covers the label wording, the empty states, and the count that keeps the bar alive.

## Checklist

- [x] My code follows the project's code style
- [x] I have run `pnpm lint` and fixed any issues (remaining errors are pre-existing and in untouched files)
- [x] I have run `pnpm format` to format my code
- [x] I have run `pnpm test` and all tests pass (no new failures against the same base)
- [x] I have added tests that prove my fix works
- [x] I have added comments to complex code sections
- [x] I have tested on macOS (required)

## Performance Impact

- [x] May affect performance (please explain)

The CLI process and the session's busy state now linger about 1.5s past the last result, which is the price of telling "done" apart from "about to continue". While background subagents run, the session stays busy instead of going idle at the result, which is the accurate state.

## Breaking Changes

- [x] No breaking changes

## Additional Notes

Deliberately out of scope: `pendingQuestion` and `pendingPlanApproval` are still single slots per session, so two agents asking at once orphans the first. The SDK passes `agentID` into `canUseTool` and Hive still ignores it, so subagent approvals cannot be attributed in the UI yet. Keeping one long-lived query per session instead of one per turn is the natural follow-up, and it would remove the close heuristic entirely.