### PR TITLE
Fix connection branch diffs across member repositories

### DIFF
--- a/src/renderer/src/components/file-tree/BranchDiffView.tsx
+++ b/src/renderer/src/components/file-tree/BranchDiffView.tsx
@@ -1,35 +1,18 @@
-import { useState, useEffect, useCallback, useRef, useMemo, memo } from 'react'
-import { RefreshCw, ChevronDown, Search, GitBranch } from 'lucide-react'
+import { useState, useEffect, useCallback } from 'react'
+import { RefreshCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useGitStore } from '@/stores/useGitStore'
-import { useFileViewerStore, diffTabAbsolutePath } from '@/stores/useFileViewerStore'
-import { useFileTabState } from '@/hooks/useFileTabState'
-import { FileIcon } from './FileIcon'
-import { GitStatusIndicator, type GitStatusCode } from './GitStatusIndicator'
-import { OpenTabIndicator } from './OpenTabIndicator'
-import { activeTabRowClass } from './open-tab-classes'
+import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import { gitApi } from '@/api/git-api'
+import {
+  BranchDiffFileRow,
+  BranchSelectDropdown,
+  type BranchDiffFile,
+  type BranchInfo
+} from './branch-diff-shared'
 
 interface BranchDiffViewProps {
   worktreePath: string | null
-}
-
-interface BranchDiffFile {
-  relativePath: string
-  status: string
-}
-
-interface BranchInfo {
-  name: string
-  isRemote: boolean
-  isCheckedOut: boolean
-  worktreePath?: string
-}
-
-const KNOWN_STATUS_CODES: GitStatusCode[] = ['M', 'A', 'D', '?', 'C', '']
-
-function toGitStatusCode(raw: string): GitStatusCode {
-  return KNOWN_STATUS_CODES.includes(raw as GitStatusCode) ? (raw as GitStatusCode) : 'M'
 }
 
 export function BranchDiffView({ worktreePath }: BranchDiffViewProps): React.JSX.Element {
@@ -43,10 +26,6 @@ export function BranchDiffView({ worktreePath }: BranchDiffViewProps): React.JSX
   const [isLoadingFiles, setIsLoadingFiles] = useState(false)
   const [diffError, setDiffError] = useState<string | null>(null)
   const [isLoadingBranches, setIsLoadingBranches] = useState(false)
-  const [dropdownOpen, setDropdownOpen] = useState(false)
-  const [searchFilter, setSearchFilter] = useState('')
-  const dropdownRef = useRef<HTMLDivElement>(null)
-  const searchInputRef = useRef<HTMLInputElement>(null)
 
   // Load branches
   const loadBranches = useCallback(async () => {
@@ -110,32 +89,10 @@ export function BranchDiffView({ worktreePath }: BranchDiffViewProps): React.JSX
     return cleanup
   }, [worktreePath, selectedBranch, loadDiffFiles])
 
-  // Close dropdown on outside click
-  useEffect(() => {
-    if (!dropdownOpen) return
-    function handleClickOutside(e: MouseEvent): void {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setDropdownOpen(false)
-        setSearchFilter('')
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [dropdownOpen])
-
-  // Focus search when dropdown opens
-  useEffect(() => {
-    if (dropdownOpen && searchInputRef.current) {
-      searchInputRef.current.focus()
-    }
-  }, [dropdownOpen])
-
   const handleSelectBranch = useCallback(
     (branch: string) => {
       if (!worktreePath) return
       setSelectedDiffBranch(worktreePath, branch)
-      setDropdownOpen(false)
-      setSearchFilter('')
     },
     [worktreePath, setSelectedDiffBranch]
   )
@@ -160,15 +117,6 @@ export function BranchDiffView({ worktreePath }: BranchDiffViewProps): React.JSX
     await Promise.all([loadBranches(), loadDiffFiles()])
   }, [loadBranches, loadDiffFiles])
 
-  // Split branches into local-first, remote-second, filtered by search
-  const filteredBranches = useMemo(() => {
-    const lower = searchFilter.toLowerCase()
-    const filtered = branches.filter((b) => b.name.toLowerCase().includes(lower))
-    const local = filtered.filter((b) => !b.isRemote)
-    const remote = filtered.filter((b) => b.isRemote)
-    return { local, remote }
-  }, [branches, searchFilter])
-
   if (!worktreePath) {
     return <div className="p-4 text-sm text-muted-foreground text-center">No worktree selected</div>
   }
@@ -176,101 +124,12 @@ export function BranchDiffView({ worktreePath }: BranchDiffViewProps): React.JSX
   return (
     <div className="flex flex-col h-full" data-testid="branch-diff-view">
       {/* Branch selector */}
-      <div className="px-2 py-1.5 border-b border-border relative" ref={dropdownRef}>
-        <button
-          type="button"
-          className={cn(
-            'flex items-center gap-1.5 w-full px-2 py-1 text-xs rounded',
-            'border border-border bg-background hover:bg-accent/50 transition-colors'
-          )}
-          onClick={() => setDropdownOpen((prev) => !prev)}
-          disabled={isLoadingBranches}
-        >
-          <GitBranch className="h-3 w-3 text-muted-foreground shrink-0" />
-          <span className="truncate flex-1 text-left">
-            {selectedBranch || 'Select branch to compare...'}
-          </span>
-          <ChevronDown
-            className={cn(
-              'h-3 w-3 text-muted-foreground shrink-0 transition-transform',
-              dropdownOpen && 'rotate-180'
-            )}
-          />
-        </button>
-
-        {dropdownOpen && (
-          <div className="absolute left-0 right-0 mt-1 mx-2 z-50 rounded-[11px] border border-black/14 dark:border-white/14 bg-[rgba(255,255,255,0.82)] dark:bg-[rgba(0,0,0,0.72)] backdrop-blur-2xl shadow-[0_16px_36px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.04)] max-h-64 flex flex-col overflow-hidden">
-            {/* Search input */}
-            <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-border">
-              <Search className="h-3 w-3 text-muted-foreground shrink-0" />
-              <input
-                ref={searchInputRef}
-                type="text"
-                className="flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
-                placeholder="Filter branches..."
-                value={searchFilter}
-                onChange={(e) => setSearchFilter(e.target.value)}
-              />
-            </div>
-
-            {/* Branch list */}
-            <div className="overflow-y-auto flex-1">
-              {filteredBranches.local.length > 0 && (
-                <div>
-                  <div className="px-2 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
-                    Local
-                  </div>
-                  {filteredBranches.local.map((branch) => (
-                    <button
-                      key={branch.name}
-                      type="button"
-                      className={cn(
-                        'flex items-center gap-1.5 w-full px-2 py-1 text-xs hover:bg-black/6 dark:hover:bg-white/8',
-                        branch.name === selectedBranch && 'bg-accent text-accent-foreground'
-                      )}
-                      onClick={() => handleSelectBranch(branch.name)}
-                    >
-                      <span className="truncate">{branch.name}</span>
-                      {branch.isCheckedOut && (
-                        <span className="text-[10px] text-muted-foreground ml-auto shrink-0">
-                          current
-                        </span>
-                      )}
-                    </button>
-                  ))}
-                </div>
-              )}
-
-              {filteredBranches.remote.length > 0 && (
-                <div>
-                  <div className="px-2 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
-                    Remote
-                  </div>
-                  {filteredBranches.remote.map((branch) => (
-                    <button
-                      key={branch.name}
-                      type="button"
-                      className={cn(
-                        'flex items-center gap-1.5 w-full px-2 py-1 text-xs hover:bg-black/6 dark:hover:bg-white/8',
-                        branch.name === selectedBranch && 'bg-accent text-accent-foreground'
-                      )}
-                      onClick={() => handleSelectBranch(branch.name)}
-                    >
-                      <span className="truncate">{branch.name}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
-
-              {filteredBranches.local.length === 0 && filteredBranches.remote.length === 0 && (
-                <div className="px-2 py-3 text-xs text-muted-foreground text-center">
-                  No branches found
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
+      <BranchSelectDropdown
+        branches={branches}
+        selectedBranch={selectedBranch}
+        onSelect={handleSelectBranch}
+        disabled={isLoadingBranches}
+      />
 
       {/* File list */}
       {!selectedBranch ? (
@@ -324,41 +183,3 @@ export function BranchDiffView({ worktreePath }: BranchDiffViewProps): React.JSX
     </div>
   )
 }
-
-interface BranchDiffFileRowProps {
-  file: BranchDiffFile
-  worktreePath: string
-  onClick: (file: BranchDiffFile) => void
-}
-
-// Memoized because this list is not virtualized: without it every row re-renders
-// whenever a tab opens or closes.
-const BranchDiffFileRow = memo(function BranchDiffFileRow({
-  file,
-  worktreePath,
-  onClick
-}: BranchDiffFileRowProps): React.JSX.Element {
-  const fileName = file.relativePath.split('/').pop() || file.relativePath
-  const ext = fileName.includes('.') ? '.' + fileName.split('.').pop() : null
-  const tabState = useFileTabState(
-    diffTabAbsolutePath({ worktreePath, filePath: file.relativePath })
-  )
-
-  return (
-    <div
-      className={cn(
-        'relative flex items-center gap-1.5 px-2 py-0.5 hover:bg-accent/30 cursor-pointer',
-        activeTabRowClass(tabState)
-      )}
-      onClick={() => onClick(file)}
-      data-testid={`branch-diff-file-${file.relativePath}`}
-    >
-      <OpenTabIndicator state={tabState} />
-      <FileIcon name={fileName} extension={ext} isDirectory={false} className="h-3.5 w-3.5" />
-      <span className="text-xs truncate flex-1" title={file.relativePath}>
-        {file.relativePath}
-      </span>
-      <GitStatusIndicator status={toGitStatusCode(file.status)} className="mr-1" />
-    </div>
-  )
-})

--- a/src/renderer/src/components/file-tree/ConnectionBranchDiffView.test.tsx
+++ b/src/renderer/src/components/file-tree/ConnectionBranchDiffView.test.tsx
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { ConnectionBranchDiffView } from './ConnectionBranchDiffView'
+import { useGitStore } from '@/stores/useGitStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useFileViewerStore } from '@/stores/useFileViewerStore'
+
+const gitApiMocks = vi.hoisted(() => ({
+  listBranchesWithStatus: vi.fn(),
+  getBranchDiffFiles: vi.fn(),
+  onStatusChanged: vi.fn(),
+  onBranchChanged: vi.fn()
+}))
+vi.mock('@/api/git-api', () => ({ gitApi: gitApiMocks }))
+
+const branch = (
+  name: string,
+  opts: { isRemote?: boolean; isCheckedOut?: boolean; worktreePath?: string } = {}
+) => ({
+  name,
+  isRemote: opts.isRemote ?? false,
+  isCheckedOut: opts.isCheckedOut ?? false,
+  worktreePath: opts.worktreePath
+})
+const file = (relativePath: string, status = 'M') => ({
+  relativePath,
+  status,
+  additions: 1,
+  deletions: 0,
+  binary: false
+})
+
+const members = [
+  { worktree_path: '/repo/a', project_name: 'alpha', worktree_branch: 'feat-a' },
+  { worktree_path: '/repo/b', project_name: 'beta', worktree_branch: 'feat-b' }
+]
+
+const initialGitState = useGitStore.getState()
+const initialConnectionState = useConnectionStore.getState()
+const initialFileViewerState = useFileViewerStore.getState()
+
+type StatusListener = (event: { worktreePath: string }) => void
+
+describe('ConnectionBranchDiffView', () => {
+  let statusListeners: StatusListener[]
+  let branchListeners: StatusListener[]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    statusListeners = []
+    branchListeners = []
+    gitApiMocks.onStatusChanged.mockImplementation((cb: StatusListener) => {
+      statusListeners.push(cb)
+      return () => {
+        statusListeners = statusListeners.filter((l) => l !== cb)
+      }
+    })
+    gitApiMocks.onBranchChanged.mockImplementation((cb: StatusListener) => {
+      branchListeners.push(cb)
+      return () => {
+        branchListeners = branchListeners.filter((l) => l !== cb)
+      }
+    })
+    gitApiMocks.listBranchesWithStatus.mockImplementation(async (path: string) => ({
+      success: true,
+      branches:
+        path === '/repo/a'
+          ? [
+              branch('main', { isCheckedOut: true, worktreePath: '/repo/a' }),
+              branch('develop'),
+              branch('origin/main', { isRemote: true })
+            ]
+          : [branch('main'), branch('origin/main', { isRemote: true }), branch('only-b')]
+    }))
+    gitApiMocks.getBranchDiffFiles.mockImplementation(async (path: string) => ({
+      success: true,
+      files: path === '/repo/a' ? [file('src/a.ts')] : [file('src/b.ts'), file('README.md', 'A')]
+    }))
+    useConnectionStore.setState({ selectedConnectionId: 'conn-1' } as never)
+    useGitStore.setState({ selectedDiffBranch: new Map(), branchInfoByWorktree: new Map() })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useGitStore.setState(initialGitState, true)
+    useConnectionStore.setState(initialConnectionState, true)
+    useFileViewerStore.setState(initialFileViewerState, true)
+  })
+
+  const selectBranch = async (name: string): Promise<void> => {
+    fireEvent.click(screen.getByTestId('branch-select-trigger'))
+    fireEvent.click(await screen.findByText(name))
+  }
+
+  it('loads branches for every member and lists only the common ones', async () => {
+    render(<ConnectionBranchDiffView members={members} />)
+    await waitFor(() => expect(gitApiMocks.listBranchesWithStatus).toHaveBeenCalledTimes(2))
+    expect(gitApiMocks.listBranchesWithStatus.mock.calls.map((c) => c[0])).toEqual([
+      '/repo/a',
+      '/repo/b'
+    ])
+    await waitFor(() => expect(screen.getByTestId('branch-select-trigger')).not.toBeDisabled())
+
+    fireEvent.click(screen.getByTestId('branch-select-trigger'))
+    const menu = await screen.findByTestId('branch-select-menu')
+    expect(within(menu).getByText('main')).toBeInTheDocument()
+    expect(within(menu).getByText('origin/main')).toBeInTheDocument()
+    expect(within(menu).queryByText('develop')).toBeNull()
+    expect(within(menu).queryByText('only-b')).toBeNull()
+    // "current" only when every member has it checked out — beta does not.
+    expect(within(menu).queryByText('current')).toBeNull()
+  })
+
+  it('shows an empty message when no branch is shared by every member', async () => {
+    gitApiMocks.listBranchesWithStatus.mockImplementation(async (path: string) => ({
+      success: true,
+      branches: path === '/repo/a' ? [branch('a-only')] : [branch('b-only')]
+    }))
+    render(<ConnectionBranchDiffView members={members} />)
+    await waitFor(() => expect(screen.getByTestId('branch-select-trigger')).not.toBeDisabled())
+    fireEvent.click(screen.getByTestId('branch-select-trigger'))
+    expect(await screen.findByText('No branches shared by all repos')).toBeInTheDocument()
+  })
+
+  it('remembers the selection per connection and loads a diff section per member', async () => {
+    render(<ConnectionBranchDiffView members={members} />)
+    expect(screen.getAllByText('Loading branches...').length).toBeGreaterThan(0)
+    expect(
+      await screen.findByText('Select a branch to see differences across 2 repos')
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('branch-select-trigger')).not.toBeDisabled()
+
+    await selectBranch('main')
+
+    expect(useGitStore.getState().selectedDiffBranch.get('connection:conn-1')).toBe('main')
+    await waitFor(() => expect(gitApiMocks.getBranchDiffFiles).toHaveBeenCalledTimes(2))
+    expect(gitApiMocks.getBranchDiffFiles).toHaveBeenCalledWith('/repo/a', 'main')
+    expect(gitApiMocks.getBranchDiffFiles).toHaveBeenCalledWith('/repo/b', 'main')
+
+    const alpha = await screen.findByTestId('branch-diff-member-/repo/a')
+    const beta = await screen.findByTestId('branch-diff-member-/repo/b')
+    expect(await within(alpha).findByText('src/a.ts')).toBeInTheDocument()
+    expect(within(alpha).getByText('alpha')).toBeInTheDocument()
+    expect(within(alpha).getByText('feat-a')).toBeInTheDocument()
+    expect(await within(beta).findByText('README.md')).toBeInTheDocument()
+    expect(within(beta).getByText('src/b.ts')).toBeInTheDocument()
+    expect(within(beta).getByText('2')).toBeInTheDocument()
+
+    expect(screen.getByText('3 files changed across 2 repos')).toBeInTheDocument()
+  })
+
+  it('opens the diff against the member worktree when a file is clicked', async () => {
+    useGitStore.setState({ selectedDiffBranch: new Map([['connection:conn-1', 'main']]) })
+    render(<ConnectionBranchDiffView members={members} />)
+
+    fireEvent.click(await screen.findByText('src/b.ts'))
+
+    expect(useFileViewerStore.getState().activeDiff).toMatchObject({
+      worktreePath: '/repo/b',
+      filePath: 'src/b.ts',
+      fileName: 'b.ts',
+      staged: false,
+      isUntracked: false,
+      compareBranch: 'main'
+    })
+  })
+
+  it('surfaces a member diff error without hiding the other members', async () => {
+    gitApiMocks.getBranchDiffFiles.mockImplementation(async (path: string) =>
+      path === '/repo/b'
+        ? {
+            success: false,
+            error: "fatal: ambiguous argument 'main': unknown revision or path not in the working tree."
+          }
+        : { success: true, files: [file('src/a.ts')] }
+    )
+    useGitStore.setState({ selectedDiffBranch: new Map([['connection:conn-1', 'main']]) })
+    render(<ConnectionBranchDiffView members={members} />)
+
+    expect(await screen.findByText('Branch not found in this repo')).toBeInTheDocument()
+    expect(await screen.findByText('src/a.ts')).toBeInTheDocument()
+    expect(screen.getByText('1 file changed across 1 repo')).toBeInTheDocument()
+  })
+
+  it('marks a member with no differences and collapses it', async () => {
+    gitApiMocks.getBranchDiffFiles.mockImplementation(async (path: string) => ({
+      success: true,
+      files: path === '/repo/a' ? [file('src/a.ts')] : []
+    }))
+    useGitStore.setState({ selectedDiffBranch: new Map([['connection:conn-1', 'main']]) })
+    render(<ConnectionBranchDiffView members={members} />)
+
+    const beta = await screen.findByTestId('branch-diff-member-/repo/b')
+    expect(await within(beta).findByText('no diff')).toBeInTheDocument()
+    expect(await screen.findByText('src/a.ts')).toBeInTheDocument()
+  })
+
+  it('collapses and expands a member section', async () => {
+    useGitStore.setState({ selectedDiffBranch: new Map([['connection:conn-1', 'main']]) })
+    render(<ConnectionBranchDiffView members={members} />)
+    const alpha = await screen.findByTestId('branch-diff-member-/repo/a')
+    expect(await within(alpha).findByText('src/a.ts')).toBeInTheDocument()
+
+    fireEvent.click(within(alpha).getByText('alpha'))
+    expect(within(alpha).queryByText('src/a.ts')).toBeNull()
+
+    fireEvent.click(within(alpha).getByText('alpha'))
+    expect(within(alpha).getByText('src/a.ts')).toBeInTheDocument()
+  })
+
+  it('reloads only the member whose git status changed', async () => {
+    useGitStore.setState({ selectedDiffBranch: new Map([['connection:conn-1', 'main']]) })
+    render(<ConnectionBranchDiffView members={members} />)
+    await waitFor(() => expect(gitApiMocks.getBranchDiffFiles).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(statusListeners.length).toBeGreaterThan(0))
+
+    gitApiMocks.getBranchDiffFiles.mockClear()
+    gitApiMocks.getBranchDiffFiles.mockImplementation(async () => ({
+      success: true,
+      files: [file('src/b-new.ts')]
+    }))
+    await act(async () => {
+      statusListeners.forEach((l) => l({ worktreePath: '/repo/b' }))
+    })
+
+    await waitFor(() => expect(gitApiMocks.getBranchDiffFiles).toHaveBeenCalledTimes(1))
+    expect(gitApiMocks.getBranchDiffFiles).toHaveBeenCalledWith('/repo/b', 'main')
+    expect(await screen.findByText('src/b-new.ts')).toBeInTheDocument()
+    // An unrelated worktree does not trigger a reload.
+    await act(async () => {
+      statusListeners.forEach((l) => l({ worktreePath: '/repo/other' }))
+    })
+    expect(gitApiMocks.getBranchDiffFiles).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes branches and every member diff', async () => {
+    useGitStore.setState({ selectedDiffBranch: new Map([['connection:conn-1', 'main']]) })
+    render(<ConnectionBranchDiffView members={members} />)
+    await waitFor(() => expect(gitApiMocks.getBranchDiffFiles).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(screen.getByTestId('connection-branch-diff-refresh')).not.toBeDisabled()
+    )
+    gitApiMocks.listBranchesWithStatus.mockClear()
+    gitApiMocks.getBranchDiffFiles.mockClear()
+
+    fireEvent.click(screen.getByTestId('connection-branch-diff-refresh'))
+
+    await waitFor(() => expect(gitApiMocks.listBranchesWithStatus).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(gitApiMocks.getBranchDiffFiles).toHaveBeenCalledTimes(2))
+  })
+
+  it('ignores a member whose branch listing failed and reports it in the picker', async () => {
+    gitApiMocks.listBranchesWithStatus.mockImplementation(async (path: string) =>
+      path === '/repo/b'
+        ? { success: false, branches: [], error: 'not a git repository' }
+        : { success: true, branches: [branch('main')] }
+    )
+    render(<ConnectionBranchDiffView members={members} />)
+    await waitFor(() => expect(screen.getByTestId('branch-select-trigger')).not.toBeDisabled())
+    fireEvent.click(screen.getByTestId('branch-select-trigger'))
+    const menu = await screen.findByTestId('branch-select-menu')
+    expect(within(menu).getByText('main')).toBeInTheDocument()
+    expect(within(menu).getByTestId('branch-listing-errors')).toHaveTextContent(
+      'beta: Not a git repository'
+    )
+  })
+
+  it('tags a branch as current only when every member worktree is on it', async () => {
+    gitApiMocks.listBranchesWithStatus.mockImplementation(async (path: string) => ({
+      success: true,
+      branches: [branch('main', { isCheckedOut: true, worktreePath: path }), branch('feat')]
+    }))
+    render(<ConnectionBranchDiffView members={members} />)
+    await waitFor(() => expect(screen.getByTestId('branch-select-trigger')).not.toBeDisabled())
+    fireEvent.click(screen.getByTestId('branch-select-trigger'))
+    const menu = await screen.findByTestId('branch-select-menu')
+    const mainRow = within(menu).getByText('main').closest('button') as HTMLElement
+    expect(within(mainRow).getByText('current')).toBeInTheDocument()
+    const featRow = within(menu).getByText('feat').closest('button') as HTMLElement
+    expect(within(featRow).queryByText('current')).toBeNull()
+  })
+
+  it('drops a remembered branch that is no longer shared by every member', async () => {
+    useGitStore.setState({ selectedDiffBranch: new Map([['connection:conn-1', 'develop']]) })
+    render(<ConnectionBranchDiffView members={members} />)
+    expect(
+      await screen.findByText('"develop" is no longer shared by all repos. Select another branch.')
+    ).toBeInTheDocument()
+    expect(gitApiMocks.getBranchDiffFiles).not.toHaveBeenCalled()
+    expect(screen.getByText('No branch selected')).toBeInTheDocument()
+  })
+
+  it('reloads the branch lists when a member switches branch', async () => {
+    render(<ConnectionBranchDiffView members={members} />)
+    await waitFor(() => expect(gitApiMocks.listBranchesWithStatus).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(branchListeners.length).toBeGreaterThan(0))
+    gitApiMocks.listBranchesWithStatus.mockClear()
+
+    await act(async () => {
+      branchListeners.forEach((l) => l({ worktreePath: '/repo/a' }))
+    })
+    await waitFor(() => expect(gitApiMocks.listBranchesWithStatus).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      branchListeners.forEach((l) => l({ worktreePath: '/repo/other' }))
+    })
+    expect(gitApiMocks.listBranchesWithStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-lists branches (debounced) after a member status change', async () => {
+    render(<ConnectionBranchDiffView members={members} />)
+    await waitFor(() => expect(gitApiMocks.listBranchesWithStatus).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(statusListeners.length).toBeGreaterThan(0))
+    gitApiMocks.listBranchesWithStatus.mockClear()
+
+    await act(async () => {
+      statusListeners.forEach((l) => l({ worktreePath: '/repo/a' }))
+      statusListeners.forEach((l) => l({ worktreePath: '/repo/b' }))
+    })
+    expect(gitApiMocks.listBranchesWithStatus).not.toHaveBeenCalled()
+    await waitFor(
+      () => expect(gitApiMocks.listBranchesWithStatus).toHaveBeenCalledTimes(2),
+      { timeout: 3000 }
+    )
+  })
+
+  it('keeps separate tabs for the same relative path in different members', async () => {
+    gitApiMocks.getBranchDiffFiles.mockImplementation(async () => ({
+      success: true,
+      files: [file('package.json')]
+    }))
+    useGitStore.setState({ selectedDiffBranch: new Map([['connection:conn-1', 'main']]) })
+    render(<ConnectionBranchDiffView members={members} />)
+    const alpha = await screen.findByTestId('branch-diff-member-/repo/a')
+    const beta = await screen.findByTestId('branch-diff-member-/repo/b')
+
+    fireEvent.click(await within(alpha).findByText('package.json'))
+    fireEvent.click(await within(beta).findByText('package.json'))
+
+    const diffTabs = Array.from(useFileViewerStore.getState().openFiles.values()).filter(
+      (t) => t.type === 'diff'
+    )
+    expect(diffTabs.map((t) => (t.type === 'diff' ? t.worktreePath : null))).toEqual([
+      '/repo/a',
+      '/repo/b'
+    ])
+    expect(useFileViewerStore.getState().activeDiff?.worktreePath).toBe('/repo/b')
+  })
+
+  it('renders a placeholder for a connection with no members', () => {
+    render(<ConnectionBranchDiffView members={[]} />)
+    expect(screen.getByText('No connection members')).toBeInTheDocument()
+    expect(gitApiMocks.listBranchesWithStatus).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/file-tree/ConnectionBranchDiffView.tsx
+++ b/src/renderer/src/components/file-tree/ConnectionBranchDiffView.tsx
@@ -1,0 +1,433 @@
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { RefreshCw, ChevronDown, ChevronRight, GitBranch, AlertTriangle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useGitStore } from '@/stores/useGitStore'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useFileViewerStore } from '@/stores/useFileViewerStore'
+import { gitApi } from '@/api/git-api'
+import {
+  connectionDiffBranchKey,
+  describeMemberGitError,
+  intersectMemberBranches,
+  type MemberBranchListing
+} from '@/lib/connection-branch-diff'
+import { BranchDiffFileRow, BranchSelectDropdown, type BranchDiffFile } from './branch-diff-shared'
+
+interface ConnectionMemberInfo {
+  worktree_path: string
+  project_name: string
+  worktree_branch: string
+}
+
+interface ConnectionBranchDiffViewProps {
+  members: ConnectionMemberInfo[]
+}
+
+interface MemberDiffState {
+  files: BranchDiffFile[]
+  isLoading: boolean
+  error: string | null
+}
+
+const EMPTY_DIFF: MemberDiffState = { files: [], isLoading: false, error: null }
+// Same cap as the Changes tab's member sections, so one big repo cannot push
+// the others off-screen.
+const MEMBER_MAX_HEIGHT = 300
+const LOADING_DIFF: MemberDiffState = { files: [], isLoading: true, error: null }
+// Status events fire per saved file; coalesce them before re-listing branches.
+const BRANCH_RELOAD_DEBOUNCE_MS = 750
+
+async function loadMemberBranches(worktreePath: string): Promise<MemberBranchListing> {
+  try {
+    const result = await gitApi.listBranchesWithStatus(worktreePath)
+    if (result.success && result.branches) {
+      return { worktreePath, branches: result.branches }
+    }
+    return {
+      worktreePath,
+      error: describeMemberGitError(result.error || 'Failed to load branches')
+    }
+  } catch (error) {
+    return {
+      worktreePath,
+      error: describeMemberGitError(
+        error instanceof Error ? error.message : 'Failed to load branches'
+      )
+    }
+  }
+}
+
+async function loadMemberDiffFiles(
+  worktreePath: string,
+  branch: string
+): Promise<Pick<MemberDiffState, 'files' | 'error'>> {
+  try {
+    const result = await gitApi.getBranchDiffFiles(worktreePath, branch)
+    if (result.success && result.files) {
+      return { files: result.files, error: null }
+    }
+    return { files: [], error: describeMemberGitError(result.error || 'Failed to load diff files') }
+  } catch (error) {
+    return {
+      files: [],
+      error: describeMemberGitError(
+        error instanceof Error ? error.message : 'Failed to load diff files'
+      )
+    }
+  }
+}
+
+/**
+ * Diffs tab for a connection: one compare branch (offered only when every
+ * member repo has a branch of that name), then a collapsible section per
+ * member listing the files that differ in that member's worktree, the same
+ * way the Changes tab shows per-member working-tree changes.
+ */
+export function ConnectionBranchDiffView({
+  members
+}: ConnectionBranchDiffViewProps): React.JSX.Element {
+  const connectionId = useConnectionStore((s) => s.selectedConnectionId)
+  const selectionKey = connectionId ? connectionDiffBranchKey(connectionId) : null
+  const rememberedBranch = useGitStore((s) =>
+    selectionKey ? (s.selectedDiffBranch.get(selectionKey) ?? null) : null
+  )
+  const setSelectedDiffBranch = useGitStore((s) => s.setSelectedDiffBranch)
+  const branchInfoByWorktree = useGitStore((s) => s.branchInfoByWorktree)
+
+  const [listings, setListings] = useState<MemberBranchListing[]>([])
+  const [isLoadingBranches, setIsLoadingBranches] = useState(false)
+  const [diffByMember, setDiffByMember] = useState<Map<string, MemberDiffState>>(new Map())
+  const [collapsedMembers, setCollapsedMembers] = useState<Set<string>>(new Set())
+
+  // Member paths keyed by content so effects only re-run when the set changes,
+  // not when the store hands out a fresh members array with the same entries.
+  const memberPathsKey = members.map((m) => m.worktree_path).join('\n')
+  const memberPaths = useMemo(
+    () => (memberPathsKey ? memberPathsKey.split('\n') : []),
+    [memberPathsKey]
+  )
+
+  // Guards against stale async results landing after members/branch changed.
+  const branchesRequestRef = useRef(0)
+  const diffRequestRef = useRef(new Map<string, number>())
+
+  // Load every member's branch list; the picker shows the intersection.
+  const loadBranches = useCallback(async () => {
+    const requestId = ++branchesRequestRef.current
+    if (memberPaths.length === 0) {
+      setListings([])
+      return
+    }
+    setIsLoadingBranches(true)
+    try {
+      const results = await Promise.all(memberPaths.map(loadMemberBranches))
+      if (requestId !== branchesRequestRef.current) return
+      setListings(results)
+    } finally {
+      if (requestId === branchesRequestRef.current) setIsLoadingBranches(false)
+    }
+  }, [memberPaths])
+
+  // Load (or reload) the branch diff for one member. A refresh keeps the
+  // previous rows visible while loading so the list does not flicker.
+  const loadMemberDiff = useCallback(
+    async (worktreePath: string, branch: string) => {
+      const requestId = (diffRequestRef.current.get(worktreePath) ?? 0) + 1
+      diffRequestRef.current.set(worktreePath, requestId)
+      setDiffByMember((prev) => {
+        const next = new Map(prev)
+        next.set(worktreePath, { ...(prev.get(worktreePath) ?? EMPTY_DIFF), isLoading: true })
+        return next
+      })
+      const result = await loadMemberDiffFiles(worktreePath, branch)
+      if (diffRequestRef.current.get(worktreePath) !== requestId) return
+      setDiffByMember((prev) => {
+        const next = new Map(prev)
+        next.set(worktreePath, { ...result, isLoading: false })
+        return next
+      })
+    },
+    []
+  )
+
+  const commonBranches = useMemo(() => intersectMemberBranches(listings), [listings])
+
+  // The remembered branch only stays selected while every member still has it
+  // (a member may have been added, or a branch deleted, since it was picked).
+  const selectedBranch = useMemo(
+    () =>
+      rememberedBranch && commonBranches.some((b) => b.name === rememberedBranch)
+        ? rememberedBranch
+        : null,
+    [rememberedBranch, commonBranches]
+  )
+
+  const loadAllDiffs = useCallback(async () => {
+    if (!selectedBranch) {
+      setDiffByMember(new Map())
+      return
+    }
+    setDiffByMember(new Map(memberPaths.map((p) => [p, LOADING_DIFF])))
+    await Promise.all(memberPaths.map((p) => loadMemberDiff(p, selectedBranch)))
+  }, [selectedBranch, memberPaths, loadMemberDiff])
+
+  useEffect(() => {
+    loadBranches()
+  }, [loadBranches])
+
+  useEffect(() => {
+    loadAllDiffs()
+  }, [loadAllDiffs])
+
+  // A git status change in any member refreshes just that member's diff. The
+  // worktree watcher also raises this for HEAD/refs changes (checkout, fetch,
+  // branch create/delete), so the common-branch list is re-derived too, but
+  // debounced since a burst of saves raises one event per file.
+  useEffect(() => {
+    if (memberPaths.length === 0) return
+    let reloadTimer: ReturnType<typeof setTimeout> | null = null
+    const cleanup = gitApi.onStatusChanged((event) => {
+      if (!memberPaths.includes(event.worktreePath)) return
+      if (selectedBranch) loadMemberDiff(event.worktreePath, selectedBranch)
+      if (reloadTimer) clearTimeout(reloadTimer)
+      reloadTimer = setTimeout(() => {
+        reloadTimer = null
+        loadBranches()
+      }, BRANCH_RELOAD_DEBOUNCE_MS)
+    })
+    return () => {
+      if (reloadTimer) clearTimeout(reloadTimer)
+      cleanup()
+    }
+  }, [selectedBranch, memberPaths, loadMemberDiff, loadBranches])
+
+  // A member switching branch changes what is common (and what is "current").
+  // Only fires for worktrees with a branch watcher (expanded sidebar projects);
+  // the status listener above covers the rest.
+  useEffect(() => {
+    if (memberPaths.length === 0) return
+    const cleanup = gitApi.onBranchChanged((event) => {
+      if (memberPaths.includes(event.worktreePath)) {
+        loadBranches()
+      }
+    })
+    return cleanup
+  }, [memberPaths, loadBranches])
+
+  const failedListings = useMemo(
+    () =>
+      listings
+        .filter((l) => l.error)
+        .map((l) => ({
+          worktreePath: l.worktreePath,
+          projectName:
+            members.find((m) => m.worktree_path === l.worktreePath)?.project_name ??
+            l.worktreePath,
+          error: l.error as string
+        })),
+    [listings, members]
+  )
+  const allListingsFailed = listings.length > 0 && failedListings.length === listings.length
+  // Background re-lists (after status events) keep the picker usable; only the
+  // first load, when nothing is known yet, locks it.
+  const isInitialBranchLoad = isLoadingBranches && listings.length === 0
+
+  const handleSelectBranch = useCallback(
+    (branch: string) => {
+      if (!selectionKey) return
+      setSelectedDiffBranch(selectionKey, branch)
+    },
+    [selectionKey, setSelectedDiffBranch]
+  )
+
+  const handleFileClick = useCallback(
+    (worktreePath: string, file: BranchDiffFile) => {
+      if (!selectedBranch) return
+      const fileName = file.relativePath.split('/').pop() || file.relativePath
+      useFileViewerStore.getState().setActiveDiff({
+        worktreePath,
+        filePath: file.relativePath,
+        fileName,
+        staged: false,
+        isUntracked: false,
+        compareBranch: selectedBranch
+      })
+    },
+    [selectedBranch]
+  )
+
+  const toggleMember = useCallback((path: string) => {
+    setCollapsedMembers((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }, [])
+
+  const isLoadingAnyDiff = useMemo(
+    () => Array.from(diffByMember.values()).some((d) => d.isLoading),
+    [diffByMember]
+  )
+
+  const handleRefresh = useCallback(async () => {
+    await Promise.all([loadBranches(), loadAllDiffs()])
+  }, [loadBranches, loadAllDiffs])
+
+  const summary = useMemo(() => {
+    let totalFiles = 0
+    let reposWithChanges = 0
+    for (const path of memberPaths) {
+      const count = diffByMember.get(path)?.files.length ?? 0
+      totalFiles += count
+      if (count > 0) reposWithChanges += 1
+    }
+    return { totalFiles, reposWithChanges }
+  }, [memberPaths, diffByMember])
+
+  if (members.length === 0) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground text-center">No connection members</div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full" data-testid="connection-branch-diff-view">
+      {/* Branch selector: only branches every member has */}
+      <BranchSelectDropdown
+        branches={commonBranches}
+        selectedBranch={selectedBranch}
+        onSelect={handleSelectBranch}
+        disabled={isInitialBranchLoad}
+        placeholder={
+          isInitialBranchLoad ? 'Loading branches...' : 'Select a branch common to all repos...'
+        }
+        emptyMessage={
+          allListingsFailed ? 'Could not load branches' : 'No branches shared by all repos'
+        }
+        footer={
+          failedListings.length > 0 ? (
+            <div
+              className="px-2 py-1.5 border-t border-border text-[10px] text-destructive space-y-0.5"
+              data-testid="branch-listing-errors"
+            >
+              {failedListings.map((f) => (
+                <div key={f.worktreePath} className="flex items-start gap-1">
+                  <AlertTriangle className="h-3 w-3 shrink-0 mt-px" />
+                  <span className="truncate">
+                    {f.projectName}: {f.error}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : null
+        }
+      />
+
+      {/* Per-member sections */}
+      {!selectedBranch ? (
+        <div className="flex-1 flex items-center justify-center text-xs text-muted-foreground px-4 text-center">
+          {isInitialBranchLoad
+            ? 'Loading branches...'
+            : rememberedBranch && listings.length > 0
+              ? `"${rememberedBranch}" is no longer shared by all repos. Select another branch.`
+              : `Select a branch to see differences across ${members.length} repo${members.length === 1 ? '' : 's'}`}
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto">
+          {members.map((member) => {
+            const diff = diffByMember.get(member.worktree_path) ?? EMPTY_DIFF
+            const isCollapsed = collapsedMembers.has(member.worktree_path)
+            const hasNoChanges = !diff.isLoading && !diff.error && diff.files.length === 0
+            const currentBranch =
+              branchInfoByWorktree.get(member.worktree_path)?.name || member.worktree_branch
+
+            return (
+              <div
+                key={member.worktree_path}
+                className="border-b border-border last:border-b-0"
+                data-testid={`branch-diff-member-${member.worktree_path}`}
+              >
+                {/* Member header */}
+                <button
+                  type="button"
+                  className="flex items-center justify-between w-full px-2 py-1.5 text-xs hover:bg-accent/50"
+                  onClick={() => toggleMember(member.worktree_path)}
+                >
+                  <span className="flex items-center gap-1.5 min-w-0">
+                    {isCollapsed || hasNoChanges ? (
+                      <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+                    ) : (
+                      <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+                    )}
+                    <span className="font-medium truncate">{member.project_name}</span>
+                    <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
+                    <span className="text-muted-foreground truncate">{currentBranch || '...'}</span>
+                  </span>
+                  <span className="flex items-center gap-1 shrink-0">
+                    {diff.isLoading ? (
+                      <RefreshCw className="h-3 w-3 animate-spin text-muted-foreground" />
+                    ) : diff.error ? (
+                      <AlertTriangle className="h-3 w-3 text-destructive" />
+                    ) : hasNoChanges ? (
+                      <span className="text-muted-foreground text-[10px]">no diff</span>
+                    ) : (
+                      <span className="text-[10px] px-1 py-0.5 rounded bg-muted">
+                        {diff.files.length}
+                      </span>
+                    )}
+                  </span>
+                </button>
+
+                {/* Member content */}
+                {!isCollapsed && diff.error && (
+                  <div className="px-4 pb-2 text-xs text-destructive">{diff.error}</div>
+                )}
+                {!isCollapsed && !diff.error && diff.files.length > 0 && (
+                  <div
+                    className="pl-3 pb-1 overflow-y-auto"
+                    style={{ maxHeight: `${MEMBER_MAX_HEIGHT}px` }}
+                  >
+                    {diff.files.map((file) => (
+                      <BranchDiffFileRow
+                        key={file.relativePath}
+                        file={file}
+                        worktreePath={member.worktree_path}
+                        onClick={(f) => handleFileClick(member.worktree_path, f)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Status bar */}
+      <div className="flex items-center justify-between px-2 py-1 border-t border-border bg-muted/30">
+        <span className="text-[10px] text-muted-foreground">
+          {!selectedBranch
+            ? isInitialBranchLoad
+              ? 'Loading...'
+              : 'No branch selected'
+            : summary.totalFiles === 0
+              ? 'No differences'
+              : `${summary.totalFiles} file${summary.totalFiles === 1 ? '' : 's'} changed across ${summary.reposWithChanges} repo${summary.reposWithChanges === 1 ? '' : 's'}`}
+        </span>
+        <button
+          className={cn(
+            'p-0.5 text-muted-foreground hover:text-foreground rounded',
+            (isLoadingAnyDiff || isLoadingBranches) && 'animate-spin'
+          )}
+          onClick={handleRefresh}
+          disabled={isLoadingAnyDiff || isLoadingBranches}
+          title="Refresh all"
+          data-testid="connection-branch-diff-refresh"
+        >
+          <RefreshCw className="h-3 w-3" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/file-tree/FileSidebar.tsx
+++ b/src/renderer/src/components/file-tree/FileSidebar.tsx
@@ -8,6 +8,7 @@ import { useGitStore } from '@/stores/useGitStore'
 import { FileTree } from './FileTree'
 import { ChangesView } from './ChangesView'
 import { BranchDiffView } from './BranchDiffView'
+import { ConnectionBranchDiffView } from './ConnectionBranchDiffView'
 import { PrReviewViewer } from '@/components/pr-review/PrReviewViewer'
 
 interface ConnectionMemberInfo {
@@ -174,7 +175,11 @@ export function FileSidebar({
               connectionMembers={connectionMembers}
             />
           ) : activeTab === 'diffs' ? (
-            <BranchDiffView worktreePath={worktreePath} />
+            isConnectionMode ? (
+              <ConnectionBranchDiffView members={connectionMembers ?? []} />
+            ) : (
+              <BranchDiffView worktreePath={worktreePath} />
+            )
           ) : (
             <FileTree
               worktreePath={worktreePath}

--- a/src/renderer/src/components/file-tree/branch-diff-shared.tsx
+++ b/src/renderer/src/components/file-tree/branch-diff-shared.tsx
@@ -1,0 +1,238 @@
+import { useState, useEffect, useRef, useMemo, memo } from 'react'
+import { ChevronDown, Search, GitBranch } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { diffTabAbsolutePath } from '@/stores/useFileViewerStore'
+import { useFileTabState } from '@/hooks/useFileTabState'
+import { FileIcon } from './FileIcon'
+import { GitStatusIndicator, type GitStatusCode } from './GitStatusIndicator'
+import { OpenTabIndicator } from './OpenTabIndicator'
+import { activeTabRowClass } from './open-tab-classes'
+
+/**
+ * Pieces shared by the single-worktree Diffs tab (BranchDiffView) and the
+ * connection Diffs tab (ConnectionBranchDiffView): the branch picker and the
+ * file row. Data loading stays in each view since they differ in shape.
+ */
+
+export interface BranchDiffFile {
+  relativePath: string
+  status: string
+}
+
+export interface BranchInfo {
+  name: string
+  isRemote: boolean
+  isCheckedOut: boolean
+  worktreePath?: string
+}
+
+const KNOWN_STATUS_CODES: GitStatusCode[] = ['M', 'A', 'D', '?', 'C', '']
+
+function toGitStatusCode(raw: string): GitStatusCode {
+  return KNOWN_STATUS_CODES.includes(raw as GitStatusCode) ? (raw as GitStatusCode) : 'M'
+}
+
+interface BranchSelectDropdownProps {
+  branches: BranchInfo[]
+  selectedBranch: string | null
+  onSelect: (branch: string) => void
+  disabled?: boolean
+  placeholder?: string
+  /** Shown in place of "No branches found" when the list is empty and unfiltered. */
+  emptyMessage?: string
+  /** Optional content rendered below the branch list (e.g. per-member warnings). */
+  footer?: React.ReactNode
+}
+
+/** Searchable branch picker with Local / Remote sections and a "current" tag. */
+export function BranchSelectDropdown({
+  branches,
+  selectedBranch,
+  onSelect,
+  disabled,
+  placeholder = 'Select branch to compare...',
+  emptyMessage = 'No branches found',
+  footer
+}: BranchSelectDropdownProps): React.JSX.Element {
+  const [dropdownOpen, setDropdownOpen] = useState(false)
+  const [searchFilter, setSearchFilter] = useState('')
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!dropdownOpen) return
+    function handleClickOutside(e: MouseEvent): void {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false)
+        setSearchFilter('')
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [dropdownOpen])
+
+  // Focus search when dropdown opens
+  useEffect(() => {
+    if (dropdownOpen && searchInputRef.current) {
+      searchInputRef.current.focus()
+    }
+  }, [dropdownOpen])
+
+  const handleSelect = (branch: string): void => {
+    onSelect(branch)
+    setDropdownOpen(false)
+    setSearchFilter('')
+  }
+
+  // Split branches into local-first, remote-second, filtered by search
+  const filteredBranches = useMemo(() => {
+    const lower = searchFilter.toLowerCase()
+    const filtered = branches.filter((b) => b.name.toLowerCase().includes(lower))
+    const local = filtered.filter((b) => !b.isRemote)
+    const remote = filtered.filter((b) => b.isRemote)
+    return { local, remote }
+  }, [branches, searchFilter])
+
+  const isEmpty = filteredBranches.local.length === 0 && filteredBranches.remote.length === 0
+
+  return (
+    <div className="px-2 py-1.5 border-b border-border relative" ref={dropdownRef}>
+      <button
+        type="button"
+        className={cn(
+          'flex items-center gap-1.5 w-full px-2 py-1 text-xs rounded',
+          'border border-border bg-background hover:bg-accent/50 transition-colors'
+        )}
+        onClick={() => setDropdownOpen((prev) => !prev)}
+        disabled={disabled}
+        data-testid="branch-select-trigger"
+      >
+        <GitBranch className="h-3 w-3 text-muted-foreground shrink-0" />
+        <span className="truncate flex-1 text-left">{selectedBranch || placeholder}</span>
+        <ChevronDown
+          className={cn(
+            'h-3 w-3 text-muted-foreground shrink-0 transition-transform',
+            dropdownOpen && 'rotate-180'
+          )}
+        />
+      </button>
+
+      {dropdownOpen && (
+        <div
+          className="absolute left-0 right-0 mt-1 mx-2 z-50 rounded-[11px] border border-black/14 dark:border-white/14 bg-[rgba(255,255,255,0.82)] dark:bg-[rgba(0,0,0,0.72)] backdrop-blur-2xl shadow-[0_16px_36px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.04)] max-h-64 flex flex-col overflow-hidden"
+          data-testid="branch-select-menu"
+        >
+          {/* Search input */}
+          <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-border">
+            <Search className="h-3 w-3 text-muted-foreground shrink-0" />
+            <input
+              ref={searchInputRef}
+              type="text"
+              className="flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+              placeholder="Filter branches..."
+              value={searchFilter}
+              onChange={(e) => setSearchFilter(e.target.value)}
+            />
+          </div>
+
+          {/* Branch list */}
+          <div className="overflow-y-auto flex-1">
+            {filteredBranches.local.length > 0 && (
+              <div>
+                <div className="px-2 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+                  Local
+                </div>
+                {filteredBranches.local.map((branch) => (
+                  <button
+                    key={branch.name}
+                    type="button"
+                    className={cn(
+                      'flex items-center gap-1.5 w-full px-2 py-1 text-xs hover:bg-black/6 dark:hover:bg-white/8',
+                      branch.name === selectedBranch && 'bg-accent text-accent-foreground'
+                    )}
+                    onClick={() => handleSelect(branch.name)}
+                  >
+                    <span className="truncate">{branch.name}</span>
+                    {branch.isCheckedOut && (
+                      <span className="text-[10px] text-muted-foreground ml-auto shrink-0">
+                        current
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {filteredBranches.remote.length > 0 && (
+              <div>
+                <div className="px-2 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+                  Remote
+                </div>
+                {filteredBranches.remote.map((branch) => (
+                  <button
+                    key={branch.name}
+                    type="button"
+                    className={cn(
+                      'flex items-center gap-1.5 w-full px-2 py-1 text-xs hover:bg-black/6 dark:hover:bg-white/8',
+                      branch.name === selectedBranch && 'bg-accent text-accent-foreground'
+                    )}
+                    onClick={() => handleSelect(branch.name)}
+                  >
+                    <span className="truncate">{branch.name}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {isEmpty && (
+              <div className="px-2 py-3 text-xs text-muted-foreground text-center">
+                {searchFilter ? 'No branches found' : emptyMessage}
+              </div>
+            )}
+          </div>
+
+          {footer}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface BranchDiffFileRowProps {
+  file: BranchDiffFile
+  worktreePath: string
+  onClick: (file: BranchDiffFile) => void
+}
+
+// Memoized because this list is not virtualized: without it every row re-renders
+// whenever a tab opens or closes.
+export const BranchDiffFileRow = memo(function BranchDiffFileRow({
+  file,
+  worktreePath,
+  onClick
+}: BranchDiffFileRowProps): React.JSX.Element {
+  const fileName = file.relativePath.split('/').pop() || file.relativePath
+  const ext = fileName.includes('.') ? '.' + fileName.split('.').pop() : null
+  const tabState = useFileTabState(
+    diffTabAbsolutePath({ worktreePath, filePath: file.relativePath })
+  )
+
+  return (
+    <div
+      className={cn(
+        'relative flex items-center gap-1.5 px-2 py-0.5 hover:bg-accent/30 cursor-pointer',
+        activeTabRowClass(tabState)
+      )}
+      onClick={() => onClick(file)}
+      data-testid={`branch-diff-file-${file.relativePath}`}
+    >
+      <OpenTabIndicator state={tabState} />
+      <FileIcon name={fileName} extension={ext} isDirectory={false} className="h-3.5 w-3.5" />
+      <span className="text-xs truncate flex-1" title={file.relativePath}>
+        {file.relativePath}
+      </span>
+      <GitStatusIndicator status={toGitStatusCode(file.status)} className="mr-1" />
+    </div>
+  )
+})

--- a/src/renderer/src/components/layout/MainPane.test.tsx
+++ b/src/renderer/src/components/layout/MainPane.test.tsx
@@ -63,6 +63,12 @@ vi.mock('./MainPaneTerminalPanel', () => ({
   MainPaneTerminalPanel: () => null
 }))
 
+vi.mock('@/components/diff/MonacoDiffView', () => ({
+  default: ({ worktreePath, compareBranch }: { worktreePath: string; compareBranch?: string }) => (
+    <div data-testid="monaco-diff-view" data-worktree={worktreePath} data-branch={compareBranch} />
+  )
+}))
+
 const initialConnectionState = useConnectionStore.getState()
 const initialFileViewerState = useFileViewerStore.getState()
 const initialKanbanState = useKanbanStore.getState()
@@ -337,6 +343,29 @@ describe('MainPane terminal activation gating', () => {
     renderMainPane()
 
     expect(screen.getByTestId('session-view-conn-session-1')).toBeTruthy()
+  })
+
+  it('renders a member branch diff while a connection (no worktree) is selected', async () => {
+    setupMainPaneState()
+    useWorktreeStore.setState({ selectedWorktreeId: null })
+    useConnectionStore.setState({ selectedConnectionId: 'connection-1', loaded: true })
+    useFileViewerStore.getState().setActiveDiff({
+      worktreePath: '/repo/member-a',
+      filePath: 'src/index.ts',
+      fileName: 'index.ts',
+      staged: false,
+      isUntracked: false,
+      compareBranch: 'main'
+    })
+
+    renderMainPane()
+
+    const diff = await screen.findByTestId('monaco-diff-view')
+    expect(diff.getAttribute('data-worktree')).toBe('/repo/member-a')
+    expect(diff.getAttribute('data-branch')).toBe('main')
+    expect(useFileViewerStore.getState().activeFilePath).toBe(
+      'diff:/repo/member-a:src/index.ts:branch:main'
+    )
   })
 
   it('unmounts a latched session when its tab is closed', () => {

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -476,7 +476,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
           }
         >
           <MonacoDiffView
-            key={`${activeDiff.filePath}|${activeDiff.compareBranch ?? ''}|${activeDiff.staged}|${activeDiff.prReviewWorktreeId ?? ''}`}
+            key={`${activeDiff.worktreePath}|${activeDiff.filePath}|${activeDiff.compareBranch ?? ''}|${activeDiff.staged}|${activeDiff.prReviewWorktreeId ?? ''}`}
             worktreePath={activeDiff.worktreePath}
             filePath={activeDiff.filePath}
             fileName={activeDiff.fileName}

--- a/src/renderer/src/lib/connection-branch-diff.test.ts
+++ b/src/renderer/src/lib/connection-branch-diff.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import {
+  connectionDiffBranchKey,
+  describeMemberGitError,
+  intersectMemberBranches,
+  type BranchWithStatus
+} from './connection-branch-diff'
+
+const b = (name: string, opts: Partial<BranchWithStatus> = {}): BranchWithStatus => ({
+  name,
+  isRemote: name.includes('/'),
+  isCheckedOut: false,
+  ...opts
+})
+
+describe('intersectMemberBranches', () => {
+  it('returns only branches present by name in every loaded member', () => {
+    const result = intersectMemberBranches([
+      { worktreePath: '/a', branches: [b('main'), b('feat/x'), b('origin/main'), b('only-a')] },
+      { worktreePath: '/b', branches: [b('feat/x'), b('main'), b('origin/main'), b('only-b')] },
+      { worktreePath: '/c', branches: [b('origin/main'), b('main'), b('feat/x')] }
+    ])
+    expect(result.map((r) => r.name)).toEqual(['main', 'feat/x', 'origin/main'])
+  })
+
+  it('keeps the first member ordering and remote flag', () => {
+    const result = intersectMemberBranches([
+      { worktreePath: '/a', branches: [b('origin/main'), b('main')] },
+      { worktreePath: '/b', branches: [b('main'), b('origin/main')] }
+    ])
+    expect(result).toEqual([
+      { name: 'origin/main', isRemote: true, isCheckedOut: false },
+      { name: 'main', isRemote: false, isCheckedOut: false }
+    ])
+  })
+
+  it('marks a branch current only when every member worktree is checked out on it', () => {
+    const result = intersectMemberBranches([
+      {
+        worktreePath: '/a',
+        branches: [
+          b('main', { isCheckedOut: true, worktreePath: '/a' }),
+          b('feat', { isCheckedOut: true, worktreePath: '/a' }),
+          // checked out in a sibling worktree of the same repo, not in /a
+          b('other', { isCheckedOut: true, worktreePath: '/a-sibling' })
+        ]
+      },
+      {
+        worktreePath: '/b',
+        branches: [
+          b('main', { isCheckedOut: true, worktreePath: '/b' }),
+          b('feat', { isCheckedOut: false }),
+          b('other', { isCheckedOut: true, worktreePath: '/b' })
+        ]
+      }
+    ])
+    expect(result.find((r) => r.name === 'main')?.isCheckedOut).toBe(true)
+    expect(result.find((r) => r.name === 'feat')?.isCheckedOut).toBe(false)
+    expect(result.find((r) => r.name === 'other')?.isCheckedOut).toBe(false)
+  })
+
+  it('does not let a local branch match a remote one of the same base name', () => {
+    const result = intersectMemberBranches([
+      { worktreePath: '/a', branches: [b('main')] },
+      { worktreePath: '/b', branches: [b('origin/main')] }
+    ])
+    expect(result).toEqual([])
+  })
+
+  it('ignores members whose listing failed instead of emptying the result', () => {
+    const result = intersectMemberBranches([
+      { worktreePath: '/a', branches: [b('main'), b('feat')] },
+      { worktreePath: '/b', error: 'not a git repository' },
+      { worktreePath: '/c', branches: [b('main')] }
+    ])
+    expect(result.map((r) => r.name)).toEqual(['main'])
+  })
+
+  it('returns nothing when no member loaded', () => {
+    expect(intersectMemberBranches([])).toEqual([])
+    expect(intersectMemberBranches([{ worktreePath: '/a', error: 'boom' }])).toEqual([])
+  })
+
+  it('treats a single member as its own intersection', () => {
+    const result = intersectMemberBranches([
+      { worktreePath: '/a', branches: [b('main'), b('feat')] }
+    ])
+    expect(result.map((r) => r.name)).toEqual(['main', 'feat'])
+  })
+
+  it('dedupes a name repeated within one member', () => {
+    const result = intersectMemberBranches([
+      { worktreePath: '/a', branches: [b('main'), b('main')] },
+      { worktreePath: '/b', branches: [b('main')] }
+    ])
+    expect(result).toHaveLength(1)
+  })
+})
+
+describe('connectionDiffBranchKey', () => {
+  it('namespaces the connection id so it cannot collide with a worktree path', () => {
+    expect(connectionDiffBranchKey('abc')).toBe('connection:abc')
+  })
+})
+
+describe('describeMemberGitError', () => {
+  it('maps the common raw git failures to readable text', () => {
+    expect(
+      describeMemberGitError('fatal: not a git repository (or any of the parent directories): .git')
+    ).toBe('Not a git repository')
+    expect(
+      describeMemberGitError(
+        "fatal: ambiguous argument 'nope': unknown revision or path not in the working tree."
+      )
+    ).toBe('Branch not found in this repo')
+  })
+
+  it('passes unknown errors through unchanged', () => {
+    expect(describeMemberGitError('index.lock exists')).toBe('index.lock exists')
+  })
+})

--- a/src/renderer/src/lib/connection-branch-diff.ts
+++ b/src/renderer/src/lib/connection-branch-diff.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure helpers for the connection Diffs tab: a connection groups several
+ * worktrees (one per repo), so "the branch to compare against" only makes
+ * sense when every member repo has a branch of that name.
+ */
+
+export interface BranchWithStatus {
+  name: string
+  isRemote: boolean
+  isCheckedOut: boolean
+  worktreePath?: string
+}
+
+/** One member's branch listing, or the reason it could not be loaded. */
+export type MemberBranchListing =
+  | { worktreePath: string; branches: BranchWithStatus[]; error?: undefined }
+  | { worktreePath: string; branches?: undefined; error: string }
+
+/**
+ * Branches present (by exact display name) in every successfully loaded member.
+ *
+ * Members whose listing failed are ignored for the intersection rather than
+ * emptying it, so one broken repo does not blank the whole picker; callers
+ * surface those failures separately. Order follows the first loaded member
+ * (git's alphabetical local-then-remote order). A name counts as "current"
+ * only when every member worktree itself is checked out on it (the backend's
+ * `isCheckedOut` means "checked out in some worktree of that repo", so the
+ * reported worktree path is matched against the member's), and as remote when
+ * the first member reports it remote (remote names carry the `origin/` prefix,
+ * so a local and a remote branch never share a display name).
+ */
+export function intersectMemberBranches(listings: MemberBranchListing[]): BranchWithStatus[] {
+  const loaded = listings.filter(
+    (l): l is Extract<MemberBranchListing, { branches: BranchWithStatus[] }> => !!l.branches
+  )
+  if (loaded.length === 0) return []
+
+  const byName = loaded.map((l) => {
+    const map = new Map<string, BranchWithStatus>()
+    for (const b of l.branches) {
+      if (!map.has(b.name)) map.set(b.name, b)
+    }
+    return map
+  })
+
+  const [first, ...rest] = byName
+  const common: BranchWithStatus[] = []
+  for (const [name, branch] of first) {
+    if (!rest.every((m) => m.has(name))) continue
+    common.push({
+      name,
+      isRemote: branch.isRemote,
+      isCheckedOut: loaded.every((l, i) => {
+        const entry = byName[i].get(name)
+        return entry?.isCheckedOut === true && entry.worktreePath === l.worktreePath
+      })
+    })
+  }
+  return common
+}
+
+/** Store key under which a connection's chosen compare branch is remembered. */
+export function connectionDiffBranchKey(connectionId: string): string {
+  return `connection:${connectionId}`
+}
+
+/**
+ * The git RPCs return raw stderr; turn the two failures a member can hit in
+ * this view into something readable, and pass anything else through.
+ */
+export function describeMemberGitError(error: string): string {
+  if (/not a git repository/i.test(error)) return 'Not a git repository'
+  if (/unknown revision|bad revision|ambiguous argument/i.test(error)) {
+    return 'Branch not found in this repo'
+  }
+  return error
+}

--- a/src/renderer/src/stores/useFileViewerStore.ts
+++ b/src/renderer/src/stores/useFileViewerStore.ts
@@ -40,9 +40,19 @@ export interface ActiveDiff {
   prReviewWorktreeId?: string
 }
 
-function diffTabKey(diff: { filePath: string; staged: boolean; compareBranch?: string }): string {
+/**
+ * Branch-compare diffs carry the worktree in their key: a connection opens them
+ * for several repos at once, and two members often share a relative path
+ * (package.json, README.md), which must not collapse into one tab.
+ */
+function diffTabKey(diff: {
+  worktreePath: string
+  filePath: string
+  staged: boolean
+  compareBranch?: string
+}): string {
   return diff.compareBranch
-    ? `diff:${diff.filePath}:branch:${diff.compareBranch}`
+    ? `diff:${diff.worktreePath}:${diff.filePath}:branch:${diff.compareBranch}`
     : `diff:${diff.filePath}:${diff.staged ? 'staged' : 'unstaged'}`
 }
 

--- a/test/phase-12/renderer-api-cleanup.test.ts
+++ b/test/phase-12/renderer-api-cleanup.test.ts
@@ -22437,11 +22437,11 @@ describe('renderer API cleanup', () => {
     const effectStart = source.indexOf(
       '  // Listen for git status changes to auto-refresh file list'
     )
-    const closeDropdownStart = source.indexOf('  // Close dropdown on outside click', effectStart)
-    const effectSource = source.slice(effectStart, closeDropdownStart)
+    const selectHandlerStart = source.indexOf('  const handleSelectBranch = useCallback(', effectStart)
+    const effectSource = source.slice(effectStart, selectHandlerStart)
 
     expect(effectStart).toBeGreaterThan(-1)
-    expect(closeDropdownStart).toBeGreaterThan(effectStart)
+    expect(selectHandlerStart).toBeGreaterThan(effectStart)
     expect(source).toContain("import { gitApi } from '@/api/git-api'")
     expect(effectSource).toContain('if (!worktreePath || !selectedBranch) return')
     expect(effectSource).toContain('const cleanup = gitApi.onStatusChanged((event) => {')


### PR DESCRIPTION
## Summary

- Add connection-level branch diff support across all member worktrees.
- Show only branches shared by every repository and persist selections per connection.
- Render collapsible per-member diff sections with independent errors, refreshes, and file tabs.
- Extract shared branch-diff UI and add connection diff utilities.

## Testing

- Added comprehensive `ConnectionBranchDiffView` component tests.
- Added connection branch-diff utility tests.
- Updated layout, file viewer store, and renderer API cleanup tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches file-viewer tab identity for branch diffs and connection-scoped git loading, so tab collisions or stale async results could mis-show diffs, but this is UI-only with no auth or data-write changes.
> 
> **Overview**
> The Diffs tab now works in connection mode: pick one compare branch shared by every member repo, then see collapsible per-member file lists (with independent errors, refresh, and git-status updates).
> 
> Shared picker/row UI is extracted from the single-worktree view. Branch-compare tabs include the worktree in their key so the same relative path in two members opens as two diffs, and Monaco remounts when the worktree changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa0b4074ad296bf55e8276b28e3f9487fe8b2baf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->