### PR TITLE
Debounce project filter input

### DIFF
--- a/src/renderer/src/components/connections/ConnectionList.tsx
+++ b/src/renderer/src/components/connections/ConnectionList.tsx
@@ -35,7 +35,7 @@ export function ConnectionList(): React.JSX.Element | null {
   const connectionModeActive = useConnectionStore((s) => s.connectionModeActive)
 
   // Sidebar filter: a connection matches iff at least one of its projects matches
-  const filterQuery = useFilterStore((s) => s.filterQuery)
+  const filterQuery = useFilterStore((s) => s.debouncedFilterQuery)
   const activeLanguages = useFilterStore((s) => s.activeLanguages)
   const projects = useProjectStore((s) => s.projects)
   const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)

--- a/src/renderer/src/components/layout/LeftSidebar.tsx
+++ b/src/renderer/src/components/layout/LeftSidebar.tsx
@@ -102,6 +102,7 @@ export function LeftSidebar(): React.JSX.Element {
   // Filter store for language filters and the text filter query
   // (in the store so keyboard navigation can respect the visible list)
   const filterQuery = useFilterStore((s) => s.filterQuery)
+  const debouncedFilterQuery = useFilterStore((s) => s.debouncedFilterQuery)
   const setFilterQuery = useFilterStore((s) => s.setFilterQuery)
   const activeLanguages = useFilterStore((s) => s.activeLanguages)
   const removeLanguage = useFilterStore((s) => s.removeLanguage)
@@ -310,7 +311,7 @@ export function LeftSidebar(): React.JSX.Element {
             <ConnectionList />
             <ProjectList
               onAddProject={handleAddProject}
-              filterQuery={filterQuery}
+              filterQuery={debouncedFilterQuery}
               activeLanguages={activeLanguages}
             />
           </div>

--- a/src/renderer/src/stores/__tests__/useFilterStore.test.ts
+++ b/src/renderer/src/stores/__tests__/useFilterStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useFilterStore, FILTER_DEBOUNCE_MS } from '../useFilterStore'
+
+describe('useFilterStore filter query debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    useFilterStore.getState().clearAll()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('updates filterQuery immediately but debouncedFilterQuery after the delay', () => {
+    useFilterStore.getState().setFilterQuery('he')
+
+    expect(useFilterStore.getState().filterQuery).toBe('he')
+    expect(useFilterStore.getState().debouncedFilterQuery).toBe('')
+
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS)
+
+    expect(useFilterStore.getState().debouncedFilterQuery).toBe('he')
+  })
+
+  it('only applies the last value when typing rapidly', () => {
+    useFilterStore.getState().setFilterQuery('h')
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS - 1)
+    useFilterStore.getState().setFilterQuery('hi')
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS - 1)
+
+    expect(useFilterStore.getState().debouncedFilterQuery).toBe('')
+
+    vi.advanceTimersByTime(1)
+
+    expect(useFilterStore.getState().debouncedFilterQuery).toBe('hi')
+  })
+
+  it('clears both values immediately when the query is emptied', () => {
+    useFilterStore.getState().setFilterQuery('hive')
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS)
+    useFilterStore.getState().setFilterQuery('')
+
+    expect(useFilterStore.getState().filterQuery).toBe('')
+    expect(useFilterStore.getState().debouncedFilterQuery).toBe('')
+  })
+
+  it('cancels a pending debounce when cleared', () => {
+    useFilterStore.getState().setFilterQuery('hive')
+    useFilterStore.getState().setFilterQuery('')
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS)
+
+    expect(useFilterStore.getState().debouncedFilterQuery).toBe('')
+  })
+
+  it('clearAll cancels a pending debounce and resets both values', () => {
+    useFilterStore.getState().setFilterQuery('hive')
+    useFilterStore.getState().clearAll()
+    vi.advanceTimersByTime(FILTER_DEBOUNCE_MS)
+
+    expect(useFilterStore.getState().filterQuery).toBe('')
+    expect(useFilterStore.getState().debouncedFilterQuery).toBe('')
+  })
+})

--- a/src/renderer/src/stores/useFilterStore.ts
+++ b/src/renderer/src/stores/useFilterStore.ts
@@ -24,16 +24,25 @@ export const COLON_COMMANDS: ColonCommand[] = [
 
 interface FilterState {
   activeLanguages: string[]
+  /** Live input value — updates on every keystroke, drives the search field. */
   filterQuery: string
+  /** Trailing-debounced copy of filterQuery — drives project filtering so
+      typing doesn't re-filter the whole sidebar on every letter. */
+  debouncedFilterQuery: string
   addLanguage: (lang: string) => void
   removeLanguage: (lang: string) => void
   setFilterQuery: (query: string) => void
   clearAll: () => void
 }
 
+export const FILTER_DEBOUNCE_MS = 150
+
+let filterDebounceTimer: ReturnType<typeof setTimeout> | null = null
+
 export const useFilterStore = create<FilterState>()((set) => ({
   activeLanguages: [],
   filterQuery: '',
+  debouncedFilterQuery: '',
   addLanguage: (lang) =>
     set((state) => ({
       activeLanguages: state.activeLanguages.includes(lang)
@@ -44,6 +53,25 @@ export const useFilterStore = create<FilterState>()((set) => ({
     set((state) => ({
       activeLanguages: state.activeLanguages.filter((l) => l !== lang)
     })),
-  setFilterQuery: (query) => set({ filterQuery: query }),
-  clearAll: () => set({ activeLanguages: [], filterQuery: '' })
+  setFilterQuery: (query) => {
+    if (filterDebounceTimer !== null) clearTimeout(filterDebounceTimer)
+    // Clearing must feel instant (Escape / clear button restores the full list).
+    if (!query) {
+      filterDebounceTimer = null
+      set({ filterQuery: '', debouncedFilterQuery: '' })
+      return
+    }
+    set({ filterQuery: query })
+    filterDebounceTimer = setTimeout(() => {
+      filterDebounceTimer = null
+      set({ debouncedFilterQuery: query })
+    }, FILTER_DEBOUNCE_MS)
+  },
+  clearAll: () => {
+    if (filterDebounceTimer !== null) {
+      clearTimeout(filterDebounceTimer)
+      filterDebounceTimer = null
+    }
+    set({ activeLanguages: [], filterQuery: '', debouncedFilterQuery: '' })
+  }
 }))


### PR DESCRIPTION
## Summary

- Add a 150 ms trailing debounce for project filtering.
- Keep the live query responsive while filtering uses the debounced value.
- Clear pending debounce timers when the query is cleared or filters reset.
- Add unit tests covering delayed updates, rapid typing, and reset behavior.

## Testing

- Added Vitest coverage for filter query debounce behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filter timing change with instant clear behavior preserved; no auth, data, or API impact.
> 
> **Overview**
> Sidebar project and connection filtering no longer runs on every keystroke. **`useFilterStore`** now keeps **`filterQuery`** for the live search field and a **150ms** trailing-debounced **`debouncedFilterQuery`** for list filtering.
> 
> **`ProjectList`** and **`ConnectionList`** read the debounced value so the sidebar doesn’t re-filter while typing. Clearing the field, **Escape**, or **`clearAll`** still resets both strings immediately and cancels any pending timer.
> 
> Vitest coverage was added for delay, rapid typing, clear, and **`clearAll`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52767f970ec3dbca83c0c0214c2f5b94d9ff6256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->