### PR TITLE
Detect live backend PTYs when tiling progress sessions

### DIFF
--- a/src/main/desktop/backend-manager.test.ts
+++ b/src/main/desktop/backend-manager.test.ts
@@ -70,7 +70,8 @@ const scriptRunnerMocks = vi.hoisted(() => ({
 const ptyServiceMocks = vi.hoisted(() => ({
   has: vi.fn(),
   resize: vi.fn(),
-  write: vi.fn()
+  write: vi.fn(),
+  getIds: vi.fn(() => [] as string[])
 }))
 
 const ghosttyServiceMocks = vi.hoisted(() => ({
@@ -177,7 +178,8 @@ vi.mock('../services/pty-service', () => ({
   ptyService: {
     has: ptyServiceMocks.has,
     resize: ptyServiceMocks.resize,
-    write: ptyServiceMocks.write
+    write: ptyServiceMocks.write,
+    getIds: ptyServiceMocks.getIds
   }
 }))
 
@@ -3675,6 +3677,37 @@ describe('desktop backend manager', () => {
       makeDesktopCommandResult('terminal-create-claude-cli-1', {
         ok: true,
         value: { success: true, cols: 120, rows: 32 }
+      }),
+      expect.any(Function)
+    )
+  })
+
+  it('answers backend terminalGetLiveIds commands with the live PTY ids', async () => {
+    const child = new FakeChildProcess()
+    ptyServiceMocks.getIds.mockReturnValue(['session-live-1', 'session-live-2'])
+
+    await startDesktopBackend(
+      {
+        executablePath: '/electron',
+        entryPath: '/app/server.js',
+        cwd: '/app',
+        baseDir: mkdtempSync(join(tmpdir(), 'hive-backend-manager-')),
+        port: 0
+      },
+      {
+        spawnProcess: vi.fn(() => child as never),
+        fetch: vi.fn(async () => new Response('{}', { status: 200 })),
+        logger: makeLogger()
+      }
+    )
+
+    child.emit('message', makeDesktopCommandRequest('terminal-get-live-ids-1', 'terminalGetLiveIds'))
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(child.send).toHaveBeenCalledWith(
+      makeDesktopCommandResult('terminal-get-live-ids-1', {
+        ok: true,
+        value: { terminalIds: ['session-live-1', 'session-live-2'] }
       }),
       expect.any(Function)
     )

--- a/src/main/desktop/backend-manager.ts
+++ b/src/main/desktop/backend-manager.ts
@@ -2945,6 +2945,18 @@ const handleDesktopBackendCommand = (
     return undefined
   }
 
+  if (message.command === 'terminalGetLiveIds') {
+    sendDesktopBackendCommandResult(
+      child,
+      makeDesktopCommandResult(message.id, {
+        ok: true,
+        value: { terminalIds: ptyService.getIds() }
+      }),
+      log
+    )
+    return undefined
+  }
+
   if (message.command === 'terminalDestroy') {
     try {
       destroyNodePtyTerminal(message.payload.terminalId)

--- a/src/renderer/src/api/terminal-api.ts
+++ b/src/renderer/src/api/terminal-api.ts
@@ -98,6 +98,22 @@ export const terminalApi = {
     }>('terminalOps.createClaudeCli', { sessionId, opts })
     return { success: true, value: result }
   },
+  /**
+   * IDs of sessions/terminals whose PTY is alive in the backend right now.
+   * Fail-soft: RPC errors resolve to an empty list so callers can treat the
+   * result as "known-live" rather than authoritative.
+   */
+  getLiveTerminalIds: async (): Promise<string[]> => {
+    try {
+      const result = await getRendererRpcClient().request<{ terminalIds: string[] }>(
+        'terminalOps.getLiveTerminalIds',
+        {}
+      )
+      return Array.isArray(result?.terminalIds) ? result.terminalIds : []
+    } catch {
+      return []
+    }
+  },
   setClaudeCliPlanAutoApprove: async (
     sessionId: string,
     enabled: boolean

--- a/src/renderer/src/lib/__tests__/tiled-sessions.test.ts
+++ b/src/renderer/src/lib/__tests__/tiled-sessions.test.ts
@@ -1,6 +1,14 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { KanbanTicket } from '../../../../main/db/types'
 import { computeGridLayout, openTiledInProgressSessions } from '../tiled-sessions'
+
+const terminalApiMocks = vi.hoisted(() => ({
+  getLiveTerminalIds: vi.fn<() => Promise<string[]>>().mockResolvedValue([])
+}))
+
+vi.mock('@/api/terminal-api', () => ({
+  terminalApi: terminalApiMocks
+}))
 import { useSessionStore, type Session } from '@/stores/useSessionStore'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useProjectStore } from '@/stores/useProjectStore'
@@ -91,6 +99,8 @@ describe('openTiledInProgressSessions', () => {
     useKanbanStore.setState(initialKanbanState, true)
     useProjectStore.setState(initialProjectState, true)
     usePinnedStore.setState(initialPinnedState, true)
+    terminalApiMocks.getLiveTerminalIds.mockClear()
+    terminalApiMocks.getLiveTerminalIds.mockResolvedValue([])
   })
 
   it('builds a snapshot for a single-project board (no project names on tiles)', async () => {
@@ -164,6 +174,54 @@ describe('openTiledInProgressSessions', () => {
     expect(byTitle.get('CLI idle')?.isRunning).toBe(false)
     expect(byTitle.get('No session')?.sessionId).toBeNull()
     expect(byTitle.get('No session')?.isRunning).toBe(false)
+  })
+
+  it('marks a terminal-backed session running when its PTY is alive in the backend but not mounted', async () => {
+    useProjectStore.setState({ projects: [{ id: 'p1', name: 'Acme' }] as never })
+    useKanbanStore.setState({
+      tickets: new Map([
+        [
+          'p1',
+          [
+            makeTicket({
+              id: 't-cli-bg',
+              title: 'CLI background',
+              current_session_id: 's-cli-bg',
+              sort_order: 0
+            }),
+            makeTicket({
+              id: 't-cli-dead',
+              title: 'CLI dead',
+              current_session_id: 's-cli-dead',
+              sort_order: 1
+            })
+          ]
+        ]
+      ])
+    })
+    useSessionStore.setState({
+      sessionsByWorktree: new Map([
+        [
+          'wt1',
+          [
+            makeSession({ id: 's-cli-bg', agent_sdk: 'claude-code-cli' }),
+            makeSession({ id: 's-cli-dead', agent_sdk: 'claude-code-cli' })
+          ]
+        ]
+      ]),
+      // Neither session was activated in this renderer lifetime
+      mountedTerminalMirror: new Set()
+    })
+    // ...but the backend still holds a live PTY for one of them (e.g. window
+    // reloaded while the agent kept working)
+    terminalApiMocks.getLiveTerminalIds.mockResolvedValue(['s-cli-bg'])
+
+    await openTiledInProgressSessions({ projectId: 'p1' })
+
+    const tiles = useSessionStore.getState().tiledSessionsTab?.tiles ?? []
+    const byTitle = new Map(tiles.map((t) => [t.title, t]))
+    expect(byTitle.get('CLI background')?.isRunning).toBe(true)
+    expect(byTitle.get('CLI dead')?.isRunning).toBe(false)
   })
 
   it('merges tickets sharing one session into a single tile', async () => {

--- a/src/renderer/src/lib/tiled-sessions.ts
+++ b/src/renderer/src/lib/tiled-sessions.ts
@@ -1,6 +1,7 @@
 import type { KanbanTicket } from '../../../main/db/types'
 import { isTerminalBacked } from '@shared/types/agent-sdk'
 import { dbApi } from '@/api/db-api'
+import { terminalApi } from '@/api/terminal-api'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
@@ -113,6 +114,14 @@ export async function openTiledInProgressSessions(
   const isMultiProject = !!scope.connectionId || !!scope.isPinnedMode
   const projects = useProjectStore.getState().projects
 
+  // The renderer's mounted-terminal mirror only knows sessions activated in
+  // THIS renderer lifetime — a claude-cli PTY can be alive in the backend
+  // (e.g. after a window reload, or driven by hooks/subagents with its tab
+  // never opened) while the mirror misses it. Ask the backend for the ground
+  // truth and use the union. Fail-soft: on RPC failure this is empty and we
+  // degrade to the mirror-only behavior.
+  const livePtyIds = new Set(await terminalApi.getLiveTerminalIds())
+
   const tiles: TiledSessionTile[] = []
   const tileBySessionId = new Map<string, TiledSessionTile>()
 
@@ -134,13 +143,16 @@ export async function openTiledInProgressSessions(
 
     const agentSdk = session?.agent_sdk ?? null
     // Terminal-backed sessions spawn their process when their view mounts, so
-    // "running" means the view/PTY is already mounted this run. Chat sessions
+    // "running" means the view is already mounted this run OR the backend
+    // reports a live PTY for the session (mounting such a tile reattaches —
+    // ptyService.create reuses the live PTY, it never respawns). Chat sessions
     // don't spawn OS processes on mount — active status is enough.
     const isRunning =
       !!session &&
       session.status === 'active' &&
       (!isTerminalBacked(agentSdk) ||
-        useSessionStore.getState().mountedTerminalMirror.has(session.id))
+        useSessionStore.getState().mountedTerminalMirror.has(session.id) ||
+        livePtyIds.has(session.id))
 
     const tile: TiledSessionTile = {
       ticketIds: [ticket.id],

--- a/src/server/__tests__/rpc-router.test.ts
+++ b/src/server/__tests__/rpc-router.test.ts
@@ -7165,6 +7165,48 @@ describe('rpc router', () => {
     expect(calls).toEqual(['getConfig'])
   })
 
+  it('handles terminalOps.getLiveTerminalIds through the terminal ops RPC domain', async () => {
+    const calls: string[] = []
+    const router = makeRpcRouter({
+      eventBus: makeEventBus(),
+      terminalOps: {
+        getConfig: () => Effect.succeed({}),
+        create: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        createClaudeCli: () => Effect.succeed({ success: true, cols: 80, rows: 24 }),
+        setClaudeCliPlanAutoApprove: () => Effect.succeed({ success: true }),
+        ghosttyInit: () => Effect.succeed({ success: true, version: 'test' }),
+        ghosttyIsAvailable: () =>
+          Effect.succeed({ available: false, initialized: false, platform: 'linux' }),
+        ghosttyCreateSurface: () => Effect.succeed({ success: true, surfaceId: 1 }),
+        ghosttySetFrame: () => Effect.succeed(undefined),
+        ghosttySetSize: () => Effect.succeed(undefined),
+        write: () => Effect.succeed(undefined),
+        resize: () => Effect.succeed(undefined),
+        destroy: () => Effect.succeed(undefined),
+        getLiveTerminalIds: () =>
+          Effect.sync(() => {
+            calls.push('getLiveTerminalIds')
+            return { terminalIds: ['session-live'] }
+          })
+      }
+    })
+
+    const response = await Effect.runPromise(
+      router.handle({
+        id: 'terminal-live-ids-1',
+        method: 'terminalOps.getLiveTerminalIds',
+        params: {}
+      })
+    )
+
+    expect(response).toEqual({
+      id: 'terminal-live-ids-1',
+      ok: true,
+      value: { terminalIds: ['session-live'] }
+    })
+    expect(calls).toEqual(['getLiveTerminalIds'])
+  })
+
   it('validates terminalOps.getConfig params', async () => {
     const calls: string[] = []
     const router = makeRpcRouter({

--- a/src/server/rpc/domains/terminal-ops.ts
+++ b/src/server/rpc/domains/terminal-ops.ts
@@ -13,7 +13,8 @@ import {
   type TerminalGhosttyFocusDiagnosticsResult,
   type TerminalGhosttyKeyEvent,
   type TerminalGhosttyRect,
-  type TerminalGhosttyInitResult
+  type TerminalGhosttyInitResult,
+  type TerminalLiveIdsResult
 } from '../../../shared/desktop-command'
 import type { GhosttyTerminalConfig } from '../../../shared/types/terminal'
 import type { RpcHandler } from '../router'
@@ -88,6 +89,8 @@ export interface TerminalOpsRpcService {
   readonly write: (terminalId: string, data: string) => Effect.Effect<void, unknown>
   readonly resize: (terminalId: string, cols: number, rows: number) => Effect.Effect<void, unknown>
   readonly destroy: (terminalId: string) => Effect.Effect<void, unknown>
+  /** IDs of terminals whose PTY is alive right now (local process + desktop main). */
+  readonly getLiveTerminalIds?: () => Effect.Effect<TerminalLiveIdsResult, unknown>
 }
 
 const emptyParamsSchema = z.union([z.object({}).strict(), z.undefined(), z.null()])
@@ -332,6 +335,13 @@ const isTerminalGhosttyAvailabilityResult = (
   typeof value.initialized === 'boolean' &&
   'platform' in value &&
   typeof value.platform === 'string'
+
+const isTerminalLiveIdsResult = (value: unknown): value is TerminalLiveIdsResult =>
+  typeof value === 'object' &&
+  value !== null &&
+  'terminalIds' in value &&
+  Array.isArray(value.terminalIds) &&
+  value.terminalIds.every((id) => typeof id === 'string')
 
 const isTerminalGhosttyCreateSurfaceResult = (
   value: unknown
@@ -1152,6 +1162,52 @@ const requestDesktopTerminalCreateClaudeCli = (
   })
 }
 
+/**
+ * Ask the Electron main process which PTYs are alive. Fail-soft: any
+ * transport error/timeout resolves to an empty list — callers merge this
+ * with the local ptyService, so a miss degrades to "not visible", never an
+ * error.
+ */
+const requestDesktopTerminalGetLiveIds = (): Promise<TerminalLiveIdsResult> => {
+  const send = process.send
+  if (!send) return Promise.resolve({ terminalIds: [] })
+
+  const id = `terminal-get-live-ids-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const command = 'terminalGetLiveIds'
+
+  return new Promise<TerminalLiveIdsResult>((resolve) => {
+    let settled = false
+    const cleanup = (): void => {
+      clearTimeout(timeout)
+      process.off('message', onMessage)
+    }
+    const finish = (value: TerminalLiveIdsResult): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(value)
+    }
+    const timeout = setTimeout(() => {
+      finish({ terminalIds: [] })
+    }, 5_000)
+
+    const onMessage = (message: unknown): void => {
+      if (!isDesktopCommandResult(message) || message.id !== id) return
+      if (message.ok && isTerminalLiveIdsResult(message.value)) {
+        finish(message.value)
+        return
+      }
+      finish({ terminalIds: [] })
+    }
+
+    process.on('message', onMessage)
+    send.call(process, makeDesktopCommandRequest(id, command), (error) => {
+      if (!error) return
+      finish({ terminalIds: [] })
+    })
+  })
+}
+
 const requestDesktopTerminalSetClaudeCliPlanAutoApprove = (
   sessionId: string,
   enabled: boolean
@@ -1531,6 +1587,18 @@ export const makeLiveTerminalOpsRpcService = (eventBus?: EventBus): TerminalOpsR
         if (!result.success) throw new Error(result.error ?? 'Failed to destroy terminal')
       },
       catch: (cause) => cause
+    }),
+  getLiveTerminalIds: () =>
+    Effect.tryPromise({
+      try: async () => {
+        // PTYs live locally in single-process mode and in the Electron main
+        // process in desktop mode — merge both so either topology answers.
+        const remote = await requestDesktopTerminalGetLiveIds()
+        return {
+          terminalIds: Array.from(new Set([...ptyService.getIds(), ...remote.terminalIds]))
+        }
+      },
+      catch: (cause) => cause
     })
 })
 
@@ -1814,6 +1882,18 @@ export const makeTerminalOpsRpcHandlers = (
             catch: (cause) => cause
           })
           return yield* service.destroy(parsed.terminalId)
+        })
+    ],
+    [
+      'terminalOps.getLiveTerminalIds',
+      (params) =>
+        Effect.gen(function* () {
+          yield* Effect.try({
+            try: () => emptyParamsSchema.parse(params),
+            catch: (cause) => cause
+          })
+          return yield* (service.getLiveTerminalIds?.() ??
+            Effect.succeed({ terminalIds: [] as readonly string[] }))
         })
     ]
   ])

--- a/src/shared/desktop-command.ts
+++ b/src/shared/desktop-command.ts
@@ -63,6 +63,7 @@ export type DesktopCommandName =
   | 'terminalDestroy'
   | 'terminalWrite'
   | 'terminalCreateClaudeCli'
+  | 'terminalGetLiveIds'
   | 'remoteLaunchClaudeTmux'
   | 'terminalGhosttyInit'
   | 'terminalGhosttyIsAvailable'
@@ -409,6 +410,11 @@ export type DiscordClaudeCliQuestionReplyPayload = TelegramClaudeCliQuestionRepl
 export type DiscordClaudeCliQuestionRejectPayload = TelegramClaudeCliQuestionRejectPayload
 export type DiscordClaudeCliPlanReplyPayload = TelegramClaudeCliPlanReplyPayload
 export type DiscordClaudeCliReplyResult = TelegramClaudeCliReplyResult
+
+/** IDs of terminals whose PTY is currently alive in the Electron main process. */
+export interface TerminalLiveIdsResult {
+  readonly terminalIds: readonly string[]
+}
 
 export interface TerminalGhosttyAvailabilityResult {
   readonly available: boolean
@@ -945,6 +951,7 @@ export type DesktopCommandRequest =
   | TerminalDestroyDesktopCommandRequest
   | TerminalWriteDesktopCommandRequest
   | TerminalCreateClaudeCliDesktopCommandRequest
+  | TerminalGetLiveIdsDesktopCommandRequest
   | RemoteLaunchClaudeTmuxDesktopCommandRequest
   | TerminalGhosttyInitDesktopCommandRequest
   | TerminalGhosttyIsAvailableDesktopCommandRequest
@@ -1381,6 +1388,12 @@ export interface TerminalCreateClaudeCliDesktopCommandRequest {
   readonly id: string
   readonly command: 'terminalCreateClaudeCli'
   readonly payload: TerminalCreateClaudeCliPayload
+}
+
+export interface TerminalGetLiveIdsDesktopCommandRequest {
+  readonly type: typeof DESKTOP_COMMAND_REQUEST_TYPE
+  readonly id: string
+  readonly command: 'terminalGetLiveIds'
 }
 
 export interface RemoteLaunchClaudeTmuxDesktopCommandRequest {
@@ -2008,6 +2021,10 @@ export function makeDesktopCommandRequest(
   command: 'terminalCreateClaudeCli',
   payload: TerminalCreateClaudeCliPayload
 ): TerminalCreateClaudeCliDesktopCommandRequest
+export function makeDesktopCommandRequest(
+  id: string,
+  command: 'terminalGetLiveIds'
+): TerminalGetLiveIdsDesktopCommandRequest
 export function makeDesktopCommandRequest(
   id: string,
   command: 'remoteLaunchClaudeTmux',
@@ -2893,6 +2910,14 @@ export function makeDesktopCommandRequest(
     } as TerminalCreateClaudeCliDesktopCommandRequest
   }
 
+  if (command === 'terminalGetLiveIds') {
+    return {
+      type: DESKTOP_COMMAND_REQUEST_TYPE,
+      id,
+      command
+    } as TerminalGetLiveIdsDesktopCommandRequest
+  }
+
   if (command === 'remoteLaunchClaudeTmux') {
     if (!payload) {
       throw new Error('Missing remoteLaunchClaudeTmux payload')
@@ -3583,6 +3608,7 @@ export const isDesktopCommandRequest = (value: unknown): value is DesktopCommand
       (value.command === 'terminalWrite' && isTerminalWritePayload(value.payload)) ||
       (value.command === 'terminalCreateClaudeCli' &&
         isTerminalCreateClaudeCliPayload(value.payload)) ||
+      value.command === 'terminalGetLiveIds' ||
       (value.command === 'remoteLaunchClaudeTmux' &&
         isRemoteLaunchClaudeTmuxPayload(value.payload)) ||
       value.command === 'terminalGhosttyInit' ||


### PR DESCRIPTION
## Summary
- Add RPC and desktop commands to retrieve live terminal/PTY IDs.
- Merge backend PTY state with renderer-mounted state when determining running tiled sessions.
- Add fail-soft handling and coverage for desktop, RPC, and tiled-session behavior.

## Testing
- Added unit tests for live PTY detection, RPC routing, and tiled-session running state.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new desktop IPC/RPC path that enumerates live PTY IDs and changes how “running” is computed for tiled CLI sessions. Fail-soft empty lists limit blast radius, but desktop command plumbing is still a moderately important surface.
> 
> **Overview**
> Tiled in-progress views no longer miss CLI agents that kept running after a window reload or without ever opening their tab. `openTiledInProgressSessions` now unions the renderer’s mounted-terminal mirror with backend-reported live PTY IDs, so a terminal-backed tile is **running** if either source says the session is alive.
> 
> Adds `terminalOps.getLiveTerminalIds` (and desktop command `terminalGetLiveIds`) that merge local `ptyService.getIds()` with Electron-main PTY IDs. Renderer and desktop IPC fail-soft to an empty list on timeout or transport error so a miss degrades to the old mirror-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73fe35e0db8a982e3f0eb31738d3a9c268749686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->