### PR TITLE
Detect and surface Claude CLI API errors

### DIFF
--- a/src/main/services/__tests__/claude-cli-interaction-ledger.test.ts
+++ b/src/main/services/__tests__/claude-cli-interaction-ledger.test.ts
@@ -19,6 +19,7 @@ interface HookStep {
   status: SessionStatusType | null
   plan?: string
   prompt?: string
+  backgroundTasks?: Array<{ id?: string; type?: string; status?: string }>
 }
 
 function buildHook(step: HookStep): ParsedClaudeHook {
@@ -27,6 +28,7 @@ function buildHook(step: HookStep): ParsedClaudeHook {
   if (step.id) hook.tool_use_id = step.id
   if (step.plan) hook.tool_input = { plan: step.plan }
   if (step.prompt !== undefined) hook.prompt = step.prompt
+  if (step.backgroundTasks) hook.background_tasks = step.backgroundTasks
   return hook
 }
 
@@ -70,6 +72,40 @@ describe('passthrough when no interactions pending', () => {
     expect(
       statuses(process({ event: 'PostToolUse', tool: 'AskUserQuestion', status: 'working' }))
     ).toEqual(['working'])
+  })
+})
+
+describe('StopFailure turn boundary (API-error turn end)', () => {
+  it('resets a latched question and publishes the completion', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+
+    expect(statuses(process({ event: 'StopFailure', status: 'completed' }))).toEqual(['completed'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
+  })
+
+  it('preserves a latch when background subagents are still running (a blocked subagent owns it)', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+
+    const publishes = process({
+      event: 'StopFailure',
+      status: 'completed',
+      backgroundTasks: [{ id: 'agent-1', type: 'subagent', status: 'running' }]
+    })
+    expect(publishes).toEqual([])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(true)
+  })
+
+  it('resets a stale latch when the snapshot shows no running subagent work', () => {
+    process({ event: 'PreToolUse', tool: 'AskUserQuestion', status: 'answering' })
+
+    const publishes = process({
+      event: 'StopFailure',
+      status: 'completed',
+      backgroundTasks: [{ id: 'shell-1', type: 'shell', status: 'running' }]
+    })
+    expect(statuses(publishes)).toEqual(['completed'])
+    expect(hasBlockingClaudeCliInteraction(SESSION)).toBe(false)
   })
 })
 

--- a/src/main/services/__tests__/claude-cli-subagent-tracker.test.ts
+++ b/src/main/services/__tests__/claude-cli-subagent-tracker.test.ts
@@ -97,6 +97,42 @@ describe('deferring a Stop with running background subagents', () => {
   })
 })
 
