### PR TITLE
Mirror active account refresh in usage bar

### DIFF
--- a/src/renderer/src/stores/useUsageStore.ts
+++ b/src/renderer/src/stores/useUsageStore.ts
@@ -174,17 +174,42 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
       state.savedAccounts[p].some((account) => account.id === id)
     )
     const userInitiated = opts?.userInitiated ?? false
-    const account = provider
-      ? state.savedAccounts[provider].find((a) => a.id === id)
-      : undefined
+    const account = provider ? state.savedAccounts[provider].find((a) => a.id === id) : undefined
 
     set((current) => ({
       refreshingAccountIds: new Set([...current.refreshingAccountIds, id])
     }))
     try {
       const result = await usageApi.fetchForAccount(id, userInitiated)
+      if (result.success && result.data && provider && account) {
+        // The bottom usage bar reads the provider's live usage, not the saved
+        // account row — when the refreshed account is the active one, mirror
+        // the fresh data so both views agree.
+        const accountState = useAccountStore.getState()
+        const activeEmail =
+          provider === 'anthropic' ? accountState.anthropicEmail : accountState.openaiEmail
+        if (activeEmail !== null && activeEmail === account.email) {
+          if (provider === 'anthropic') {
+            set({
+              anthropicUsage: result.data as UsageData,
+              anthropicLastError: null,
+              anthropicLastRetryAfter: null,
+              anthropicLastFetchedAt: Date.now()
+            })
+          } else {
+            set({
+              openaiUsage: result.data as OpenAIUsageData,
+              openaiLastError: null,
+              openaiLastFetchedAt: Date.now()
+            })
+          }
+        }
+      }
       if (result.needsLogin && userInitiated && provider) {
-        useLoginStore.getState().startLogin(provider, account?.email).catch(() => {})
+        useLoginStore
+          .getState()
+          .startLogin(provider, account?.email)
+          .catch(() => {})
       } else if (!result.success && userInitiated) {
         toast.error(
           `${providerLabel(provider ?? 'anthropic')} account refresh failed: ${result.error ?? 'Unknown error'}`
@@ -192,7 +217,9 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
       }
     } catch (err) {
       if (userInitiated) {
-        toast.error(`${providerLabel(provider ?? 'anthropic')} account refresh failed: ${errorMessage(err)}`)
+        toast.error(
+          `${providerLabel(provider ?? 'anthropic')} account refresh failed: ${errorMessage(err)}`
+        )
       }
     } finally {
       // Reload in its own catch so a reload hiccup after a SUCCESSFUL fetch
@@ -213,9 +240,7 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
     const provider = (['anthropic', 'openai'] as UsageProvider[]).find((p) =>
       state.savedAccounts[p].some((account) => account.id === id)
     )
-    const account = provider
-      ? state.savedAccounts[provider].find((a) => a.id === id)
-      : undefined
+    const account = provider ? state.savedAccounts[provider].find((a) => a.id === id) : undefined
 
     set((current) => ({
       removingAccountIds: new Set([...current.removingAccountIds, id])
@@ -242,9 +267,7 @@ export const useUsageStore = create<UsageState>()((set, get) => ({
     const provider = (['anthropic', 'openai'] as UsageProvider[]).find((p) =>
       state.savedAccounts[p].some((account) => account.id === id)
     )
-    const account = provider
-      ? state.savedAccounts[provider].find((a) => a.id === id)
-      : undefined
+    const account = provider ? state.savedAccounts[provider].find((a) => a.id === id) : undefined
 
     set((current) => ({
       switchingAccountIds: new Set([...current.switchingAccountIds, id])
@@ -509,10 +532,7 @@ function resolveCustomProviderUsage(
   customProviderId: string | null | undefined
 ): UsageProvider | null | undefined {
   if (!customProviderId) return undefined
-  const provider = findCustomProvider(
-    useSettingsStore.getState().customProviders,
-    customProviderId
-  )
+  const provider = findCustomProvider(useSettingsStore.getState().customProviders, customProviderId)
   if (!provider || !provider.command.trim()) return undefined
   return customProviderUsageToUsageProvider(provider.usageProvider)
 }
@@ -540,7 +560,9 @@ export function resolveDefaultUsageProvider(
   return 'anthropic'
 }
 
-function hasUsageWindow(value: unknown): value is { utilization: number; resets_at: string | null } {
+function hasUsageWindow(
+  value: unknown
+): value is { utilization: number; resets_at: string | null } {
   if (typeof value !== 'object' || value === null) return false
   const record = value as Record<string, unknown>
   // resets_at is legitimately null (or absent) for a window with no active

--- a/test/usage/use-usage-store.test.ts
+++ b/test/usage/use-usage-store.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SavedAccountDTO } from '@shared/types/usage'
 import { resetRendererRpcClientForTests, setRendererRpcClient } from '@/api/rpc-client'
 import { useUsageStore, type UsageData } from '@/stores/useUsageStore'
+import { useAccountStore } from '@/stores/useAccountStore'
 import { toast } from '@/lib/toast'
 
 vi.mock('@/lib/toast', () => ({
@@ -151,7 +152,9 @@ describe('useUsageStore', () => {
     await useUsageStore.getState().forceRefreshProvider('anthropic')
 
     expect(request.mock.calls.filter(([method]) => method === 'usageOps.fetch')).toHaveLength(0)
-    expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/^Rate limited — retry in \d+s$/))
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringMatching(/^Rate limited — retry in \d+s$/)
+    )
   })
 
   it('clears Anthropic errors and advances debounce after a successful fetch', async () => {
@@ -216,6 +219,43 @@ describe('useUsageStore', () => {
     await useUsageStore.getState().refreshSavedAccount('acc-1', { userInitiated: true })
 
     expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('mirrors a popover refresh of the ACTIVE account into the live usage bar', async () => {
+    useAccountStore.setState({ anthropicEmail: 'a@b.com' })
+    useUsageStore.setState({
+      anthropicUsage: null,
+      savedAccounts: { anthropic: [anthropicAccount('acc-1', 'a@b.com')], openai: [] }
+    } as Partial<ReturnType<typeof useUsageStore.getState>>)
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.fetchForAccount')
+        return { success: true, status: 'ok', data: sampleUsage }
+      if (method === 'accountOps.listSaved') return []
+      return null
+    })
+
+    await useUsageStore.getState().refreshSavedAccount('acc-1', { userInitiated: true })
+
+    expect(usageState().anthropicUsage).toEqual(sampleUsage)
+    expect(usageState().anthropicLastFetchedAt).toBe(Date.now())
+  })
+
+  it('does not touch the live usage bar when refreshing a NON-active account', async () => {
+    useAccountStore.setState({ anthropicEmail: 'a@b.com' })
+    useUsageStore.setState({
+      anthropicUsage: null,
+      savedAccounts: { anthropic: [anthropicAccount('acc-2', 'other@b.com')], openai: [] }
+    } as Partial<ReturnType<typeof useUsageStore.getState>>)
+    request.mockImplementation(async (method: string) => {
+      if (method === 'usageOps.fetchForAccount')
+        return { success: true, status: 'ok', data: sampleUsage }
+      if (method === 'accountOps.listSaved') return []
+      return null
+    })
+
+    await useUsageStore.getState().refreshSavedAccount('acc-2', { userInitiated: true })
+
+    expect(usageState().anthropicUsage).toBeNull()
   })
 
   it('toasts switch success even when a post-switch reload fails', async () => {


### PR DESCRIPTION
## Summary

- Sync refreshed active-account usage into the main usage bar.
- Keep the live usage bar unchanged when refreshing an inactive account.
- Add coverage for active and non-active account refresh behavior.

## Testing

- Added Vitest coverage in `test/usage/use-usage-store.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-store sync for usage display; no auth, API, or persistence changes. Matching by email is the only extra coupling to the account store.
> 
> **Overview**
> When a saved account is refreshed from the popover, the bottom usage bar now updates if that account is the currently active Anthropic or OpenAI login. Previously the bar only read provider-level live usage, so a successful popover refresh left it stale.
> 
> Inactive accounts are unchanged: their refresh still updates the saved-account row only. Tests cover both the active-mirror path and the non-active no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92cf3cd9e55b13a094475a395aee690b5dc13216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->