### PR TITLE
Trust project folders before spawning Claude CLI sessions

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -106,9 +106,10 @@ export function resolveDatabasePath(options?: {
   return join(homeDir, '.hive', 'hive.db')
 }
 
-type ProjectRow = Omit<Project, 'auto_assign_port' | 'custom_commands'> & {
+type ProjectRow = Omit<Project, 'auto_assign_port' | 'custom_commands' | 'trust_check_done'> & {
   auto_assign_port: number | boolean
   custom_commands: string | null
+  trust_check_done?: number | boolean
 }
 
 type CompactionWorkerSuccess = CompactionResult & { ok: true }
@@ -341,6 +342,7 @@ export class DatabaseService {
     return {
       ...row,
       auto_assign_port: Boolean(row.auto_assign_port),
+      trust_check_done: Boolean(row.trust_check_done),
       custom_commands: this.parseProjectCustomCommands(row.custom_commands)
     } as Project
   }
@@ -702,6 +704,7 @@ export class DatabaseService {
     )
     this.safeAddColumn('connections', 'is_base', 'INTEGER NOT NULL DEFAULT 0')
     this.safeAddColumn('projects', 'kanban_simple_mode', 'INTEGER NOT NULL DEFAULT 0')
+    this.safeAddColumn('projects', 'trust_check_done', 'INTEGER NOT NULL DEFAULT 0')
     this.safeAddColumn('projects', 'kanban_storage_mode', "TEXT NOT NULL DEFAULT 'internal'")
     this.safeAddColumn('projects', 'kanban_markdown_config', 'TEXT DEFAULT NULL')
     this.safeAddColumn('projects', 'custom_commands', 'TEXT DEFAULT NULL')
@@ -3487,6 +3490,11 @@ export class DatabaseService {
       enabled ? 1 : 0,
       projectId
     )
+  }
+
+  updateProjectTrustCheck(projectId: string, done: boolean): void {
+    const db = this.getDb()
+    db.prepare('UPDATE projects SET trust_check_done = ? WHERE id = ?').run(done ? 1 : 0, projectId)
   }
 
   // Ticket followup message operations

--- a/src/main/db/migration-safety.test.ts
+++ b/src/main/db/migration-safety.test.ts
@@ -300,6 +300,24 @@ describeIf('database migration safety', () => {
     db.close()
   })
 
+  it('supports the project trust_check_done flag end-to-end on a fresh database', () => {
+    const db = new DatabaseService(makeDbPath())
+    db.init()
+
+    expect(columnNames(db, 'projects')).toEqual(expect.arrayContaining(['trust_check_done']))
+
+    const project = db.createProject({ name: 'Project', path: makeDbPath() })
+    expect(project.trust_check_done).toBe(false)
+
+    db.updateProjectTrustCheck(project.id, true)
+    expect(db.getProject(project.id)?.trust_check_done).toBe(true)
+
+    db.updateProjectTrustCheck(project.id, false)
+    expect(db.getProject(project.id)?.trust_check_done).toBe(false)
+
+    db.close()
+  })
+
   it('supports the multi-model ticket columns end-to-end on a fresh database', () => {
     const db = new DatabaseService(makeDbPath())
     db.init()

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 46
+export const CURRENT_SCHEMA_VERSION = 47
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -741,6 +741,13 @@ DROP TABLE IF EXISTS diff_comments;`
     name: 'add_ticket_unread',
     up: `-- NOTE: ALTER TABLE for kanban_tickets.unread and
          -- markdown_kanban_card_state.unread is handled idempotently by
+         -- safeAddColumn() in database.ts to avoid "duplicate column" errors.`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 47,
+    name: 'add_project_trust_check',
+    up: `-- NOTE: ALTER TABLE for projects.trust_check_done is handled idempotently by
          -- safeAddColumn() in database.ts to avoid "duplicate column" errors.`,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -23,6 +23,9 @@ export interface Project {
   worktree_create_script: string | null
   custom_commands: CustomProjectCommand[] | null
   auto_assign_port: boolean
+  /** True once the claude CLI folder-trust pre-flight verified/stamped this
+   * project's root in ~/.claude.json (so later launches skip the file check). */
+  trust_check_done?: boolean
   kanban_storage_mode?: KanbanStorageMode
   kanban_markdown_config?: string | null
   sort_order: number

--- a/src/main/services/__tests__/claude-trust.test.ts
+++ b/src/main/services/__tests__/claude-trust.test.ts
@@ -1,0 +1,247 @@
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { homedir, tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Project } from '../../db/types'
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import {
+  ensureFolderTrustedInClaudeConfig,
+  ensureProjectTrustCheck,
+  resolveClaudeConfigPath
+} from '../claude-trust'
+
+let dir: string
+let configPath: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'claude-trust-test-'))
+  configPath = join(dir, '.claude.json')
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+async function readConfig(): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(configPath, 'utf-8'))
+}
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'project-1',
+    name: 'Project',
+    path: '/repo/root',
+    description: null,
+    tags: null,
+    language: null,
+    custom_icon: null,
+    detected_icon: null,
+    setup_script: null,
+    run_script: null,
+    archive_script: null,
+    worktree_create_script: null,
+    custom_commands: null,
+    auto_assign_port: false,
+    trust_check_done: false,
+    sort_order: 0,
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_accessed_at: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+describe('ensureFolderTrustedInClaudeConfig', () => {
+  it('creates the config with a trusted entry when the file is missing', async () => {
+    await expect(ensureFolderTrustedInClaudeConfig(configPath, '/repo/root')).resolves.toBe(true)
+
+    expect(await readConfig()).toEqual({
+      projects: { '/repo/root': { hasTrustDialogAccepted: true } }
+    })
+  })
+
+  it('adds the project entry while preserving unrelated config content', async () => {
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        numStartups: 12,
+        oauthAccount: { emailAddress: 'someone@example.com' },
+        projects: { '/other/project': { hasTrustDialogAccepted: false, lastCost: 3 } }
+      })
+    )
+
+    await expect(ensureFolderTrustedInClaudeConfig(configPath, '/repo/root')).resolves.toBe(true)
+
+    expect(await readConfig()).toEqual({
+      numStartups: 12,
+      oauthAccount: { emailAddress: 'someone@example.com' },
+      projects: {
+        '/other/project': { hasTrustDialogAccepted: false, lastCost: 3 },
+        '/repo/root': { hasTrustDialogAccepted: true }
+      }
+    })
+  })
+
+  it('flips an untrusted entry to trusted while keeping its sibling keys', async () => {
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        projects: { '/repo/root': { hasTrustDialogAccepted: false, exampleFilesGeneratedAt: 42 } }
+      })
+    )
+
+    await expect(ensureFolderTrustedInClaudeConfig(configPath, '/repo/root')).resolves.toBe(true)
+
+    expect(await readConfig()).toEqual({
+      projects: { '/repo/root': { hasTrustDialogAccepted: true, exampleFilesGeneratedAt: 42 } }
+    })
+  })
+
+  it('does not rewrite the file when the folder is already trusted', async () => {
+    const original = `{"projects":{"/repo/root":{"hasTrustDialogAccepted":true}}}`
+    await writeFile(configPath, original)
+
+    await expect(ensureFolderTrustedInClaudeConfig(configPath, '/repo/root')).resolves.toBe(true)
+
+    // A rewrite would pretty-print; byte equality proves the file was untouched.
+    expect(await readFile(configPath, 'utf-8')).toBe(original)
+  })
+
+  it('leaves an unparseable config untouched and reports failure', async () => {
+    await writeFile(configPath, '{ this is not json')
+
+    await expect(ensureFolderTrustedInClaudeConfig(configPath, '/repo/root')).resolves.toBe(false)
+
+    expect(await readFile(configPath, 'utf-8')).toBe('{ this is not json')
+  })
+
+  it('leaves a non-object config untouched and reports failure', async () => {
+    await writeFile(configPath, '[1,2,3]')
+
+    await expect(ensureFolderTrustedInClaudeConfig(configPath, '/repo/root')).resolves.toBe(false)
+
+    expect(await readFile(configPath, 'utf-8')).toBe('[1,2,3]')
+  })
+
+  it('serializes concurrent writes for different folders into one config', async () => {
+    await Promise.all([
+      ensureFolderTrustedInClaudeConfig(configPath, '/repo/a'),
+      ensureFolderTrustedInClaudeConfig(configPath, '/repo/b'),
+      ensureFolderTrustedInClaudeConfig(configPath, '/repo/c')
+    ])
+
+    expect(await readConfig()).toEqual({
+      projects: {
+        '/repo/a': { hasTrustDialogAccepted: true },
+        '/repo/b': { hasTrustDialogAccepted: true },
+        '/repo/c': { hasTrustDialogAccepted: true }
+      }
+    })
+  })
+})
+
+describe('ensureProjectTrustCheck', () => {
+  function makeDb(
+    project: Project | null,
+    setting: string | null = null
+  ): {
+    getProject: ReturnType<typeof vi.fn>
+    updateProjectTrustCheck: ReturnType<typeof vi.fn>
+    getSetting: ReturnType<typeof vi.fn>
+  } {
+    return {
+      getProject: vi.fn(() => project),
+      updateProjectTrustCheck: vi.fn(),
+      getSetting: vi.fn(() => setting)
+    }
+  }
+
+  it('trusts the project root and stamps trust_check_done', async () => {
+    const db = makeDb(makeProject())
+
+    await ensureProjectTrustCheck(db, 'project-1', { configPath })
+
+    expect(await readConfig()).toEqual({
+      projects: { '/repo/root': { hasTrustDialogAccepted: true } }
+    })
+    expect(db.updateProjectTrustCheck).toHaveBeenCalledWith('project-1', true)
+  })
+
+  it('skips connection projects entirely', async () => {
+    const db = makeDb(makeProject({ kind: 'connection' }))
+
+    await ensureProjectTrustCheck(db, 'project-1', { configPath })
+
+    await expect(readFile(configPath, 'utf-8')).rejects.toThrow()
+    expect(db.updateProjectTrustCheck).not.toHaveBeenCalled()
+  })
+
+  it('skips projects already stamped trust_check_done', async () => {
+    const db = makeDb(makeProject({ trust_check_done: true }))
+
+    await ensureProjectTrustCheck(db, 'project-1', { configPath })
+
+    await expect(readFile(configPath, 'utf-8')).rejects.toThrow()
+    expect(db.updateProjectTrustCheck).not.toHaveBeenCalled()
+  })
+
+  it('does not stamp trust_check_done when the config could not be updated', async () => {
+    await writeFile(configPath, '{ corrupt')
+    const db = makeDb(makeProject())
+
+    await ensureProjectTrustCheck(db, 'project-1', { configPath })
+
+    expect(db.updateProjectTrustCheck).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op for an unknown project', async () => {
+    const db = makeDb(null)
+
+    await ensureProjectTrustCheck(db, 'missing', { configPath })
+
+    expect(db.updateProjectTrustCheck).not.toHaveBeenCalled()
+  })
+
+  it('never throws, even when the db lookup fails', async () => {
+    const db = {
+      getProject: vi.fn(() => {
+        throw new Error('db exploded')
+      }),
+      updateProjectTrustCheck: vi.fn(),
+      getSetting: vi.fn(() => null)
+    }
+
+    await expect(ensureProjectTrustCheck(db, 'project-1', { configPath })).resolves.toBeUndefined()
+    expect(db.updateProjectTrustCheck).not.toHaveBeenCalled()
+  })
+
+  it("honors a CLAUDE_CONFIG_DIR from the user's settings env vars", async () => {
+    const db = makeDb(
+      makeProject(),
+      JSON.stringify({ environmentVariables: [{ key: 'CLAUDE_CONFIG_DIR', value: dir }] })
+    )
+
+    await ensureProjectTrustCheck(db, 'project-1')
+
+    expect(await readConfig()).toEqual({
+      projects: { '/repo/root': { hasTrustDialogAccepted: true } }
+    })
+    expect(db.updateProjectTrustCheck).toHaveBeenCalledWith('project-1', true)
+  })
+})
+
+describe('resolveClaudeConfigPath', () => {
+  it('uses $CLAUDE_CONFIG_DIR/.claude.json when the variable is set', () => {
+    expect(resolveClaudeConfigPath({ CLAUDE_CONFIG_DIR: '/custom/cfg' })).toBe(
+      join('/custom/cfg', '.claude.json')
+    )
+  })
+
+  it('falls back to ~/.claude.json when unset or empty', () => {
+    expect(resolveClaudeConfigPath({})).toBe(join(homedir(), '.claude.json'))
+    expect(resolveClaudeConfigPath({ CLAUDE_CONFIG_DIR: '' })).toBe(join(homedir(), '.claude.json'))
+  })
+})

--- a/src/main/services/claude-trust.ts
+++ b/src/main/services/claude-trust.ts
@@ -1,0 +1,126 @@
+import { existsSync } from 'fs'
+import { readFile } from 'fs/promises'
+import { homedir } from 'os'
+import { join } from 'path'
+import type { Project } from '../db/types'
+import { atomicWriteJson } from './atomic-json'
+import { getUserEnvironmentVariables } from './env-vars'
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'ClaudeTrust' })
+
+/** The slice of DatabaseService the trust pre-flight needs (kept narrow for tests). */
+interface TrustCheckDb {
+  getProject(id: string): Project | null
+  updateProjectTrustCheck(projectId: string, done: boolean): void
+  getSetting(key: string): string | null
+}
+
+/** Mirror the claude CLI's own config resolution — `$CLAUDE_CONFIG_DIR/.claude.json`
+ * when the variable is set, else `~/.claude.json`. `env` must be the environment
+ * the spawned CLI will actually see, or the trust write lands in a file the CLI
+ * never reads. */
+export function resolveClaudeConfigPath(env: Record<string, string | undefined>): string {
+  return join(env.CLAUDE_CONFIG_DIR || homedir(), '.claude.json')
+}
+
+// Serializes read-modify-write cycles on the config file so concurrent session
+// launches (e.g. a multi-model ticket launching several sessions at once)
+// can't interleave and drop each other's writes.
+let writeChain: Promise<unknown> = Promise.resolve()
+
+/**
+ * Ensure `projects[folderPath].hasTrustDialogAccepted === true` in the claude
+ * CLI config at `configPath`, creating the file or the entry as needed while
+ * preserving everything else. Returns false without touching the file when it
+ * exists but can't be parsed — it also holds oauth state, so clobbering it is
+ * far worse than letting the CLI show its trust dialog.
+ */
+export async function ensureFolderTrustedInClaudeConfig(
+  configPath: string,
+  folderPath: string
+): Promise<boolean> {
+  const run = writeChain.then(() => ensureFolderTrusted(configPath, folderPath))
+  writeChain = run.catch(() => undefined)
+  return run
+}
+
+async function ensureFolderTrusted(configPath: string, folderPath: string): Promise<boolean> {
+  let config: Record<string, unknown> = {}
+  if (existsSync(configPath)) {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(await readFile(configPath, 'utf-8'))
+    } catch (error) {
+      log.warn('Claude config exists but is unparseable; leaving it untouched', {
+        configPath,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return false
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      log.warn('Claude config is not a JSON object; leaving it untouched', { configPath })
+      return false
+    }
+    config = parsed as Record<string, unknown>
+  }
+
+  const projects =
+    typeof config.projects === 'object' &&
+    config.projects !== null &&
+    !Array.isArray(config.projects)
+      ? (config.projects as Record<string, unknown>)
+      : {}
+  const entry =
+    typeof projects[folderPath] === 'object' && projects[folderPath] !== null
+      ? (projects[folderPath] as Record<string, unknown>)
+      : {}
+  if (entry.hasTrustDialogAccepted === true) {
+    return true
+  }
+
+  projects[folderPath] = { ...entry, hasTrustDialogAccepted: true }
+  config.projects = projects
+  await atomicWriteJson(configPath, config, { pretty: true })
+  log.info('Marked folder trusted in claude config', { configPath, folderPath })
+  return true
+}
+
+/**
+ * One-time-per-project pre-flight before spawning a claude CLI session: make
+ * sure the project's root path is trusted in ~/.claude.json so the CLI doesn't
+ * stall on the folder-trust dialog (which would swallow an argv prompt behind
+ * an interactive question). Connection projects are skipped — their sessions
+ * run against remote hosts, where the local config has no bearing. Once the
+ * config is verified/updated the project is stamped `trust_check_done`, so
+ * later launches cost a single DB read. Never throws: a failed pre-flight must
+ * not block the session launch.
+ */
+export async function ensureProjectTrustCheck(
+  db: TrustCheckDb,
+  projectId: string,
+  opts?: { configPath?: string }
+): Promise<void> {
+  try {
+    const project = db.getProject(projectId)
+    if (!project) return
+    if ((project.kind ?? 'git') !== 'git') return
+    if (project.trust_check_done) return
+
+    // The spawned CLI's env is process.env with the user's settings env vars
+    // assigned on top (see pty-service/claude-cli-spawner) — resolve the config
+    // path from that same view.
+    const configPath =
+      opts?.configPath ??
+      resolveClaudeConfigPath({ ...process.env, ...getUserEnvironmentVariables(db) })
+    const trusted = await ensureFolderTrustedInClaudeConfig(configPath, project.path)
+    if (trusted) {
+      db.updateProjectTrustCheck(project.id, true)
+    }
+  } catch (error) {
+    log.warn('Claude trust pre-flight failed; continuing session launch', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}

--- a/src/main/services/env-vars.ts
+++ b/src/main/services/env-vars.ts
@@ -1,7 +1,10 @@
 import { APP_SETTINGS_DB_KEY } from '@shared/types/settings'
-import type { DatabaseService } from '../db/database'
 
-export function getUserEnvironmentVariables(db: DatabaseService | null): Record<string, string> {
+export function getUserEnvironmentVariables(
+  db: {
+    getSetting(key: string): string | null
+  } | null
+): Record<string, string> {
   if (!db) return {}
   try {
     const raw = db.getSetting(APP_SETTINGS_DB_KEY)

--- a/src/main/services/terminal-pty-bridge.claude-cli.test.ts
+++ b/src/main/services/terminal-pty-bridge.claude-cli.test.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => {
     clearAllClaudeCliInteractions: vi.fn(),
     clearClaudeCliSubagentTracking: vi.fn(),
     clearAllClaudeCliSubagentTracking: vi.fn(),
+    ensureProjectTrustCheck: vi.fn(async () => {}),
     ptyService: {
       has: vi.fn(() => false),
       create: vi.fn(() => ({ cols: 120, rows: 40 })),
@@ -98,6 +99,10 @@ vi.mock('./claude-binary-resolver', () => ({
 
 vi.mock('./claude-cli-plan-handoff', () => ({
   externalizeGoalHandoffPlan: vi.fn((prompt: string) => prompt)
+}))
+
+vi.mock('./claude-trust', () => ({
+  ensureProjectTrustCheck: mocks.ensureProjectTrustCheck
 }))
 
 // Keep the real writeClaudeCliPrompt (bracketed paste) but stub the timer-based
@@ -183,9 +188,11 @@ function setupDb(session: Session = makeSession()): void {
     getSession: vi.fn(() => session),
     getWorktree: vi.fn(() => ({ path: '/repo/worktree' })),
     getConnection: vi.fn(() => ({ path: '/repo/connection' })),
+    getProject: vi.fn(() => ({ id: session.project_id, path: '/repo', kind: 'git' })),
     getSetting: vi.fn(() => null),
     getSessionByClaudeSessionId: vi.fn(() => null),
-    updateSession: vi.fn()
+    updateSession: vi.fn(),
+    updateProjectTrustCheck: vi.fn()
   })
 }
 
@@ -245,6 +252,21 @@ describe('Claude CLI terminal hook status wiring', () => {
       'Implement the plan'
     ])
     expect(mocks.publishClaudeCliStatus).not.toHaveBeenCalled()
+  })
+
+  it('runs the project trust pre-flight before spawning the PTY', async () => {
+    const result = await createClaudeCliTerminal('hive-session-1', {
+      pendingPrompt: 'Implement the plan'
+    })
+
+    expect(result.success).toBe(true)
+    expect(mocks.ensureProjectTrustCheck).toHaveBeenCalledWith(
+      mocks.getDatabase.mock.results.at(-1)!.value,
+      'project-1'
+    )
+    const trustOrder = mocks.ensureProjectTrustCheck.mock.invocationCallOrder[0]
+    const spawnOrder = mocks.ptyService.create.mock.invocationCallOrder[0]
+    expect(trustOrder).toBeLessThan(spawnOrder)
   })
 
   it('injects the pending prompt into an already-running PTY instead of dropping it', async () => {

--- a/src/main/services/terminal-pty-bridge.ts
+++ b/src/main/services/terminal-pty-bridge.ts
@@ -25,6 +25,7 @@ import {
 import { setClaudeCliPlanAutoApprove } from './claude-cli-plan-auto-approve'
 import { logClaudeBinaryVersion, resolveClaudeBinaryPath } from './claude-binary-resolver'
 import { buildClaudeCliPtySpawn } from './claude-cli-spawner'
+import { ensureProjectTrustCheck } from './claude-trust'
 import { getCustomProviderById } from './custom-providers'
 import type { CustomProviderModel } from '@shared/types/custom-provider'
 import { externalizeGoalHandoffPlan } from './claude-cli-plan-handoff'
@@ -323,6 +324,11 @@ export async function createClaudeCliTerminal(
     }
 
     const alreadyExists = ptyService.has(sessionId)
+    // The claude CLI stalls a fresh spawn on its folder-trust dialog (which
+    // would swallow an argv prompt behind an interactive question), so make
+    // sure the project root is trusted in ~/.claude.json before the PTY starts.
+    // One config check per project — afterwards this is a single DB read.
+    await ensureProjectTrustCheck(db, session.project_id)
     const { port } = await getClaudeHookServer()
     ensureClaudeCliStatusSubscription()
     const hookSettingsJson = buildClaudeCliHookSettings(port, sessionId)


### PR DESCRIPTION
## Summary

- Add a Claude config pre-flight that marks Git project roots as trusted.
- Persist `trust_check_done` per project to avoid repeated config checks.
- Resolve custom `CLAUDE_CONFIG_DIR` settings and serialize concurrent config updates.
- Run the trust check before PTY creation with migration and service coverage.

## Testing

- Added Claude trust service tests for config creation, preservation, invalid files, concurrency, and project behavior.
- Added database migration safety coverage for `trust_check_done`.
- Added terminal PTY ordering coverage to verify trust runs before spawning.
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The pre-flight mutates the user’s Claude CLI config (including OAuth-adjacent state), though it only patches trust entries and bails on parse errors; session launch still proceeds if the check fails.
> 
> **Overview**
> Adds a **one-time-per-git-project pre-flight** before Claude CLI PTY creation so the folder-trust dialog does not block argv prompts. A new `claude-trust` service sets `projects[path].hasTrustDialogAccepted` in the CLI’s `.claude.json` (honoring `CLAUDE_CONFIG_DIR` from user settings), uses **serialized read-modify-write** for concurrent launches, and **refuses to clobber** invalid config.
> 
> Projects gain a persisted **`trust_check_done`** flag (schema v47 + `updateProjectTrustCheck`) so later spawns only hit the DB; connection projects and already-stamped projects are skipped, and failures never block launch. **`createClaudeCliTerminal`** now awaits this check **before** spawning the PTY.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d864cc4dab8c5e069f5ea62a097aeb6c1ce04ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->