+describe('StopFailure (API-error turn end)', () => {
+  it('passes even with running background subagents (never defers)', () => {
+    expect(
+      process(
+        { event: 'StopFailure', backgroundTasks: [bgTask('a')] },
+        buildMapped(SESSION, 'completed')
+      )
+    ).toEqual({ kind: 'pass' })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+  })
+
+  it('clears an existing deferral so the watchdog never fires', () => {
+    vi.useFakeTimers()
+    const handler = vi.fn().mockReturnValue(true)
+    setClaudeCliDeferredCompletionHandler(handler)
+
+    process({ event: 'Stop', backgroundTasks: [bgTask('a')] }, buildMapped(SESSION, 'completed'))
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(true)
+
+    expect(process({ event: 'StopFailure' }, buildMapped(SESSION, 'completed'))).toEqual({
+      kind: 'pass'
+    })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+
+    vi.advanceTimersByTime(SUBAGENT_WATCHDOG_TIMEOUT_MS)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('a subagent-scoped StopFailure is never a session completion', () => {
+    expect(process({ event: 'StopFailure', agentId: 'agent-1' })).toEqual({
+      kind: 'subagent_scoped'
+    })
+    expect(isClaudeCliCompletionDeferred(SESSION)).toBe(false)
+  })
+})
+
 describe('full happy path (real trace replay)', () => {
   it('defers, drains via notification, then completes on a clean Stop', () => {
     expect(

--- a/src/main/services/__tests__/claude-hook-server.test.ts
+++ b/src/main/services/__tests__/claude-hook-server.test.ts
@@ -105,6 +105,11 @@ describe('mapHookEventToStatus', () => {
     ],
     ['Stop maps to completed', { hook_event_name: 'Stop' }, 'completed'],
     [
+      'StopFailure maps to completed',
+      { hook_event_name: 'StopFailure', error: 'server_error' },
+      'completed'
+    ],
+    [
       'PreToolUse ExitPlanMode maps to plan_ready',
       { hook_event_name: 'PreToolUse', tool_name: 'ExitPlanMode' },
       'plan_ready'
@@ -195,6 +200,17 @@ describe('buildClaudeCliHookSettings', () => {
         ],
         Stop: [
           {
+            hooks: [
+              {
+                type: 'http',
+                url: 'http://127.0.0.1:34819/hook/hive-session-1/stop'
+              }
+            ]
+          }
+        ],
+        StopFailure: [
+          {
+            matcher: '*',
             hooks: [
               {
                 type: 'http',
@@ -422,6 +438,137 @@ describe('ClaudeHookServer HTTP round-trip', () => {
         metadata: { hookEventName: 'Stop', hookPath: 'stop' }
       }
     )
+  })
+
+  it('publishes an api-error event and a completed status for StopFailure', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'StopFailure',
+      error: 'server_error',
+      error_details: '500 Internal Server Error',
+      last_assistant_message: 'API Error: 500 Internal server error.'
+    })
+
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:api-error',
+        {
+          sessionId: 'hive-session-1',
+          error: 'server_error',
+          errorDetails: '500 Internal Server Error',
+          lastAssistantMessage: 'API Error: 500 Internal server error.'
+        }
+      )
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:status',
+        {
+          sessionId: 'hive-session-1',
+          status: 'completed',
+          metadata: { hookEventName: 'StopFailure', hookPath: 'stop', apiError: 'server_error' }
+        }
+      )
+    })
+  })
+
+  it('still publishes the api-error event when the completed status is dedup-swallowed', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'stop', { hook_event_name: 'Stop' })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:status',
+        expect.objectContaining({ sessionId: 'hive-session-1', status: 'completed' })
+      )
+    })
+
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'StopFailure',
+      error: 'overloaded'
+    })
+
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:api-error',
+        { sessionId: 'hive-session-1', error: 'overloaded' }
+      )
+    })
+    // The status publish itself is dedup-swallowed: still just the one from Stop.
+    const statusCalls = backendManagerMocks.publishDesktopBackendEvent.mock.calls.filter(
+      ([channel]) => channel === 'claude-cli:status'
+    )
+    expect(statusCalls).toHaveLength(1)
+  })
+
+  it('ignores subagent-scoped StopFailure for both channels', async () => {
+    const { port } = await getClaudeHookServer()
+
+    const response = await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'StopFailure',
+      error: 'server_error',
+      agent_id: 'agent-1'
+    })
+
+    expect(response).toEqual({ status: 200, text: '{}' })
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    expect(backendManagerMocks.publishDesktopBackendEvent).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a StopFailure immediately even while background subagents are running', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'StopFailure',
+      error: 'rate_limit',
+      background_tasks: [{ id: 'agent-1', type: 'subagent', status: 'running' }]
+    })
+
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:status',
+        {
+          sessionId: 'hive-session-1',
+          status: 'completed',
+          metadata: { hookEventName: 'StopFailure', hookPath: 'stop', apiError: 'rate_limit' }
+        }
+      )
+    })
+  })
+
+  it('keeps a blocked subagent question latched through a StopFailure with running subagents', async () => {
+    const { port } = await getClaudeHookServer()
+
+    await postHook(port, 'hive-session-1', 'tool', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion'
+    })
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:status',
+        expect.objectContaining({ sessionId: 'hive-session-1', status: 'answering' })
+      )
+    })
+
+    await postHook(port, 'hive-session-1', 'stop', {
+      hook_event_name: 'StopFailure',
+      error: 'rate_limit',
+      background_tasks: [{ id: 'agent-1', type: 'subagent', status: 'running' }]
+    })
+
+    // The api-error event still fires, but the answering latch survives — no
+    // 'completed' publish while the subagent is genuinely blocked on its
+    // question.
+    await vi.waitFor(() => {
+      expect(backendManagerMocks.publishDesktopBackendEvent).toHaveBeenCalledWith(
+        'claude-cli:api-error',
+        expect.objectContaining({ sessionId: 'hive-session-1', error: 'rate_limit' })
+      )
+    })
+    expect(hasBlockingClaudeCliInteraction('hive-session-1')).toBe(true)
+    const statusCalls = backendManagerMocks.publishDesktopBackendEvent.mock.calls.filter(
+      ([channel]) => channel === 'claude-cli:status'
+    )
+    expect(statusCalls).toHaveLength(1)
   })
 
   it('keeps a pending question surfaced through unrelated sub-agent hooks until answered', async () => {

--- a/src/main/services/__tests__/cli-hook-hold-core.test.ts
+++ b/src/main/services/__tests__/cli-hook-hold-core.test.ts
@@ -182,6 +182,27 @@ describe('CliHookHoldCore', () => {
     expect(transport2.some((event) => event.type === 'session.idle')).toBe(true)
   })
 
+  it('StopFailure emits idle with the rendered API-error text as the final message', () => {
+    const { core, transport } = makeCore()
+    core.register(SESSION)
+    const res = makeRes()
+
+    const owned = core.onHook(
+      SESSION,
+      {
+        hook_event_name: 'StopFailure',
+        last_assistant_message: 'API Error: 500 Internal server error.'
+      },
+      res
+    )
+
+    expect(owned).toBe(false)
+    expect(transport.find((event) => event.type === 'message.updated')).toMatchObject({
+      data: { role: 'assistant', content: 'API Error: 500 Internal server error.' }
+    })
+    expect(transport.some((event) => event.type === 'session.idle')).toBe(true)
+  })
+
   it('emitSessionIdle(sessionId, text) emits message.updated then session.idle', () => {
     const { core, transport } = makeCore()
 

--- a/src/main/services/__tests__/hive-enterprise-claude-cli-telemetry.test.ts
+++ b/src/main/services/__tests__/hive-enterprise-claude-cli-telemetry.test.ts
@@ -462,6 +462,45 @@ describe('Claude CLI Hive Enterprise telemetry', () => {
     ])
   })
 
+  it('closes the active prompt on StopFailure (API-error turn end fires instead of Stop)', async () => {
+    const transcriptPath = makeTranscript(
+      `${assistantLine({ input: 100, output: 5, cacheRead: 20, cacheWrite: 7 })}\n`
+    )
+    const db = makeDb({
+      hiveEnterpriseServerUrl: 'https://enterprise.example.com',
+      hiveAuthToken: 'token-1',
+      hiveOrganizationId: 'org-1'
+    })
+
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'Continue',
+        transcript_path: transcriptPath
+      },
+      { db, requestGraphql }
+    )
+
+    await handleClaudeCliHiveTelemetryHook(
+      'hive-session-1',
+      { hook_event_name: 'StopFailure', transcript_path: transcriptPath },
+      { db, requestGraphql }
+    )
+
+    expect(requestGraphql).toHaveBeenCalledTimes(2)
+    expect(requestGraphql.mock.calls[1][2]).toEqual(expect.stringContaining('recordPromptIdle'))
+    expect(requestGraphql.mock.calls[1][3]).toEqual({
+      input: {
+        promptId: SERVER_PROMPT_ID,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0
+      }
+    })
+  })
+
   it('ignores a task-notification UserPromptSubmit, recording no active prompt', async () => {
     const db = makeDb({
       hiveEnterpriseServerUrl: 'https://enterprise.example.com',

--- a/src/main/services/claude-cli-background-work-tracker.ts
+++ b/src/main/services/claude-cli-background-work-tracker.ts
@@ -125,10 +125,12 @@ function responseId(hook: ParsedClaudeHook, field: string): string | null {
 
 function canStartBackgroundWork(hook: ParsedClaudeHook): boolean {
   if (hook.hook_event_name === 'SubagentStart') return true
-  // Stop/SubagentStop snapshots can adopt background subagents this process
-  // never saw start (e.g. hooks lost mid-flight).
+  // Stop/StopFailure/SubagentStop snapshots can adopt background subagents
+  // this process never saw start (e.g. hooks lost mid-flight).
   if (
-    (hook.hook_event_name === 'Stop' || hook.hook_event_name === 'SubagentStop') &&
+    (hook.hook_event_name === 'Stop' ||
+      hook.hook_event_name === 'StopFailure' ||
+      hook.hook_event_name === 'SubagentStop') &&
     (hook.background_tasks ?? []).some(
       (task) => task.type === 'subagent' && task.status === 'running'
     )
@@ -201,7 +203,11 @@ function reconcileWithSnapshot(work: SessionWork, hook: ParsedClaudeHook): void 
   // parent workflow task does) yet outlive main-agent turns. A SubagentStop's
   // snapshot proves nothing about sibling foreground agents, so it never
   // prunes.
-  if (hook.hook_event_name === 'Stop' && !hook.agent_id && !runningWorkflow) {
+  if (
+    (hook.hook_event_name === 'Stop' || hook.hook_event_name === 'StopFailure') &&
+    !hook.agent_id &&
+    !runningWorkflow
+  ) {
     for (const id of work.subagents) {
       if (!runningSubagents.has(id)) work.subagents.delete(id)
     }
@@ -247,7 +253,7 @@ export function processClaudeCliBackgroundWorkHook(
       // re-adopted it after its SubagentStop.
       work.subagents.delete(id)
     }
-  } else if (event === 'Stop' || event === 'SubagentStop') {
+  } else if (event === 'Stop' || event === 'StopFailure' || event === 'SubagentStop') {
     reconcileWithSnapshot(work, hook)
     // Delete after reconciling: a background subagent's own SubagentStop
     // still self-lists it as 'running' (result not yet consumed), and the

--- a/src/main/services/claude-cli-interaction-ledger.ts
+++ b/src/main/services/claude-cli-interaction-ledger.ts
@@ -44,8 +44,15 @@ const ledgers = new Map<string, Map<string, BlockingEntry>>()
 
 // Turn boundaries: a new prompt or a finished/started session invalidates any
 // interaction the hooks failed to resolve explicitly (e.g. a permission denied
-// in the TUI, which fires no per-tool hook).
-const RESET_EVENTS = new Set(['UserPromptSubmit', 'Stop', 'SessionStart', 'SessionEnd'])
+// in the TUI, which fires no per-tool hook). StopFailure is the API-error twin
+// of Stop — it fires instead of Stop, so it is a turn boundary too.
+const RESET_EVENTS = new Set([
+  'UserPromptSubmit',
+  'Stop',
+  'StopFailure',
+  'SessionStart',
+  'SessionEnd'
+])
 
 function entrySize(entry: BlockingEntry): number {
   return entry.toolUseIds.size + entry.count
@@ -155,6 +162,23 @@ export function processClaudeCliHook(
   const isTaskNotificationResume = event === 'UserPromptSubmit' && isTaskNotificationPrompt(hook.prompt)
 
   if (RESET_EVENTS.has(event) && !isTaskNotificationResume) {
+    // A main-turn API error (StopFailure) with background subagents still
+    // running: any latched question/permission belongs to a live subagent
+    // that remains blocked on it. Preserve the latch and suppress the
+    // completion — mirroring the deferred-Stop watchdog's
+    // hasBlockingClaudeCliInteraction guard. Without running subagent work
+    // the latch can only be stale (the main agent cannot hit an API error
+    // while blocked on its own dialog), so the normal reset applies.
+    if (
+      event === 'StopFailure' &&
+      (ledgers.get(sessionId)?.size ?? 0) > 0 &&
+      (hook.background_tasks ?? []).some(
+        (task) =>
+          (task.type === 'subagent' || task.type === 'workflow') && task.status === 'running'
+      )
+    ) {
+      return []
+    }
     ledgers.delete(sessionId)
     return mapped ? [mapped] : []
   }

--- a/src/main/services/claude-cli-model-watcher.test.ts
+++ b/src/main/services/claude-cli-model-watcher.test.ts
@@ -133,6 +133,27 @@ describe('handleClaudeCliModelChangeHook', () => {
     )
   })
 
+  it('consumes the transcript at a StopFailure boundary (API-error turn end)', () => {
+    const db = makeDb(makeSession())
+    writeFileSync(transcriptPath, assistantLine('claude-fable-5'))
+    handleClaudeCliModelChangeHook(SESSION_ID, stopHook(), { db })
+
+    // A usage-limit degrade lands mid-turn, then the turn dies with an API
+    // error — StopFailure is the only turn boundary that fires.
+    appendFileSync(
+      transcriptPath,
+      assistantLine('claude-sonnet-5-20250929') +
+        assistantLine('<synthetic>', { isApiErrorMessage: true })
+    )
+    handleClaudeCliModelChangeHook(
+      SESSION_ID,
+      { hook_event_name: 'StopFailure', transcript_path: transcriptPath },
+      { db }
+    )
+
+    expect(db.updateSession).toHaveBeenCalledWith(SESSION_ID, { model_id: 'sonnet' })
+  })
+
   it('detects an opening-turn safety fallback (empty transcript baseline, first line differs)', () => {
     // The ticket case: a session launched on fable whose very first prompt
     // triggers a safety degrade to opus 4.8. SessionStart baselines the still

--- a/src/main/services/claude-cli-model-watcher.ts
+++ b/src/main/services/claude-cli-model-watcher.ts
@@ -91,7 +91,15 @@ const BASELINE_TAIL_BYTES = 512 * 1024
 
 // A model switch only becomes visible when the next assistant line is written,
 // so per-turn boundaries are the natural (and cheap) polling points.
-const MODEL_HOOK_EVENTS = new Set(['SessionStart', 'UserPromptSubmit', 'Stop', 'SessionEnd'])
+// StopFailure is the API-error twin of Stop — same turn boundary (the
+// synthetic '<synthetic>' model on API-error lines is filtered below).
+const MODEL_HOOK_EVENTS = new Set([
+  'SessionStart',
+  'UserPromptSubmit',
+  'Stop',
+  'StopFailure',
+  'SessionEnd'
+])
 
 // Mirrors the claude-cli catalog in claude-code-implementer.ts: sonnet/haiku
 // effort tops out at 'high'; only fable/opus offer xhigh/max. A degrade must

--- a/src/main/services/claude-cli-subagent-tracker.ts
+++ b/src/main/services/claude-cli-subagent-tracker.ts
@@ -230,6 +230,19 @@ export function processClaudeCliSubagentHook(
     return { kind: 'pass' }
   }
 
+  if (event === 'StopFailure') {
+    // An API error ended the turn (StopFailure fires instead of Stop). Never
+    // defer, even with background subagents in flight: the failure must
+    // surface immediately, and a later task-notification resume flips the
+    // session back to working on its own.
+    if (hook.agent_id) {
+      rearm(sessionId)
+      return { kind: 'subagent_scoped' }
+    }
+    clearClaudeCliSubagentTracking(sessionId)
+    return { kind: 'pass' }
+  }
+
   if (event === 'Stop' && hook.agent_id) {
     rearm(sessionId)
     return { kind: 'subagent_scoped' }

--- a/src/main/services/claude-hook-server.ts
+++ b/src/main/services/claude-hook-server.ts
@@ -33,6 +33,10 @@ import {
   type ClaudeCliBackgroundWorkPayload
 } from '@shared/types/claude-cli-background-work'
 import {
+  CLAUDE_CLI_API_ERROR_CHANNEL,
+  type ClaudeCliApiErrorPayload
+} from '@shared/types/claude-cli-api-error'
+import {
   clearAllClaudeCliPlanAutoApprove,
   consumeClaudeCliPlanAutoApprove,
   isClaudeCliPlanAutoApproveArmed,
@@ -62,9 +66,12 @@ export interface ParsedClaudeHook {
   }
   /** PostToolUse tool result (backgroundTaskId / taskId live here). */
   tool_response?: unknown
-  /** Final assistant message of the turn (Stop hook). Read both spellings: */
+  /** Final assistant message of the turn (Stop/StopFailure hooks). Read both spellings: */
   assistant_message?: string
   last_assistant_message?: string
+  /** StopFailure: structured API-error classification (server_error, rate_limit, …). */
+  error?: string
+  error_details?: string
   /** Present on subagent-scoped hooks (SubagentStart/SubagentStop, subagent-scoped Stop). */
   agent_id?: string
   agent_type?: string
@@ -82,6 +89,8 @@ export interface ClaudeCliStatusPayload {
     toolName?: string
     plan?: string
     taskNotification?: boolean
+    /** StopFailure: the turn ended with this API-error classification. */
+    apiError?: string
   }
 }
 
@@ -122,6 +131,15 @@ export function buildClaudeCliHookSettings(port: number, hiveSessionId: string):
       ],
       Stop: [
         {
+          hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'stop') }]
+        }
+      ],
+      // Fires instead of Stop when the turn ends because of an API error
+      // (claude v2.1.241+). Without it a failed turn leaves the session
+      // "working" forever — no Stop ever arrives.
+      StopFailure: [
+        {
+          matcher: '*',
           hooks: [{ type: 'http', url: hookUrl(port, hiveSessionId, 'stop') }]
         }
       ],
@@ -171,6 +189,9 @@ export function mapHookEventToStatus(hook: ParsedClaudeHook): SessionStatusType 
     case 'SessionStart':
     case 'SessionEnd':
     case 'Stop':
+    // An API error ends the turn just like a Stop; the error classification
+    // rides the status metadata + the dedicated api-error channel.
+    case 'StopFailure':
       return 'completed'
     case 'UserPromptSubmit':
       return hook.permission_mode === 'plan' ? 'planning' : 'working'
@@ -219,6 +240,10 @@ function buildStatusMetadata(
 
   if (hook.hook_event_name === 'UserPromptSubmit' && isTaskNotificationPrompt(hook.prompt)) {
     metadata.taskNotification = true
+  }
+
+  if (hook.hook_event_name === 'StopFailure') {
+    metadata.apiError = typeof hook.error === 'string' ? hook.error : 'unknown'
   }
 
   return metadata
@@ -368,6 +393,27 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
       if (backgroundWork) {
         publishClaudeCliBackgroundWork({ sessionId: route.sessionId, ...backgroundWork })
       }
+      // API errors end the turn as StopFailure instead of Stop. The structured
+      // classification rides its own channel so the status dedup can't eat it
+      // (e.g. when a watchdog already published 'completed' for this turn).
+      // Subagent-scoped failures (agent_id set) are not a main-turn failure.
+      if (body.hook_event_name === 'StopFailure' && !body.agent_id) {
+        const apiError: ClaudeCliApiErrorPayload = {
+          sessionId: route.sessionId,
+          error: typeof body.error === 'string' ? body.error : 'unknown'
+        }
+        if (typeof body.error_details === 'string') apiError.errorDetails = body.error_details
+        const lastMessage = body.last_assistant_message ?? body.assistant_message
+        if (typeof lastMessage === 'string') apiError.lastAssistantMessage = lastMessage
+        log.warn('Claude CLI turn ended with an API error', {
+          sessionId: route.sessionId,
+          error: apiError.error,
+          errorDetails: apiError.errorDetails
+        })
+        void Promise.resolve(
+          publishDesktopBackendEvent(CLAUDE_CLI_API_ERROR_CHANNEL, apiError)
+        ).catch(() => undefined)
+      }
       // Background Task subagents can keep running after the main agent's
       // Stop fires; the tracker decides whether this Stop is truly final
       // ('pass'), must be swallowed because work is still in flight
@@ -431,7 +477,13 @@ async function handleHook(req: http.IncomingMessage, res: http.ServerResponse): 
       // transport the session went idle while background work is in flight.
       if (!bypassTransport) {
         owned = cliHookTransportRouter.routeHook(route.sessionId, body, res, {
-          suppressIdle: gate.kind !== 'pass'
+          // Also suppress idle when a StopFailure preserved a background
+          // subagent's latched question/permission (the ledger kept it) —
+          // the session is still blocked awaiting input, not idle.
+          suppressIdle:
+            gate.kind !== 'pass' ||
+            (body.hook_event_name === 'StopFailure' &&
+              hasBlockingClaudeCliInteraction(route.sessionId))
         })
       }
 

--- a/src/main/services/cli-hook-hold-core.ts
+++ b/src/main/services/cli-hook-hold-core.ts
@@ -88,7 +88,10 @@ export class CliHookHoldCore {
     if (event === 'PreToolUse' && body.tool_name === 'ExitPlanMode') {
       return this.holdPlan(sessionId, body, res)
     }
-    if (event === 'Stop') {
+    // StopFailure is the API-error turn end (fires instead of Stop); its
+    // last_assistant_message is the rendered "API Error: …" text, so the
+    // transport user still learns how the turn ended.
+    if (event === 'Stop' || event === 'StopFailure') {
       if (!ctx?.suppressIdle) this.emitIdle(sessionId, body)
       return false
     }

--- a/src/main/services/hive-enterprise-claude-cli-telemetry.ts
+++ b/src/main/services/hive-enterprise-claude-cli-telemetry.ts
@@ -363,7 +363,15 @@ export async function handleClaudeCliHiveTelemetryHook(
   deps: ClaudeCliHiveTelemetryDeps = {}
 ): Promise<void> {
   try {
-    if (hook.hook_event_name !== 'UserPromptSubmit' && hook.hook_event_name !== 'Stop') return
+    if (
+      hook.hook_event_name !== 'UserPromptSubmit' &&
+      hook.hook_event_name !== 'Stop' &&
+      // API-error turn end: fires instead of Stop, must still close the
+      // active prompt row or the next turn inherits its duration.
+      hook.hook_event_name !== 'StopFailure'
+    ) {
+      return
+    }
 
     const resolvedDeps = {
       db: deps.db ?? getDatabase(),

--- a/src/renderer/src/api/__tests__/terminal-api.test.ts
+++ b/src/renderer/src/api/__tests__/terminal-api.test.ts
@@ -252,6 +252,40 @@ describe('terminalApi', () => {
     expect(callback).toHaveBeenCalledWith(payload)
   })
 
+  it('subscribes to Claude CLI api-error events through the renderer RPC client', () => {
+    const request = vi.fn()
+    const unsubscribe = vi.fn()
+    const subscribe = vi.fn(
+      (_channel: string, _listener: (event: ServerEvent) => void): (() => void) => unsubscribe
+    )
+    const callback = vi.fn()
+    const payload = {
+      sessionId: 'session-1',
+      error: 'server_error',
+      errorDetails: '500 Internal Server Error',
+      lastAssistantMessage: 'API Error: 500 Internal server error.'
+    } as const
+
+    setRendererRpcClient({ request, subscribe })
+
+    expect(terminalApi.onClaudeCliApiError(callback)).toBe(unsubscribe)
+    expect(subscribe).toHaveBeenCalledWith('claude-cli:api-error', expect.any(Function))
+
+    const listener = subscribe.mock.calls[0]?.[1]
+    listener?.({ channel: 'claude-cli:api-error', payload })
+    listener?.({
+      channel: 'claude-cli:api-error',
+      payload: { sessionId: 'session-1' }
+    })
+    listener?.({
+      channel: 'claude-cli:api-error',
+      payload: { sessionId: 'session-1', error: 42 }
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith(payload)
+  })
+
   it('routes ghosttyPasteText through the renderer RPC client', async () => {
     const request = vi.fn().mockResolvedValue(undefined)
     const subscribe = vi.fn()

--- a/src/renderer/src/api/terminal-api.ts
+++ b/src/renderer/src/api/terminal-api.ts
@@ -16,8 +16,13 @@ import {
   isClaudeCliBackgroundWorkPayload,
   type ClaudeCliBackgroundWorkPayload
 } from '@shared/types/claude-cli-background-work'
+import {
+  CLAUDE_CLI_API_ERROR_CHANNEL,
+  isClaudeCliApiErrorPayload,
+  type ClaudeCliApiErrorPayload
+} from '@shared/types/claude-cli-api-error'
 
-export type { ClaudeCliBackgroundWorkPayload }
+export type { ClaudeCliBackgroundWorkPayload, ClaudeCliApiErrorPayload }
 
 export type ClaudeCliSessionStatusType =
   | 'working'
@@ -39,6 +44,7 @@ export interface ClaudeCliStatusPayload {
     readonly toolName?: string
     readonly plan?: string
     readonly taskNotification?: boolean
+    readonly apiError?: string
   }
 }
 
@@ -164,6 +170,13 @@ export const terminalApi = {
         if (isClaudeCliBackgroundWorkPayload(event.payload)) callback(event.payload)
       }
     )
+  },
+  onClaudeCliApiError: (
+    callback: (payload: ClaudeCliApiErrorPayload) => void
+  ): (() => void) => {
+    return getRendererRpcClient().subscribe(CLAUDE_CLI_API_ERROR_CHANNEL, (event: ServerEvent) => {
+      if (isClaudeCliApiErrorPayload(event.payload)) callback(event.payload)
+    })
   },
   ghosttyPasteText: async (terminalId: string, text: string): Promise<Envelope<void>> => {
     await getRendererRpcClient().request<void>('terminalOps.ghosttyPasteText', { terminalId, text })

--- a/src/renderer/src/components/kanban/KanbanTicketCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.tsx
@@ -511,6 +511,19 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     )
   )
 
+  // ── API-error classification from the linked session's last turn ──
+  // Cleared by the store when the session is relaunched; a fresh launch
+  // rewrites current_session_id, which re-keys this selector.
+  const sessionApiError = useWorktreeStatusStore(
+    useCallback(
+      (state) => {
+        if (!ticket.current_session_id) return null
+        return state.sessionApiErrors[ticket.current_session_id] ?? null
+      },
+      [ticket.current_session_id]
+    )
+  )
+
   // ── Live background shells/monitors in the linked claude-cli session ──
   const backgroundWork = useWorktreeStatusStore(
     useCallback(
@@ -653,7 +666,7 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
     )
   )
 
-  const isError = sessionStatus === 'error'
+  const isError = sessionStatus === 'error' || sessionApiError !== null
   const hasAttachments = ticket.attachments.length > 0
   // Surface the model on cards that are part of a multi-model duplicate
   // group — for single-model launches the name is noise, unless the user
@@ -1158,15 +1171,18 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
                   (isBlocked || blockingDiagnostic) && 'opacity-60',
                   // Highlighted as a blocker of the currently hovered ticket
                   isHighlightedAsBlocker && 'border-dashed !border-amber-500/70 ring-1 ring-amber-500/30',
-                  !isHighlightedAsBlocker && borderState === 'default' && 'border-border',
+                  // API-errored session: full red perimeter, overriding mode
+                  // rails and mark stripes until the session is relaunched
+                  !isHighlightedAsBlocker && isError && '!border-red-500/70 ring-1 ring-red-500/25',
+                  !isHighlightedAsBlocker && !isError && borderState === 'default' && 'border-border',
                   // Mode cue lives in a 2px left rail; the perimeter stays neutral
-                  !isHighlightedAsBlocker && borderState === 'blue' && 'border-border border-l-2 !border-l-blue-500/60',
-                  !isHighlightedAsBlocker && borderState === 'violet' && 'border-border border-l-2 !border-l-violet-500/60',
+                  !isHighlightedAsBlocker && !isError && borderState === 'blue' && 'border-border border-l-2 !border-l-blue-500/60',
+                  !isHighlightedAsBlocker && !isError && borderState === 'violet' && 'border-border border-l-2 !border-l-violet-500/60',
                   // Left accent stripe for marks
-                  ticket.mark === 'common' && 'border-l-2 !border-l-green-500',
-                  ticket.mark === 'rare' && 'border-l-2 !border-l-blue-500',
-                  ticket.mark === 'epic' && 'border-l-2 !border-l-pink-500',
-                  ticket.mark === 'legendary' && 'border-l-2 !border-l-orange-500'
+                  !isError && ticket.mark === 'common' && 'border-l-2 !border-l-green-500',
+                  !isError && ticket.mark === 'rare' && 'border-l-2 !border-l-blue-500',
+                  !isError && ticket.mark === 'epic' && 'border-l-2 !border-l-pink-500',
+                  !isError && ticket.mark === 'legendary' && 'border-l-2 !border-l-orange-500'
                 )}
               >
             {/* Title + top-right indicators */}
@@ -1472,7 +1488,15 @@ export const KanbanTicketCard = memo(function KanbanTicketCard({
 
                 {/* Error badge */}
                 {isError && (
-                  <span className={cn(ticketPillBaseClass, 'border-red-500/30 bg-red-500/10 text-red-500')}>
+                  <span
+                    data-testid="kanban-ticket-error-badge"
+                    title={
+                      sessionApiError
+                        ? `Claude API error: ${sessionApiError.replace(/_/g, ' ')}`
+                        : undefined
+                    }
+                    className={cn(ticketPillBaseClass, 'border-red-500/30 bg-red-500/10 text-red-500')}
+                  >
                     <AlertCircle className="h-2.5 w-2.5" />
                     Error
                   </span>

--- a/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useClaudeCliStatusListener.test.tsx
@@ -4,6 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   onClaudeCliStatus: vi.fn(),
   onClaudeCliBackgroundWork: vi.fn().mockReturnValue(() => {}),
+  onClaudeCliApiError: vi.fn().mockReturnValue(() => {}),
+  toastError: vi.fn(),
+  setSessionApiError: vi.fn(),
   setSessionBackgroundWork: vi.fn(),
   setClaudeCliPlanAutoApprove: vi.fn().mockResolvedValue({ success: true }),
   setSessionStatus: vi.fn(),
@@ -14,7 +17,7 @@ const mocks = vi.hoisted(() => ({
   setSelectedTicketId: vi.fn(),
   fetchUsageForProvider: vi.fn(),
   resolveUsageProvider: vi.fn().mockReturnValue('anthropic'),
-  sessionById: new Map<string, { id: string; agent_sdk: string }>(),
+  sessionById: new Map<string, { id: string; agent_sdk: string; name?: string }>(),
   lastSendMode: new Map<string, 'plan' | 'build'>(),
   modeBySession: new Map<string, 'build' | 'plan' | 'super-plan'>(),
   sessionStatuses: {} as Record<string, { status: string } | null>,
@@ -38,6 +41,7 @@ vi.mock('@/stores/useWorktreeStatusStore', () => ({
     getState: () => ({
       sessionStatuses: mocks.sessionStatuses,
       setSessionStatus: mocks.setSessionStatus,
+      setSessionApiError: mocks.setSessionApiError,
       setSessionBackgroundWork: mocks.setSessionBackgroundWork
     })
   }
@@ -77,7 +81,14 @@ vi.mock('@/api/terminal-api', () => ({
   terminalApi: {
     onClaudeCliStatus: mocks.onClaudeCliStatus,
     onClaudeCliBackgroundWork: mocks.onClaudeCliBackgroundWork,
+    onClaudeCliApiError: mocks.onClaudeCliApiError,
     setClaudeCliPlanAutoApprove: mocks.setClaudeCliPlanAutoApprove
+  }
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    error: mocks.toastError
   }
 }))
 
@@ -119,6 +130,7 @@ type SubscribedPayload = {
     toolName?: string
     plan?: string
     taskNotification?: boolean
+    apiError?: string
   }
 }
 
@@ -137,6 +149,9 @@ describe('useClaudeCliStatusListener', () => {
       return unsubscribe
     })
     unsubscribe.mockClear()
+    mocks.onClaudeCliApiError.mockReset()
+    mocks.onClaudeCliApiError.mockReturnValue(() => {})
+    mocks.toastError.mockClear()
     mocks.setClaudeCliPlanAutoApprove.mockClear()
     mocks.setSessionStatus.mockClear()
     mocks.setPendingPlan.mockClear()
@@ -806,5 +821,106 @@ describe('useClaudeCliStatusListener — background work counts', () => {
     unmount()
 
     expect(unsubscribeBackgroundWork).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useClaudeCliStatusListener — API errors', () => {
+  type ApiErrorPayload = {
+    sessionId: string
+    error: string
+    errorDetails?: string
+    lastAssistantMessage?: string
+  }
+
+  let subscribedApiError: ((payload: ApiErrorPayload) => void) | null = null
+  let subscribedStatus: ((payload: SubscribedPayload) => void) | null = null
+
+  beforeEach(() => {
+    subscribedStatus = null
+    mocks.onClaudeCliStatus.mockReturnValue(() => {})
+    mocks.toastError.mockClear()
+    mocks.setSessionStatus.mockClear()
+    mocks.setSessionApiError.mockClear()
+    mocks.sessionById.clear()
+    mocks.lastSendMode.clear()
+    subscribedApiError = null
+    mocks.onClaudeCliApiError.mockImplementation((callback: (payload: ApiErrorPayload) => void) => {
+      subscribedApiError = callback
+      return () => {}
+    })
+  })
+
+  it('raises an error toast with the classification, session name, and rendered message', () => {
+    mocks.sessionById.set('hive-session-1', {
+      id: 'hive-session-1',
+      agent_sdk: 'claude-code-cli',
+      name: 'My session'
+    })
+
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedApiError?.({
+      sessionId: 'hive-session-1',
+      error: 'server_error',
+      errorDetails: '500 Internal Server Error',
+      lastAssistantMessage: 'API Error: 500 Internal server error.'
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'Claude API error (internal server error) in "My session"',
+      {
+        description: 'API Error: 500 Internal server error.',
+        duration: 8000
+      }
+    )
+    expect(mocks.setSessionApiError).toHaveBeenCalledWith('hive-session-1', 'server_error')
+  })
+
+  it('falls back to a bare title for unknown classifications and unnamed sessions', () => {
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedApiError?.({
+      sessionId: 'hive-session-1',
+      error: 'unknown'
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith('Claude API error', {
+      description: undefined,
+      duration: 8000
+    })
+  })
+
+  it('unsubscribes from api-error events on unmount', () => {
+    const unsubscribeApiError = vi.fn()
+    mocks.onClaudeCliApiError.mockReturnValue(unsubscribeApiError)
+
+    const { unmount } = renderHook(() => useClaudeCliStatusListener())
+    unmount()
+
+    expect(unsubscribeApiError).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not rewrite a StopFailure completion to plan_ready in plan mode', () => {
+    mocks.onClaudeCliStatus.mockImplementation(
+      (callback: (payload: SubscribedPayload) => void) => {
+        subscribedStatus = callback
+        return () => {}
+      }
+    )
+    mocks.lastSendMode.set('hive-session-1', 'plan')
+
+    renderHook(() => useClaudeCliStatusListener())
+
+    subscribedStatus?.({
+      sessionId: 'hive-session-1',
+      status: 'completed',
+      metadata: { hookEventName: 'StopFailure', hookPath: 'stop', apiError: 'server_error' }
+    })
+
+    expect(mocks.setSessionStatus).toHaveBeenCalledWith('hive-session-1', 'completed', {
+      hookEventName: 'StopFailure',
+      hookPath: 'stop',
+      apiError: 'server_error'
+    })
   })
 })

--- a/src/renderer/src/hooks/useClaudeCliStatusListener.ts
+++ b/src/renderer/src/hooks/useClaudeCliStatusListener.ts
@@ -9,6 +9,7 @@ import { lastSendMode } from '@/lib/message-send-times'
 import { notifyKanbanSessionSync } from '@/stores/store-coordination'
 import { isPlanLike } from '@/lib/constants'
 import { isHandoffPickerOpenForSession } from '@/lib/handoff-ui-state'
+import { toast } from '@/lib/toast'
 
 type ClaudeCliStatusMetadata = {
   reason?: string
@@ -17,6 +18,21 @@ type ClaudeCliStatusMetadata = {
   toolName?: string
   plan?: string
   taskNotification?: boolean
+  apiError?: string
+}
+
+// StopFailure `error` classifications → user-facing labels. Unlisted values
+// (including 'unknown') fall back to the bare "Claude API error" title.
+const CLAUDE_API_ERROR_LABELS: Record<string, string> = {
+  rate_limit: 'rate limited',
+  overloaded: 'servers overloaded',
+  authentication_failed: 'authentication failed',
+  oauth_org_not_allowed: 'organization not allowed',
+  billing_error: 'billing error',
+  invalid_request: 'invalid request',
+  model_not_found: 'model not found',
+  server_error: 'internal server error',
+  max_output_tokens: 'max output tokens exceeded'
 }
 
 function closeLinkedTicketModal(sessionId: string): void {
@@ -212,9 +228,30 @@ export function useClaudeCliStatusListener(): void {
       }
     )
 
+    // A claude-cli turn that ended with an API error (StopFailure hook). The
+    // status pipeline above already flips the session to 'completed'; this is
+    // the user-facing alert with the structured classification, plus the
+    // per-session error mark the linked kanban ticket renders (red border +
+    // Error badge) until the session is relaunched.
+    const unsubscribeApiError = terminalApi.onClaudeCliApiError(
+      ({ sessionId, error, errorDetails, lastAssistantMessage }) => {
+        useWorktreeStatusStore.getState().setSessionApiError(sessionId, error)
+        const sessionName = useSessionStore.getState().getSessionById(sessionId)?.name
+        const label = CLAUDE_API_ERROR_LABELS[error]
+        toast.error(
+          `Claude API error${label ? ` (${label})` : ''}${sessionName ? ` in "${sessionName}"` : ''}`,
+          {
+            description: lastAssistantMessage ?? errorDetails,
+            duration: 8000
+          }
+        )
+      }
+    )
+
     return () => {
       unsubscribe()
       unsubscribeBackgroundWork()
+      unsubscribeApiError()
     }
   }, [])
 }

--- a/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
+++ b/src/renderer/src/stores/useKanbanStore.session-sync.test.ts
@@ -232,6 +232,22 @@ describe('reconcileFinishedSessions — recovers dropped finish moves on load', 
     expect(kanbanApi.ticket.move).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', 'review', 0)
   })
 
+  it('moves an API-errored in_progress plan ticket to review without flagging plan_ready', async () => {
+    seed(makeTicket({ column: 'in_progress', mode: 'plan', plan_ready: false }))
+    useWorktreeStatusStore.setState({
+      sessionStatuses: {
+        [SESSION_ID]: { status: 'completed', timestamp: 0, apiError: 'server_error' }
+      }
+    })
+
+    useKanbanStore.getState().reconcileFinishedSessions(PROJECT_ID)
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('review')
+    expect(kanbanApi.ticket.move).toHaveBeenCalledWith(PROJECT_ID, 'ticket-1', 'review', 0)
+    expect(kanbanApi.ticket.update).not.toHaveBeenCalled()
+  })
+
   it('does not move when the session has no status', async () => {
     seed(makeTicket({ column: 'in_progress', mode: 'build' }))
     setSessionStatus(SESSION_ID, null)
@@ -347,6 +363,103 @@ describe('syncTicketWithSession — explicit follow-up reopens done/merged ticke
     await flush()
 
     expect(columnOf('ticket-1')).toBe('merged')
+    expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
+  })
+})
+
+describe('sessionApiErrors — error mark lifecycle', () => {
+  afterEach(() => {
+    useWorktreeStatusStore.setState({ sessionApiErrors: {} })
+  })
+
+  it('keeps the error through completed/unread statuses, clears on a hook-evidenced relaunch', () => {
+    const store = useWorktreeStatusStore.getState()
+    store.setSessionApiError(SESSION_ID, 'server_error')
+    store.setSessionStatus(SESSION_ID, 'completed', { apiError: 'server_error' })
+    expect(useWorktreeStatusStore.getState().sessionApiErrors[SESSION_ID]).toBe('server_error')
+
+    store.setSessionStatus(SESSION_ID, 'unread')
+    expect(useWorktreeStatusStore.getState().sessionApiErrors[SESSION_ID]).toBe('server_error')
+
+    store.setSessionStatus(SESSION_ID, 'working', { hookEventName: 'UserPromptSubmit' })
+    expect(useWorktreeStatusStore.getState().sessionApiErrors[SESSION_ID]).toBeUndefined()
+  })
+
+  it('clears on a planning relaunch detected as a plan followup', () => {
+    const store = useWorktreeStatusStore.getState()
+    store.setSessionApiError(SESSION_ID, 'rate_limit')
+    store.setSessionStatus(SESSION_ID, 'planning', { reason: 'claude_cli_plan_followup' })
+    expect(useWorktreeStatusStore.getState().sessionApiErrors[SESSION_ID]).toBeUndefined()
+  })
+
+  it('survives an optimistic pre-send working write (no hook evidence yet)', () => {
+    const store = useWorktreeStatusStore.getState()
+    store.setSessionApiError(SESSION_ID, 'overloaded')
+    store.setSessionStatus(SESSION_ID, 'working')
+    expect(useWorktreeStatusStore.getState().sessionApiErrors[SESSION_ID]).toBe('overloaded')
+  })
+
+  it('survives a failed-relaunch rollback (clearSessionStatus)', () => {
+    const store = useWorktreeStatusStore.getState()
+    store.setSessionApiError(SESSION_ID, 'authentication_failed')
+    // Modal relaunch: optimistic working write, then the send fails and rolls back.
+    store.setSessionStatus(SESSION_ID, 'working')
+    store.clearSessionStatus(SESSION_ID)
+    expect(useWorktreeStatusStore.getState().sessionApiErrors[SESSION_ID]).toBe(
+      'authentication_failed'
+    )
+  })
+
+  it('survives clearWorktreeUnread even though the completed status entry is nulled', async () => {
+    const { useSessionStore } = await import('./useSessionStore')
+    const sessionsByWorktree = new Map([
+      ['wt-1', [{ id: SESSION_ID }]]
+    ]) as unknown as ReturnType<typeof useSessionStore.getState>['sessionsByWorktree']
+    useSessionStore.setState({ sessionsByWorktree })
+    try {
+      const store = useWorktreeStatusStore.getState()
+      store.setSessionApiError(SESSION_ID, 'server_error')
+      store.setSessionStatus(SESSION_ID, 'completed', { apiError: 'server_error' })
+
+      store.clearWorktreeUnread('wt-1')
+
+      expect(useWorktreeStatusStore.getState().sessionStatuses[SESSION_ID]).toBeNull()
+      expect(useWorktreeStatusStore.getState().sessionApiErrors[SESSION_ID]).toBe('server_error')
+    } finally {
+      useSessionStore.setState({ sessionsByWorktree: new Map() })
+    }
+  })
+})
+
+describe('setSessionStatus — API-errored completions dispatch session_error', () => {
+  it('moves an in_progress plan ticket to review without flagging plan_ready', async () => {
+    seed(makeTicket({ column: 'in_progress', mode: 'plan', plan_ready: false }))
+
+    useWorktreeStatusStore.getState().setSessionStatus(SESSION_ID, 'completed', {
+      hookEventName: 'StopFailure',
+      apiError: 'server_error'
+    })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('review')
+    const ticket = useKanbanStore
+      .getState()
+      .tickets.get(PROJECT_ID)
+      ?.find((t) => t.id === 'ticket-1')
+    expect(ticket?.plan_ready).toBe(false)
+    expect(kanbanApi.ticket.update).not.toHaveBeenCalled()
+  })
+
+  it('leaves a done ticket untouched on an API-errored completion', async () => {
+    seed(makeTicket({ column: 'done', mode: 'build' }))
+
+    useWorktreeStatusStore.getState().setSessionStatus(SESSION_ID, 'completed', {
+      hookEventName: 'StopFailure',
+      apiError: 'rate_limit'
+    })
+    await flush()
+
+    expect(columnOf('ticket-1')).toBe('done')
     expect(kanbanApi.ticket.move).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -527,7 +527,11 @@ export const useKanbanStore = create<KanbanState>()(
             // asking/no-status, so we don't yank not-yet-started or actively-
             // running sessions out of in_progress.
             if (status !== 'completed' && status !== 'plan_ready') continue
-            if (isPlanLike(ticket.mode) && !ticket.plan_ready) {
+            // An API-errored completion produced no plan — move to review
+            // (needs attention) but never flag plan_ready, matching the
+            // session_error path this reconcile stands in for.
+            const apiErrored = Boolean(statuses[ticket.current_session_id]?.apiError)
+            if (isPlanLike(ticket.mode) && !ticket.plan_ready && !apiErrored) {
               get().updateTicket(ticket.id, projectId, { plan_ready: true }).catch(() => {})
             }
             get().moveTicket(ticket.id, projectId, 'review', ticket.sort_order).catch(() => {})

--- a/src/renderer/src/stores/useWorktreeStatusStore.ts
+++ b/src/renderer/src/stores/useWorktreeStatusStore.ts
@@ -44,6 +44,8 @@ export interface SessionStatusEntry {
   hookPath?: string
   toolName?: string
   plan?: string
+  /** The turn ended with this Claude API error classification (StopFailure). */
+  apiError?: string
 }
 
 export type MergeConflictFlow =
@@ -60,6 +62,14 @@ export interface SessionBackgroundWork {
 interface WorktreeStatusState {
   // sessionId → status info (null means no status / cleared)
   sessionStatuses: Record<string, SessionStatusEntry | null>
+  // sessionId → API-error classification from the session's last turn
+  // (claude-cli StopFailure). Kept separate from sessionStatuses so the
+  // error mark on the linked kanban ticket survives unread-clearing, status
+  // dedup, and failed-relaunch rollbacks; cleared only when a new turn
+  // verifiably starts (working/planning with UserPromptSubmit hook evidence
+  // or a plan-followup), and a fresh launch re-keys current_session_id so
+  // stale entries are never rendered.
+  sessionApiErrors: Record<string, string>
   // sessionId → live background subagent/shell/monitor counts, reported by both
   // the claude-cli hook path and the Claude SDK path (entries are dropped when
   // all counts reach zero)
@@ -91,8 +101,10 @@ interface WorktreeStatusState {
       toolName?: string
       plan?: string
       taskNotification?: boolean
+      apiError?: string
     }
   ) => void
+  setSessionApiError: (sessionId: string, error: string) => void
   setSessionBackgroundWork: (sessionId: string, work: SessionBackgroundWork) => void
   clearSessionStatus: (sessionId: string) => void
   clearWorktreeUnread: (worktreeId: string) => void
@@ -113,6 +125,7 @@ interface WorktreeStatusState {
 
 export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => ({
   sessionStatuses: {},
+  sessionApiErrors: {},
   backgroundWorkBySession: {},
   lastMessageTimeByWorktree: {},
   reviewSessionByWorktree: {},
@@ -134,6 +147,7 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
       toolName?: string
       plan?: string
       taskNotification?: boolean
+      apiError?: string
     }
   ) => {
     set((state) => {
@@ -142,6 +156,23 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
           ...state.sessionStatuses,
           [sessionId]: status ? { status, timestamp: Date.now(), ...metadata } : null
         }
+      }
+
+      // The session's API-error mark clears only when a new turn actually
+      // starts: a working/planning publish carrying UserPromptSubmit hook
+      // evidence (or the transcript watcher's plan-followup reason). The
+      // modal's optimistic pre-send 'working' writes and their failure
+      // rollbacks (clearSessionStatus) leave it intact — a relaunch that
+      // never reached claude must not strip the mark. Launching a fresh
+      // session re-keys the ticket's current_session_id instead.
+      if (
+        state.sessionApiErrors[sessionId] !== undefined &&
+        (status === 'working' || status === 'planning') &&
+        (metadata?.hookEventName === 'UserPromptSubmit' ||
+          metadata?.reason === 'claude_cli_plan_followup')
+      ) {
+        const { [sessionId]: _dropped, ...rest } = state.sessionApiErrors
+        next.sessionApiErrors = rest
       }
 
       // Auto-clear review session when its session completes or is cleared
@@ -167,12 +198,19 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
 
     // ── Kanban coordination: notify kanban store of relevant status changes ──
     if (status === 'completed') {
-      const mode = lastSendMode.get(sessionId) as 'build' | 'plan' | undefined
-      notifyKanbanSessionSync(sessionId, {
-        type: 'session_completed',
-        sessionMode: mode,
-        tokenDelta: metadata?.tokenDelta
-      })
+      if (metadata?.apiError) {
+        // The turn ended with a Claude API error (StopFailure), not a real
+        // completion: session_error moves an in_progress ticket to review
+        // without flagging plan_ready — no plan was produced.
+        notifyKanbanSessionSync(sessionId, { type: 'session_error' })
+      } else {
+        const mode = lastSendMode.get(sessionId) as 'build' | 'plan' | undefined
+        notifyKanbanSessionSync(sessionId, {
+          type: 'session_completed',
+          sessionMode: mode,
+          tokenDelta: metadata?.tokenDelta
+        })
+      }
     } else if (status === 'plan_ready') {
       notifyKanbanSessionSync(sessionId, { type: 'plan_ready' })
     } else if (status === 'working' || status === 'planning') {
@@ -229,7 +267,16 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
     })
   },
 
+  setSessionApiError: (sessionId: string, error: string) => {
+    set((state) => ({
+      sessionApiErrors: { ...state.sessionApiErrors, [sessionId]: error }
+    }))
+  },
+
   clearSessionStatus: (sessionId: string) => {
+    // Deliberately keeps sessionApiErrors: this is also the failure-rollback
+    // path of modal relaunches, and a relaunch that never started a turn must
+    // not strip the error mark.
     set((state) => ({
       sessionStatuses: {
         ...state.sessionStatuses,
@@ -325,9 +372,12 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
     // If the last message was sent in plan mode and the session completed,
     // show "Plan ready". Otherwise show normal "Ready".
     if (hasCompleted) {
-      const completedInPlan = sessions.some(
-        (s) => sessionStatuses[s.id]?.status === 'completed' && lastSendMode.get(s.id) === 'plan'
-      )
+      const completedInPlan = sessions.some((s) => {
+        const entry = sessionStatuses[s.id]
+        // An API-errored turn end (apiError set) produced no plan — never
+        // derive "Plan ready" from it.
+        return entry?.status === 'completed' && !entry.apiError && lastSendMode.get(s.id) === 'plan'
+      })
       return completedInPlan ? 'plan_ready' : 'completed'
     }
 
@@ -373,9 +423,12 @@ export const useWorktreeStatusStore = create<WorktreeStatusState>((set, get) => 
     if (hasPlanReady) return 'plan_ready'
 
     if (hasCompleted) {
-      const completedInPlan = sessions.some(
-        (s) => sessionStatuses[s.id]?.status === 'completed' && lastSendMode.get(s.id) === 'plan'
-      )
+      const completedInPlan = sessions.some((s) => {
+        const entry = sessionStatuses[s.id]
+        // An API-errored turn end (apiError set) produced no plan — never
+        // derive "Plan ready" from it.
+        return entry?.status === 'completed' && !entry.apiError && lastSendMode.get(s.id) === 'plan'
+      })
       return completedInPlan ? 'plan_ready' : 'completed'
     }
 

--- a/src/shared/types/claude-cli-api-error.ts
+++ b/src/shared/types/claude-cli-api-error.ts
@@ -1,0 +1,33 @@
+/**
+ * A Claude CLI turn that ended with an API error: claude-cli fires a
+ * `StopFailure` hook instead of `Stop`, carrying a structured error
+ * classification. Published by the main-process hook server on the dedicated
+ * channel below (the status channel dedups by status string, which could
+ * swallow the error when a synthetic 'completed' was already published).
+ */
+export const CLAUDE_CLI_API_ERROR_CHANNEL = 'claude-cli:api-error'
+
+/**
+ * Documented StopFailure `error` values: rate_limit, overloaded,
+ * authentication_failed, oauth_org_not_allowed, billing_error,
+ * invalid_request, model_not_found, server_error, max_output_tokens, unknown.
+ * Kept as a plain string so new classifications flow through untouched.
+ */
+export interface ClaudeCliApiErrorPayload {
+  sessionId: string
+  error: string
+  errorDetails?: string
+  /** Rendered failure text, e.g. "API Error: 500 Internal server error…". */
+  lastAssistantMessage?: string
+}
+
+export function isClaudeCliApiErrorPayload(value: unknown): value is ClaudeCliApiErrorPayload {
+  if (typeof value !== 'object' || value === null) return false
+  const payload = value as Record<string, unknown>
+  return (
+    typeof payload.sessionId === 'string' &&
+    typeof payload.error === 'string' &&
+    (payload.errorDetails === undefined || typeof payload.errorDetails === 'string') &&
+    (payload.lastAssistantMessage === undefined || typeof payload.lastAssistantMessage === 'string')
+  )
+}


### PR DESCRIPTION
## Summary
- Handle Claude CLI `StopFailure` hooks as completed API-error turns.
- Publish structured API-error events through main, renderer, and shared APIs.
- Preserve blocked subagent interactions while surfacing failures immediately.
- Mark affected Kanban tickets as errored and show descriptive error toasts.
- Update telemetry, model tracking, background-work handling, and test coverage.

## Testing
- Added coverage for hook-server API-error handling and deduplication.
- Added coverage for interaction latches, subagent tracking, telemetry, and model watching.
- Added renderer API, status-listener, store synchronization, and Kanban behavior tests.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Claude CLI session completion state machine, interaction latches, and Kanban ticket movement. Incorrect handling could leave sessions stuck, drop blocking questions, or mis-flag plan_ready.
> 
> **Overview**
> Claude CLI turns that die on an API error (`StopFailure`, claude v2.1.241+) now complete instead of hanging as **working**. The hook server maps `StopFailure` to `completed`, publishes a dedicated `claude-cli:api-error` event (so status dedup cannot swallow it), and never defers that failure even when background subagents are still running.
> 
> The renderer toasts the classified error, stores a per-session mark, and paints the linked Kanban card with a red border and Error badge until a real new turn starts. Completions with `apiError` dispatch `session_error` so in-progress tickets move to review **without** `plan_ready`.
> 
> Latched questions/permissions owned by a still-running subagent are preserved; stale latches reset. Telemetry, model watching, background-work snapshots, and hook-hold idle all treat `StopFailure` as the Stop twin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1aeb040a322b5fbeb135f2438ddf045224b5489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->