### PR TITLE
Add three-way auto-pin project setting

### DIFF
--- a/src/renderer/src/components/kanban/KanbanTicketCard.sidebar-hover-highlight.test.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketCard.sidebar-hover-highlight.test.tsx
@@ -77,14 +77,27 @@ describe('KanbanTicketCard sidebar hover highlight', () => {
     expect(card).not.toHaveAttribute(HIGHLIGHT_ATTR)
   })
 
-  it('highlights the ticket while its worktree is hovered (pinned board)', () => {
+  it('highlights all of the project’s tickets while any of its worktrees is hovered', () => {
+    // Ticket runs on wt-1, but hovering a *different* branch of the same
+    // project still highlights it (worktree-agnostic highlight).
     render(<KanbanTicketCard ticket={{ ...baseTicket, worktree_id: 'wt-1' }} isPinnedMode />)
     const card = screen.getByTestId('kanban-ticket-ticket-1')
 
-    hover({ kind: 'worktree', id: 'wt-1' })
+    hover({ kind: 'worktree', id: 'wt-2', projectId: 'project-1' })
     expect(card).toHaveAttribute(HIGHLIGHT_ATTR)
 
-    hover({ kind: 'worktree', id: 'wt-2' })
+    hover({ kind: 'worktree', id: 'wt-2', projectId: 'project-2' })
+    expect(card).not.toHaveAttribute(HIGHLIGHT_ATTR)
+  })
+
+  it('falls back to exact worktree matching when the project is unresolved', () => {
+    render(<KanbanTicketCard ticket={{ ...baseTicket, worktree_id: 'wt-1' }} isPinnedMode />)
+    const card = screen.getByTestId('kanban-ticket-ticket-1')
+
+    hover({ kind: 'worktree', id: 'wt-1', projectId: null })
+    expect(card).toHaveAttribute(HIGHLIGHT_ATTR)
+
+    hover({ kind: 'worktree', id: 'wt-2', projectId: null })
     expect(card).not.toHaveAttribute(HIGHLIGHT_ATTR)
   })
 
@@ -126,7 +139,7 @@ describe('KanbanTicketCard sidebar hover highlight', () => {
 
     hover({ kind: 'connection', id: 'conn-1' })
     expect(card).not.toHaveAttribute(HIGHLIGHT_ATTR)
-    hover({ kind: 'worktree', id: 'other' })
+    hover({ kind: 'worktree', id: 'other', projectId: 'other-project' })
     expect(card).not.toHaveAttribute(HIGHLIGHT_ATTR)
   })
 })

--- a/src/renderer/src/components/kanban/KanbanTicketModal.tsx
+++ b/src/renderer/src/components/kanban/KanbanTicketModal.tsx
@@ -119,7 +119,7 @@ import { submitShortcutLabel } from '@/lib/shortcut-labels'
 import { quickLaunchTicket, quickLaunchTicketOnConnection } from './WorktreePickerModal'
 import type { KanbanTicket, KanbanTicketUpdate, Session, Worktree } from '../../../../main/db/types'
 import { unwrapEnvelope } from '@/lib/ipc-envelope'
