### PR TITLE
Add archive flow for connection-project tickets

### DIFF
--- a/src/renderer/src/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/src/components/kanban/KanbanColumn.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/stores/useKanbanStore'
 import type { MarkdownCardPlaceholder } from '@/stores/useKanbanStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useProjectStore } from '@/stores/useProjectStore'
 import { useUsageStore, resolveDefaultUsageProvider } from '@/stores/useUsageStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { isBlockerSatisfied } from '@/lib/blocker-utils'
@@ -679,7 +680,20 @@ export function KanbanColumn({
                 draggedTicket.current_session_id
               )
               if (ticketConnectionId) {
-                const mergeQueue = await buildConnectionMergeQueue(ticketConnectionId)
+                // Connection-PROJECT tickets mimic single-project behavior:
+                // each member worktree gets the archive/keep step, and
+                // Review/Merged → Done drops queue already-merged members
+                // too (the archivePromptOnly analog above)
+                const offerArchive =
+                  useProjectStore.getState().projects.find((p) => p.id === ticketProjectId)
+                    ?.kind === 'connection'
+                const archivePromptOnly =
+                  offerArchive &&
+                  column === 'done' &&
+                  (sourceColumn === 'review' || sourceColumn === 'merged')
+                const mergeQueue = await buildConnectionMergeQueue(ticketConnectionId, {
+                  includeAlreadyMerged: archivePromptOnly
+                })
                 if (mergeQueue.length > 0) {
                   const [firstTarget, ...restTargets] = mergeQueue
                   const sortOrder = store.computeSortOrder(
@@ -693,7 +707,8 @@ export function KanbanColumn({
                     targetColumn: column,
                     worktreeId: firstTarget.worktreeId,
                     worktreeProjectId: firstTarget.projectId,
-                    remainingWorktrees: restTargets
+                    remainingWorktrees: restTargets,
+                    offerArchive
                   })
                   return
                 }

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -70,6 +70,7 @@ import { useCommandApprovalStore } from '@/stores/useCommandApprovalStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
 import { isBlockerSatisfied } from '@/lib/blocker-utils'
+import { buildConnectionMergeQueue, resolveTicketConnectionId } from '@/lib/connection-merge'
 import { useGitStore } from '@/stores/useGitStore'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
@@ -3490,6 +3491,41 @@ function ReviewModeContent({
               projectId: ticket.project_id,
               sortOrder,
               targetColumn: 'done'
+            })
+            return
+          }
+        }
+      } catch {
+        // Fall through to normal move on error
+      }
+    } else if (ticket.current_session_id) {
+      // Connection tickets have no worktree_id — queue the merge flow once
+      // per member worktree, mirroring the board drop path. Connection-PROJECT
+      // tickets also get the archive/keep step for each member (and queue
+      // already-merged members so the prompt still shows).
+      try {
+        const connectionId = await resolveTicketConnectionId(ticket.current_session_id)
+        if (connectionId) {
+          const offerArchive =
+            useProjectStore.getState().projects.find((p) => p.id === ticket.project_id)?.kind ===
+            'connection'
+          const mergeQueue = await buildConnectionMergeQueue(connectionId, {
+            includeAlreadyMerged: offerArchive
+          })
+          if (mergeQueue.length > 0) {
+            const [firstTarget, ...restTargets] = mergeQueue
+            const kanbanStore = useKanbanStore.getState()
+            const doneTickets = kanbanStore.getTicketsByColumn(ticket.project_id, 'done')
+            const sortOrder = kanbanStore.computeSortOrder(doneTickets, doneTickets.length)
+            kanbanStore.setPendingDoneMove({
+              ticketId: ticket.id,
+              projectId: ticket.project_id,
+              sortOrder,
+              targetColumn: 'done',
+              worktreeId: firstTarget.worktreeId,
+              worktreeProjectId: firstTarget.projectId,
+              remainingWorktrees: restTargets,
+              offerArchive
             })
             return
           }

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.test.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.test.tsx
@@ -285,3 +285,104 @@ describe('MergeOnDoneDialog — connection member queue', () => {
     expect(screen.queryByText(/Branch already merged/)).toBeNull()
   })
 })
+
+describe('MergeOnDoneDialog — connection-project member queue (offerArchive)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    moveTicketMock.mockResolvedValue(undefined)
+    archiveWorktreeMock.mockResolvedValue({ success: true })
+    mockAlreadyMergedBranch()
+    setupStores()
+    useKanbanStore.setState({
+      tickets: new Map([['project-1', [{ ...ticket, worktree_id: null }]]]),
+      pendingDoneMove: {
+        ticketId: 'ticket-1',
+        projectId: 'project-1',
+        sortOrder: 5,
+        targetColumn: 'done',
+        worktreeId: 'worktree-1',
+        worktreeProjectId: 'project-1',
+        remainingWorktrees: [{ worktreeId: 'worktree-next', projectId: 'project-2' }],
+        offerArchive: true
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useKanbanStore.setState({ pendingDoneMove: null })
+  })
+
+  it('offers the archive/keep step for an already-merged member', async () => {
+    render(<MergeOnDoneDialog />)
+
+    expect(await screen.findByText(/Branch already merged/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Archive' })).toBeTruthy()
+    expect(moveTicketMock).not.toHaveBeenCalled()
+  })
+
+  it('offers the archive/keep step after a successful merge', async () => {
+    gitApiMocks.branchDiffShortStat.mockResolvedValue({
+      success: true,
+      filesChanged: 2,
+      insertions: 10,
+      deletions: 3,
+      commitsAhead: 1
+    })
+    gitApiMocks.getRemoteUrl.mockResolvedValue({ url: null })
+    gitApiMocks.merge.mockResolvedValue({ success: true })
+
+    render(<MergeOnDoneDialog />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Merge' }))
+
+    expect(await screen.findByText(/Merge successful/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Archive' })).toBeTruthy()
+    // Queue must not advance until the archive/keep choice is made
+    expect(useKanbanStore.getState().pendingDoneMove?.worktreeId).toBe('worktree-1')
+  })
+
+  it('Archive archives the member worktree and advances the queue', async () => {
+    render(<MergeOnDoneDialog />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Archive' }))
+
+    await waitFor(() =>
+      expect(archiveWorktreeMock).toHaveBeenCalledWith(
+        'worktree-1',
+        '/repo/feature',
+        'feature',
+        '/repo/main'
+      )
+    )
+    const next = useKanbanStore.getState().pendingDoneMove
+    expect(next?.worktreeId).toBe('worktree-next')
+    // offerArchive must survive queue advancement so later members get the prompt
+    expect(next?.offerArchive).toBe(true)
+    expect(moveTicketMock).not.toHaveBeenCalled()
+  })
+
+  it('Keep advances the queue without archiving, then moves after the last member', async () => {
+    useKanbanStore.setState({
+      pendingDoneMove: {
+        ticketId: 'ticket-1',
+        projectId: 'project-1',
+        sortOrder: 5,
+        targetColumn: 'done',
+        worktreeId: 'worktree-1',
+        worktreeProjectId: 'project-1',
+        remainingWorktrees: [],
+        offerArchive: true
+      }
+    })
+
+    render(<MergeOnDoneDialog />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Keep' }))
+
+    await waitFor(() =>
+      expect(moveTicketMock).toHaveBeenCalledWith('ticket-1', 'project-1', 'done', 5)
+    )
+    expect(archiveWorktreeMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
+++ b/src/renderer/src/components/kanban/MergeOnDoneDialog.tsx
@@ -207,9 +207,11 @@ export function MergeOnDoneDialog() {
         // commit/merge steps but still offer the archive/keep choice
         const alreadyMerged = !hasUncommitted && branchStats.commitsAhead === 0
 
-        // Connection members never get the archive prompt — archiving would
-        // tear the worktree out of the connection (symlink + membership)
-        if (pending.worktreeId && alreadyMerged) {
+        // Plain-connection members never get the archive prompt — archiving
+        // would tear the worktree out of a connection the user still needs.
+        // Connection-PROJECT members (offerArchive) fall through to it so the
+        // instance's worktrees can be archived like any feature worktree.
+        if (pending.worktreeId && alreadyMerged && !pending.offerArchive) {
           await completeDoneMove({
             ticketId: pending.ticketId,
             projectId: pending.projectId,
@@ -417,9 +419,9 @@ export function MergeOnDoneDialog() {
       }
 
       toast.success('Branch merged successfully')
-      // Connection members advance the queue instead of offering the
-      // destructive archive step (see init)
-      if (pendingDoneMove.worktreeId) {
+      // Plain-connection members advance the queue instead of offering the
+      // destructive archive step; connection-project members get it (see init)
+      if (pendingDoneMove.worktreeId && !pendingDoneMove.offerArchive) {
         await completeDoneMove(pendingIdentity)
         return
       }

--- a/src/renderer/src/lib/connection-merge.test.ts
+++ b/src/renderer/src/lib/connection-merge.test.ts
@@ -156,6 +156,36 @@ describe('buildConnectionMergeQueue', () => {
     expect(queue).toEqual([{ worktreeId: 'wt-ahead', projectId: 'proj-1' }])
   })
 
+  it('includeAlreadyMerged queues clean members too, but still skips on-base ones', async () => {
+    connectionApiMocks.get.mockResolvedValue({
+      success: true,
+      connection: {
+        id: 'conn-1',
+        members: [
+          { worktree_id: 'wt-clean', project_id: 'proj-1' },
+          { worktree_id: 'wt-on-base', project_id: 'proj-2' }
+        ]
+      }
+    })
+    dbApiMocks.worktree.get.mockImplementation(async (id: string) => {
+      if (id === 'wt-clean') return worktree({ id: 'wt-clean' })
+      if (id === 'wt-on-base') return worktree({ id: 'wt-on-base', branch_name: 'main' })
+      return null
+    })
+    dbApiMocks.worktree.getActiveByProject.mockResolvedValue([mainWorktree])
+    gitApiMocks.hasUncommittedChanges.mockResolvedValue(false)
+    gitApiMocks.branchDiffShortStat.mockResolvedValue({
+      success: true,
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+      commitsAhead: 0
+    })
+
+    const queue = await buildConnectionMergeQueue('conn-1', { includeAlreadyMerged: true })
+    expect(queue).toEqual([{ worktreeId: 'wt-clean', projectId: 'proj-1' }])
+  })
+
   it('skips members whose base worktree is missing', async () => {
     connectionApiMocks.get.mockResolvedValue({
       success: true,

--- a/src/renderer/src/lib/connection-merge.ts
+++ b/src/renderer/src/lib/connection-merge.ts
@@ -34,9 +34,14 @@ export async function resolveTicketConnectionId(
  * deleted or archived connection yields an empty queue (nothing to merge);
  * an unverifiable member (DB/git failure) rejects so callers can abort the
  * move instead of treating unchecked work as clean.
+ *
+ * `includeAlreadyMerged` also queues clean members so each still gets the
+ * archive/keep step — the connection-project analog of the single-project
+ * archive-prompt-only path on Review/Merged → Done drops.
  */
 export async function buildConnectionMergeQueue(
-  connectionId: string
+  connectionId: string,
+  opts?: { includeAlreadyMerged?: boolean }
 ): Promise<ConnectionMergeTarget[]> {
   const result = await connectionApi.get(connectionId)
   if (!result.success || !result.connection) {
@@ -78,7 +83,7 @@ export async function buildConnectionMergeQueue(
         )
       }
 
-      if (hasUncommitted || branchStatResult.commitsAhead > 0) {
+      if (hasUncommitted || branchStatResult.commitsAhead > 0 || opts?.includeAlreadyMerged) {
         return { worktreeId: worktree.id, projectId: member.project_id }
       }
       return null

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -216,6 +216,12 @@ export interface PendingDoneMove {
   worktreeProjectId?: string
   /** Connection flow: member worktrees still to merge after the current one */
   remainingWorktrees?: { worktreeId: string; projectId: string }[]
+  /**
+   * Connection-project flow: offer the archive/keep step for each member
+   * worktree (plain connections skip it — archiving would tear a worktree
+   * out of a connection the user still needs).
+   */
+  offerArchive?: boolean
 }
 
 // ── State interface ────────────────────────────────────────────────────
@@ -1601,7 +1607,8 @@ export const useKanbanStore = create<KanbanState>()(
               targetColumn: pending.targetColumn,
               worktreeId: nextWorktree.worktreeId,
               worktreeProjectId: nextWorktree.projectId,
-              remainingWorktrees: restWorktrees
+              remainingWorktrees: restWorktrees,
+              offerArchive: pending.offerArchive
             }
           })
           return


### PR DESCRIPTION
## Summary
- Queue connection-project member worktrees for merge and archive/keep handling.
- Preserve archive prompts while advancing through queued members.
- Add coverage for already-merged members and archive/keep behavior.

## Testing
- Added unit tests for connection merge queue behavior.
- Added dialog tests for archive, keep, successful merge, and already-merged flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches merge-on-done and worktree archive for multi-member connections. Wrong `offerArchive` gating could archive worktrees out of a live connection or skip cleanup on connection-project tickets.
> 
> **Overview**
> Connection-**project** tickets now get the same per-member archive/keep prompt as single-project merge-on-done. Plain connections still skip archive so membership is not torn apart.
> 
> `pendingDoneMove.offerArchive` is set when the ticket’s project `kind` is `connection`, and is preserved as the merge queue advances. `buildConnectionMergeQueue` can include already-merged (clean) members so Review/Merged → Done still shows the prompt. Board drop and the ticket modal “Move to Done” path both queue this flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e7284a6f85ff50ef089c6ac78a0136c6447afdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->