### PR TITLE
Add Push All and Pull All controls for connection projects

### DIFF
--- a/src/renderer/src/components/file-tree/ChangesView.tsx
+++ b/src/renderer/src/components/file-tree/ChangesView.tsx
@@ -39,6 +39,7 @@ import { FileIcon } from './FileIcon'
 import { GitStatusIndicator } from './GitStatusIndicator'
 import { GitCommitForm } from '@/components/git/GitCommitForm'
 import { GitPushPull } from '@/components/git/GitPushPull'
+import { ConnectionPushPull } from '@/components/git/ConnectionPushPull'
 
 interface ConnectionMemberInfo {
   worktree_path: string
@@ -603,6 +604,9 @@ export function ChangesView({
             )
           })}
         </div>
+
+        {/* Push/Pull across all member repos */}
+        <ConnectionPushPull members={connectionMembers ?? []} />
       </div>
     )
   }

--- a/src/renderer/src/components/git/ConnectionPushPull.test.tsx
+++ b/src/renderer/src/components/git/ConnectionPushPull.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ConnectionPushPull } from './ConnectionPushPull'
+import { useGitStore } from '@/stores/useGitStore'
+import { toast } from '@/lib/toast'
+
+vi.mock('@/lib/toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() }
+}))
+
+const members = [
+  { worktree_path: '/a', project_name: 'alpha' },
+  { worktree_path: '/b', project_name: 'beta' },
+  { worktree_path: '/c', project_name: 'gamma' }
+]
+
+const info = (ahead: number, behind: number, tracking: string | null) => ({
+  name: 'feat',
+  ahead,
+  behind,
+  tracking
+})
+
+describe('ConnectionPushPull', () => {
+  const push = vi.fn()
+  const pull = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    push.mockResolvedValue({ success: true })
+    pull.mockResolvedValue({ success: true })
+    useGitStore.setState({
+      push,
+      pull,
+      branchInfoByWorktree: new Map([
+        ['/a', info(2, 1, 'origin/feat')],
+        ['/b', info(1, 0, 'origin/feat')],
+        ['/c', info(0, 0, null)]
+      ]) as never
+    })
+  })
+
+  it('renders nothing without members', () => {
+    const { container } = render(<ConnectionPushPull members={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows aggregated ahead/behind counts', () => {
+    render(<ConnectionPushPull members={members} />)
+    expect(screen.getByTestId('connection-push-button')).toHaveTextContent('(3)')
+    expect(screen.getByTestId('connection-pull-button')).toHaveTextContent('(1)')
+  })
+
+  it('pushes every member path', async () => {
+    render(<ConnectionPushPull members={members} />)
+    fireEvent.click(screen.getByTestId('connection-push-button'))
+    await waitFor(() => expect(push).toHaveBeenCalledTimes(3))
+    expect(push.mock.calls.map((c) => c[0])).toEqual(['/a', '/b', '/c'])
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Pushed 3 repos'))
+  })
+
+  it('pulls only members with an upstream and reports skipped ones', async () => {
+    render(<ConnectionPushPull members={members} />)
+    fireEvent.click(screen.getByTestId('connection-pull-button'))
+    await waitFor(() => expect(pull).toHaveBeenCalledTimes(2))
+    expect(pull.mock.calls.map((c) => c[0])).toEqual(['/a', '/b'])
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith('Pulled 2 repos', {
+        description: '1 repo without upstream skipped'
+      })
+    )
+  })
+
+  it('continues after a failure and reports which repos failed', async () => {
+    push.mockImplementation(async (p: string) =>
+      p === '/b' ? { success: false, error: 'rejected' } : { success: true }
+    )
+    render(<ConnectionPushPull members={members} />)
+    fireEvent.click(screen.getByTestId('connection-push-button'))
+    await waitFor(() => expect(push).toHaveBeenCalledTimes(3))
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Push failed for 1 of 3 repos', {
+        description: 'beta: rejected'
+      })
+    )
+  })
+
+  it('disables pull when no member has an upstream', () => {
+    useGitStore.setState({
+      branchInfoByWorktree: new Map([['/a', info(0, 0, null)]]) as never
+    })
+    render(<ConnectionPushPull members={[members[0]]} />)
+    expect(screen.getByTestId('connection-pull-button')).toBeDisabled()
+    expect(screen.getByTestId('connection-push-button')).not.toBeDisabled()
+  })
+})