-import { autoPinBaseWorktree } from '@/lib/auto-pin'
+import { autoPinForBoardPrompt } from '@/lib/auto-pin'
 import {
   registerHivePromptHandoff,
   startHivePromptTelemetry
@@ -144,13 +144,17 @@ function completionSendMode(mode: FollowUpMode): 'build' | 'plan' {
 }
 
 function recordSuccessfulFollowupSideEffects(
-  session: { project_id: string; worktree_id: string | null },
+  session: { project_id: string; worktree_id: string | null; connection_id?: string | null },
   sessionId: string,
   prompt: string,
   followUpMode: FollowUpMode,
   model?: ReturnType<typeof resolveSessionModel>
 ): void {
-  void autoPinBaseWorktree(session.project_id)
+  void autoPinForBoardPrompt({
+    projectId: session.project_id,
+    worktreeId: session.worktree_id,
+    connectionId: session.connection_id ?? null
+  })
   startHivePromptTelemetry({
     sessionId,
     prompt,

--- a/src/renderer/src/components/kanban/WorktreePickerModal.tsx
+++ b/src/renderer/src/components/kanban/WorktreePickerModal.tsx
@@ -43,7 +43,7 @@ import { CodexFastToggle } from '@/components/sessions/CodexFastToggle'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
-import { autoPinBaseWorktree } from '@/lib/auto-pin'
+import { autoPinForBoardPrompt } from '@/lib/auto-pin'
 import {
   PLAN_MODE_PREFIX,
   getSuperModePrefix,
@@ -386,7 +386,7 @@ export async function quickLaunchTicket(ticket: KanbanTicket): Promise<boolean> 
     return false
   }
 
-  void autoPinBaseWorktree(projectId)
+  // Auto-pin happened inside launchTicketWithModel once the worktree existed.
   if (useSettingsStore.getState().boardMode === 'sticky-tab') {
     const { BOARD_TAB_ID } = await import('@/stores/useSessionStore')
     useSessionStore.getState().setActiveSession(BOARD_TAB_ID)
@@ -474,7 +474,7 @@ export async function quickLaunchTicketOnConnection(
       void useConnectionStore.getState().renameConnection(connectionId, ticketTitle)
     }
 
-    void autoPinBaseWorktree(ticket.project_id)
+    void autoPinForBoardPrompt({ projectId: ticket.project_id, connectionId })
 
     const usageProvider = resolveDefaultUsageProvider(agentSdk)
     if (usageProvider) {
@@ -1553,7 +1553,7 @@ export function WorktreePickerModal({
           void useConnectionStore.getState().renameConnection(connectionId, ticketTitle)
         }
 
-        void autoPinBaseWorktree(ticket.project_id)
+        void autoPinForBoardPrompt({ projectId: ticket.project_id, connectionId })
 
         // Trigger usage refresh so the board shows up-to-date usage (debounced in store)
         const connUsageProvider = resolveDefaultUsageProvider(agentSdk)
@@ -1889,9 +1889,8 @@ export function WorktreePickerModal({
         return
       }
 
-      void autoPinBaseWorktree(projectId)
-
       // ── Multi-model launch: hand off to the background orchestrator ──
+      // (auto-pin runs inside launchTicketWithModel per created worktree)
       // It owns EVERYTHING after this point — worktree creation, ticket
       // duplication, all ticket updates, and the per-SDK prompt composition — so
       // the modal creates/mutates nothing here and closes immediately (no spinner).
@@ -1947,6 +1946,10 @@ export function WorktreePickerModal({
         setIsSending(false)
         return
       }
+
+      // Setting-gated auto-pin so the ticket shows on the pinned board — now
+      // that the worktree exists, 'current-branch' mode can pin it directly.
+      void autoPinForBoardPrompt({ projectId, worktreeId })
 
       // Resolve the worktree record once — needed for plan-file creation and
       // the OpenCode connect below. Newly created worktrees are already in the

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -11,6 +11,14 @@ import claudeIcon from '@/assets/model-icons/claude.svg'
 import openaiIcon from '@/assets/model-icons/openai.svg'
 import { isAgentSdkAvailable } from '@/lib/agent-sdk-availability'
 import { isForceBoardMode } from '@/api/hive-enterprise/client'
+import { resolveAutoPinMode } from '@/lib/auto-pin'
+import type { AutoPinMode } from '@/stores/useSettingsStore'
+
+const AUTO_PIN_MODE_OPTIONS: { value: AutoPinMode; label: string; testId: string }[] = [
+  { value: 'off', label: 'Off', testId: 'auto-pin-mode-off' },
+  { value: 'root-branch', label: 'Root branch', testId: 'auto-pin-mode-root-branch' },
+  { value: 'current-branch', label: 'Current branch', testId: 'auto-pin-mode-current-branch' }
+]
 
 export function SettingsGeneral(): React.JSX.Element {
   const { setTheme } = useThemeStore()
@@ -20,7 +28,6 @@ export function SettingsGeneral(): React.JSX.Element {
     warnBeforeQuitting,
     boardMode,
     followUpTriggerColumn,
-    autoPinBaseWorktreeOnBoardPrompt,
     automaticallyCreateTicket,
     showMergedColumn,
     vimModeEnabled,
@@ -40,9 +47,10 @@ export function SettingsGeneral(): React.JSX.Element {
     setActiveSection
   } = useSettingsStore()
   const { resetToDefaults: resetShortcuts } = useShortcutStore()
-  // Org "Force board mode" policy overrides auto-start (off) and auto-pin (on);
-  // both toggles are locked while it is active.
+  // Org "Force board mode" policy overrides auto-start (off) and auto-pin
+  // (Root branch); both controls are locked while it is active.
   const forceBoardMode = useSettingsStore(isForceBoardMode)
+  const autoPinMode = useSettingsStore(resolveAutoPinMode)
 
   const handleResetAll = (): void => {
     resetToDefaults()
@@ -226,39 +234,37 @@ export function SettingsGeneral(): React.JSX.Element {
       </div>
 
       {/* Auto-pin project on board prompts */}
-      <div className="flex items-center justify-between gap-4">
-        <div>
-          <label className="text-sm font-medium">Auto-pin project on board prompts</label>
-          <p className="text-xs text-muted-foreground">
-            {forceBoardMode
-              ? 'Enabled by your organization (Force board mode)'
-              : "When a board action sends a prompt for a ticket, automatically pin the project's base worktree so its tickets appear on the pinned board."}
-          </p>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Auto-pin project on board prompts</label>
+        <p className="text-xs text-muted-foreground">
+          {forceBoardMode
+            ? 'Set to Root branch by your organization (Force board mode)'
+            : 'When a board action sends a prompt for a ticket, automatically pin the project so its tickets appear on the pinned board. Root branch pins the base worktree; Current branch pins the worktree the session was sent on.'}
+        </p>
+        <div className="flex gap-2" role="radiogroup" data-testid="auto-pin-mode">
+          {AUTO_PIN_MODE_OPTIONS.map((option) => {
+            const selected = autoPinMode === option.value
+            return (
+              <button
+                key={option.value}
+                role="radio"
+                aria-checked={selected}
+                disabled={forceBoardMode}
+                onClick={() => updateSetting('autoPinOnBoardPrompt', option.value)}
+                className={cn(
+                  'px-3 py-1.5 rounded-md text-[13px] border transition-colors',
+                  selected
+                    ? 'bg-primary text-primary-foreground border-primary'
+                    : 'bg-muted/50 text-muted-foreground border-border hover:bg-accent/50',
+                  forceBoardMode && 'cursor-not-allowed opacity-50'
+                )}
+                data-testid={option.testId}
+              >
+                {option.label}
+              </button>
+            )
+          })}
         </div>
-        <button
-          role="switch"
-          aria-checked={forceBoardMode ? true : autoPinBaseWorktreeOnBoardPrompt}
-          disabled={forceBoardMode}
-          onClick={() =>
-            updateSetting('autoPinBaseWorktreeOnBoardPrompt', !autoPinBaseWorktreeOnBoardPrompt)
-          }
-          className={cn(
-            'relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors',
-            forceBoardMode
-              ? 'bg-primary cursor-not-allowed opacity-50'
-              : autoPinBaseWorktreeOnBoardPrompt
-                ? 'bg-primary cursor-pointer'
-                : 'bg-muted cursor-pointer'
-          )}
-          data-testid="auto-pin-base-worktree-toggle"
-        >
-          <span
-            className={cn(
-              'pointer-events-none block h-4 w-4 rounded-full bg-background ring-0 transition-transform',
-              forceBoardMode || autoPinBaseWorktreeOnBoardPrompt ? 'translate-x-4' : 'translate-x-0'
-            )}
-          />
-        </button>
       </div>
 
       {/* Automatically create ticket */}

--- a/src/renderer/src/hooks/__tests__/useSidebarHoverHighlight.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useSidebarHoverHighlight.test.tsx
@@ -3,6 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useSidebarHoverHighlight } from '../useSidebarHoverHighlight'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+type WorktreesByProject = ReturnType<typeof useWorktreeStore.getState>['worktreesByProject']
 
 describe('useSidebarHoverHighlight', () => {
   afterEach(() => {
@@ -12,6 +15,7 @@ describe('useSidebarHoverHighlight', () => {
       isPinnedBoardActive: false
     })
     useSessionStore.setState({ sessionsByConnection: new Map() })
+    useWorktreeStore.setState({ worktreesByProject: new Map() })
     vi.restoreAllMocks()
   })
 
@@ -19,10 +23,28 @@ describe('useSidebarHoverHighlight', () => {
     const { result } = renderHook(() => useSidebarHoverHighlight('worktree', 'wt1'))
 
     act(() => result.current.onMouseEnter())
-    expect(useKanbanStore.getState().hoveredSidebarTarget).toEqual({ kind: 'worktree', id: 'wt1' })
+    expect(useKanbanStore.getState().hoveredSidebarTarget).toEqual({
+      kind: 'worktree',
+      id: 'wt1',
+      projectId: null
+    })
 
     act(() => result.current.onMouseLeave())
     expect(useKanbanStore.getState().hoveredSidebarTarget).toBeNull()
+  })
+
+  it('resolves the worktree’s project so the highlight is worktree-agnostic', () => {
+    useWorktreeStore.setState({
+      worktreesByProject: new Map([['p1', [{ id: 'wt1' }]]]) as unknown as WorktreesByProject
+    })
+    const { result } = renderHook(() => useSidebarHoverHighlight('worktree', 'wt1'))
+
+    act(() => result.current.onMouseEnter())
+    expect(useKanbanStore.getState().hoveredSidebarTarget).toEqual({
+      kind: 'worktree',
+      id: 'wt1',
+      projectId: 'p1'
+    })
   })
 
   it('does not clear a target set by a different card', () => {

--- a/src/renderer/src/hooks/useSidebarHoverHighlight.ts
+++ b/src/renderer/src/hooks/useSidebarHoverHighlight.ts
@@ -2,17 +2,28 @@ import { useCallback, useEffect } from 'react'
 import { useKanbanStore } from '@/stores/useKanbanStore'
 import type { SidebarHoverTarget } from '@/stores/useKanbanStore'
 import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
 
 interface SidebarHoverHandlers {
   onMouseEnter: () => void
   onMouseLeave: () => void
 }
 
+/** Project owning a worktree, from the already-loaded worktree store. */
+function findWorktreeProjectId(worktreeId: string): string | null {
+  for (const [projectId, worktrees] of useWorktreeStore.getState().worktreesByProject) {
+    if (worktrees.some((w) => w.id === worktreeId)) return projectId
+  }
+  return null
+}
+
 /**
  * Mouse enter/leave handlers for a sidebar card (project header, worktree,
  * connection). While the card is hovered, board ticket cards linked to it are
- * highlighted. Clears the target on unmount so a card removed mid-hover does
- * not leave a stale highlight behind.
+ * highlighted. Worktree hover is worktree-agnostic: it highlights every ticket
+ * of the worktree's project, not just the ones on that branch. Clears the
+ * target on unmount so a card removed mid-hover does not leave a stale
+ * highlight behind.
  */
 export function useSidebarHoverHighlight(
   kind: SidebarHoverTarget['kind'],
@@ -20,7 +31,11 @@ export function useSidebarHoverHighlight(
 ): SidebarHoverHandlers {
   const onMouseEnter = useCallback(() => {
     const kanban = useKanbanStore.getState()
-    kanban.setHoveredSidebarTarget({ kind, id } as SidebarHoverTarget)
+    const target: SidebarHoverTarget =
+      kind === 'worktree'
+        ? { kind, id, projectId: findWorktreeProjectId(id) }
+        : ({ kind, id } as SidebarHoverTarget)
+    kanban.setHoveredSidebarTarget(target)
     // Connection tickets are linked through their session, and connection
     // sessions are only loaded once a connection is opened. While a board is
     // showing, fetch them in the background so the highlight can resolve.

--- a/src/renderer/src/lib/auto-launch.multi-model.test.ts
+++ b/src/renderer/src/lib/auto-launch.multi-model.test.ts
@@ -19,10 +19,6 @@ vi.mock('@/lib/multi-model-launch', () => ({
   runMultiModelLaunch: vi.fn()
 }))
 
-vi.mock('@/lib/auto-pin', () => ({
-  autoPinBaseWorktree: vi.fn()
-}))
-
 const initialProjectState = useProjectStore.getState()
 
 function setupProject(): void {

--- a/src/renderer/src/lib/auto-launch.ts
+++ b/src/renderer/src/lib/auto-launch.ts
@@ -1,6 +1,5 @@
 import { useProjectStore } from '@/stores/useProjectStore'
 import { toast } from '@/lib/toast'
-import { autoPinBaseWorktree } from '@/lib/auto-pin'
 import { launchTicketWithModel, type LaunchModelConfig } from '@/lib/ticket-launch'
 import { runMultiModelLaunch } from '@/lib/multi-model-launch'
 import type { HandoffAgentSdk } from '@shared/types/agent-sdk'
@@ -112,10 +111,8 @@ export async function autoLaunchTicket(ticket: AutoLaunchTicket): Promise<void> 
     return
   }
 
-  // Pin the base worktree once per batch (not per model — a future multi-launch
-  // must not re-pin for every model it spawns).
-  void autoPinBaseWorktree(ticket.project_id)
-
+  // Auto-pin happens inside launchTicketWithModel once each worktree exists
+  // ('current-branch' mode pins the launched worktree, not the base).
   const entries = resolveModelEntries(config)
 
   // Multiple models + a brand-new worktree: one worktree + duplicated ticket

--- a/src/renderer/src/lib/auto-pin.test.ts
+++ b/src/renderer/src/lib/auto-pin.test.ts
@@ -1,13 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const settingsState = {
-  autoPinBaseWorktreeOnBoardPrompt: true
+const settingsState: {
+  autoPinOnBoardPrompt: 'off' | 'root-branch' | 'current-branch'
+  hiveAuthToken: string | null
+  hiveOrganizationId: string | null
+  hiveOrganizationForceBoardMode: boolean
+} = {
+  autoPinOnBoardPrompt: 'root-branch',
+  hiveAuthToken: null,
+  hiveOrganizationId: null,
+  hiveOrganizationForceBoardMode: false
 }
 vi.mock('@/stores/useSettingsStore', () => ({
   useSettingsStore: { getState: () => settingsState }
 }))
+const forceBoardMode = { value: false }
 vi.mock('@/api/hive-enterprise/client', () => ({
-  isForceBoardMode: () => false
+  isForceBoardMode: () => forceBoardMode.value
 }))
 
 const pinnedState = {
@@ -15,8 +24,8 @@ const pinnedState = {
   pinnedConnectionIds: new Set<string>(),
   isWorktreePinned: vi.fn((id: string) => pinnedState.pinnedWorktreeIds.has(id)),
   isConnectionPinned: vi.fn((id: string) => pinnedState.pinnedConnectionIds.has(id)),
-  pinWorktree: vi.fn(async () => {}),
-  pinConnection: vi.fn(async () => {})
+  pinWorktree: vi.fn(async (_id: string) => {}),
+  pinConnection: vi.fn(async (_id: string) => {})
 }
 vi.mock('@/stores/usePinnedStore', () => ({
   usePinnedStore: { getState: () => pinnedState }
@@ -24,7 +33,10 @@ vi.mock('@/stores/usePinnedStore', () => ({
 
 const worktreeState = {
   defaultByProject: new Map<string, { id: string } | null>(),
-  getDefaultWorktree: vi.fn((projectId: string) => worktreeState.defaultByProject.get(projectId) ?? null),
+  worktreesByProject: new Map<string, { id: string }[]>(),
+  getDefaultWorktree: vi.fn(
+    (projectId: string) => worktreeState.defaultByProject.get(projectId) ?? null
+  ),
   loadWorktrees: vi.fn(async () => {})
 }
 vi.mock('@/stores/useWorktreeStore', () => ({
@@ -46,38 +58,108 @@ vi.mock('@/stores/useConnectionStore', () => ({
   useConnectionStore: { getState: () => connectionState }
 }))
 
-import { autoPinBaseWorktree } from './auto-pin'
+import { autoPinForBoardPrompt, resolveAutoPinMode } from './auto-pin'
 
 const CONN_PROJECT = 'conn-project-1'
 const GIT_PROJECT = 'git-project-1'
 
-describe('autoPinBaseWorktree', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    settingsState.autoPinBaseWorktreeOnBoardPrompt = true
-    pinnedState.pinnedWorktreeIds = new Set()
-    pinnedState.pinnedConnectionIds = new Set()
-    worktreeState.defaultByProject = new Map([[GIT_PROJECT, { id: 'wt-default' }]])
-    projectState.projects = [
-      { id: GIT_PROJECT, kind: 'git' },
-      { id: CONN_PROJECT, kind: 'connection' }
-    ]
-    connectionState.connections = [
-      { id: 'inst-1', saved_project_id: CONN_PROJECT, is_base: 0 },
-      { id: 'base-1', saved_project_id: CONN_PROJECT, is_base: 1 },
-      { id: 'adhoc', saved_project_id: null, is_base: 0 }
-    ]
+beforeEach(() => {
+  vi.clearAllMocks()
+  settingsState.autoPinOnBoardPrompt = 'root-branch'
+  forceBoardMode.value = false
+  pinnedState.pinnedWorktreeIds = new Set()
+  pinnedState.pinnedConnectionIds = new Set()
+  worktreeState.defaultByProject = new Map([[GIT_PROJECT, { id: 'wt-default' }]])
+  worktreeState.worktreesByProject = new Map([
+    [GIT_PROJECT, [{ id: 'wt-default' }, { id: 'wt-feature' }]],
+    ['other-project', [{ id: 'wt-elsewhere' }]]
+  ])
+  projectState.projects = [
+    { id: GIT_PROJECT, kind: 'git' },
+    { id: CONN_PROJECT, kind: 'connection' }
+  ]
+  connectionState.connections = [
+    { id: 'inst-1', saved_project_id: CONN_PROJECT, is_base: 0 },
+    { id: 'base-1', saved_project_id: CONN_PROJECT, is_base: 1 },
+    { id: 'adhoc', saved_project_id: null, is_base: 0 }
+  ]
+})
+
+describe('resolveAutoPinMode', () => {
+  it('returns the local setting when no org policy applies', () => {
+    settingsState.autoPinOnBoardPrompt = 'current-branch'
+    expect(resolveAutoPinMode(settingsState)).toBe('current-branch')
+    settingsState.autoPinOnBoardPrompt = 'off'
+    expect(resolveAutoPinMode(settingsState)).toBe('off')
   })
 
-  it('git project: pins the default worktree (unchanged behavior)', async () => {
-    await autoPinBaseWorktree(GIT_PROJECT)
+  it('forces root-branch under org Force board mode regardless of the local setting', () => {
+    forceBoardMode.value = true
+    settingsState.autoPinOnBoardPrompt = 'off'
+    expect(resolveAutoPinMode(settingsState)).toBe('root-branch')
+    settingsState.autoPinOnBoardPrompt = 'current-branch'
+    expect(resolveAutoPinMode(settingsState)).toBe('root-branch')
+  })
+})
+
+describe('autoPinForBoardPrompt — off', () => {
+  it('never pins when the setting is off, even with a worktree/connection target', async () => {
+    settingsState.autoPinOnBoardPrompt = 'off'
+
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT, worktreeId: 'wt-feature' })
+    await autoPinForBoardPrompt({ projectId: CONN_PROJECT, connectionId: 'inst-1' })
+
+    expect(pinnedState.pinWorktree).not.toHaveBeenCalled()
+    expect(pinnedState.pinConnection).not.toHaveBeenCalled()
+    expect(worktreeState.loadWorktrees).not.toHaveBeenCalled()
+  })
+
+  it('no-ops without a project id', async () => {
+    await autoPinForBoardPrompt({ projectId: null, worktreeId: 'wt-feature' })
+    await autoPinForBoardPrompt({ projectId: undefined })
+
+    expect(pinnedState.pinWorktree).not.toHaveBeenCalled()
+    expect(pinnedState.pinConnection).not.toHaveBeenCalled()
+  })
+})
+
+describe('autoPinForBoardPrompt — root-branch (legacy "on")', () => {
+  it('git project: pins the default worktree', async () => {
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT })
 
     expect(pinnedState.pinWorktree).toHaveBeenCalledWith('wt-default')
     expect(pinnedState.pinConnection).not.toHaveBeenCalled()
   })
 
+  it('git project: ignores the session worktree and still pins the default', async () => {
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT, worktreeId: 'wt-feature' })
+
+    expect(pinnedState.pinWorktree).toHaveBeenCalledTimes(1)
+    expect(pinnedState.pinWorktree).toHaveBeenCalledWith('wt-default')
+  })
+
+  it('git project: no-op when the default worktree is already pinned', async () => {
+    pinnedState.pinnedWorktreeIds = new Set(['wt-default'])
+
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT })
+
+    expect(pinnedState.pinWorktree).not.toHaveBeenCalled()
+  })
+
+  it('git project: loads worktrees when the default is not in the store yet', async () => {
+    worktreeState.defaultByProject = new Map()
+    worktreeState.loadWorktrees.mockImplementationOnce(async () => {
+      worktreeState.defaultByProject = new Map([[GIT_PROJECT, { id: 'wt-default' }]])
+    })
+
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT })
+
+    expect(worktreeState.loadWorktrees).toHaveBeenCalledWith(GIT_PROJECT)
+    expect(pinnedState.pinWorktree).toHaveBeenCalledWith('wt-default')
+  })
+
   it('connection project: pins the BASE instance, never another instance', async () => {
-    await autoPinBaseWorktree(CONN_PROJECT)
+    await autoPinForBoardPrompt({ projectId: CONN_PROJECT, connectionId: 'inst-1' })
 
     expect(pinnedState.pinConnection).toHaveBeenCalledTimes(1)
     expect(pinnedState.pinConnection).toHaveBeenCalledWith('base-1')
@@ -89,7 +171,7 @@ describe('autoPinBaseWorktree', () => {
   it('connection project: no-op when the base instance is already pinned', async () => {
     pinnedState.pinnedConnectionIds = new Set(['base-1'])
 
-    await autoPinBaseWorktree(CONN_PROJECT)
+    await autoPinForBoardPrompt({ projectId: CONN_PROJECT })
 
     expect(pinnedState.pinConnection).not.toHaveBeenCalled()
   })
@@ -100,7 +182,7 @@ describe('autoPinBaseWorktree', () => {
       connectionState.connections = [{ id: 'base-1', saved_project_id: CONN_PROJECT, is_base: 1 }]
     })
 
-    await autoPinBaseWorktree(CONN_PROJECT)
+    await autoPinForBoardPrompt({ projectId: CONN_PROJECT })
 
     expect(connectionState.loadConnections).toHaveBeenCalledTimes(1)
     expect(pinnedState.pinConnection).toHaveBeenCalledWith('base-1')
@@ -109,28 +191,128 @@ describe('autoPinBaseWorktree', () => {
   it('connection project: gives up quietly when no base instance exists', async () => {
     connectionState.connections = [{ id: 'inst-1', saved_project_id: CONN_PROJECT, is_base: 0 }]
 
-    await autoPinBaseWorktree(CONN_PROJECT)
+    await autoPinForBoardPrompt({ projectId: CONN_PROJECT })
 
     expect(connectionState.loadConnections).toHaveBeenCalledTimes(1)
     expect(pinnedState.pinConnection).not.toHaveBeenCalled()
     expect(pinnedState.pinWorktree).not.toHaveBeenCalled()
   })
 
-  it('respects the setting for connection projects too', async () => {
-    settingsState.autoPinBaseWorktreeOnBoardPrompt = false
+  it('org Force board mode pins the root branch even when the local setting is off', async () => {
+    forceBoardMode.value = true
+    settingsState.autoPinOnBoardPrompt = 'off'
 
-    await autoPinBaseWorktree(CONN_PROJECT)
-    await autoPinBaseWorktree(GIT_PROJECT)
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT, worktreeId: 'wt-feature' })
 
-    expect(pinnedState.pinConnection).not.toHaveBeenCalled()
+    expect(pinnedState.pinWorktree).toHaveBeenCalledWith('wt-default')
+  })
+})
+
+describe('autoPinForBoardPrompt — current-branch', () => {
+  beforeEach(() => {
+    settingsState.autoPinOnBoardPrompt = 'current-branch'
+  })
+
+  it("git project: pins the session's worktree instead of the default", async () => {
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT, worktreeId: 'wt-feature' })
+
+    expect(pinnedState.pinWorktree).toHaveBeenCalledTimes(1)
+    expect(pinnedState.pinWorktree).toHaveBeenCalledWith('wt-feature')
+    expect(worktreeState.loadWorktrees).not.toHaveBeenCalled()
+  })
+
+  it("git project: no-op when the session's worktree is already pinned", async () => {
+    pinnedState.pinnedWorktreeIds = new Set(['wt-feature'])
+
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT, worktreeId: 'wt-feature' })
+
     expect(pinnedState.pinWorktree).not.toHaveBeenCalled()
   })
 
+  it('git project: each session pins its own worktree (multi-model launches)', async () => {
+    worktreeState.worktreesByProject.set(GIT_PROJECT, [
+      { id: 'wt-default' },
+      { id: 'wt-model-a' },
+      { id: 'wt-model-b' }
+    ])
+
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT, worktreeId: 'wt-model-a' })
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT, worktreeId: 'wt-model-b' })
+
+    expect(pinnedState.pinWorktree.mock.calls.map((c) => c[0])).toEqual([
+      'wt-model-a',
+      'wt-model-b'
+    ])
+  })
+
+  it('git project: falls back to the default worktree when no worktree is known', async () => {
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT })
+
+    expect(pinnedState.pinWorktree).toHaveBeenCalledTimes(1)
+    expect(pinnedState.pinWorktree).toHaveBeenCalledWith('wt-default')
+  })
+
+  it('git project: a null worktree id (connection session) falls back to the default', async () => {
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT, worktreeId: null })
+
+    expect(pinnedState.pinWorktree).toHaveBeenCalledTimes(1)
+    expect(pinnedState.pinWorktree).toHaveBeenCalledWith('wt-default')
+  })
+
+  it('git project: reloads worktrees for a just-created worktree, then pins it', async () => {
+    worktreeState.worktreesByProject.set(GIT_PROJECT, [{ id: 'wt-default' }])
+    worktreeState.loadWorktrees.mockImplementationOnce(async () => {
+      worktreeState.worktreesByProject.set(GIT_PROJECT, [{ id: 'wt-default' }, { id: 'wt-new' }])
+    })
+
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT, worktreeId: 'wt-new' })
+
+    expect(worktreeState.loadWorktrees).toHaveBeenCalledWith(GIT_PROJECT)
+    expect(pinnedState.pinWorktree).toHaveBeenCalledWith('wt-new')
+  })
+
+  it("git project: falls back to the default when the worktree isn't in this project", async () => {
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT, worktreeId: 'wt-elsewhere' })
+
+    expect(worktreeState.loadWorktrees).toHaveBeenCalledTimes(1)
+    expect(pinnedState.pinWorktree).toHaveBeenCalledWith('wt-default')
+  })
+
+  it("connection project: pins the session's instance instead of the base", async () => {
+    await autoPinForBoardPrompt({ projectId: CONN_PROJECT, connectionId: 'inst-1' })
+
+    expect(pinnedState.pinConnection).toHaveBeenCalledTimes(1)
+    expect(pinnedState.pinConnection).toHaveBeenCalledWith('inst-1')
+    expect(connectionState.loadConnections).not.toHaveBeenCalled()
+  })
+
+  it('connection project: falls back to the base when no instance is known', async () => {
+    await autoPinForBoardPrompt({ projectId: CONN_PROJECT })
+
+    expect(pinnedState.pinConnection).toHaveBeenCalledWith('base-1')
+  })
+
+  it("connection project: falls back to the base for a connection that isn't an instance of the project", async () => {
+    await autoPinForBoardPrompt({ projectId: CONN_PROJECT, connectionId: 'adhoc' })
+
+    expect(connectionState.loadConnections).toHaveBeenCalledTimes(1)
+    expect(pinnedState.pinConnection).toHaveBeenCalledWith('base-1')
+  })
+
+  it('git project: a connection-backed session (no worktree) falls back to the default worktree', async () => {
+    await autoPinForBoardPrompt({ projectId: GIT_PROJECT, worktreeId: null, connectionId: 'adhoc' })
+
+    expect(pinnedState.pinWorktree).toHaveBeenCalledWith('wt-default')
+    expect(pinnedState.pinConnection).not.toHaveBeenCalled()
+  })
+})
+
+describe('autoPinForBoardPrompt — resilience', () => {
   it('never throws (pin failure is swallowed)', async () => {
     pinnedState.pinConnection.mockRejectedValueOnce(new Error('boom'))
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    await expect(autoPinBaseWorktree(CONN_PROJECT)).resolves.toBeUndefined()
+    await expect(autoPinForBoardPrompt({ projectId: CONN_PROJECT })).resolves.toBeUndefined()
     expect(errorSpy).toHaveBeenCalled()
     errorSpy.mockRestore()
   })

--- a/src/renderer/src/lib/auto-pin.ts
+++ b/src/renderer/src/lib/auto-pin.ts
@@ -1,4 +1,4 @@
-import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSettingsStore, type AppSettings, type AutoPinMode } from '@/stores/useSettingsStore'
 import { usePinnedStore } from '@/stores/usePinnedStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useProjectStore } from '@/stores/useProjectStore'
@@ -6,56 +6,135 @@ import { useConnectionStore } from '@/stores/useConnectionStore'
 import { isForceBoardMode } from '@/api/hive-enterprise/client'
 import { findBaseInstanceConnection } from '@/lib/connection-project'
 
+type AutoPinSettings = Pick<
+  AppSettings,
+  'autoPinOnBoardPrompt' | 'hiveAuthToken' | 'hiveOrganizationId' | 'hiveOrganizationForceBoardMode'
+>
+
 /**
- * When the "auto-pin project on board prompts" setting is enabled, pin the
- * project's base (is_default) worktree so the project's tickets appear on the
- * pinned board. Connection projects (projects.kind === 'connection') have no
- * worktrees — their base INSTANCE (the connection over every member's default
- * worktree) is pinned instead, which scopes the project onto the pinned board
- * the same way. Never throws — call fire-and-forget via `void`.
+ * The auto-pin mode actually in effect. The org "Force board mode" policy
+ * forces 'root-branch' (the pre-3-way "on" behavior) and cannot be changed
+ * locally; otherwise it is the user's own setting.
  */
-export async function autoPinBaseWorktree(projectId: string | null | undefined): Promise<void> {
+export function resolveAutoPinMode(settings: AutoPinSettings): AutoPinMode {
+  return isForceBoardMode(settings) ? 'root-branch' : settings.autoPinOnBoardPrompt
+}
+
+export interface AutoPinTarget {
+  projectId: string | null | undefined
+  /**
+   * The worktree the session was sent on (git projects). In 'current-branch'
+   * mode this is pinned instead of the project's base worktree.
+   */
+  worktreeId?: string | null
+  /**
+   * The connection instance the session was sent on (connection projects). In
+   * 'current-branch' mode this is pinned instead of the project's base instance.
+   */
+  connectionId?: string | null
+}
+
+/**
+ * Setting-gated auto-pin for board prompts: pins something in the project so
+ * its tickets appear on the pinned board (pinning ANY worktree / instance of a
+ * project scopes the whole project onto the pinned board).
+ *
+ * - 'off': no-op.
+ * - 'root-branch': the project's base (is_default) worktree. Connection
+ *   projects (projects.kind === 'connection') have no worktrees — their base
+ *   INSTANCE (the connection over every member's default worktree) is pinned.
+ * - 'current-branch': the worktree / connection instance the session was sent
+ *   on, when the caller knows it and it belongs to the project; otherwise the
+ *   same fallback as 'root-branch'.
+ *
+ * Never throws — call fire-and-forget via `void`.
+ */
+export async function autoPinForBoardPrompt(target: AutoPinTarget): Promise<void> {
   try {
+    const { projectId } = target
     if (!projectId) return
-    // Org "Force board mode" policy pins unconditionally — the local setting
-    // is forced on and cannot be disabled.
-    const settings = useSettingsStore.getState()
-    if (!settings.autoPinBaseWorktreeOnBoardPrompt && !isForceBoardMode(settings)) return
+    const mode = resolveAutoPinMode(useSettingsStore.getState())
+    if (mode === 'off') return
+    const currentBranch = mode === 'current-branch'
 
     const project = useProjectStore.getState().projects.find((p) => p.id === projectId)
     if (project?.kind === 'connection') {
-      await pinConnectionProjectBase(projectId)
+      await pinConnectionProjectInstance(projectId, currentBranch ? target.connectionId : null)
       return
     }
-
-    let base = useWorktreeStore.getState().getDefaultWorktree(projectId)
-    if (!base) {
-      // The project's worktrees may not be loaded yet (e.g. auto-launch firing
-      // from a store subscription shortly after startup)
-      await useWorktreeStore.getState().loadWorktrees(projectId)
-      base = useWorktreeStore.getState().getDefaultWorktree(projectId)
-    }
-    if (!base) return
-
-    const pinned = usePinnedStore.getState()
-    if (pinned.isWorktreePinned(base.id)) return
-    await pinned.pinWorktree(base.id)
+    await pinGitProjectWorktree(projectId, currentBranch ? target.worktreeId : null)
   } catch (err) {
-    console.error('[auto-pin] failed to auto-pin base worktree:', err)
+    console.error('[auto-pin] failed to auto-pin for board prompt:', err)
   }
 }
 
-async function pinConnectionProjectBase(projectId: string): Promise<void> {
-  let base = findBaseInstanceConnection(projectId)
-  if (!base) {
+/**
+ * The project's worktree matching `worktreeId` (must belong to `projectId` so
+ * pinning it scopes this project's board), else the project's base worktree.
+ */
+function resolveWorktreeTarget(
+  projectId: string,
+  worktreeId: string | null | undefined
+): { id: string } | null {
+  const state = useWorktreeStore.getState()
+  if (worktreeId) {
+    const current = state.worktreesByProject.get(projectId)?.find((w) => w.id === worktreeId)
+    if (current) return current
+  }
+  return state.getDefaultWorktree(projectId)
+}
+
+async function pinGitProjectWorktree(
+  projectId: string,
+  worktreeId: string | null | undefined
+): Promise<void> {
+  let target = resolveWorktreeTarget(projectId, worktreeId)
+  if (!target || (worktreeId && target.id !== worktreeId)) {
+    // The project's worktrees may not be loaded yet (e.g. auto-launch firing
+    // from a store subscription shortly after startup), or the requested
+    // worktree was only just created.
+    await useWorktreeStore.getState().loadWorktrees(projectId)
+    target = resolveWorktreeTarget(projectId, worktreeId)
+  }
+  if (!target) return
+
+  const pinned = usePinnedStore.getState()
+  if (pinned.isWorktreePinned(target.id)) return
+  await pinned.pinWorktree(target.id)
+}
+
+/**
+ * The project's instance matching `connectionId` (must be an instance of
+ * `projectId` — an ad-hoc connection would not scope the project's board),
+ * else the project's base instance.
+ */
+function resolveConnectionTarget(
+  projectId: string,
+  connectionId: string | null | undefined
+): { id: string } | null {
+  if (connectionId) {
+    const current = useConnectionStore
+      .getState()
+      .connections.find((c) => c.id === connectionId && c.saved_project_id === projectId)
+    if (current) return current
+  }
+  return findBaseInstanceConnection(projectId)
+}
+
+async function pinConnectionProjectInstance(
+  projectId: string,
+  connectionId: string | null | undefined
+): Promise<void> {
+  let target = resolveConnectionTarget(projectId, connectionId)
+  if (!target || (connectionId && target.id !== connectionId)) {
     // Connections may not be loaded yet, or the base was only just healed
     // server-side (connectionOps.getAll creates a missing base on listing).
     await useConnectionStore.getState().loadConnections()
-    base = findBaseInstanceConnection(projectId)
+    target = resolveConnectionTarget(projectId, connectionId)
   }
-  if (!base) return
+  if (!target) return
 
   const pinned = usePinnedStore.getState()
-  if (pinned.isConnectionPinned(base.id)) return
-  await pinned.pinConnection(base.id)
+  if (pinned.isConnectionPinned(target.id)) return
+  await pinned.pinConnection(target.id)
 }

--- a/src/renderer/src/lib/connection-project-launch.ts
+++ b/src/renderer/src/lib/connection-project-launch.ts
@@ -29,7 +29,7 @@ import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { startHivePromptTelemetry } from '@/lib/hive-enterprise-telemetry'
 import { createPlanFile, exceedsGoalPromptLimit, planFilePrompt } from '@/lib/goal-plan-file'
 import { resolveBadgeModel } from '@/lib/ticket-launch'
-import { autoPinBaseWorktree } from '@/lib/auto-pin'
+import { autoPinForBoardPrompt } from '@/lib/auto-pin'
 import {
   PLAN_MODE_PREFIX,
   getSuperModePrefix,
@@ -409,9 +409,10 @@ export async function startTicketSessionOnConnectionInstance(args: {
       void useConnectionStore.getState().renameConnection(connectionId, ticketTitle)
     }
 
-    // Setting-gated auto-pin: pins the project's base instance so this board
-    // shows on the pinned board (the git-project paths pin the default worktree).
-    void autoPinBaseWorktree(savedProjectId)
+    // Setting-gated auto-pin so this board shows on the pinned board: the
+    // project's base instance, or in 'current-branch' mode the instance the
+    // session was sent on (the git-project paths pin worktrees the same way).
+    void autoPinForBoardPrompt({ projectId: savedProjectId, connectionId })
 
     const usageProvider = resolveDefaultUsageProvider(sdk)
     if (usageProvider) {

--- a/src/renderer/src/lib/sidebar-hover-highlight.test.ts
+++ b/src/renderer/src/lib/sidebar-hover-highlight.test.ts
@@ -13,19 +13,37 @@ describe('isTicketLinkedToSidebarTarget', () => {
     expect(isTicketLinkedToSidebarTarget(ticket, { kind: 'project', id: 'p2' })).toBe(false)
   })
 
-  it('matches tickets running on the hovered worktree', () => {
-    expect(isTicketLinkedToSidebarTarget(ticket, { kind: 'worktree', id: 'wt1' })).toBe(true)
-    expect(isTicketLinkedToSidebarTarget(ticket, { kind: 'worktree', id: 'wt2' })).toBe(false)
+  it('matches every ticket of the hovered worktree’s project, regardless of branch', () => {
+    const otherBranch = { project_id: 'p1', worktree_id: 'wt2', pending_launch_config: null }
+    expect(
+      isTicketLinkedToSidebarTarget(otherBranch, { kind: 'worktree', id: 'wt1', projectId: 'p1' })
+    ).toBe(true)
+    expect(
+      isTicketLinkedToSidebarTarget(ticket, { kind: 'worktree', id: 'wt1', projectId: 'p2' })
+    ).toBe(false)
   })
 
-  it('matches tickets queued to launch on the hovered worktree', () => {
+  it('falls back to exact worktree matching when the project is unresolved', () => {
+    expect(
+      isTicketLinkedToSidebarTarget(ticket, { kind: 'worktree', id: 'wt1', projectId: null })
+    ).toBe(true)
+    expect(
+      isTicketLinkedToSidebarTarget(ticket, { kind: 'worktree', id: 'wt2', projectId: null })
+    ).toBe(false)
+  })
+
+  it('matches tickets queued to launch on the hovered worktree when the project is unresolved', () => {
     const queued = {
       project_id: 'p1',
       worktree_id: null,
       pending_launch_config: JSON.stringify({ worktree: { type: 'existing', worktreeId: 'wt9' } })
     }
-    expect(isTicketLinkedToSidebarTarget(queued, { kind: 'worktree', id: 'wt9' })).toBe(true)
-    expect(isTicketLinkedToSidebarTarget(queued, { kind: 'worktree', id: 'wt1' })).toBe(false)
+    expect(
+      isTicketLinkedToSidebarTarget(queued, { kind: 'worktree', id: 'wt9', projectId: null })
+    ).toBe(true)
+    expect(
+      isTicketLinkedToSidebarTarget(queued, { kind: 'worktree', id: 'wt1', projectId: null })
+    ).toBe(false)
   })
 
   it('leaves connection targets to the caller', () => {

--- a/src/renderer/src/lib/sidebar-hover-highlight.ts
+++ b/src/renderer/src/lib/sidebar-hover-highlight.ts
@@ -28,6 +28,10 @@ export function isTicketLinkedToSidebarTarget(
     case 'project':
       return ticket.project_id === target.id
     case 'worktree':
+      // Worktree hover is worktree-agnostic: highlight every ticket of the
+      // owning project. Fall back to exact worktree matching only when the
+      // project could not be resolved.
+      if (target.projectId) return ticket.project_id === target.projectId
       return ticket.worktree_id === target.id || getQueuedWorktreeId(ticket) === target.id
     default:
       return false

--- a/src/renderer/src/lib/ticket-launch.ts
+++ b/src/renderer/src/lib/ticket-launch.ts
@@ -12,6 +12,7 @@ import {
   matchCustomProviderModel
 } from '@shared/types/custom-provider'
 import { resolveCustomProviderSelectedModel } from '@/lib/handoffSelection'
+import { autoPinForBoardPrompt } from '@/lib/auto-pin'
 import { messageSendTimes, lastSendMode, userExplicitSendTimes } from '@/lib/message-send-times'
 import { bumpWorktreeLastMessage } from '@/lib/last-message-utils'
 import { snapshotTokenBaseline } from '@/lib/token-baselines'
@@ -230,6 +231,13 @@ export async function launchTicketWithModel(spec: TicketLaunchSpec): Promise<Tic
       worktreeId = spec.worktree.worktreeId
     }
     createdWorktreeId = worktreeId
+
+    // Setting-gated auto-pin so the ticket shows on the pinned board. Fired
+    // here (not by callers) because 'current-branch' mode needs the worktree
+    // the session is sent on, which only exists from this point. Idempotent,
+    // so a multi-model batch re-running this per model is a no-op in
+    // 'root-branch' mode and pins each model's worktree in 'current-branch'.
+    void autoPinForBoardPrompt({ projectId: spec.projectId, worktreeId })
 
     // Resolve the worktree record once — needed for plan-file creation and the
     // OpenCode connect below. Newly created worktrees are already in the store.

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -2168,11 +2168,16 @@ registerKanbanAutoCreateTicket(({ sessionId, rawPrompt }) => {
         created_from_session: true
       })
 
-      // Mirror the manual-open behavior: when auto-pin is enabled, pin the
-      // project's root/base worktree so the auto-created ticket shows on the
-      // pinned board. No-op unless `autoPinBaseWorktreeOnBoardPrompt` is on.
-      const { autoPinBaseWorktree } = await import('@/lib/auto-pin')
-      void autoPinBaseWorktree(session.project_id)
+      // Mirror the manual-open behavior: pin per the auto-pin setting (the
+      // project's root/base worktree, or the session's own worktree /
+      // connection instance) so the auto-created ticket shows on the pinned
+      // board. No-op when `autoPinOnBoardPrompt` is 'off'.
+      const { autoPinForBoardPrompt } = await import('@/lib/auto-pin')
+      void autoPinForBoardPrompt({
+        projectId: session.project_id,
+        worktreeId: session.worktree_id,
+        connectionId: session.connection_id
+      })
     } catch {
       // Best-effort — never disrupt the user's send/prompt flow.
     }

--- a/src/renderer/src/stores/useKanbanStore.ts
+++ b/src/renderer/src/stores/useKanbanStore.ts
@@ -43,7 +43,9 @@ export type TicketKey = string
 // highlight ring (see `isTicketLinkedToSidebarTarget`).
 export type SidebarHoverTarget =
   | { kind: 'project'; id: string }
-  | { kind: 'worktree'; id: string }
+  // Worktree hover highlights project-wide: `projectId` is the owning project,
+  // resolved at hover time (null when the worktree store can't resolve it).
+  | { kind: 'worktree'; id: string; projectId: string | null }
   | { kind: 'connection'; id: string }
 
 export interface MarkdownCardPlaceholder {
@@ -2057,7 +2059,16 @@ export const useKanbanStore = create<KanbanState>()(
       setHoveredSidebarTarget: (target: SidebarHoverTarget | null) => {
         const current = get().hoveredSidebarTarget
         if (current === target) return
-        if (current && target && current.kind === target.kind && current.id === target.id) return
+        if (
+          current &&
+          target &&
+          current.kind === target.kind &&
+          current.id === target.id &&
+          (current.kind === 'worktree' ? current.projectId : null) ===
+            (target.kind === 'worktree' ? target.projectId : null)
+        ) {
+          return
+        }
         set({ hoveredSidebarTarget: target })
       }
     }),

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -41,6 +41,41 @@ export type EmbeddedTerminalBackend = 'xterm' | 'ghostty'
 export type TerminalPosition = 'sidebar' | 'bottom'
 export type MergeConflictMode = 'build' | 'plan' | 'always-ask'
 export type FollowUpTriggerColumn = 'review' | 'done'
+/**
+ * What a board prompt auto-pins so the project's tickets show on the pinned
+ * board: nothing, the project's root/base worktree (or base connection
+ * instance), or the worktree/instance the session was actually sent on.
+ */
+export type AutoPinMode = 'off' | 'root-branch' | 'current-branch'
+export const AUTO_PIN_MODES: readonly AutoPinMode[] = ['off', 'root-branch', 'current-branch']
+export function isAutoPinMode(value: unknown): value is AutoPinMode {
+  return (AUTO_PIN_MODES as readonly unknown[]).includes(value)
+}
+/** Pre-3-way boolean setting; migrated to `autoPinOnBoardPrompt` on load. */
+const LEGACY_AUTO_PIN_KEY = 'autoPinBaseWorktreeOnBoardPrompt'
+
+/**
+ * Migrate a persisted settings blob from the legacy
+ * `autoPinBaseWorktreeOnBoardPrompt` boolean to the 3-way `autoPinOnBoardPrompt`
+ * mode. `true` meant "pin the project's root/base worktree" → 'root-branch';
+ * `false` → 'off'. A user's explicit new-key choice always wins over the legacy
+ * key, and an unrecognized new-key value is dropped so the default applies.
+ * Pure: returns the input untouched when there is nothing to migrate.
+ */
+export function migrateLegacyAutoPinSetting<T extends Record<string, unknown>>(persisted: T): T {
+  const hasLegacy = LEGACY_AUTO_PIN_KEY in persisted
+  const hasNew = 'autoPinOnBoardPrompt' in persisted
+  if (!hasLegacy && (!hasNew || isAutoPinMode(persisted.autoPinOnBoardPrompt))) return persisted
+
+  const { [LEGACY_AUTO_PIN_KEY]: legacy, autoPinOnBoardPrompt, ...rest } = persisted
+  const migrated: Record<string, unknown> = rest
+  if (isAutoPinMode(autoPinOnBoardPrompt)) {
+    migrated.autoPinOnBoardPrompt = autoPinOnBoardPrompt
+  } else if (hasLegacy) {
+    migrated.autoPinOnBoardPrompt = legacy === true ? 'root-branch' : 'off'
+  }
+  return migrated as T
+}
 
 // Re-exported from the shared single source of truth (see @shared/types/agent-sdk)
 // so existing `import { AgentSdk } from '@/stores/useSettingsStore'` sites keep working.
@@ -83,7 +118,7 @@ export interface AppSettings {
   mergeConflictMode: MergeConflictMode
   boardMode: 'toggle' | 'sticky-tab'
   followUpTriggerColumn: FollowUpTriggerColumn
-  autoPinBaseWorktreeOnBoardPrompt: boolean
+  autoPinOnBoardPrompt: AutoPinMode
   /** Auto-create a kanban ticket on the first message of a manually-created session. */
   automaticallyCreateTicket: boolean
   /** Show the optional Merged column on the board between Review and Done. */
@@ -216,7 +251,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   mergeConflictMode: 'always-ask',
   boardMode: 'sticky-tab',
   followUpTriggerColumn: 'done',
-  autoPinBaseWorktreeOnBoardPrompt: false,
+  autoPinOnBoardPrompt: 'off',
   automaticallyCreateTicket: false,
   showMergedColumn: false,
   defaultEditor: 'vscode',
@@ -365,7 +400,8 @@ async function loadSettingsFromDatabase(): Promise<AppSettings | null> {
 
       const value = await dbApi.setting.get(APP_SETTINGS_DB_KEY)
       if (value) {
-        const parsed = JSON.parse(value)
+        // Legacy autoPinBaseWorktreeOnBoardPrompt boolean → autoPinOnBoardPrompt mode
+        const parsed = migrateLegacyAutoPinSetting(JSON.parse(value))
         const result = {
           ...DEFAULT_SETTINGS,
           ...parsed,
@@ -446,7 +482,7 @@ function extractSettings(state: SettingsState): AppSettings {
     mergeConflictMode: state.mergeConflictMode,
     boardMode: state.boardMode,
     followUpTriggerColumn: state.followUpTriggerColumn,
-    autoPinBaseWorktreeOnBoardPrompt: state.autoPinBaseWorktreeOnBoardPrompt,
+    autoPinOnBoardPrompt: state.autoPinOnBoardPrompt,
     automaticallyCreateTicket: state.automaticallyCreateTicket,
     showMergedColumn: state.showMergedColumn,
     defaultEditor: state.defaultEditor,
@@ -805,6 +841,13 @@ export const useSettingsStore = create<SettingsState>()(
     {
       name: 'hive-settings',
       storage: createJSONStorage(() => localStorage),
+      // Same legacy autoPin migration as the settings DB path, so the ~200ms
+      // window before loadFromDatabase resolves (and a missing DB row, which
+      // is then seeded from this hydrated state) never regress a user's choice.
+      merge: (persisted, current) => ({
+        ...current,
+        ...migrateLegacyAutoPinSetting((persisted ?? {}) as Record<string, unknown>)
+      }),
       partialize: (state) => ({
         autoStartSession: state.autoStartSession,
         autoPullBeforeWorktree: state.autoPullBeforeWorktree,
@@ -817,7 +860,7 @@ export const useSettingsStore = create<SettingsState>()(
         mergeConflictMode: state.mergeConflictMode,
         boardMode: state.boardMode,
         followUpTriggerColumn: state.followUpTriggerColumn,
-        autoPinBaseWorktreeOnBoardPrompt: state.autoPinBaseWorktreeOnBoardPrompt,
+        autoPinOnBoardPrompt: state.autoPinOnBoardPrompt,
         automaticallyCreateTicket: state.automaticallyCreateTicket,
         showMergedColumn: state.showMergedColumn,
         defaultEditor: state.defaultEditor,

--- a/test/kanban/force-board-mode-auto-pin.test.ts
+++ b/test/kanban/force-board-mode-auto-pin.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { autoPinBaseWorktree } from '@/lib/auto-pin'
+import { autoPinForBoardPrompt, resolveAutoPinMode } from '@/lib/auto-pin'
 import { isForceBoardMode } from '@/api/hive-enterprise/client'
 
 let mockSettings: Record<string, unknown> = {}
@@ -26,72 +26,98 @@ vi.mock('@/stores/usePinnedStore', () => ({
 }))
 
 const mockGetDefaultWorktree = vi.fn()
+const mockWorktreesByProject = new Map<string, { id: string }[]>([
+  ['project-1', [{ id: 'base-worktree-1' }, { id: 'feature-worktree-1' }]]
+])
 
 vi.mock('@/stores/useWorktreeStore', () => ({
   useWorktreeStore: {
     getState: () => ({
+      worktreesByProject: mockWorktreesByProject,
       getDefaultWorktree: mockGetDefaultWorktree,
       loadWorktrees: vi.fn().mockResolvedValue(undefined)
     })
   }
 }))
 
+const policyOn = {
+  hiveAuthToken: 'token-1',
+  hiveOrganizationId: 'org-1',
+  hiveOrganizationForceBoardMode: true
+}
+const policyOff = {
+  hiveAuthToken: null,
+  hiveOrganizationId: null,
+  hiveOrganizationForceBoardMode: false
+}
+
 describe('isForceBoardMode', () => {
   it('is false unless logged in to an org with the policy enabled', () => {
-    const enabled = {
-      hiveAuthToken: 'token-1',
-      hiveOrganizationId: 'org-1',
-      hiveOrganizationForceBoardMode: true
-    }
-    expect(isForceBoardMode(enabled)).toBe(true)
-    expect(isForceBoardMode({ ...enabled, hiveAuthToken: null })).toBe(false)
-    expect(isForceBoardMode({ ...enabled, hiveOrganizationId: null })).toBe(false)
-    expect(isForceBoardMode({ ...enabled, hiveOrganizationForceBoardMode: false })).toBe(false)
+    expect(isForceBoardMode(policyOn)).toBe(true)
+    expect(isForceBoardMode({ ...policyOn, hiveAuthToken: null })).toBe(false)
+    expect(isForceBoardMode({ ...policyOn, hiveOrganizationId: null })).toBe(false)
+    expect(isForceBoardMode({ ...policyOn, hiveOrganizationForceBoardMode: false })).toBe(false)
   })
 })
 
-describe('autoPinBaseWorktree under org Force board mode', () => {
+describe('resolveAutoPinMode under org Force board mode', () => {
+  it('forces root-branch whatever the local mode is', () => {
+    for (const mode of ['off', 'root-branch', 'current-branch'] as const) {
+      expect(resolveAutoPinMode({ ...policyOn, autoPinOnBoardPrompt: mode })).toBe('root-branch')
+    }
+  })
+
+  it('passes the local mode through when the policy is off', () => {
+    for (const mode of ['off', 'root-branch', 'current-branch'] as const) {
+      expect(resolveAutoPinMode({ ...policyOff, autoPinOnBoardPrompt: mode })).toBe(mode)
+    }
+  })
+})
+
+describe('autoPinForBoardPrompt under org Force board mode', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsWorktreePinned.mockReturnValue(false)
     mockGetDefaultWorktree.mockReturnValue({ id: 'base-worktree-1' })
-    mockSettings = {
-      autoPinBaseWorktreeOnBoardPrompt: false,
-      hiveAuthToken: null,
-      hiveOrganizationId: null,
-      hiveOrganizationForceBoardMode: false
-    }
+    mockSettings = { autoPinOnBoardPrompt: 'off', ...policyOff }
   })
 
   it('does not pin when the local setting is off and the policy is off', async () => {
-    await autoPinBaseWorktree('project-1')
+    await autoPinForBoardPrompt({ projectId: 'project-1' })
 
     expect(mockPinWorktree).not.toHaveBeenCalled()
   })
 
-  it('pins even with the local setting off when the policy is on', async () => {
-    mockSettings = {
-      autoPinBaseWorktreeOnBoardPrompt: false,
-      hiveAuthToken: 'token-1',
-      hiveOrganizationId: 'org-1',
-      hiveOrganizationForceBoardMode: true
-    }
+  it('pins the base worktree with the local setting off when the policy is on', async () => {
+    mockSettings = { autoPinOnBoardPrompt: 'off', ...policyOn }
 
-    await autoPinBaseWorktree('project-1')
+    await autoPinForBoardPrompt({ projectId: 'project-1' })
 
     expect(mockPinWorktree).toHaveBeenCalledWith('base-worktree-1')
   })
 
-  it('still pins from the local setting alone', async () => {
-    mockSettings = {
-      autoPinBaseWorktreeOnBoardPrompt: true,
-      hiveAuthToken: null,
-      hiveOrganizationId: null,
-      hiveOrganizationForceBoardMode: false
-    }
+  it("pins the base worktree (not the session's) even in current-branch mode when the policy is on", async () => {
+    mockSettings = { autoPinOnBoardPrompt: 'current-branch', ...policyOn }
 
-    await autoPinBaseWorktree('project-1')
+    await autoPinForBoardPrompt({ projectId: 'project-1', worktreeId: 'feature-worktree-1' })
+
+    expect(mockPinWorktree).toHaveBeenCalledTimes(1)
+    expect(mockPinWorktree).toHaveBeenCalledWith('base-worktree-1')
+  })
+
+  it('still pins from the local setting alone', async () => {
+    mockSettings = { autoPinOnBoardPrompt: 'root-branch', ...policyOff }
+
+    await autoPinForBoardPrompt({ projectId: 'project-1' })
 
     expect(mockPinWorktree).toHaveBeenCalledWith('base-worktree-1')
+  })
+
+  it("pins the session's worktree in current-branch mode when the policy is off", async () => {
+    mockSettings = { autoPinOnBoardPrompt: 'current-branch', ...policyOff }
+
+    await autoPinForBoardPrompt({ projectId: 'project-1', worktreeId: 'feature-worktree-1' })
+
+    expect(mockPinWorktree).toHaveBeenCalledWith('feature-worktree-1')
   })
 })

--- a/test/kanban/plan-review-followup-dispatch.test.tsx
+++ b/test/kanban/plan-review-followup-dispatch.test.tsx
@@ -136,7 +136,7 @@ const apiMocks = vi.hoisted(() => ({
     startHivePromptTelemetry: vi.fn()
   },
   autoPin: {
-    autoPinBaseWorktree: vi.fn().mockResolvedValue(undefined)
+    autoPinForBoardPrompt: vi.fn().mockResolvedValue(undefined)
   },
   claudeCliPortal: {
     registerTarget: vi.fn(() => vi.fn())
@@ -449,7 +449,11 @@ describe('Plan review followup dispatch', () => {
         undefined
       )
     })
-    expect(apiMocks.autoPin.autoPinBaseWorktree).toHaveBeenCalledWith('proj-1')
+    expect(apiMocks.autoPin.autoPinForBoardPrompt).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      worktreeId: 'wt-1',
+      connectionId: null
+    })
     expect(apiMocks.hiveTelemetry.startHivePromptTelemetry).toHaveBeenCalledWith({
       sessionId: 'session-1',
       prompt: 'Please add error handling to step 2',
@@ -558,7 +562,11 @@ describe('Plan review followup dispatch', () => {
         undefined
       )
     })
-    expect(apiMocks.autoPin.autoPinBaseWorktree).toHaveBeenCalledWith('proj-1')
+    expect(apiMocks.autoPin.autoPinForBoardPrompt).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      worktreeId: null,
+      connectionId: 'conn-1'
+    })
     expect(apiMocks.hiveTelemetry.startHivePromptTelemetry).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'session-conn-old',
@@ -605,7 +613,11 @@ describe('Plan review followup dispatch', () => {
     expect(apiMocks.terminalApi.createClaudeCli).not.toHaveBeenCalled()
     expect(mockOpencodeOps.reconnect).not.toHaveBeenCalled()
     expect(mockOpencodeOps.prompt).not.toHaveBeenCalled()
-    expect(apiMocks.autoPin.autoPinBaseWorktree).toHaveBeenCalledWith('proj-1')
+    expect(apiMocks.autoPin.autoPinForBoardPrompt).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      worktreeId: 'wt-1',
+      connectionId: null
+    })
     expect(apiMocks.hiveTelemetry.startHivePromptTelemetry).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'session-1',
@@ -737,7 +749,11 @@ describe('Plan review followup dispatch', () => {
     })
 
     const outboundPrompt = mockOpencodeOps.prompt.mock.calls.at(-1)?.[2]?.[0]?.text
-    expect(apiMocks.autoPin.autoPinBaseWorktree).toHaveBeenCalledWith('proj-1')
+    expect(apiMocks.autoPin.autoPinForBoardPrompt).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      worktreeId: 'wt-1',
+      connectionId: null
+    })
     expect(apiMocks.hiveTelemetry.startHivePromptTelemetry).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'session-1',

--- a/test/settings/auto-pin-mode-migration.test.ts
+++ b/test/settings/auto-pin-mode-migration.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AUTO_PIN_MODES,
+  isAutoPinMode,
+  migrateLegacyAutoPinSetting
+} from '@/stores/useSettingsStore'
+
+/**
+ * The auto-pin setting changed from the boolean
+ * `autoPinBaseWorktreeOnBoardPrompt` to the 3-way `autoPinOnBoardPrompt`
+ * mode. Both persistence layers (settings DB row + localStorage 'hive-settings')
+ * run this migration on load so existing users keep their behavior.
+ */
+describe('migrateLegacyAutoPinSetting', () => {
+  it('maps legacy true → root-branch (the old "on" pinned the root/base worktree)', () => {
+    const migrated = migrateLegacyAutoPinSetting({
+      autoPinBaseWorktreeOnBoardPrompt: true,
+      boardMode: 'sticky-tab'
+    })
+
+    expect(migrated).toEqual({ autoPinOnBoardPrompt: 'root-branch', boardMode: 'sticky-tab' })
+    expect('autoPinBaseWorktreeOnBoardPrompt' in migrated).toBe(false)
+  })
+
+  it('maps legacy false → off', () => {
+    expect(migrateLegacyAutoPinSetting({ autoPinBaseWorktreeOnBoardPrompt: false })).toEqual({
+      autoPinOnBoardPrompt: 'off'
+    })
+  })
+
+  it('treats a non-boolean legacy value as off', () => {
+    expect(migrateLegacyAutoPinSetting({ autoPinBaseWorktreeOnBoardPrompt: 'yes' })).toEqual({
+      autoPinOnBoardPrompt: 'off'
+    })
+  })
+
+  it('leaves settings that never had the legacy key alone (default applies via merge)', () => {
+    const input = { boardMode: 'toggle' }
+    const migrated = migrateLegacyAutoPinSetting(input)
+
+    expect(migrated).toBe(input)
+    expect('autoPinOnBoardPrompt' in migrated).toBe(false)
+  })
+
+  it('keeps an explicit new-key choice over a lingering legacy key', () => {
+    expect(
+      migrateLegacyAutoPinSetting({
+        autoPinBaseWorktreeOnBoardPrompt: true,
+        autoPinOnBoardPrompt: 'current-branch'
+      })
+    ).toEqual({ autoPinOnBoardPrompt: 'current-branch' })
+    expect(
+      migrateLegacyAutoPinSetting({
+        autoPinBaseWorktreeOnBoardPrompt: true,
+        autoPinOnBoardPrompt: 'off'
+      })
+    ).toEqual({ autoPinOnBoardPrompt: 'off' })
+  })
+
+  it('returns already-migrated settings untouched', () => {
+    const input = { autoPinOnBoardPrompt: 'root-branch', boardMode: 'toggle' }
+    expect(migrateLegacyAutoPinSetting(input)).toBe(input)
+  })
+
+  it('drops an unrecognized new-key value so the default applies', () => {
+    expect(migrateLegacyAutoPinSetting({ autoPinOnBoardPrompt: 'sideways' })).toEqual({})
+    // ...unless a legacy key can still say what the user wanted
+    expect(
+      migrateLegacyAutoPinSetting({
+        autoPinOnBoardPrompt: 'sideways',
+        autoPinBaseWorktreeOnBoardPrompt: true
+      })
+    ).toEqual({ autoPinOnBoardPrompt: 'root-branch' })
+  })
+
+  it('is idempotent', () => {
+    const once = migrateLegacyAutoPinSetting({ autoPinBaseWorktreeOnBoardPrompt: true })
+    expect(migrateLegacyAutoPinSetting(once)).toBe(once)
+  })
+})
+
+describe('isAutoPinMode', () => {
+  it('accepts exactly the three modes', () => {
+    expect(AUTO_PIN_MODES).toEqual(['off', 'root-branch', 'current-branch'])
+    for (const mode of AUTO_PIN_MODES) expect(isAutoPinMode(mode)).toBe(true)
+    expect(isAutoPinMode(true)).toBe(false)
+    expect(isAutoPinMode('on')).toBe(false)
+    expect(isAutoPinMode(undefined)).toBe(false)
+  })
+})

--- a/test/settings/force-board-mode-toggles.test.tsx
+++ b/test/settings/force-board-mode-toggles.test.tsx
@@ -41,7 +41,7 @@ function baseState(overrides: Record<string, unknown> = {}): Record<string, unkn
     autoPullBeforeWorktree: true,
     boardMode: 'sticky-tab',
     followUpTriggerColumn: 'done',
-    autoPinBaseWorktreeOnBoardPrompt: false,
+    autoPinOnBoardPrompt: 'off',
     automaticallyCreateTicket: false,
     showMergedColumn: false,
     vimModeEnabled: false,
@@ -72,24 +72,47 @@ describe('SettingsGeneral under org Force board mode', () => {
     mockSettingsState = baseState()
   })
 
-  it('keeps both toggles interactive when the policy is off', async () => {
+  it('keeps both controls interactive when the policy is off', async () => {
     const { SettingsGeneral } = await import('@/components/settings/SettingsGeneral')
     render(<SettingsGeneral />)
 
     const autoStart = screen.getByTestId('auto-start-session-toggle')
-    const autoPin = screen.getByTestId('auto-pin-base-worktree-toggle')
+    const off = screen.getByTestId('auto-pin-mode-off')
+    const rootBranch = screen.getByTestId('auto-pin-mode-root-branch')
+    const currentBranch = screen.getByTestId('auto-pin-mode-current-branch')
 
     expect(autoStart).toHaveAttribute('aria-checked', 'true')
     expect(autoStart).not.toBeDisabled()
-    expect(autoPin).toHaveAttribute('aria-checked', 'false')
-    expect(autoPin).not.toBeDisabled()
+    expect(off).toHaveAttribute('aria-checked', 'true')
+    expect(rootBranch).toHaveAttribute('aria-checked', 'false')
+    expect(currentBranch).toHaveAttribute('aria-checked', 'false')
+    for (const button of [off, rootBranch, currentBranch]) {
+      expect(button).not.toBeDisabled()
+    }
 
-    await userEvent.click(autoPin)
-    expect(mockUpdateSetting).toHaveBeenCalledWith('autoPinBaseWorktreeOnBoardPrompt', true)
+    await userEvent.click(rootBranch)
+    expect(mockUpdateSetting).toHaveBeenCalledWith('autoPinOnBoardPrompt', 'root-branch')
+    await userEvent.click(currentBranch)
+    expect(mockUpdateSetting).toHaveBeenCalledWith('autoPinOnBoardPrompt', 'current-branch')
   })
 
-  it('locks auto-start off and auto-pin on when the policy is on', async () => {
+  it('reflects the persisted auto-pin mode', async () => {
+    mockSettingsState = baseState({ autoPinOnBoardPrompt: 'current-branch' })
+    const { SettingsGeneral } = await import('@/components/settings/SettingsGeneral')
+    render(<SettingsGeneral />)
+
+    expect(screen.getByTestId('auto-pin-mode-off')).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByTestId('auto-pin-mode-root-branch')).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByTestId('auto-pin-mode-current-branch')).toHaveAttribute(
+      'aria-checked',
+      'true'
+    )
+  })
+
+  it('locks auto-start off and auto-pin to Root branch when the policy is on', async () => {
     mockSettingsState = baseState({
+      // A local 'current-branch' choice is overridden, not just 'off'
+      autoPinOnBoardPrompt: 'current-branch',
       hiveAuthToken: 'token-1',
       hiveOrganizationId: 'org-1',
       hiveOrganizationForceBoardMode: true
@@ -98,18 +121,27 @@ describe('SettingsGeneral under org Force board mode', () => {
     render(<SettingsGeneral />)
 
     const autoStart = screen.getByTestId('auto-start-session-toggle')
-    const autoPin = screen.getByTestId('auto-pin-base-worktree-toggle')
+    const off = screen.getByTestId('auto-pin-mode-off')
+    const rootBranch = screen.getByTestId('auto-pin-mode-root-branch')
+    const currentBranch = screen.getByTestId('auto-pin-mode-current-branch')
 
     expect(autoStart).toHaveAttribute('aria-checked', 'false')
     expect(autoStart).toBeDisabled()
-    expect(autoPin).toHaveAttribute('aria-checked', 'true')
-    expect(autoPin).toBeDisabled()
+    expect(off).toHaveAttribute('aria-checked', 'false')
+    expect(rootBranch).toHaveAttribute('aria-checked', 'true')
+    expect(currentBranch).toHaveAttribute('aria-checked', 'false')
+    for (const button of [off, rootBranch, currentBranch]) {
+      expect(button).toBeDisabled()
+    }
 
     expect(screen.getByText('Disabled by your organization (Force board mode)')).toBeInTheDocument()
-    expect(screen.getByText('Enabled by your organization (Force board mode)')).toBeInTheDocument()
+    expect(
+      screen.getByText('Set to Root branch by your organization (Force board mode)')
+    ).toBeInTheDocument()
 
     await userEvent.click(autoStart)
-    await userEvent.click(autoPin)
+    await userEvent.click(off)
+    await userEvent.click(currentBranch)
     expect(mockUpdateSetting).not.toHaveBeenCalled()
   })
 })

--- a/test/settings/show-merged-column.test.tsx
+++ b/test/settings/show-merged-column.test.tsx
@@ -43,7 +43,7 @@ describe('SettingsGeneral merged column toggle', () => {
       autoPullBeforeWorktree: true,
       boardMode: 'sticky-tab',
       followUpTriggerColumn: 'done',
-      autoPinBaseWorktreeOnBoardPrompt: false,
+      autoPinOnBoardPrompt: 'off',
       automaticallyCreateTicket: false,
       showMergedColumn: false,
       vimModeEnabled: false,


### PR DESCRIPTION
## Summary
- Replace the boolean auto-pin preference with Off, Root branch, and Current branch modes.
- Pin the session’s worktree or connection instance when Current branch is selected, with root fallback behavior.
- Enforce Root branch auto-pinning under Force board mode.
- Migrate legacy auto-pin settings and expand coverage across launch, Kanban, and settings flows.

## Testing
- Added and updated Vitest coverage for auto-pin modes, migration, forced board mode, and launch behavior.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pinned-board visibility and org policy behavior across many launch and Kanban paths; mistakes could pin the wrong branch or skip pinning, but behavior is heavily test-covered and failures in auto-pin are swallowed.
> 
> **Overview**
> Replaces the on/off **auto-pin on board prompts** setting with **Off**, **Root branch**, and **Current branch**. Root branch keeps pinning the project’s default worktree or base connection instance; Current branch pins the worktree or connection instance the session was actually launched on (with sensible fallbacks when IDs are missing or not loaded yet). Org **Force board mode** still overrides the UI and effective mode to Root branch via `resolveAutoPinMode`.
> 
> **`autoPinBaseWorktree`** is renamed to **`autoPinForBoardPrompt`** and takes `projectId` plus optional `worktreeId` / `connectionId`. Call sites that used to pin only by project now pass session context where needed; duplicate batch-level pinning is removed from auto-launch paths, and pinning after worktree creation is centralized in **`launchTicketWithModel`** so Current branch can pin the real branch once the worktree exists. Legacy boolean settings migrate to the new enum on both DB load and localStorage hydrate.
> 
> **Sidebar hover on worktrees** is now **project-scoped**: hovering any branch highlights all tickets for that project on the board (with exact worktree matching only when `projectId` cannot be resolved). Settings General swaps the auto-pin switch for a three-option radio group; tests cover migration, modes, force-board policy, hover linking, and follow-up dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 093a10468282f0177058d25bc5d6343c4391196d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->