### PR TITLE
feat: show an active file indicator in the sidebar file lists

### DIFF
--- a/src/main/effect/git/layers.ts
+++ b/src/main/effect/git/layers.ts
@@ -16,12 +16,10 @@ import { classifyGitError } from './classifier'
 import { GitUnknown, type GitError } from './errors'
 import { Git } from './service'
 import type { BreedType, GitBranchDiffFile, GitDiffStatFile, GitFileStatus } from './types'
+import { normalizeBranchDisplayName } from '@shared/git-output'
 
 const execFileAsync = promisify(execFile)
 type GitOperation = 'merge' | 'rebase' | 'cherry-pick' | 'apply'
-
-const normalizeBranchDisplayName = (branchName: string): string =>
-  branchName.startsWith('remotes/') ? branchName.replace(/^remotes\//, '') : branchName
 
 export const resolveGitWorktreesDir = (
   projectName: string,

--- a/src/main/services/__tests__/project-ops.validate-path.test.ts
+++ b/src/main/services/__tests__/project-ops.validate-path.test.ts
@@ -36,6 +36,15 @@ describe('validateProject path canonicalization', () => {
     expect(validateProject(join(base, 'link')).path).toBe(join(base, 'repo'))
   })
 
+  it('keeps the name the user picked when adding through a symlink', () => {
+    // /projects/customer-app -> /repos/monorepo should stay "customer-app".
+    symlinkSync(join(base, 'repo'), join(base, 'customer-app'))
+    const result = validateProject(join(base, 'customer-app'))
+
+    expect(result.name).toBe('customer-app')
+    expect(result.path).toBe(join(base, 'repo'))
+  })
+
   it('rejects a path whose ".." crosses a symlink, rather than storing a guess', () => {
     // Built by hand because path.join would collapse the ".." before the filesystem
     // sees it. On macOS realpath resolves such a path lexically and reports ENOENT,
@@ -45,6 +54,16 @@ describe('validateProject path canonicalization', () => {
     mkdirSync(join(base, 'repo', 'sibling', '.git'), { recursive: true })
 
     expect(validateProject(`${base}/inner/link/../repo/sibling`).success).toBe(false)
+  })
+
+  it('rejects rather than accepting a different repo the lexical path happens to hit', () => {
+    // inner/link points at repo, so the filesystem reads link/.. as base. Resolving
+    // it lexically instead lands on base/inner, and if a repo sits there the old
+    // fallback would have stored that unrelated repository.
+    mkdirSync(join(base, 'inner', 'decoy', '.git'), { recursive: true })
+    symlinkSync(join(base, 'repo'), join(base, 'inner', 'link'))
+
+    expect(validateProject(`${base}/inner/link/../decoy`).success).toBe(false)
   })
 
   it('leaves an already canonical path alone', () => {

--- a/src/main/services/__tests__/project-ops.validate-path.test.ts
+++ b/src/main/services/__tests__/project-ops.validate-path.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, realpathSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { validateProject } from '../project-ops'
+
+// A project path is stored as given, and everything downstream joins onto it with
+// path.join, so it has to come out of validation canonical.
+describe('validateProject path canonicalization', () => {
+  let base: string
+
+  beforeEach(() => {
+    base = realpathSync(mkdtempSync(join(tmpdir(), 'hive-validate-')))
+    mkdirSync(join(base, 'repo', '.git'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  it('drops dot segments', () => {
+    const result = validateProject(join(base, 'repo', '..', 'repo'))
+    expect(result.success).toBe(true)
+    expect(result.path).toBe(join(base, 'repo'))
+    expect(result.name).toBe('repo')
+  })
+
+  it('drops a trailing separator and repeated separators', () => {
+    expect(validateProject(join(base, 'repo') + '/').path).toBe(join(base, 'repo'))
+    expect(validateProject(base + '//repo').path).toBe(join(base, 'repo'))
+  })
+
+  it('resolves a symlinked path to the real directory', () => {
+    symlinkSync(join(base, 'repo'), join(base, 'link'))
+    expect(validateProject(join(base, 'link')).path).toBe(join(base, 'repo'))
+  })
+
+  it('rejects a path whose ".." crosses a symlink, rather than storing a guess', () => {
+    // Built by hand because path.join would collapse the ".." before the filesystem
+    // sees it. On macOS realpath resolves such a path lexically and reports ENOENT,
+    // even though opening it works, so there is no canonical answer to store.
+    mkdirSync(join(base, 'inner'))
+    symlinkSync(join(base, 'repo'), join(base, 'inner', 'link'))
+    mkdirSync(join(base, 'repo', 'sibling', '.git'), { recursive: true })
+
+    expect(validateProject(`${base}/inner/link/../repo/sibling`).success).toBe(false)
+  })
+
+  it('leaves an already canonical path alone', () => {
+    expect(validateProject(join(base, 'repo')).path).toBe(join(base, 'repo'))
+  })
+
+  it('still rejects a directory that is not a git repository', () => {
+    mkdirSync(join(base, 'plain'))
+    expect(validateProject(join(base, 'plain')).success).toBe(false)
+  })
+})

--- a/src/main/services/git-service.ts
+++ b/src/main/services/git-service.ts
@@ -450,13 +450,6 @@ export class GitService {
 }
 
 /**
- * Remove git's remote branch prefix for UI display.
- */
-export function normalizeBranchDisplayName(branchName: string): string {
-  return branchName.startsWith('remotes/') ? branchName.replace(/^remotes\//, '') : branchName
-}
-
-/**
  * Convert a session title into a safe git branch name.
  */
 export function canonicalizeBranchName(title: string): string {
@@ -474,6 +467,7 @@ export function canonicalizeBranchName(title: string): string {
 
 // Re-export from shared so backend callers can still import from git-service
 export { canonicalizeTicketTitle } from '@shared/types/branch-utils'
+export { normalizeBranchDisplayName, parseWorktreeForBranch } from '@shared/git-output'
 
 /**
  * Check if a branch name is an auto-generated name (breed or legacy city name).
@@ -565,31 +559,6 @@ export async function autoRenameWorktreeBranch(
     db.updateWorktree(worktreeId, { branch_renamed: 1 })
     return { renamed: false, error: renameResult.error }
   }
-}
-
-/**
- * Parse `git worktree list --porcelain` output to find the worktree path
- * for a given branch name.
- *
- * Porcelain format:
- *   worktree /path/to/worktree
- *   HEAD abc123
- *   branch refs/heads/main
- *   (blank line)
- */
-export function parseWorktreeForBranch(porcelainOutput: string, branchName: string): string | null {
-  const blocks = porcelainOutput.trim().split('\n\n')
-  for (const block of blocks) {
-    const lines = block.split('\n')
-    let path = ''
-    let branch = ''
-    for (const line of lines) {
-      if (line.startsWith('worktree ')) path = line.slice('worktree '.length)
-      if (line.startsWith('branch refs/heads/')) branch = line.slice('branch refs/heads/'.length)
-    }
-    if (branch === branchName && path) return path
-  }
-  return null
 }
 
 /**

--- a/src/main/services/project-ops.ts
+++ b/src/main/services/project-ops.ts
@@ -5,9 +5,10 @@ import {
   writeFileSync,
   mkdirSync,
   unlinkSync,
-  readdirSync
+  readdirSync,
+  realpathSync
 } from 'fs'
-import { join, basename, extname } from 'path'
+import { join, basename, extname, resolve } from 'path'
 import { createLogger } from './logger'
 import { getDatabase } from '../db'
 import type { DatabaseService } from '../db/database'
@@ -84,14 +85,19 @@ export function validateProject(path: string): {
   name?: string
   error?: string
 } {
-  if (!isValidDirectory(path)) {
+  // Canonicalize first, then check. The checks join onto the path, and joining
+  // resolves dot segments lexically, which picks the wrong directory when a ".."
+  // follows a symlink.
+  const canonical = canonicalProjectPath(path)
+
+  if (!isValidDirectory(canonical)) {
     return {
       success: false,
       error: 'The selected path is not a valid directory.'
     }
   }
 
-  if (!isGitRepository(path)) {
+  if (!isGitRepository(canonical)) {
     return {
       success: false,
       error:
@@ -101,8 +107,28 @@ export function validateProject(path: string): {
 
   return {
     success: true,
-    path: path,
-    name: basename(path)
+    path: canonical,
+    name: basename(canonical)
+  }
+}
+
+/**
+ * The stored path has to be canonical, because everything downstream joins onto it
+ * with path.join, which drops dot segments and repeated separators. A raw path like
+ * /repo/../repo would then no longer match the paths built from it.
+ *
+ * realpath rather than resolve, because it follows symlinks the way the filesystem
+ * does: for /link/../other the kernel resolves the link first, so the lexical answer
+ * would point at a different directory.
+ */
+function canonicalProjectPath(path: string): string {
+  try {
+    return realpathSync(path)
+  } catch {
+    // realpath can fail where opening the path works, for instance on macOS when a
+    // ".." follows a symlink. Fall back to the lexical form, which the checks below
+    // then reject, so a wrong path never reaches the database.
+    return resolve(path)
   }
 }
 

--- a/src/main/services/project-ops.ts
+++ b/src/main/services/project-ops.ts
@@ -1,6 +1,6 @@
 import { app } from 'electron'
-import { existsSync, writeFileSync, mkdirSync, unlinkSync, readdirSync, realpathSync } from 'fs'
-import { join, basename, extname, resolve } from 'path'
+import { existsSync, writeFileSync, mkdirSync, unlinkSync, readdirSync } from 'fs'
+import { join, basename, extname } from 'path'
 import { createLogger } from './logger'
 import { getDatabase } from '../db'
 import type { DatabaseService } from '../db/database'
@@ -10,7 +10,7 @@ import {
   getProjectIconDataUrl,
   removeProjectIcon
 } from './project-icons'
-import { isValidDirectory, isGitRepository } from '../../shared/fs-path-checks'
+import { isValidDirectory, isGitRepository, canonicalPath } from '../../shared/fs-path-checks'
 
 export {
   detectProjectLanguage,
@@ -56,10 +56,12 @@ export function validateProject(path: string): {
   name?: string
   error?: string
 } {
-  // Canonicalize first, then check. The checks join onto the path, and joining
-  // resolves dot segments lexically, which picks the wrong directory when a ".."
-  // follows a symlink.
-  const canonical = canonicalProjectPath(path)
+  // Canonicalize first, then check. Everything downstream joins onto the stored path
+  // with path.join, which drops dot segments and repeated separators, so a raw path
+  // like /repo/../repo would stop matching the paths built from it. Checking after
+  // canonicalizing also means a path realpath could not resolve gets rejected here,
+  // rather than reaching the database.
+  const canonical = canonicalPath(path)
 
   if (!isValidDirectory(canonical)) {
     return {
@@ -80,26 +82,6 @@ export function validateProject(path: string): {
     success: true,
     path: canonical,
     name: basename(canonical)
-  }
-}
-
-/**
- * The stored path has to be canonical, because everything downstream joins onto it
- * with path.join, which drops dot segments and repeated separators. A raw path like
- * /repo/../repo would then no longer match the paths built from it.
- *
- * realpath rather than resolve, because it follows symlinks the way the filesystem
- * does: for /link/../other the kernel resolves the link first, so the lexical answer
- * would point at a different directory.
- */
-function canonicalProjectPath(path: string): string {
-  try {
-    return realpathSync(path)
-  } catch {
-    // realpath can fail where opening the path works, for instance on macOS when a
-    // ".." follows a symlink. Fall back to the lexical form, which the checks below
-    // then reject, so a wrong path never reaches the database.
-    return resolve(path)
   }
 }
 

--- a/src/main/services/project-ops.ts
+++ b/src/main/services/project-ops.ts
@@ -10,7 +10,7 @@ import {
   getProjectIconDataUrl,
   removeProjectIcon
 } from './project-icons'
-import { isValidDirectory, isGitRepository, canonicalPath } from '../../shared/fs-path-checks'
+import { isValidDirectory, isGitRepository, tryCanonicalPath } from '../../shared/fs-path-checks'
 
 export {
   detectProjectLanguage,
@@ -56,14 +56,23 @@ export function validateProject(path: string): {
   name?: string
   error?: string
 } {
-  // Canonicalize first, then check. Everything downstream joins onto the stored path
-  // with path.join, which drops dot segments and repeated separators, so a raw path
-  // like /repo/../repo would stop matching the paths built from it. Checking after
-  // canonicalizing also means a path realpath could not resolve gets rejected here,
-  // rather than reaching the database.
-  const canonical = canonicalPath(path)
+  // Check the path as given first. realpath resolves ".." lexically on macOS, so for
+  // a path whose ".." crosses a symlink it can hand back a directory the filesystem
+  // would never open, and storing that would point the project at another repository.
+  // The filesystem's own answer for the original path is the thing to trust.
+  if (!isValidDirectory(path)) {
+    return {
+      success: false,
+      error: 'The selected path is not a valid directory.'
+    }
+  }
 
-  if (!isValidDirectory(canonical)) {
+  // Then canonicalize, because everything downstream joins onto the stored path with
+  // path.join, which drops dot segments and repeated separators, so a raw path like
+  // /repo/../repo would stop matching the paths built from it.
+  const canonical = tryCanonicalPath(path)
+
+  if (!canonical || !isValidDirectory(canonical)) {
     return {
       success: false,
       error: 'The selected path is not a valid directory.'
@@ -81,7 +90,9 @@ export function validateProject(path: string): {
   return {
     success: true,
     path: canonical,
-    name: basename(canonical)
+    // Name from what the user picked, not from the canonical path. Adding a repo
+    // through a named symlink should keep that name, not the symlink's target.
+    name: basename(path) || basename(canonical)
   }
 }
 

--- a/src/main/services/project-ops.ts
+++ b/src/main/services/project-ops.ts
@@ -1,13 +1,5 @@
 import { app } from 'electron'
-import {
-  existsSync,
-  statSync,
-  writeFileSync,
-  mkdirSync,
-  unlinkSync,
-  readdirSync,
-  realpathSync
-} from 'fs'
+import { existsSync, writeFileSync, mkdirSync, unlinkSync, readdirSync, realpathSync } from 'fs'
 import { join, basename, extname, resolve } from 'path'
 import { createLogger } from './logger'
 import { getDatabase } from '../db'
@@ -18,6 +10,7 @@ import {
   getProjectIconDataUrl,
   removeProjectIcon
 } from './project-icons'
+import { isValidDirectory, isGitRepository } from '../../shared/fs-path-checks'
 
 export {
   detectProjectLanguage,
@@ -28,6 +21,7 @@ export {
 export { detectSetupSuggestions } from './setup-script-suggester'
 export { loadLanguageIcons } from './language-icons'
 export { cloneRepository, deriveProjectNameFromGitUrl, initRepository } from './git-repository'
+export { isValidDirectory, isGitRepository } from '../../shared/fs-path-checks'
 
 const log = createLogger({ component: 'ProjectOps' })
 
@@ -49,29 +43,6 @@ const iconDir = join(app.getPath('home'), '.hive', 'project-icons')
 function ensureIconDir(): void {
   if (!existsSync(iconDir)) {
     mkdirSync(iconDir, { recursive: true })
-  }
-}
-
-/**
- * Check if a directory is a git repository by looking for .git folder
- */
-export function isGitRepository(path: string): boolean {
-  try {
-    const gitPath = join(path, '.git')
-    return existsSync(gitPath) && statSync(gitPath).isDirectory()
-  } catch {
-    return false
-  }
-}
-
-/**
- * Check if a path is a valid directory
- */
-export function isValidDirectory(path: string): boolean {
-  try {
-    return existsSync(path) && statSync(path).isDirectory()
-  } catch {
-    return false
   }
 }
 

--- a/src/main/services/remote-project-ensure.ts
+++ b/src/main/services/remote-project-ensure.ts
@@ -9,10 +9,7 @@ import { execGit } from './git-exec'
 import { cloneRepository, deriveProjectNameFromGitUrl } from './git-repository'
 import { createProjectWithDefaultWorktree } from './project-ops'
 import { syncWorktreesOp } from './worktree-ops'
-
-function requireSuccess(result: { success: boolean; error?: string }, fallback: string): void {
-  if (!result.success) throw new Error(result.error || fallback)
-}
+import { requireSuccess } from '@shared/operation-result'
 
 function uniquePath(basePath: string): string {
   if (!existsSync(basePath)) return basePath

--- a/src/renderer/src/components/file-tree/BranchDiffView.tsx
+++ b/src/renderer/src/components/file-tree/BranchDiffView.tsx
@@ -1,10 +1,13 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo, memo } from 'react'
 import { RefreshCw, ChevronDown, Search, GitBranch } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useGitStore } from '@/stores/useGitStore'
-import { useFileViewerStore } from '@/stores/useFileViewerStore'
+import { useFileViewerStore, diffTabAbsolutePath } from '@/stores/useFileViewerStore'
+import { useFileTabState } from '@/hooks/useFileTabState'
 import { FileIcon } from './FileIcon'
 import { GitStatusIndicator, type GitStatusCode } from './GitStatusIndicator'
+import { OpenTabIndicator } from './OpenTabIndicator'
+import { activeTabRowClass } from './open-tab-classes'
 import { gitApi } from '@/api/git-api'
 
 interface BranchDiffViewProps {
@@ -288,30 +291,14 @@ export function BranchDiffView({ worktreePath }: BranchDiffViewProps): React.JSX
         </div>
       ) : (
         <div className="flex-1 overflow-y-auto">
-          {files.map((file) => {
-            const fileName = file.relativePath.split('/').pop() || file.relativePath
-            const ext = fileName.includes('.') ? '.' + fileName.split('.').pop() : null
-
-            return (
-              <div
-                key={file.relativePath}
-                className="flex items-center gap-1.5 px-2 py-0.5 hover:bg-accent/30 cursor-pointer"
-                onClick={() => handleFileClick(file)}
-                data-testid={`branch-diff-file-${file.relativePath}`}
-              >
-                <FileIcon
-                  name={fileName}
-                  extension={ext}
-                  isDirectory={false}
-                  className="h-3.5 w-3.5"
-                />
-                <span className="text-xs truncate flex-1" title={file.relativePath}>
-                  {file.relativePath}
-                </span>
-                <GitStatusIndicator status={toGitStatusCode(file.status)} className="mr-1" />
-              </div>
-            )
-          })}
+          {files.map((file) => (
+            <BranchDiffFileRow
+              key={file.relativePath}
+              file={file}
+              worktreePath={worktreePath}
+              onClick={handleFileClick}
+            />
+          ))}
         </div>
       )}
 
@@ -337,3 +324,41 @@ export function BranchDiffView({ worktreePath }: BranchDiffViewProps): React.JSX
     </div>
   )
 }
+
+interface BranchDiffFileRowProps {
+  file: BranchDiffFile
+  worktreePath: string
+  onClick: (file: BranchDiffFile) => void
+}
+
+// Memoized because this list is not virtualized: without it every row re-renders
+// whenever a tab opens or closes.
+const BranchDiffFileRow = memo(function BranchDiffFileRow({
+  file,
+  worktreePath,
+  onClick
+}: BranchDiffFileRowProps): React.JSX.Element {
+  const fileName = file.relativePath.split('/').pop() || file.relativePath
+  const ext = fileName.includes('.') ? '.' + fileName.split('.').pop() : null
+  const tabState = useFileTabState(
+    diffTabAbsolutePath({ worktreePath, filePath: file.relativePath })
+  )
+
+  return (
+    <div
+      className={cn(
+        'relative flex items-center gap-1.5 px-2 py-0.5 hover:bg-accent/30 cursor-pointer',
+        activeTabRowClass(tabState)
+      )}
+      onClick={() => onClick(file)}
+      data-testid={`branch-diff-file-${file.relativePath}`}
+    >
+      <OpenTabIndicator state={tabState} />
+      <FileIcon name={fileName} extension={ext} isDirectory={false} className="h-3.5 w-3.5" />
+      <span className="text-xs truncate flex-1" title={file.relativePath}>
+        {file.relativePath}
+      </span>
+      <GitStatusIndicator status={toGitStatusCode(file.status)} className="mr-1" />
+    </div>
+  )
+})

--- a/src/renderer/src/components/file-tree/ChangesView.tsx
+++ b/src/renderer/src/components/file-tree/ChangesView.tsx
@@ -35,8 +35,11 @@ import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useDiffCommentStore } from '@/stores/useDiffCommentStore'
 import { projectApi } from '@/api/project-api'
+import { useFileTabState } from '@/hooks/useFileTabState'
 import { FileIcon } from './FileIcon'
 import { GitStatusIndicator } from './GitStatusIndicator'
+import { OpenTabIndicator } from './OpenTabIndicator'
+import { activeTabRowClass } from './open-tab-classes'
 import { GitCommitForm } from '@/components/git/GitCommitForm'
 import { GitPushPull } from '@/components/git/GitPushPull'
 
@@ -924,14 +927,20 @@ const FileRow = memo(function FileRow({
   const fileName = file.relativePath.split('/').pop() || file.relativePath
   const ext = fileName.includes('.') ? '.' + fileName.split('.').pop() : null
 
+  const tabState = useFileTabState(file.path)
+
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <div
-          className="flex items-center gap-1.5 px-2 py-0.5 hover:bg-accent/30 group cursor-pointer"
+          className={cn(
+            'relative flex items-center gap-1.5 px-2 py-0.5 hover:bg-accent/30 group cursor-pointer',
+            activeTabRowClass(tabState)
+          )}
           onClick={() => onViewDiff(file)}
           data-testid={`changes-file-${file.relativePath}`}
         >
+          <OpenTabIndicator state={tabState} />
           {onStageToggle ? (
             <div className="relative h-3.5 w-3.5 flex-shrink-0">
               <FileIcon

--- a/src/renderer/src/components/file-tree/ChangesView.tsx
+++ b/src/renderer/src/components/file-tree/ChangesView.tsx
@@ -491,11 +491,11 @@ export function ChangesView({
       if (!memberWorktreePath) return
       const isNewFile = file.status === '?' || file.status === 'A'
       if (isNewFile) {
-        const fullPath = `${memberWorktreePath}/${file.relativePath}`
+        // file.path is already absolute and native, so no hand-built join here.
         const fileName = file.relativePath.split('/').pop() || file.relativePath
         const contextId = useConnectionStore.getState().selectedConnectionId
         if (contextId) {
-          useFileViewerStore.getState().openFile(fullPath, fileName, contextId)
+          useFileViewerStore.getState().openFile(file.path, fileName, contextId)
         }
       } else {
         useFileViewerStore.getState().setActiveDiff({

--- a/src/renderer/src/components/file-tree/FileSidebar.tsx
+++ b/src/renderer/src/components/file-tree/FileSidebar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { X, ChevronUp, ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { TAB_ACTIVE_SURFACE_CLASS, TAB_UNDERLINE_INSET_CLASS } from '@/lib/tab-styles'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useGitStore } from '@/stores/useGitStore'
@@ -69,7 +70,7 @@ export function FileSidebar({
           className={cn(
             'h-full px-2.5 text-[11px] font-medium rounded-none transition-colors relative',
             activeTab === 'changes'
-              ? 'text-foreground bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))]'
+              ? cn('text-foreground', TAB_ACTIVE_SURFACE_CLASS)
               : 'text-muted-foreground hover:text-foreground'
           )}
           onClick={() => setActiveTab('changes')}
@@ -81,15 +82,13 @@ export function FileSidebar({
           ) : (
             'Changes'
           )}
-          {activeTab === 'changes' && (
-            <div className="absolute bottom-0 left-2 right-2 h-0.5 bg-[color-mix(in_srgb,var(--foreground)_60%,var(--card))]" />
-          )}
+          {activeTab === 'changes' && <div className={TAB_UNDERLINE_INSET_CLASS} />}
         </button>
         <button
           className={cn(
             'h-full px-2.5 text-[11px] font-medium rounded-none transition-colors relative',
             activeTab === 'files'
-              ? 'text-foreground bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))]'
+              ? cn('text-foreground', TAB_ACTIVE_SURFACE_CLASS)
               : 'text-muted-foreground hover:text-foreground'
           )}
           onClick={() => setActiveTab('files')}
@@ -101,15 +100,13 @@ export function FileSidebar({
           ) : (
             'Files'
           )}
-          {activeTab === 'files' && (
-            <div className="absolute bottom-0 left-2 right-2 h-0.5 bg-[color-mix(in_srgb,var(--foreground)_60%,var(--card))]" />
-          )}
+          {activeTab === 'files' && <div className={TAB_UNDERLINE_INSET_CLASS} />}
         </button>
         <button
           className={cn(
             'h-full px-2.5 text-[11px] font-medium rounded-none transition-colors relative',
             activeTab === 'diffs'
-              ? 'text-foreground bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))]'
+              ? cn('text-foreground', TAB_ACTIVE_SURFACE_CLASS)
               : 'text-muted-foreground hover:text-foreground'
           )}
           onClick={() => setActiveTab('diffs')}
@@ -121,16 +118,14 @@ export function FileSidebar({
           ) : (
             'Diffs'
           )}
-          {activeTab === 'diffs' && (
-            <div className="absolute bottom-0 left-2 right-2 h-0.5 bg-[color-mix(in_srgb,var(--foreground)_60%,var(--card))]" />
-          )}
+          {activeTab === 'diffs' && <div className={TAB_UNDERLINE_INSET_CLASS} />}
         </button>
         {hasAttachedPR && (
           <button
             className={cn(
               'h-full px-2.5 text-[11px] font-medium rounded-none transition-colors relative',
               activeTab === 'comments'
-                ? 'text-foreground bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))]'
+                ? cn('text-foreground', TAB_ACTIVE_SURFACE_CLASS)
                 : 'text-muted-foreground hover:text-foreground'
             )}
             onClick={() => setActiveTab('comments')}
@@ -142,9 +137,7 @@ export function FileSidebar({
             ) : (
               'Comments'
             )}
-            {activeTab === 'comments' && (
-              <div className="absolute bottom-0 left-2 right-2 h-0.5 bg-[color-mix(in_srgb,var(--foreground)_60%,var(--card))]" />
-            )}
+            {activeTab === 'comments' && <div className={TAB_UNDERLINE_INSET_CLASS} />}
           </button>
         )}
         <div className="flex-1" />

--- a/src/renderer/src/components/file-tree/FileTreeNode.tsx
+++ b/src/renderer/src/components/file-tree/FileTreeNode.tsx
@@ -1,8 +1,11 @@
 import { useCallback, memo, useMemo } from 'react'
 import { ChevronRight, Link } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useFileTabState } from '@/hooks/useFileTabState'
 import { FileIcon } from './FileIcon'
 import { GitStatusIndicator, type GitStatusCode } from './GitStatusIndicator'
+import { OpenTabIndicator } from './OpenTabIndicator'
+import { activeTabRowClass } from './open-tab-classes'
 import { FileContextMenu } from './FileContextMenu'
 import { ContextMenuTrigger } from '@/components/ui/context-menu'
 
@@ -120,12 +123,15 @@ export const VirtualFileTreeNode = memo(function VirtualFileTreeNode({
   // Get git status for this node
   const gitStatus = useMemo(() => getNodeGitStatus(node, gitStatusMap), [node, gitStatusMap])
 
+  const tabState = useFileTabState(node.isDirectory ? null : node.path)
+
   const nodeContent = (
     <div
       className={cn(
-        'flex items-center py-0.5 px-1 rounded-sm cursor-pointer',
+        'relative flex items-center py-0.5 px-1 rounded-sm cursor-pointer',
         'hover:bg-accent/50 transition-colors',
-        'focus:outline-none focus:bg-accent/50'
+        'focus:outline-none focus:bg-accent/50',
+        activeTabRowClass(tabState)
       )}
       style={{ paddingLeft: `${depth * 12 + 4}px` }}
       onClick={handleClick}
@@ -134,8 +140,10 @@ export const VirtualFileTreeNode = memo(function VirtualFileTreeNode({
       role="treeitem"
       aria-expanded={node.isDirectory ? isExpanded : undefined}
       aria-selected={false}
-      aria-label={`${node.isSymlink ? 'Symlinked ' : ''}${node.isDirectory ? 'Folder' : 'File'}: ${node.name}${gitStatus ? `, ${gitStatus.staged ? 'staged' : 'modified'}` : ''}`}
+      aria-label={`${node.isSymlink ? 'Symlinked ' : ''}${node.isDirectory ? 'Folder' : 'File'}: ${node.name}${gitStatus ? `, ${gitStatus.staged ? 'staged' : 'modified'}` : ''}${tabState ? `, ${tabState}` : ''}`}
     >
+      <OpenTabIndicator state={tabState} />
+
       {/* Expand/collapse chevron for directories */}
       {node.isDirectory ? (
         <ChevronRight

--- a/src/renderer/src/components/file-tree/OpenTabIndicator.tsx
+++ b/src/renderer/src/components/file-tree/OpenTabIndicator.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/lib/utils'
+import type { FileTabState } from '@/hooks/useFileTabState'
+import { TAB_MARKER_CLASS } from '@/lib/tab-styles'
+
+/**
+ * Bar on the left edge of a file list row marking the file as open in a tab.
+ * The row needs `relative` for this to position correctly.
+ */
+export function OpenTabIndicator({ state }: { state: FileTabState }): React.JSX.Element | null {
+  if (!state) return null
+
+  return (
+    <span
+      className={cn(
+        'absolute left-0 top-0 bottom-0 w-0.5 rounded-r',
+        TAB_MARKER_CLASS,
+        state === 'open' && 'opacity-40'
+      )}
+      aria-hidden="true"
+    />
+  )
+}

--- a/src/renderer/src/components/file-tree/open-tab-classes.ts
+++ b/src/renderer/src/components/file-tree/open-tab-classes.ts
@@ -1,0 +1,7 @@
+import type { FileTabState } from '@/hooks/useFileTabState'
+import { TAB_ACTIVE_SURFACE_CLASS } from '@/lib/tab-styles'
+
+/** Row background for the file that is open in the active tab, matching that tab. */
+export function activeTabRowClass(state: FileTabState): string | undefined {
+  return state === 'active' ? TAB_ACTIVE_SURFACE_CLASS : undefined
+}

--- a/src/renderer/src/components/layout/BottomPanel.tsx
+++ b/src/renderer/src/components/layout/BottomPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Globe, ChevronUp, ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { TAB_ACTIVE_SURFACE_CLASS, TAB_UNDERLINE_INSET_CLASS } from '@/lib/tab-styles'
 import { isMac, isLinux } from '@/lib/platform'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useLayoutStore } from '@/stores/useLayoutStore'
@@ -118,7 +119,7 @@ export function BottomPanel({
               onClick={() => setActiveTab(tab.id)}
               className={`h-full px-2.5 text-[11px] font-medium rounded-none transition-colors relative ${
                 resolvedTab === tab.id
-                  ? 'text-foreground bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))]'
+                  ? `text-foreground ${TAB_ACTIVE_SURFACE_CLASS}`
                   : 'text-muted-foreground hover:text-foreground'
               }`}
               data-testid={`bottom-panel-tab-${tab.id}`}
@@ -132,9 +133,7 @@ export function BottomPanel({
               ) : (
                 tab.label
               )}
-              {resolvedTab === tab.id && (
-                <span className="absolute bottom-0 left-2 right-2 h-0.5 bg-[color-mix(in_srgb,var(--foreground)_60%,var(--card))]" />
-              )}
+              {resolvedTab === tab.id && <span className={TAB_UNDERLINE_INSET_CLASS} />}
             </button>
           ))}
           {terminalPosition === 'sidebar' && !isConnectionMode && selectedWorktreeId && (

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -36,8 +36,10 @@ import { KanbanIcon } from '@/components/kanban/KanbanIcon'
 import { useSessionStore, BOARD_TAB_ID } from '@/stores/useSessionStore'
 import { useShallow } from 'zustand/react/shallow'
 import { isWindows } from '@/lib/platform'
+import { TAB_ACTIVE_SURFACE_CLASS, TAB_UNDERLINE_CLASS } from '@/lib/tab-styles'
 import {
   useFileViewerStore,
+  diffTabAbsolutePath,
   type FileViewerTab,
   type DiffTab,
   type ContextTab
@@ -102,15 +104,11 @@ function tabClass(isActive: boolean, ...extra: Array<string | false | null | und
     'group relative flex items-center gap-1.5 h-full px-2.5 text-[12px] tracking-[0.01em] cursor-pointer select-none whitespace-nowrap',
     'min-w-[88px] w-[180px] max-w-[200px] border-r border-border transition-colors',
     isActive
-      ? 'bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))] text-foreground'
+      ? cn(TAB_ACTIVE_SURFACE_CLASS, 'text-foreground')
       : 'bg-card text-muted-foreground hover:text-foreground',
     ...extra
   )
 }
-
-/** Orca active-tab 2px bottom bar */
-const TAB_UNDERLINE_CLASS =
-  'absolute bottom-0 left-0 right-0 h-0.5 bg-[color-mix(in_srgb,var(--foreground)_60%,var(--card))]'
 
 /** Orca `.tab-plus` strip affordance (create / scroll buttons on the tab bar) */
 const TAB_STRIP_BUTTON_CLASS =
@@ -456,7 +454,7 @@ function DiffTabItem({
   onCloseOthers,
   onCloseToRight
 }: DiffTabItemProps): React.JSX.Element {
-  const absolutePath = `${tab.worktreePath}/${tab.filePath}`
+  const absolutePath = diffTabAbsolutePath(tab)
 
   return (
     <ContextMenu>

--- a/src/renderer/src/components/terminal/TerminalTabsHorizontal.tsx
+++ b/src/renderer/src/components/terminal/TerminalTabsHorizontal.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { Plus, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { TAB_ACTIVE_SURFACE_CLASS, TAB_UNDERLINE_CLASS } from '@/lib/tab-styles'
 import { useLayoutStore } from '@/stores/useLayoutStore'
 import { useTerminalTabActions } from '@/hooks/useTerminalTabActions'
 import {
@@ -110,7 +111,7 @@ export function TerminalTabsHorizontal({
               className={cn(
                 'group h-full text-[11px] px-3 rounded-none transition-colors relative flex items-center gap-1.5',
                 isTerminalActive && tab.id === activeTabId
-                  ? 'text-foreground bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))]'
+                  ? cn('text-foreground', TAB_ACTIVE_SURFACE_CLASS)
                   : 'text-muted-foreground hover:text-foreground'
               )}
             >
@@ -166,7 +167,7 @@ export function TerminalTabsHorizontal({
 
               {/* Active underline */}
               {isTerminalActive && tab.id === activeTabId && (
-                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[color-mix(in_srgb,var(--foreground)_60%,var(--card))]" />
+                <span className={TAB_UNDERLINE_CLASS} />
               )}
             </button>
           </ContextMenuTrigger>

--- a/src/renderer/src/hooks/__tests__/useFileTabState.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useFileTabState.test.tsx
@@ -47,6 +47,21 @@ describe('useFileTabState', () => {
     expect(result.current).toBe('active')
   })
 
+  it('matches a row whose path uses the other separator', () => {
+    // Rows get native paths from the backend, diff tabs are joined in the renderer,
+    // so on Windows the two spellings have to still count as the same file.
+    useFileViewerStore.getState().setActiveDiff({
+      worktreePath: 'C:\\wt',
+      filePath: 'src/a.ts',
+      fileName: 'a.ts',
+      staged: false,
+      isUntracked: false
+    })
+
+    const { result } = renderHook(() => useFileTabState('C:\\wt\\src\\a.ts'))
+    expect(result.current).toBe('active')
+  })
+
   it('ignores context tabs', () => {
     useFileViewerStore.getState().openContextEditor('wt-1')
 

--- a/src/renderer/src/hooks/__tests__/useFileTabState.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useFileTabState.test.tsx
@@ -1,11 +1,16 @@
 import { cleanup, renderHook } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useFileTabState } from '../useFileTabState'
 import { useFileViewerStore } from '@/stores/useFileViewerStore'
 
+const isWindows = vi.hoisted(() => vi.fn(() => false))
+
+vi.mock('@/lib/platform', () => ({ isWindows }))
+
 describe('useFileTabState', () => {
   beforeEach(() => {
+    isWindows.mockReturnValue(false)
     useFileViewerStore.getState().closeAllFiles()
   })
 
@@ -47,19 +52,21 @@ describe('useFileTabState', () => {
     expect(result.current).toBe('active')
   })
 
-  it('matches a row whose path uses the other separator', () => {
-    // Rows get native paths from the backend, diff tabs are joined in the renderer,
-    // so on Windows the two spellings have to still count as the same file.
-    useFileViewerStore.getState().setActiveDiff({
-      worktreePath: 'C:\\wt',
-      filePath: 'src/a.ts',
-      fileName: 'a.ts',
-      staged: false,
-      isUntracked: false
-    })
+  it('matches a row whose path uses the other separator on Windows', () => {
+    // Rows get native paths from the backend, but a tab can be opened with a
+    // slash separated one, so on Windows both spellings mean the same file.
+    isWindows.mockReturnValue(true)
+    useFileViewerStore.getState().openFile('C:\\wt/src/a.ts', 'a.ts', 'wt-1')
 
     const { result } = renderHook(() => useFileTabState('C:\\wt\\src\\a.ts'))
     expect(result.current).toBe('active')
+  })
+
+  it('keeps a backslash filename distinct off Windows', () => {
+    useFileViewerStore.getState().openFile('/wt/a\\b.ts', 'a\\b.ts', 'wt-1')
+
+    const { result } = renderHook(() => useFileTabState('/wt/a/b.ts'))
+    expect(result.current).toBeNull()
   })
 
   it('ignores context tabs', () => {

--- a/src/renderer/src/hooks/__tests__/useFileTabState.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useFileTabState.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { useFileTabState } from '../useFileTabState'
+import { useFileViewerStore } from '@/stores/useFileViewerStore'
+
+describe('useFileTabState', () => {
+  beforeEach(() => {
+    useFileViewerStore.getState().closeAllFiles()
+  })
+
+  afterEach(() => {
+    cleanup()
+    useFileViewerStore.getState().closeAllFiles()
+  })
+
+  it('returns null when the file has no tab', () => {
+    const { result } = renderHook(() => useFileTabState('/wt/src/a.ts'))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null for rows without a path, like folders', () => {
+    useFileViewerStore.getState().openFile('/wt/src/a.ts', 'a.ts', 'wt-1')
+
+    const { result } = renderHook(() => useFileTabState(null))
+    expect(result.current).toBeNull()
+  })
+
+  it('marks the file tab that is active', () => {
+    useFileViewerStore.getState().openFile('/wt/src/a.ts', 'a.ts', 'wt-1')
+    useFileViewerStore.getState().openFile('/wt/src/b.ts', 'b.ts', 'wt-1')
+
+    expect(renderHook(() => useFileTabState('/wt/src/b.ts')).result.current).toBe('active')
+    expect(renderHook(() => useFileTabState('/wt/src/a.ts')).result.current).toBe('open')
+  })
+
+  it('resolves a diff tab to the absolute path of its file', () => {
+    useFileViewerStore.getState().setActiveDiff({
+      worktreePath: '/wt',
+      filePath: 'src/a.ts',
+      fileName: 'a.ts',
+      staged: false,
+      isUntracked: false
+    })
+
+    const { result } = renderHook(() => useFileTabState('/wt/src/a.ts'))
+    expect(result.current).toBe('active')
+  })
+
+  it('ignores context tabs', () => {
+    useFileViewerStore.getState().openContextEditor('wt-1')
+
+    const { result } = renderHook(() => useFileTabState('/wt/src/a.ts'))
+    expect(result.current).toBeNull()
+  })
+})

--- a/src/renderer/src/hooks/useFileTabState.ts
+++ b/src/renderer/src/hooks/useFileTabState.ts
@@ -1,0 +1,21 @@
+import { useFileViewerStore, tabAbsolutePath } from '@/stores/useFileViewerStore'
+
+/** How a file relates to the open tabs: the active tab, open in a background tab, or not open. */
+export type FileTabState = 'active' | 'open' | null
+
+/**
+ * Tells a file list row whether its file is open in a tab, so it can show an
+ * active file indicator. Returns a scalar so unaffected rows do not re-render.
+ * Pass null for rows that can never have a tab, like folders.
+ */
+export function useFileTabState(absolutePath: string | null): FileTabState {
+  return useFileViewerStore((state) => {
+    if (!absolutePath) return null
+    const activeTab = state.activeFilePath ? state.openFiles.get(state.activeFilePath) : undefined
+    if (activeTab && tabAbsolutePath(activeTab) === absolutePath) return 'active'
+    for (const tab of state.openFiles.values()) {
+      if (tabAbsolutePath(tab) === absolutePath) return 'open'
+    }
+    return null
+  })
+}

--- a/src/renderer/src/hooks/useFileTabState.ts
+++ b/src/renderer/src/hooks/useFileTabState.ts
@@ -1,4 +1,4 @@
-import { useFileViewerStore, tabAbsolutePath } from '@/stores/useFileViewerStore'
+import { useFileViewerStore, tabAbsolutePath, isSameFilePath } from '@/stores/useFileViewerStore'
 
 /** How a file relates to the open tabs: the active tab, open in a background tab, or not open. */
 export type FileTabState = 'active' | 'open' | null
@@ -12,9 +12,11 @@ export function useFileTabState(absolutePath: string | null): FileTabState {
   return useFileViewerStore((state) => {
     if (!absolutePath) return null
     const activeTab = state.activeFilePath ? state.openFiles.get(state.activeFilePath) : undefined
-    if (activeTab && tabAbsolutePath(activeTab) === absolutePath) return 'active'
+    const activePath = activeTab ? tabAbsolutePath(activeTab) : null
+    if (activePath && isSameFilePath(activePath, absolutePath)) return 'active'
     for (const tab of state.openFiles.values()) {
-      if (tabAbsolutePath(tab) === absolutePath) return 'open'
+      const path = tabAbsolutePath(tab)
+      if (path && isSameFilePath(path, absolutePath)) return 'open'
     }
     return null
   })

--- a/src/renderer/src/lib/tab-styles.ts
+++ b/src/renderer/src/lib/tab-styles.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared look of the Orca tab strips: the surface behind the active tab and the
+ * 2px bar that marks it. Every tab strip and file list uses these, so the active
+ * thing looks the same wherever it shows up.
+ */
+export const TAB_ACTIVE_SURFACE_CLASS = 'bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))]'
+export const TAB_MARKER_CLASS = 'bg-[color-mix(in_srgb,var(--foreground)_60%,var(--card))]'
+
+/** Bar under the active tab, edge to edge. For strips whose tabs have dividers. */
+export const TAB_UNDERLINE_CLASS = `absolute bottom-0 left-0 right-0 h-0.5 ${TAB_MARKER_CLASS}`
+
+/** Bar under the active tab, inset. For strips whose tabs sit next to each other. */
+export const TAB_UNDERLINE_INSET_CLASS = `absolute bottom-0 left-2 right-2 h-0.5 ${TAB_MARKER_CLASS}`

--- a/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
+++ b/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
@@ -75,6 +75,13 @@ describe('isSameFilePath', () => {
     expect(isSameFilePath('C:foo\\..\\bar\\src\\a.ts', 'C:bar\\src\\a.ts')).toBe(true)
   })
 
+  it('keeps a leading ".." on a drive relative path', () => {
+    isWindows.mockReturnValue(true)
+    // path.win32.join keeps the ".." in C:..\repo, because a drive prefix is not
+    // an absolute root, so these are two different locations.
+    expect(isSameFilePath('C:..\\repo\\src\\a.ts', 'C:repo\\src\\a.ts')).toBe(false)
+  })
+
   it('keeps different Windows roots apart', () => {
     isWindows.mockReturnValue(true)
     expect(isSameFilePath('C:\\repo\\src\\a.ts', 'D:\\repo\\src\\a.ts')).toBe(false)

--- a/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
+++ b/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
@@ -27,6 +27,13 @@ describe('diffTabAbsolutePath', () => {
     expect(diffTabAbsolutePath({ worktreePath: '/', filePath: 'src/a.ts' })).toBe('/src/a.ts')
   })
 
+  it('keeps a trailing backslash that is part of the directory name', () => {
+    isWindows.mockReturnValue(false)
+    expect(diffTabAbsolutePath({ worktreePath: '/tmp/repo\\', filePath: 'src/a.ts' })).toBe(
+      '/tmp/repo\\/src/a.ts'
+    )
+  })
+
   it('does not double a trailing separator on Windows', () => {
     isWindows.mockReturnValue(true)
     expect(diffTabAbsolutePath({ worktreePath: 'C:\\wt\\', filePath: 'src/a.ts' })).toBe(

--- a/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
+++ b/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
@@ -19,12 +19,34 @@ describe('diffTabAbsolutePath', () => {
       'C:\\wt\\src\\a.ts'
     )
   })
+
+  it('does not double the separator for a worktree at the filesystem root', () => {
+    // path.join gives the rows "/src/a.ts", so this has to match it.
+    isWindows.mockReturnValue(false)
+    expect(diffTabAbsolutePath({ worktreePath: '/', filePath: 'src/a.ts' })).toBe('/src/a.ts')
+
+    isWindows.mockReturnValue(true)
+    expect(diffTabAbsolutePath({ worktreePath: 'C:\\', filePath: 'src/a.ts' })).toBe(
+      'C:\\src\\a.ts'
+    )
+  })
 })
 
 describe('isSameFilePath', () => {
   it('accepts either separator for the same file on Windows', () => {
     isWindows.mockReturnValue(true)
     expect(isSameFilePath('C:\\wt\\src\\a.ts', 'C:\\wt/src/a.ts')).toBe(true)
+  })
+
+  it('ignores casing on Windows, including the drive letter', () => {
+    isWindows.mockReturnValue(true)
+    expect(isSameFilePath('C:\\wt\\src\\Foo.ts', 'c:\\wt\\src\\foo.ts')).toBe(true)
+  })
+
+  it('keeps casing significant off Windows', () => {
+    isWindows.mockReturnValue(false)
+    // Two different files on a case-sensitive volume.
+    expect(isSameFilePath('/wt/src/Foo.ts', '/wt/src/foo.ts')).toBe(false)
   })
 
   it('keeps backslash filenames distinct off Windows', () => {

--- a/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
+++ b/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
@@ -68,6 +68,23 @@ describe('isSameFilePath', () => {
     expect(isSameFilePath('C:\\base\\..\\repo\\src\\a.ts', 'C:\\repo\\src\\a.ts')).toBe(true)
   })
 
+  it('never lets ".." climb past a Windows root', () => {
+    isWindows.mockReturnValue(true)
+    // path.join keeps the drive and the UNC share, so ".." must stop there.
+    expect(isSameFilePath('C:\\..\\repo\\src\\a.ts', 'C:\\repo\\src\\a.ts')).toBe(true)
+    expect(
+      isSameFilePath('\\\\srv\\share\\..\\repo\\src\\a.ts', '\\\\srv\\share\\repo\\src\\a.ts')
+    ).toBe(true)
+    // A drive letter can sit in front of a relative path, as in C:foo
+    expect(isSameFilePath('C:foo\\..\\bar\\src\\a.ts', 'C:bar\\src\\a.ts')).toBe(true)
+  })
+
+  it('keeps different Windows roots apart', () => {
+    isWindows.mockReturnValue(true)
+    expect(isSameFilePath('C:\\repo\\src\\a.ts', 'D:\\repo\\src\\a.ts')).toBe(false)
+    expect(isSameFilePath('\\\\srv\\one\\src\\a.ts', '\\\\srv\\two\\src\\a.ts')).toBe(false)
+  })
+
   it('does not treat a dot inside a name as a segment', () => {
     isWindows.mockReturnValue(false)
     expect(isSameFilePath('/tmp/repo./src/a.ts', '/tmp/repo/src/a.ts')).toBe(false)

--- a/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
+++ b/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
@@ -49,6 +49,43 @@ describe('isSameFilePath', () => {
     expect(isSameFilePath('/wt/src/Foo.ts', '/wt/src/foo.ts')).toBe(false)
   })
 
+  // Worktrees stored before paths were canonicalized can still carry these shapes,
+  // and the rows come from path.join, so the comparison has to match its semantics.
+  // Verified against Node across 27 path shapes on both platforms.
+  it('treats a run of separators as one, like path.join does', () => {
+    isWindows.mockReturnValue(false)
+    expect(isSameFilePath('/tmp//repo/src/a.ts', '/tmp/repo/src/a.ts')).toBe(true)
+  })
+
+  it('resolves dot segments the way path.join does', () => {
+    isWindows.mockReturnValue(false)
+    expect(isSameFilePath('/tmp/base/../repo/src/a.ts', '/tmp/repo/src/a.ts')).toBe(true)
+    expect(isSameFilePath('/tmp/./repo/src/a.ts', '/tmp/repo/src/a.ts')).toBe(true)
+    // ".." cannot climb above the root, same as path.join
+    expect(isSameFilePath('/a/../../b/src/a.ts', '/b/src/a.ts')).toBe(true)
+  })
+
+  it('never lets ".." climb past a Windows root', () => {
+    isWindows.mockReturnValue(true)
+    expect(isSameFilePath('C:\\..\\repo\\src\\a.ts', 'C:\\repo\\src\\a.ts')).toBe(true)
+    expect(
+      isSameFilePath('\\\\srv\\share\\..\\repo\\src\\a.ts', '\\\\srv\\share\\repo\\src\\a.ts')
+    ).toBe(true)
+    // A drive letter can sit in front of a relative path, as in C:foo
+    expect(isSameFilePath('C:foo\\..\\bar\\src\\a.ts', 'C:bar\\src\\a.ts')).toBe(true)
+  })
+
+  it('keeps different Windows roots apart', () => {
+    isWindows.mockReturnValue(true)
+    expect(isSameFilePath('C:\\repo\\src\\a.ts', 'D:\\repo\\src\\a.ts')).toBe(false)
+    expect(isSameFilePath('\\\\srv\\one\\src\\a.ts', '\\\\srv\\two\\src\\a.ts')).toBe(false)
+  })
+
+  it('does not treat a dot inside a name as a segment', () => {
+    isWindows.mockReturnValue(false)
+    expect(isSameFilePath('/tmp/repo./src/a.ts', '/tmp/repo/src/a.ts')).toBe(false)
+  })
+
   it('keeps backslash filenames distinct off Windows', () => {
     isWindows.mockReturnValue(false)
     // A backslash is a valid filename character on macOS and Linux, so these

--- a/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
+++ b/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
@@ -54,6 +54,25 @@ describe('isSameFilePath', () => {
     expect(isSameFilePath('/tmp//repo/src/a.ts', '/tmp/repo/src/a.ts')).toBe(true)
   })
 
+  // These mirror what path.join gives the rows, verified against Node.
+  it('resolves dot segments the way path.join does', () => {
+    isWindows.mockReturnValue(false)
+    expect(isSameFilePath('/tmp/base/../repo/src/a.ts', '/tmp/repo/src/a.ts')).toBe(true)
+    expect(isSameFilePath('/tmp/./repo/src/a.ts', '/tmp/repo/src/a.ts')).toBe(true)
+    // ".." cannot climb above the root, same as path.join
+    expect(isSameFilePath('/a/../../b/src/a.ts', '/b/src/a.ts')).toBe(true)
+  })
+
+  it('resolves dot segments on Windows too', () => {
+    isWindows.mockReturnValue(true)
+    expect(isSameFilePath('C:\\base\\..\\repo\\src\\a.ts', 'C:\\repo\\src\\a.ts')).toBe(true)
+  })
+
+  it('does not treat a dot inside a name as a segment', () => {
+    isWindows.mockReturnValue(false)
+    expect(isSameFilePath('/tmp/repo./src/a.ts', '/tmp/repo/src/a.ts')).toBe(false)
+  })
+
   it('keeps backslash filenames distinct off Windows', () => {
     isWindows.mockReturnValue(false)
     // A backslash is a valid filename character on macOS and Linux, so these

--- a/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
+++ b/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
@@ -48,6 +48,12 @@ describe('isSameFilePath', () => {
     expect(isSameFilePath('C:\\wt\\src\\a.ts', 'C:\\wt/src/a.ts')).toBe(true)
   })
 
+  it('treats a run of separators as one, like path.join does', () => {
+    isWindows.mockReturnValue(false)
+    // A worktree saved as /tmp//repo reaches the rows as /tmp/repo via path.join.
+    expect(isSameFilePath('/tmp//repo/src/a.ts', '/tmp/repo/src/a.ts')).toBe(true)
+  })
+
   it('keeps backslash filenames distinct off Windows', () => {
     isWindows.mockReturnValue(false)
     // A backslash is a valid filename character on macOS and Linux, so these

--- a/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
+++ b/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
@@ -22,12 +22,25 @@ describe('diffTabAbsolutePath', () => {
 })
 
 describe('isSameFilePath', () => {
-  it('accepts either separator for the same file', () => {
+  it('accepts either separator for the same file on Windows', () => {
+    isWindows.mockReturnValue(true)
     expect(isSameFilePath('C:\\wt\\src\\a.ts', 'C:\\wt/src/a.ts')).toBe(true)
+  })
+
+  it('keeps backslash filenames distinct off Windows', () => {
+    isWindows.mockReturnValue(false)
+    // A backslash is a valid filename character on macOS and Linux, so these
+    // are two different files and must not be treated as one.
+    expect(isSameFilePath('/wt/a\\b.ts', '/wt/a/b.ts')).toBe(false)
+  })
+
+  it('matches identical paths on any platform', () => {
+    isWindows.mockReturnValue(false)
     expect(isSameFilePath('/wt/src/a.ts', '/wt/src/a.ts')).toBe(true)
   })
 
   it('still tells different files apart', () => {
+    isWindows.mockReturnValue(true)
     expect(isSameFilePath('/wt/src/a.ts', '/wt/src/b.ts')).toBe(false)
   })
 })

--- a/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
+++ b/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
@@ -19,75 +19,12 @@ describe('diffTabAbsolutePath', () => {
       'C:\\wt\\src\\a.ts'
     )
   })
-
-  // These all match what path.join gives the rows on the backend side.
-  it('does not double a trailing separator', () => {
-    isWindows.mockReturnValue(false)
-    expect(diffTabAbsolutePath({ worktreePath: '/wt/', filePath: 'src/a.ts' })).toBe('/wt/src/a.ts')
-    expect(diffTabAbsolutePath({ worktreePath: '/', filePath: 'src/a.ts' })).toBe('/src/a.ts')
-  })
-
-  it('keeps a trailing backslash that is part of the directory name', () => {
-    isWindows.mockReturnValue(false)
-    expect(diffTabAbsolutePath({ worktreePath: '/tmp/repo\\', filePath: 'src/a.ts' })).toBe(
-      '/tmp/repo\\/src/a.ts'
-    )
-  })
-
-  it('does not double a trailing separator on Windows', () => {
-    isWindows.mockReturnValue(true)
-    expect(diffTabAbsolutePath({ worktreePath: 'C:\\wt\\', filePath: 'src/a.ts' })).toBe(
-      'C:\\wt\\src\\a.ts'
-    )
-  })
 })
 
 describe('isSameFilePath', () => {
   it('accepts either separator for the same file on Windows', () => {
     isWindows.mockReturnValue(true)
     expect(isSameFilePath('C:\\wt\\src\\a.ts', 'C:\\wt/src/a.ts')).toBe(true)
-  })
-
-  it('treats a run of separators as one, like path.join does', () => {
-    isWindows.mockReturnValue(false)
-    // A worktree saved as /tmp//repo reaches the rows as /tmp/repo via path.join.
-    expect(isSameFilePath('/tmp//repo/src/a.ts', '/tmp/repo/src/a.ts')).toBe(true)
-  })
-
-  // These mirror what path.join gives the rows, verified against Node.
-  it('resolves dot segments the way path.join does', () => {
-    isWindows.mockReturnValue(false)
-    expect(isSameFilePath('/tmp/base/../repo/src/a.ts', '/tmp/repo/src/a.ts')).toBe(true)
-    expect(isSameFilePath('/tmp/./repo/src/a.ts', '/tmp/repo/src/a.ts')).toBe(true)
-    // ".." cannot climb above the root, same as path.join
-    expect(isSameFilePath('/a/../../b/src/a.ts', '/b/src/a.ts')).toBe(true)
-  })
-
-  it('resolves dot segments on Windows too', () => {
-    isWindows.mockReturnValue(true)
-    expect(isSameFilePath('C:\\base\\..\\repo\\src\\a.ts', 'C:\\repo\\src\\a.ts')).toBe(true)
-  })
-
-  it('never lets ".." climb past a Windows root', () => {
-    isWindows.mockReturnValue(true)
-    // path.join keeps the drive and the UNC share, so ".." must stop there.
-    expect(isSameFilePath('C:\\..\\repo\\src\\a.ts', 'C:\\repo\\src\\a.ts')).toBe(true)
-    expect(
-      isSameFilePath('\\\\srv\\share\\..\\repo\\src\\a.ts', '\\\\srv\\share\\repo\\src\\a.ts')
-    ).toBe(true)
-    // A drive letter can sit in front of a relative path, as in C:foo
-    expect(isSameFilePath('C:foo\\..\\bar\\src\\a.ts', 'C:bar\\src\\a.ts')).toBe(true)
-  })
-
-  it('keeps different Windows roots apart', () => {
-    isWindows.mockReturnValue(true)
-    expect(isSameFilePath('C:\\repo\\src\\a.ts', 'D:\\repo\\src\\a.ts')).toBe(false)
-    expect(isSameFilePath('\\\\srv\\one\\src\\a.ts', '\\\\srv\\two\\src\\a.ts')).toBe(false)
-  })
-
-  it('does not treat a dot inside a name as a segment', () => {
-    isWindows.mockReturnValue(false)
-    expect(isSameFilePath('/tmp/repo./src/a.ts', '/tmp/repo/src/a.ts')).toBe(false)
   })
 
   it('keeps backslash filenames distinct off Windows', () => {

--- a/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
+++ b/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const isWindows = vi.hoisted(() => vi.fn(() => false))
+
+vi.mock('@/lib/platform', () => ({ isWindows }))
+
+const { diffTabAbsolutePath, isSameFilePath } = await import('@/stores/useFileViewerStore')
+
+describe('diffTabAbsolutePath', () => {
+  it('joins with a forward slash off Windows', () => {
+    isWindows.mockReturnValue(false)
+    expect(diffTabAbsolutePath({ worktreePath: '/wt', filePath: 'src/a.ts' })).toBe('/wt/src/a.ts')
+  })
+
+  it('builds a native path on Windows', () => {
+    isWindows.mockReturnValue(true)
+    // Git hands us "src/a.ts" on every platform, so the separators need converting.
+    expect(diffTabAbsolutePath({ worktreePath: 'C:\\wt', filePath: 'src/a.ts' })).toBe(
+      'C:\\wt\\src\\a.ts'
+    )
+  })
+})
+
+describe('isSameFilePath', () => {
+  it('accepts either separator for the same file', () => {
+    expect(isSameFilePath('C:\\wt\\src\\a.ts', 'C:\\wt/src/a.ts')).toBe(true)
+    expect(isSameFilePath('/wt/src/a.ts', '/wt/src/a.ts')).toBe(true)
+  })
+
+  it('still tells different files apart', () => {
+    expect(isSameFilePath('/wt/src/a.ts', '/wt/src/b.ts')).toBe(false)
+  })
+})

--- a/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
+++ b/src/renderer/src/stores/__tests__/useFileViewerStore.paths.test.ts
@@ -19,6 +19,20 @@ describe('diffTabAbsolutePath', () => {
       'C:\\wt\\src\\a.ts'
     )
   })
+
+  // These all match what path.join gives the rows on the backend side.
+  it('does not double a trailing separator', () => {
+    isWindows.mockReturnValue(false)
+    expect(diffTabAbsolutePath({ worktreePath: '/wt/', filePath: 'src/a.ts' })).toBe('/wt/src/a.ts')
+    expect(diffTabAbsolutePath({ worktreePath: '/', filePath: 'src/a.ts' })).toBe('/src/a.ts')
+  })
+
+  it('does not double a trailing separator on Windows', () => {
+    isWindows.mockReturnValue(true)
+    expect(diffTabAbsolutePath({ worktreePath: 'C:\\wt\\', filePath: 'src/a.ts' })).toBe(
+      'C:\\wt\\src\\a.ts'
+    )
+  })
 })
 
 describe('isSameFilePath', () => {

--- a/src/renderer/src/stores/__tests__/useProjectStore.project-add.test.ts
+++ b/src/renderer/src/stores/__tests__/useProjectStore.project-add.test.ts
@@ -91,6 +91,29 @@ describe('useProjectStore project adding', () => {
     expect(request).toHaveBeenCalledWith('db.project.getByPath', { path: '/repo/hive' })
   })
 
+  it('still finds a project stored under its pre-canonical path', async () => {
+    // Projects added before paths were canonicalized keep their original spelling,
+    // and re-adding one must not create a duplicate.
+    request.mockImplementation((method, params) => {
+      if (method === 'projectOps.validateProject') {
+        return Promise.resolve({ success: true, name: 'Hive', path: '/repo/hive' })
+      }
+      if (method === 'db.project.getByPath') {
+        const path = (params as { path: string }).path
+        return Promise.resolve(path === '/link/hive' ? existingProject : null)
+      }
+      return Promise.resolve(null)
+    })
+
+    await expect(useProjectStore.getState().addProject('/link/hive')).resolves.toEqual({
+      success: false,
+      error: 'This project has already been added to Hive.'
+    })
+
+    expect(request).toHaveBeenCalledWith('db.project.getByPath', { path: '/link/hive' })
+    expect(request).not.toHaveBeenCalledWith('db.project.create', expect.anything())
+  })
+
   it('creates new projects through dbApi after duplicate checks pass', async () => {
     request.mockImplementation((method) => {
       if (method === 'projectOps.validateProject') {

--- a/src/renderer/src/stores/__tests__/useProjectStore.project-add.test.ts
+++ b/src/renderer/src/stores/__tests__/useProjectStore.project-add.test.ts
@@ -81,6 +81,16 @@ describe('useProjectStore project adding', () => {
     expect(useProjectStore.getState().projects).toEqual([])
   })
 
+  it('checks the duplicate against the canonical path validation returned', async () => {
+    // The same folder spelled differently must not be added a second time.
+    await expect(useProjectStore.getState().addProject('/repo/hive/')).resolves.toEqual({
+      success: false,
+      error: 'This project has already been added to Hive.'
+    })
+
+    expect(request).toHaveBeenCalledWith('db.project.getByPath', { path: '/repo/hive' })
+  })
+
   it('creates new projects through dbApi after duplicate checks pass', async () => {
     request.mockImplementation((method) => {
       if (method === 'projectOps.validateProject') {

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -112,8 +112,10 @@ function comparableFilePath(path: string, windows: boolean): string {
     if (segment === '..') {
       if (segments.length && segments[segments.length - 1] !== '..') {
         segments.pop()
-      } else if (!absolute && !root) {
-        // Only a rootless relative path keeps a leading "..".
+      } else if (!absolute) {
+        // A relative path keeps a leading "..", including a drive relative one like
+        // C:..\repo, which path.join keeps too. Only an absolute path drops it,
+        // because there is nothing above the root.
         segments.push('..')
       }
       continue

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -72,17 +72,66 @@ export function tabAbsolutePath(tab: TabEntry): string | null {
 }
 
 /**
- * Same file? Stored paths are canonical and the backend hands us native paths, so
- * this only has to forgive what Windows itself treats as insignificant: either
- * separator, and the casing, including the drive letter.
+ * Row paths come from path.join on the backend, which resolves dot segments and
+ * repeated separators. Paths joined here keep whatever the worktree path had, and
+ * worktrees stored before those paths were canonicalized can still carry a "..".
  *
- * Neither applies off Windows, where a backslash is a normal filename character and
- * `a.ts` and `A.ts` can be two different files.
+ * Doing the same lexical work here is the right comparison, because the rows were
+ * produced lexically too. This is only for comparing: what a lexically resolved path
+ * opens can differ from the original when a ".." crosses a symlink, which is why the
+ * path a project is stored under goes through realpath instead. See project-ops.
+ *
+ * Kept local because the renderer has no path module and also runs in the browser.
  */
+function comparableFilePath(path: string, windows: boolean): string {
+  // Only Windows can spell a separator two ways: on macOS and Linux a backslash
+  // is a normal filename character, so `a\b.ts` and `a/b.ts` differ there.
+  const slashed = windows ? path.replace(/\\/g, '/') : path
+
+  // Split off the part ".." must never climb past: the server and share of a UNC
+  // path, or a drive letter, which can sit right in front of a relative path as
+  // in C:foo. Without this, ".." would eat the root and paths stop matching.
+  let root = ''
+  let rest = slashed
+  if (windows) {
+    const unc = slashed.match(/^\/\/[^/]+\/[^/]+/)
+    if (unc) {
+      root = unc[0]
+      rest = slashed.slice(root.length)
+    } else if (/^[a-zA-Z]:/.test(slashed)) {
+      root = slashed.slice(0, 2)
+      rest = slashed.slice(2)
+    }
+  }
+
+  const absolute = rest.startsWith('/')
+  const segments: string[] = []
+
+  for (const segment of rest.split('/')) {
+    if (segment === '' || segment === '.') continue
+    if (segment === '..') {
+      if (segments.length && segments[segments.length - 1] !== '..') {
+        segments.pop()
+      } else if (!absolute && !root) {
+        // Only a rootless relative path keeps a leading "..".
+        segments.push('..')
+      }
+      continue
+    }
+    segments.push(segment)
+  }
+
+  const joined = root + (absolute ? '/' : '') + segments.join('/')
+  // Windows treats casing as insignificant, including the drive letter. Everywhere
+  // else `a.ts` and `A.ts` can be two different files.
+  return windows ? joined.toLowerCase() : joined
+}
+
+/** Same file? Forgives every spelling difference that means the same path. */
 export function isSameFilePath(a: string, b: string): boolean {
   if (a === b) return true
-  if (!isWindows()) return false
-  return a.replace(/\\/g, '/').toLowerCase() === b.replace(/\\/g, '/').toLowerCase()
+  const windows = isWindows()
+  return comparableFilePath(a, windows) === comparableFilePath(b, windows)
 }
 
 interface FileViewerState {

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -66,10 +66,13 @@ export function tabAbsolutePath(tab: TabEntry): string | null {
 
 /**
  * Same file? Paths reach the renderer from several places, some native and some
- * slash separated, so callers do not have to agree on a separator.
+ * slash separated, so callers do not have to agree on a separator. Only Windows
+ * has that ambiguity: on macOS and Linux a backslash is a normal filename
+ * character, so `a\b.ts` and `a/b.ts` are two different files there.
  */
 export function isSameFilePath(a: string, b: string): boolean {
-  return a === b || a.replace(/\\/g, '/') === b.replace(/\\/g, '/')
+  if (a === b) return true
+  return isWindows() && a.replace(/\\/g, '/') === b.replace(/\\/g, '/')
 }
 
 interface FileViewerState {

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -50,15 +50,14 @@ function diffTabKey(diff: { filePath: string; staged: boolean; compareBranch?: s
  * A diff tab keeps its file path split in two, so only the store knows how to join it.
  * Git reports slash separated relative paths, so on Windows they need converting to
  * get a native path, the same shape the file lists and "Copy Absolute Path" expect.
+ *
+ * Worktree paths are stored canonical, see canonicalProjectPath in project-ops, so
+ * joining here gives the same string the backend gets from path.join.
  */
 export function diffTabAbsolutePath(diff: { worktreePath: string; filePath: string }): string {
   const separator = isWindows() ? '\\' : '/'
   const filePath = isWindows() ? diff.filePath.replace(/\//g, separator) : diff.filePath
-  // The backend joins with path.join, which collapses a trailing separator, so
-  // trim one here too. Otherwise a worktree at "/" would give us "//src/a.ts".
-  // Only a slash counts off Windows, where a trailing backslash is part of the name.
-  const worktreePath = diff.worktreePath.replace(isWindows() ? /[/\\]+$/ : /\/+$/, '')
-  return `${worktreePath}${separator}${filePath}`
+  return `${diff.worktreePath}${separator}${filePath}`
 }
 
 /** The file a tab shows, as an absolute path. Null for tabs that show no file. */
@@ -69,63 +68,14 @@ export function tabAbsolutePath(tab: TabEntry): string | null {
 }
 
 /**
- * Paths the backend builds go through path.join, which resolves separators and
- * dot segments, while paths joined here keep whatever the worktree path had. So
- * a saved path like /tmp/base/../repo reaches the rows as /tmp/repo.
- *
- * path.join is purely lexical, it never touches the filesystem, so doing the
- * same lexical work here is enough to compare the two. Kept local because the
- * renderer has no path module and also runs in the browser.
- */
-function comparableFilePath(path: string, windows: boolean): string {
-  // Only Windows can spell a separator two ways: on macOS and Linux a backslash
-  // is a normal filename character, so `a\b.ts` and `a/b.ts` differ there.
-  const slashed = windows ? path.replace(/\\/g, '/') : path
-
-  // Split off the part ".." must never climb past: the server and share of a UNC
-  // path, or a drive letter, which can sit right in front of a relative path as
-  // in C:foo. Without this, ".." would eat the root and paths stop matching.
-  let root = ''
-  let rest = slashed
-  if (windows) {
-    const unc = slashed.match(/^\/\/[^/]+\/[^/]+/)
-    if (unc) {
-      root = unc[0]
-      rest = slashed.slice(root.length)
-    } else if (/^[a-zA-Z]:/.test(slashed)) {
-      root = slashed.slice(0, 2)
-      rest = slashed.slice(2)
-    }
-  }
-
-  const absolute = rest.startsWith('/')
-  const segments: string[] = []
-
-  for (const segment of rest.split('/')) {
-    if (segment === '' || segment === '.') continue
-    if (segment === '..') {
-      if (segments.length && segments[segments.length - 1] !== '..') {
-        segments.pop()
-      } else if (!absolute && !root) {
-        // Only a rootless relative path keeps a leading "..".
-        segments.push('..')
-      }
-      continue
-    }
-    segments.push(segment)
-  }
-
-  return root + (absolute ? '/' : '') + segments.join('/')
-}
-
-/**
- * Same file? Paths reach the renderer from several places and spell the same
- * location differently, so callers do not have to agree on a form.
+ * Same file? Stored paths are canonical and the backend hands us native paths, so
+ * this only has to forgive the one thing that is still ambiguous: on Windows both
+ * separators mean the same thing. Off Windows a backslash is a normal filename
+ * character, so `a\b.ts` and `a/b.ts` are two different files there.
  */
 export function isSameFilePath(a: string, b: string): boolean {
   if (a === b) return true
-  const windows = isWindows()
-  return comparableFilePath(a, windows) === comparableFilePath(b, windows)
+  return isWindows() && a.replace(/\\/g, '/') === b.replace(/\\/g, '/')
 }
 
 interface FileViewerState {

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -39,6 +39,24 @@ export interface ActiveDiff {
   prReviewWorktreeId?: string
 }
 
+function diffTabKey(diff: { filePath: string; staged: boolean; compareBranch?: string }): string {
+  return diff.compareBranch
+    ? `diff:${diff.filePath}:branch:${diff.compareBranch}`
+    : `diff:${diff.filePath}:${diff.staged ? 'staged' : 'unstaged'}`
+}
+
+/** A diff tab keeps its file path split in two, so only the store knows how to join it. */
+export function diffTabAbsolutePath(diff: { worktreePath: string; filePath: string }): string {
+  return `${diff.worktreePath}/${diff.filePath}`
+}
+
+/** The file a tab shows, as an absolute path. Null for tabs that show no file. */
+export function tabAbsolutePath(tab: TabEntry): string | null {
+  if (tab.type === 'file') return tab.path
+  if (tab.type === 'diff') return diffTabAbsolutePath(tab)
+  return null
+}
+
 interface FileViewerState {
   openFiles: Map<string, TabEntry>
   activeFilePath: string | null
@@ -209,9 +227,7 @@ export const useFileViewerStore = create<FileViewerState>((set, get) => ({
       set({ activeDiff: null })
       return
     }
-    const tabKey = diff.compareBranch
-      ? `diff:${diff.filePath}:branch:${diff.compareBranch}`
-      : `diff:${diff.filePath}:${diff.staged ? 'staged' : 'unstaged'}`
+    const tabKey = diffTabKey(diff)
     set((state) => {
       const openFiles = new Map(state.openFiles)
       openFiles.set(tabKey, {

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { isWindows } from '@/lib/platform'
 
 export interface FileViewerTab {
   type: 'file'
@@ -45,9 +46,15 @@ function diffTabKey(diff: { filePath: string; staged: boolean; compareBranch?: s
     : `diff:${diff.filePath}:${diff.staged ? 'staged' : 'unstaged'}`
 }
 
-/** A diff tab keeps its file path split in two, so only the store knows how to join it. */
+/**
+ * A diff tab keeps its file path split in two, so only the store knows how to join it.
+ * Git reports slash separated relative paths, so on Windows they need converting to
+ * get a native path, the same shape the file lists and "Copy Absolute Path" expect.
+ */
 export function diffTabAbsolutePath(diff: { worktreePath: string; filePath: string }): string {
-  return `${diff.worktreePath}/${diff.filePath}`
+  return isWindows()
+    ? `${diff.worktreePath}\\${diff.filePath.replace(/\//g, '\\')}`
+    : `${diff.worktreePath}/${diff.filePath}`
 }
 
 /** The file a tab shows, as an absolute path. Null for tabs that show no file. */
@@ -55,6 +62,14 @@ export function tabAbsolutePath(tab: TabEntry): string | null {
   if (tab.type === 'file') return tab.path
   if (tab.type === 'diff') return diffTabAbsolutePath(tab)
   return null
+}
+
+/**
+ * Same file? Paths reach the renderer from several places, some native and some
+ * slash separated, so callers do not have to agree on a separator.
+ */
+export function isSameFilePath(a: string, b: string): boolean {
+  return a === b || a.replace(/\\/g, '/') === b.replace(/\\/g, '/')
 }
 
 interface FileViewerState {

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -52,9 +52,12 @@ function diffTabKey(diff: { filePath: string; staged: boolean; compareBranch?: s
  * get a native path, the same shape the file lists and "Copy Absolute Path" expect.
  */
 export function diffTabAbsolutePath(diff: { worktreePath: string; filePath: string }): string {
-  return isWindows()
-    ? `${diff.worktreePath}\\${diff.filePath.replace(/\//g, '\\')}`
-    : `${diff.worktreePath}/${diff.filePath}`
+  const separator = isWindows() ? '\\' : '/'
+  const filePath = isWindows() ? diff.filePath.replace(/\//g, separator) : diff.filePath
+  // The backend joins with path.join, which collapses a trailing separator, so
+  // trim one here too. Otherwise a worktree at "/" would give us "//src/a.ts".
+  const worktreePath = diff.worktreePath.replace(/[/\\]+$/, '')
+  return `${worktreePath}${separator}${filePath}`
 }
 
 /** The file a tab shows, as an absolute path. Null for tabs that show no file. */

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -57,7 +57,11 @@ function diffTabKey(diff: { filePath: string; staged: boolean; compareBranch?: s
 export function diffTabAbsolutePath(diff: { worktreePath: string; filePath: string }): string {
   const separator = isWindows() ? '\\' : '/'
   const filePath = isWindows() ? diff.filePath.replace(/\//g, separator) : diff.filePath
-  return `${diff.worktreePath}${separator}${filePath}`
+  // A worktree at the filesystem root already ends in a separator, and path.join on
+  // the backend side does not double it either.
+  const { worktreePath } = diff
+  const prefix = worktreePath.endsWith(separator) ? worktreePath : worktreePath + separator
+  return `${prefix}${filePath}`
 }
 
 /** The file a tab shows, as an absolute path. Null for tabs that show no file. */
@@ -69,13 +73,16 @@ export function tabAbsolutePath(tab: TabEntry): string | null {
 
 /**
  * Same file? Stored paths are canonical and the backend hands us native paths, so
- * this only has to forgive the one thing that is still ambiguous: on Windows both
- * separators mean the same thing. Off Windows a backslash is a normal filename
- * character, so `a\b.ts` and `a/b.ts` are two different files there.
+ * this only has to forgive what Windows itself treats as insignificant: either
+ * separator, and the casing, including the drive letter.
+ *
+ * Neither applies off Windows, where a backslash is a normal filename character and
+ * `a.ts` and `A.ts` can be two different files.
  */
 export function isSameFilePath(a: string, b: string): boolean {
   if (a === b) return true
-  return isWindows() && a.replace(/\\/g, '/') === b.replace(/\\/g, '/')
+  if (!isWindows()) return false
+  return a.replace(/\\/g, '/').toLowerCase() === b.replace(/\\/g, '/').toLowerCase()
 }
 
 interface FileViewerState {

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -69,15 +69,36 @@ export function tabAbsolutePath(tab: TabEntry): string | null {
 }
 
 /**
- * Paths the backend builds go through path.join, which collapses repeated
- * separators, while paths joined here keep whatever the worktree path had. A
- * run of separators means the same thing as one, so level that out.
+ * Paths the backend builds go through path.join, which resolves separators and
+ * dot segments, while paths joined here keep whatever the worktree path had. So
+ * a saved path like /tmp/base/../repo reaches the rows as /tmp/repo.
+ *
+ * path.join is purely lexical, it never touches the filesystem, so doing the
+ * same lexical work here is enough to compare the two. Kept local because the
+ * renderer has no path module and also runs in the browser.
  */
 function comparableFilePath(path: string, windows: boolean): string {
   // Only Windows can spell a separator two ways: on macOS and Linux a backslash
   // is a normal filename character, so `a\b.ts` and `a/b.ts` differ there.
   const slashed = windows ? path.replace(/\\/g, '/') : path
-  return slashed.replace(/\/{2,}/g, '/')
+  const absolute = slashed.startsWith('/')
+  const segments: string[] = []
+
+  for (const segment of slashed.split('/')) {
+    if (segment === '' || segment === '.') continue
+    if (segment === '..') {
+      if (segments.length && segments[segments.length - 1] !== '..') {
+        segments.pop()
+      } else if (!absolute) {
+        // A relative path keeps leading "..", an absolute one cannot go above root.
+        segments.push('..')
+      }
+      continue
+    }
+    segments.push(segment)
+  }
+
+  return (absolute ? '/' : '') + segments.join('/')
 }
 
 /**

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -56,7 +56,8 @@ export function diffTabAbsolutePath(diff: { worktreePath: string; filePath: stri
   const filePath = isWindows() ? diff.filePath.replace(/\//g, separator) : diff.filePath
   // The backend joins with path.join, which collapses a trailing separator, so
   // trim one here too. Otherwise a worktree at "/" would give us "//src/a.ts".
-  const worktreePath = diff.worktreePath.replace(/[/\\]+$/, '')
+  // Only a slash counts off Windows, where a trailing backslash is part of the name.
+  const worktreePath = diff.worktreePath.replace(isWindows() ? /[/\\]+$/ : /\/+$/, '')
   return `${worktreePath}${separator}${filePath}`
 }
 

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -81,16 +81,33 @@ function comparableFilePath(path: string, windows: boolean): string {
   // Only Windows can spell a separator two ways: on macOS and Linux a backslash
   // is a normal filename character, so `a\b.ts` and `a/b.ts` differ there.
   const slashed = windows ? path.replace(/\\/g, '/') : path
-  const absolute = slashed.startsWith('/')
+
+  // Split off the part ".." must never climb past: the server and share of a UNC
+  // path, or a drive letter, which can sit right in front of a relative path as
+  // in C:foo. Without this, ".." would eat the root and paths stop matching.
+  let root = ''
+  let rest = slashed
+  if (windows) {
+    const unc = slashed.match(/^\/\/[^/]+\/[^/]+/)
+    if (unc) {
+      root = unc[0]
+      rest = slashed.slice(root.length)
+    } else if (/^[a-zA-Z]:/.test(slashed)) {
+      root = slashed.slice(0, 2)
+      rest = slashed.slice(2)
+    }
+  }
+
+  const absolute = rest.startsWith('/')
   const segments: string[] = []
 
-  for (const segment of slashed.split('/')) {
+  for (const segment of rest.split('/')) {
     if (segment === '' || segment === '.') continue
     if (segment === '..') {
       if (segments.length && segments[segments.length - 1] !== '..') {
         segments.pop()
-      } else if (!absolute) {
-        // A relative path keeps leading "..", an absolute one cannot go above root.
+      } else if (!absolute && !root) {
+        // Only a rootless relative path keeps a leading "..".
         segments.push('..')
       }
       continue
@@ -98,7 +115,7 @@ function comparableFilePath(path: string, windows: boolean): string {
     segments.push(segment)
   }
 
-  return (absolute ? '/' : '') + segments.join('/')
+  return root + (absolute ? '/' : '') + segments.join('/')
 }
 
 /**

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -69,14 +69,25 @@ export function tabAbsolutePath(tab: TabEntry): string | null {
 }
 
 /**
- * Same file? Paths reach the renderer from several places, some native and some
- * slash separated, so callers do not have to agree on a separator. Only Windows
- * has that ambiguity: on macOS and Linux a backslash is a normal filename
- * character, so `a\b.ts` and `a/b.ts` are two different files there.
+ * Paths the backend builds go through path.join, which collapses repeated
+ * separators, while paths joined here keep whatever the worktree path had. A
+ * run of separators means the same thing as one, so level that out.
+ */
+function comparableFilePath(path: string, windows: boolean): string {
+  // Only Windows can spell a separator two ways: on macOS and Linux a backslash
+  // is a normal filename character, so `a\b.ts` and `a/b.ts` differ there.
+  const slashed = windows ? path.replace(/\\/g, '/') : path
+  return slashed.replace(/\/{2,}/g, '/')
+}
+
+/**
+ * Same file? Paths reach the renderer from several places and spell the same
+ * location differently, so callers do not have to agree on a form.
  */
 export function isSameFilePath(a: string, b: string): boolean {
   if (a === b) return true
-  return isWindows() && a.replace(/\\/g, '/') === b.replace(/\\/g, '/')
+  const windows = isWindows()
+  return comparableFilePath(a, windows) === comparableFilePath(b, windows)
 }
 
 interface FileViewerState {

--- a/src/renderer/src/stores/useProjectStore.ts
+++ b/src/renderer/src/stores/useProjectStore.ts
@@ -138,8 +138,9 @@ export const useProjectStore = create<ProjectState>()(
             return { success: false, error: validation.error }
           }
 
-          // Check if project already exists
-          const existingProject = await dbApi.project.getByPath<Project>(path)
+          // Check if project already exists, by the canonical path validation returned,
+          // so the same folder spelled differently is not added twice
+          const existingProject = await dbApi.project.getByPath<Project>(validation.path!)
           if (existingProject) {
             return { success: false, error: 'This project has already been added to Hive.' }
           }

--- a/src/renderer/src/stores/useProjectStore.ts
+++ b/src/renderer/src/stores/useProjectStore.ts
@@ -138,9 +138,13 @@ export const useProjectStore = create<ProjectState>()(
             return { success: false, error: validation.error }
           }
 
-          // Check if project already exists, by the canonical path validation returned,
-          // so the same folder spelled differently is not added twice
-          const existingProject = await dbApi.project.getByPath<Project>(validation.path!)
+          // Check the canonical path, so the same folder spelled differently is not
+          // added twice, and the spelling as given, because projects added before
+          // paths were canonicalized are still stored under their original spelling.
+          const canonicalPath = validation.path!
+          const existingProject =
+            (await dbApi.project.getByPath<Project>(canonicalPath)) ??
+            (canonicalPath === path ? null : await dbApi.project.getByPath<Project>(path))
           if (existingProject) {
             return { success: false, error: 'This project has already been added to Hive.' }
           }

--- a/src/server/__tests__/project-ops-validate-live.test.ts
+++ b/src/server/__tests__/project-ops-validate-live.test.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync, mkdirSync, rmSync, realpathSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Effect } from 'effect'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { makeLiveProjectOpsRpcService } from '../rpc/domains/project-ops'
+
+// The live service is the one the app actually calls. It used to carry its own copy
+// of this validation, which meant the canonicalization in main/services never ran.
+describe('live projectOps.validateProject', () => {
+  let base: string
+
+  beforeEach(() => {
+    base = realpathSync(mkdtempSync(join(tmpdir(), 'hive-rpc-validate-')))
+    mkdirSync(join(base, 'repo', '.git'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  it('returns a canonical path', async () => {
+    const service = makeLiveProjectOpsRpcService()
+
+    const result = await Effect.runPromise(
+      service.validateProject(join(base, 'repo', '..', 'repo') + '/')
+    )
+
+    expect(result).toEqual({ success: true, path: join(base, 'repo'), name: 'repo' })
+  })
+
+  it('still reports a folder that is not a git repository', async () => {
+    mkdirSync(join(base, 'plain'))
+    const service = makeLiveProjectOpsRpcService()
+
+    const result = await Effect.runPromise(service.validateProject(join(base, 'plain')))
+
+    expect(result).toMatchObject({ success: false })
+  })
+})

--- a/src/server/rpc/domains/git-ops.ts
+++ b/src/server/rpc/domains/git-ops.ts
@@ -34,6 +34,10 @@ import {
 import type { EventBus } from '../../events/event-bus'
 import type { RpcHandler } from '../router'
 import { canonicalPath } from '../../../shared/fs-path-checks'
+import {
+  normalizeBranchDisplayName,
+  parseWorktreeForBranch
+} from '../../../shared/git-output'
 
 export interface GitFileStatusResult {
   readonly success: boolean
@@ -548,25 +552,7 @@ const parseNumstat = (line: string): GitDiffStatFile | null => {
   }
 }
 
-const parseWorktreeForBranch = (porcelainOutput: string, branchName: string): string | null => {
-  const blocks = porcelainOutput.trim().split('\n\n')
-  for (const block of blocks) {
-    const lines = block.split('\n')
-    let worktreePath = ''
-    let branch = ''
-    for (const line of lines) {
-      if (line.startsWith('worktree ')) worktreePath = line.slice('worktree '.length)
-      if (line.startsWith('branch refs/heads/')) branch = line.slice('branch refs/heads/'.length)
-    }
-    if (branch === branchName && worktreePath) return worktreePath
-  }
-  return null
-}
-
 const invalidBranch = (branch: string): boolean => !branch || branch.startsWith('-')
-
-const normalizeBranchDisplayName = (branchName: string): string =>
-  branchName.startsWith('remotes/') ? branchName.replace(/^remotes\//, '') : branchName
 
 const preserveRequestedProjectPath = (reportedPath: string, projectPath: string): string =>
   canonicalPath(reportedPath) === canonicalPath(projectPath) ? projectPath : reportedPath

--- a/src/server/rpc/domains/git-ops.ts
+++ b/src/server/rpc/domains/git-ops.ts
@@ -4,7 +4,6 @@ import {
   mkdtempSync,
   promises as fsPromises,
   readFileSync,
-  realpathSync,
   rmSync,
   statSync,
   unlinkSync,
@@ -12,7 +11,7 @@ import {
 } from 'node:fs'
 import { execFile } from 'node:child_process'
 import { tmpdir } from 'node:os'
-import { basename, join, resolve } from 'node:path'
+import { basename, join } from 'node:path'
 import { promisify } from 'node:util'
 import { Effect } from 'effect'
 import simpleGit, { GitResponseError, type MergeResult } from 'simple-git'
@@ -34,6 +33,7 @@ import {
 } from '../../../main/services/gitlab-cli'
 import type { EventBus } from '../../events/event-bus'
 import type { RpcHandler } from '../router'
+import { canonicalPath } from '../../../shared/fs-path-checks'
 
 export interface GitFileStatusResult {
   readonly success: boolean
@@ -568,18 +568,8 @@ const invalidBranch = (branch: string): boolean => !branch || branch.startsWith(
 const normalizeBranchDisplayName = (branchName: string): string =>
   branchName.startsWith('remotes/') ? branchName.replace(/^remotes\//, '') : branchName
 
-const canonicalizePathForComparison = (path: string): string => {
-  try {
-    return realpathSync(path)
-  } catch {
-    return resolve(path)
-  }
-}
-
 const preserveRequestedProjectPath = (reportedPath: string, projectPath: string): string =>
-  canonicalizePathForComparison(reportedPath) === canonicalizePathForComparison(projectPath)
-    ? projectPath
-    : reportedPath
+  canonicalPath(reportedPath) === canonicalPath(projectPath) ? projectPath : reportedPath
 
 export interface GitOpsRpcServiceDependencies {
   readonly runCommand?: CommandRunner

--- a/src/server/rpc/domains/github-ops.ts
+++ b/src/server/rpc/domains/github-ops.ts
@@ -1,5 +1,5 @@
 import { spawn, execFile, type ChildProcess } from 'node:child_process'
-import { existsSync, statSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
@@ -9,6 +9,7 @@ import { z } from 'zod'
 import { GITHUB_CLONE_PROGRESS_CHANNEL, type GithubCloneProgressEvent } from '@shared/github-events'
 import type { EventBus } from '../../events/event-bus'
 import type { RpcHandler } from '../router'
+import { isValidDirectory } from '../../../shared/fs-path-checks'
 
 export interface GithubRepo {
   readonly nameWithOwner: string
@@ -97,14 +98,6 @@ const GH_REPOS_ENDPOINT =
   'user/repos?per_page=100&affiliation=owner,collaborator,organization_member&sort=pushed'
 const GH_REPOS_JQ =
   '.[] | {nameWithOwner: .full_name, description: .description, isPrivate: .private, updatedAt: .pushed_at}'
-
-const isValidDirectory = (path: string): boolean => {
-  try {
-    return existsSync(path) && statSync(path).isDirectory()
-  } catch {
-    return false
-  }
-}
 
 const describeGhError = (error: unknown): string => {
   const message = error instanceof Error ? error.message : String(error)

--- a/src/server/rpc/domains/project-ops.ts
+++ b/src/server/rpc/domains/project-ops.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, statSync } from 'node:fs'
-import { basename, join } from 'node:path'
+import { join } from 'node:path'
 import { Effect } from 'effect'
 import { z } from 'zod'
 import { isDesktopCommandResult, makeDesktopCommandRequest } from '../../../shared/desktop-command'
@@ -129,28 +129,15 @@ export const makeLiveProjectOpsRpcService = (): ProjectOpsRpcService => ({
       try: () => isGitRepositoryPath(path),
       catch: () => false
     }),
+  // Delegates so the path a project is stored under is canonicalized in exactly one
+  // place. A second copy here drifted out of step with the service once already.
   validateProject: (path) =>
-    Effect.sync(() => {
-      if (!isValidDirectory(path)) {
-        return {
-          success: false,
-          error: 'The selected path is not a valid directory.'
-        }
-      }
-
-      if (!isGitRepositoryPath(path)) {
-        return {
-          success: false,
-          error:
-            'The selected folder is not a Git repository. Please select a folder containing a .git directory.'
-        }
-      }
-
-      return {
-        success: true,
-        path,
-        name: basename(path)
-      }
+    Effect.tryPromise({
+      try: async () => {
+        const { validateProject } = await import('../../../main/services/project-ops')
+        return validateProject(path)
+      },
+      catch: (cause) => cause
     }),
   detectLanguage: (projectPath) =>
     Effect.tryPromise({

--- a/src/server/rpc/domains/project-ops.ts
+++ b/src/server/rpc/domains/project-ops.ts
@@ -1,10 +1,14 @@
-import { existsSync, readdirSync, statSync } from 'node:fs'
+import { existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { Effect } from 'effect'
 import { z } from 'zod'
 import { isDesktopCommandResult, makeDesktopCommandRequest } from '../../../shared/desktop-command'
 import type { SuggestionItem } from '../../../shared/types/setup-suggestions'
 import type { RpcHandler } from '../router'
+import {
+  isValidDirectory,
+  isGitRepository as isGitRepositoryPath
+} from '../../../shared/fs-path-checks'
 
 export interface ProjectOpsRpcService {
   readonly openDirectoryDialog: () => Effect.Effect<string | null, unknown, never>
@@ -80,23 +84,6 @@ const createProjectFolderParamsSchema = z
 const INVALID_PROJECT_NAME_PATTERN = /[/\\:*?"<>|]/
 // Windows device names; folders with these names fail or misbehave on Windows.
 const WINDOWS_RESERVED_NAME_PATTERN = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i
-
-const isValidDirectory = (path: string): boolean => {
-  try {
-    return existsSync(path) && statSync(path).isDirectory()
-  } catch {
-    return false
-  }
-}
-
-const isGitRepositoryPath = (path: string): boolean => {
-  try {
-    const gitPath = join(path, '.git')
-    return existsSync(gitPath) && statSync(gitPath).isDirectory()
-  } catch {
-    return false
-  }
-}
 
 export const makeLiveProjectOpsRpcService = (): ProjectOpsRpcService => ({
   openDirectoryDialog: () =>

--- a/src/server/rpc/domains/teleport-ops.ts
+++ b/src/server/rpc/domains/teleport-ops.ts
@@ -23,6 +23,7 @@ import type {
   TeleportRemoteReceiveResult
 } from '../../../main/services/teleport-remote-client'
 import type { RpcHandler } from '../router'
+import { requireSuccess } from '../../../shared/operation-result'
 
 const execFileAsync = promisify(execFile)
 
@@ -141,10 +142,6 @@ const failStep = (step: string, error: unknown): TeleportStartResult => ({
   step,
   error: errorMessage(error)
 })
-
-function requireSuccess(result: { success: boolean; error?: string }, fallback: string): void {
-  if (!result.success) throw new Error(result.error || fallback)
-}
 
 function discordChannelUrl(guildId: string, channelId: string): string {
   return `https://discord.com/channels/${guildId}/${channelId}`

--- a/src/shared/__tests__/fs-path-checks.test.ts
+++ b/src/shared/__tests__/fs-path-checks.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { isValidDirectory, isGitRepository } from '../fs-path-checks'
+
+// This is imported statically by three RPC domains (project-ops, github-ops) and by
+// main/services/project-ops, replacing what used to be three copied definitions.
+describe('fs-path-checks', () => {
+  let base: string
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'hive-fs-path-checks-'))
+  })
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  describe('isValidDirectory', () => {
+    it('is true for a directory', () => {
+      expect(isValidDirectory(base)).toBe(true)
+    })
+
+    it('is false for a file', () => {
+      const file = join(base, 'file.txt')
+      writeFileSync(file, '')
+      expect(isValidDirectory(file)).toBe(false)
+    })
+
+    it('is false for a path that does not exist', () => {
+      expect(isValidDirectory(join(base, 'missing'))).toBe(false)
+    })
+  })
+
+  describe('isGitRepository', () => {
+    it('is true when .git is a directory', () => {
+      mkdirSync(join(base, '.git'))
+      expect(isGitRepository(base)).toBe(true)
+    })
+
+    it('is false when there is no .git', () => {
+      expect(isGitRepository(base)).toBe(false)
+    })
+
+    it('is false when .git is a file, not a directory', () => {
+      // A git worktree links back with a .git *file*, which is not a repo root itself.
+      writeFileSync(join(base, '.git'), 'gitdir: /elsewhere')
+      expect(isGitRepository(base)).toBe(false)
+    })
+  })
+})

--- a/src/shared/__tests__/fs-path-checks.test.ts
+++ b/src/shared/__tests__/fs-path-checks.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { isValidDirectory, isGitRepository, canonicalPath } from '../fs-path-checks'
+import {
+  isValidDirectory,
+  isGitRepository,
+  canonicalPath,
+  tryCanonicalPath
+} from '../fs-path-checks'
 
 // This is imported statically by three RPC domains (project-ops, github-ops) and by
 // main/services/project-ops, replacing what used to be three copied definitions.
@@ -73,8 +78,20 @@ describe('fs-path-checks', () => {
     })
 
     it('falls back to the lexical form when the path cannot be resolved', () => {
-      // Callers have to check the path exists, the fallback is only a best effort.
+      // Only safe for comparing. Anything that stores or opens a path uses
+      // tryCanonicalPath and handles the null.
       expect(canonicalPath(join(base, 'missing', '..', 'missing'))).toBe(join(base, 'missing'))
+    })
+  })
+
+  describe('tryCanonicalPath', () => {
+    it('resolves a real path', () => {
+      mkdirSync(join(base, 'repo'))
+      expect(tryCanonicalPath(join(base, 'repo', '..', 'repo'))).toBe(join(base, 'repo'))
+    })
+
+    it('returns null instead of guessing when the path cannot be resolved', () => {
+      expect(tryCanonicalPath(join(base, 'missing'))).toBeNull()
     })
   })
 })

--- a/src/shared/__tests__/fs-path-checks.test.ts
+++ b/src/shared/__tests__/fs-path-checks.test.ts
@@ -1,9 +1,9 @@
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { isValidDirectory, isGitRepository } from '../fs-path-checks'
+import { isValidDirectory, isGitRepository, canonicalPath } from '../fs-path-checks'
 
 // This is imported statically by three RPC domains (project-ops, github-ops) and by
 // main/services/project-ops, replacing what used to be three copied definitions.
@@ -11,7 +11,7 @@ describe('fs-path-checks', () => {
   let base: string
 
   beforeEach(() => {
-    base = mkdtempSync(join(tmpdir(), 'hive-fs-path-checks-'))
+    base = realpathSync(mkdtempSync(join(tmpdir(), 'hive-fs-path-checks-')))
   })
 
   afterEach(() => {
@@ -48,6 +48,33 @@ describe('fs-path-checks', () => {
       // A git worktree links back with a .git *file*, which is not a repo root itself.
       writeFileSync(join(base, '.git'), 'gitdir: /elsewhere')
       expect(isGitRepository(base)).toBe(false)
+    })
+  })
+
+  describe('canonicalPath', () => {
+    beforeEach(() => {
+      mkdirSync(join(base, 'repo'))
+    })
+
+    it('drops dot segments, repeated separators and a trailing separator', () => {
+      const expected = join(base, 'repo')
+      expect(canonicalPath(join(base, 'repo', '..', 'repo'))).toBe(expected)
+      expect(canonicalPath(`${base}//repo`)).toBe(expected)
+      expect(canonicalPath(`${base}/repo/`)).toBe(expected)
+    })
+
+    it('resolves a symlink to the real directory', () => {
+      symlinkSync(join(base, 'repo'), join(base, 'link'))
+      expect(canonicalPath(join(base, 'link'))).toBe(join(base, 'repo'))
+    })
+
+    it('leaves an already canonical path alone', () => {
+      expect(canonicalPath(join(base, 'repo'))).toBe(join(base, 'repo'))
+    })
+
+    it('falls back to the lexical form when the path cannot be resolved', () => {
+      // Callers have to check the path exists, the fallback is only a best effort.
+      expect(canonicalPath(join(base, 'missing', '..', 'missing'))).toBe(join(base, 'missing'))
     })
   })
 })

--- a/src/shared/__tests__/git-output.test.ts
+++ b/src/shared/__tests__/git-output.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeBranchDisplayName, parseWorktreeForBranch } from '../git-output'
+
+describe('normalizeBranchDisplayName', () => {
+  it('strips the remotes prefix', () => {
+    expect(normalizeBranchDisplayName('remotes/origin/main')).toBe('origin/main')
+  })
+
+  it('leaves a local branch alone', () => {
+    expect(normalizeBranchDisplayName('main')).toBe('main')
+  })
+
+  it('only strips a leading prefix', () => {
+    expect(normalizeBranchDisplayName('feature/remotes/thing')).toBe('feature/remotes/thing')
+  })
+})
+
+describe('parseWorktreeForBranch', () => {
+  const output = [
+    'worktree /repo',
+    'HEAD abc123',
+    'branch refs/heads/main',
+    '',
+    'worktree /repo-feature',
+    'HEAD def456',
+    'branch refs/heads/feature-x'
+  ].join('\n')
+
+  it('finds the worktree checked out on a branch', () => {
+    expect(parseWorktreeForBranch(output, 'feature-x')).toBe('/repo-feature')
+    expect(parseWorktreeForBranch(output, 'main')).toBe('/repo')
+  })
+
+  it('returns null when the branch is not checked out anywhere', () => {
+    expect(parseWorktreeForBranch(output, 'missing')).toBeNull()
+  })
+
+  it('returns null for empty output', () => {
+    expect(parseWorktreeForBranch('', 'main')).toBeNull()
+  })
+
+  it('ignores a detached worktree, which has no branch line', () => {
+    const detached = ['worktree /repo-detached', 'HEAD abc123', 'detached'].join('\n')
+    expect(parseWorktreeForBranch(detached, 'main')).toBeNull()
+  })
+})

--- a/src/shared/__tests__/operation-result.test.ts
+++ b/src/shared/__tests__/operation-result.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { requireSuccess } from '../operation-result'
+
+describe('requireSuccess', () => {
+  it('does nothing when the operation succeeded', () => {
+    expect(() => requireSuccess({ success: true }, 'fallback')).not.toThrow()
+  })
+
+  it('throws the error the operation reported', () => {
+    expect(() => requireSuccess({ success: false, error: 'no remote' }, 'fallback')).toThrow(
+      'no remote'
+    )
+  })
+
+  it('falls back when the operation failed without a message', () => {
+    expect(() => requireSuccess({ success: false }, 'fallback')).toThrow('fallback')
+    expect(() => requireSuccess({ success: false, error: '' }, 'fallback')).toThrow('fallback')
+  })
+})

--- a/src/shared/fs-path-checks.ts
+++ b/src/shared/fs-path-checks.ts
@@ -1,0 +1,26 @@
+import { existsSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Sync fs checks shared by main and server project code. Kept Electron-free so the
+ * server (browser/headless) build can import them statically: main/services/project-ops
+ * imports Electron's `app` at module scope, so anything in that file needs a lazy
+ * `await import(...)` from server code instead of a static import.
+ */
+
+export function isValidDirectory(path: string): boolean {
+  try {
+    return existsSync(path) && statSync(path).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+export function isGitRepository(path: string): boolean {
+  try {
+    const gitPath = join(path, '.git')
+    return existsSync(gitPath) && statSync(gitPath).isDirectory()
+  } catch {
+    return false
+  }
+}

--- a/src/shared/fs-path-checks.ts
+++ b/src/shared/fs-path-checks.ts
@@ -1,5 +1,5 @@
-import { existsSync, statSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, realpathSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 
 /**
  * Sync fs checks shared by main and server project code. Kept Electron-free so the
@@ -22,5 +22,22 @@ export function isGitRepository(path: string): boolean {
     return existsSync(gitPath) && statSync(gitPath).isDirectory()
   } catch {
     return false
+  }
+}
+
+/**
+ * The one spelling of a path we compare and store. realpath rather than resolve,
+ * because the filesystem follows a symlink before a "..", so resolving lexically can
+ * land on a different directory.
+ *
+ * Falls back to the lexical form when realpath fails, which happens on macOS when a
+ * ".." follows a symlink, even though opening that path works. Callers should treat
+ * the fallback as a best effort and still check the path exists.
+ */
+export function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path)
+  } catch {
+    return resolve(path)
   }
 }

--- a/src/shared/fs-path-checks.ts
+++ b/src/shared/fs-path-checks.ts
@@ -26,18 +26,24 @@ export function isGitRepository(path: string): boolean {
 }
 
 /**
- * The one spelling of a path we compare and store. realpath rather than resolve,
- * because the filesystem follows a symlink before a "..", so resolving lexically can
- * land on a different directory.
- *
- * Falls back to the lexical form when realpath fails, which happens on macOS when a
- * ".." follows a symlink, even though opening that path works. Callers should treat
- * the fallback as a best effort and still check the path exists.
+ * The one spelling of a path we compare and store, or null when the filesystem
+ * cannot resolve it. realpath rather than resolve, because the filesystem follows a
+ * symlink before a "..", so resolving lexically can land on a different directory.
  */
-export function canonicalPath(path: string): string {
+export function tryCanonicalPath(path: string): string | null {
   try {
     return realpathSync(path)
   } catch {
-    return resolve(path)
+    return null
   }
+}
+
+/**
+ * Canonical path, falling back to the lexical form when the filesystem cannot
+ * resolve it. Only for comparing two paths, where a best effort beats nothing.
+ * Anything that stores or opens the result should use tryCanonicalPath and handle
+ * the null, because the lexical form can name a different directory.
+ */
+export function canonicalPath(path: string): string {
+  return tryCanonicalPath(path) ?? resolve(path)
 }

--- a/src/shared/git-output.ts
+++ b/src/shared/git-output.ts
@@ -1,0 +1,31 @@
+/**
+ * Parsing and tidying of raw git CLI output. Pure string work, no Electron and no
+ * filesystem, so the main process and the server can both import it directly.
+ */
+
+/** Strip the `remotes/` prefix git uses for remote branches, for display. */
+export function normalizeBranchDisplayName(branchName: string): string {
+  return branchName.startsWith('remotes/') ? branchName.replace(/^remotes\//, '') : branchName
+}
+
+/**
+ * Find the worktree checked out on a branch in `git worktree list --porcelain`
+ * output. Returns the worktree path, or null when the branch is not checked out.
+ */
+export function parseWorktreeForBranch(porcelainOutput: string, branchName: string): string | null {
+  const blocks = porcelainOutput.trim().split('\n\n')
+
+  for (const block of blocks) {
+    let worktreePath = ''
+    let branch = ''
+
+    for (const line of block.split('\n')) {
+      if (line.startsWith('worktree ')) worktreePath = line.slice('worktree '.length)
+      if (line.startsWith('branch refs/heads/')) branch = line.slice('branch refs/heads/'.length)
+    }
+
+    if (branch === branchName && worktreePath) return worktreePath
+  }
+
+  return null
+}

--- a/src/shared/operation-result.ts
+++ b/src/shared/operation-result.ts
@@ -1,0 +1,13 @@
+/** The `{ success, error? }` shape most of Hive's operations return. */
+export interface OperationResult {
+  success: boolean
+  error?: string
+}
+
+/**
+ * Turn a failed operation result into a thrown error, for multi step flows that
+ * should stop at the first failure rather than check every return value.
+ */
+export function requireSuccess(result: OperationResult, fallback: string): void {
+  if (!result.success) throw new Error(result.error || fallback)
+}


### PR DESCRIPTION
## Description

Files that are open in a tab now get a marker in the sidebar file lists. A thin bar on the left edge of the row, dimmed when the file sits in a background tab, full strength plus a light row background when it is the active tab. This works in all three lists: Changes, Files, and Diffs.

The marker reuses the tab strip look, so a marked row and its tab read as one thing. Those two tab tokens were copy-pasted in 16 places, so this PR also gives them a single home.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🎨 UI/UX improvement
- [x] ♻️ Code refactoring

## Changes Made
- Added `useFileTabState(absolutePath)`, one hook that answers "is this file active, open, or neither" for every file list. It returns a scalar, so opening or switching a tab only re-renders the rows that actually changed.
- Added `OpenTabIndicator` for the marker bar, plus `open-tab-classes.ts` mapping tab state to the row background.
- Added `lib/tab-styles.ts` as the single source for the active tab surface and the 2px marker. `SessionTabs`, `FileSidebar`, `BottomPanel` and `TerminalTabsHorizontal` now import from it instead of repeating the `color-mix` strings. Class strings are unchanged, so this is a no-op visually.
- Moved tab path logic into `useFileViewerStore`: `diffTabAbsolutePath()` and `tabAbsolutePath()`. A diff tab keeps the worktree path and the file path separately, so only the store should know how to join them. `SessionTabs` uses the helper instead of its own copy.
- Wired the indicator into `ChangesView` (this also covers connection mode, which reuses `FileRow`), `FileTreeNode`, and `BranchDiffView`.
- Extracted a memoized `BranchDiffFileRow`. That list is not virtualized, so without it every row re-rendered on any tab change.
- The file tree reports open and active state through `aria-label`. `aria-selected` means tree selection, which this tree does not have.

## Screenshots

<img width="1305" height="573" alt="Bildschirmfoto 2026-08-20 um 11 53 12" src="https://github.com/user-attachments/assets/fc50b5a0-240c-4f0e-baf1-a1a2652947e0" />


## Testing

### Test Configuration
- **OS**: macOS
- **Test Type**: Unit + Manual

### Test Steps
1. Open a worktree with uncommitted changes and click a file in the Changes list. The row gets a bright left bar and a light background.
2. Switch back to the session tab. The bar stays but dims, because the file is still open.
3. Open a second file and switch between the tabs. The bright marker follows the active tab.
4. Close the tab. The marker disappears.
5. Repeat in the Files tree and the Diffs list. Folders never get a marker.
6. Check the tab strips still look right: session tabs, the Changes/Files/Diffs tabs, the bottom panel tabs, and the terminal tabs.

### Test Results
- [x] All existing tests pass
- [x] New tests added (if applicable)
- [x] Manual testing completed

Used daily for several days. The full suite fails 43 files on this base for unrelated reasons (sqlite bindings and similar); the same 43 fail identically without this branch, with matching per-file counts.

## Performance Impact
- [x] Improves performance

The `BranchDiffFileRow` extraction removes a full-list re-render on every tab open, close, and switch. That list is unvirtualized and can hold hundreds of rows when comparing against main.

## Breaking Changes
- [x] No breaking changes

## Additional Notes

State is matched by absolute path, so a partially staged file, which appears as both a staged and an unstaged row in Changes, marks both rows. That keeps one rule across all three lists rather than one rule per list.