--- a/src/renderer/src/components/git/ConnectionPushPull.tsx
+++ b/src/renderer/src/components/git/ConnectionPushPull.tsx
@@ -1,0 +1,168 @@
+import { useCallback, useMemo, useState } from 'react'
+import { ArrowUpCircle, ArrowDownCircle, Loader2 } from 'lucide-react'
+import { toast } from '@/lib/toast'
+import { Button } from '@/components/ui/button'
+import { useGitStore } from '@/stores/useGitStore'
+import { cn } from '@/lib/utils'
+
+interface ConnectionPushPullMember {
+  worktree_path: string
+  project_name: string
+}
+
+interface ConnectionPushPullProps {
+  members: ConnectionPushPullMember[]
+  className?: string
+}
+
+type MemberResult = { member: ConnectionPushPullMember; success: boolean; error?: string }
+
+function describeFailures(failures: MemberResult[]): string {
+  return failures
+    .map((f) => `${f.member.project_name}: ${f.error || 'unknown error'}`)
+    .join('\n')
+}
+
+/**
+ * Push/Pull controls for a connection: runs the operation against every member
+ * worktree path (each member's checked-out branch), just like the single-worktree
+ * GitPushPull does for a normal project.
+ */
+export function ConnectionPushPull({
+  members,
+  className
+}: ConnectionPushPullProps): React.JSX.Element | null {
+  const push = useGitStore((s) => s.push)
+  const pull = useGitStore((s) => s.pull)
+  const branchInfoByWorktree = useGitStore((s) => s.branchInfoByWorktree)
+  const [isPushingAll, setIsPushingAll] = useState(false)
+  const [isPullingAll, setIsPullingAll] = useState(false)
+
+  const { ahead, behind, trackedMembers } = useMemo(() => {
+    let ahead = 0
+    let behind = 0
+    const trackedMembers: ConnectionPushPullMember[] = []
+    for (const member of members) {
+      const info = branchInfoByWorktree.get(member.worktree_path)
+      ahead += info?.ahead || 0
+      behind += info?.behind || 0
+      if (info?.tracking) trackedMembers.push(member)
+    }
+    return { ahead, behind, trackedMembers }
+  }, [members, branchInfoByWorktree])
+
+  const runAll = useCallback(
+    async (
+      targets: ConnectionPushPullMember[],
+      op: (worktreePath: string) => Promise<{ success: boolean; error?: string }>
+    ): Promise<MemberResult[]> => {
+      const results: MemberResult[] = []
+      for (const member of targets) {
+        try {
+          const result = await op(member.worktree_path)
+          results.push({ member, success: result.success, error: result.error })
+        } catch (error) {
+          results.push({
+            member,
+            success: false,
+            error: error instanceof Error ? error.message : String(error)
+          })
+        }
+      }
+      return results
+    },
+    []
+  )
+
+  const handlePushAll = useCallback(async () => {
+    if (members.length === 0) return
+    setIsPushingAll(true)
+    try {
+      const results = await runAll(members, (p) => push(p))
+      const failures = results.filter((r) => !r.success)
+      if (failures.length === 0) {
+        toast.success(`Pushed ${results.length} repo${results.length === 1 ? '' : 's'}`)
+      } else {
+        toast.error(
+          `Push failed for ${failures.length} of ${results.length} repo${results.length === 1 ? '' : 's'}`,
+          { description: describeFailures(failures) }
+        )
+      }
+    } finally {
+      setIsPushingAll(false)
+    }
+  }, [members, push, runAll])
+
+  const handlePullAll = useCallback(async () => {
+    if (trackedMembers.length === 0) return
+    setIsPullingAll(true)
+    try {
+      const results = await runAll(trackedMembers, (p) => pull(p))
+      const failures = results.filter((r) => !r.success)
+      const skipped = members.length - trackedMembers.length
+      if (failures.length === 0) {
+        toast.success(`Pulled ${results.length} repo${results.length === 1 ? '' : 's'}`, {
+          description:
+            skipped > 0 ? `${skipped} repo${skipped === 1 ? '' : 's'} without upstream skipped` : undefined
+        })
+      } else {
+        toast.error(
+          `Pull failed for ${failures.length} of ${results.length} repo${results.length === 1 ? '' : 's'}`,
+          { description: describeFailures(failures) }
+        )
+      }
+    } finally {
+      setIsPullingAll(false)
+    }
+  }, [members.length, trackedMembers, pull, runAll])
+
+  if (members.length === 0) return null
+
+  const isOperating = isPushingAll || isPullingAll
+
+  return (
+    <div
+      className={cn('flex gap-2 px-2 py-2 border-t border-border', className)}
+      data-testid="connection-push-pull"
+    >
+      <Button
+        variant="outline"
+        size="sm"
+        className="flex-1 h-7 text-xs"
+        onClick={handlePushAll}
+        disabled={isOperating}
+        title={`Push all ${members.length} repos`}
+        data-testid="connection-push-button"
+      >
+        {isPushingAll ? (
+          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+        ) : (
+          <ArrowUpCircle className="h-3 w-3 mr-1" />
+        )}
+        Push all
+        {ahead > 0 && <span className="ml-1 text-[10px] opacity-75">({ahead})</span>}
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className="flex-1 h-7 text-xs"
+        onClick={handlePullAll}
+        disabled={isOperating || trackedMembers.length === 0}
+        title={
+          trackedMembers.length === 0
+            ? 'No repo has an upstream branch'
+            : `Pull all ${trackedMembers.length} repos with an upstream`
+        }
+        data-testid="connection-pull-button"
+      >
+        {isPullingAll ? (
+          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+        ) : (
+          <ArrowDownCircle className="h-3 w-3 mr-1" />
+        )}
+        Pull all
+        {behind > 0 && <span className="ml-1 text-[10px] opacity-75">({behind})</span>}
+      </Button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/git/index.ts
+++ b/src/renderer/src/components/git/index.ts
@@ -1,3 +1,4 @@
 export { GitStatusPanel } from './GitStatusPanel'
 export { GitCommitForm } from './GitCommitForm'
 export { GitPushPull } from './GitPushPull'
+export { ConnectionPushPull } from './ConnectionPushPull'


### PR DESCRIPTION
## Summary

- Add connection-level Push all and Pull all buttons for member repositories.
- Aggregate ahead/behind counts and skip repositories without upstream branches when pulling.
- Report operation failures and skipped repositories through toast notifications.
- Add comprehensive component tests for rendering, aggregation, operations, failures, and disabled states.

## Testing

- Added Vitest coverage for `ConnectionPushPull` behavior.
- Not run: full test suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Triggers real git push/pull across multiple repos via existing store APIs. Sequential continue-on-error is reasonable, but a bulk push can still affect remotes if used accidentally.
> 
> **Overview**
> Adds **Push all** / **Pull all** on the connection Changes view so users can sync every member worktree in one action, instead of only per-repo `GitPushPull`.
> 
> `ConnectionPushPull` sums ahead/behind across members, pushes every path, and pulls only repos with an upstream (skipping the rest). Operations run sequentially, keep going after failures, and toast success or which projects failed. Pull is disabled when no member has tracking. Covered by component tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548bedce2b4dc77ef88e89c176cf99e7dd8f5ed1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->